### PR TITLE
fix(stats): two-tier n_events guard on common_sparse (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,21 @@ CONTRIBUTING §7 (Release workflow).
 
 ### Fixed
 
+- **`(COMMON, SPARSE, None, PANEL)` event-count guard.** The procedure
+  previously checked only ``n_periods`` (via per-asset
+  ``MIN_TS_OBS = 20`` in ``compute_ts_betas``); a broadcast dummy with
+  a single non-zero event would still produce a β driven entirely by
+  that one observation, with no warning. Two-tier guard added on the
+  event count: ``n_events < MIN_BROADCAST_EVENTS_HARD = 5`` raises
+  ``InsufficientSampleError``;
+  ``MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_RELIABLE = 20``
+  emits the new ``WarningCode.SPARSE_COMMON_FEW_EVENTS``. Mirrors the
+  existing ``n_periods`` two-tier (``MIN_PERIODS_HARD`` / ``_RELIABLE``).
+  Constants live in ``factrix/_stats/constants.py``; the
+  ``BROADCAST_`` prefix disambiguates from the CAAR
+  ``MIN_EVENTS = 10`` in ``factrix/_types.py`` (different statistic).
+  Empty-panel sparse-PANEL behaviour shifts from silent
+  ``primary_p = 1.0`` to an explicit raise. (#29)
 - **`WarningCode.SPARSE_MAGNITUDE_DROPPED`** is now scope- and mode-gated.
   Previously emitted by `suggest_config` whenever a SPARSE factor carried
   non-±1 magnitudes — but only the `(INDIVIDUAL, SPARSE, PANEL)` routing

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -32,6 +32,12 @@ class WarningCode(StrEnum):
     # never raises — cross-asset t-test on E[β] is well-defined for N≥2.
     SMALL_CROSS_SECTION_N = "small_cross_section_n"
     BORDERLINE_CROSS_SECTION_N = "borderline_cross_section_n"
+    # Fired by the (COMMON, SPARSE, PANEL) procedure when the broadcast
+    # dummy carries MIN_BROADCAST_EVENTS_HARD ≤ n_events <
+    # MIN_BROADCAST_EVENTS_RELIABLE. Per-asset β is identifiable but
+    # the cross-event averaging is too thin for asymptotic t to be
+    # trusted. Below the HARD floor raises InsufficientSampleError instead.
+    SPARSE_COMMON_FEW_EVENTS = "sparse_common_few_events"
 
     @property
     def description(self) -> str:
@@ -61,6 +67,11 @@ _WARNING_DESCRIPTIONS.update({
         "PANEL cross-asset t-test with MIN_ASSETS ≤ n_assets < "
         "MIN_ASSETS_RELIABLE (10..29); residual t_crit inflation "
         "5–15% — read borderline p-values cautiously.",
+    WarningCode.SPARSE_COMMON_FEW_EVENTS:
+        "(COMMON, SPARSE, PANEL) broadcast dummy has "
+        "MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_RELIABLE "
+        "(5..19); per-asset β estimable but cross-event averaging too thin "
+        "for asymptotic t.",
 })
 
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -221,6 +221,12 @@ class _CommonSparsePanelProcedure:
     a cross-asset t-test on ``E[β]``. Plan §4.3: same per-asset β →
     cross-asset t-test pattern as COMMON × CONTINUOUS, with the dummy
     replacing the continuous factor. ADF skipped (I6).
+
+    Two-tier event-count guard on the broadcast dummy: with very few
+    non-zero events the per-asset β is fit from a handful of points,
+    yielding an asymptotic t the cross-asset aggregation cannot
+    rescue. Below ``MIN_BROADCAST_EVENTS_HARD`` raises; the borderline
+    tier surfaces ``SPARSE_COMMON_FEW_EVENTS``.
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema] = InputSchema(
@@ -230,11 +236,61 @@ class _CommonSparsePanelProcedure:
     def compute(
         self, raw: Any, config: "AnalysisConfig",
     ) -> "FactorProfile":
-        return _compute_common_panel(raw, config, with_adf=False)
+        import polars as pl
+
+        from factrix._codes import WarningCode
+        from factrix._errors import InsufficientSampleError
+        from factrix._stats.constants import (
+            MIN_BROADCAST_EVENTS_HARD,
+            MIN_BROADCAST_EVENTS_RELIABLE,
+        )
+
+        # Broadcast factor is the same per date across assets; count
+        # event dates by collapsing to one row per date first.
+        n_events = int(
+            raw.group_by("date")
+            .agg(pl.col("factor").first())
+            .filter(pl.col("factor") != 0)
+            .height,
+        )
+        if n_events < MIN_BROADCAST_EVENTS_HARD:
+            if n_events == 0:
+                detail = (
+                    "the broadcast factor has no non-zero observations; ensure "
+                    "events are encoded as ±1 on event dates (zero on non-event "
+                    "dates) before dispatching"
+                )
+            else:
+                detail = (
+                    "aggregate to a coarser frequency, broaden the event "
+                    "definition, or switch to a continuous factory"
+                )
+            raise InsufficientSampleError(
+                f"n_events={n_events} below "
+                f"MIN_BROADCAST_EVENTS_HARD={MIN_BROADCAST_EVENTS_HARD}; "
+                f"per-asset β on a broadcast sparse dummy is fit from too few "
+                f"informative observations to support the cross-asset t-test. "
+                f"To resolve: {detail}.",
+                actual_periods=n_events,
+                required_periods=MIN_BROADCAST_EVENTS_HARD,
+            )
+
+        extra_warnings: frozenset[WarningCode] = (
+            frozenset({WarningCode.SPARSE_COMMON_FEW_EVENTS})
+            if n_events < MIN_BROADCAST_EVENTS_RELIABLE
+            else frozenset()
+        )
+        return _compute_common_panel(
+            raw, config, with_adf=False, extra_warnings=extra_warnings,
+        )
 
 
 def _compute_common_panel(
-    raw: Any, config: "AnalysisConfig", *, with_adf: bool,
+    raw: Any,
+    config: "AnalysisConfig",
+    *,
+    with_adf: bool,
+    extra_warnings: "frozenset[WarningCode]" = frozenset(),
 ) -> "FactorProfile":
     """Shared core for the two ``(COMMON, *, None, PANEL)`` procedures.
 
@@ -274,7 +330,7 @@ def _compute_common_panel(
         StatCode.TS_BETA_T_NW: t_stat,
         StatCode.TS_BETA_P: p_value,
     }
-    warnings: set[WarningCode] = set()
+    warnings: set[WarningCode] = set(extra_warnings)
     n_tier = cross_section_tier(N)
     if n_tier is not None:
         warnings.add(n_tier)

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -32,6 +32,27 @@ MIN_ASSETS: int = 10
 MIN_ASSETS_RELIABLE: int = 30
 
 
+# Broadcast-dummy event count for the ``(COMMON, SPARSE, None, PANEL)``
+# procedure. Per-asset OLS β on a sparse {-1, 0, +1} dummy is driven
+# entirely by the event observations — total ``n_periods`` is already
+# checked (``MIN_TS_OBS = 20`` per asset in ``compute_ts_betas``), but
+# with ``n_events = 1`` a β is still fit from a single point with no
+# diagnostic. These thresholds guard the event-count axis specifically.
+# Naming is procedure-domain-specific to avoid colliding with the
+# CAAR-side ``MIN_EVENTS`` in ``factrix/_types.py`` (different statistic).
+#
+# ``n_events < MIN_BROADCAST_EVENTS_HARD`` → :class:`factrix._errors.InsufficientSampleError`
+# (β not identifiable: with fewer than 5 informative observations the
+# slope and its SE are both dominated by individual points).
+MIN_BROADCAST_EVENTS_HARD: int = 5
+
+# ``MIN_BROADCAST_EVENTS_HARD <= n_events < MIN_BROADCAST_EVENTS_RELIABLE`` →
+# :attr:`factrix._codes.WarningCode.SPARSE_COMMON_FEW_EVENTS`. Aligns with
+# the ``MIN_TS_OBS = 20`` philosophy: slope is estimable but cross-event
+# averaging is too thin for the asymptotic t-distribution to be trusted.
+MIN_BROADCAST_EVENTS_RELIABLE: int = 20
+
+
 def auto_bartlett(T: int) -> int:
     """Newey & West (1994) automatic Bartlett-kernel lag.
 

--- a/tests/test_common_panel_procedures.py
+++ b/tests/test_common_panel_procedures.py
@@ -282,9 +282,14 @@ class TestEmptyPanelFallback:
         assert profile.n_obs == 0
         assert profile.stats[StatCode.TS_BETA] == 0.0
 
-    def test_sparse_empty_returns_p_one(
+    def test_sparse_empty_raises_insufficient_events(
         self, cfg_sparse: AnalysisConfig,
     ) -> None:
+        # n_events=0 trips the MIN_EVENTS_HARD guard before any β fitting.
+        # Empty panels should not silently return p=1.0 here — the procedure
+        # cannot fit per-asset β on a dummy with no events.
+        from factrix._errors import InsufficientSampleError
+
         empty = pl.DataFrame(
             schema={
                 "date": pl.Date,
@@ -293,9 +298,43 @@ class TestEmptyPanelFallback:
                 "forward_return": pl.Float64,
             },
         )
-        profile = _CommonSparsePanelProcedure().compute(empty, cfg_sparse)
-        assert profile.primary_p == 1.0
-        assert profile.n_obs == 0
+        with pytest.raises(InsufficientSampleError):
+            _CommonSparsePanelProcedure().compute(empty, cfg_sparse)
+
+
+class TestSparseCommonEventCountGuard:
+    """Two-tier event-count guard on `(COMMON, SPARSE, PANEL)` (#25)."""
+
+    def test_three_events_raises(self, cfg_sparse: AnalysisConfig) -> None:
+        from factrix._errors import InsufficientSampleError
+
+        # density=0.05 × n_dates=60 → max(2, 3) = 3 events < MIN_EVENTS_HARD=5.
+        panel = _make_common_panel(
+            n_dates=60, n_assets=15, seed=51, true_beta=0.0,
+            factor_kind="sparse", sparse_event_density=0.05,
+        )
+        with pytest.raises(InsufficientSampleError):
+            _CommonSparsePanelProcedure().compute(panel, cfg_sparse)
+
+    def test_ten_events_emits_borderline_warning(
+        self, cfg_sparse: AnalysisConfig,
+    ) -> None:
+        # 10 events, in [MIN_EVENTS_HARD=5, MIN_EVENTS_RELIABLE=20) → warn.
+        panel = _make_common_panel(
+            n_dates=60, n_assets=15, seed=52, true_beta=0.0,
+            factor_kind="sparse", sparse_event_density=10 / 60,
+        )
+        profile = _CommonSparsePanelProcedure().compute(panel, cfg_sparse)
+        assert WarningCode.SPARSE_COMMON_FEW_EVENTS in profile.warnings
+
+    def test_thirty_events_silent(self, cfg_sparse: AnalysisConfig) -> None:
+        # 30 events ≥ MIN_EVENTS_RELIABLE=20 → no event-count warning.
+        panel = _make_common_panel(
+            n_dates=60, n_assets=15, seed=53, true_beta=0.0,
+            factor_kind="sparse", sparse_event_density=0.5,
+        )
+        profile = _CommonSparsePanelProcedure().compute(panel, cfg_sparse)
+        assert WarningCode.SPARSE_COMMON_FEW_EVENTS not in profile.warnings
 
 
 class TestCrossSectionNWarnings:


### PR DESCRIPTION
Closes #25.

## Summary

`(COMMON, SPARSE, None, PANEL)` previously checked only `n_periods` via per-asset `MIN_TS_OBS = 20`. A broadcast dummy with a single non-zero event would still produce a β fit from that one point with no warning, then aggregate cross-asset.

Two-tier event-count guard added on the broadcast dummy:

| `n_events` | Behaviour |
|---|---|
| `< MIN_BROADCAST_EVENTS_HARD = 5` | raise `InsufficientSampleError` |
| `[5, 20)` | emit new `WarningCode.SPARSE_COMMON_FEW_EVENTS` |
| `≥ MIN_BROADCAST_EVENTS_RELIABLE = 20` | silent |

Mirrors the existing `n_periods` two-tier shape (`MIN_PERIODS_HARD` / `_RELIABLE`). The `BROADCAST_` prefix disambiguates the new constants from the CAAR `MIN_EVENTS = 10` in `factrix/_types.py` (different statistic).

## Empty-panel behaviour change

Empty sparse panels previously returned `primary_p = 1.0` (continuous-sibling fallback inherited via `_compute_common_panel`). With the new guard, `n_events = 0` raises `InsufficientSampleError` upfront with a tailored error message ("ensure events are encoded as ±1 on event dates" — distinct from the "aggregate to coarser frequency" message used for non-zero-but-insufficient cases). Existing `test_sparse_empty_returns_p_one` renamed and updated.

## Test plan

- [x] `uv run pytest -q` — 574 passed (was 571; +3 new tests in `TestSparseCommonEventCountGuard` + 1 updated empty-panel test)
- [x] 3-event panel raises (density 0.05 × 60 = 3)
- [x] 10-event panel emits `SPARSE_COMMON_FEW_EVENTS`
- [x] 30-event panel silent on the new code

## /simplify pass applied

Single-agent review (small diff per the new agent-count-by-task-size cadence). 4 of 7 findings applied:

- **Reuse — `event_count_tier` helper**: skipped (single-tier code; structural parallel with `cross_section_tier` doesn't apply since that helper picks between 2 codes)
- **Quality — `extra_warnings` default**: applied (default `frozenset()` instead of `None`-or-empty branch)
- **Quality — empty-panel error message**: applied (separate detail string for `n_events == 0` vs nonzero-but-insufficient)
- **Naming — collision with CAAR `MIN_EVENTS`**: applied (renamed to `MIN_BROADCAST_EVENTS_HARD` / `_RELIABLE`)
- Skipped: typo finding (`continuous factory` is correct in factrix vocabulary), import hoisting (existing file convention is function-local imports)

## Out of scope

- `describe_analysis_modes` does not currently surface any sample-floor thresholds (`MIN_PERIODS_HARD` / `MIN_ASSETS` etc are also not shown there); adding only `MIN_BROADCAST_EVENTS` would be inconsistent. Issue #25's AC bullet on this dropped — note tracked here.
- Petersen (2009) clustered SE for the cross-asset t-test — separately deferred per `_compute_common_panel` docstring; not in `n_events`-axis scope.