### PR TITLE
docs(llms): add llms.txt and llms-full.txt for agent ergonomics (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ site/
 
 # MkDocs build-time artifacts (synced from SSOT by hooks; see scripts/)
 docs/examples/*.ipynb
+docs/llms.txt
+docs/llms-full.txt

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ uv pip install git+https://github.com/awwesomeman/factrix.git
 
 See the [installation guide](https://awwesomeman.github.io/factrix/getting-started/install/) for `pip` / `conda`, version pinning, and development setup.
 
-## Quickstart
+## Typical usage
+
+**Single factor — IC evaluation**
 
 ```python
 import factrix as fl
@@ -50,7 +52,22 @@ cfg     = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_p
 profile = fl.evaluate(panel, cfg)
 
 print(profile.verdict(), '| primary_p =', round(profile.primary_p, 4))
-# → pass | primary_p = 0.0
+print(profile.diagnose())   # WarningCode / InfoCode list
+```
+
+**Multi-factor BHY screening**
+
+```python
+profiles  = [fl.evaluate(p, cfg) for p in [panel_a, panel_b, panel_c, panel_d, panel_e]]
+survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
+```
+
+**Single-asset (timeseries) fallback**
+
+```python
+cfg     = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
+profile = fl.evaluate(single_asset_panel, cfg)  # mode auto-switches to TIMESERIES
+print(profile.stats.get(fl.StatCode.TS_BETA))
 ```
 
 ## Documentation

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -323,6 +323,22 @@ PR 不該 merge**——先 fix 再繼續。
 範例（inline 公式）：`ts_beta.ts_beta_sign_consistency`
 範例（Formula block）：`fama_macbeth.pooled_ols`、`_helpers._sample_non_overlapping`
 
+### LLM agent reference 同步
+
+SSOT 在 `factrix/llms.txt` 與 `factrix/llms-full.txt`（隨 wheel 出貨；mkdocs
+hook 在 build 時鏡像到 site root）。內容與 mkdocs 站部分重疊但**不互為
+SSOT**——agent 要密度、人類要漸進披露，目標結構性互斥，所以雙軌維護。
+
+下列任一變更落地時，同 PR 內同步 `factrix/llms*.txt`（無 CI 守門）：
+
+- `factrix/__init__.py` `__all__` 增刪
+- 公開 API signature 變更（factory、`evaluate`、`bhy`、`FactorProfile`）
+- `WarningCode` / `InfoCode` / `StatCode` 新增 / 改名 / 描述改寫
+- Mode dispatch 規則或 canonical panel schema 改變
+
+PR 前 self-check：跑過三個 code block、`uv run mkdocs build --strict` 乾淨、
+`tiktoken` cl100k count < 8000。
+
 ---
 
 ## 7. 版本管理與發布 (SemVer & Release)

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -25,6 +25,16 @@ Schema reflection::
 
     print(fl.describe_analysis_modes())
     print(fl.suggest_config(panel))
+
+LLM agent reference: ``llms-full.txt`` covers concepts, public API, and
+typical usage patterns in a single fetch. Two access paths::
+
+    # Web — deployed at the docs site root
+    https://awwesomeman.github.io/factrix/llms-full.txt
+
+    # Local — shipped inside the wheel as package data
+    import importlib.resources
+    text = importlib.resources.files("factrix").joinpath("llms-full.txt").read_text()
 """
 
 from factrix import datasets, multi_factor

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -1,0 +1,312 @@
+# factrix — LLM reference
+
+> factrix is a polars-native Python library that answers one question for a given
+> factor signal: **Does this factor carry statistical edge?** It runs the
+> appropriate statistical procedure (IC regression, Fama-MacBeth, CAAR event
+> study, or timeseries beta) based on a three-axis config, returns a structured
+> result with a p-value and warning flags, and screens large candidate sets with
+> per-family BHY FDR correction. Install:
+> `uv pip install git+https://github.com/awwesomeman/factrix.git`
+
+Source: https://github.com/awwesomeman/factrix
+Docs: https://awwesomeman.github.io/factrix/
+Full index: https://awwesomeman.github.io/factrix/llms.txt
+
+---
+
+## Core concept: three axes
+
+Every analysis is specified by three orthogonal axes that together select the
+statistical procedure.
+
+**FactorScope** — who carries the factor value:
+- `INDIVIDUAL` — each asset has its own factor value per date (cross-sectional
+  signal, e.g. P/B ratio)
+- `COMMON` — a single factor value is broadcast to all assets per date (macro
+  signal, e.g. VIX)
+
+**Signal** — the value type:
+- `CONTINUOUS` — real-valued (returns, z-scores, raw fundamentals)
+- `SPARSE` — categorical trigger in `{-1, 0, +1}` (event flags, regime dummies)
+
+**Metric** — the statistical procedure. Only meaningful for the
+`(INDIVIDUAL, CONTINUOUS)` cell:
+- `Metric.IC` — Information Coefficient (Spearman rank correlation, Newey-West)
+- `Metric.FM` — Fama-MacBeth cross-sectional regression lambda
+
+For all other cells (`INDIVIDUAL × SPARSE`, `COMMON × CONTINUOUS`,
+`COMMON × SPARSE`) the procedure is uniquely determined by `scope × signal`,
+so `metric=None`.
+
+**Mode** — derived at evaluate time, never set by the user:
+- `PANEL` — `n_assets > 1`
+- `TIMESERIES` — `n_assets == 1`
+
+`SPARSE × TIMESERIES` collapses the scope axis at dispatch time and tags the
+returned profile with `InfoCode.SCOPE_AXIS_COLLAPSED`.
+`(INDIVIDUAL, CONTINUOUS) × TIMESERIES` is **not** registered — the dispatch
+raises `ModeAxisError` carrying a `suggested_fix` `AnalysisConfig`.
+
+---
+
+## Canonical panel schema
+
+Every `evaluate()` call expects a polars DataFrame with these columns:
+
+| Column          | Required at | Built by                        |
+|-----------------|-------------|---------------------------------|
+| `date`          | input       | caller                          |
+| `asset_id`      | input       | caller                          |
+| `factor`        | input       | caller (the signal under test)  |
+| `price`         | input       | caller                          |
+| `forward_return`| evaluate    | `compute_forward_return`        |
+
+Synthetic panels: `fl.datasets.make_cs_panel(...)` for CONTINUOUS,
+`fl.datasets.make_event_panel(...)` for SPARSE. Both require `n_assets >= 2`.
+
+---
+
+## Typical usage
+
+### 1. Single-factor IC evaluation
+
+```python
+import factrix as fl
+from factrix.preprocess.returns import compute_forward_return
+
+# raw has columns ["date", "asset_id", "price", "factor"]
+raw   = fl.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=2024)
+panel = compute_forward_return(raw, forward_periods=5)   # appends `forward_return`
+
+cfg     = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
+profile = fl.evaluate(panel, cfg)
+
+print(profile.verdict())             # Verdict.PASS | Verdict.FAIL
+print(profile.primary_p)             # procedure-canonical p-value (float)
+print(profile.diagnose())            # dict — see FactorProfile below
+print(dict(profile.stats))           # {StatCode: float} — IC mean, t-stat, etc.
+```
+
+### 2. Multi-factor BHY screening
+
+```python
+import factrix as fl
+from factrix.preprocess.returns import compute_forward_return
+
+raw_panels = [
+    fl.datasets.make_cs_panel(n_assets=80, n_dates=400, ic_target=ic, seed=s)
+    for ic, s in [(0.08, 1), (0.06, 2), (0.01, 3), (0.0, 4), (0.05, 5)]
+]
+cfg       = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
+profiles  = [fl.evaluate(compute_forward_return(p, forward_periods=5), cfg)
+             for p in raw_panels]
+
+survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
+# survivors: list[FactorProfile] passing per-family BHY step-up at FDR 0.05.
+# Profiles are auto-partitioned into families by (dispatch cell, forward horizon);
+# BHY runs independently inside each family.
+```
+
+### 3. Single-asset panel — `ModeAxisError` with `suggested_fix`
+
+`(INDIVIDUAL, CONTINUOUS)` has no procedure when `n_assets == 1` (no
+cross-section to compute IC across). `evaluate` raises `ModeAxisError` carrying
+the nearest-legal config:
+
+```python
+import factrix as fl
+
+panel = build_single_asset_panel()   # n_assets == 1, columns as in §schema
+cfg   = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
+
+try:
+    profile = fl.evaluate(panel, cfg)
+except fl.ModeAxisError as exc:
+    cfg = exc.suggested_fix           # AnalysisConfig.common_continuous(forward_periods=5)
+    profile = fl.evaluate(panel, cfg)
+
+# profile.mode == Mode.TIMESERIES; primary_p is the timeseries-beta p-value
+print(profile.stats[fl.StatCode.TS_BETA])
+```
+
+For `SPARSE × TIMESERIES` the dispatch silently collapses the scope axis
+instead of raising; the resulting profile carries
+`InfoCode.SCOPE_AXIS_COLLAPSED` in `info_notes`.
+
+---
+
+## Public API
+
+### `AnalysisConfig`
+
+Three-axis frozen dataclass. Construct via the four factory methods —
+direct construction works but every path runs through the same axis-validation
+gate. **All factory parameters are keyword-only.**
+
+```
+AnalysisConfig.individual_continuous(*, metric: Metric = Metric.IC,
+                                     forward_periods: int = 5) -> AnalysisConfig
+AnalysisConfig.individual_sparse(*, forward_periods: int = 5) -> AnalysisConfig
+                                     # CAAR event study
+AnalysisConfig.common_continuous(*, forward_periods: int = 5) -> AnalysisConfig
+                                     # timeseries beta on broadcast factor
+AnalysisConfig.common_sparse(*, forward_periods: int = 5) -> AnalysisConfig
+                                     # CAAR on broadcast event flag
+```
+
+Serialisation: `cfg.to_dict()` → `dict`; `AnalysisConfig.from_dict(d)` →
+`AnalysisConfig` (re-runs validation).
+
+`forward_periods` counts **rows** of the time axis, not calendar days. Daily
+panel + `forward_periods=5` = 5 trading days; weekly = 5 weeks.
+
+---
+
+### `evaluate`
+
+```
+factrix.evaluate(raw: polars.DataFrame, config: AnalysisConfig) -> FactorProfile
+```
+
+Single dispatch entry. Derives mode from `raw["asset_id"].n_unique()`, applies
+scope-collapse for `SPARSE × TIMESERIES`, and routes to the registered
+procedure. Raises:
+- `IncompatibleAxisError` — config axes form an illegal cell
+- `ModeAxisError` — the routed cell has no procedure under the derived mode;
+  the exception carries `.suggested_fix: AnalysisConfig | None` with the
+  nearest-legal config
+
+---
+
+### `FactorProfile`
+
+Frozen dataclass. All fields are read-only.
+
+```
+profile.config        : AnalysisConfig
+profile.mode          : Mode                       # PANEL or TIMESERIES (derived)
+profile.primary_p     : float                      # procedure-canonical p-value
+profile.n_obs         : int                        # effective sample size
+profile.n_assets      : int                        # cross-section width
+profile.warnings      : frozenset[WarningCode]
+profile.info_notes    : frozenset[InfoCode]
+profile.stats         : Mapping[StatCode, float]   # cell-specific scalars
+
+profile.verdict(*, threshold: float = 0.05, gate: StatCode | None = None) -> Verdict
+    # PASS if primary_p (or stats[gate]) < threshold
+
+profile.diagnose() -> dict[str, Any]
+    # {"mode", "n_obs", "n_assets", "primary_p",
+    #  "warnings": [str, ...],          # sorted WarningCode .value strings
+    #  "info_notes": [str, ...],        # sorted InfoCode .value strings
+    #  "stats": {str: float, ...}}      # StatCode .value → float
+```
+
+---
+
+### `multi_factor.bhy`
+
+```
+factrix.multi_factor.bhy(
+    profiles: Iterable[FactorProfile],
+    *,
+    threshold: float = 0.05,
+    gate: StatCode | None = None,
+) -> list[FactorProfile]
+```
+
+Per-family BHY step-up FDR. Profiles auto-partition into families keyed by
+`(dispatch cell, forward_periods)`; BHY runs independently within each family
+and the surviving subsets concat in input order. Cross-family aggregation is
+the caller's responsibility (deliberately not done here).
+
+`gate=` overrides which p-value drives BHY; only `StatCode`s where
+`is_p_value` is `True` are accepted (BHY math requires probabilities). A
+`ValueError` fires for non-p-value gates; a `KeyError` fires if a profile in a
+family lacks the gated key.
+
+---
+
+### `describe_analysis_modes` / `suggest_config`
+
+```
+factrix.describe_analysis_modes(*, format: Literal["text", "json"] = "text"
+                                ) -> str | list[dict[str, Any]]
+    # Enumerate legal analysis cells with PANEL / TIMESERIES routing.
+
+factrix.suggest_config(raw, *, forward_periods: int = 5) -> SuggestConfigResult
+    # Inspect a panel; propose an AnalysisConfig + structured reasoning + warnings.
+    # Suggestion is never auto-applied — caller (or agent) reads .reasoning.
+```
+
+---
+
+### Preprocessing
+
+```python
+from factrix.preprocess.returns import compute_forward_return
+
+panel = compute_forward_return(
+    df,                                # cols: date, asset_id, price (sorted, regular spacing)
+    forward_periods: int = 5,          # row-count horizon, not calendar days
+) -> polars.DataFrame                  # appends `forward_return`; drops null rows;
+                                       # entry at t+1, exit at t+1+N; per-period normalised
+```
+
+Frequency / regular spacing is the caller's responsibility — factrix never
+inspects the `date` dtype.
+
+---
+
+## WarningCode reference (verbatim from `factrix._codes`)
+
+| WarningCode | Description (canonical) |
+|---|---|
+| `unreliable_se_short_periods` | `n_periods` is below `MIN_PERIODS_RELIABLE=30`; NW HAC SE may be biased. |
+| `event_window_overlap` | Adjacent events sit within `forward_periods`; AR windows overlap. |
+| `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
+| `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
+| `small_cross_section_n` | PANEL cross-asset t-test with `n_assets < MIN_ASSETS (10)`; df too low. |
+| `borderline_cross_section_n` | PANEL cross-asset t-test with `MIN_ASSETS ≤ n_assets < MIN_ASSETS_RELIABLE` (10..29); residual t_crit inflation 5–15%. |
+| `sparse_common_few_events` | `(COMMON, SPARSE, PANEL)` broadcast dummy has 5..19 events; per-asset β estimable but cross-event averaging too thin for asymptotic t. |
+
+`InfoCode.SCOPE_AXIS_COLLAPSED` — `N=1` collapsed scope axis; routed via the
+`_SCOPE_COLLAPSED` sentinel (only fires for `SPARSE × TIMESERIES`).
+
+Read live descriptions programmatically:
+`fl.WarningCode.PERSISTENT_REGRESSOR.description`.
+
+---
+
+## StatCode reference
+
+`StatCode.is_p_value` is `True` iff the value name ends in `_p` (the only
+codes `bhy(gate=...)` accepts).
+
+| StatCode | Set by | Meaning |
+|---|---|---|
+| `IC_MEAN`            | IC procedure   | Mean cross-sectional IC |
+| `IC_T_NW`            | IC procedure   | Newey-West t-stat for IC |
+| `IC_P`               | IC procedure   | p-value (= `primary_p` for IC cell) |
+| `FM_LAMBDA_MEAN`     | FM procedure   | Mean Fama-MacBeth lambda |
+| `FM_LAMBDA_T_NW`     | FM procedure   | Newey-West t-stat |
+| `FM_LAMBDA_P`        | FM procedure   | p-value (= `primary_p` for FM cell) |
+| `TS_BETA`            | TS / COMMON    | Timeseries beta |
+| `TS_BETA_T_NW`       | TS / COMMON    | Newey-West t-stat |
+| `TS_BETA_P`          | TS / COMMON    | p-value |
+| `CAAR_MEAN`          | CAAR procedure | Mean cumulative abnormal return |
+| `CAAR_T_NW`          | CAAR procedure | Newey-West t-stat |
+| `CAAR_P`             | CAAR procedure | p-value |
+| `FACTOR_ADF_P`       | all procedures | Diagnostic: factor ADF unit-root p-value |
+| `LJUNG_BOX_P`        | IC / FM        | Diagnostic: residual autocorrelation p-value |
+| `EVENT_TEMPORAL_HHI` | CAAR           | Temporal concentration HHI (0–1) |
+| `NW_LAGS_USED`       | NW-adjusted    | Actual Newey-West lag count used |
+
+---
+
+## Links
+
+- Docs: https://awwesomeman.github.io/factrix/
+- Source: https://github.com/awwesomeman/factrix
+- Issues: https://github.com/awwesomeman/factrix/issues
+- llms.txt index: https://awwesomeman.github.io/factrix/llms.txt

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -1,0 +1,19 @@
+# factrix
+
+> Polars-native factor signal validator. Tests one factor. Screens a thousand.
+> Source: https://github.com/awwesomeman/factrix
+> Docs: https://awwesomeman.github.io/factrix/
+
+## Pages
+
+- [Get Started](https://awwesomeman.github.io/factrix/getting-started/): installation, quickstart, three-axis concepts
+- [Concepts](https://awwesomeman.github.io/factrix/getting-started/concepts/): FactorScope / Signal / Metric / Mode explained
+- [Quickstart](https://awwesomeman.github.io/factrix/getting-started/quickstart/): five-minute end-to-end example
+- [Guides](https://awwesomeman.github.io/factrix/guides/): PANEL vs TIMESERIES, BHY batch screening, choosing a metric
+- [API — AnalysisConfig](https://awwesomeman.github.io/factrix/api/analysis-config/): four factory methods, from_dict / to_dict
+- [API — evaluate](https://awwesomeman.github.io/factrix/api/evaluate/): single-factor dispatch entry point
+- [API — FactorProfile](https://awwesomeman.github.io/factrix/api/factor-profile/): result schema, verdict(), diagnose()
+- [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() FDR-corrected screening
+- [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode / InfoCode / StatCode / Verdict enums
+- [Reference — metric applicability](https://awwesomeman.github.io/factrix/reference/metric-applicability/): which metrics apply to which axis combinations
+- [Full LLM reference](https://awwesomeman.github.io/factrix/llms-full.txt): single-fetch file covering concepts + API + usage patterns

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,12 @@ theme:
 hooks:
   - scripts/gen_metric_matrix.py
   - scripts/sync_examples.py
+  - scripts/sync_llms_txt.py
+
+watch:
+  - factrix
+  - examples
+  - scripts
 
 plugins:
   - search:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ addopts = "-v --tb=short"
 include = ["factrix*"]
 namespaces = false
 
+[tool.setuptools.package-data]
+factrix = ["llms.txt", "llms-full.txt"]
+
 [build-system]
 requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/scripts/sync_llms_txt.py
+++ b/scripts/sync_llms_txt.py
@@ -1,0 +1,52 @@
+"""Build-time sync of ``factrix/llms*.txt`` into ``docs/`` site root.
+
+The package directory ``factrix/`` is the SSOT for ``llms.txt`` and
+``llms-full.txt`` — this lets the wheel ship them under
+``site-packages/factrix/`` so agents grepping installed packages find
+them locally, while this hook mirrors the same content into the docs
+site so they also deploy at the public URL root.
+
+Usage (manual)::
+
+    python scripts/sync_llms_txt.py
+
+MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
+
+    The ``on_pre_build(config)`` function is called by MkDocs before
+    each build.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_SRC_DIR = _REPO_ROOT / "factrix"
+_DST_DIR = _REPO_ROOT / "docs"
+_FILES = ("llms.txt", "llms-full.txt")
+
+_BANNER = (
+    "<!-- GENERATED FILE — DO NOT EDIT.\n"
+    "     SSOT lives at factrix/{name}; regenerated on every mkdocs build\n"
+    "     by scripts/sync_llms_txt.py. Edits here will be overwritten. -->\n"
+    "\n"
+)
+
+
+def sync() -> None:
+    """Copy ``factrix/llms*.txt`` into ``docs/`` with a generated banner."""
+    for name in _FILES:
+        src = _SRC_DIR / name
+        dst = _DST_DIR / name
+        body = src.read_text(encoding="utf-8")
+        dst.write_text(_BANNER.format(name=name) + body, encoding="utf-8")
+        print(f"sync_llms_txt: wrote {dst.relative_to(_REPO_ROOT)}")
+
+
+def on_pre_build(config):  # noqa: ANN001, ARG001 — mkdocs hook signature
+    """MkDocs ``on_pre_build`` hook — runs before each build."""
+    sync()
+
+
+if __name__ == "__main__":
+    sync()


### PR DESCRIPTION
## Summary

- New SSOT `factrix/llms.txt` + `factrix/llms-full.txt` ship inside the wheel (`[tool.setuptools.package-data]`) so agents grepping `site-packages/factrix/` discover them locally; mkdocs hook `scripts/sync_llms_txt.py` mirrors the same content into `docs/` (gitignored, regenerated each build) so the deployed site root URL also resolves.
- `factrix/__init__.py` docstring carries both the deployed URL and the `importlib.resources.files("factrix") / "llms-full.txt"` path; this is the bridge that lets a local-channel agent hand off to the web channel.
- README adds a "Typical usage" cheatsheet for PyPI / GitHub viewers (separate audience from agents — README is invisible from `site-packages`).
- `mkdocs.yml` `watch:` now lists `factrix/`, `examples/`, `scripts/` so `mkdocs serve` live-reloads on SSOT edits, retroactively closing the same gap for the existing `sync_examples.py` / `gen_metric_matrix.py` hooks.
- `contributing.md` adds a short sync-discipline note listing the trigger conditions for updating the SSOT (no CI gate; manual self-check by maintainer).

## Test plan

- [x] `uv run mkdocs build --strict` clean
- [x] `tiktoken` cl100k count of `factrix/llms-full.txt` ≤ 8000 (3207 / 8000)
- [x] `unzip -l dist/factrix-*.whl` shows files at `factrix/llms*.txt` (inside the package, not wheel root)
- [x] `importlib.resources.files("factrix").joinpath("llms-full.txt").is_file()` after pip install
- [x] All three `llms-full.txt` typical-usage code blocks executed against the live API (signatures verified against `factrix._codes`, `factrix._profile`, `factrix._multi_factor`, `factrix.preprocess.returns`)
- [ ] After merge: `https://awwesomeman.github.io/factrix/dev/llms-full.txt` and `/llms.txt` resolve and serve banner-prefixed content
- [ ] After merge: fresh agent given only the `llms-full.txt` URL produces runnable code for "screen 5 factors with IC + BHY"

Closes #44
