### PR TITLE
feat(introspect): SuggestConfigResult.detected (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,39 @@ this section to the next versioned heading and adds a fresh `[Unreleased]`
 above it. This decouples per-PR cadence from per-tag cadence — see
 CONTRIBUTING §7 (Release workflow).
 
-### Changed (docs)
+### Added
+
+- **`WarningCode.SMALL_CROSS_SECTION_N`** + **`BORDERLINE_CROSS_SECTION_N`**
+  — emitted by the `common_continuous` PANEL procedure and by
+  `suggest_config` based on `n_assets`. `2 ≤ n_assets < 10` → SMALL
+  (df=`n_assets`-1 ≤ 8, t_crit inflated 18%–548% vs asymptotic 1.96);
+  `10 ≤ n_assets < 30` → BORDERLINE (residual inflation 5%–15%);
+  `n_assets ≥ 30` → no warning. Two-tier mirrors the existing
+  `n_periods` structure (`MIN_PERIODS_HARD` / `MIN_PERIODS_RELIABLE`).
+  SMALL implies BORDERLINE so only the more severe code emits per
+  profile. Procedure still runs at all `n_assets ≥ 2` — warnings
+  surface the inference-power decay rather than blocking execution.
+  (#17)
+- `MIN_ASSETS = 10` and `MIN_ASSETS_RELIABLE = 30` constants in
+  `factrix/_stats/constants.py`, alongside `MIN_PERIODS_HARD` /
+  `MIN_PERIODS_RELIABLE`. Naming deliberately omits `_HARD` for
+  `MIN_ASSETS` because the `n_assets` axis only warns — re-using the
+  `n_periods` `_HARD` (which means "raise") would mislead. (#17)
+- **`factrix.metrics`** module docstring gains a fifth category,
+  Time-Series / Standalone Diagnostic, listing the `ts_beta` family +
+  `ts_quantile_spread` + `ts_asymmetry`. `help(factrix.metrics)` now
+  surfaces them; previously the docstring categorisation hid them
+  despite being fully exported. (#19)
+- **`SuggestConfigResult.detected: dict[str, Any]`** — new field
+  carrying the structured panel observations behind the suggestion
+  (`scope`, `signal`, `mode`, `n_assets`, `n_periods`, `sparsity`,
+  `magnitude_dropped`). All keys always present, type-stable. AI
+  agents and pipeline gates branch on these without parsing the
+  `reasoning` strings or re-deriving observations from the raw panel.
+  `reasoning` (human-readable narrative) and `warnings` unchanged.
+  (#21)
+
+### Changed
 
 - README §樣本守門 重寫：新增「factory × `n_assets` regime 行為矩陣」表 +
   「計算順序對照」段 + 「兩軸守門對稱」表，明確區分
@@ -32,53 +64,22 @@ CONTRIBUTING §7 (Release workflow).
   `common_continuous`（time-series first → cross-asset）的計算順序差異——
   使用者誤以為兩者皆「先橫斷面再時序」是 `common_continuous` N=1 退化
   與 small-`n_assets` 結果不可信的根因。修正先前 L247「`n_assets` < 10
-  切 FM」誤導建議——FM 在 `n_assets` = 2..9 同樣不可靠。
+  切 FM」誤導建議——FM 在 `n_assets` = 2..9 同樣不可靠。 (#16)
 - ARCHITECTURE.md 增補 §Cross-sectional guards (`n_assets`)（two-tier
-  threshold 設計理由 + t_crit 衰減表 + 與 `MIN_PERIODS_*` 命名差異說明）
-  與 §Procedure pipelines（每個 PANEL continuous procedure 的計算管線、
-  small-`n_assets` failure mode、threshold 對應），把行為矩陣背後的
-  statistical rationale 集中到一處。
-
-### Added
-
-- **`WarningCode.SMALL_CROSS_SECTION_N`** + **`BORDERLINE_CROSS_SECTION_N`**
-  — emitted by the `common_continuous` PANEL procedure
-  (`_compute_common_panel`) and by `suggest_config` based on `n_assets`.
-  `2 ≤ n_assets < 10` → SMALL (df=`n_assets`-1 ≤ 8, t_crit inflated
-  18%–548% vs asymptotic 1.96); `10 ≤ n_assets < 30` → BORDERLINE
-  (residual inflation 5%–15%); `n_assets ≥ 30` → no warning. Two-tier
-  mirrors the existing `n_periods` structure (`MIN_PERIODS_HARD` /
-  `MIN_PERIODS_RELIABLE`); SMALL implies BORDERLINE so only the more
-  severe code emits per profile. Procedure still runs at all
-  `n_assets ≥ 2` — warnings surface the inference-power decay rather
-  than blocking execution. `suggest_config().reasoning["mode"]` is
-  amended to point at the corresponding code when `n_assets < 30`.
-- `MIN_ASSETS = 10` and `MIN_ASSETS_RELIABLE = 30` constants in
-  `factrix/_stats/constants.py`, alongside `MIN_PERIODS_HARD` /
-  `MIN_PERIODS_RELIABLE`. Naming deliberately omits `_HARD` for
-  `MIN_ASSETS` because the `n_assets` axis only warns — re-using the
-  `n_periods` `_HARD` (which means "raise") would mislead.
-- **`factrix.metrics`** module docstring gains a fifth category,
-  Time-Series / Standalone Diagnostic, listing the `ts_beta` family +
-  `ts_quantile_spread` + `ts_asymmetry`. `help(factrix.metrics)` now
-  surfaces them; previously the docstring categorisation hid them
-  despite being fully exported (#18).
-
-### Migration
-
+  threshold 設計理由 + t_crit 衰減表）與 §Procedure pipelines（每個 PANEL
+  continuous procedure 的計算管線、small-`n_assets` failure mode、threshold
+  對應），把行為矩陣背後的 statistical rationale 集中到一處。 (#16)
 - **`MIN_IC_PERIODS` → `MIN_ASSETS_PER_DATE_IC`** (in `factrix/_types.py`).
   The "PERIODS" suffix was misleading — the value has always been
-  checked against per-date asset counts, not period counts. **Direct
-  rename, no alias.** Pre-1.0 + single-consumer convention: callers
-  (factor-analysis workspace via SHA pin) update the import once.
+  checked against per-date asset counts, not period counts. **Migration:**
+  update the import; no deprecation alias kept (pre-1.0 + single-consumer
+  convention; the factor-analysis workspace pins by SHA). (#19)
 - **`WarningCode.UNRELIABLE_SE_SHORT_SERIES` → `UNRELIABLE_SE_SHORT_PERIODS`**.
-  Vocabulary aligned with the `n_periods` parameter name canonicalised
-  in #15. Both Python identifier and serialised string value change to
-  `"unreliable_se_short_periods"`. **Direct rename, no alias.** Update
-  imports + any string-based filters / log queries that match the old
-  value (#18).
-
-Refs #15, #18.
+  Vocabulary aligned with the `n_periods` parameter name canonicalised in
+  PR #16. Both Python identifier and serialised string value change to
+  `"unreliable_se_short_periods"`. **Migration:** update imports + any
+  string-based filters / log queries that match the old serialised value;
+  no alias kept. (#19)
 
 ## v0.7.0 (2026-05-04)
 

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -29,6 +29,15 @@ from factrix._stats.constants import (
 # Sparsity threshold above which `factor` is treated as an event series.
 _SPARSITY_THRESHOLD: float = 0.5
 
+# Canonical key set on ``SuggestConfigResult.detected``. Module-level so
+# tests + future programmatic consumers can membership-check without
+# duplicating the literal set; the dataclass docstring carries the
+# per-key types/meanings.
+DETECTED_KEYS: frozenset[str] = frozenset({
+    "scope", "signal", "mode",
+    "n_assets", "n_periods", "sparsity", "magnitude_dropped",
+})
+
 
 # ---------------------------------------------------------------------------
 # describe_analysis_modes
@@ -189,37 +198,63 @@ def describe_analysis_modes(
 
 @dataclass(frozen=True, slots=True)
 class SuggestConfigResult:
-    """Auto-detected ``AnalysisConfig`` plus per-axis reasoning.
+    """Auto-detected ``AnalysisConfig`` plus structured observations + reasoning.
 
-    ``reasoning`` is a structured dict with the four invariant keys
-    ``scope`` / ``signal`` / ``metric`` / ``mode`` (plan §7.2 I4) so AI
-    agents can pattern-match. ``warnings`` is a list of ``WarningCode``
-    enums (I2) — pre-computed evaluate-time warnings the user can act
-    on before running the suggested config.
+    ``detected`` carries the **structured panel observations** that drove
+    the suggestion (machine-readable; AI agents and pipeline gates branch
+    on these without parsing strings). ``reasoning`` is the human-readable
+    mirror of the same information per axis.
+
+    ``warnings`` is a list of ``WarningCode`` enums — pre-computed
+    evaluate-time warnings the user can act on before running the
+    suggested config.
+
+    ``detected`` keys (always present, type-stable):
+
+    | Key                  | Type      | Meaning                                   |
+    |----------------------|-----------|-------------------------------------------|
+    | ``scope``            | str       | ``"individual"`` / ``"common"``           |
+    | ``signal``           | str       | ``"continuous"`` / ``"sparse"``           |
+    | ``mode``             | str       | ``"panel"`` / ``"timeseries"``            |
+    | ``n_assets``         | int       | unique ``asset_id`` count                 |
+    | ``n_periods``        | int       | unique ``date`` count                     |
+    | ``sparsity``         | float     | zero-ratio in ``factor`` column           |
+    | ``magnitude_dropped``| bool      | True iff SPARSE + non-±1 magnitudes       |
     """
 
     suggested: AnalysisConfig
+    detected: dict[str, Any]
     reasoning: dict[str, str]
     warnings: list[WarningCode] = field(default_factory=list)
 
 
-def _detect_signal(raw: Any) -> tuple[Signal, str, bool]:
+def _detect_signal(raw: Any) -> tuple[Signal, str, bool, float]:
     """Sparsity ratio in ``factor`` ≥ 0.5 → SPARSE, else CONTINUOUS.
 
-    The third return value is ``magnitude_dropped``: ``True`` iff the
-    detected signal is SPARSE *and* the non-zero values are not strictly
-    ternary {-1, +1}. Sparse procedures coerce via ``.sign()`` so any
-    non-±1 magnitude is silently dropped — the flag lets ``suggest_config``
-    surface ``WarningCode.SPARSE_MAGNITUDE_DROPPED``.
+    Returns ``(signal, reason, magnitude_dropped, sparsity)``.
+
+    - ``magnitude_dropped``: ``True`` iff the detected signal is SPARSE
+      and the non-zero values are not strictly ternary {-1, +1}. Sparse
+      procedures coerce via ``.sign()`` so any non-±1 magnitude is
+      silently dropped — the flag lets ``suggest_config`` surface
+      ``WarningCode.SPARSE_MAGNITUDE_DROPPED``.
+    - ``sparsity``: zero-ratio in the factor column. Surfaced for
+      ``SuggestConfigResult.detected`` so callers can branch on the raw
+      observation rather than re-deriving it from the panel.
     """
     import polars as pl
 
+    import math
+
     n = len(raw)
     if n == 0:
+        # nan, not 0.0 — there is no zero-ratio with zero observations.
+        # Reporting 0.0 would falsely imply "fully dense".
         return (
             Signal.CONTINUOUS,
             "factor column empty: defaulting to CONTINUOUS",
             False,
+            math.nan,
         )
     n_zero, all_ternary = raw.select(
         n_zero=(pl.col("factor") == 0).sum(),
@@ -238,7 +273,7 @@ def _detect_signal(raw: Any) -> tuple[Signal, str, bool]:
     magnitude_dropped = signal is Signal.SPARSE and not bool(all_ternary)
     if magnitude_dropped:
         reason += " (non-±1 magnitudes present; .sign() coercion will drop them)"
-    return signal, reason, magnitude_dropped
+    return signal, reason, magnitude_dropped, sparsity
 
 
 def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
@@ -291,10 +326,11 @@ def suggest_config(
     caller (or an AI agent) reads ``reasoning`` and ``warnings`` to
     decide whether to override.
     """
-    signal, signal_reason, magnitude_dropped = _detect_signal(raw)
+    signal, signal_reason, magnitude_dropped, sparsity = _detect_signal(raw)
     scope, scope_reason = _detect_scope(raw)
 
     n_assets = int(raw["asset_id"].n_unique())
+    n_periods = int(raw["date"].n_unique())
     mode = _derive_mode(raw)
     mode_reason = (
         f"n_assets = {n_assets} detected → "
@@ -329,7 +365,6 @@ def suggest_config(
 
     warnings: list[WarningCode] = []
     if mode is Mode.TIMESERIES:
-        n_periods = len(raw)
         if MIN_PERIODS_HARD <= n_periods < MIN_PERIODS_RELIABLE:
             warnings.append(WarningCode.UNRELIABLE_SE_SHORT_PERIODS)
     if n_tier is not None:
@@ -337,8 +372,19 @@ def suggest_config(
     if magnitude_dropped:
         warnings.append(WarningCode.SPARSE_MAGNITUDE_DROPPED)
 
+    detected: dict[str, Any] = {
+        "scope": scope.value,
+        "signal": signal.value,
+        "mode": mode.value,
+        "n_assets": n_assets,
+        "n_periods": n_periods,
+        "sparsity": sparsity,
+        "magnitude_dropped": magnitude_dropped,
+    }
+
     return SuggestConfigResult(
         suggested=suggested,
+        detected=detected,
         reasoning=reasoning,
         warnings=warnings,
     )

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -12,6 +12,7 @@ from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import WarningCode
 from factrix._describe import (
+    DETECTED_KEYS,
     SuggestConfigResult,
     describe_analysis_modes,
     suggest_config,
@@ -345,6 +346,70 @@ class TestSuggestConfigCrossSectionNWarnings:
     def test_mode_reasoning_mentions_warning_at_small_n(self) -> None:
         result = suggest_config(_make_individual_continuous_panel_n(5))
         assert "SMALL_CROSS_SECTION_N" in result.reasoning["mode"]
+
+
+# ---------------------------------------------------------------------------
+# suggest_config — detected (issue #20)
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestConfigDetected:
+    """`detected` carries the structured panel observations behind the
+    suggestion. Same data the reasoning strings narrate, but
+    machine-readable for AI agents / pipeline gates."""
+
+    @pytest.mark.parametrize(
+        "fixture_factory",
+        [
+            lambda: _make_individual_continuous_panel(),
+            lambda: _make_sparse_panel(),
+            lambda: _make_timeseries(n_dates=80, sparse=False, seed=41),
+        ],
+        ids=["individual_continuous", "sparse_panel", "timeseries"],
+    )
+    def test_keys_match_canonical_set(self, fixture_factory) -> None:
+        result = suggest_config(fixture_factory())
+        assert set(result.detected.keys()) == DETECTED_KEYS
+
+    def test_individual_continuous_values(self) -> None:
+        result = suggest_config(_make_individual_continuous_panel())
+        d = result.detected
+        assert d["scope"] == "individual"
+        assert d["signal"] == "continuous"
+        assert d["mode"] == "panel"
+        assert d["n_assets"] == 20
+        assert d["n_periods"] == 60
+        assert 0.0 <= d["sparsity"] < 0.5
+        assert d["magnitude_dropped"] is False
+
+    def test_sparse_values(self) -> None:
+        result = suggest_config(_make_sparse_panel())
+        d = result.detected
+        assert d["signal"] == "sparse"
+        assert d["sparsity"] >= 0.5
+        assert d["magnitude_dropped"] is False
+
+    def test_sparse_weighted_flags_magnitude_dropped(self) -> None:
+        result = suggest_config(_make_sparse_weighted_panel())
+        assert result.detected["magnitude_dropped"] is True
+
+    def test_timeseries_mode(self) -> None:
+        ts = _make_timeseries(n_dates=80, sparse=False, seed=42)
+        d = suggest_config(ts).detected
+        assert d["mode"] == "timeseries"
+        assert d["n_assets"] == 1
+        assert d["n_periods"] == 80
+
+    def test_consistency_with_suggested_config(self) -> None:
+        # detected.scope/signal must round-trip to the suggested config's axes.
+        for fixture in (
+            _make_individual_continuous_panel(),
+            _make_common_continuous_panel(),
+            _make_sparse_panel(),
+        ):
+            result = suggest_config(fixture)
+            assert result.detected["scope"] == result.suggested.scope.value
+            assert result.detected["signal"] == result.suggested.signal.value
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #20.

## Summary

Add \`SuggestConfigResult.detected: dict[str, Any]\` carrying the 7 structured observations that drove the suggestion. Same data the \`reasoning\` strings narrate, but machine-readable so AI agents and pipeline gates branch on raw values instead of parsing prose.

\`alternatives\` from the original #9 R6 sketch deferred — semantics need real user feedback before locking the contract.

## Test plan

- [x] 6 boundary tests in \`tests/test_introspection.py::TestSuggestConfigDetected\` covering key invariance (parametrized over individual_continuous / sparse / timeseries fixtures), value correctness, magnitude_dropped flag, round-trip consistency between \`detected\` and \`suggested\`
- [x] Full \`uv run pytest -q\` — 569 passed (was 561; +8 R6 tests)
- [x] Empty-panel branch returns \`sparsity=nan\` (verified by inspection)
- [x] Existing tests still pass — \`SuggestConfigResult\` field-ordering changed from \`(suggested, reasoning, warnings)\` to \`(suggested, detected, reasoning, warnings)\` but every internal caller uses kwargs

## /simplify pass applied

Pre-commit review pulled four changes:
- \`sparsity=nan\` (not \`0.0\`) for empty panel — correctness
- Dropped paranoid \`if \"date\" in raw.columns\` guard — consistency with \`_detect_scope\` / \`_derive_mode\` which both unconditionally index
- \`DETECTED_KEYS: frozenset\` module constant in \`_describe.py\` — SSOT + immutability hardening; tests import it
- 3 redundant key-invariance tests collapsed via \`@pytest.mark.parametrize\`