### PR TITLE
feat(introspect): two-tier n_assets guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ CONTRIBUTING §7 (Release workflow).
   small-`n_assets` failure mode、threshold 對應），把行為矩陣背後的
   statistical rationale 集中到一處。
 
+### Added
+
+- **`WarningCode.SMALL_CROSS_SECTION_N`** + **`BORDERLINE_CROSS_SECTION_N`**
+  — emitted by the `common_continuous` PANEL procedure
+  (`_compute_common_panel`) and by `suggest_config` based on `n_assets`.
+  `2 ≤ n_assets < 10` → SMALL (df=`n_assets`-1 ≤ 8, t_crit inflated
+  18%–548% vs asymptotic 1.96); `10 ≤ n_assets < 30` → BORDERLINE
+  (residual inflation 5%–15%); `n_assets ≥ 30` → no warning. Two-tier
+  mirrors the existing `n_periods` structure (`MIN_PERIODS_HARD` /
+  `MIN_PERIODS_RELIABLE`); SMALL implies BORDERLINE so only the more
+  severe code emits per profile. Procedure still runs at all
+  `n_assets ≥ 2` — warnings surface the inference-power decay rather
+  than blocking execution. `suggest_config().reasoning["mode"]` is
+  amended to point at the corresponding code when `n_assets < 30`.
+- `MIN_ASSETS = 10` and `MIN_ASSETS_RELIABLE = 30` constants in
+  `factrix/_stats/constants.py`, alongside `MIN_PERIODS_HARD` /
+  `MIN_PERIODS_RELIABLE`. Naming deliberately omits `_HARD` for
+  `MIN_ASSETS` because the `n_assets` axis only warns — re-using the
+  `n_periods` `_HARD` (which means "raise") would mislead.
+
 Refs #15.
 
 ## v0.7.0 (2026-05-04)

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -27,6 +27,11 @@ class WarningCode(StrEnum):
     # coerce via .sign() so magnitude is silently dropped — surface it
     # so users with SUE/notch-delta signals can rescale or re-route.
     SPARSE_MAGNITUDE_DROPPED = "sparse_magnitude_dropped"
+    # Two-tier cross-asset N guards for PANEL common_continuous. Mirrors
+    # the n_periods two-tier (UNRELIABLE_SE_SHORT_SERIES) but the axis
+    # never raises — cross-asset t-test on E[β] is well-defined for N≥2.
+    SMALL_CROSS_SECTION_N = "small_cross_section_n"
+    BORDERLINE_CROSS_SECTION_N = "borderline_cross_section_n"
 
     @property
     def description(self) -> str:
@@ -48,7 +53,33 @@ _WARNING_DESCRIPTIONS.update({
     WarningCode.SPARSE_MAGNITUDE_DROPPED:
         "Sparse factor has non-±1 magnitudes; sparse procedures will "
         "coerce via .sign() and drop magnitude information.",
+    WarningCode.SMALL_CROSS_SECTION_N:
+        "PANEL cross-asset t-test with n_assets < MIN_ASSETS (10); "
+        "df=n_assets-1 too low — t_crit at n_assets=3 ≈ 4.30 "
+        "(+119% vs asymptotic 1.96).",
+    WarningCode.BORDERLINE_CROSS_SECTION_N:
+        "PANEL cross-asset t-test with MIN_ASSETS ≤ n_assets < "
+        "MIN_ASSETS_RELIABLE (10..29); residual t_crit inflation "
+        "5–15% — read borderline p-values cautiously.",
 })
+
+
+def cross_section_tier(n_assets: int) -> WarningCode | None:
+    """Map ``n_assets`` to the appropriate cross-asset N warning code.
+
+    Tiers are mutually exclusive — SMALL is strictly more severe than
+    BORDERLINE — so callers can membership-check the more severe code
+    without an else branch. Returns ``None`` at ``n_assets ≥
+    MIN_ASSETS_RELIABLE`` (clean) or ``n_assets < 2`` (PANEL impossible
+    by upstream mode routing; defensive).
+    """
+    from factrix._stats.constants import MIN_ASSETS, MIN_ASSETS_RELIABLE
+
+    if 2 <= n_assets < MIN_ASSETS:
+        return WarningCode.SMALL_CROSS_SECTION_N
+    if MIN_ASSETS <= n_assets < MIN_ASSETS_RELIABLE:
+        return WarningCode.BORDERLINE_CROSS_SECTION_N
+    return None
 
 
 class InfoCode(StrEnum):

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, cross_section_tier
 from factrix._evaluate import _derive_mode
 from factrix._registry import (
     _DISPATCH_REGISTRY,
@@ -19,7 +19,11 @@ from factrix._registry import (
     _ScopeCollapsedSentinel,
     _route_scope,
 )
-from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_RELIABLE
+from factrix._stats.constants import (
+    MIN_ASSETS_RELIABLE,
+    MIN_PERIODS_HARD,
+    MIN_PERIODS_RELIABLE,
+)
 
 
 # Sparsity threshold above which `factor` is treated as an event series.
@@ -296,6 +300,12 @@ def suggest_config(
         f"n_assets = {n_assets} detected → "
         f"{'TIMESERIES' if mode is Mode.TIMESERIES else 'PANEL'}"
     )
+    n_tier = cross_section_tier(n_assets) if mode is Mode.PANEL else None
+    if n_tier is not None:
+        mode_reason += (
+            f" (n_assets < MIN_ASSETS_RELIABLE = {MIN_ASSETS_RELIABLE} → "
+            f"cross-asset df low, see WarningCode.{n_tier.name})"
+        )
 
     suggested = _build_suggested(scope, signal, forward_periods=forward_periods)
 
@@ -322,6 +332,8 @@ def suggest_config(
         n_periods = len(raw)
         if MIN_PERIODS_HARD <= n_periods < MIN_PERIODS_RELIABLE:
             warnings.append(WarningCode.UNRELIABLE_SE_SHORT_SERIES)
+    if n_tier is not None:
+        warnings.append(n_tier)
     if magnitude_dropped:
         warnings.append(WarningCode.SPARSE_MAGNITUDE_DROPPED)
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -250,7 +250,7 @@ def _compute_common_panel(
     import numpy as np
     import polars as pl
 
-    from factrix._codes import StatCode, WarningCode
+    from factrix._codes import StatCode, WarningCode, cross_section_tier
     from factrix._profile import FactorProfile
     from factrix._stats import _adf, _calc_t_stat, _p_value_from_t
     from factrix.metrics.ts_beta import compute_ts_betas
@@ -275,6 +275,9 @@ def _compute_common_panel(
         StatCode.TS_BETA_P: p_value,
     }
     warnings: set[WarningCode] = set()
+    n_tier = cross_section_tier(N)
+    if n_tier is not None:
+        warnings.add(n_tier)
 
     if with_adf:
         # The broadcast factor is the same series across every asset on

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -16,6 +16,21 @@ MIN_PERIODS_HARD: int = 20
 # tagged with :attr:`factrix._codes.WarningCode.UNRELIABLE_SE_SHORT_SERIES`.
 MIN_PERIODS_RELIABLE: int = 30
 
+# ``n_assets < MIN_ASSETS`` → :attr:`factrix._codes.WarningCode.SMALL_CROSS_SECTION_N`
+# from PANEL ``common_continuous`` and from ``suggest_config``. The cross-asset
+# t-test on E[β] has df = n_assets - 1; below 10 the critical t inflates
+# severely (n_assets=3 → t_crit≈4.30 vs asymptotic 1.96). The axis intentionally
+# never raises — N=2..9 is well-defined statistics, only weak.
+# Naming deliberately omits ``_HARD``: the n_assets axis only warns, so reusing
+# the n_periods ``_HARD`` (which means "raise") would be misleading.
+MIN_ASSETS: int = 10
+
+# ``MIN_ASSETS <= n_assets < MIN_ASSETS_RELIABLE`` →
+# :attr:`factrix._codes.WarningCode.BORDERLINE_CROSS_SECTION_N`. Mirrors
+# ``MIN_PERIODS_RELIABLE`` semantically: residual t_crit inflation 5–15%
+# (n_assets=10 → +15%, n_assets=20 → +7%, n_assets=30 → +5%).
+MIN_ASSETS_RELIABLE: int = 30
+
 
 def auto_bartlett(T: int) -> int:
     """Newey & West (1994) automatic Bartlett-kernel lag.

--- a/tests/test_common_panel_procedures.py
+++ b/tests/test_common_panel_procedures.py
@@ -296,3 +296,49 @@ class TestEmptyPanelFallback:
         profile = _CommonSparsePanelProcedure().compute(empty, cfg_sparse)
         assert profile.primary_p == 1.0
         assert profile.n_obs == 0
+
+
+class TestCrossSectionNWarnings:
+    """Two-tier n_assets guards on PANEL common_continuous (#15).
+
+    Mirrors the existing n_periods two-tier (UNRELIABLE_SE_SHORT_SERIES).
+    Only one of the two codes fires per profile — SMALL implies
+    BORDERLINE — so callers can `if SMALL in warnings:` without
+    double-checking.
+    """
+
+    def _profile_for(
+        self, n_assets: int, cfg_continuous: AnalysisConfig,
+    ) -> FactorProfile:
+        panel = _make_common_panel(
+            n_dates=60, n_assets=n_assets, seed=11, true_beta=0.5,
+        )
+        return _CommonContPanelProcedure().compute(panel, cfg_continuous)
+
+    def test_emits_small_at_n5(
+        self, cfg_continuous: AnalysisConfig,
+    ) -> None:
+        profile = self._profile_for(5, cfg_continuous)
+        assert WarningCode.SMALL_CROSS_SECTION_N in profile.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in profile.warnings
+
+    def test_only_small_at_n9(
+        self, cfg_continuous: AnalysisConfig,
+    ) -> None:
+        profile = self._profile_for(9, cfg_continuous)
+        assert WarningCode.SMALL_CROSS_SECTION_N in profile.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in profile.warnings
+
+    def test_emits_borderline_at_n15(
+        self, cfg_continuous: AnalysisConfig,
+    ) -> None:
+        profile = self._profile_for(15, cfg_continuous)
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N in profile.warnings
+        assert WarningCode.SMALL_CROSS_SECTION_N not in profile.warnings
+
+    def test_no_warning_at_n35(
+        self, cfg_continuous: AnalysisConfig,
+    ) -> None:
+        profile = self._profile_for(35, cfg_continuous)
+        assert WarningCode.SMALL_CROSS_SECTION_N not in profile.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in profile.warnings

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -115,10 +115,11 @@ class TestDescribeAnalysisModes:
 # ---------------------------------------------------------------------------
 
 
-def _make_individual_continuous_panel(seed: int = 1) -> pl.DataFrame:
-    """Factor varies across assets at each date."""
+def _make_individual_continuous_panel_n(
+    n_assets: int, *, n_dates: int = 60, seed: int = 17,
+) -> pl.DataFrame:
+    """Factor varies across assets at each date; ``n_assets`` is parametric."""
     rng = np.random.default_rng(seed)
-    n_dates, n_assets = 60, 20
     rows: list[dict[str, object]] = []
     for t in range(n_dates):
         d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
@@ -129,6 +130,11 @@ def _make_individual_continuous_panel(seed: int = 1) -> pl.DataFrame:
                 "forward_return": float(rng.standard_normal()),
             })
     return pl.DataFrame(rows)
+
+
+def _make_individual_continuous_panel(seed: int = 1) -> pl.DataFrame:
+    """Factor varies across assets at each date (fixed n_assets=20)."""
+    return _make_individual_continuous_panel_n(20, seed=seed)
 
 
 def _make_common_continuous_panel(seed: int = 2) -> pl.DataFrame:
@@ -306,6 +312,39 @@ class TestSparseMagnitudeWarning:
     def test_signal_reasoning_mentions_coercion_when_dropped(self) -> None:
         result = suggest_config(_make_sparse_weighted_panel())
         assert ".sign()" in result.reasoning["signal"]
+
+
+# ---------------------------------------------------------------------------
+# suggest_config — n_assets two-tier guard (issue #15)
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestConfigCrossSectionNWarnings:
+    def test_panel_n5_emits_small(self) -> None:
+        result = suggest_config(_make_individual_continuous_panel_n(5))
+        assert WarningCode.SMALL_CROSS_SECTION_N in result.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in result.warnings
+
+    def test_panel_n15_emits_borderline(self) -> None:
+        result = suggest_config(_make_individual_continuous_panel_n(15))
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N in result.warnings
+        assert WarningCode.SMALL_CROSS_SECTION_N not in result.warnings
+
+    def test_panel_n35_no_n_warning(self) -> None:
+        result = suggest_config(_make_individual_continuous_panel_n(35))
+        assert WarningCode.SMALL_CROSS_SECTION_N not in result.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in result.warnings
+
+    def test_n1_no_panel_warning(self) -> None:
+        # N=1 routes to TIMESERIES, so PANEL guards must not fire.
+        ts = _make_timeseries(n_dates=80, sparse=False, seed=33)
+        result = suggest_config(ts)
+        assert WarningCode.SMALL_CROSS_SECTION_N not in result.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in result.warnings
+
+    def test_mode_reasoning_mentions_warning_at_small_n(self) -> None:
+        result = suggest_config(_make_individual_continuous_panel_n(5))
+        assert "SMALL_CROSS_SECTION_N" in result.reasoning["mode"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
PR-2 of 2 for #15. Companion to merged PR-1 (#16, docs contract).

## Summary

- New \`WarningCode.SMALL_CROSS_SECTION_N\` (n_assets < 10) + \`BORDERLINE_CROSS_SECTION_N\` (10 ≤ n_assets < 30) for PANEL \`common_continuous\`
- New constants \`MIN_ASSETS = 10\`, \`MIN_ASSETS_RELIABLE = 30\` in \`factrix/_stats/constants.py\` alongside \`MIN_PERIODS_*\`
- Tier dispatch centralized in \`cross_section_tier(n_assets) -> WarningCode | None\` helper (\`factrix/_codes.py\`); SMALL implies BORDERLINE so only the more severe code emits per profile
- \`_compute_common_panel\` and \`suggest_config\` both consume the helper
- \`suggest_config().reasoning['mode']\` now points at the relevant warning when \`n_assets < 30\`
- 9 new boundary tests across both call sites (n_assets ∈ {1, 5, 9, 15, 35})

## Why

Filling the contract laid down by #16: cross-asset t-test on E[β] has df = n_assets - 1; below 10 the t_crit inflates 18%–548% vs asymptotic 1.96, and 5%–15% in the 10..29 range. Users today receive p-values that look ordinary at small N but cannot reject under realistic effect sizes — no signal surfaces this. Two-tier mirrors the existing \`n_periods\` structure; intentionally never raises so the user sees the result *and* knows it is weak (vs being forced to choose between \"cannot run\" and \"unaware\").

## /simplify pass applied

Initial implementation duplicated tier logic in three sites. Aggregated review pulled it into one helper:

- \`cross_section_tier(n_assets)\` in \`_codes.py\` is now the single source of truth for tier boundaries
- Stringly-typed tier name (\`tier = \"SMALL_CROSS_SECTION_N\" if ...\`) replaced with \`enum.name\` reference
- Test fixture \`_make_individual_continuous_panel\` now delegates to \`_make_individual_continuous_panel_n(20)\`, removing the duplicate row-builder

## Test plan

- [x] \`uv run pytest tests/test_common_panel_procedures.py tests/test_introspection.py -v\` — all green (57 tests)
- [x] \`uv run pytest -q\` — 561 passed, 0 failed (was 552 pre-#15; +9 new boundary tests)
- [x] Manual boundary check via fixtures: n_assets ∈ {5, 9, 15, 35} produce expected single-code emission; n_assets=1 routes to TIMESERIES with no PANEL warning
- [x] \`suggest_config().reasoning['mode']\` includes \`SMALL_CROSS_SECTION_N\` reference at n_assets=5 (verified by \`test_mode_reasoning_mentions_warning_at_small_n\`)