### PR TITLE
docs(api): google-style sweep on public api for mkdocstrings (#33)

### DIFF
--- a/docs/reference/api/analysis-config.md
+++ b/docs/reference/api/analysis-config.md
@@ -1,0 +1,21 @@
+# AnalysisConfig
+
+Three-axis spec for a single-factor analysis. Constructed via one of
+the four factory methods on the class — direct construction works but
+runs the same `__post_init__` validation, so the factories are the
+documented user surface.
+
+See [Methodology reference](../methodology.md) for the axis taxonomy
+and [Statistical methods](../statistical-methods.md) for procedure
+selection rationale.
+
+::: factrix.AnalysisConfig
+    options:
+      show_root_heading: false
+      members:
+        - individual_continuous
+        - individual_sparse
+        - common_continuous
+        - common_sparse
+        - to_dict
+        - from_dict

--- a/docs/reference/api/datasets.md
+++ b/docs/reference/api/datasets.md
@@ -1,0 +1,17 @@
+# datasets
+
+Synthetic panel generators for examples, tests, and documentation.
+Both emit raw canonical-column panels (`date, asset_id, price,
+factor`); attach `forward_return` (e.g. via
+`factrix.preprocess.returns.compute_forward_return`) before passing
+to [`evaluate`](evaluate.md).
+
+The dataset's `signal_horizon` is a property of the generated
+synthetic signal, not a pipeline parameter. When
+`AnalysisConfig.forward_periods == signal_horizon` the pipeline
+realizes the nominal IC / drift; other horizons realize a decayed
+signal.
+
+::: factrix.datasets.make_cs_panel
+
+::: factrix.datasets.make_event_panel

--- a/docs/reference/api/evaluate.md
+++ b/docs/reference/api/evaluate.md
@@ -1,0 +1,7 @@
+# evaluate
+
+Single-factor evaluation entry point. Routes a `(raw, AnalysisConfig)`
+pair to the procedure registered for the dispatch cell and returns a
+[`FactorProfile`](factor-profile.md).
+
+::: factrix.evaluate

--- a/docs/reference/api/factor-profile.md
+++ b/docs/reference/api/factor-profile.md
@@ -1,0 +1,16 @@
+# FactorProfile
+
+Procedure-canonical analysis result for a single factor. Every
+registered procedure produces an instance of this dataclass with
+cell-specific scalars keyed in the `stats` mapping; adding a new
+metric does not grow the schema.
+
+See [Metric applicability](../metric-applicability.md) for `n_obs`
+and `n_assets` thresholds per procedure.
+
+::: factrix.FactorProfile
+    options:
+      show_root_heading: false
+      members:
+        - verdict
+        - diagnose

--- a/docs/reference/api/multi-factor.md
+++ b/docs/reference/api/multi-factor.md
@@ -1,0 +1,8 @@
+# multi_factor
+
+Collection-level FDR control across factor profiles. Currently exposes
+`bhy` only. See [Statistical methods](../statistical-methods.md) for
+the underlying Benjamini-Hochberg-Yekutieli procedure and its
+assumptions.
+
+::: factrix.multi_factor.bhy

--- a/factrix/_analysis_config.py
+++ b/factrix/_analysis_config.py
@@ -76,21 +76,26 @@ class AnalysisConfig:
     direct construction works but bypasses no validation — every path
     runs through ``__post_init__``.
 
-    ``forward_periods`` semantics (frequency-agnostic):
-        Counts **rows on the panel's time axis**, not calendar time.
-        factrix never inspects the ``date`` column's dtype or spacing;
-        it shifts ``forward_periods`` rows per ``asset_id``. Therefore
-        ``forward_periods=5`` on a daily panel = 5 trading days, on a
-        weekly panel = 5 weeks, on a 1-min bar panel = 5 minutes. The
-        caller owns frequency and regular spacing.
+    Attributes:
+        scope: Factor scope axis. ``INDIVIDUAL`` = per-asset factor;
+            ``COMMON`` = single broadcast value per date.
+        signal: Signal type axis. ``CONTINUOUS`` = real-valued;
+            ``SPARSE`` = ``{-1, 0, +1}`` trigger.
+        metric: Procedure metric axis. Only populated for
+            ``(INDIVIDUAL, CONTINUOUS, *)`` cells (``IC`` or ``FM``);
+            ``None`` elsewhere.
+        forward_periods: Forward-return horizon in **rows** of the
+            panel's time axis, not calendar time. factrix never
+            inspects ``date`` dtype or spacing; the caller owns
+            frequency and regular spacing. ``forward_periods=5``
+            therefore means 5 trading days on a daily panel, 5 weeks
+            on a weekly panel, 5 minutes on a 1-min bar panel.
     """
 
     scope: FactorScope
     signal: Signal
     metric: Metric | None
     forward_periods: int = 5
-    """Forward-return horizon, in **rows** of the time axis (not calendar
-    time). See class docstring for frequency semantics."""
 
     def __post_init__(self) -> None:
         _validate_axis_compat(self.scope, self.signal, self.metric)
@@ -104,8 +109,15 @@ class AnalysisConfig:
     ) -> Self:
         """Per-(date, asset) continuous factor.
 
-        ``metric=IC`` for rank predictive ordering; ``metric=FM`` for
-        unit-of-exposure premium (Fama-MacBeth λ).
+        Args:
+            metric: ``IC`` for rank predictive ordering; ``FM`` for
+                unit-of-exposure premium (Fama-MacBeth λ).
+            forward_periods: Forward-return horizon (rows of the time
+                axis).
+
+        Returns:
+            A validated ``AnalysisConfig`` for the
+            ``(INDIVIDUAL, CONTINUOUS, metric)`` cell.
         """
         return cls(
             FactorScope.INDIVIDUAL, Signal.CONTINUOUS, metric,
@@ -116,8 +128,17 @@ class AnalysisConfig:
     def individual_sparse(cls, *, forward_periods: int = 5) -> Self:
         """Per-(date, asset) sparse trigger (``{-1, 0, +1}``).
 
-        PANEL canonical: CAAR cross-event t-test.
-        TIMESERIES (N=1): TS dummy regression + NW HAC SE (§5.2).
+        PANEL canonical procedure is the CAAR cross-event t-test;
+        TIMESERIES (N=1) collapses to a dummy regression with NW HAC
+        SE.
+
+        Args:
+            forward_periods: Forward-return horizon (rows of the time
+                axis).
+
+        Returns:
+            A validated ``AnalysisConfig`` for the
+            ``(INDIVIDUAL, SPARSE, None)`` cell.
         """
         return cls(
             FactorScope.INDIVIDUAL, Signal.SPARSE, None,
@@ -128,7 +149,16 @@ class AnalysisConfig:
     def common_continuous(cls, *, forward_periods: int = 5) -> Self:
         """Broadcast continuous factor (e.g. VIX).
 
-        Canonical: per-asset β → cross-asset t-test on ``E[β]``.
+        Canonical procedure is the per-asset β estimate followed by a
+        cross-asset t-test on ``E[β]``.
+
+        Args:
+            forward_periods: Forward-return horizon (rows of the time
+                axis).
+
+        Returns:
+            A validated ``AnalysisConfig`` for the
+            ``(COMMON, CONTINUOUS, None)`` cell.
         """
         return cls(
             FactorScope.COMMON, Signal.CONTINUOUS, None,
@@ -140,7 +170,15 @@ class AnalysisConfig:
         """Broadcast sparse trigger (FOMC, policy, index rebalance).
 
         PANEL canonical: per-asset β on dummy + cross-asset t-test.
-        TIMESERIES (N=1): TS dummy regression + NW HAC SE (§5.2).
+        TIMESERIES (N=1): TS dummy regression + NW HAC SE.
+
+        Args:
+            forward_periods: Forward-return horizon (rows of the time
+                axis).
+
+        Returns:
+            A validated ``AnalysisConfig`` for the
+            ``(COMMON, SPARSE, None)`` cell.
         """
         return cls(
             FactorScope.COMMON, Signal.SPARSE, None,
@@ -148,7 +186,12 @@ class AnalysisConfig:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict (string-valued enums)."""
+        """Serialise to a JSON-compatible dict.
+
+        Returns:
+            A dict with string-valued enums and integer
+            ``forward_periods``, suitable for JSON serialisation.
+        """
         return {
             "scope": self.scope.value,
             "signal": self.signal.value,
@@ -160,8 +203,18 @@ class AnalysisConfig:
     def from_dict(cls, d: dict[str, Any]) -> Self:
         """Reconstruct from ``to_dict``'s output.
 
-        Goes through ``__post_init__`` so an invalid triple raises
-        ``IncompatibleAxisError`` rather than silently constructing.
+        Goes through ``__post_init__``, so an invalid triple raises
+        ``IncompatibleAxisError`` instead of silently constructing.
+
+        Args:
+            d: Mapping in the shape produced by ``to_dict``.
+
+        Returns:
+            A validated ``AnalysisConfig``.
+
+        Raises:
+            IncompatibleAxisError: If the ``(scope, signal, metric)``
+                triple is not a legal cell.
         """
         m = d.get("metric")
         return cls(

--- a/factrix/_evaluate.py
+++ b/factrix/_evaluate.py
@@ -46,7 +46,31 @@ def _derive_mode(raw: Any) -> Mode:
 
 
 def _evaluate(raw: Any, config: "AnalysisConfig") -> "FactorProfile":
-    """Dispatch ``config + raw`` to the registered procedure."""
+    """Dispatch ``config + raw`` to the registered procedure.
+
+    Mode is derived from ``raw`` (``N == 1`` → ``TIMESERIES``, else
+    ``PANEL``). Sparse signals at ``N == 1`` collapse the scope axis
+    so ``individual_sparse`` and ``common_sparse`` route to the same
+    cell, tagged with ``InfoCode.SCOPE_AXIS_COLLAPSED`` on the
+    returned profile.
+
+    Args:
+        raw: Canonical-column panel (``date, asset_id, factor,
+            forward_return``). Schema is validated downstream by the
+            registered procedure.
+        config: Validated ``AnalysisConfig`` produced by one of the
+            four factory methods.
+
+    Returns:
+        A ``FactorProfile`` populated by the procedure registered for
+        the routed dispatch cell.
+
+    Raises:
+        ModeAxisError: If the routed cell has no registered procedure
+            under the derived mode (e.g. ``(INDIVIDUAL, CONTINUOUS, *)``
+            at ``N == 1``); the error carries a nearest-legal
+            ``suggested_fix``.
+    """
     mode = _derive_mode(raw)
     routed_scope = _route_scope(config.scope, config.signal, mode)
     extra_info: frozenset[InfoCode] = (

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -96,19 +96,37 @@ def bhy(
 ) -> list["FactorProfile"]:
     """BHY step-up FDR within each family; return the surviving subset.
 
-    ``threshold`` is the FDR level (plan §7.5 invariant — never
-    ``alpha``). ``gate`` chooses the p-value the test runs on:
-    ``None`` = procedure-canonical ``primary_p``; otherwise a
-    ``StatCode`` whose ``is_p_value`` is ``True`` is read from every
-    profile's ``stats`` mapping (``KeyError`` if a family member does
-    not populate it). Non-p ``StatCode`` values raise ``ValueError`` —
-    BHY step-up requires probabilities, so passing e.g.
-    ``StatCode.IC_T_NW`` would silently corrupt FDR control.
+    Profiles are grouped by family key (= dispatch cell × forward
+    horizon); each family runs an independent BHY step-up on its
+    p-values. Cross-family aggregation is the user's responsibility
+    and is deliberately not done here. A warning fires when most
+    families are size-1 (BHY on a singleton is identical to a raw
+    threshold and provides no FDR correction).
 
-    Profiles are grouped by family key (= registry ``_DispatchKey``);
-    each family runs an independent BHY step-up on its p-values.
-    Cross-family aggregation is the user's responsibility and is
-    deliberately not done here (§5.6).
+    Args:
+        profiles: Iterable of ``FactorProfile`` to screen. Profiles
+            from different cells / horizons partition into separate
+            families automatically.
+        threshold: FDR level (not ``alpha``). Default ``0.05``.
+        gate: ``StatCode`` whose ``is_p_value`` is ``True`` selects
+            an alternate p-value from each profile's ``stats``;
+            ``None`` uses the procedure-canonical ``primary_p``.
+
+    Returns:
+        The subset of ``profiles`` that survive the BHY step-up
+        within their respective families, in input order across
+        families.
+
+    Raises:
+        ValueError: If ``gate`` is a ``StatCode`` whose
+            ``is_p_value`` is ``False`` (BHY step-up requires
+            probabilities).
+        KeyError: If ``gate`` is set and any profile in a family
+            does not populate that key in ``stats``.
+
+    Warns:
+        RuntimeWarning: If most families contain a single profile —
+            BHY on n=1 provides no correction beyond a raw cutoff.
     """
     if gate is not None and not gate.is_p_value:
         raise ValueError(

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -24,12 +24,25 @@ if TYPE_CHECKING:
 class FactorProfile:
     """Procedure-canonical analysis result for one factor.
 
-    ``n_obs`` is the cell-canonical effective sample size (varies by
-    procedure: T for IC/FM/TS, event count for CAAR, asset count for
-    COMMON×* PANEL). ``n_assets`` is the cross-section width of the
-    raw panel (always ``panel["asset_id"].n_unique()``); reading both
-    side by side disambiguates whether a small ``n_obs`` came from a
-    short series or a thin cross-section.
+    Reading ``n_obs`` and ``n_assets`` side by side disambiguates
+    whether a small ``n_obs`` came from a short series or a thin
+    cross-section.
+
+    Attributes:
+        config: The ``AnalysisConfig`` that produced this profile.
+        mode: Evaluation mode derived from raw data; ``PANEL`` when
+            ``n_assets > 1``, ``TIMESERIES`` at ``N == 1``.
+        primary_p: Procedure-canonical p-value used by ``verdict()``
+            and ``multi_factor.bhy``.
+        n_obs: Cell-canonical effective sample size (T for IC/FM/TS,
+            event count for CAAR, asset count for ``COMMON × *``
+            PANEL).
+        n_assets: Cross-section width of the raw panel
+            (``panel["asset_id"].n_unique()``).
+        warnings: ``WarningCode`` flags emitted by the procedure.
+        info_notes: ``InfoCode`` annotations (e.g. axis collapses).
+        stats: Cell-specific scalars keyed by ``StatCode`` (t-stats,
+            secondary p-values, HHI, etc.).
     """
 
     config: "AnalysisConfig"
@@ -50,17 +63,35 @@ class FactorProfile:
         """Pass/fail at ``threshold`` against ``primary_p`` (or ``gate``).
 
         ``threshold`` is a generic cutoff — not tied to Type-I-error
-        semantics, since ``gate`` may name a non-p stat (t-stat, HHI,
-        etc.). ``gate=None`` uses the procedure-canonical ``primary_p``;
-        supplying a ``StatCode`` swaps the gate for user policy and the
-        comparison ``value < threshold`` is interpreted by the caller.
-        Raises ``KeyError`` if the requested gate is not populated.
+        semantics, because ``gate`` may name a non-p stat (t-stat,
+        HHI, etc.). The comparison ``value < threshold`` is
+        interpreted by the caller.
+
+        Args:
+            threshold: Cutoff applied to the gated value. Default
+                ``0.05``.
+            gate: ``StatCode`` whose value is read from ``stats``;
+                ``None`` uses the procedure-canonical ``primary_p``.
+
+        Returns:
+            ``Verdict.PASS`` if the gated value is below ``threshold``,
+            otherwise ``Verdict.FAIL``.
+
+        Raises:
+            KeyError: If ``gate`` is not populated in ``stats``.
         """
         p = self.primary_p if gate is None else self.stats[gate]
         return Verdict.PASS if p < threshold else Verdict.FAIL
 
     def diagnose(self) -> dict[str, Any]:
-        """Secondary stats + flag sets for human / AI agent triage."""
+        """Secondary stats + flag sets for human / AI agent triage.
+
+        Returns:
+            A plain-Python dict with mode, sample sizes, primary p,
+            warning / info code names sorted alphabetically, and the
+            full ``stats`` mapping with enum keys converted to their
+            string values.
+        """
         return {
             "mode": self.mode.value,
             "n_obs": self.n_obs,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,3 +102,9 @@ nav:
       - Methodology: reference/methodology.md
       - Statistical methods: reference/statistical-methods.md
       - Metric applicability: reference/metric-applicability.md
+      - API:
+          - AnalysisConfig: reference/api/analysis-config.md
+          - evaluate: reference/api/evaluate.md
+          - FactorProfile: reference/api/factor-profile.md
+          - multi_factor: reference/api/multi-factor.md
+          - datasets: reference/api/datasets.md


### PR DESCRIPTION
## Summary

- Restructure prose docstrings on the four public entries (`AnalysisConfig` + factories + `to_dict` / `from_dict`; `FactorProfile.verdict` / `diagnose`; `evaluate`; `multi_factor.bhy`) into Google-style `Args:` / `Returns:` / `Raises:` / `Attributes:` blocks.
- Add 5 mkdocstrings stub pages under `docs/reference/api/`; thread them into the `Reference` nav.
- `datasets.make_cs_panel` / `make_event_panel` already in Google-style — left untouched.

Private modules (underscore-prefixed) are deliberately not part of this sweep — issue #33 scopes them out.

## Test plan

- [x] `uv run mkdocs build --strict` passes; reference pages render with parameter tables, exception lists, and cross-links to `methodology.md` / `statistical-methods.md`.
- [x] `uv run pytest -q` — 577/577 pass (no behavioural change).
- [ ] Post-merge: verify `dev` site shows the new `Reference / API` sub-nav with all 5 pages.

Closes #33