### PR TITLE
fix(introspect): scope-gate magnitude_dropped (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,19 @@ CONTRIBUTING §7 (Release workflow).
   string-based filters / log queries that match the old serialised value;
   no alias kept. (#19)
 
+### Fixed
+
+- **`WarningCode.SPARSE_MAGNITUDE_DROPPED`** is now scope- and mode-gated.
+  Previously emitted by `suggest_config` whenever a SPARSE factor carried
+  non-±1 magnitudes — but only the `(INDIVIDUAL, SPARSE, PANEL)` routing
+  (CAAR via `compute_caar`) actually applies `.sign()` coercion. The
+  `(COMMON, SPARSE, PANEL)` and `(*, SPARSE, *) × N=1` routings feed the
+  raw factor into OLS, preserving magnitude — emitting the warning there
+  misled callers into rescaling unnecessarily. The same predicate now
+  gates `SuggestConfigResult.detected["magnitude_dropped"]` and the
+  `reasoning["signal"]` `.sign()` addendum, so the three user-facing
+  surfaces stay coherent. (#28)
+
 ## v0.7.0 (2026-05-04)
 
 Closes the silent-coercion gap in sparse-procedure dispatch. Until now,

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -219,7 +219,7 @@ class SuggestConfigResult:
     | ``n_assets``         | int       | unique ``asset_id`` count                 |
     | ``n_periods``        | int       | unique ``date`` count                     |
     | ``sparsity``         | float     | zero-ratio in ``factor`` column           |
-    | ``magnitude_dropped``| bool      | True iff SPARSE + non-±1 magnitudes       |
+    | ``magnitude_dropped``| bool      | True iff the suggested routing actually drops magnitude (SPARSE + INDIVIDUAL + PANEL + non-±1) |
     """
 
     suggested: AnalysisConfig
@@ -231,13 +231,16 @@ class SuggestConfigResult:
 def _detect_signal(raw: Any) -> tuple[Signal, str, bool, float]:
     """Sparsity ratio in ``factor`` ≥ 0.5 → SPARSE, else CONTINUOUS.
 
-    Returns ``(signal, reason, magnitude_dropped, sparsity)``.
+    Returns ``(signal, reason, has_nonternary_magnitudes, sparsity)``.
 
-    - ``magnitude_dropped``: ``True`` iff the detected signal is SPARSE
-      and the non-zero values are not strictly ternary {-1, +1}. Sparse
-      procedures coerce via ``.sign()`` so any non-±1 magnitude is
-      silently dropped — the flag lets ``suggest_config`` surface
-      ``WarningCode.SPARSE_MAGNITUDE_DROPPED``.
+    - ``has_nonternary_magnitudes``: ``True`` iff at least one factor
+      value is non-zero and not in ``{-1, +1}``. This is a **raw
+      observation**, scope/mode-blind. Whether those magnitudes will
+      actually be dropped depends on the dispatched procedure — only
+      ``_CAARSparsePanelProcedure`` (INDIVIDUAL × SPARSE × PANEL)
+      coerces via ``.sign()``. ``suggest_config`` combines this flag
+      with scope and mode to compute the user-facing
+      ``magnitude_dropped``.
     - ``sparsity``: zero-ratio in the factor column. Surfaced for
       ``SuggestConfigResult.detected`` so callers can branch on the raw
       observation rather than re-deriving it from the panel.
@@ -270,10 +273,10 @@ def _detect_signal(raw: Any) -> tuple[Signal, str, bool, float]:
         f"sparsity ratio = {sparsity:.2f} "
         f"(threshold {_SPARSITY_THRESHOLD}): → {signal.value.upper()}"
     )
-    magnitude_dropped = signal is Signal.SPARSE and not bool(all_ternary)
-    if magnitude_dropped:
-        reason += " (non-±1 magnitudes present; .sign() coercion will drop them)"
-    return signal, reason, magnitude_dropped, sparsity
+    has_nonternary_magnitudes = (
+        signal is Signal.SPARSE and not bool(all_ternary)
+    )
+    return signal, reason, has_nonternary_magnitudes, sparsity
 
 
 def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
@@ -326,12 +329,27 @@ def suggest_config(
     caller (or an AI agent) reads ``reasoning`` and ``warnings`` to
     decide whether to override.
     """
-    signal, signal_reason, magnitude_dropped, sparsity = _detect_signal(raw)
+    signal, signal_reason, has_nonternary, sparsity = _detect_signal(raw)
     scope, scope_reason = _detect_scope(raw)
 
     n_assets = int(raw["asset_id"].n_unique())
     n_periods = int(raw["date"].n_unique())
     mode = _derive_mode(raw)
+
+    # Magnitude is only dropped on the INDIVIDUAL × SPARSE × PANEL routing
+    # (`_CAARSparsePanelProcedure` → `compute_caar`'s `.sign()` coercion).
+    # COMMON × SPARSE and N=1 sparse routings feed the raw factor into OLS,
+    # so a non-±1 magnitude is preserved there — emitting the warning on
+    # those routings would mislead the caller into rescaling unnecessarily.
+    magnitude_dropped = (
+        has_nonternary
+        and scope is FactorScope.INDIVIDUAL
+        and mode is Mode.PANEL
+    )
+    if magnitude_dropped:
+        signal_reason += (
+            " (non-±1 magnitudes present; .sign() coercion will drop them)"
+        )
     mode_reason = (
         f"n_assets = {n_assets} detected → "
         f"{'TIMESERIES' if mode is Mode.TIMESERIES else 'PANEL'}"

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -277,13 +277,17 @@ class TestSuggestConfigWarnings:
 # ---------------------------------------------------------------------------
 
 
+def _sparse_weighted_factor(rng, shape) -> np.ndarray:
+    """8% non-zero events, magnitudes ~ N(0, 2) — the non-±1 sparse pattern."""
+    is_event = rng.choice([0.0, 1.0], size=shape, p=[0.92, 0.08])
+    return is_event * rng.standard_normal(shape) * 2.0
+
+
 def _make_sparse_weighted_panel(seed: int = 21) -> pl.DataFrame:
     """Sparse layout but non-zero values are continuous magnitudes (SUE-like)."""
     rng = np.random.default_rng(seed)
     n_dates, n_assets = 60, 15
-    is_event = rng.choice([0.0, 1.0], size=(n_dates, n_assets), p=[0.92, 0.08])
-    magnitudes = rng.standard_normal((n_dates, n_assets)) * 2.0
-    factor = is_event * magnitudes
+    factor = _sparse_weighted_factor(rng, (n_dates, n_assets))
     rows: list[dict[str, object]] = []
     for t in range(n_dates):
         d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
@@ -293,6 +297,39 @@ def _make_sparse_weighted_panel(seed: int = 21) -> pl.DataFrame:
                 "factor": float(factor[t, j]),
                 "forward_return": float(rng.standard_normal()),
             })
+    return pl.DataFrame(rows)
+
+
+def _make_common_sparse_weighted_panel(seed: int = 22) -> pl.DataFrame:
+    """Broadcast sparse factor with non-±1 magnitudes when non-zero."""
+    rng = np.random.default_rng(seed)
+    n_dates, n_assets = 60, 15
+    factor_t = _sparse_weighted_factor(rng, n_dates)
+    rows: list[dict[str, object]] = []
+    for t in range(n_dates):
+        d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
+        for j in range(n_assets):
+            rows.append({
+                "date": d, "asset_id": f"A{j:03d}",
+                "factor": float(factor_t[t]),
+                "forward_return": float(rng.standard_normal()),
+            })
+    return pl.DataFrame(rows)
+
+
+def _make_timeseries_sparse_weighted(n_dates: int = 80, seed: int = 23) -> pl.DataFrame:
+    """N=1 sparse with non-±1 magnitudes."""
+    rng = np.random.default_rng(seed)
+    factor = _sparse_weighted_factor(rng, n_dates)
+    rows = [
+        {
+            "date": dt.date(2024, 1, 1) + dt.timedelta(days=t),
+            "asset_id": "SPY",
+            "factor": float(factor[t]),
+            "forward_return": float(rng.standard_normal()),
+        }
+        for t in range(n_dates)
+    ]
     return pl.DataFrame(rows)
 
 
@@ -313,6 +350,25 @@ class TestSparseMagnitudeWarning:
     def test_signal_reasoning_mentions_coercion_when_dropped(self) -> None:
         result = suggest_config(_make_sparse_weighted_panel())
         assert ".sign()" in result.reasoning["signal"]
+
+
+class TestSparseMagnitudeWarningScopeGating:
+    """Warning is gated to the (INDIVIDUAL, SPARSE, PANEL) routing only."""
+
+    def test_common_sparse_weighted_no_warning(self) -> None:
+        result = suggest_config(_make_common_sparse_weighted_panel())
+        assert result.suggested.signal is Signal.SPARSE
+        assert result.suggested.scope is FactorScope.COMMON
+        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
+        assert result.detected["magnitude_dropped"] is False
+        assert ".sign()" not in result.reasoning["signal"]
+
+    def test_timeseries_sparse_weighted_no_warning(self) -> None:
+        result = suggest_config(_make_timeseries_sparse_weighted(n_dates=80))
+        assert result.suggested.signal is Signal.SPARSE
+        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
+        assert result.detected["magnitude_dropped"] is False
+        assert ".sign()" not in result.reasoning["signal"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #23.

## Summary

`SPARSE_MAGNITUDE_DROPPED` was emitted by `suggest_config` whenever a SPARSE factor carried non-±1 magnitudes, regardless of the routing the suggestion would dispatch to. Only `(INDIVIDUAL, SPARSE, PANEL)` (CAAR) applies `.sign()` coercion; `(COMMON, SPARSE, PANEL)` and N=1 sparse paths feed raw factor into OLS and preserve magnitude. The warning misled callers into rescaling unnecessarily on those two routings.

`_detect_signal` now returns `has_nonternary_magnitudes` (raw, scope/mode-blind). `suggest_config` computes the gated `magnitude_dropped = has_nonternary AND scope=INDIVIDUAL AND mode=PANEL` after scope and mode are known. The gated value drives all three user-facing surfaces (warning emission, `detected["magnitude_dropped"]`, `reasoning["signal"]` `.sign()` addendum).

## Test plan

- [x] `uv run pytest -q` — 571 passed (was 569; +2 R6 gating tests in `TestSparseMagnitudeWarningScopeGating`)
- [x] Existing 4 `TestSparseMagnitudeWarning` tests still pass (use individual × sparse × PANEL fixture → gating preserves their assertions)
- [x] New tests cover common × sparse weighted (broadcast factor + non-±1 magnitudes) and N=1 sparse weighted — both assert warning NOT emitted, `detected[..]` is False, no `.sign()` addendum

## /simplify pass applied

3 review-agent findings:
- Dropped redundant `signal is Signal.SPARSE` clause from gating predicate (`has_nonternary` already implies SPARSE per `_detect_signal`'s definition)
- Extracted `_sparse_weighted_factor(rng, shape)` kernel — 3 fixtures (existing `_make_sparse_weighted_panel` + 2 new ones) share the same is-event × magnitude formula
- Compressed test class docstring to single line (production-side comment carries the rationale; duplicated docstring would drift)