### PR TITLE
chore(hooks): add pre-commit hook for ruff lint gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# pre-commit: enforce ruff baseline on staged Python files.
+#
+# Mirrors the lint job in .github/workflows/test.yml so commits that
+# would fail CI fail locally instead. Bypass with ``git commit
+# --no-verify`` when you really mean it (e.g. WIP, partial reformat).
+#
+# Scoped to staged .py files for speed — at factrix's size whole-repo
+# would be sub-second, but the staged scope keeps the hook silent on
+# commits that touch only YAML / Markdown / .txt.
+
+set -e
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.py$' || true)
+if [ -z "$staged" ]; then
+    exit 0
+fi
+
+# shellcheck disable=SC2086
+echo "[pre-commit] ruff check on staged .py files..."
+echo "$staged" | xargs uv run ruff check || {
+    echo "[pre-commit] FAIL — fix with: uv run ruff check --fix <files>"
+    echo "[pre-commit] bypass:        git commit --no-verify"
+    exit 1
+}
+
+echo "[pre-commit] ruff format --check on staged .py files..."
+echo "$staged" | xargs uv run ruff format --check || {
+    echo "[pre-commit] FAIL — fix with: uv run ruff format <files>"
+    echo "[pre-commit] bypass:        git commit --no-verify"
+    exit 1
+}

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -93,9 +93,14 @@ git config core.hooksPath .githooks
 ```
 
 這條 config 是 per-clone local，不會跨機器自動同步，所以每個 clone /
-新機器都要跑一次。
+新機器都要跑一次。設好之後下面所有 hook 自動生效，無需個別 install。
 
-目前唯一的 hook 是 `pre-push`：當 push 含 `chore(release): vX.Y.Z`
+`pre-commit` — 當 staged changes 含 `*.py` 時，跑 `ruff check` +
+`ruff format --check`（鏡像 CI 的 `lint` job）。失敗 → block commit；
+fix-then-commit 或 `git commit --no-verify` 繞過。Scope 限定 staged
+檔案，touch YAML / Markdown / .txt 的 commit 完全不觸發。
+
+`pre-push` — 當 push 含 `chore(release): vX.Y.Z`
 （亦即 `cz bump` 產出的 release commit），會檢查 `CHANGELOG.md` 中對
 應 `## vX.Y.Z` section 的非空白行數 ≥ 25。低於門檻 → block push，逼
 你補 WHY narrative（BREAKING migration、行為方向、動機）再 push。


### PR DESCRIPTION
## Summary

Add a custom `.githooks/pre-commit` shell hook that runs `ruff check` + `ruff format --check` against staged `*.py` files before each commit. Mirrors the `lint` job in `test.yml` so CI failures get caught locally instead of after a PR round-trip.

The hook reuses the existing `.githooks/` setup (single `git config core.hooksPath .githooks` already documented for `pre-push`) — no new install step for contributors. Custom shell hook chosen over the pre-commit framework because the latter would require a second install command and a more elaborate coordination story with `core.hooksPath`; for factrix's solo-maintainer scope the shell script is enough.

Bypass with `git commit --no-verify` for WIP commits; the failure message prints the fix command (`uv run ruff check --fix <files>`) and the bypass.

Independent of #52 — the hook is rule-set-agnostic and runs whatever `[tool.ruff.lint]` is at commit time. Merges fine in either order with the in-flight #52 PR.

## Test plan

- [x] Hook passes on clean staged `.py` (manual smoke test against `factrix/__init__.py`)
- [x] Hook fails on a deliberately broken file (unused import / unformatted whitespace) and prints the fix path
- [x] Hook noops when no `*.py` are staged (touch only YAML / Markdown / `.txt`)
- [x] CI green (lint + 4-cell pytest + wheel smoke + docs strict — no code path touched)

Refs #50
