### PR TITLE
fix(stats): calendar-time CAAR for PANEL NW HAC (#24)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,24 +257,33 @@ Failure modes:
 ### `individual_sparse` (CAAR PANEL) — cross-section first (events)
 
 ```
-per-event-date mean of signed_car = return × factor   (cross-section step)
-                                                    →  n_event_dates-length CAAR series
-                                                    →  NW HAC t-test on mean(CAAR)   (time-series step)
+per-event-date mean of signed_car = return × factor      (cross-section step)
+                                                       →  event-date-indexed CAAR
+reindex to dense calendar, zero-fill non-event dates   →  n_periods-length CAAR series
+                                                       →  NW HAC t-test on mean(CAAR)   (time-series step)
 ```
 
-The CAAR series is **event-date-indexed** (filter `factor != 0` before the
-cross-section step), not per-asset CAAR. Magnitude is preserved as a weight
-in `signed_car` (no `.sign()` coercion at this layer — `compute_caar`'s
-docstring carries the input-form behaviour table).
+The CAAR series is **calendar-indexed**: `compute_caar` produces an
+event-date-indexed primitive (filter `factor != 0`), which the procedure
+then reindexes against the full date set with zero-fill. This is the
+calendar-time portfolio approach (Jaffe 1974, Mandelker 1974; Fama 1998
+§2) — restores the lag rule's "consecutive observations are 1 calendar
+period apart" assumption that an event-only series would otherwise
+break. With it, sparse events let zero-padding zero out spurious
+autocovariance terms and clustered events get the real MA(h-1) overlap
+weighted correctly. Pipeline parity with IC / FM / common-sparse PANEL.
+
+Magnitude is preserved as a weight in `signed_car` (no `.sign()` coercion
+at this layer — `compute_caar`'s docstring carries the input-form
+behaviour table). User-facing `CAAR_MEAN` reports the per-event-date
+mean (the average effect on event days); `n_obs` and `NW_LAGS_USED`
+reflect the dense series.
 
 Failure modes:
 
-- `n_events < MIN_EVENTS` → CAAR series too short → primary_p reverts to insufficient.
+- `n_events < MIN_EVENTS` → event series too short → primary_p reverts to insufficient.
 - `n_periods < MIN_PERIODS_HARD` (overall panel length) → `InsufficientSampleError`.
 - `MIN_PERIODS_HARD ≤ n_periods < MIN_PERIODS_RELIABLE` → `UNRELIABLE_SE_SHORT_PERIODS`.
-- NW HAC lag rule currently uses index distance on the filtered event-date
-  series; for sparse or clustered events the calendar-gap structure can
-  diverge from the assumed MA(`forward_periods` − 1) overlap.
 
 ### `common_continuous` — time-series first
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,27 @@ CONTRIBUTING §7 (Release workflow).
 
 ### Fixed
 
+- **`(INDIVIDUAL, SPARSE, None, PANEL)` NW HAC lag rule.** The procedure
+  previously fed `compute_caar`'s event-date-indexed series straight into
+  NW HAC, but the `forward_periods - 1` lag floor assumes consecutive
+  observations are 1 calendar period apart. On the event-only filtered
+  series that assumption breaks: sparse events (calendar gap >
+  `forward_periods`) over-corrected an MA(h-1) overlap that did not
+  exist (deflating t / inflating p); clustered events
+  (gap < `forward_periods`) under-corrected the real overlap structure
+  (inflating t / deflating p). The procedure now reindexes the CAAR
+  series to the full calendar and zero-fills non-event dates before NW
+  HAC — the **calendar-time portfolio approach** (Jaffe 1974; Mandelker
+  1974; Fama 1998 §2). Mathematically the t-statistic is invariant to
+  the dense reframing in the iid limit (`mean_dense × n_total =
+  mean_event × n_event`), so the canonical p is unchanged where the lag
+  rule was already valid; only the previously-biased regimes shift. All
+  four NW-HAC PANEL procedures (IC / FM / CAAR / common-sparse) now run
+  on calendar-dense series with the same `_resolve_nw_lags` machinery.
+  **Output contract:** `FactorProfile.n_obs` and
+  `StatCode.NW_LAGS_USED` now report the dense-series counts (was
+  event-date counts); `StatCode.CAAR_MEAN` continues to report the
+  per-event-date mean (user-facing statistic unchanged). (#24)
 - **`(COMMON, SPARSE, None, PANEL)` event-count guard.** The procedure
   previously checked only ``n_periods`` (via per-asset
   ``MIN_TS_OBS = 20`` in ``compute_ts_betas``); a broadcast dummy with

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -148,14 +148,29 @@ class _FMContPanelProcedure:
 
 
 class _CAARSparsePanelProcedure:
-    """``(INDIVIDUAL, SPARSE, None, PANEL)`` — per-event-date weighted CAAR.
+    """``(INDIVIDUAL, SPARSE, None, PANEL)`` — calendar-time CAAR.
 
-    Plan §4.3: dispatches to ``compute_caar`` (see for the
-    magnitude-preserving per-row formula and input-form behaviour),
-    then runs an HH-floored NW HAC t-test on the resulting event-date-
-    indexed CAAR series. Same NW HAC machinery as IC and FM PANEL —
-    h-period forward returns induce MA(h-1) on the CAAR series
-    identically.
+    Plan §4.3 / Issue #24. Dispatches to ``compute_caar`` (see for the
+    magnitude-preserving per-row formula), reindexes the event-date-
+    indexed series to the **dense calendar** (zero-fill on non-event
+    dates), then runs an HH-floored NW HAC t-test on the dense series.
+
+    Densification is the calendar-time portfolio approach (Jaffe 1974,
+    Mandelker 1974; Fama 1998 §2) — restores the lag rule's "consecutive
+    observations are 1 calendar period apart" assumption that
+    ``compute_caar``'s event-date filter would otherwise break. With it,
+    sparse events let zero-padding zero out spurious autocovariance
+    terms and clustered events get the real MA(h-1) overlap structure
+    weighted correctly. Pipeline parity with IC / FM / common-sparse
+    PANEL: same ``_resolve_nw_lags`` + ``_newey_west_t_test`` machinery,
+    same dense-series semantics.
+
+    Output contract: ``CAAR_MEAN`` reports the event-only mean
+    (user-facing statistic — the average effect on event days);
+    ``n_obs`` and ``NW_LAGS_USED`` reflect the dense series the t-stat
+    is computed on. ``mean_dense × n_total = mean_event × n_event``, so
+    the t-statistic is invariant to the dense reframing in the iid
+    limit (canonical p unchanged when the lag rule was already valid).
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema] = InputSchema(
@@ -166,6 +181,7 @@ class _CAARSparsePanelProcedure:
         self, raw: Any, config: "AnalysisConfig",
     ) -> "FactorProfile":
         import numpy as np
+        import polars as pl
 
         from factrix._codes import StatCode
         from factrix._profile import FactorProfile
@@ -173,15 +189,29 @@ class _CAARSparsePanelProcedure:
         from factrix._stats.constants import auto_bartlett
         from factrix.metrics.caar import compute_caar
 
-        caar_values = compute_caar(raw)["caar"].drop_nulls().to_numpy()
-        n_periods = int(len(caar_values))
+        event_caar = compute_caar(raw)
+        all_dates = raw.select(pl.col("date").unique().sort())
+        dense = (
+            all_dates
+            .join(event_caar, on="date", how="left")
+            .with_columns(pl.col("caar").fill_null(0.0))
+            .sort("date")
+        )
+        caar_dense = dense["caar"].to_numpy()
+        n_periods = int(len(caar_dense))
         n_assets = int(raw["asset_id"].n_unique())
+
+        event_mean = (
+            float(event_caar["caar"].drop_nulls().mean())
+            if event_caar.height > 0 else 0.0
+        )
         nw_lags = (
-            _resolve_nw_lags(n_periods, auto_bartlett(n_periods), config.forward_periods)
+            _resolve_nw_lags(
+                n_periods, auto_bartlett(n_periods), config.forward_periods,
+            )
             if n_periods >= 2 else 0
         )
-        caar_mean = float(np.mean(caar_values)) if n_periods > 0 else 0.0
-        t_stat, p_value, _ = _newey_west_t_test(caar_values, lags=nw_lags)
+        t_stat, p_value, _ = _newey_west_t_test(caar_dense, lags=nw_lags)
 
         return FactorProfile(
             config=config,
@@ -190,7 +220,7 @@ class _CAARSparsePanelProcedure:
             n_obs=n_periods,
             n_assets=n_assets,
             stats={
-                StatCode.CAAR_MEAN: caar_mean,
+                StatCode.CAAR_MEAN: event_mean,
                 StatCode.CAAR_T_NW: t_stat,
                 StatCode.CAAR_P: p_value,
                 StatCode.NW_LAGS_USED: float(nw_lags),

--- a/tests/test_caar_procedure.py
+++ b/tests/test_caar_procedure.py
@@ -159,3 +159,115 @@ class TestEndToEndViaEvaluate:
         assert profile.mode is Mode.PANEL
         assert StatCode.CAAR_P in profile.stats
         assert profile.verdict() is Verdict.PASS
+
+
+# ---------------------------------------------------------------------------
+# Calendar-time portfolio regimes (issue #24)
+# ---------------------------------------------------------------------------
+
+
+def _make_panel_with_event_dates(
+    *,
+    event_dates: list[dt.date],
+    all_dates: list[dt.date],
+    n_assets: int,
+    seed: int,
+    beta: float,
+) -> pl.DataFrame:
+    """Panel with ±1 events only on the listed event_dates.
+
+    Forward returns follow ``β·factor + N(0,1)`` so per-event signed AR
+    has mean ≈ β. Non-event dates carry factor=0 with pure-noise return.
+    """
+    rng = np.random.default_rng(seed)
+    rows: list[dict[str, object]] = []
+    for d in all_dates:
+        is_event = d in set(event_dates)
+        for j in range(n_assets):
+            if is_event:
+                f = float(rng.choice([-1.0, 1.0]))
+            else:
+                f = 0.0
+            rows.append({
+                "date": d,
+                "asset_id": f"A{j:03d}",
+                "factor": f,
+                "forward_return": float(beta * f + rng.standard_normal()),
+            })
+    return pl.DataFrame(rows)
+
+
+class TestCalendarTimeRegimes:
+    def test_sparse_regime_n_obs_is_calendar_count(
+        self, cfg: AnalysisConfig,
+    ) -> None:
+        # 4 events on a 120-day panel → n_obs is the dense-series length.
+        start = dt.date(2024, 1, 1)
+        all_dates = [start + dt.timedelta(days=i) for i in range(120)]
+        event_dates = [start + dt.timedelta(days=30 * k) for k in range(4)]
+        panel = _make_panel_with_event_dates(
+            event_dates=event_dates, all_dates=all_dates,
+            n_assets=10, seed=7, beta=0.0,
+        )
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+        assert profile.n_obs == 120
+
+    def test_sparse_regime_caar_mean_uses_event_only_average(
+        self, cfg: AnalysisConfig,
+    ) -> None:
+        # CAAR_MEAN must be the per-event-date mean (≈ β=1.0), not the
+        # zero-diluted dense mean (≈ 0.033 = β × n_event/n_calendar).
+        start = dt.date(2024, 1, 1)
+        all_dates = [start + dt.timedelta(days=i) for i in range(120)]
+        event_dates = [start + dt.timedelta(days=30 * k) for k in range(4)]
+        panel = _make_panel_with_event_dates(
+            event_dates=event_dates, all_dates=all_dates,
+            n_assets=40, seed=11, beta=1.0,
+        )
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+        assert 0.6 < profile.stats[StatCode.CAAR_MEAN] < 1.4
+
+    def test_dense_regime_matches_event_only_when_every_date_is_event(
+        self, cfg: AnalysisConfig,
+    ) -> None:
+        # When every date carries an event, the dense reindex is a no-op —
+        # the procedure should agree with a hand-rolled NW HAC on the
+        # raw CAAR series (the pre-fix codepath, in this regime only).
+        from factrix._stats import _newey_west_t_test, _resolve_nw_lags
+        from factrix._stats.constants import auto_bartlett
+        from factrix.metrics.caar import compute_caar
+
+        start = dt.date(2024, 1, 1)
+        all_dates = [start + dt.timedelta(days=i) for i in range(80)]
+        panel = _make_panel_with_event_dates(
+            event_dates=all_dates, all_dates=all_dates,
+            n_assets=20, seed=23, beta=0.5,
+        )
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+
+        event_caar = compute_caar(panel)["caar"].drop_nulls().to_numpy()
+        T = len(event_caar)
+        lags = _resolve_nw_lags(T, auto_bartlett(T), cfg.forward_periods)
+        ref_t, ref_p, _ = _newey_west_t_test(event_caar, lags=lags)
+        assert profile.stats[StatCode.CAAR_T_NW] == pytest.approx(ref_t)
+        assert profile.stats[StatCode.CAAR_P] == pytest.approx(ref_p)
+
+    def test_clustered_regime_picks_up_overlap_via_nw_hac(
+        self, cfg: AnalysisConfig,
+    ) -> None:
+        # Two clusters of 4 consecutive event days within forward_periods=5;
+        # estimator must produce a finite p without collapsing.
+        start = dt.date(2024, 1, 1)
+        all_dates = [start + dt.timedelta(days=i) for i in range(60)]
+        clusters = [
+            start + dt.timedelta(days=10 + k) for k in range(4)
+        ] + [
+            start + dt.timedelta(days=40 + k) for k in range(4)
+        ]
+        panel = _make_panel_with_event_dates(
+            event_dates=clusters, all_dates=all_dates,
+            n_assets=15, seed=31, beta=0.5,
+        )
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+        assert 0.0 <= profile.stats[StatCode.CAAR_P] <= 1.0
+        assert profile.n_obs == 60


### PR DESCRIPTION
## Summary

- `_CAARSparsePanelProcedure.compute()` now reindexes `compute_caar`'s event-date-indexed series to the full calendar (zero-fill non-event dates) before NW HAC. Restores the lag rule's "consecutive observations are 1 calendar period apart" assumption that the event-only filter would otherwise break — the calendar-time portfolio approach (Jaffe 1974; Mandelker 1974; Fama 1998 §2).
- Sparse events (calendar gap > `forward_periods`) no longer over-correct a non-existent MA(h-1) overlap; clustered events (gap < `forward_periods`) get the real overlap weighted via the NW HAC kernel. All four NW-HAC PANEL procedures (IC / FM / CAAR / common-sparse) now share the same dense-series + `_resolve_nw_lags` machinery — CAAR is no longer the lone special case.
- Output contract: `n_obs` and `NW_LAGS_USED` now reflect the dense-series counts; `CAAR_MEAN` continues to report the per-event-date mean (user-facing statistic unchanged). t-statistic is invariant to the reframing in the iid limit (`mean_dense × n_total = mean_event × n_event`), so the canonical p is unchanged where the lag rule was already valid; only the previously-biased regimes shift.

## Test plan

- [x] `pytest` — 577 passed (was 573 + 4 new regime tests).
- [x] `TestCalendarTimeRegimes` covers three regimes: sparse (events ~monthly on a 120-day panel), clustered (two clusters of 4 consecutive event days within `forward_periods=5`), and dense (every-date events — sanity check that dense ≡ event-only). Sparse regime pins `n_obs = n_calendar` (the dense series the t-stat is computed on); CAAR_MEAN remains the per-event-date average.
- [x] Existing `TestNwLagFloor::test_nw_lags_floor_at_forward_periods_minus_one` reads `T = profile.n_obs` dynamically — verifies the lag floor on the dense series counts.

## Sub-issue (separately tracked)

- [ ] #36 — `caar()` standalone (path A, non-overlapping subsampling) has an analogous "index distance ≠ calendar distance" issue on the event-filtered series; different estimator, different fix.

Closes #24