### PR TITLE
feat(introspect): warn on dropped sparse magnitude

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -23,6 +23,10 @@ class WarningCode(StrEnum):
     # persistent-regressor flag, §5.2 / §7.3). Not raised for SPARSE.
     PERSISTENT_REGRESSOR = "persistent_regressor"
     SERIAL_CORRELATION_DETECTED = "serial_correlation_detected"
+    # Fired when SPARSE-detected factor has non-±1 magnitudes. CAAR/BMP
+    # coerce via .sign() so magnitude is silently dropped — surface it
+    # so users with SUE/notch-delta signals can rescale or re-route.
+    SPARSE_MAGNITUDE_DROPPED = "sparse_magnitude_dropped"
 
     @property
     def description(self) -> str:
@@ -41,6 +45,9 @@ _WARNING_DESCRIPTIONS.update({
         "ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias.",
     WarningCode.SERIAL_CORRELATION_DETECTED:
         "Ljung-Box p < 0.05 on residuals; NW lag may be under-set.",
+    WarningCode.SPARSE_MAGNITUDE_DROPPED:
+        "Sparse factor has non-±1 magnitudes; sparse procedures will "
+        "coerce via .sign() and drop magnitude information.",
 })
 
 

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -199,19 +199,42 @@ class SuggestConfigResult:
     warnings: list[WarningCode] = field(default_factory=list)
 
 
-def _detect_signal(raw: Any) -> tuple[Signal, str]:
-    """Sparsity ratio in ``factor`` ≥ 0.5 → SPARSE, else CONTINUOUS."""
+def _detect_signal(raw: Any) -> tuple[Signal, str, bool]:
+    """Sparsity ratio in ``factor`` ≥ 0.5 → SPARSE, else CONTINUOUS.
+
+    The third return value is ``magnitude_dropped``: ``True`` iff the
+    detected signal is SPARSE *and* the non-zero values are not strictly
+    ternary {-1, +1}. Sparse procedures coerce via ``.sign()`` so any
+    non-±1 magnitude is silently dropped — the flag lets ``suggest_config``
+    surface ``WarningCode.SPARSE_MAGNITUDE_DROPPED``.
+    """
+    import polars as pl
+
     n = len(raw)
     if n == 0:
-        return Signal.CONTINUOUS, "factor column empty: defaulting to CONTINUOUS"
-    n_zero = int((raw["factor"] == 0).sum())
+        return (
+            Signal.CONTINUOUS,
+            "factor column empty: defaulting to CONTINUOUS",
+            False,
+        )
+    n_zero, all_ternary = raw.select(
+        n_zero=(pl.col("factor") == 0).sum(),
+        all_ternary=(
+            (pl.col("factor") == 0) | (pl.col("factor").abs() == 1)
+        ).all(),
+    ).row(0)
     sparsity = n_zero / n
-    decision = "SPARSE" if sparsity >= _SPARSITY_THRESHOLD else "CONTINUOUS"
-    return (
-        Signal.SPARSE if decision == "SPARSE" else Signal.CONTINUOUS,
-        f"sparsity ratio = {sparsity:.2f} "
-        f"(threshold {_SPARSITY_THRESHOLD}): → {decision}",
+    signal = (
+        Signal.SPARSE if sparsity >= _SPARSITY_THRESHOLD else Signal.CONTINUOUS
     )
+    reason = (
+        f"sparsity ratio = {sparsity:.2f} "
+        f"(threshold {_SPARSITY_THRESHOLD}): → {signal.value.upper()}"
+    )
+    magnitude_dropped = signal is Signal.SPARSE and not bool(all_ternary)
+    if magnitude_dropped:
+        reason += " (non-±1 magnitudes present; .sign() coercion will drop them)"
+    return signal, reason, magnitude_dropped
 
 
 def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
@@ -264,7 +287,7 @@ def suggest_config(
     caller (or an AI agent) reads ``reasoning`` and ``warnings`` to
     decide whether to override.
     """
-    signal, signal_reason = _detect_signal(raw)
+    signal, signal_reason, magnitude_dropped = _detect_signal(raw)
     scope, scope_reason = _detect_scope(raw)
 
     n_assets = int(raw["asset_id"].n_unique())
@@ -299,6 +322,8 @@ def suggest_config(
         n_periods = len(raw)
         if MIN_PERIODS_HARD <= n_periods < MIN_PERIODS_RELIABLE:
             warnings.append(WarningCode.UNRELIABLE_SE_SHORT_SERIES)
+    if magnitude_dropped:
+        warnings.append(WarningCode.SPARSE_MAGNITUDE_DROPPED)
 
     return SuggestConfigResult(
         suggested=suggested,

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -43,9 +43,18 @@ def compute_caar(
 
     Only rows where ``factor ≠ 0`` are included (event rows).
 
+    Note:
+        ``factor_col`` is coerced via ``.sign()``: any non-±1 magnitude
+        is **dropped silently here** (sign-only semantics). For
+        magnitude-bearing event signals (SUE z-score, ratings notch
+        delta, etc.) ``suggest_config`` raises
+        ``WarningCode.SPARSE_MAGNITUDE_DROPPED`` so the user can either
+        rescale to ±1 before calling, or route to a continuous procedure.
+
     Args:
         df: Panel with ``date``, ``asset_id``, ``factor_col``, ``return_col``.
-        factor_col: Column with discrete signal {-1, 0, +1}.
+        factor_col: Column with discrete signal {-1, 0, +1}; non-±1
+            magnitudes are coerced to their sign.
         return_col: Column with forward/abnormal return.
 
     Returns:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -266,6 +266,49 @@ class TestSuggestConfigWarnings:
 
 
 # ---------------------------------------------------------------------------
+# suggest_config — sparse magnitude drop warning (issue #8)
+# ---------------------------------------------------------------------------
+
+
+def _make_sparse_weighted_panel(seed: int = 21) -> pl.DataFrame:
+    """Sparse layout but non-zero values are continuous magnitudes (SUE-like)."""
+    rng = np.random.default_rng(seed)
+    n_dates, n_assets = 60, 15
+    is_event = rng.choice([0.0, 1.0], size=(n_dates, n_assets), p=[0.92, 0.08])
+    magnitudes = rng.standard_normal((n_dates, n_assets)) * 2.0
+    factor = is_event * magnitudes
+    rows: list[dict[str, object]] = []
+    for t in range(n_dates):
+        d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
+        for j in range(n_assets):
+            rows.append({
+                "date": d, "asset_id": f"A{j:03d}",
+                "factor": float(factor[t, j]),
+                "forward_return": float(rng.standard_normal()),
+            })
+    return pl.DataFrame(rows)
+
+
+class TestSparseMagnitudeWarning:
+    def test_pure_ternary_sparse_no_magnitude_warning(self) -> None:
+        result = suggest_config(_make_sparse_panel())
+        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
+
+    def test_continuous_sparse_emits_magnitude_warning(self) -> None:
+        result = suggest_config(_make_sparse_weighted_panel())
+        assert result.suggested.signal is Signal.SPARSE
+        assert WarningCode.SPARSE_MAGNITUDE_DROPPED in result.warnings
+
+    def test_continuous_dense_no_magnitude_warning(self) -> None:
+        result = suggest_config(_make_individual_continuous_panel())
+        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
+
+    def test_signal_reasoning_mentions_coercion_when_dropped(self) -> None:
+        result = suggest_config(_make_sparse_weighted_panel())
+        assert ".sign()" in result.reasoning["signal"]
+
+
+# ---------------------------------------------------------------------------
 # Frozen result type
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "factrix"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- `_detect_signal` now also reports whether SPARSE-detected factors have non-±1 magnitudes
- `suggest_config` surfaces a new `WarningCode.SPARSE_MAGNITUDE_DROPPED` when that condition holds
- `compute_caar` docstring made the `.sign()` coercion explicit (no behavior change)

## Why

Closes the silent-coercion half of #8. Today a user feeding a sparse-but-continuous signal (SUE z-score, ratings notch delta, event-day return, etc.) gets routed to `Signal.SPARSE` purely on zero-ratio, then has their magnitude information silently dropped inside CAAR / BMP via `pl.col(factor).sign()`. No warning, no info note, no way to know unless they read the source.

This PR is the **interim mitigation** path called out in the issue: stop the silent part. Users now see `WarningCode.SPARSE_MAGNITUDE_DROPPED` in `suggest_config(...).warnings` and can decide to (a) rescale to ±1 before calling, (b) route to a continuous procedure, or (c) accept the sign-only semantics knowingly.

## Out of scope (deferred to follow-up issue)

- Level 3 axis design (Option A `Signal.SPARSE_WEIGHTED` vs Option B new `metric` value vs Option C new `*_event_weighted()` factories) — touches axis SSOT, cell grid, new procedure, t-test reference distribution, KP clustering interaction. Deserves dedicated design discussion, not bundled here.
- README rewording — defer until axis design lands.

## Test plan

- [x] `tests/test_introspection.py::TestSparseMagnitudeWarning` — 4 new tests cover ternary-sparse (no warning), continuous-sparse (warning fires), continuous-dense (no warning), reasoning string mentions coercion
- [x] Full suite: 552 passed, 0 failed
- [x] Backward compat: `_detect_signal` is private; only caller is `suggest_config` in same module