### PR TITLE
feat(metrics): ts_quantile_spread + ts_asymmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
 | **精確公式 / 演算法 / 邊界 case**（authoritative source）                       | 對應 module docstring：`help(factrix.metrics.ic)`、…                            |
 | **為什麼選這個方法**（論文依據、deviation）                                     | [`docs/statistical_methods.md`](docs/statistical_methods.md)                   |
 | **資料夠不夠用**（N/T 下限、fallback 語意）                                     | [`docs/metric_applicability.md`](docs/metric_applicability.md)                 |
+| **Standalone diagnostics**（不走 `evaluate()` 的補位 metric — 抓 OLS β 漏掉的 shape / asymmetry） | [`docs/metric_applicability.md` §`ts_quantile_spread` / `ts_asymmetry`](docs/metric_applicability.md#ts_quantile_spread--ts_asymmetry-的適用範圍) |
 | Profile / Config 介面                                                         | `help(fl.FactorProfile)`、`help(fl.AnalysisConfig)`                            |
 | 內部結構（registry SSOT、Procedure protocol、Mode 推導、Invariants）            | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                          |
 | 想貢獻                                                                        | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                          |

--- a/docs/metric_applicability.md
+++ b/docs/metric_applicability.md
@@ -274,7 +274,7 @@ factrix 預設採**拉式**通知（user 主動呼叫 `.diagnose()` / 讀 `metad
 | **COMMON × CONTINUOUS, TIMESERIES** (N=1) | ✓ | ✓ |
 | **INDIVIDUAL × CONTINUOUS** (任何 mode) | ✗ guard → 改用 cross-sectional `quantile_spread` | ✗ → `quantile_spread.long_alpha / short_alpha` |
 | **(\*, SPARSE / binary / ternary)** | ✗ Gate A → `event_quality.*` | ✗ Gate B → `event_hit_rate` |
-| **factor 全 ≥ 0 或全 ≤ 0** | ✓ | ✗ Gate B（無雙側）→ `metadata["method_a_skipped"]` / `method_b_skipped` 記錄 reason |
+| **factor 全 ≥ 0 或全 ≤ 0** | ✓ | ✗ Gate B（無雙側）→ 整個 metric 短路，reason 寫入 `metadata["reason"]`（method 不分 A/B，兩個都不出）；Gate C 失敗才是「method A 出、method B 不出」，由 `metadata["method_b_skipped"]` 記錄 |
 
 任一 gate 失敗 → `MetricOutput` 帶 `metadata["reason"]` + redirect hint，**不 silently 回 NaN**（與 §跨類通用 §Metric 短路 慣例一致）。
 

--- a/docs/metric_applicability.md
+++ b/docs/metric_applicability.md
@@ -249,6 +249,44 @@ factrix 預設採**拉式**通知（user 主動呼叫 `.diagnose()` / 讀 `metad
 
 ---
 
+## `ts_quantile_spread` / `ts_asymmetry` 的適用範圍
+
+兩個 **standalone diagnostic**（不進 registry、不影響 `verdict()`）— 補位 `(COMMON, CONTINUOUS, *)` cell 的 OLS β 假設線性 + 對稱所漏掉的 shape：
+
+- `ts_quantile_spread`：factor 自己歷史分桶 → 桶間條件期望檢定（top-bottom Wald）+ Spearman 單調性 diagnostic。抓 U-shape / inverted-U / extreme-only。
+- `ts_asymmetry`：factor 正負兩側 response 是否對稱（method A 條件期望、method B 分段斜率）。抓 long-side ≠ short-side。
+
+兩者皆 OLS + NW HAC + Wald，與 `ts_beta_t_nw` 對齊；**不**用 Welch t（iid 假設在 overlapping forward return 下破裂）。
+
+### 適用性（gates）
+
+| Gate | 條件 | 影響 |
+|------|------|------|
+| **A**. distinct 數量 | `n_unique(factor) ≥ n_groups × 2` | `ts_quantile_spread` 是否可跑 |
+| **B**. 雙側存在 | `(factor>0).any() and (factor<0).any()` | `ts_asymmetry` 兩個方法的最低門檻 |
+| **C**. 雙側內變異 | `n_unique(factor[factor>0]) ≥ 2 and n_unique(factor[factor<0]) ≥ 2` | `ts_asymmetry` method B 的額外條件 |
+
+### 適用性矩陣
+
+| 你手上的資料 | `ts_quantile_spread` | `ts_asymmetry` |
+|---|---|---|
+| **COMMON × CONTINUOUS, PANEL** (N≥2) | ✓ 收成 `equal_weight` per-date（`metadata["aggregation"]` 記錄）| ✓ |
+| **COMMON × CONTINUOUS, TIMESERIES** (N=1) | ✓ | ✓ |
+| **INDIVIDUAL × CONTINUOUS** (任何 mode) | ✗ guard → 改用 cross-sectional `quantile_spread` | ✗ → `quantile_spread.long_alpha / short_alpha` |
+| **(\*, SPARSE / binary / ternary)** | ✗ Gate A → `event_quality.*` | ✗ Gate B → `event_hit_rate` |
+| **factor 全 ≥ 0 或全 ≤ 0** | ✓ | ✗ Gate B（無雙側）→ `metadata["method_a_skipped"]` / `method_b_skipped` 記錄 reason |
+
+任一 gate 失敗 → `MetricOutput` 帶 `metadata["reason"]` + redirect hint，**不 silently 回 NaN**（與 §跨類通用 §Metric 短路 慣例一致）。
+
+### API policy
+
+- `n_groups: int = 5` default、user override、`n_periods // n_groups < 5` soft warning、`n_periods < MIN_PORTFOLIO_PERIODS` hard short-circuit。**不** auto-adjust。
+- v1 PANEL 收法固定 `equal_weight`；`value_weight` / `factor_weight` 後續 issue。
+
+設計細節 / Wald regression 公式 / 為何不用 Welch → 見 [issue #5](https://github.com/awwesomeman/factrix/issues/5) 與兩個 module docstring。
+
+---
+
 ## 常見 decision tree（給 debug 用）
 
 ```

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -400,6 +400,75 @@ def _ols_nw_slope_t(
     return beta, t_stat, p_value, resid
 
 
+def _ols_nw_multivariate(
+    y: np.ndarray,
+    X: np.ndarray,
+    *,
+    lags: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Multi-regressor OLS ``y = Xβ + ε`` with Newey-West HAC covariance.
+
+    Returns ``(β̂, V_hac, resid)``. ``X`` carries its own intercept column
+    if needed — this routine does not auto-add one. Bartlett kernel
+    matches ``_newey_west_se`` / ``_ols_nw_slope_t`` so HAC math stays
+    in one place.
+
+    Returns ``(zeros(k), zeros((k,k)), zeros(n))`` if ``X'X`` is singular
+    (e.g. perfectly collinear columns) or ``n < k + 1``.
+    """
+    n, k = X.shape
+    if len(y) != n or n < k + 1:
+        return np.zeros(k), np.zeros((k, k)), np.zeros(n)
+
+    XtX = X.T @ X
+    try:
+        XtX_inv = np.linalg.inv(XtX)
+    except np.linalg.LinAlgError:
+        return np.zeros(k), np.zeros((k, k)), np.zeros(n)
+
+    beta = XtX_inv @ (X.T @ y)
+    resid = y - X @ beta
+
+    # Score matrix: u_t = x_t * e_t (n × k).
+    U = X * resid[:, None]
+
+    # S = Γ_0 + Σ_{j=1..L} w_j (Γ_j + Γ_j')
+    # Γ_0 = Σ u_t u_t' (sum form, matches _ols_nw_slope_t convention).
+    S = U.T @ U
+    L = max(0, min(lags, n - 1))
+    for j in range(1, L + 1):
+        gamma_j = U[j:].T @ U[:-j]
+        weight = 1.0 - j / (L + 1)
+        S += weight * (gamma_j + gamma_j.T)
+
+    V_hac = XtX_inv @ S @ XtX_inv
+    return beta, V_hac, resid
+
+
+def _wald_p_linear(
+    beta: np.ndarray,
+    V: np.ndarray,
+    R: np.ndarray,
+    q: np.ndarray | float = 0.0,
+) -> tuple[float, float]:
+    """Wald χ² test of the linear restriction ``Rβ = q``.
+
+    ``R`` is ``(r, k)``; ``q`` is ``(r,)`` or scalar for r=1. Returns
+    ``(W, p)`` with ``W ~ χ²_r`` under H₀. Returns ``(0.0, 1.0)`` if
+    the middle matrix is singular (degenerate restriction).
+    """
+    R = np.atleast_2d(R)
+    diff = R @ beta - np.atleast_1d(q)
+    middle = R @ V @ R.T
+    try:
+        middle_inv = np.linalg.inv(middle)
+    except np.linalg.LinAlgError:
+        return 0.0, 1.0
+    W = float(diff @ middle_inv @ diff)
+    p = float(sp_stats.chi2.sf(W, df=R.shape[0]))
+    return W, p
+
+
 def _ljung_box_p(
     resid: np.ndarray,
     *,

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -80,6 +80,8 @@ from factrix.metrics.ts_beta import (
     compute_rolling_mean_beta,
     ts_beta_sign_consistency,
 )
+from factrix.metrics.ts_quantile import ts_quantile_spread
+from factrix.metrics.ts_asymmetry import ts_asymmetry
 
 __all__ = [
     "compute_ic", "ic", "ic_ir", "regime_ic", "multi_horizon_ic",
@@ -96,4 +98,5 @@ __all__ = [
     "beta_sign_consistency",
     "compute_ts_betas", "ts_beta", "mean_r_squared",
     "compute_rolling_mean_beta", "ts_beta_sign_consistency",
+    "ts_quantile_spread", "ts_asymmetry",
 ]

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -20,6 +20,38 @@ from factrix._types import MetricOutput
 TIE_RATIO_WARN_THRESHOLD = 0.3
 
 
+def _aggregate_to_per_date(
+    df: pl.DataFrame,
+    *,
+    factor_col: str = "factor",
+    return_col: str = "forward_return",
+    factor_alias: str = "_f",
+    return_alias: str = "_r",
+) -> pl.DataFrame:
+    """Collapse a panel to one row per ``date`` (mean factor + mean return).
+
+    For COMMON-scope factors (broadcast within date) the mean is the
+    identity. For single-asset TIMESERIES it is also the identity.
+    For INDIVIDUAL panels the cross-section is silently averaged —
+    callers using this on time-series-only metrics document that
+    aggregation in their own docstrings.
+    """
+    return (
+        df.lazy()
+        .group_by("date")
+        .agg(
+            pl.col(factor_col).mean().alias(factor_alias),
+            pl.col(return_col).mean().alias(return_alias),
+        )
+        .filter(
+            pl.col(factor_alias).is_not_null()
+            & pl.col(return_alias).is_not_null()
+        )
+        .sort("date")
+        .collect()
+    )
+
+
 def _short_circuit_output(
     name: str,
     reason: str,

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -1,0 +1,183 @@
+"""Long-side / short-side asymmetry test (issue #5).
+
+Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
+cells. OLS β reports a single slope and assumes the response is
+symmetric around zero — `β > 0` could be "rises more on positive
+factor" *or* "falls less on negative factor", and a strategy team
+needs to know which.
+
+Two methods, both fit by OLS with Newey-West HAC covariance and
+tested by Wald χ² so cross-method p-values stay comparable and the
+overlapping-forward-return autocorrelation is handled the same way
+as `ts_beta_t_nw`. Welch t is intentionally avoided — its iid
+assumption breaks under `forward_periods > 1`.
+
+- Method A (conditional means): `r = β_long·I(f>0) + β_short·I(f<0)
+  + β_zero·I(f=0)`. H0: `β_long + β_short = 0` — symmetric magnitude.
+- Method B (piecewise slopes): `r = α + β_pos·max(f,0) + β_neg·min(f,0)`.
+  H0: `β_pos = β_neg` — slope on the positive side equals slope on
+  the negative side.
+
+Gates (issue #5):
+- Gate B (mandatory for either method): factor must have both
+  positive and negative observations.
+- Gate C (method B only): each side needs ≥ 2 distinct factor
+  values to identify a slope. Below the gate, method B is skipped
+  and `metadata["method_b_skipped"]` records the reason.
+
+Standalone metric — does not enter the registry.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from factrix._stats import (
+    _ols_nw_multivariate,
+    _resolve_nw_lags,
+    _significance_marker,
+    _wald_p_linear,
+)
+from factrix._types import MIN_PORTFOLIO_PERIODS, MetricOutput
+from factrix.metrics._helpers import (
+    _aggregate_to_per_date,
+    _short_circuit_output,
+)
+
+
+def ts_asymmetry(
+    df: pl.DataFrame,
+    *,
+    factor_col: str = "factor",
+    return_col: str = "forward_return",
+    forward_periods: int | None = None,
+    nw_lags: int | None = None,
+) -> MetricOutput:
+    """Long/short asymmetry of factor → return relationship.
+
+    Reported headline:
+    - ``value`` = method-A magnitude ``β_long + β_short`` (0 under
+      perfect symmetry; positive = long side stronger)
+    - ``stat``  = ``value`` / NW HAC SE
+    - ``metadata["p_value"]`` = method-A Wald p (two-sided)
+
+    Method B (Gate C passing) populates ``beta_pos`` / ``beta_neg`` /
+    ``p_wald_slopes``; otherwise ``method_b_skipped`` carries the
+    reason.
+    """
+    if "date" not in df.columns:
+        return _short_circuit_output(
+            "ts_asymmetry", "no_date_column",
+        )
+    for col in (factor_col, return_col):
+        if col not in df.columns:
+            return _short_circuit_output(
+                "ts_asymmetry", f"no_{col}_column",
+            )
+
+    per_date = _aggregate_to_per_date(
+        df, factor_col=factor_col, return_col=return_col,
+    )
+    n_periods = len(per_date)
+
+    if n_periods < MIN_PORTFOLIO_PERIODS:
+        return _short_circuit_output(
+            "ts_asymmetry", "insufficient_portfolio_periods",
+            n_observed=n_periods, min_required=MIN_PORTFOLIO_PERIODS,
+        )
+
+    f = per_date["_f"].to_numpy()
+    r = per_date["_r"].to_numpy()
+
+    pos_mask = f > 0
+    neg_mask = f < 0
+    zero_mask = ~(pos_mask | neg_mask)
+
+    n_pos = int(pos_mask.sum())
+    n_neg = int(neg_mask.sum())
+    n_zero = int(zero_mask.sum())
+
+    if n_pos == 0 or n_neg == 0:
+        return _short_circuit_output(
+            "ts_asymmetry", "no_two_sided_factor",
+            n_pos=n_pos, n_neg=n_neg, n_zero=n_zero, n_periods=n_periods,
+            hint=(
+                "factor lacks one of {positive, negative} regions; "
+                "long/short asymmetry is undefined. For unsigned event "
+                "signals ({0,1}-style) use factrix.metrics.event_quality "
+                "(event_hit_rate / event_ic / profit_factor)."
+            ),
+        )
+
+    lags = _resolve_nw_lags(n_periods, nw_lags, forward_periods)
+
+    # Drop the zero column when n_zero==0 to keep the design matrix full-rank.
+    cols = [pos_mask.astype(float), neg_mask.astype(float)]
+    if n_zero > 0:
+        cols.append(zero_mask.astype(float))
+    X_a = np.column_stack(cols)
+
+    beta_a, V_a, _ = _ols_nw_multivariate(r, X_a, lags=lags)
+
+    R_a = np.zeros((1, X_a.shape[1]))
+    R_a[0, 0] = 1.0
+    R_a[0, 1] = 1.0
+    asym_value = float(beta_a[0] + beta_a[1])
+    asym_var = float((R_a @ V_a @ R_a.T)[0, 0])
+    asym_se = float(np.sqrt(asym_var)) if asym_var > 0 else 0.0
+    asym_t = asym_value / asym_se if asym_se > 0 else 0.0
+    _, p_a = _wald_p_linear(beta_a, V_a, R_a, q=0.0)
+
+    e_long = float(beta_a[0])
+    e_short = float(beta_a[1])
+    # >1 → short side larger magnitude than long side.
+    abs_ratio = float("nan") if e_long == 0.0 else abs(e_short) / abs(e_long)
+
+    method_b: dict[str, object] = {}
+    n_unique_pos = int(np.unique(f[pos_mask]).size)
+    n_unique_neg = int(np.unique(f[neg_mask]).size)
+    if n_unique_pos < 2 or n_unique_neg < 2:
+        method_b["method_b_skipped"] = (
+            f"each side needs >=2 distinct factor values to identify a "
+            f"slope (got n_unique_pos={n_unique_pos}, n_unique_neg="
+            f"{n_unique_neg}). Method A already carries the full information "
+            f"for categorical / binary signals."
+        )
+    else:
+        f_pos = np.where(pos_mask, f, 0.0)
+        f_neg = np.where(neg_mask, f, 0.0)
+        X_b = np.column_stack([np.ones(n_periods), f_pos, f_neg])
+        beta_b, V_b, _ = _ols_nw_multivariate(r, X_b, lags=lags)
+        R_b = np.array([[0.0, 1.0, -1.0]])
+        _, p_b = _wald_p_linear(beta_b, V_b, R_b, q=0.0)
+        method_b.update(
+            intercept=float(beta_b[0]),
+            beta_pos=float(beta_b[1]),
+            beta_neg=float(beta_b[2]),
+            p_wald_slopes=p_b,
+            h0_method_b="beta_pos = beta_neg",
+        )
+
+    return MetricOutput(
+        name="ts_asymmetry",
+        value=asym_value,
+        stat=asym_t,
+        significance=_significance_marker(p_a),
+        metadata={
+            "p_value": p_a,
+            "stat_type": "wald (NW HAC)",
+            "h0": "beta_long + beta_short = 0",
+            "method": "method A: dummy regression on sign(factor)",
+            "beta_long": e_long,
+            "beta_short": e_short,
+            "abs_short_over_long": abs_ratio,
+            **({"beta_zero": float(beta_a[2])} if n_zero > 0 else {}),
+            "n_pos": n_pos,
+            "n_neg": n_neg,
+            "n_zero": n_zero,
+            "n_periods": n_periods,
+            "nw_lags_used": lags,
+            **method_b,
+        },
+    )

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -1,0 +1,165 @@
+"""Time-series quantile bucketing + monotonicity test (issue #5).
+
+Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
+cells: bucket factor history into quantiles and check the conditional
+mean forward return per bucket. Catches U-shape / inverted-U /
+extreme-only signals that OLS β assumes away (linear) and reports
+pass / fail on as a single slope.
+
+Standalone metric — does not enter the registry. See
+`ARCHITECTURE.md` §"Registry procedure vs standalone metric" for the
+distinction. SPARSE / binary signals are out of scope; the input gate
+redirects to `event_quality` helpers.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import polars as pl
+from scipy import stats as sp_stats
+
+from factrix._stats import (
+    _ols_nw_multivariate,
+    _resolve_nw_lags,
+    _significance_marker,
+    _wald_p_linear,
+)
+from factrix._types import EPSILON, MIN_PORTFOLIO_PERIODS, MetricOutput
+from factrix.metrics._helpers import (
+    _aggregate_to_per_date,
+    _short_circuit_output,
+)
+
+
+def ts_quantile_spread(
+    df: pl.DataFrame,
+    *,
+    factor_col: str = "factor",
+    return_col: str = "forward_return",
+    n_groups: int = 5,
+    forward_periods: int | None = None,
+    nw_lags: int | None = None,
+) -> MetricOutput:
+    """Bucket time-series factor by historical quantiles, test conditional means.
+
+    Reported:
+    - ``value`` = top-bottom spread (β_{K-1} - β_0)
+    - ``stat``  = Wald on ``H0: β_{K-1} = β_0`` → two-sided p in metadata
+    - ``metadata["spearman_rho"]`` / ``spearman_p`` = small-sample
+      monotonicity diagnostic across the K bucket means
+    - ``metadata["buckets"]`` = per-bucket ``{idx, mean_return, n}``
+
+    Gate (issue #5): ``n_unique(factor) >= n_groups * 2``. Below the
+    gate the factor cannot sustain quantile cuts — short-circuits with
+    a redirect to ``event_quality.*`` for binary / sparse signals.
+    """
+    if "date" not in df.columns:
+        return _short_circuit_output(
+            "ts_quantile_spread", "no_date_column",
+        )
+    for col in (factor_col, return_col):
+        if col not in df.columns:
+            return _short_circuit_output(
+                "ts_quantile_spread", f"no_{col}_column",
+            )
+
+    per_date = _aggregate_to_per_date(
+        df, factor_col=factor_col, return_col=return_col,
+    )
+    n_periods = len(per_date)
+
+    if n_periods < MIN_PORTFOLIO_PERIODS:
+        return _short_circuit_output(
+            "ts_quantile_spread", "insufficient_portfolio_periods",
+            n_observed=n_periods, min_required=MIN_PORTFOLIO_PERIODS,
+            n_groups=n_groups,
+        )
+
+    n_distinct = int(per_date["_f"].n_unique())
+    if n_distinct < n_groups * 2:
+        return _short_circuit_output(
+            "ts_quantile_spread", "insufficient_factor_variation",
+            n_distinct=n_distinct, n_groups=n_groups, n_periods=n_periods,
+            hint=(
+                "factor has too few distinct values for quantile cuts. "
+                "Reduce n_groups, or for binary / sparse signals use "
+                "factrix.metrics.event_quality.* "
+                "(event_hit_rate / event_ic / profit_factor / event_skewness)."
+            ),
+        )
+
+    per_bucket_periods = n_periods // n_groups
+    if per_bucket_periods < 5:
+        warnings.warn(
+            f"ts_quantile_spread: median {per_bucket_periods} periods per "
+            f"bucket (T={n_periods}, n_groups={n_groups}). Each bucket mean "
+            f"sits on a thin sample; consider reducing n_groups.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    r = per_date["_r"].to_numpy()
+
+    # Ordinal rank → each row in exactly one bucket; clip handles rank=T edge.
+    ranks = per_date["_f"].rank(method="ordinal").to_numpy().astype(np.int64)
+    bucket_idx = np.minimum(
+        ((ranks - 1) * n_groups) // n_periods,
+        n_groups - 1,
+    ).astype(np.int64)
+
+    X = np.zeros((n_periods, n_groups))
+    X[np.arange(n_periods), bucket_idx] = 1.0
+
+    lags = _resolve_nw_lags(n_periods, nw_lags, forward_periods)
+    beta, V_hac, _ = _ols_nw_multivariate(r, X, lags=lags)
+
+    R = np.zeros((1, n_groups))
+    R[0, n_groups - 1] = 1.0
+    R[0, 0] = -1.0
+    spread_value = float(beta[n_groups - 1] - beta[0])
+    _, p_spread = _wald_p_linear(beta, V_hac, R, q=0.0)
+
+    spread_var = float((R @ V_hac @ R.T)[0, 0])
+    spread_t = (
+        spread_value / float(np.sqrt(spread_var))
+        if spread_var >= EPSILON else 0.0
+    )
+
+    counts = np.bincount(bucket_idx, minlength=n_groups).astype(int)
+
+    # Spearman across K bucket means: non-parametric shape check, K small.
+    if n_groups >= 3:
+        rho_res = sp_stats.spearmanr(np.arange(n_groups), beta)
+        rho = float(rho_res.statistic)
+        rho_p = float(rho_res.pvalue) if not np.isnan(rho_res.pvalue) else 1.0
+    else:
+        rho, rho_p = float("nan"), 1.0
+
+    return MetricOutput(
+        name="ts_quantile_spread",
+        value=spread_value,
+        stat=spread_t,
+        significance=_significance_marker(p_spread),
+        metadata={
+            "p_value": p_spread,
+            "stat_type": "wald (NW HAC)",
+            "h0": "beta_top = beta_bottom",
+            "method": "OLS on bucket dummies + Newey-West HAC",
+            "spearman_rho": rho,
+            "spearman_p": rho_p,
+            "n_groups": n_groups,
+            "n_periods": n_periods,
+            "n_distinct_factor": n_distinct,
+            "nw_lags_used": lags,
+            "buckets": [
+                {
+                    "idx": int(k),
+                    "mean_return": float(beta[k]),
+                    "n": int(counts[k]),
+                }
+                for k in range(n_groups)
+            ],
+        },
+    )

--- a/tests/stats/test_ols_nw_multivariate.py
+++ b/tests/stats/test_ols_nw_multivariate.py
@@ -1,0 +1,92 @@
+"""Unit tests for ``_ols_nw_multivariate`` + ``_wald_p_linear`` (issue #5)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from factrix._stats import _ols_nw_multivariate, _wald_p_linear
+
+
+class TestPointEstimates:
+    def test_recovers_ols_at_lags_zero(self):
+        rng = np.random.default_rng(0)
+        n = 500
+        X = np.column_stack([np.ones(n), rng.standard_normal(n), rng.standard_normal(n)])
+        true_beta = np.array([0.5, 1.2, -0.7])
+        y = X @ true_beta + rng.standard_normal(n) * 0.3
+        beta, _V, _ = _ols_nw_multivariate(y, X, lags=0)
+        beta_lstsq, *_ = np.linalg.lstsq(X, y, rcond=None)
+        np.testing.assert_allclose(beta, beta_lstsq, atol=1e-12)
+
+    def test_singular_design_returns_zeros(self):
+        n = 100
+        x1 = np.arange(n, dtype=float)
+        # Two columns identical → X'X singular.
+        X = np.column_stack([x1, x1])
+        y = np.arange(n, dtype=float)
+        beta, V, resid = _ols_nw_multivariate(y, X, lags=0)
+        np.testing.assert_array_equal(beta, np.zeros(2))
+        np.testing.assert_array_equal(V, np.zeros((2, 2)))
+        np.testing.assert_array_equal(resid, np.zeros(n))
+
+    def test_n_below_k_plus_one_returns_zeros(self):
+        # 2 obs, 3 params — under-identified.
+        X = np.array([[1.0, 0.5, -0.3], [1.0, 1.5, 0.2]])
+        y = np.array([0.1, 0.2])
+        beta, V, _ = _ols_nw_multivariate(y, X, lags=0)
+        np.testing.assert_array_equal(beta, np.zeros(3))
+        np.testing.assert_array_equal(V, np.zeros((3, 3)))
+
+
+class TestHACVariance:
+    def test_lags_increase_se_under_autocorrelated_resid(self):
+        # Construct AR(1) errors so non-zero lags inflate the HAC SE
+        # versus the iid estimate (lags=0).
+        rng = np.random.default_rng(1)
+        n = 1000
+        x = rng.standard_normal(n)
+        eps = np.zeros(n)
+        for t in range(1, n):
+            eps[t] = 0.7 * eps[t - 1] + rng.standard_normal()
+        y = 0.5 + 1.0 * x + eps
+        X = np.column_stack([np.ones(n), x])
+        _, V0, _ = _ols_nw_multivariate(y, X, lags=0)
+        _, V8, _ = _ols_nw_multivariate(y, X, lags=8)
+        # SE on slope coefficient (index 1) should grow with lags.
+        assert np.sqrt(V8[1, 1]) > np.sqrt(V0[1, 1])
+
+
+class TestWaldLinear:
+    def test_size_under_null(self):
+        # Repeated draws under H0 should give roughly uniform p-values.
+        # Loose check: average rejection at α=0.05 within [0.02, 0.10]
+        # for 200 reps with T=300.
+        rng = np.random.default_rng(2024)
+        rejects = 0
+        n_trials = 200
+        n = 300
+        for _ in range(n_trials):
+            x1 = rng.standard_normal(n)
+            x2 = rng.standard_normal(n)
+            X = np.column_stack([np.ones(n), x1, x2])
+            y = rng.standard_normal(n) * 0.5  # no signal
+            beta, V, _ = _ols_nw_multivariate(y, X, lags=0)
+            R = np.array([[0.0, 1.0, -1.0]])
+            _, p = _wald_p_linear(beta, V, R, q=0.0)
+            if p < 0.05:
+                rejects += 1
+        rate = rejects / n_trials
+        assert 0.02 < rate < 0.10, f"empirical rejection rate {rate} out of band"
+
+    def test_power_under_alternative(self):
+        # When the restriction is clearly violated, Wald rejects.
+        rng = np.random.default_rng(7)
+        n = 500
+        x1 = rng.standard_normal(n)
+        x2 = rng.standard_normal(n)
+        X = np.column_stack([np.ones(n), x1, x2])
+        y = 1.0 * x1 + (-1.0) * x2 + rng.standard_normal(n) * 0.3
+        beta, V, _ = _ols_nw_multivariate(y, X, lags=0)
+        R = np.array([[0.0, 1.0, -1.0]])  # H0: β1 = β2
+        _, p = _wald_p_linear(beta, V, R, q=0.0)
+        assert p < 1e-6

--- a/tests/test_ts_asymmetry.py
+++ b/tests/test_ts_asymmetry.py
@@ -1,0 +1,129 @@
+"""Tests for ``factrix.metrics.ts_asymmetry`` (issue #5)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from factrix.metrics import ts_asymmetry
+
+
+def _series_panel(
+    factor: np.ndarray,
+    forward_return: np.ndarray,
+) -> pl.DataFrame:
+    T = len(factor)
+    return pl.DataFrame({
+        "date": list(range(T)),
+        "asset_id": [0] * T,
+        "factor": factor,
+        "forward_return": forward_return,
+    })
+
+
+class TestSymmetricDgp:
+    def test_linear_dgp_does_not_reject_symmetry(self):
+        # r = 0.05*f → both sides have equal-magnitude conditional means.
+        rng = np.random.default_rng(11)
+        T = 600
+        f = rng.standard_normal(T)
+        r = 0.05 * f + rng.standard_normal(T) * 0.5
+        out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
+        # H0: β_long + β_short = 0; under symmetric DGP we should not reject.
+        assert out.metadata["p_value"] > 0.05
+        # Method B should run (continuous f → both sides have variation).
+        assert "p_wald_slopes" in out.metadata
+        assert out.metadata["p_wald_slopes"] > 0.05
+
+
+class TestAsymmetricDgp:
+    def test_long_only_alpha_detected(self):
+        # Edge only on the positive side: r = 0.20*max(f,0) + ε.
+        # E[r|f<0] ≈ 0, E[r|f>0] > 0 → β_long + β_short > 0, reject H0.
+        rng = np.random.default_rng(2)
+        T = 800
+        f = rng.standard_normal(T)
+        r = 0.20 * np.maximum(f, 0) + rng.standard_normal(T) * 0.4
+        out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
+        assert out.value > 0
+        assert out.metadata["p_value"] < 0.05
+        assert out.metadata["beta_long"] > out.metadata["beta_short"]
+        # Slope test should also reject β_pos = β_neg.
+        assert out.metadata["p_wald_slopes"] < 0.05
+        assert out.metadata["beta_pos"] > out.metadata["beta_neg"]
+
+
+class TestGateBNoTwoSides:
+    def test_unsigned_factor_short_circuits(self):
+        # All f >= 0 → no negative side; asymmetry undefined.
+        rng = np.random.default_rng(0)
+        T = 200
+        f = rng.uniform(0, 1, size=T)
+        r = rng.standard_normal(T)
+        out = ts_asymmetry(_series_panel(f, r))
+        assert out.metadata["reason"] == "no_two_sided_factor"
+        assert out.metadata["n_neg"] == 0
+        assert "event_quality" in out.metadata["hint"]
+
+    def test_zero_only_factor_short_circuits(self):
+        T = 200
+        f = np.zeros(T)
+        r = np.random.default_rng(0).standard_normal(T)
+        out = ts_asymmetry(_series_panel(f, r))
+        assert out.metadata["reason"] == "no_two_sided_factor"
+
+
+class TestGateCMethodBSkip:
+    def test_signed_binary_skips_method_b(self):
+        # Signed binary {-1, +1} passes Gate B but fails Gate C
+        # (each side has 1 unique value → cannot identify a slope).
+        rng = np.random.default_rng(0)
+        T = 200
+        f = rng.choice([-1.0, 1.0], size=T)
+        r = 0.10 * f + rng.standard_normal(T) * 0.5
+        out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
+        assert "p_wald_slopes" not in out.metadata
+        assert "method_b_skipped" in out.metadata
+        # Method A still ran.
+        assert "beta_long" in out.metadata
+        assert "beta_short" in out.metadata
+
+    def test_three_state_signed_skips_method_b(self):
+        # {-1, 0, +1} sparse signal: each side has 1 unique value too.
+        rng = np.random.default_rng(0)
+        T = 300
+        f = rng.choice([-1.0, 0.0, 1.0], size=T)
+        r = 0.10 * f + rng.standard_normal(T) * 0.5
+        out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
+        assert "method_b_skipped" in out.metadata
+        # n_zero accounted for and zero column added to design.
+        assert out.metadata["n_zero"] > 0
+        assert "beta_zero" in out.metadata
+
+
+class TestSampleFloor:
+    def test_short_series_short_circuits(self):
+        T = 4
+        rng = np.random.default_rng(0)
+        f = rng.standard_normal(T)
+        r = rng.standard_normal(T)
+        out = ts_asymmetry(_series_panel(f, r))
+        assert out.metadata["reason"] == "insufficient_portfolio_periods"
+
+
+class TestRatioDiagnostic:
+    def test_short_dominant_ratio_above_one(self):
+        rng = np.random.default_rng(4)
+        T = 600
+        f = rng.standard_normal(T)
+        # Negative side carries 3x the magnitude.
+        r = 0.05 * np.maximum(f, 0) + 0.15 * np.minimum(f, 0) + rng.standard_normal(T) * 0.3
+        out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
+        assert out.metadata["abs_short_over_long"] > 1.0
+
+
+class TestMissingColumns:
+    def test_missing_date_short_circuits(self):
+        df = pl.DataFrame({"asset_id": [0, 0], "factor": [1.0, -1.0], "forward_return": [0.1, 0.2]})
+        out = ts_asymmetry(df)
+        assert out.metadata["reason"] == "no_date_column"

--- a/tests/test_ts_quantile.py
+++ b/tests/test_ts_quantile.py
@@ -1,0 +1,158 @@
+"""Tests for ``factrix.metrics.ts_quantile_spread`` (issue #5)."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import polars as pl
+import pytest
+
+from factrix.metrics import ts_quantile_spread
+
+
+def _series_panel(
+    factor: np.ndarray,
+    forward_return: np.ndarray,
+) -> pl.DataFrame:
+    T = len(factor)
+    return pl.DataFrame({
+        "date": list(range(T)),
+        "asset_id": [0] * T,
+        "factor": factor,
+        "forward_return": forward_return,
+    })
+
+
+class TestLinearDgp:
+    def test_recovers_positive_spread(self):
+        rng = np.random.default_rng(42)
+        T = 600
+        f = rng.standard_normal(T)
+        r = 0.10 * f + rng.standard_normal(T) * 0.5
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+        assert out.value > 0
+        assert out.metadata["p_value"] < 0.05
+        assert out.metadata["spearman_rho"] > 0.5
+
+    def test_top_bucket_mean_exceeds_bottom(self):
+        rng = np.random.default_rng(7)
+        T = 600
+        f = rng.standard_normal(T)
+        r = 0.10 * f + rng.standard_normal(T) * 0.5
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+        buckets = out.metadata["buckets"]
+        assert buckets[-1]["mean_return"] > buckets[0]["mean_return"]
+        # All five buckets accounted for, sums to T
+        assert sum(b["n"] for b in buckets) == T
+
+
+class TestNullDgp:
+    def test_pure_noise_rejection_rate_at_size(self):
+        # Single-seed p > 0.05 is a flaky test — under H0, by definition
+        # 5% of draws reject. Check empirical rejection across many seeds
+        # stays close to nominal 5% instead.
+        T = 400
+        rejects = 0
+        n_trials = 100
+        for seed in range(n_trials):
+            rng = np.random.default_rng(seed)
+            f = rng.standard_normal(T)
+            r = rng.standard_normal(T) * 0.5
+            out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+            if out.metadata["p_value"] < 0.05:
+                rejects += 1
+        rate = rejects / n_trials
+        # Wide-but-meaningful band: 0–13% covers binomial noise at n=100
+        # while still flagging gross bias (e.g. 30% rejection under null).
+        assert 0.0 <= rate <= 0.13, f"empirical size {rate} out of band"
+
+
+class TestNonLinearDgp:
+    def test_u_shape_caught_by_buckets_not_by_sign(self):
+        # E[r | f] = c·f² — symmetric U-shape. β_OLS ≈ 0 but the
+        # extreme buckets carry the largest mean returns, the middle
+        # the smallest. Spearman across bucket means is NOT monotone
+        # (so |rho| should be small) but the per-bucket pattern is
+        # clearly non-trivial — top and bottom buckets both above
+        # middle buckets.
+        rng = np.random.default_rng(3)
+        T = 800
+        f = rng.standard_normal(T)
+        r = 0.30 * (f * f) + rng.standard_normal(T) * 0.4
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+        means = [b["mean_return"] for b in out.metadata["buckets"]]
+        # Extremes higher than middle bucket
+        assert means[0] > means[2]
+        assert means[-1] > means[2]
+
+
+class TestGateAFactorVariation:
+    def test_binary_factor_short_circuits(self):
+        rng = np.random.default_rng(0)
+        T = 200
+        f = rng.choice([0.0, 1.0], size=T)
+        r = rng.standard_normal(T)
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+        assert out.metadata["reason"] == "insufficient_factor_variation"
+        assert out.metadata["n_distinct"] == 2
+        assert "event_quality" in out.metadata["hint"]
+
+    def test_signed_binary_factor_short_circuits(self):
+        rng = np.random.default_rng(0)
+        T = 200
+        f = rng.choice([-1.0, 0.0, 1.0], size=T)
+        r = rng.standard_normal(T)
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+        assert out.metadata["reason"] == "insufficient_factor_variation"
+
+    def test_lower_n_groups_passes_when_distinct_allows(self):
+        # 6 distinct values, n_groups=2 → 6 >= 4 passes Gate A.
+        rng = np.random.default_rng(0)
+        T = 200
+        f = rng.integers(0, 6, size=T).astype(float)
+        r = rng.standard_normal(T)
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=2)
+        assert "reason" not in out.metadata or out.metadata.get("reason") is None
+
+
+class TestSampleFloor:
+    def test_short_series_short_circuits(self):
+        rng = np.random.default_rng(0)
+        T = 4
+        f = rng.standard_normal(T)
+        r = rng.standard_normal(T)
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
+        assert out.metadata["reason"] == "insufficient_portfolio_periods"
+
+
+class TestPerBucketWarning:
+    def test_thin_buckets_emit_warning(self):
+        # T=20, n_groups=5 → 4 per bucket → triggers <5 warning.
+        rng = np.random.default_rng(0)
+        T = 20
+        f = rng.standard_normal(T)
+        r = rng.standard_normal(T)
+        with pytest.warns(UserWarning, match="periods per bucket"):
+            ts_quantile_spread(_series_panel(f, r), n_groups=5)
+
+    def test_fat_buckets_silent(self):
+        rng = np.random.default_rng(0)
+        T = 200
+        f = rng.standard_normal(T)
+        r = rng.standard_normal(T)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ts_quantile_spread(_series_panel(f, r), n_groups=5)
+
+
+class TestMissingColumns:
+    def test_missing_date_short_circuits(self):
+        df = pl.DataFrame({"asset_id": [0, 0], "factor": [1.0, 2.0], "forward_return": [0.1, 0.2]})
+        out = ts_quantile_spread(df)
+        assert out.metadata["reason"] == "no_date_column"
+
+    def test_missing_factor_short_circuits(self):
+        df = pl.DataFrame({"date": [0, 1], "asset_id": [0, 0], "forward_return": [0.1, 0.2]})
+        out = ts_quantile_spread(df)
+        assert out.metadata["reason"] == "no_factor_column"

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "factrix"
-version = "0.6.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- 新增 `ts_quantile_spread`、`ts_asymmetry` 兩個 standalone diagnostic metric，補位 `(COMMON, CONTINUOUS, *)` cell 的 OLS β 假設線性 + 對稱所漏掉的 shape / asymmetry。
- 兩 metric 用 OLS + NW HAC + Wald，與 `ts_beta_t_nw` 同框架，跨 metric p-value 可比。為此新增 `factrix/_stats/__init__.py` 內的 multivariate OLS + Wald helpers。
- Standalone tier：不進 registry、不影響 `verdict()`；三個 gate（distinct 數量 / 雙側存在 / 雙側內變異）短路時寫 `metadata["reason"]` + redirect hint，**不** silently 回 NaN。
- 配套 `docs/metric_applicability.md` 新增 §`ts_quantile_spread / ts_asymmetry 的適用範圍`、README §文件導引 link。

設計細節 / Wald regression 公式 / 為何不用 Welch → 見 #5 與兩個 module docstring。

## Test plan

- [ ] `uv run pytest tests/test_ts_quantile.py tests/test_ts_asymmetry.py tests/stats/test_ols_nw_multivariate.py`
- [ ] `uv run pytest`（full suite，確認沒回歸）
- [ ] 手動 sanity：在 VIX-like 連續 macro factor + 500 trading days 跑 `ts_asymmetry`，確認 method A/B 兩段 Wald p 都正常返回
- [ ] 手動 sanity：在 factor 全 ≥ 0 的資料上跑 `ts_asymmetry`，確認整個 metric 短路且 `metadata["reason"]` 有內容
- [ ] 手動 sanity：在 INDIVIDUAL × CONTINUOUS panel 上跑兩個 metric，確認 guard 短路 + redirect hint 指向 cross-sectional 對應 metric

Closes #5