### PR TITLE
docs(api): google-style sweep on metrics docstrings (#27)

### DIFF
--- a/docs/reference/standalone-metrics.md
+++ b/docs/reference/standalone-metrics.md
@@ -1,0 +1,56 @@
+# Standalone metric pipelines
+
+Cross-module index of every module under `factrix/metrics/`. Use this
+page to pick the existing aggregation pattern a new metric should
+match, or to mechanically check that a candidate metric satisfies the
+[NW HAC discipline](statistical-methods.md) the rest of the suite
+follows.
+
+The matrix is a curated index, complementing the auto-generated
+[API reference](api/datasets.md): the API pages document the call
+surface, this page documents the *aggregation pattern* — the order in
+which the cross-section step, the time-series step, and inference SE
+compose.
+
+## Aggregation vocabulary
+
+- **CS-first** — aggregate cross-section per date first, then aggregate
+  the resulting time series.
+- **TS-first** — aggregate time-series per asset first, then aggregate
+  across assets.
+- **TS-only** — single-series time-series operation; no cross-section
+  step.
+- **Static CS** — single cross-section, no time-axis aggregation.
+- **Per-event** — aggregation centred on event dates (per-event-date
+  step), then cross-event aggregation.
+
+## Matrix
+
+| Module | Public functions | Cell scope | Aggregation order | Inference SE | Reuses primitives |
+|---|---|---|---|---|---|
+| [`metrics/caar.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/caar.py) | `compute_caar`, `caar`, `bmp_test` | `(*, SPARSE, *, PANEL)` | per-event | non-overlapping t / z | `_calc_t_stat`, `_p_value_from_t`, `_p_value_from_z`, `_significance_marker`, `_sample_non_overlapping`, `_short_circuit_output` |
+| [`metrics/clustering.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/clustering.py) | `clustering_diagnostic` | `(*, SPARSE, *, PANEL)` | static CS | no formal H₀ | `_short_circuit_output` |
+| [`metrics/concentration.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/concentration.py) | `top_concentration` | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | across-time t (one-sided H₀: ratio ≥ 0.5) | `_calc_t_stat`, `_p_value_from_t`, `_significance_marker`, `_sample_non_overlapping`, `_short_circuit_output`, `_compute_tie_ratio` |
+| [`metrics/corrado.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/corrado.py) | `corrado_rank_test` | `(*, SPARSE, *, PANEL)` | per-event | nonparametric rank | `_calc_t_stat`, `_p_value_from_z`, `_significance_marker`, `_short_circuit_output` |
+| [`metrics/event_horizon.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/event_horizon.py) | `compute_event_returns`, `event_around_return`, `multi_horizon_hit_rate` | `(*, SPARSE, *, PANEL)` | per-event | binomial | `_short_circuit_output`, `_significance_marker` |
+| [`metrics/event_quality.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/event_quality.py) | `event_hit_rate`, `event_ic`, `profit_factor`, `event_skewness`, `signal_density` | `(*, SPARSE, *, PANEL)` | per-event | binomial / nonparametric rank | `_binomial_two_sided_p`, `_significance_marker`, `_short_circuit_output`, `_signed_car` |
+| [`metrics/fama_macbeth.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/fama_macbeth.py) | `compute_fm_betas`, `fama_macbeth`, `pooled_ols`, `beta_sign_consistency` | `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | CS-first | NW HAC / clustered t | `_newey_west_t_test`, `_p_value_from_t`, `_significance_marker`, `_short_circuit_output` |
+| [`metrics/hit_rate.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/hit_rate.py) | `hit_rate` | `(*, CONTINUOUS, *, TIMESERIES)` | TS-only | binomial | `_binomial_two_sided_p`, `_significance_marker`, `_short_circuit_output`, `_sample_non_overlapping` |
+| [`metrics/ic.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/ic.py) | `compute_ic`, `ic`, `ic_newey_west`, `ic_ir`, `regime_ic`, `multi_horizon_ic` | `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | CS-first | NW HAC / cross-asset t | `_newey_west_t_test`, `_calc_t_stat`, `_p_value_from_t`, `_significance_marker`, `_sample_non_overlapping`, `_short_circuit_output` |
+| [`metrics/mfe_mae.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/mfe_mae.py) | `compute_mfe_mae`, `mfe_mae_summary` | `(*, SPARSE, *, PANEL)` | per-event | no formal H₀ | `_short_circuit_output` |
+| [`metrics/monotonicity.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/monotonicity.py) | `monotonicity` | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | cross-asset t | `_calc_t_stat`, `_p_value_from_t`, `_significance_marker`, `_sample_non_overlapping`, `_short_circuit_output`, `_assign_quantile_groups`, `_compute_tie_ratio` |
+| [`metrics/oos.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/oos.py) | `multi_split_oos_decay` | `(*, CONTINUOUS, *, TIMESERIES)` | TS-only | no formal H₀ | `_short_circuit_output` |
+| [`metrics/quantile.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/quantile.py) | `compute_spread_series`, `quantile_spread`, `quantile_spread_vw`, `compute_group_returns` | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | cross-asset t | `_calc_t_stat`, `_p_value_from_t`, `_significance_marker`, `_sample_non_overlapping`, `_short_circuit_output`, `_assign_quantile_groups`, `_compute_tie_ratio`, `_lag_within_asset` |
+| [`metrics/spanning.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/spanning.py) | `spanning_alpha`, `greedy_forward_selection` | factor-return-series consumer (post-PANEL pipeline) | TS-only | NW HAC / OLS t | `_p_value_from_t`, `_significance_marker`, `_short_circuit_output`, `_ols_alpha` |
+| [`metrics/tradability.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/tradability.py) `notional_turnover`, `breakeven_cost`, `net_spread` | `notional_turnover`, `breakeven_cost`, `net_spread` | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first (per-date Q1/Qn membership delta → time mean) | no formal H₀ | `_sample_non_overlapping`, `_short_circuit_output`, `_assign_quantile_groups` |
+| [`metrics/tradability.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/tradability.py) `turnover` | `turnover` | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | TS-only (rank autocorrelation across consecutive dates) | no formal H₀ | `_short_circuit_output` |
+| [`metrics/trend.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/trend.py) | `ic_trend` | `(*, CONTINUOUS, *, TIMESERIES)` | TS-only | Theil-Sen rank-based CI | `_significance_marker`, `_short_circuit_output`, `_adf`, `_p_value_from_t` |
+| [`metrics/ts_asymmetry.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/ts_asymmetry.py) | `ts_asymmetry` | `(COMMON, CONTINUOUS, *, PANEL)` | CS-first | NW HAC Wald | `_significance_marker`, `_short_circuit_output`, `_aggregate_to_per_date`, `_ols_nw_multivariate`, `_wald_p_linear` |
+| [`metrics/ts_beta.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/ts_beta.py) | `compute_ts_betas`, `ts_beta`, `mean_r_squared`, `compute_rolling_mean_beta`, `ts_beta_sign_consistency`, `ts_beta_single_asset_fallback` | `(COMMON, CONTINUOUS, *, PANEL)` | TS-first | cross-asset t | `_calc_t_stat`, `_p_value_from_t`, `_significance_marker`, `_short_circuit_output` |
+| [`metrics/ts_quantile.py`](https://github.com/awwesomeman/factrix/blob/main/factrix/metrics/ts_quantile.py) | `ts_quantile_spread` | `(COMMON, CONTINUOUS, *, PANEL)` | CS-first | NW HAC Wald | `_significance_marker`, `_short_circuit_output`, `_aggregate_to_per_date`, `_ols_nw_multivariate`, `_wald_p_linear` |
+
+For per-module formula derivations, read each module's top-level
+docstring (linked above); for the underlying paper references and
+inference-SE rationale, see [Statistical methods](statistical-methods.md);
+for `n_obs` / `n_assets` thresholds per metric, see
+[Metric applicability](metric-applicability.md).

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -1,5 +1,9 @@
 """CAAR (Cumulative Average Abnormal Return) significance tests.
 
+Aggregation: per-event-date weighted abnormal return (per-event-date
+step) then non-overlapping cross-event sample; t-test on CAAR, or BMP
+standardized AR z-test for event-induced variance.
+
 Tests H₀: event abnormal return = 0, using two complementary methods:
     compute_caar — per-event-date weighted abnormal return series
     caar         — CAAR t-test (parametric, non-overlapping sampling)

--- a/factrix/metrics/clustering.py
+++ b/factrix/metrics/clustering.py
@@ -1,5 +1,9 @@
 """Event clustering diagnostic for event signals.
 
+Aggregation: static cross-section — single HHI computed once over the
+event-date histogram; no time-axis aggregation, no formal H₀
+(descriptive concentration index).
+
 When events cluster on the same dates, the independence assumption
 underlying the CAAR t-test is violated, potentially inflating the
 test statistic. The Herfindahl-Hirschman Index (HHI) on event dates

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -1,5 +1,9 @@
 """Top-bucket concentration analysis for cross-sectional panels.
 
+Aggregation: per-date HHI inverse on top-bucket weights (cross-section
+step) → per-date ratio series, then non-overlapping sample;
+across-time t against ``H₀: ratio ≥ 0.5``.
+
 Measures whether top-bucket (long-leg) alpha is concentrated in a few
 stocks or broadly distributed, using HHI (Herfindahl-Hirschman Index)
 inverse.

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -1,5 +1,9 @@
 """Corrado (1989) nonparametric rank test for event signals.
 
+Aggregation: per-asset full-sample ranks of abnormal returns
+(time-series step), then aggregate event-period ranks across events;
+nonparametric rank test on standardized rank deviation.
+
 A non-parametric alternative to the CAAR t-test. Ranks abnormal returns
 across the full sample (event + non-event periods) for each asset, then
 tests whether event-period ranks deviate from their expected value.

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -1,5 +1,8 @@
 """Multi-horizon event analysis — how does the signal behave across time?
 
+Aggregation: per-event return profile across `k` offsets (per-event
+step); descriptive curve plus binomial test on per-horizon hit rate.
+
 Answers:
     - Is there pre-event leakage? (T-6..T-1 should be ~0)
     - At which horizon is the signal strongest?

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -1,5 +1,9 @@
 """Per-event quality descriptive statistics for event signals.
 
+Aggregation: per-event scalar (hit / IC / skew / density) computed
+on `signed_car`, then cross-event aggregation; binomial inference for
+hit rate, nonparametric for IC / skewness, descriptive elsewhere.
+
 All metrics operate on the ``signed_car`` (return x sign(factor)) of
 individual events. They describe the quality and shape of per-event
 outcomes — distinct from significance testing (caar.py) and path

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -1,5 +1,9 @@
 """Fama-MacBeth regression and macro panel metrics.
 
+Aggregation: per-date cross-sectional OLS slope λ (cross-section step)
+→ time series of λ, then NW HAC t on its mean; pooled OLS variant
+clusters SE by date.
+
 ``compute_fm_betas``: per-date cross-sectional OLS → (date, beta) DataFrame.
 ``fama_macbeth``: Newey-West t-test on the beta series.
 ``pooled_ols``: pooled OLS with clustered SE by date.
@@ -41,7 +45,15 @@ def compute_fm_betas(
 ) -> pl.DataFrame:
     """Per-date cross-sectional OLS: R_i = α + β · Signal_i + ε.
 
-    Returns DataFrame with columns ``date, beta``.
+    Args:
+        df: Long panel with ``date, asset_id, factor, forward_return``.
+        factor_col: Column carrying the factor exposure.
+        return_col: Column carrying the forward return.
+
+    Returns:
+        DataFrame with ``date, beta`` (one row per date that admits a
+        finite OLS solution; dates with fewer than 3 observations or
+        a singular design are dropped).
     """
     dates = df["date"].unique().sort()
     rows: list[dict] = []

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -1,5 +1,8 @@
 """Hit rate computation for any time-indexed series.
 
+Aggregation: time-series only, sampled non-overlapping on a 1-D
+series; binomial test against `p = 0.5`.
+
 Input: DataFrame with ``date, value`` or a 1-D array.
 Output: proportion of periods where the value satisfies a condition
 (default: value > 0).

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -1,5 +1,9 @@
 """IC (Information Coefficient) computation for cross-sectional panels.
 
+Aggregation: per-date Spearman rank IC (cross-section step) → IC time
+series, then non-overlapping cross-asset t or NW HAC t on its mean;
+regime / multi-horizon variants slice or repeat the same pipeline.
+
 Input: DataFrame with ``date, asset_id, factor, forward_return``.
 Output: time-indexed IC series (``date, ic``) that can be fed into
 any ``series/`` tool (oos, trend, significance, hit_rate).

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -1,5 +1,9 @@
 """MFE/MAE — per-event price path excursion analysis.
 
+Aggregation: per-event MFE / MAE excursion over a fixed window
+(per-event step), then cross-event quantile / ratio summary;
+descriptive (no formal H₀).
+
 Answers: "what does the price path look like after events?"
 
 Requires bar-by-bar ``price`` data within the event window.

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -1,5 +1,9 @@
 """Monotonicity test for cross-sectional panels.
 
+Aggregation: per-date Spearman corr between quantile index and group
+mean return (cross-section step), then non-overlapping cross-asset t
+on the per-date series.
+
 Measures whether factor quantile groups exhibit monotonic return ordering.
 Per-date: split into n_groups by factor rank, compute mean return per group,
 Spearman corr between group index and return.

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -1,5 +1,8 @@
 """Out-of-sample (OOS) persistence analysis for any time-indexed series.
 
+Aggregation: time-series only, IS/OOS window split on a 1-D series;
+descriptive decay diagnostic (no formal H₀).
+
 Input: DataFrame with ``date, value`` (IC series, CAAR series, spread series).
 Output: MetricOutput with ``value`` = median survival ratio + sign-flip / status
 detail in ``metadata``.

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -1,5 +1,8 @@
 """Quantile analysis for cross-sectional panels.
 
+Aggregation: per-date long-short spread on quantile groups
+(cross-section step), then non-overlapping t on the spread series.
+
 Input: DataFrame with ``date, asset_id, factor, forward_return``.
 Output: spread series, long/short alpha decomposition.
 

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -1,5 +1,9 @@
 """Spanning regression — single-factor test and multi-factor selection.
 
+Aggregation: regression of factor return time-series on base-factor
+returns (time-series step); NW HAC t on alpha. The greedy stepwise
+selection variant inflates t-stats and is not for inference.
+
 ``spanning_alpha``: does a single factor have alpha after controlling for
 base factors? Standard factor research tool (Barillas & Shanken 2017).
 

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -1,5 +1,9 @@
 """Tradability metrics: Turnover, Breakeven Cost, Net Spread.
 
+Aggregation: per-date turnover / cost diagnostics on quantile-group
+membership (cross-section step), then time-series mean; descriptive
+(no formal H₀).
+
 Two flavours of turnover co-exist here, measuring different things:
 
 - ``turnover()`` — ``1 − mean(rank autocorrelation)``. Rank-stability

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -1,5 +1,8 @@
 """IC trend analysis using Theil-Sen estimator.
 
+Aggregation: time-series only, Theil-Sen median pairwise slope on a
+1-D series; CI from the rank-based pairwise slope distribution.
+
 Input: DataFrame with ``date, value`` (typically an IC series).
 Output: slope + confidence interval for trend detection.
 

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -1,5 +1,10 @@
 """Long-side / short-side asymmetry test (issue #5).
 
+Aggregation: per-date aggregation of factor and forward return to a
+common ``(_f, _r)`` series (cross-section step), then NW HAC OLS with
+sign-asymmetric slopes on the resulting time series; Wald χ² on the
+slope difference.
+
 Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
 cells. OLS β reports a single slope and assumes the response is
 symmetric around zero — `β > 0` could be "rises more on positive
@@ -57,6 +62,7 @@ def ts_asymmetry(
     """Long/short asymmetry of factor → return relationship.
 
     Reported headline:
+
     - ``value`` = method-A magnitude ``β_long + β_short`` (0 under
       perfect symmetry; positive = long side stronger)
     - ``stat``  = ``value`` / NW HAC SE
@@ -65,6 +71,24 @@ def ts_asymmetry(
     Method B (Gate C passing) populates ``beta_pos`` / ``beta_neg`` /
     ``p_wald_slopes``; otherwise ``method_b_skipped`` carries the
     reason.
+
+    Args:
+        df: Long panel; aggregated to per-date ``(_f, _r)`` internally.
+        factor_col: Column carrying the factor.
+        return_col: Column carrying the forward return.
+        forward_periods: Overlap horizon of the forward return; used
+            to floor the NW bandwidth so the kernel is consistent
+            with the autocorrelation it must absorb.
+        nw_lags: Override for the NW lag count. ``None`` resolves to
+            the standard rule given ``forward_periods`` and ``T``.
+
+    Returns:
+        ``MetricOutput`` whose ``value`` is the method-A magnitude;
+        diagnostic statistics live in ``metadata``. Short-circuits
+        with a reason code when input shape is insufficient (no
+        ``date`` column, missing ``factor`` / return column, fewer
+        than ``MIN_PORTFOLIO_PERIODS`` per-date rows, or no two-sided
+        factor variation).
     """
     if "date" not in df.columns:
         return _short_circuit_output(

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -1,5 +1,9 @@
 """Time-series beta metrics for macro common factors.
 
+Aggregation: per-asset full-sample OLS β (time-series step), then
+cross-asset t on the β distribution; rolling-window variant slices
+the time axis before the per-asset step.
+
 macro_common factors (VIX, gold, USD index) are a single time series
 shared across all assets. Per-asset time-series regression measures
 each asset's sensitivity (β) to the common factor.
@@ -39,7 +43,15 @@ def compute_ts_betas(
 ) -> pl.DataFrame:
     """Per-asset time-series OLS: R_{i,t} = α_i + β_i · F_t + ε.
 
-    Returns DataFrame with ``asset_id, beta, alpha, t_stat, r_squared, n_obs``.
+    Args:
+        df: Long panel with ``date, asset_id, factor, forward_return``.
+        factor_col: Column carrying the (broadcast) factor.
+        return_col: Column carrying the per-asset forward return.
+
+    Returns:
+        DataFrame with ``asset_id, beta, alpha, t_stat, r_squared,
+        n_obs``. Assets with fewer than ``MIN_TS_OBS`` valid rows or a
+        singular design are dropped.
     """
     assets = df["asset_id"].unique().sort()
     rows: list[dict] = []

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -1,5 +1,9 @@
 """Time-series quantile bucketing + monotonicity test (issue #5).
 
+Aggregation: per-date aggregation to a common ``(_f, _r)`` series
+(cross-section step), then quantile-bucketed NW HAC OLS on that time
+series; Wald χ² on the top-bottom bucket spread.
+
 Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
 cells: bucket factor history into quantiles and check the conditional
 mean forward return per bucket. Catches U-shape / inverted-U /
@@ -45,6 +49,7 @@ def ts_quantile_spread(
     """Bucket time-series factor by historical quantiles, test conditional means.
 
     Reported:
+
     - ``value`` = top-bottom spread (β_{K-1} - β_0)
     - ``stat``  = Wald on ``H0: β_{K-1} = β_0`` → two-sided p in metadata
     - ``metadata["spearman_rho"]`` / ``spearman_p`` = small-sample
@@ -54,6 +59,25 @@ def ts_quantile_spread(
     Gate (issue #5): ``n_unique(factor) >= n_groups * 2``. Below the
     gate the factor cannot sustain quantile cuts — short-circuits with
     a redirect to ``event_quality.*`` for binary / sparse signals.
+
+    Args:
+        df: Long panel; aggregated to per-date ``(_f, _r)`` internally.
+        factor_col: Column carrying the factor.
+        return_col: Column carrying the forward return.
+        n_groups: Number of quantile buckets ``K`` to cut the factor
+            history into.
+        forward_periods: Overlap horizon of the forward return; floors
+            the NW bandwidth.
+        nw_lags: Override for the NW lag count. ``None`` resolves to
+            the standard rule given ``forward_periods`` and ``T``.
+
+    Returns:
+        ``MetricOutput`` whose ``value`` is the top-bottom bucket
+        spread; bucket detail and the Spearman monotonicity diagnostic
+        live in ``metadata``. Short-circuits with a reason code when
+        input shape is insufficient (no ``date`` / factor / return
+        column, fewer than ``MIN_PORTFOLIO_PERIODS`` rows, or factor
+        variation below ``n_groups * 2`` distinct values).
     """
     if "date" not in df.columns:
         return _short_circuit_output(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Methodology: reference/methodology.md
       - Statistical methods: reference/statistical-methods.md
       - Metric applicability: reference/metric-applicability.md
+      - Standalone metrics: reference/standalone-metrics.md
       - API:
           - AnalysisConfig: reference/api/analysis-config.md
           - evaluate: reference/api/evaluate.md


### PR DESCRIPTION
## Summary

- Added `Aggregation:` paragraph to all 19 `factrix/metrics/*.py` module docstrings, encoding the cross-section / time-series / inference pattern the standalone-metrics matrix already classifies
- Fixed 4 classification errors caught during review (ts_asymmetry, ts_quantile, clustering, concentration — both docstring and matrix row corrected)
- Added `docs/reference/standalone-metrics.md` with the 19-row aggregation pattern matrix; tradability split into two rows (CS-first vs TS-only), spanning cell scope tightened
- Selected public functions (fama_macbeth, ts_asymmetry, ts_beta, ts_quantile) received Google-style `Args:` / `Returns:` additions

## Test plan

- [ ] `uv run mkdocs build --strict` — clean (1.45s, no warnings)
- [ ] `uv run pytest -q` — 577 passed, 0 failures
- [ ] Matrix classification verified against source code for all 4 corrected rows

Closes #27