### PR TITLE
feat(caar): preserve magnitude in compute_caar (#12)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,15 +257,15 @@ Failure modes:
 ### `individual_sparse` (CAAR PANEL) — cross-section first (events)
 
 ```
-per-event-date mean of signed_car = return × sign(factor)   (cross-section step)
-                                                          →  n_event_dates-length CAAR series
-                                                          →  NW HAC t-test on mean(CAAR)   (time-series step)
+per-event-date mean of signed_car = return × factor   (cross-section step)
+                                                    →  n_event_dates-length CAAR series
+                                                    →  NW HAC t-test on mean(CAAR)   (time-series step)
 ```
 
 The CAAR series is **event-date-indexed** (filter `factor != 0` before the
-cross-section step), not per-asset CAAR. `signed_car` coerces the factor via
-`.sign()` — non-±1 magnitudes are dropped at this layer (see
-`WarningCode.SPARSE_MAGNITUDE_DROPPED`).
+cross-section step), not per-asset CAAR. Magnitude is preserved as a weight
+in `signed_car` (no `.sign()` coercion at this layer — `compute_caar`'s
+docstring carries the input-form behaviour table).
 
 Failure modes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,15 +49,24 @@ CONTRIBUTING §7 (Release workflow).
   despite being fully exported. (#19)
 - **`SuggestConfigResult.detected: dict[str, Any]`** — new field
   carrying the structured panel observations behind the suggestion
-  (`scope`, `signal`, `mode`, `n_assets`, `n_periods`, `sparsity`,
-  `magnitude_dropped`). All keys always present, type-stable. AI
-  agents and pipeline gates branch on these without parsing the
-  `reasoning` strings or re-deriving observations from the raw panel.
-  `reasoning` (human-readable narrative) and `warnings` unchanged.
-  (#21)
+  (`scope`, `signal`, `mode`, `n_assets`, `n_periods`, `sparsity`).
+  All keys always present, type-stable. AI agents and pipeline gates
+  branch on these without parsing the `reasoning` strings or
+  re-deriving observations from the raw panel. `reasoning`
+  (human-readable narrative) and `warnings` unchanged. (#21)
 
 ### Changed
 
+- **`compute_caar` per-row formula: `return × sign(factor)` →
+  `return × factor`.** Magnitude is now preserved as a weight rather
+  than being silently dropped via `.sign()` coercion. `{0, 1}` and
+  `{-1, 0, +1}` callers see no behaviour change (sign was identity);
+  `{0, R}` non-ternary callers — previously flagged by
+  `WarningCode.SPARSE_MAGNITUDE_DROPPED` as wrong — now get the
+  magnitude-weighted statistic they were trying to compute. Callers
+  wanting ternary semantics on a non-ternary input apply `.sign()` to
+  the input column themselves before calling. See `compute_caar`
+  docstring for the input-form behaviour table. (#12)
 - README §樣本守門 重寫：新增「factory × `n_assets` regime 行為矩陣」表 +
   「計算順序對照」段 + 「兩軸守門對稱」表，明確區分
   `individual_continuous`（cross-section first → time-series）與
@@ -98,16 +107,22 @@ CONTRIBUTING §7 (Release workflow).
   ``MIN_EVENTS = 10`` in ``factrix/_types.py`` (different statistic).
   Empty-panel sparse-PANEL behaviour shifts from silent
   ``primary_p = 1.0`` to an explicit raise. (#29)
-- **`WarningCode.SPARSE_MAGNITUDE_DROPPED`** is now scope- and mode-gated.
-  Previously emitted by `suggest_config` whenever a SPARSE factor carried
-  non-±1 magnitudes — but only the `(INDIVIDUAL, SPARSE, PANEL)` routing
-  (CAAR via `compute_caar`) actually applies `.sign()` coercion. The
-  `(COMMON, SPARSE, PANEL)` and `(*, SPARSE, *) × N=1` routings feed the
-  raw factor into OLS, preserving magnitude — emitting the warning there
-  misled callers into rescaling unnecessarily. The same predicate now
-  gates `SuggestConfigResult.detected["magnitude_dropped"]` and the
-  `reasoning["signal"]` `.sign()` addendum, so the three user-facing
-  surfaces stay coherent. (#28)
+### Removed
+
+- **`WarningCode.SPARSE_MAGNITUDE_DROPPED`** enum value + description.
+  The warning existed to flag callers that the dispatched sparse
+  procedure would drop magnitude via `.sign()`. With the
+  `compute_caar` semantic shift above, no routing drops magnitude any
+  more — the warning has nothing left to warn about. (#12)
+- **`SuggestConfigResult.detected["magnitude_dropped"]`** key removed;
+  `DETECTED_KEYS` reduced from 7 to 6. `_detect_signal` returns a
+  3-tuple `(signal, reason, sparsity)` (was 4-tuple including
+  `has_nonternary_magnitudes`). The `suggest_config` `magnitude_dropped`
+  predicate, scope/mode gating, and `reasoning["signal"]` `.sign()`
+  addendum are all gone — same root cause. **Migration:** delete any
+  branch that reads `result.detected["magnitude_dropped"]` or
+  membership-checks `WarningCode.SPARSE_MAGNITUDE_DROPPED`; on `{0, R}`
+  inputs, `compute_caar` now does the right thing without warning. (#12)
 
 ## v0.7.0 (2026-05-04)
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -23,10 +23,6 @@ class WarningCode(StrEnum):
     # persistent-regressor flag, §5.2 / §7.3). Not raised for SPARSE.
     PERSISTENT_REGRESSOR = "persistent_regressor"
     SERIAL_CORRELATION_DETECTED = "serial_correlation_detected"
-    # Fired when SPARSE-detected factor has non-±1 magnitudes. CAAR/BMP
-    # coerce via .sign() so magnitude is silently dropped — surface it
-    # so users with SUE/notch-delta signals can rescale or re-route.
-    SPARSE_MAGNITUDE_DROPPED = "sparse_magnitude_dropped"
     # Two-tier cross-asset N guards for PANEL common_continuous. Mirrors
     # the n_periods two-tier (UNRELIABLE_SE_SHORT_PERIODS) but the axis
     # never raises — cross-asset t-test on E[β] is well-defined for N≥2.
@@ -56,9 +52,6 @@ _WARNING_DESCRIPTIONS.update({
         "ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias.",
     WarningCode.SERIAL_CORRELATION_DETECTED:
         "Ljung-Box p < 0.05 on residuals; NW lag may be under-set.",
-    WarningCode.SPARSE_MAGNITUDE_DROPPED:
-        "Sparse factor has non-±1 magnitudes; sparse procedures will "
-        "coerce via .sign() and drop magnitude information.",
     WarningCode.SMALL_CROSS_SECTION_N:
         "PANEL cross-asset t-test with n_assets < MIN_ASSETS (10); "
         "df=n_assets-1 too low — t_crit at n_assets=3 ≈ 4.30 "

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -35,7 +35,7 @@ _SPARSITY_THRESHOLD: float = 0.5
 # per-key types/meanings.
 DETECTED_KEYS: frozenset[str] = frozenset({
     "scope", "signal", "mode",
-    "n_assets", "n_periods", "sparsity", "magnitude_dropped",
+    "n_assets", "n_periods", "sparsity",
 })
 
 
@@ -219,7 +219,6 @@ class SuggestConfigResult:
     | ``n_assets``         | int       | unique ``asset_id`` count                 |
     | ``n_periods``        | int       | unique ``date`` count                     |
     | ``sparsity``         | float     | zero-ratio in ``factor`` column           |
-    | ``magnitude_dropped``| bool      | True iff the suggested routing actually drops magnitude (SPARSE + INDIVIDUAL + PANEL + non-±1) |
     """
 
     suggested: AnalysisConfig
@@ -228,25 +227,14 @@ class SuggestConfigResult:
     warnings: list[WarningCode] = field(default_factory=list)
 
 
-def _detect_signal(raw: Any) -> tuple[Signal, str, bool, float]:
+def _detect_signal(raw: Any) -> tuple[Signal, str, float]:
     """Sparsity ratio in ``factor`` ≥ 0.5 → SPARSE, else CONTINUOUS.
 
-    Returns ``(signal, reason, has_nonternary_magnitudes, sparsity)``.
-
-    - ``has_nonternary_magnitudes``: ``True`` iff at least one factor
-      value is non-zero and not in ``{-1, +1}``. This is a **raw
-      observation**, scope/mode-blind. Whether those magnitudes will
-      actually be dropped depends on the dispatched procedure — only
-      ``_CAARSparsePanelProcedure`` (INDIVIDUAL × SPARSE × PANEL)
-      coerces via ``.sign()``. ``suggest_config`` combines this flag
-      with scope and mode to compute the user-facing
-      ``magnitude_dropped``.
-    - ``sparsity``: zero-ratio in the factor column. Surfaced for
-      ``SuggestConfigResult.detected`` so callers can branch on the raw
-      observation rather than re-deriving it from the panel.
+    Returns ``(signal, reason, sparsity)`` where ``sparsity`` is the
+    zero-ratio in the factor column, surfaced on
+    ``SuggestConfigResult.detected`` so callers can branch on the raw
+    observation rather than re-deriving it from the panel.
     """
-    import polars as pl
-
     import math
 
     n = len(raw)
@@ -256,15 +244,9 @@ def _detect_signal(raw: Any) -> tuple[Signal, str, bool, float]:
         return (
             Signal.CONTINUOUS,
             "factor column empty: defaulting to CONTINUOUS",
-            False,
             math.nan,
         )
-    n_zero, all_ternary = raw.select(
-        n_zero=(pl.col("factor") == 0).sum(),
-        all_ternary=(
-            (pl.col("factor") == 0) | (pl.col("factor").abs() == 1)
-        ).all(),
-    ).row(0)
+    n_zero = int((raw["factor"] == 0).sum())
     sparsity = n_zero / n
     signal = (
         Signal.SPARSE if sparsity >= _SPARSITY_THRESHOLD else Signal.CONTINUOUS
@@ -273,10 +255,7 @@ def _detect_signal(raw: Any) -> tuple[Signal, str, bool, float]:
         f"sparsity ratio = {sparsity:.2f} "
         f"(threshold {_SPARSITY_THRESHOLD}): → {signal.value.upper()}"
     )
-    has_nonternary_magnitudes = (
-        signal is Signal.SPARSE and not bool(all_ternary)
-    )
-    return signal, reason, has_nonternary_magnitudes, sparsity
+    return signal, reason, sparsity
 
 
 def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
@@ -329,27 +308,13 @@ def suggest_config(
     caller (or an AI agent) reads ``reasoning`` and ``warnings`` to
     decide whether to override.
     """
-    signal, signal_reason, has_nonternary, sparsity = _detect_signal(raw)
+    signal, signal_reason, sparsity = _detect_signal(raw)
     scope, scope_reason = _detect_scope(raw)
 
     n_assets = int(raw["asset_id"].n_unique())
     n_periods = int(raw["date"].n_unique())
     mode = _derive_mode(raw)
 
-    # Magnitude is only dropped on the INDIVIDUAL × SPARSE × PANEL routing
-    # (`_CAARSparsePanelProcedure` → `compute_caar`'s `.sign()` coercion).
-    # COMMON × SPARSE and N=1 sparse routings feed the raw factor into OLS,
-    # so a non-±1 magnitude is preserved there — emitting the warning on
-    # those routings would mislead the caller into rescaling unnecessarily.
-    magnitude_dropped = (
-        has_nonternary
-        and scope is FactorScope.INDIVIDUAL
-        and mode is Mode.PANEL
-    )
-    if magnitude_dropped:
-        signal_reason += (
-            " (non-±1 magnitudes present; .sign() coercion will drop them)"
-        )
     mode_reason = (
         f"n_assets = {n_assets} detected → "
         f"{'TIMESERIES' if mode is Mode.TIMESERIES else 'PANEL'}"
@@ -387,8 +352,6 @@ def suggest_config(
             warnings.append(WarningCode.UNRELIABLE_SE_SHORT_PERIODS)
     if n_tier is not None:
         warnings.append(n_tier)
-    if magnitude_dropped:
-        warnings.append(WarningCode.SPARSE_MAGNITUDE_DROPPED)
 
     detected: dict[str, Any] = {
         "scope": scope.value,
@@ -397,7 +360,6 @@ def suggest_config(
         "n_assets": n_assets,
         "n_periods": n_periods,
         "sparsity": sparsity,
-        "magnitude_dropped": magnitude_dropped,
     }
 
     return SuggestConfigResult(

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -148,12 +148,14 @@ class _FMContPanelProcedure:
 
 
 class _CAARSparsePanelProcedure:
-    """``(INDIVIDUAL, SPARSE, None, PANEL)`` — per-event AR → CAAR.
+    """``(INDIVIDUAL, SPARSE, None, PANEL)`` — per-event-date weighted CAAR.
 
-    Plan §4.3: per-event signed AR aggregated to a CAAR series across
-    event dates, then a cross-event t-test on the CAAR mean. Same
-    HH-floored NW HAC machinery as IC and FM PANEL — h-period
-    forward returns induce MA(h-1) on the CAAR series identically.
+    Plan §4.3: dispatches to ``compute_caar`` (see for the
+    magnitude-preserving per-row formula and input-form behaviour),
+    then runs an HH-floored NW HAC t-test on the resulting event-date-
+    indexed CAAR series. Same NW HAC machinery as IC and FM PANEL —
+    h-period forward returns induce MA(h-1) on the CAAR series
+    identically.
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema] = InputSchema(

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -1,7 +1,7 @@
 """CAAR (Cumulative Average Abnormal Return) significance tests.
 
 Tests H₀: event abnormal return = 0, using two complementary methods:
-    compute_caar — per-event-date signed abnormal return series
+    compute_caar — per-event-date weighted abnormal return series
     caar         — CAAR t-test (parametric, non-overlapping sampling)
     bmp_test     — BMP standardized AR test (robust to event-induced variance)
 
@@ -36,25 +36,38 @@ def compute_caar(
     factor_col: str = "factor",
     return_col: str = "forward_return",
 ) -> pl.DataFrame:
-    """Per-event-date signed abnormal return series.
+    """Per-event-date weighted abnormal return series.
 
-    ``signed_car = return × sign(factor)``
-    ``caar = per-date mean of signed_car across events``
+    Aggregation:
+        CS-first. For each event date, take the cross-sectional mean of
+        ``signed_car = return × factor`` across event rows
+        (``factor ≠ 0``); the resulting ``n_event_dates``-length CAAR
+        series feeds a downstream NW HAC t-test on the mean.
 
-    Only rows where ``factor ≠ 0`` are included (event rows).
+    Magnitude is preserved — no ``.sign()`` coercion. The statistic that
+    emerges depends on the input form (general primitive ``{0, R}``;
+    special cases ``{0, 1}`` and ``{-1, 0, +1}`` reduce naturally):
 
-    Note:
-        ``factor_col`` is coerced via ``.sign()``: any non-±1 magnitude
-        is **dropped silently here** (sign-only semantics). For
-        magnitude-bearing event signals (SUE z-score, ratings notch
-        delta, etc.) ``suggest_config`` raises
-        ``WarningCode.SPARSE_MAGNITUDE_DROPPED`` so the user can either
-        rescale to ±1 before calling, or route to a continuous procedure.
+    | Input ``factor``      | ``signed_car`` reduces to | Statistic tested              |
+    |-----------------------|---------------------------|-------------------------------|
+    | ``{0, 1}``            | ``return`` on event rows  | Average event-day return      |
+    | ``{0, R}``, ``R ∈ ℝ`` | ``return × R``            | Magnitude-weighted CAAR       |
+    | ``{-1, 0, +1}``       | ``return × ±1``           | Signed CAAR (literature std.) |
+
+    If the caller wants ternary semantics on a non-ternary input, apply
+    ``.sign()`` to the input column before calling.
+
+    Scale:
+        CAAR magnitude tracks the units of ``factor`` (bps, z-score,
+        unit-less ±1). Hypothesis tests via the downstream ``caar``
+        t-statistic are scale-invariant (numerator and denominator both
+        scale linearly), but cross-factor *effect-size* comparisons
+        require commensurate units.
 
     Args:
         df: Panel with ``date``, ``asset_id``, ``factor_col``, ``return_col``.
-        factor_col: Column with discrete signal {-1, 0, +1}; non-±1
-            magnitudes are coerced to their sign.
+        factor_col: Numeric column. Magnitude is preserved as a weight
+            in the per-row product; only zero rows are filtered.
         return_col: Column with forward/abnormal return.
 
     Returns:
@@ -63,8 +76,7 @@ def compute_caar(
     return (
         df.filter(pl.col(factor_col) != 0)
         .with_columns(
-            (pl.col(return_col) * pl.col(factor_col).sign())
-            .alias("_signed_car")
+            (pl.col(return_col) * pl.col(factor_col)).alias("_signed_car")
         )
         .group_by("date")
         .agg(pl.col("_signed_car").mean().alias("caar"))

--- a/tests/test_caar.py
+++ b/tests/test_caar.py
@@ -115,6 +115,74 @@ class TestComputeCaar:
 
 
 # ---------------------------------------------------------------------------
+# compute_caar — input-form behaviour matrix (issue #12)
+# ---------------------------------------------------------------------------
+
+
+def _two_event_panel(
+    factor_a: float, factor_b: float, ret_a: float, ret_b: float,
+) -> pl.DataFrame:
+    return pl.DataFrame({
+        "date": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+        "asset_id": ["A", "B"],
+        "factor": [factor_a, factor_b],
+        "forward_return": [ret_a, ret_b],
+    })
+
+
+class TestComputeCaarInputForms:
+    def test_occurrence_only_zero_one(self):
+        df = _two_event_panel(1.0, 1.0, 0.02, -0.01)
+        result = compute_caar(df)
+        assert result["caar"].to_list() == pytest.approx([0.02, -0.01])
+
+    def test_signed_ternary(self):
+        df = _two_event_panel(-1.0, 1.0, -0.02, 0.03)
+        result = compute_caar(df)
+        assert result["caar"].to_list() == pytest.approx([0.02, 0.03])
+
+    def test_magnitude_weighted_zero_R(self):
+        df = _two_event_panel(2.5, -3.0, 0.01, 0.02)
+        result = compute_caar(df)
+        assert result["caar"].to_list() == pytest.approx([0.025, -0.06])
+
+    def test_magnitude_preserved_not_dropped(self):
+        # Pins the post-change behaviour — sign-coerced math would yield
+        # 0.01, magnitude-preserving math yields 0.025.
+        df = pl.DataFrame({
+            "date": [datetime(2020, 1, 1)],
+            "asset_id": ["A"],
+            "factor": [2.5],
+            "forward_return": [0.01],
+        })
+        result = compute_caar(df)
+        assert result["caar"][0] == pytest.approx(0.025)
+        assert result["caar"][0] != pytest.approx(0.01)
+
+    def test_within_date_cs_average_weighted(self):
+        df = pl.DataFrame({
+            "date": [datetime(2020, 1, 1), datetime(2020, 1, 1)],
+            "asset_id": ["A", "B"],
+            "factor": [2.0, -1.0],
+            "forward_return": [0.03, 0.04],
+        })
+        result = compute_caar(df)
+        assert len(result) == 1
+        assert result["caar"][0] == pytest.approx(0.01)
+
+    def test_caller_can_opt_into_ternary_via_sign(self):
+        df = pl.DataFrame({
+            "date": [datetime(2020, 1, 1)],
+            "asset_id": ["A"],
+            "factor": [2.5],
+            "forward_return": [0.01],
+        })
+        coerced = df.with_columns(pl.col("factor").sign())
+        result = compute_caar(coerced)
+        assert result["caar"][0] == pytest.approx(0.01)
+
+
+# ---------------------------------------------------------------------------
 # caar (significance test)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -9,7 +9,7 @@ import polars as pl
 import pytest
 
 from factrix._analysis_config import AnalysisConfig
-from factrix._axis import FactorScope, Metric, Mode, Signal
+from factrix._axis import Metric
 from factrix._codes import WarningCode
 from factrix._describe import (
     DETECTED_KEYS,
@@ -273,105 +273,6 @@ class TestSuggestConfigWarnings:
 
 
 # ---------------------------------------------------------------------------
-# suggest_config — sparse magnitude drop warning (issue #8)
-# ---------------------------------------------------------------------------
-
-
-def _sparse_weighted_factor(rng, shape) -> np.ndarray:
-    """8% non-zero events, magnitudes ~ N(0, 2) — the non-±1 sparse pattern."""
-    is_event = rng.choice([0.0, 1.0], size=shape, p=[0.92, 0.08])
-    return is_event * rng.standard_normal(shape) * 2.0
-
-
-def _make_sparse_weighted_panel(seed: int = 21) -> pl.DataFrame:
-    """Sparse layout but non-zero values are continuous magnitudes (SUE-like)."""
-    rng = np.random.default_rng(seed)
-    n_dates, n_assets = 60, 15
-    factor = _sparse_weighted_factor(rng, (n_dates, n_assets))
-    rows: list[dict[str, object]] = []
-    for t in range(n_dates):
-        d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
-        for j in range(n_assets):
-            rows.append({
-                "date": d, "asset_id": f"A{j:03d}",
-                "factor": float(factor[t, j]),
-                "forward_return": float(rng.standard_normal()),
-            })
-    return pl.DataFrame(rows)
-
-
-def _make_common_sparse_weighted_panel(seed: int = 22) -> pl.DataFrame:
-    """Broadcast sparse factor with non-±1 magnitudes when non-zero."""
-    rng = np.random.default_rng(seed)
-    n_dates, n_assets = 60, 15
-    factor_t = _sparse_weighted_factor(rng, n_dates)
-    rows: list[dict[str, object]] = []
-    for t in range(n_dates):
-        d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
-        for j in range(n_assets):
-            rows.append({
-                "date": d, "asset_id": f"A{j:03d}",
-                "factor": float(factor_t[t]),
-                "forward_return": float(rng.standard_normal()),
-            })
-    return pl.DataFrame(rows)
-
-
-def _make_timeseries_sparse_weighted(n_dates: int = 80, seed: int = 23) -> pl.DataFrame:
-    """N=1 sparse with non-±1 magnitudes."""
-    rng = np.random.default_rng(seed)
-    factor = _sparse_weighted_factor(rng, n_dates)
-    rows = [
-        {
-            "date": dt.date(2024, 1, 1) + dt.timedelta(days=t),
-            "asset_id": "SPY",
-            "factor": float(factor[t]),
-            "forward_return": float(rng.standard_normal()),
-        }
-        for t in range(n_dates)
-    ]
-    return pl.DataFrame(rows)
-
-
-class TestSparseMagnitudeWarning:
-    def test_pure_ternary_sparse_no_magnitude_warning(self) -> None:
-        result = suggest_config(_make_sparse_panel())
-        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
-
-    def test_continuous_sparse_emits_magnitude_warning(self) -> None:
-        result = suggest_config(_make_sparse_weighted_panel())
-        assert result.suggested.signal is Signal.SPARSE
-        assert WarningCode.SPARSE_MAGNITUDE_DROPPED in result.warnings
-
-    def test_continuous_dense_no_magnitude_warning(self) -> None:
-        result = suggest_config(_make_individual_continuous_panel())
-        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
-
-    def test_signal_reasoning_mentions_coercion_when_dropped(self) -> None:
-        result = suggest_config(_make_sparse_weighted_panel())
-        assert ".sign()" in result.reasoning["signal"]
-
-
-class TestSparseMagnitudeWarningScopeGating:
-    """Warning is gated to the (INDIVIDUAL, SPARSE, PANEL) routing only."""
-
-    def test_common_sparse_weighted_no_warning(self) -> None:
-        result = suggest_config(_make_common_sparse_weighted_panel())
-        assert result.suggested.signal is Signal.SPARSE
-        assert result.suggested.scope is FactorScope.COMMON
-        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
-        assert result.detected["magnitude_dropped"] is False
-        assert ".sign()" not in result.reasoning["signal"]
-
-    def test_timeseries_sparse_weighted_no_warning(self) -> None:
-        result = suggest_config(_make_timeseries_sparse_weighted(n_dates=80))
-        assert result.suggested.signal is Signal.SPARSE
-        assert WarningCode.SPARSE_MAGNITUDE_DROPPED not in result.warnings
-        assert result.detected["magnitude_dropped"] is False
-        assert ".sign()" not in result.reasoning["signal"]
-
-
-# ---------------------------------------------------------------------------
 # suggest_config — n_assets two-tier guard (issue #15)
 # ---------------------------------------------------------------------------
 
@@ -436,18 +337,12 @@ class TestSuggestConfigDetected:
         assert d["n_assets"] == 20
         assert d["n_periods"] == 60
         assert 0.0 <= d["sparsity"] < 0.5
-        assert d["magnitude_dropped"] is False
 
     def test_sparse_values(self) -> None:
         result = suggest_config(_make_sparse_panel())
         d = result.detected
         assert d["signal"] == "sparse"
         assert d["sparsity"] >= 0.5
-        assert d["magnitude_dropped"] is False
-
-    def test_sparse_weighted_flags_magnitude_dropped(self) -> None:
-        result = suggest_config(_make_sparse_weighted_panel())
-        assert result.detected["magnitude_dropped"] is True
 
     def test_timeseries_mode(self) -> None:
         ts = _make_timeseries(n_dates=80, sparse=False, seed=42)


### PR DESCRIPTION
## Summary

- `compute_caar` per-row formula: `return × sign(factor)` → `return × factor`. Magnitude is now preserved as a weight on event rows; `{0, 1}` and `{-1, 0, +1}` callers see no behaviour change (sign was identity), only `{0, R}` non-ternary callers flip from "warn-but-do-the-wrong-thing" to "do-the-right-thing-and-remove-the-warning".
- Cascade-removes the now-obsolete scaffolding: `WarningCode.SPARSE_MAGNITUDE_DROPPED`, `SuggestConfigResult.detected["magnitude_dropped"]` (`DETECTED_KEYS` 7→6), `_detect_signal`'s 4-tuple `has_nonternary_magnitudes` slot, and the scope/mode-gated predicate in `suggest_config`. Single source of truth for the input-form behaviour table lives on `compute_caar`'s docstring; `_CAARSparsePanelProcedure` and ARCHITECTURE.md §individual_sparse reference it.
- Companion CHANGELOG entries: `### Changed` (semantic shift on `{0, R}`) + `### Removed` (warning + detected key + tuple slot, single cascade).

## Test plan

- [x] `pytest` — 573 passed (was 572; 6 new `TestComputeCaarInputForms` cases minus 1 dropped `test_sparse_weighted_flags_magnitude_dropped`).
- [x] `TestComputeCaarInputForms` exercises §Behaviour change matrix: `{0, 1}` occurrence-only, `{-1, 0, +1}` signed ternary, `{0, R}` magnitude-weighted, within-date CS averaging on multi-event-same-date, and the `.sign()` opt-in escape hatch.
- [x] `_CAARSparsePanelProcedure` end-to-end (`tests/test_caar_procedure.py`) unchanged — the procedure dispatches to `compute_caar` and inherits the magnitude-preserving behaviour automatically.
- [x] `tests/test_introspection.py::TestSuggestConfigDetected::test_keys_match_canonical_set` confirms the canonical 6-key shape post-removal.

Closes #12