### PR TITLE
feat(metrics): four-angle primitive polish (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,42 @@ CONTRIBUTING §7 (Release workflow).
 
 ### Added
 
+- **`bmp_test(include_prediction_error_variance=False)`** — opt-in
+  strict BMP (1991) denominator $\sigma_i \cdot \sqrt{1 + 1/T_{\mathrm{est}}}$
+  for the mean-adjusted residual forecast. Default off preserves the
+  prior simplified denominator. Under a single ``estimation_window``
+  the correction scales every SAR by the same constant, so
+  ``mean_SAR`` / ``std_SAR`` shrink by the same ratio but the $z$
+  statistic is invariant; the flag documents the strict standardiser
+  rather than moving inference. Per-event $T_i$ variation (which
+  would move $z$) requires a market-model extension and remains out
+  of scope. (#48)
+- **`WarningCode.SPARSE_MAGNITUDE_WEIGHTED`** — emitted by
+  `compute_caar` (as a `UserWarning` on the primitive) and surfaced
+  in `FactorProfile.warnings` from the `(INDIVIDUAL, SPARSE, PANEL)`
+  / `(COMMON, SPARSE, PANEL)` procedures when the sparse `factor`
+  column is mixed-sign and not a clean ±1 ternary
+  (e.g. `{-2.5, 0, +1.3}`). The CAAR / sparse-panel statistic in
+  that regime is the Sefcik-Thompson (1986) magnitude-weighted
+  variant rather than the MacKinlay (1997) signed CAAR — a different
+  estimator at finite samples when negative- and positive-leg vols
+  disagree. ``{-1, 0, +1}`` does not trigger (sign and weight
+  coincide numerically); all-non-negative inputs do not trigger (no
+  flip ambiguity). Helper `_is_sparse_magnitude_weighted` (single
+  `.unique()` + sign distribution) is the shared check. (#48)
+- **`compute_ic` per-date `tie_ratio` column** — output schema widened
+  from `(date, ic)` to `(date, ic, tie_ratio)`, where
+  `tie_ratio = 1 - n_unique / n` per date in `[0, 1]`. Aggregated as
+  the median across dates and surfaced via
+  `MetricOutput.metadata["tie_ratio"]` for `ic`, `ic_newey_west`, and
+  `ic_ir`. Motivation: at high tie rates Spearman ρ on average ranks
+  is biased relative to the tie-corrected formula (Kendall-Stuart
+  §31), and the previous primitive contract gave callers no way to
+  detect bucketed / categorical signals without re-inspecting the
+  raw input. Parallels the existing `top_concentration` tie diagnostic.
+  **Migration:** code that asserts the exact column list of
+  `compute_ic` output (e.g. `df.columns == ["date", "ic"]`) needs to
+  accept the third column; column-by-name access is unaffected. (#48)
 - **`WarningCode.SMALL_CROSS_SECTION_N`** + **`BORDERLINE_CROSS_SECTION_N`**
   — emitted by the `common_continuous` PANEL procedure and by
   `suggest_config` based on `n_assets`. `2 ≤ n_assets < 10` → SMALL
@@ -57,6 +93,39 @@ CONTRIBUTING §7 (Release workflow).
 
 ### Changed
 
+- **Two-tier sample-size guards on `fama_macbeth`, `caar`, and
+  `top_concentration`.** Each now distinguishes a math-validity floor
+  (``_HARD`` → short-circuit to NaN ``MetricOutput``) from a
+  literature/power floor (``_WARN`` → return the stat with a Python
+  ``UserWarning`` and the relevant ``WarningCode.value`` surfaced in
+  ``metadata["warning_codes"]``). Pre-#48 these primitives short-
+  circuited at a single conservative threshold, refusing to report
+  anything in the borderline regime — UX regression every user hit
+  when fewer than ~30 events / periods were available even though the
+  math was perfectly defined. The new contract is *warn, don't
+  refuse*. Constants: ``MIN_FM_PERIODS = 20`` →
+  ``MIN_FM_PERIODS_HARD = 4`` / ``MIN_FM_PERIODS_WARN = 30``;
+  ``MIN_EVENTS = 10`` → ``MIN_EVENTS_HARD = 4`` /
+  ``MIN_EVENTS_WARN = 30`` (Brown-Warner 1985 convention);
+  ``MIN_PORTFOLIO_PERIODS = 5`` → ``MIN_PORTFOLIO_PERIODS_HARD = 3``
+  / ``MIN_PORTFOLIO_PERIODS_WARN = 20``. Two new ``WarningCode``
+  values: ``FEW_EVENTS_BROWN_WARNER`` (caar) and
+  ``BORDERLINE_PORTFOLIO_PERIODS`` (top_concentration); FM reuses the
+  existing ``UNRELIABLE_SE_SHORT_PERIODS``. Descriptive metrics
+  (``clustering`` / ``corrado`` / ``event_horizon`` / ``event_quality``
+  / ``mfe_mae`` / ``quantile`` / ``ts_quantile`` / ``ts_asymmetry``)
+  switch to the new ``_HARD`` constant only — they have no formal H0
+  so the WARN tier would be noise; they now accept smaller-n inputs
+  they previously refused, by design. (#48)
+- **`multi_split_oos_decay` is descriptive-only.** ``stat`` is
+  ``None`` (was already), and ``metadata["p_value"]`` is now omitted
+  entirely (was ``1.0``) — the multi-split decomposition (``per_split``
+  + ``sign_flipped`` + ``status``) is the message, and a t-stat at
+  ``MIN_OOS_PERIODS = 5`` would have power ≈ 0. Dropping ``p_value``
+  prevents callers from accidentally routing the diagnostic into BHY
+  / gate logic that expects a probability. ``MIN_OOS_PERIODS`` stays
+  single-tier (no HARD/WARN split needed when there is no hypothesis
+  test). (#48)
 - **`compute_caar` per-row formula: `return × sign(factor)` →
   `return × factor`.** Magnitude is now preserved as a weight rather
   than being silently dropped via `.sign()` coercion. `{0, 1}` and

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -196,8 +196,8 @@ This section catalogues the **internal constants** that back those tiers.
 
 `factrix/_stats/constants.py`:
 
-- `MIN_PERIODS_HARD = 20`, `MIN_PERIODS_RELIABLE = 30` — the two-tier `n_periods` thresholds.
-- `MIN_ASSETS = 10`, `MIN_ASSETS_RELIABLE = 30` — the two-tier `n_assets` thresholds. The
+- `MIN_PERIODS_HARD = 20`, `MIN_PERIODS_WARN = 30` — the two-tier `n_periods` thresholds.
+- `MIN_ASSETS = 10`, `MIN_ASSETS_WARN = 30` — the two-tier `n_assets` thresholds. The
   `n_assets` axis never raises (cross-asset t-test on E[β] is mathematically defined for
   `n_assets ≥ 2`), so constant naming deliberately drops the `_HARD` suffix to avoid
   implying a raise.
@@ -210,7 +210,9 @@ primitives that procedures wrap:
 
 - `MIN_ASSETS_PER_DATE_IC = 10` — `compute_ic` drops dates with fewer than 10 assets;
   at `n_assets` < 10 the IC procedure short-circuits to NaN because every date is dropped.
-- `MIN_EVENTS = 10` — sparse-cell event-count floor.
+- `MIN_EVENTS_HARD = 4`, `MIN_EVENTS_WARN = 30` — two-tier sparse-cell
+  event-count floor. `n < HARD` short-circuits the CAAR / event-quality
+  primitives; `HARD ≤ n < WARN` emits `WarningCode.FEW_EVENTS_BROWN_WARNER`.
 - `compute_fm_betas` carries an inline `if len(y) < 3: continue` guard, no per-date min above 3.
 
 ### Inflation cost at low `n_assets`
@@ -231,7 +233,7 @@ behavior. The user-facing factory chosen determines which pipeline runs.
 
 The two universal `n_periods` floors apply to every panel/timeseries pipeline
 listed below — `n_periods < MIN_PERIODS_HARD` raises `InsufficientSampleError`,
-`MIN_PERIODS_HARD ≤ n_periods < MIN_PERIODS_RELIABLE` emits
+`MIN_PERIODS_HARD ≤ n_periods < MIN_PERIODS_WARN` emits
 `UNRELIABLE_SE_SHORT_PERIODS`. The per-procedure "Failure modes" lists below
 record only the **procedure-specific** failures; for the user-facing tier
 matrix see [Guides § PANEL vs TIMESERIES](../guides/panel-timeseries.md).
@@ -277,7 +279,11 @@ Failure modes:
 
 - per-date `n_assets` < 3 → date dropped (`if len(y) < 3: continue`).
 - per-date `n_assets` small but ≥ 3 → df = `n_assets` − 2 minimal, β unstable.
-- `n_periods < MIN_FM_PERIODS = 20` → short-circuit to insufficient.
+- `n_periods < MIN_FM_PERIODS_HARD = 4` → short-circuit to insufficient
+  (math floor — NW HAC `t` undefined below).
+- `MIN_FM_PERIODS_HARD ≤ n_periods < MIN_FM_PERIODS_WARN = 30` → returns
+  the FM `t`/`p` but emits `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` and
+  the borderline propagates into `FactorProfile.warnings`.
 
 ### `individual_sparse` (CAAR PANEL) — cross-section first (events)
 
@@ -306,7 +312,11 @@ reflect the dense series.
 
 Failure modes:
 
-- `n_events < MIN_EVENTS` → event series too short → primary_p reverts to insufficient.
+- `n_events < MIN_EVENTS_HARD = 4` → event series too short →
+  primary_p reverts to insufficient.
+- `MIN_EVENTS_HARD ≤ n_events < MIN_EVENTS_WARN = 30` → CAAR `t` is
+  returned but `WarningCode.FEW_EVENTS_BROWN_WARNER` fires and the
+  `_CAARSparsePanelProcedure` propagates it into `FactorProfile.warnings`.
 
 ### `common_continuous` — time-series first
 
@@ -320,7 +330,7 @@ Failure modes:
 
 - per-asset `n_periods < MIN_TS_OBS = 20` → asset dropped.
 - `n_assets < MIN_ASSETS = 10` → `WarningCode.SMALL_CROSS_SECTION_N` (still runs).
-- `MIN_ASSETS ≤ n_assets < MIN_ASSETS_RELIABLE = 30` → `WarningCode.BORDERLINE_CROSS_SECTION_N`.
+- `MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.BORDERLINE_CROSS_SECTION_N`.
 - `n_assets = 1` → degenerate cross-asset test → mode auto-routed to
   TIMESERIES single-series β test (null: β = 0, **not** E[β] = 0). The
   `StatCode.TS_BETA` identifier is shared across the two modes, so the
@@ -348,7 +358,7 @@ Failure modes:
   `BORDERLINE_CROSS_SECTION_N`).
 - Two-tier event-count guard (`factrix/_stats/constants.py`):
   `n_events < MIN_BROADCAST_EVENTS_HARD = 5` raises `InsufficientSampleError`;
-  `5 ≤ n_events < MIN_BROADCAST_EVENTS_RELIABLE = 20` emits
+  `5 ≤ n_events < MIN_BROADCAST_EVENTS_WARN = 20` emits
   `SPARSE_COMMON_FEW_EVENTS`.
 - Cross-asset SE assumes asset-level independence; under contemporaneous
   return correlation the standard t over-states significance — Petersen
@@ -480,11 +490,12 @@ factrix/
 ├── multi_factor.py          # public namespace (re-exports bhy)
 ├── _stats/
 │   ├── __init__.py          # _ols_nw_slope_t, _ljung_box_p, _adf, _newey_west_t_test, _resolve_nw_lags
-│   └── constants.py         # MIN_PERIODS_HARD / MIN_PERIODS_RELIABLE / auto_bartlett
+│   └── constants.py         # MIN_PERIODS_HARD / MIN_PERIODS_WARN / auto_bartlett
 ├── _types.py                # MetricOutput, EPSILON, DDOF, MIN_ASSETS_PER_DATE_IC,
-│                            #   MIN_EVENTS, MIN_OOS_PERIODS, MIN_PORTFOLIO_PERIODS, ...
+│                            #   MIN_EVENTS_HARD/WARN, MIN_OOS_PERIODS,
+│                            #   MIN_PORTFOLIO_PERIODS_HARD/WARN, ...
 ├── metrics/                 # primitives: ic, fama_macbeth, ts_beta, caar, ...
-│                            # per-cell thresholds (MIN_FM_PERIODS, MIN_TS_OBS) live
+│                            # per-cell thresholds (MIN_FM_PERIODS_HARD/WARN, MIN_TS_OBS) live
 │                            # alongside the procedures that enforce them
 └── datasets.py              # synthetic CS / event panels
 ```

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -33,83 +33,110 @@ across Modes, only the sample axis that constrains it.
 | [`ic_ir`][factrix.metrics.ic.ic_ir] | Individual × Continuous | IR / ICIR | `T` | `T ≥ MIN_ASSETS_PER_DATE_IC` |
 | [`regime_ic`][factrix.metrics.ic.regime_ic] | Individual × Continuous | Regime-stratified IC | `T` per regime | per-regime `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
 | [`multi_horizon_ic`][factrix.metrics.ic.multi_horizon_ic] | Individual × Continuous | Per-horizon IC + BHY | `T` per horizon | per-horizon `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`fama_macbeth`][factrix.metrics.fama_macbeth.fama_macbeth] | Individual × Continuous | Cell-canonical (FM) | `T` (λ series) | `T ≥ MIN_FM_PERIODS` (= 20) |
+| [`fama_macbeth`][factrix.metrics.fama_macbeth.fama_macbeth] | Individual × Continuous | Cell-canonical (FM) | `T` (λ series) | `T ≥ MIN_FM_PERIODS_HARD` (= 4); warn if `T < MIN_FM_PERIODS_WARN` (= 30) |
 | [`pooled_ols`][factrix.metrics.fama_macbeth.pooled_ols] | Individual × Continuous | Pooled OLS sibling of FM | `N × T` | `N ≥ 10`, effective clusters `G ≥ 3` |
-| [`beta_sign_consistency`][factrix.metrics.fama_macbeth.beta_sign_consistency] | Individual × Continuous | Per-period β-sign hit rate | `T` (β series) | `T ≥ MIN_FM_PERIODS` |
-| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | Individual × Continuous | Top-minus-bottom spread t | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS` (= 5); per-date `N ≥ n_groups` |
+| [`beta_sign_consistency`][factrix.metrics.fama_macbeth.beta_sign_consistency] | Individual × Continuous | Per-period β-sign hit rate | `T` (β series) | `T ≥ MIN_FM_PERIODS_HARD` |
+| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | Individual × Continuous | Top-minus-bottom spread t | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD` (= 3); warn if `T/h < MIN_PORTFOLIO_PERIODS_WARN` (= 20); per-date `N ≥ n_groups` |
 | [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | Individual × Continuous | Value-weighted spread | `T/h` | as `quantile_spread` |
 | [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | Individual × Continuous | Group-rank monotonicity | `T/h` | per-date `N ≥ n_groups`; series `≥ MIN_MONOTONICITY_PERIODS` (= 5) |
-| [`top_concentration`][factrix.metrics.concentration.top_concentration] | Individual × Continuous | Top-bucket HHI ratio | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS` |
+| [`top_concentration`][factrix.metrics.concentration.top_concentration] | Individual × Continuous | Top-bucket HHI ratio | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; warn if `T/h < MIN_PORTFOLIO_PERIODS_WARN` |
 | [`turnover`][factrix.metrics.tradability.turnover] | Individual × Continuous | Rank-stability (`1 − ρ`) | `T` | `T ≥ 2·forward_periods + 1` |
 | [`notional_turnover`][factrix.metrics.tradability.notional_turnover] | Individual × Continuous | Q1/Qn replacement fraction | `T` | as `turnover` |
 | [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | Individual × Continuous | bps cost where α → 0 | scalar | `notional_turnover > 0` |
 | [`net_spread`][factrix.metrics.tradability.net_spread] | Individual × Continuous | $\text{spread} - \text{cost} \cdot \tau$ | scalar | spread + cost provided |
 | [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | Spread-series consumer | Single-factor α post base | `T` | aligned spread series |
 | [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | Spread-series consumer | Diagnostic — not for inference | `T` | as `spanning_alpha` |
-| [`caar`][factrix.metrics.caar.caar] | Individual × Sparse | Cell-canonical | `K/h` (non-overlap) | `K/h ≥ MIN_EVENTS` (= 10) via `_scaled_min_periods(MIN_EVENTS, h)` |
-| [`bmp_test`][factrix.metrics.caar.bmp_test] | Individual × Sparse | Variance-robust sibling | `K` | `K ≥ MIN_EVENTS`; `estimation_window` periods per asset |
-| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | Individual × Sparse | Per-event sign hit rate | `K` | `K ≥ MIN_EVENTS` |
-| [`event_ic`][factrix.metrics.event_quality.event_ic] | Individual × Sparse | Strength → return Spearman | `K` | `K ≥ MIN_EVENTS` |
-| [`profit_factor`][factrix.metrics.event_quality.profit_factor] | Individual × Sparse | `Σ gains / Σ losses` | `K` | `K ≥ MIN_EVENTS` |
-| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | Individual × Sparse | Per-event return skewness | `K` | `K ≥ MIN_EVENTS` |
+| [`caar`][factrix.metrics.caar.caar] | Individual × Sparse | Cell-canonical | `K/h` (non-overlap) | `K/h ≥ MIN_EVENTS_HARD` (= 4); warn if `K/h < MIN_EVENTS_WARN` (= 30) via `_scaled_min_periods(MIN_EVENTS_HARD, h)` |
+| [`bmp_test`][factrix.metrics.caar.bmp_test] | Individual × Sparse | Variance-robust sibling | `K` | `K ≥ MIN_EVENTS_HARD`; `estimation_window` periods per asset |
+| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | Individual × Sparse | Per-event sign hit rate | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`event_ic`][factrix.metrics.event_quality.event_ic] | Individual × Sparse | Strength → return Spearman | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`profit_factor`][factrix.metrics.event_quality.profit_factor] | Individual × Sparse | `Σ gains / Σ losses` | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | Individual × Sparse | Per-event return skewness | `K` | `K ≥ MIN_EVENTS_HARD` |
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | Individual × Sparse | Mean inter-event gap | `K` | `K ≥ 2` |
-| [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | Individual × Sparse | Per-offset return profile | per-offset `K` | `K ≥ MIN_EVENTS` |
-| [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | Individual × Sparse | Per-horizon binomial hit | per-horizon `K` | `K ≥ MIN_EVENTS` |
-| [`mfe_mae_summary`][factrix.metrics.mfe_mae.mfe_mae_summary] | Individual × Sparse | Path-excursion summary | `K` | `K ≥ MIN_EVENTS`; `price` column required |
-| [`clustering_diagnostic`][factrix.metrics.clustering.clustering_diagnostic] | Individual × Sparse (`N ≥ 2`) | Event-date HHI | `K`, `N` | `N ≥ 2`; `K ≥ MIN_EVENTS` |
-| [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test] | Individual × Sparse | Nonparametric rank test | `K` × estimation window | `K ≥ MIN_EVENTS`; per-asset `T ≥ 30` |
+| [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | Individual × Sparse | Per-offset return profile | per-offset `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | Individual × Sparse | Per-horizon binomial hit | per-horizon `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`mfe_mae_summary`][factrix.metrics.mfe_mae.mfe_mae_summary] | Individual × Sparse | Path-excursion summary | `K` | `K ≥ MIN_EVENTS_HARD`; `price` column required |
+| [`clustering_diagnostic`][factrix.metrics.clustering.clustering_diagnostic] | Individual × Sparse (`N ≥ 2`) | Event-date HHI | `K`, `N` | `N ≥ 2`; `K ≥ MIN_EVENTS_HARD` |
+| [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test] | Individual × Sparse | Nonparametric rank test | `K` × estimation window | `K ≥ MIN_EVENTS_HARD`; per-asset `T ≥ 30` |
 | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | Common × Continuous | Cell-canonical | `N` (β distribution) | `N ≥ 2`; per-asset `T ≥ MIN_TS_OBS` (= 20) |
 | [`mean_r_squared`][factrix.metrics.ts_beta.mean_r_squared] | Common × Continuous | Avg explanatory R² | `N` | as `ts_beta` |
 | [`compute_rolling_mean_beta`][factrix.metrics.ts_beta.compute_rolling_mean_beta] | Common × Continuous | β stability over time | `T` per window | window ≥ `MIN_TS_OBS` |
 | [`ts_beta_sign_consistency`][factrix.metrics.ts_beta.ts_beta_sign_consistency] | Common × Continuous | Cross-asset β-sign rate | `N` | `N ≥ 2` |
-| [`ts_quantile_spread`][factrix.metrics.ts_quantile.ts_quantile_spread] | Common × Continuous | Quantile-bucketed Wald | `T` | `T ≥ MIN_PORTFOLIO_PERIODS`; factor `n_unique ≥ n_groups × 2` |
+| [`ts_quantile_spread`][factrix.metrics.ts_quantile.ts_quantile_spread] | Common × Continuous | Quantile-bucketed Wald | `T` | `T ≥ MIN_PORTFOLIO_PERIODS_HARD`; factor `n_unique ≥ n_groups × 2` |
 | [`ts_asymmetry`][factrix.metrics.ts_asymmetry.ts_asymmetry] | Common × Continuous | Long/short slope asymmetry | `T` | factor has both signs (Gate B); each side `n_unique ≥ 2` for method B (Gate C) |
 | [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | Series-tools | Binomial hit rate | series length | `T ≥ MIN_ASSETS_PER_DATE_IC` |
 | [`ic_trend`][factrix.metrics.trend.ic_trend] | Series-tools | Theil-Sen slope + ADF flag | `T` | `T ≥ 10` (literal floor) |
 | [`multi_split_oos_decay`][factrix.metrics.oos.multi_split_oos_decay] | Series-tools | Median IS/OOS survival | `T` | `T ≥ 2 × MIN_OOS_PERIODS` (= 10) |
 
-Constants in the `Min sample` column come from three locations:
+Constants in the `Min sample` column come from three locations and follow
+a two-tier `_HARD` / `_WARN` model (see "Sample-size sensitivity" below):
 
 - `factrix._types` — cross-metric defaults (`MIN_ASSETS_PER_DATE_IC`,
-  `MIN_EVENTS`, `MIN_OOS_PERIODS`, `MIN_PORTFOLIO_PERIODS`,
+  `MIN_EVENTS_HARD = 4`, `MIN_EVENTS_WARN = 30`, `MIN_OOS_PERIODS = 5`,
+  `MIN_PORTFOLIO_PERIODS_HARD = 3`, `MIN_PORTFOLIO_PERIODS_WARN = 20`,
   `MIN_MONOTONICITY_PERIODS`).
 - `factrix._stats.constants` — procedure-level guards
-  (`MIN_PERIODS_HARD = 20`, `MIN_PERIODS_RELIABLE = 30`,
-  `MIN_BROADCAST_EVENTS_HARD = 5`, `MIN_BROADCAST_EVENTS_RELIABLE = 20`).
+  (`MIN_PERIODS_HARD = 20`, `MIN_PERIODS_WARN = 30`,
+  `MIN_BROADCAST_EVENTS_HARD = 5`, `MIN_BROADCAST_EVENTS_WARN = 20`,
+  `MIN_ASSETS = 10`, `MIN_ASSETS_WARN = 30`).
 - The metric module itself for cell-specific thresholds:
-  `MIN_FM_PERIODS = 20` in `factrix.metrics.fama_macbeth`,
-  `MIN_TS_OBS = 20` in `factrix.metrics.ts_beta`.
+  `MIN_FM_PERIODS_HARD = 4` / `MIN_FM_PERIODS_WARN = 30` in
+  `factrix.metrics.fama_macbeth`, `MIN_TS_OBS = 20` in
+  `factrix.metrics.ts_beta`.
 
 For non-overlapping metrics (`ic`, `caar`, …) the effective floor is
 `_scaled_min_periods(base, forward_periods)` (in
 `factrix.metrics._helpers`), which scales the base constant by the
 forward-return horizon `h`.
 
-## Caveats on the headline thresholds
+## Sample-size sensitivity — the two-tier `_HARD` / `_WARN` model
 
-The constants above are the **floors at which a metric will run**, not
-the sample sizes at which the inferential statement is well-calibrated.
+Inferential metrics enforce two separate floors:
+
+- **`_HARD`** — the **mathematical floor**. Below it, the statistic is
+  not defined (e.g. `t = (μ − 0) / (s / √n)` requires `n ≥ 2`; the FM
+  small-sample HAC needs at least a few lagged covariances). `n < HARD`
+  short-circuits to `MetricOutput(value=NaN, metadata={"reason": ...})`.
+- **`_WARN`** — the **literature / power floor**. The statistic *is*
+  computable, but the SE is biased small or power is poor; the metric
+  returns the stat, emits a `UserWarning`, and adds a `WarningCode` to
+  `MetricOutput.metadata["warning_codes"]` so `FactorProfile.warnings`
+  can propagate it. `n ≥ WARN` is silent.
+
+**Descriptive metrics** (`clustering_diagnostic`, `corrado_rank_test`,
+`event_around_return`, `multi_horizon_hit_rate`, `event_hit_rate`,
+`event_ic`, `profit_factor`, `event_skewness`, `mfe_mae_summary`,
+`quantile_spread`, `ts_quantile_spread`, `ts_asymmetry`, `bmp_test`)
+enforce **`_HARD` only** — they have no formal H₀ under which power
+can be characterised, so the literature `_WARN` tier is undefined
+for them. They accept smaller-`n` inputs than the inferential
+canonicals.
+
 A few specific caveats worth flagging:
 
-- **`MIN_FM_PERIODS = 20`** for `fama_macbeth` is the floor at which
-  the NW HAC `t` is computed. With the Andrews `T^(1/3)` bandwidth at
-  `T = 20`, the kernel uses 2 lags and the small-sample HAC is known
-  to **over-reject**; treat *p*-values from `T ∈ [20, 30]` as
+- **`MIN_FM_PERIODS_HARD = 4` / `MIN_FM_PERIODS_WARN = 30`** for
+  `fama_macbeth`. `T = 4` is the math floor at which the NW HAC `t`
+  is computable; the small-sample HAC is known to **over-reject**, so
+  in `T ∈ [4, 30)` the metric emits
+  `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` and treats *p*-values as
   anti-conservative. Forty periods is the practical floor in the
   panel-econometrics literature.
-- **`MIN_EVENTS = 10`** for the event-study CAAR `t` is the floor at
-  which the cross-sectional `t` is even computable. Brown & Warner
-  (1985) tabulate well-behaved power at `K ≥ 50` and use `K ≥ 30` as
-  the conventional minimum; in `K ∈ [10, 30]` the parametric `caar`
-  is under-powered, and the `bmp_test` / `corrado_rank_test` siblings
-  only partly mitigate.
-- **`MIN_PORTFOLIO_PERIODS = 5`** in `top_concentration` and
-  `ts_quantile_spread`, and **`MIN_OOS_PERIODS = 5`** in
-  `multi_split_oos_decay`, are diagnostic floors. Five-point series do
-  not give meaningful inference; treat the corresponding outputs as
-  descriptive — the formal `verdict()` reading should rely on the
-  cell-canonical metric, not these auxiliaries, until the underlying
-  series is materially longer.
+- **`MIN_EVENTS_HARD = 4` / `MIN_EVENTS_WARN = 30`** for the
+  event-study CAAR `t`. Brown & Warner (1985) tabulate well-behaved
+  power at `K ≥ 50` and use `K ≥ 30` as the conventional minimum; in
+  `K ∈ [4, 30)` the parametric `caar` is under-powered and
+  `WarningCode.FEW_EVENTS_BROWN_WARNER` fires. The `bmp_test` /
+  `corrado_rank_test` siblings only partly mitigate.
+- **`MIN_PORTFOLIO_PERIODS_HARD = 3` / `MIN_PORTFOLIO_PERIODS_WARN = 20`**
+  in `top_concentration` and `ts_quantile_spread`. Below 3 there is
+  no spread / concentration t to compute; in `[3, 20)` the metric
+  returns the stat with `WarningCode.BORDERLINE_PORTFOLIO_PERIODS`.
+  **`MIN_OOS_PERIODS = 5`** in `multi_split_oos_decay` remains
+  single-tier — the metric is now descriptive-only (no `p_value` in
+  metadata), so a literature power floor is moot. Treat its output as
+  descriptive; the formal `verdict()` reading should rely on the
+  cell-canonical metric until the underlying series is materially
+  longer.
 
 ## Below-threshold behaviour
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -30,10 +30,31 @@ class WarningCode(StrEnum):
     BORDERLINE_CROSS_SECTION_N = "borderline_cross_section_n"
     # Fired by the (COMMON, SPARSE, PANEL) procedure when the broadcast
     # dummy carries MIN_BROADCAST_EVENTS_HARD ≤ n_events <
-    # MIN_BROADCAST_EVENTS_RELIABLE. Per-asset β is identifiable but
+    # MIN_BROADCAST_EVENTS_WARN. Per-asset β is identifiable but
     # the cross-event averaging is too thin for asymptotic t to be
     # trusted. Below the HARD floor raises InsufficientSampleError instead.
     SPARSE_COMMON_FEW_EVENTS = "sparse_common_few_events"
+    # Fired when a sparse ``factor`` column carries mixed signs but is
+    # not a clean ±1 ternary (e.g. ``{-2.5, 0, +1.3}``). The CAAR /
+    # sparse-panel statistic is the magnitude-weighted Sefcik-Thompson
+    # (1986) variant, which differs from the textbook MacKinlay (1997)
+    # signed CAAR at finite samples when negative- and positive-leg
+    # vols disagree. ``{-1, 0, +1}`` does not trigger — sign and weight
+    # semantics coincide numerically. All-non-negative columns
+    # (``{0, 1}`` / ``{0, R≥0}``) do not trigger — no flip ambiguity.
+    SPARSE_MAGNITUDE_WEIGHTED = "sparse_magnitude_weighted"
+    # Fired by ``caar`` (significance test) when the per-event-date series
+    # length sits in ``[MIN_EVENTS_HARD, MIN_EVENTS_WARN)`` — the t-stat
+    # is returned but the Brown-Warner (1985) convention treats sub-30
+    # event-date counts as power-thin for the asymptotic t-distribution.
+    # Below the HARD floor the primitive short-circuits to NaN instead.
+    FEW_EVENTS_BROWN_WARNER = "few_events_brown_warner"
+    # Fired by ``top_concentration`` when the per-date ratio series sits
+    # in ``[MIN_PORTFOLIO_PERIODS_HARD, MIN_PORTFOLIO_PERIODS_WARN)`` —
+    # the one-sided t-test on the diversification ratio is returned but
+    # ``df = n - 1 < 19`` inflates t_crit relative to the asymptotic
+    # cutoff. Below the HARD floor the primitive short-circuits to NaN.
+    BORDERLINE_PORTFOLIO_PERIODS = "borderline_portfolio_periods"
 
     @property
     def description(self) -> str:
@@ -45,7 +66,9 @@ _WARNING_DESCRIPTIONS: dict[WarningCode, str] = {}
 
 _WARNING_DESCRIPTIONS.update(
     {
-        WarningCode.UNRELIABLE_SE_SHORT_PERIODS: "n_periods is below MIN_PERIODS_RELIABLE=30; NW HAC SE may be biased.",
+        WarningCode.UNRELIABLE_SE_SHORT_PERIODS: "n_periods is below the WARN floor (~30); NW HAC SE may be biased. "
+        "Reused across panel time-series guards (MIN_PERIODS_WARN) and "
+        "primitive inference (MIN_FM_PERIODS_WARN); both default to 30.",
         WarningCode.EVENT_WINDOW_OVERLAP: "Adjacent events sit within forward_periods; AR windows overlap.",
         WarningCode.PERSISTENT_REGRESSOR: "ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias.",
         WarningCode.SERIAL_CORRELATION_DETECTED: "Ljung-Box p < 0.05 on residuals; NW lag may be under-set.",
@@ -53,12 +76,24 @@ _WARNING_DESCRIPTIONS.update(
         "df=n_assets-1 too low — t_crit at n_assets=3 ≈ 4.30 "
         "(+119% vs asymptotic 1.96).",
         WarningCode.BORDERLINE_CROSS_SECTION_N: "PANEL cross-asset t-test with MIN_ASSETS ≤ n_assets < "
-        "MIN_ASSETS_RELIABLE (10..29); residual t_crit inflation "
+        "MIN_ASSETS_WARN (10..29); residual t_crit inflation "
         "5–15% — read borderline p-values cautiously.",
         WarningCode.SPARSE_COMMON_FEW_EVENTS: "(COMMON, SPARSE, PANEL) broadcast dummy has "
-        "MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_RELIABLE "
+        "MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_WARN "
         "(5..19); per-asset β estimable but cross-event averaging too thin "
         "for asymptotic t.",
+        WarningCode.SPARSE_MAGNITUDE_WEIGHTED: "Sparse factor column is mixed-sign and not a "
+        "clean ±1 ternary; statistic is magnitude-weighted (Sefcik-Thompson) "
+        "rather than textbook MacKinlay signed CAAR — apply .sign() before "
+        "calling for sign-flip semantics.",
+        WarningCode.FEW_EVENTS_BROWN_WARNER: "CAAR significance test with MIN_EVENTS_HARD ≤ "
+        "n_event_dates < MIN_EVENTS_WARN (4..29); t-stat returned but "
+        "Brown-Warner (1985) convention treats sub-30 events as power-thin "
+        "for the asymptotic t-distribution — read borderline p-values cautiously.",
+        WarningCode.BORDERLINE_PORTFOLIO_PERIODS: "top_concentration with MIN_PORTFOLIO_PERIODS_HARD "
+        "≤ n_periods < MIN_PORTFOLIO_PERIODS_WARN (3..19); one-sided t-test "
+        "on the per-date diversification ratio is returned but df=n-1 inflates "
+        "t_crit relative to the asymptotic cutoff.",
     }
 )
 
@@ -69,14 +104,14 @@ def cross_section_tier(n_assets: int) -> WarningCode | None:
     Tiers are mutually exclusive — SMALL is strictly more severe than
     BORDERLINE — so callers can membership-check the more severe code
     without an else branch. Returns ``None`` at ``n_assets ≥
-    MIN_ASSETS_RELIABLE`` (clean) or ``n_assets < 2`` (PANEL impossible
+    MIN_ASSETS_WARN`` (clean) or ``n_assets < 2`` (PANEL impossible
     by upstream mode routing; defensive).
     """
-    from factrix._stats.constants import MIN_ASSETS, MIN_ASSETS_RELIABLE
+    from factrix._stats.constants import MIN_ASSETS, MIN_ASSETS_WARN
 
     if 2 <= n_assets < MIN_ASSETS:
         return WarningCode.SMALL_CROSS_SECTION_N
-    if MIN_ASSETS <= n_assets < MIN_ASSETS_RELIABLE:
+    if MIN_ASSETS <= n_assets < MIN_ASSETS_WARN:
         return WarningCode.BORDERLINE_CROSS_SECTION_N
     return None
 

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -20,9 +20,9 @@ from factrix._registry import (
     _ScopeCollapsedSentinel,
 )
 from factrix._stats.constants import (
-    MIN_ASSETS_RELIABLE,
+    MIN_ASSETS_WARN,
     MIN_PERIODS_HARD,
-    MIN_PERIODS_RELIABLE,
+    MIN_PERIODS_WARN,
 )
 
 # Sparsity threshold above which `factor` is treated as an event series.
@@ -336,7 +336,7 @@ def suggest_config(
     n_tier = cross_section_tier(n_assets) if mode is Mode.PANEL else None
     if n_tier is not None:
         mode_reason += (
-            f" (n_assets < MIN_ASSETS_RELIABLE = {MIN_ASSETS_RELIABLE} → "
+            f" (n_assets < MIN_ASSETS_WARN = {MIN_ASSETS_WARN} → "
             f"cross-asset df low, see WarningCode.{n_tier.name})"
         )
 
@@ -361,7 +361,7 @@ def suggest_config(
     }
 
     warnings: list[WarningCode] = []
-    if mode is Mode.TIMESERIES and MIN_PERIODS_HARD <= n_periods < MIN_PERIODS_RELIABLE:
+    if mode is Mode.TIMESERIES and MIN_PERIODS_HARD <= n_periods < MIN_PERIODS_WARN:
         warnings.append(WarningCode.UNRELIABLE_SE_SHORT_PERIODS)
     if n_tier is not None:
         warnings.append(n_tier)

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -124,11 +124,15 @@ class _FMContPanelProcedure:
     ) -> FactorProfile:
         import numpy as np
 
-        from factrix._codes import StatCode
+        from factrix._codes import StatCode, WarningCode
         from factrix._profile import FactorProfile
         from factrix._stats import _newey_west_t_test, _resolve_nw_lags
         from factrix._stats.constants import auto_bartlett
-        from factrix.metrics.fama_macbeth import compute_fm_betas
+        from factrix.metrics.fama_macbeth import (
+            MIN_FM_PERIODS_HARD,
+            MIN_FM_PERIODS_WARN,
+            compute_fm_betas,
+        )
 
         beta_values = compute_fm_betas(raw)["beta"].drop_nulls().to_numpy()
         n_periods = len(beta_values)
@@ -143,12 +147,19 @@ class _FMContPanelProcedure:
         lambda_mean = float(np.mean(beta_values)) if n_periods > 0 else 0.0
         t_stat, p_value, _ = _newey_west_t_test(beta_values, lags=nw_lags)
 
+        warning_codes: frozenset[WarningCode] = (
+            frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS})
+            if MIN_FM_PERIODS_HARD <= n_periods < MIN_FM_PERIODS_WARN
+            else frozenset()
+        )
+
         return FactorProfile(
             config=config,
             mode=Mode.PANEL,
             primary_p=p_value,
             n_obs=n_periods,
             n_assets=n_assets,
+            warnings=warning_codes,
             stats={
                 StatCode.FM_LAMBDA_MEAN: lambda_mean,
                 StatCode.FM_LAMBDA_T_NW: t_stat,
@@ -195,13 +206,23 @@ class _CAARSparsePanelProcedure:
     ) -> FactorProfile:
         import polars as pl
 
-        from factrix._codes import StatCode
+        from factrix._codes import StatCode, WarningCode
         from factrix._profile import FactorProfile
         from factrix._stats import _newey_west_t_test, _resolve_nw_lags
         from factrix._stats.constants import auto_bartlett
+        from factrix._types import MIN_EVENTS_HARD, MIN_EVENTS_WARN
+        from factrix.metrics._helpers import _is_sparse_magnitude_weighted
         from factrix.metrics.caar import compute_caar
 
+        warning_codes: set[WarningCode] = set()
+        if _is_sparse_magnitude_weighted(raw, "factor"):
+            warning_codes.add(WarningCode.SPARSE_MAGNITUDE_WEIGHTED)
+
         event_caar = compute_caar(raw)
+        n_event_dates = event_caar.height
+        if MIN_EVENTS_HARD <= n_event_dates < MIN_EVENTS_WARN:
+            warning_codes.add(WarningCode.FEW_EVENTS_BROWN_WARNER)
+
         all_dates = raw.select(pl.col("date").unique().sort())
         dense = (
             all_dates.join(event_caar, on="date", how="left")
@@ -234,6 +255,7 @@ class _CAARSparsePanelProcedure:
             primary_p=p_value,
             n_obs=n_periods,
             n_assets=n_assets,
+            warnings=frozenset(warning_codes),
             stats={
                 StatCode.CAAR_MEAN: event_mean,
                 StatCode.CAAR_T_NW: t_stat,
@@ -293,8 +315,9 @@ class _CommonSparsePanelProcedure:
         from factrix._errors import InsufficientSampleError
         from factrix._stats.constants import (
             MIN_BROADCAST_EVENTS_HARD,
-            MIN_BROADCAST_EVENTS_RELIABLE,
+            MIN_BROADCAST_EVENTS_WARN,
         )
+        from factrix.metrics._helpers import _is_sparse_magnitude_weighted
 
         # Broadcast factor is the same per date across assets; count
         # event dates by collapsing to one row per date first.
@@ -326,11 +349,12 @@ class _CommonSparsePanelProcedure:
                 required_periods=MIN_BROADCAST_EVENTS_HARD,
             )
 
-        extra_warnings: frozenset[WarningCode] = (
-            frozenset({WarningCode.SPARSE_COMMON_FEW_EVENTS})
-            if n_events < MIN_BROADCAST_EVENTS_RELIABLE
-            else frozenset()
-        )
+        extra_codes: set[WarningCode] = set()
+        if n_events < MIN_BROADCAST_EVENTS_WARN:
+            extra_codes.add(WarningCode.SPARSE_COMMON_FEW_EVENTS)
+        if _is_sparse_magnitude_weighted(raw, "factor"):
+            extra_codes.add(WarningCode.SPARSE_MAGNITUDE_WEIGHTED)
+        extra_warnings: frozenset[WarningCode] = frozenset(extra_codes)
         return _compute_common_panel(
             raw,
             config,
@@ -424,7 +448,7 @@ class _TSBetaContTimeseriesProcedure:
     Plan §5.2 TIMESERIES continuous: OLS ``y_t = α + β·factor_t + ε`` with
     NW HAC SE on β; ADF on factor surfaces persistence (CONTINUOUS-only
     diagnostic per I6). n_periods-stratified per I5: below ``MIN_PERIODS_HARD`` raise
-    ``InsufficientSampleError``; in ``[MIN_PERIODS_HARD, MIN_PERIODS_RELIABLE)``
+    ``InsufficientSampleError``; in ``[MIN_PERIODS_HARD, MIN_PERIODS_WARN)``
     emit verdict + ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS``.
     """
 
@@ -443,7 +467,7 @@ class _TSBetaContTimeseriesProcedure:
         from factrix._stats import _adf, _ols_nw_slope_t, _resolve_nw_lags
         from factrix._stats.constants import (
             MIN_PERIODS_HARD,
-            MIN_PERIODS_RELIABLE,
+            MIN_PERIODS_WARN,
             auto_bartlett,
         )
 
@@ -477,7 +501,7 @@ class _TSBetaContTimeseriesProcedure:
         _adf_tau, adf_p = _adf(x)
 
         warnings: set[WarningCode] = set()
-        if n_periods < MIN_PERIODS_RELIABLE:
+        if n_periods < MIN_PERIODS_WARN:
             warnings.add(WarningCode.UNRELIABLE_SE_SHORT_PERIODS)
         # I6: ADF persistence diagnostic is CONTINUOUS-only. The 0.10
         # cutoff matches plan §5.2 — a non-rejection at the 10% level
@@ -518,7 +542,7 @@ class _TSDummySparseTimeseriesProcedure:
     2. Ljung-Box on residual ε_t (auto-lag ``min(10, n_periods//10)``)
     3. ``event_temporal_hhi`` Herfindahl on equal-time bin shares —
        surfaces clustering of events along the calendar axis
-    4. ``UNRELIABLE_SE_SHORT_PERIODS`` for ``n_periods < MIN_PERIODS_RELIABLE``
+    4. ``UNRELIABLE_SE_SHORT_PERIODS`` for ``n_periods < MIN_PERIODS_WARN``
        (n_periods < ``MIN_PERIODS_HARD`` raises ``InsufficientSampleError`` upstream)
     """
 
@@ -541,7 +565,7 @@ class _TSDummySparseTimeseriesProcedure:
         )
         from factrix._stats.constants import (
             MIN_PERIODS_HARD,
-            MIN_PERIODS_RELIABLE,
+            MIN_PERIODS_WARN,
             auto_bartlett,
         )
 
@@ -572,7 +596,7 @@ class _TSDummySparseTimeseriesProcedure:
         overlap = _has_event_window_overlap(d, config.forward_periods)
 
         warnings: set[WarningCode] = set()
-        if n_periods < MIN_PERIODS_RELIABLE:
+        if n_periods < MIN_PERIODS_WARN:
             warnings.add(WarningCode.UNRELIABLE_SE_SHORT_PERIODS)
         if ljung_box_p < 0.05:
             warnings.add(WarningCode.SERIAL_CORRELATION_DETECTED)

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 # trusted at all).
 MIN_PERIODS_HARD: int = 20
 
-# ``MIN_PERIODS_HARD <= T < MIN_PERIODS_RELIABLE`` → verdict still emitted, but
+# ``MIN_PERIODS_HARD <= T < MIN_PERIODS_WARN`` → verdict still emitted, but
 # tagged with :attr:`factrix._codes.WarningCode.UNRELIABLE_SE_SHORT_PERIODS`.
-MIN_PERIODS_RELIABLE: int = 30
+MIN_PERIODS_WARN: int = 30
 
 # ``n_assets < MIN_ASSETS`` → :attr:`factrix._codes.WarningCode.SMALL_CROSS_SECTION_N`
 # from PANEL ``common_continuous`` and from ``suggest_config``. The cross-asset
@@ -24,11 +24,11 @@ MIN_PERIODS_RELIABLE: int = 30
 # the n_periods ``_HARD`` (which means "raise") would be misleading.
 MIN_ASSETS: int = 10
 
-# ``MIN_ASSETS <= n_assets < MIN_ASSETS_RELIABLE`` →
+# ``MIN_ASSETS <= n_assets < MIN_ASSETS_WARN`` →
 # :attr:`factrix._codes.WarningCode.BORDERLINE_CROSS_SECTION_N`. Mirrors
-# ``MIN_PERIODS_RELIABLE`` semantically: residual t_crit inflation 5–15%
+# ``MIN_PERIODS_WARN`` semantically: residual t_crit inflation 5–15%
 # (n_assets=10 → +15%, n_assets=20 → +7%, n_assets=30 → +5%).
-MIN_ASSETS_RELIABLE: int = 30
+MIN_ASSETS_WARN: int = 30
 
 
 # Broadcast-dummy event count for the ``(COMMON, SPARSE, None, PANEL)``
@@ -45,11 +45,11 @@ MIN_ASSETS_RELIABLE: int = 30
 # slope and its SE are both dominated by individual points).
 MIN_BROADCAST_EVENTS_HARD: int = 5
 
-# ``MIN_BROADCAST_EVENTS_HARD <= n_events < MIN_BROADCAST_EVENTS_RELIABLE`` →
+# ``MIN_BROADCAST_EVENTS_HARD <= n_events < MIN_BROADCAST_EVENTS_WARN`` →
 # :attr:`factrix._codes.WarningCode.SPARSE_COMMON_FEW_EVENTS`. Aligns with
 # the ``MIN_TS_OBS = 20`` philosophy: slope is estimable but cross-event
 # averaging is too thin for the asymptotic t-distribution to be trusted.
-MIN_BROADCAST_EVENTS_RELIABLE: int = 20
+MIN_BROADCAST_EVENTS_WARN: int = 20
 
 
 def auto_bartlett(T: int) -> int:

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -35,9 +35,30 @@ MAD_CONSISTENCY_CONSTANT: float = 1.4826
 # Renamed from MIN_IC_PERIODS in #18 — the "PERIODS" suffix was misleading;
 # the value has always been checked against per-date asset counts.
 MIN_ASSETS_PER_DATE_IC: int = 10
-MIN_EVENTS: int = 10
+
+# Two-tier event-count guard for CAAR / Brown-Warner-family tests.
+# ``n < MIN_EVENTS_HARD`` short-circuits to NaN MetricOutput (math floor —
+# below 4 events the per-event-date series cannot support a meaningful
+# t-statistic). ``MIN_EVENTS_HARD ≤ n < MIN_EVENTS_WARN`` returns the
+# stat AND emits ``WarningCode.FEW_EVENTS_BROWN_WARNER`` so the caller
+# knows power is thin (Brown-Warner 1985 convention is ~30 events for
+# the asymptotic t to be honest). Descriptive event-quality / horizon /
+# clustering metrics use only the HARD floor — they have no formal
+# hypothesis test, so the WARN tier would be noise.
+MIN_EVENTS_HARD: int = 4
+MIN_EVENTS_WARN: int = 30
+
 MIN_OOS_PERIODS: int = 5
-MIN_PORTFOLIO_PERIODS: int = 5
+
+# Two-tier portfolio-period guard for portfolio-level inference (top
+# concentration t-test). ``n < MIN_PORTFOLIO_PERIODS_HARD`` short-circuits
+# (with 3 dates the cross-time t-test on the per-date ratio is undefined);
+# ``HARD ≤ n < WARN`` returns the stat with
+# ``WarningCode.BORDERLINE_PORTFOLIO_PERIODS`` and a Python ``UserWarning``.
+# Descriptive quantile / asymmetry diagnostics use only HARD.
+MIN_PORTFOLIO_PERIODS_HARD: int = 3
+MIN_PORTFOLIO_PERIODS_WARN: int = 20
+
 MIN_MONOTONICITY_PERIODS: int = 5
 
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -262,13 +262,16 @@ inspects the `date` dtype.
 
 | WarningCode | Description (canonical) |
 |---|---|
-| `unreliable_se_short_periods` | `n_periods` is below `MIN_PERIODS_RELIABLE=30`; NW HAC SE may be biased. |
+| `unreliable_se_short_periods` | `n_periods` is below `MIN_PERIODS_WARN=30`; NW HAC SE may be biased. |
 | `event_window_overlap` | Adjacent events sit within `forward_periods`; AR windows overlap. |
 | `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
 | `small_cross_section_n` | PANEL cross-asset t-test with `n_assets < MIN_ASSETS (10)`; df too low. |
-| `borderline_cross_section_n` | PANEL cross-asset t-test with `MIN_ASSETS ≤ n_assets < MIN_ASSETS_RELIABLE` (10..29); residual t_crit inflation 5–15%. |
+| `borderline_cross_section_n` | PANEL cross-asset t-test with `MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN` (10..29); residual t_crit inflation 5–15%. |
 | `sparse_common_few_events` | `(COMMON, SPARSE, PANEL)` broadcast dummy has 5..19 events; per-asset β estimable but cross-event averaging too thin for asymptotic t. |
+| `sparse_magnitude_weighted` | Sparse factor column is mixed-sign and not a clean ±1 ternary; statistic is magnitude-weighted (Sefcik-Thompson) rather than textbook MacKinlay signed CAAR — apply `.sign()` before calling for sign-flip semantics. |
+| `few_events_brown_warner` | CAAR significance test with `MIN_EVENTS_HARD ≤ n_event_dates < MIN_EVENTS_WARN` (4..29); t-stat returned but Brown-Warner (1985) convention treats sub-30 events as power-thin for the asymptotic t. |
+| `borderline_portfolio_periods` | `top_concentration` with `MIN_PORTFOLIO_PERIODS_HARD ≤ n_periods < MIN_PORTFOLIO_PERIODS_WARN` (3..19); one-sided t-test on the per-date diversification ratio is returned but `df=n-1` inflates t_crit. |
 
 `InfoCode.SCOPE_AXIS_COLLAPSED` — `N=1` collapsed scope axis; routed via the
 `_SCOPE_COLLAPSED` sentinel (only fires for `SPARSE × TIMESERIES`).

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 import polars as pl
 
-from factrix._types import MetricOutput
+from factrix._types import EPSILON, MetricOutput
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
 # tie_policy="ordinal". 0.3 is the empirical cutoff for "crowded" factors
@@ -285,6 +285,37 @@ def _warn_high_tie_ratio(
         UserWarning,
         stacklevel=3,
     )
+
+
+def _is_sparse_magnitude_weighted(
+    df: pl.DataFrame,
+    factor_col: str = "factor",
+) -> bool:
+    """``True`` iff ``factor_col`` is mixed-sign and not a clean ±1 ternary.
+
+    Sparse procedures and ``compute_caar`` accept ``{0, 1}`` event
+    indicators or ``{0, R}, R ∈ ℝ`` magnitude-weighted columns. Mixed
+    signs with non-unit magnitudes (e.g. ``{-2.5, 0, +1.3}``) yield the
+    Sefcik-Thompson (1986) magnitude-weighted statistic rather than the
+    MacKinlay (1997) signed CAAR — a different estimator at finite
+    samples when the negative- and positive-leg vols disagree.
+    ``{-1, 0, +1}`` does not trigger (sign and weight semantics coincide
+    numerically); all-non-negative columns do not trigger (no flip
+    ambiguity).
+    """
+    nz = df.filter(pl.col(factor_col) != 0)[factor_col].unique().to_list()
+    if not nz:
+        return False
+    has_neg = any(v < 0 for v in nz)
+    has_pos = any(v > 0 for v in nz)
+    if not (has_neg and has_pos):
+        return False
+    # Tolerance check on |v|=1: upstream casts (e.g. .sign() composed
+    # with floating-point arithmetic) can produce values like
+    # ``-1.0000001`` that should still register as the clean ±1
+    # ternary regime. Reuses the project-wide numerical noise floor
+    # ``EPSILON``.
+    return not all(abs(abs(v) - 1.0) < EPSILON for v in nz)
 
 
 def _median_universe_size(df: pl.DataFrame) -> int:

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -19,17 +19,28 @@ Matrix-row: compute_caar, caar, bmp_test | (*, SPARSE, *, PANEL) | per-event | n
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import polars as pl
 
+from factrix._codes import WarningCode
 from factrix._stats import (
     _calc_t_stat,
     _p_value_from_t,
     _p_value_from_z,
     _significance_marker,
 )
-from factrix._types import DDOF, EPSILON, MIN_EVENTS, KPSource, MetricOutput
+from factrix._types import (
+    DDOF,
+    EPSILON,
+    MIN_EVENTS_HARD,
+    MIN_EVENTS_WARN,
+    KPSource,
+    MetricOutput,
+)
 from factrix.metrics._helpers import (
+    _is_sparse_magnitude_weighted,
     _sample_non_overlapping,
     _scaled_min_periods,
     _short_circuit_output,
@@ -106,7 +117,26 @@ def compute_caar(
         produced when ``factor`` is continuous.
         [Brown-Warner 1985][brown-warner-1985]: daily event-study
         methodology backing the parametric-test path.
+
+    Note:
+        When ``factor_col`` triggers ``_is_sparse_magnitude_weighted``
+        the primitive emits a Python ``UserWarning`` directly. The
+        sparse PANEL procedures additionally attach
+        ``WarningCode.SPARSE_MAGNITUDE_WEIGHTED`` to
+        ``FactorProfile.warnings`` independently — the dual emission is
+        deliberate so batch runs that silence Python warnings still
+        surface the regime-switch through the structured channel.
     """
+    if _is_sparse_magnitude_weighted(df, factor_col):
+        warnings.warn(
+            "compute_caar: factor column is mixed-sign and not a clean ±1 "
+            "ternary. The result is the Sefcik-Thompson (1986) "
+            "magnitude-weighted CAAR, not the textbook MacKinlay (1997) "
+            "signed CAAR; apply .sign() to the column before calling for "
+            "sign-flip semantics.",
+            UserWarning,
+            stacklevel=2,
+        )
     return (
         df.filter(pl.col(factor_col) != 0)
         .with_columns((pl.col(return_col) * pl.col(factor_col)).alias("_signed_car"))
@@ -151,14 +181,27 @@ def caar(
     """
     vals = caar_df["caar"].drop_nulls()
     n = len(vals)
-    raw_min = _scaled_min_periods(MIN_EVENTS, forward_periods)
-    if n < raw_min:
+    raw_min_hard = _scaled_min_periods(MIN_EVENTS_HARD, forward_periods)
+    raw_min_warn = _scaled_min_periods(MIN_EVENTS_WARN, forward_periods)
+    if n < raw_min_hard:
         return _short_circuit_output(
             "caar",
             "insufficient_event_dates",
             n_observed=n,
-            min_required=raw_min,
+            min_required=raw_min_hard,
             forward_periods=forward_periods,
+        )
+
+    warning_codes: list[str] = []
+    if n < raw_min_warn:
+        warning_codes.append(WarningCode.FEW_EVENTS_BROWN_WARNER.value)
+        warnings.warn(
+            f"caar: n_event_dates={n} below MIN_EVENTS_WARN-scaled floor="
+            f"{raw_min_warn}; Brown-Warner (1985) convention treats sub-30 "
+            f"events as power-thin for the asymptotic t-distribution. "
+            f"t-stat returned but read p-values cautiously.",
+            UserWarning,
+            stacklevel=2,
         )
 
     mean_caar = float(vals.mean())
@@ -172,19 +215,23 @@ def caar(
     )
     p = _p_value_from_t(t, n_sampled)
 
+    metadata: dict = {
+        "n_event_dates": n,
+        "n_sampled": n_sampled,
+        "p_value": p,
+        "stat_type": "t",
+        "h0": "mu=0",
+        "method": "non-overlapping t-test",
+    }
+    if warning_codes:
+        metadata["warning_codes"] = warning_codes
+
     return MetricOutput(
         name="caar",
         value=mean_caar,
         stat=t,
         significance=_significance_marker(p),
-        metadata={
-            "n_event_dates": n,
-            "n_sampled": n_sampled,
-            "p_value": p,
-            "stat_type": "t",
-            "h0": "mu=0",
-            "method": "non-overlapping t-test",
-        },
+        metadata=metadata,
     )
 
 
@@ -196,6 +243,7 @@ def bmp_test(
     estimation_window: int = 60,
     forward_periods: int = 5,
     kolari_pynnonen_adjust: bool = False,
+    include_prediction_error_variance: bool = False,
 ) -> MetricOutput:
     r"""Boehmer-Musumeci-Poulsen Standardized Abnormal Return test.
 
@@ -234,6 +282,28 @@ def bmp_test(
             factors of 1.5-2×. Enable this when the event-study
             ``clustering_hhi`` diagnostic is high (≥ 0.3) or when you
             otherwise expect same-date shock sharing.
+        include_prediction_error_variance: When True, inflate the
+            per-event standardiser by $\sqrt{1 + 1/T_{\mathrm{est}}}$
+            (with $T_{\mathrm{est}}$ = ``estimation_window``) to absorb
+            the prediction-error variance of the mean-adjusted residual
+            forecast — the strict BMP (1991) denominator. Default is
+            False, preserving the prior factrix denominator (residual
+            std only). Under mean-adjusted residuals + a single
+            ``estimation_window`` the correction scales every SAR by
+            the same constant, so ``mean_SAR`` and ``std_SAR`` shrink
+            by $1/\sqrt{1 + 1/T_{\mathrm{est}}}$ but the $z$ statistic
+            is invariant: the flag documents the strict standardiser,
+            it does not move inference in this regime. Per-event $T_i$
+            variation (which would move $z$) requires a market-model
+            extension and is out of scope here.
+
+            Caveat: ``rolling_std(min_samples=20)`` accepts events with
+            as few as 20 prior returns, so the effective $T_i$ for
+            early-history events can be smaller than ``estimation_window``.
+            The constant correction is therefore an approximation in
+            that regime; ensure every event has at least
+            ``estimation_window`` prior returns when the strict denominator
+            matters.
 
     Returns:
         MetricOutput(name="bmp_test", value=mean_SAR, stat=z_bmp, ...).
@@ -252,6 +322,8 @@ def bmp_test(
         rather than market-model residuals) — adequate for the default
         Brown-Warner / MacKinlay event-study path; pair with the K-P
         adjustment when ``clustering_hhi`` flags same-date shock sharing.
+        Pass ``include_prediction_error_variance=True`` for the strict
+        BMP denominator $\sigma_i \cdot \sqrt{1 + 1/T_{\mathrm{est}}}$.
 
     References:
         [Boehmer-Musumeci-Poulsen 1991][boehmer-musumeci-poulsen-1991]:
@@ -274,6 +346,13 @@ def bmp_test(
     else:
         sorted_df = sorted_df.with_columns(pl.col(return_col).alias("_daily_ret"))
         vol_scale = 1.0
+
+    # Strict BMP (1991) denominator for mean-adjusted residuals: a
+    # forecast SE is √(1 + 1/T) larger than the in-sample residual std.
+    # Off by default — flipping it shifts every z by a known factor and
+    # downstream callers may calibrate against the simpler denominator.
+    if include_prediction_error_variance:
+        vol_scale *= float(np.sqrt(1.0 + 1.0 / estimation_window))
 
     # WHY: no .shift(1) needed — forward_return already starts at t+1
     # (compute_forward_return uses t+1 entry), so the estimation window
@@ -305,12 +384,12 @@ def bmp_test(
     )
 
     n_valid = len(valid)
-    if n_valid < MIN_EVENTS:
+    if n_valid < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "bmp_test",
             "insufficient_estimation_window",
             n_observed=n_valid,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     valid = valid.with_columns(
@@ -330,6 +409,7 @@ def bmp_test(
         "stat_type": "z",
         "h0": "mu_SAR=0",
         "method": "BMP standardized cross-sectional test",
+        "include_prediction_error_variance": include_prediction_error_variance,
     }
 
     if kolari_pynnonen_adjust:

--- a/factrix/metrics/clustering.py
+++ b/factrix/metrics/clustering.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from factrix._types import MIN_EVENTS, MetricOutput
+from factrix._types import MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
 
@@ -65,12 +65,12 @@ def clustering_diagnostic(
     events = df.filter(pl.col(factor_col) != 0)
     n_events = len(events)
 
-    if n_events < MIN_EVENTS:
+    if n_events < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "clustering_hhi",
             "insufficient_events",
             n_observed=n_events,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     # Count events per date

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -15,14 +15,18 @@ Matrix-row: top_concentration | (INDIVIDUAL, CONTINUOUS, *, PANEL) | CS-first | 
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import polars as pl
 
+from factrix._codes import WarningCode
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
     DDOF,
     EPSILON,
-    MIN_PORTFOLIO_PERIODS,
+    MIN_PORTFOLIO_PERIODS_HARD,
+    MIN_PORTFOLIO_PERIODS_WARN,
     ConcentrationWeight,
     MetricOutput,
 )
@@ -129,13 +133,27 @@ def top_concentration(
         .sort("date")
     )
 
-    if len(hhi_per_date) < MIN_PORTFOLIO_PERIODS:
+    n_periods_hhi = len(hhi_per_date)
+    if n_periods_hhi < MIN_PORTFOLIO_PERIODS_HARD:
         return _short_circuit_output(
             "top_concentration",
             "insufficient_portfolio_periods",
-            n_observed=len(hhi_per_date),
-            min_required=MIN_PORTFOLIO_PERIODS,
+            n_observed=n_periods_hhi,
+            min_required=MIN_PORTFOLIO_PERIODS_HARD,
             tie_ratio=tie_ratio,
+        )
+
+    warning_codes: list[str] = []
+    if n_periods_hhi < MIN_PORTFOLIO_PERIODS_WARN:
+        warning_codes.append(WarningCode.BORDERLINE_PORTFOLIO_PERIODS.value)
+        warnings.warn(
+            f"top_concentration: n_periods={n_periods_hhi} below "
+            f"MIN_PORTFOLIO_PERIODS_WARN={MIN_PORTFOLIO_PERIODS_WARN}; "
+            f"the one-sided t-test on the per-date diversification ratio is "
+            f"returned but df=n-1 inflates t_crit relative to the asymptotic "
+            f"cutoff. Read borderline p-values cautiously.",
+            UserWarning,
+            stacklevel=2,
         )
 
     eff_n_arr = hhi_per_date["eff_n"].to_numpy()
@@ -156,19 +174,22 @@ def top_concentration(
 
     # WHY: one-sided test → p = P(T < t), not two-sided
     p = _p_value_from_t(t, n, alternative="less")
+    metadata: dict = {
+        "p_value": p,
+        "stat_type": "t",
+        "h0": "ratio>=0.5",
+        "method": "one-sided t-test on ratio",
+        "mean_n_top": mean_n_top,
+        "ratio_eff_to_total": ratio,
+        "tie_ratio": tie_ratio,
+        "weight_by": weight_by,
+    }
+    if warning_codes:
+        metadata["warning_codes"] = warning_codes
     return MetricOutput(
         name="top_concentration",
         value=mean_eff_n,
         stat=t,
         significance=_significance_marker(p),
-        metadata={
-            "p_value": p,
-            "stat_type": "t",
-            "h0": "ratio>=0.5",
-            "method": "one-sided t-test on ratio",
-            "mean_n_top": mean_n_top,
-            "ratio_eff_to_total": ratio,
-            "tie_ratio": tie_ratio,
-            "weight_by": weight_by,
-        },
+        metadata=metadata,
     )

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -28,7 +28,7 @@ import numpy as np
 import polars as pl
 
 from factrix._stats import _calc_t_stat, _p_value_from_z, _significance_marker
-from factrix._types import EPSILON, MIN_EVENTS, MetricOutput
+from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
 
@@ -99,12 +99,12 @@ def corrado_rank_test(
     events = ranked.filter(pl.col(factor_col) != 0)
     n_events = len(events)
 
-    if n_events < MIN_EVENTS:
+    if n_events < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "corrado_rank",
             "insufficient_events",
             n_observed=n_events,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     u_event = events["_rank_u"].to_numpy() * np.sign(events[factor_col].to_numpy())

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -22,7 +22,7 @@ import numpy as np
 import polars as pl
 
 from factrix._stats import _significance_marker
-from factrix._types import EPSILON, MIN_EVENTS, MetricOutput
+from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
 
@@ -295,7 +295,7 @@ def multi_horizon_hit_rate(
     for h in horizons:
         subset = event_rets.filter(pl.col("offset") == h)["signed_return"]
         n = len(subset)
-        if n < MIN_EVENTS:
+        if n < MIN_EVENTS_HARD:
             per_horizon[h] = {"hit_rate": None, "n": n}
             continue
 

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -30,7 +30,7 @@ from factrix._stats import (
     _binomial_two_sided_p,
     _significance_marker,
 )
-from factrix._types import EPSILON, MIN_EVENTS, MetricOutput
+from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output, _signed_car
 
 
@@ -61,12 +61,12 @@ def event_hit_rate(
     events = df.filter(pl.col(factor_col) != 0)
 
     n = len(events)
-    if n < MIN_EVENTS:
+    if n < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "event_hit_rate",
             "insufficient_events",
             n_observed=n,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     signed = _signed_car(events, factor_col, return_col)
@@ -138,12 +138,12 @@ def event_ic(
     events = df.filter(pl.col(factor_col) != 0)
     n = len(events)
 
-    if n < MIN_EVENTS:
+    if n < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "event_ic",
             "insufficient_events",
             n_observed=n,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     abs_signal = np.abs(events[factor_col].to_numpy())
@@ -212,12 +212,12 @@ def profit_factor(
     events = df.filter(pl.col(factor_col) != 0)
     n = len(events)
 
-    if n < MIN_EVENTS:
+    if n < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "profit_factor",
             "insufficient_events",
             n_observed=n,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     signed = _signed_car(events, factor_col, return_col)
@@ -277,12 +277,12 @@ def event_skewness(
     events = df.filter(pl.col(factor_col) != 0)
     n = len(events)
 
-    if n < MIN_EVENTS:
+    if n < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "event_skewness",
             "insufficient_events",
             n_observed=n,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     signed = _signed_car(events, factor_col, return_col)

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -21,10 +21,12 @@ Matrix-row: compute_fm_betas, fama_macbeth, pooled_ols, beta_sign_consistency | 
 from __future__ import annotations
 
 import math
+import warnings
 
 import numpy as np
 import polars as pl
 
+from factrix._codes import WarningCode
 from factrix._stats import (
     _newey_west_t_test,
     _p_value_from_t,
@@ -33,7 +35,13 @@ from factrix._stats import (
 from factrix._types import DDOF, EPSILON, MetricOutput, ShankenVarSource
 from factrix.metrics._helpers import _short_circuit_output
 
-MIN_FM_PERIODS: int = 20
+# Two-tier sample-size guard on the FM β series. ``T < HARD`` short-
+# circuits — NW HAC SE on a 3-period series is undefined. ``HARD ≤ T <
+# WARN`` returns the stat with ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS``
+# attached (literature floor: Fama-MacBeth originally used T~30+; below
+# that the asymptotic t is borderline). ``T ≥ WARN`` is silent.
+MIN_FM_PERIODS_HARD: int = 4
+MIN_FM_PERIODS_WARN: int = 30
 
 
 # ---------------------------------------------------------------------------
@@ -190,12 +198,24 @@ def fama_macbeth(
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
 
-    if n < MIN_FM_PERIODS:
+    if n < MIN_FM_PERIODS_HARD:
         return _short_circuit_output(
             "fm_beta",
             "insufficient_fm_periods",
             n_observed=n,
-            min_required=MIN_FM_PERIODS,
+            min_required=MIN_FM_PERIODS_HARD,
+        )
+
+    warning_codes: list[str] = []
+    if n < MIN_FM_PERIODS_WARN:
+        warning_codes.append(WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value)
+        warnings.warn(
+            f"fama_macbeth: n_periods={n} below MIN_FM_PERIODS_WARN="
+            f"{MIN_FM_PERIODS_WARN}; NW HAC SE on a short β series is "
+            f"borderline (Fama-MacBeth convention is T≥30). t-stat is "
+            f"returned but read p-values cautiously.",
+            UserWarning,
+            stacklevel=2,
         )
 
     from factrix._stats import _resolve_nw_lags
@@ -218,6 +238,8 @@ def fama_macbeth(
         "forward_periods": forward_periods,
         "is_estimated_factor": is_estimated_factor,
     }
+    if warning_codes:
+        metadata["warning_codes"] = warning_codes
 
     if is_estimated_factor:
         sigma2_f = (

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -14,6 +14,7 @@ Matrix-row: compute_ic, ic, ic_newey_west, ic_ir, regime_ic, multi_horizon_ic | 
 from __future__ import annotations
 
 import math
+import warnings as _warnings
 
 import polars as pl
 
@@ -29,11 +30,44 @@ from factrix._types import (
     MetricOutput,
 )
 from factrix.metrics._helpers import (
+    TIE_RATIO_WARN_THRESHOLD,
     _sample_non_overlapping,
     _scaled_min_periods,
     _short_circuit_output,
 )
 from factrix.stats import bhy_adjusted_p
+
+
+def _median_tie_ratio(ic_df: pl.DataFrame) -> float:
+    """Median of the per-date ``tie_ratio`` column, or ``nan`` if absent/empty."""
+    if "tie_ratio" not in ic_df.columns:
+        return float("nan")
+    med = ic_df["tie_ratio"].median()
+    return float("nan") if med is None else float(med)
+
+
+def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
+    """Emit ``UserWarning`` when median tie_ratio exceeds the global threshold.
+
+    Returns the median for caller to stash in metadata. The Spearman ρ on
+    average ranks is biased relative to the tie-corrected formula
+    (Kendall-Stuart §31) at high tie densities — a bucketed / categorical
+    factor will look like it has IC ≈ 0 even if the bucketing is
+    informative. Threshold reuses the global ``TIE_RATIO_WARN_THRESHOLD``
+    (0.3) shared with the quantile-bucketing diagnostics.
+    """
+    med = _median_tie_ratio(ic_df)
+    if not math.isnan(med) and med > TIE_RATIO_WARN_THRESHOLD:
+        _warnings.warn(
+            f"{metric_name}: median tie_ratio={med:.3f} exceeds "
+            f"{TIE_RATIO_WARN_THRESHOLD:.2f}. Spearman ρ on average ranks is "
+            f"biased on bucketed / categorical factors; treat the IC "
+            f"magnitude as a lower bound and consider a tie-corrected "
+            f"correlation or a continuous transform of the factor.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return med
 
 
 def compute_ic(
@@ -47,8 +81,10 @@ def compute_ic(
         df: Panel with ``date``, ``asset_id``, ``factor_col``, ``return_col``.
 
     Returns:
-        DataFrame with columns ``date, ic`` sorted by date.
+        DataFrame with columns ``date, ic, tie_ratio`` sorted by date.
         Dates with fewer than ``MIN_ASSETS_PER_DATE_IC`` assets are dropped.
+        ``tie_ratio`` is the per-date factor tie density
+        $1 - n_{\mathrm{unique}} / n$ in $[0, 1]$.
 
     Notes:
         Per-date Spearman IC is
@@ -57,10 +93,16 @@ def compute_ic(
         average rank (``method="average"``).
 
         At high tie rates Spearman $\rho$ on average ranks is biased
-        relative to the tie-corrected formula (Kendall-Stuart §31).
-        factrix does not surface ``tie_ratio`` from this primitive; if
-        you suspect a bucketed / categorical signal, inspect tie density
-        on the input before reporting IC.
+        relative to the tie-corrected formula (Kendall-Stuart §31). The
+        per-date factor ``tie_ratio`` is surfaced alongside ``ic`` so
+        downstream callers can detect bucketed / categorical signals
+        without re-inspecting the input; ``ic`` / ``ic_newey_west`` /
+        ``ic_ir`` aggregate it as the median across dates and stash it in
+        ``MetricOutput.metadata["tie_ratio"]``. When the median exceeds
+        ``TIE_RATIO_WARN_THRESHOLD`` (0.3) those aggregators also emit a
+        ``UserWarning``: treat the IC magnitude as a lower bound and
+        consider a tie-corrected correlation or a continuous transform
+        of the factor.
 
         factrix drops dates whose cross-section has fewer than
         ``MIN_ASSETS_PER_DATE_IC`` assets — undersized panels yield
@@ -83,10 +125,11 @@ def compute_ic(
         .agg(
             pl.corr("_rank_factor", "_rank_return").alias("ic"),
             pl.len().alias("n"),
+            (1.0 - pl.col(factor_col).n_unique() / pl.len()).alias("tie_ratio"),
         )
         .filter(pl.col("n") >= MIN_ASSETS_PER_DATE_IC)
         .sort("date")
-        .select("date", "ic")
+        .select("date", "ic", "tie_ratio")
     )
 
 
@@ -121,6 +164,7 @@ def ic(
         returns carry MA(K-1) autocorrelation — the motivation for the
         non-overlap stride used here.
     """
+    median_tie = _warn_if_high_ic_tie_ratio(ic_df, "ic")
     ic_vals = ic_df["ic"].drop_nulls()
     n = len(ic_vals)
     raw_min = _scaled_min_periods(MIN_ASSETS_PER_DATE_IC, forward_periods)
@@ -158,6 +202,7 @@ def ic(
             "stat_type": "t",
             "h0": "mu=0",
             "method": "non-overlapping t-test",
+            "tie_ratio": median_tie,
         },
     )
 
@@ -194,6 +239,7 @@ def ic_newey_west(
         [Newey-West 1994][newey-west-1994]: data-adaptive lag-selection
         alternative; cited as background.
     """
+    median_tie = _warn_if_high_ic_tie_ratio(ic_df, "ic_newey_west")
     ic_vals = ic_df["ic"].drop_nulls().to_numpy()
     n = len(ic_vals)
     if n < MIN_ASSETS_PER_DATE_IC:
@@ -221,6 +267,7 @@ def ic_newey_west(
             "method": "Newey-West HAC t-test on overlapping IC series",
             "newey_west_lags": lags,
             "forward_periods": forward_periods,
+            "tie_ratio": median_tie,
         },
     )
 
@@ -255,6 +302,7 @@ def ic_ir(
         [Grinold 1989][grinold-1989]: ICIR is the time-stability
         normalisation that completes the IR decomposition.
     """
+    median_tie = _warn_if_high_ic_tie_ratio(ic_df, "ic_ir")
     ic_vals = ic_df["ic"].drop_nulls()
     n = len(ic_vals)
     if n < MIN_ASSETS_PER_DATE_IC:
@@ -280,7 +328,12 @@ def ic_ir(
     return MetricOutput(
         name="ic_ir",
         value=ratio,
-        metadata={"mean_ic": mean_ic, "std_ic": std_ic, "n_periods": n},
+        metadata={
+            "mean_ic": mean_ic,
+            "std_ic": std_ic,
+            "n_periods": n,
+            "tie_ratio": median_tie,
+        },
     )
 
 

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-from factrix._types import EPSILON, MIN_EVENTS, MetricOutput
+from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
 DEFAULT_MIN_ESTIMATION_SAMPLES: int = 20
@@ -231,7 +231,7 @@ def mfe_mae_summary(mfe_mae_df: pl.DataFrame) -> MetricOutput:
 
     Returns:
         MetricOutput with value=MFE_p50/|MAE_p75| ratio. On insufficient
-        data (empty input or fewer than ``MIN_EVENTS`` rows), returns a
+        data (empty input or fewer than ``MIN_EVENTS_HARD`` rows), returns a
         short-circuit MetricOutput (``value=NaN``, ``metadata["reason"]``
         set) so all metrics share a single return contract.
 
@@ -255,12 +255,12 @@ def mfe_mae_summary(mfe_mae_df: pl.DataFrame) -> MetricOutput:
         )
 
     n = len(mfe_mae_df)
-    if n < MIN_EVENTS:
+    if n < MIN_EVENTS_HARD:
         return _short_circuit_output(
             "mfe_mae_summary",
             "insufficient_events",
             n_events=n,
-            min_required=MIN_EVENTS,
+            min_required=MIN_EVENTS_HARD,
         )
 
     mfe_p50 = float(mfe_mae_df["mfe"].quantile(0.50))
@@ -287,7 +287,7 @@ def mfe_mae_summary(mfe_mae_df: pl.DataFrame) -> MetricOutput:
     if "mfe_z" in mfe_mae_df.columns:
         mfe_z = mfe_mae_df["mfe_z"].drop_nulls().drop_nans()
         mae_z = mfe_mae_df["mae_z"].drop_nulls().drop_nans()
-        if len(mfe_z) >= MIN_EVENTS and len(mae_z) >= MIN_EVENTS:
+        if len(mfe_z) >= MIN_EVENTS_HARD and len(mae_z) >= MIN_EVENTS_HARD:
             mfe_z_p50 = float(mfe_z.quantile(0.50))
             mae_z_p75 = float(mae_z.quantile(0.75))
             metadata["mfe_z_p50"] = mfe_z_p50

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -81,16 +81,13 @@ def multi_split_oos_decay(
         MetricOutput with:
 
         - ``name``: "oos_decay"
-        - ``value``: median survival ratio across splits (0.0 on short-circuit)
-        - ``stat``: None (descriptive statistic, not a hypothesis test)
+        - ``value``: median survival ratio across splits (NaN on short-circuit)
+        - ``stat``: None — descriptive only (no hypothesis test attached; a t-stat at ``MIN_OOS_PERIODS = 5`` would have power ≈ 0 and invite mis-reading the diagnostic as a significance test).
         - ``metadata``:
 
             - ``sign_flipped`` (bool): any split had sign flip
             - ``status`` ("PASS" | "VETOED")
             - ``per_split`` (list[dict]): see ``SplitDetail.to_dict``
-            - ``p_value`` (float): 1.0 (not a hypothesis test; conservative
-              default so downstream BHY doesn't treat descriptive stats as
-              significant by omission)
             - ``method`` (str): "multi-split OOS decay"
             - ``survival_threshold`` (float)
             - ``reason`` (str, short-circuit only): "insufficient_oos_periods"
@@ -106,9 +103,10 @@ def multi_split_oos_decay(
 
         factrix reports the **median** across splits rather than mean:
         a single regime change landing inside one split distorts the
-        mean disproportionately. Descriptive only — no formal H0 is
-        attached and ``p_value`` is set to 1.0 so downstream BHY does
-        not treat the diagnostic as a significant test.
+        mean disproportionately. Descriptive only — no ``p_value`` is
+        emitted (the multi-split structure already conveys the
+        signal-decay message; running a t-test at the
+        ``MIN_OOS_PERIODS`` floor would have power ≈ 0).
 
     References:
         - McLean & Pontiff (2016): average OOS decay ~32%.
@@ -122,7 +120,7 @@ def multi_split_oos_decay(
     n = len(vals)
 
     if n < MIN_OOS_PERIODS * 2:
-        return _short_circuit_output(
+        out = _short_circuit_output(
             "oos_decay",
             "insufficient_oos_periods",
             n_observed=n,
@@ -133,6 +131,11 @@ def multi_split_oos_decay(
             method="multi-split OOS decay",
             survival_threshold=survival_threshold,
         )
+        # Descriptive-only: drop ``p_value`` so callers cannot
+        # accidentally route oos_decay into BHY / gate logic that
+        # expects a probability.
+        out.metadata.pop("p_value", None)
+        return out
 
     split_details: list[SplitDetail] = []
     any_sign_flip = False
@@ -165,7 +168,7 @@ def multi_split_oos_decay(
         )
 
     if not split_details:
-        return _short_circuit_output(
+        out = _short_circuit_output(
             "oos_decay",
             "no_valid_splits",
             sign_flipped=False,
@@ -174,6 +177,8 @@ def multi_split_oos_decay(
             method="multi-split OOS decay",
             survival_threshold=survival_threshold,
         )
+        out.metadata.pop("p_value", None)
+        return out
 
     # WHY: 取中位數而非均值，對單一 regime change 落在某 split 點更穩健
     median_survival = float(np.median([d.survival_ratio for d in split_details]))
@@ -195,7 +200,6 @@ def multi_split_oos_decay(
             "sign_flipped": any_sign_flip,
             "status": status,
             "per_split": [sd.to_dict() for sd in split_details],
-            "p_value": 1.0,
             "method": "multi-split OOS decay",
             "survival_threshold": survival_threshold,
             "n_splits": len(split_details),

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -22,7 +22,7 @@ import polars as pl
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
     DDOF,
-    MIN_PORTFOLIO_PERIODS,
+    MIN_PORTFOLIO_PERIODS_HARD,
     MetricOutput,
 )
 from factrix.metrics._helpers import (
@@ -162,12 +162,12 @@ def quantile_spread(
     )
     spread_vals = series["spread"].drop_nulls()
     n = len(spread_vals)
-    if n < MIN_PORTFOLIO_PERIODS:
+    if n < MIN_PORTFOLIO_PERIODS_HARD:
         return _short_circuit_output(
             "quantile_spread",
             "insufficient_portfolio_periods",
             n_observed=n,
-            min_required=MIN_PORTFOLIO_PERIODS,
+            min_required=MIN_PORTFOLIO_PERIODS_HARD,
             tie_ratio=tie_ratio,
             tie_policy=tie_policy,
         )
@@ -268,7 +268,7 @@ def quantile_spread_vw(
     Returns:
         MetricOutput with per-period mean VW spread, t-stat, and p-value.
         Short-circuits if ``weight_col`` is missing or post-sampling n <
-        ``MIN_PORTFOLIO_PERIODS``.
+        ``MIN_PORTFOLIO_PERIODS_HARD``.
 
     Notes:
         Per non-overlapping date ``t``, per bucket ``b in {bot, top}``::
@@ -334,12 +334,12 @@ def quantile_spread_vw(
 
     spread_vals = vw_series["spread_vw"].drop_nulls()
     n = len(spread_vals)
-    if n < MIN_PORTFOLIO_PERIODS:
+    if n < MIN_PORTFOLIO_PERIODS_HARD:
         return _short_circuit_output(
             "quantile_spread_vw",
             "insufficient_portfolio_periods",
             n_observed=n,
-            min_required=MIN_PORTFOLIO_PERIODS,
+            min_required=MIN_PORTFOLIO_PERIODS_HARD,
             tie_ratio=tie_ratio,
             tie_policy=tie_policy,
         )

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -46,7 +46,7 @@ from factrix._stats import (
     _significance_marker,
     _wald_p_linear,
 )
-from factrix._types import MIN_PORTFOLIO_PERIODS, MetricOutput
+from factrix._types import MIN_PORTFOLIO_PERIODS_HARD, MetricOutput
 from factrix.metrics._helpers import (
     _aggregate_to_per_date,
     _short_circuit_output,
@@ -89,7 +89,7 @@ def ts_asymmetry(
         diagnostic statistics live in ``metadata``. Short-circuits
         with a reason code when input shape is insufficient (no
         ``date`` column, missing ``factor`` / return column, fewer
-        than ``MIN_PORTFOLIO_PERIODS`` per-date rows, or no two-sided
+        than ``MIN_PORTFOLIO_PERIODS_HARD`` per-date rows, or no two-sided
         factor variation).
 
     Notes:
@@ -137,12 +137,12 @@ def ts_asymmetry(
     )
     n_periods = len(per_date)
 
-    if n_periods < MIN_PORTFOLIO_PERIODS:
+    if n_periods < MIN_PORTFOLIO_PERIODS_HARD:
         return _short_circuit_output(
             "ts_asymmetry",
             "insufficient_portfolio_periods",
             n_observed=n_periods,
-            min_required=MIN_PORTFOLIO_PERIODS,
+            min_required=MIN_PORTFOLIO_PERIODS_HARD,
         )
 
     f = per_date["_f"].to_numpy()

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -32,7 +32,7 @@ from factrix._stats import (
     _significance_marker,
     _wald_p_linear,
 )
-from factrix._types import EPSILON, MIN_PORTFOLIO_PERIODS, MetricOutput
+from factrix._types import EPSILON, MIN_PORTFOLIO_PERIODS_HARD, MetricOutput
 from factrix.metrics._helpers import (
     _aggregate_to_per_date,
     _short_circuit_output,
@@ -78,7 +78,7 @@ def ts_quantile_spread(
         spread; bucket detail and the Spearman monotonicity diagnostic
         live in ``metadata``. Short-circuits with a reason code when
         input shape is insufficient (no ``date`` / factor / return
-        column, fewer than ``MIN_PORTFOLIO_PERIODS`` rows, or factor
+        column, fewer than ``MIN_PORTFOLIO_PERIODS_HARD`` rows, or factor
         variation below ``n_groups * 2`` distinct values).
 
     Notes:
@@ -122,12 +122,12 @@ def ts_quantile_spread(
     )
     n_periods = len(per_date)
 
-    if n_periods < MIN_PORTFOLIO_PERIODS:
+    if n_periods < MIN_PORTFOLIO_PERIODS_HARD:
         return _short_circuit_output(
             "ts_quantile_spread",
             "insufficient_portfolio_periods",
             n_observed=n_periods,
-            min_required=MIN_PORTFOLIO_PERIODS,
+            min_required=MIN_PORTFOLIO_PERIODS_HARD,
             n_groups=n_groups,
         )
 

--- a/tests/test_caar.py
+++ b/tests/test_caar.py
@@ -1,6 +1,7 @@
 """Tests for factrix.metrics.caar — CAAR, BMP, event_hit_rate, event_ic."""
 
 import math
+import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -181,6 +182,29 @@ class TestComputeCaarInputForms:
         assert len(result) == 1
         assert result["caar"][0] == pytest.approx(0.01)
 
+    def test_warns_on_mixed_sign_non_ternary(self):
+        df = _two_event_panel(2.5, -3.0, 0.01, 0.02)
+        with pytest.warns(UserWarning, match="magnitude-weighted CAAR"):
+            compute_caar(df)
+
+    def test_no_warn_on_clean_ternary(self):
+        df = _two_event_panel(-1.0, 1.0, -0.02, 0.03)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            compute_caar(df)  # must not raise
+
+    def test_no_warn_on_all_non_negative(self):
+        df = _two_event_panel(2.5, 3.0, 0.01, 0.02)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            compute_caar(df)
+
+    def test_no_warn_on_indicator_zero_one(self):
+        df = _two_event_panel(1.0, 1.0, 0.02, -0.01)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            compute_caar(df)
+
     def test_caller_can_opt_into_ternary_via_sign(self):
         df = pl.DataFrame(
             {
@@ -271,6 +295,61 @@ class TestBmpTest:
         # Scaling factor ≤ 1 always (r ∈ [0,1]), so |z_adj| ≤ |z_raw|.
         assert abs(adj.stat) <= abs(raw.stat) + 1e-9
         assert adj.metadata["stat_uncorrected"] == pytest.approx(raw.stat)
+
+    def test_prediction_error_variance_default_off(self, strong_signal):
+        result = bmp_test(strong_signal)
+        assert result.metadata["include_prediction_error_variance"] is False
+
+    def test_prediction_error_variance_scales_value_and_std(self, strong_signal):
+        """Strict denominator √(1+1/T) shrinks each SAR uniformly; z is invariant."""
+        T = 60
+        ratio = 1.0 / math.sqrt(1.0 + 1.0 / T)
+        raw = bmp_test(strong_signal, estimation_window=T)
+        strict = bmp_test(
+            strong_signal,
+            estimation_window=T,
+            include_prediction_error_variance=True,
+        )
+        assert strict.metadata["include_prediction_error_variance"] is True
+        # Uniform SAR rescaling → mean and std scale by the same ratio,
+        # leaving z = mean / (std / √N) invariant. This is the expected
+        # property of BMP under mean-adjusted residuals + a single
+        # estimation_window; the flag exists to document the strict
+        # standardiser, not to alter inference in this regime.
+        assert strict.stat == pytest.approx(raw.stat, rel=1e-6)
+        assert strict.value == pytest.approx(raw.value * ratio, rel=1e-6)
+        assert strict.metadata["std_sar"] == pytest.approx(
+            raw.metadata["std_sar"] * ratio, rel=1e-6
+        )
+
+    def test_pe_variance_composes_with_kolari_pynnonen(self, strong_signal):
+        """Both flags on: PE scales SAR uniformly; KP shrinks z. No interference."""
+        T = 60
+        ratio = 1.0 / math.sqrt(1.0 + 1.0 / T)
+        base = bmp_test(strong_signal, estimation_window=T)
+        pe = bmp_test(
+            strong_signal,
+            estimation_window=T,
+            include_prediction_error_variance=True,
+        )
+        both = bmp_test(
+            strong_signal,
+            estimation_window=T,
+            include_prediction_error_variance=True,
+            kolari_pynnonen_adjust=True,
+        )
+        # PE alone leaves z untouched (uniform SAR rescaling).
+        assert pe.stat == pytest.approx(base.stat, rel=1e-6)
+        # PE+KP composition: value tracks PE rescaling; z is the KP-shrunk
+        # version of the (PE-invariant) BMP z, recoverable from
+        # stat_uncorrected.
+        assert both.metadata["include_prediction_error_variance"] is True
+        assert both.value == pytest.approx(base.value * ratio, rel=1e-6)
+        if both.metadata.get("kolari_pynnonen_applied"):
+            assert abs(both.stat) <= abs(both.metadata["stat_uncorrected"]) + 1e-9
+            assert both.metadata["stat_uncorrected"] == pytest.approx(
+                base.stat, rel=1e-6
+            )
 
     def test_kolari_pynnonen_skipped_without_clusters(self):
         """No multi-event dates → r̂ undefined → correction bypassed."""

--- a/tests/test_caar_procedure.py
+++ b/tests/test_caar_procedure.py
@@ -17,7 +17,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Mode, Signal
-from factrix._codes import StatCode, Verdict
+from factrix._codes import StatCode, Verdict, WarningCode
 from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _CAARSparsePanelProcedure
 from factrix._profile import FactorProfile
@@ -307,3 +307,61 @@ class TestCalendarTimeRegimes:
         profile = _CAARSparsePanelProcedure().compute(panel, cfg)
         assert 0.0 <= profile.stats[StatCode.CAAR_P] <= 1.0
         assert profile.n_obs == 60
+
+
+class TestSparseMagnitudeWeightedWarning:
+    """Individual×Sparse procedure surfaces magnitude-weighted contract warning."""
+
+    def test_mixed_sign_non_ternary_emits_warning(
+        self,
+        cfg: AnalysisConfig,
+    ) -> None:
+        panel = _make_event_panel(n_dates=80, n_assets=20, seed=42, beta=1.0)
+        perturbed = panel.with_columns(
+            pl.when(pl.col("factor") > 0)
+            .then(2.5)
+            .when(pl.col("factor") < 0)
+            .then(-1.7)
+            .otherwise(0.0)
+            .alias("factor")
+        )
+        profile = _CAARSparsePanelProcedure().compute(perturbed, cfg)
+        assert WarningCode.SPARSE_MAGNITUDE_WEIGHTED in profile.warnings
+
+    def test_clean_ternary_silent(self, cfg: AnalysisConfig) -> None:
+        panel = _make_event_panel(n_dates=80, n_assets=20, seed=43, beta=1.0)
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+        assert WarningCode.SPARSE_MAGNITUDE_WEIGHTED not in profile.warnings
+
+
+class TestFewEventsBrownWarner:
+    """`(INDIVIDUAL, SPARSE, PANEL)` propagates Brown-Warner borderline."""
+
+    def test_borderline_event_count_emits_warning(
+        self,
+        cfg: AnalysisConfig,
+    ) -> None:
+        # Density tuned so the seed produces n_event_dates in [4, 30).
+        panel = _make_event_panel(
+            n_dates=120,
+            n_assets=10,
+            seed=51,
+            beta=0.0,
+            event_prob=0.02,
+        )
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+        if profile.n_obs >= 4:  # n_obs is dense; sanity guard
+            ev = panel.filter(pl.col("factor") != 0)["date"].n_unique()
+            if 4 <= ev < 30:
+                assert WarningCode.FEW_EVENTS_BROWN_WARNER in profile.warnings
+
+    def test_many_events_silent(self, cfg: AnalysisConfig) -> None:
+        panel = _make_event_panel(
+            n_dates=200,
+            n_assets=20,
+            seed=52,
+            beta=0.0,
+            event_prob=0.20,
+        )
+        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
+        assert WarningCode.FEW_EVENTS_BROWN_WARNER not in profile.warnings

--- a/tests/test_common_panel_procedures.py
+++ b/tests/test_common_panel_procedures.py
@@ -363,7 +363,7 @@ class TestSparseCommonEventCountGuard:
         self,
         cfg_sparse: AnalysisConfig,
     ) -> None:
-        # 10 events, in [MIN_EVENTS_HARD=5, MIN_EVENTS_RELIABLE=20) → warn.
+        # 10 events, in [MIN_EVENTS_HARD=5, MIN_EVENTS_WARN=20) → warn.
         panel = _make_common_panel(
             n_dates=60,
             n_assets=15,
@@ -376,7 +376,7 @@ class TestSparseCommonEventCountGuard:
         assert WarningCode.SPARSE_COMMON_FEW_EVENTS in profile.warnings
 
     def test_thirty_events_silent(self, cfg_sparse: AnalysisConfig) -> None:
-        # 30 events ≥ MIN_EVENTS_RELIABLE=20 → no event-count warning.
+        # 30 events ≥ MIN_EVENTS_WARN=20 → no event-count warning.
         panel = _make_common_panel(
             n_dates=60,
             n_assets=15,
@@ -387,6 +387,47 @@ class TestSparseCommonEventCountGuard:
         )
         profile = _CommonSparsePanelProcedure().compute(panel, cfg_sparse)
         assert WarningCode.SPARSE_COMMON_FEW_EVENTS not in profile.warnings
+
+
+class TestSparseMagnitudeWeightedWarning:
+    """Common×Sparse procedure surfaces magnitude-weighted contract warning."""
+
+    def test_mixed_sign_non_ternary_emits_warning(
+        self,
+        cfg_sparse: AnalysisConfig,
+    ) -> None:
+        # Build a sparse panel then perturb non-zero events to non-unit
+        # magnitudes so the {-1, 0, +1} contract is broken.
+        panel = _make_common_panel(
+            n_dates=60,
+            n_assets=15,
+            seed=71,
+            true_beta=0.0,
+            factor_kind="sparse",
+            sparse_event_density=0.5,
+        )
+        perturbed = panel.with_columns(
+            pl.when(pl.col("factor") > 0)
+            .then(2.5)
+            .when(pl.col("factor") < 0)
+            .then(-1.7)
+            .otherwise(0.0)
+            .alias("factor")
+        )
+        profile = _CommonSparsePanelProcedure().compute(perturbed, cfg_sparse)
+        assert WarningCode.SPARSE_MAGNITUDE_WEIGHTED in profile.warnings
+
+    def test_clean_ternary_silent(self, cfg_sparse: AnalysisConfig) -> None:
+        panel = _make_common_panel(
+            n_dates=60,
+            n_assets=15,
+            seed=72,
+            true_beta=0.0,
+            factor_kind="sparse",
+            sparse_event_density=0.5,
+        )
+        profile = _CommonSparsePanelProcedure().compute(panel, cfg_sparse)
+        assert WarningCode.SPARSE_MAGNITUDE_WEIGHTED not in profile.warnings
 
 
 class TestCrossSectionNWarnings:

--- a/tests/test_fm_procedure.py
+++ b/tests/test_fm_procedure.py
@@ -14,7 +14,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import StatCode, Verdict
+from factrix._codes import StatCode, Verdict, WarningCode
 from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _FMContPanelProcedure
 from factrix._profile import FactorProfile
@@ -170,3 +170,31 @@ class TestEndToEndViaEvaluate:
         assert isinstance(profile, FactorProfile)
         assert StatCode.FM_LAMBDA_P in profile.stats
         assert profile.verdict() is Verdict.PASS
+
+
+class TestFMShortPeriodsWarning:
+    """`(INDIVIDUAL, CONTINUOUS, FM, PANEL)` propagates short-periods warning."""
+
+    def test_borderline_periods_emits_warning(
+        self,
+        fm_config: AnalysisConfig,
+    ) -> None:
+        # MIN_FM_PERIODS_HARD=4 ≤ n_periods=10 < MIN_FM_PERIODS_WARN=30
+        panel = _make_panel(
+            n_dates=10,
+            n_assets=15,
+            seed=99,
+            factor_strength=0.5,
+        )
+        profile = _FMContPanelProcedure().compute(panel, fm_config)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in profile.warnings
+
+    def test_long_periods_silent(self, fm_config: AnalysisConfig) -> None:
+        panel = _make_panel(
+            n_dates=60,
+            n_assets=15,
+            seed=100,
+            factor_strength=0.5,
+        )
+        profile = _FMContPanelProcedure().compute(panel, fm_config)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS not in profile.warnings

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -17,7 +17,7 @@ from factrix._errors import (
 )
 from factrix._stats.constants import (
     MIN_PERIODS_HARD,
-    MIN_PERIODS_RELIABLE,
+    MIN_PERIODS_WARN,
     auto_bartlett,
 )
 
@@ -86,12 +86,32 @@ class TestCodeEnums:
 
 class TestStatsConstants:
     def test_thresholds_ordered(self) -> None:
-        assert MIN_PERIODS_HARD < MIN_PERIODS_RELIABLE
+        assert MIN_PERIODS_HARD < MIN_PERIODS_WARN
 
     def test_threshold_values(self) -> None:
         # Pinned per §5.2 — these are statistical contract, not a default.
         assert MIN_PERIODS_HARD == 20
-        assert MIN_PERIODS_RELIABLE == 30
+        assert MIN_PERIODS_WARN == 30
+
+    def test_two_tier_thresholds_ordered(self) -> None:
+        # Issue #48 D: every two-tier (HARD, WARN) pair must satisfy
+        # HARD < WARN; otherwise the borderline tier is empty and
+        # callers either short-circuit or run silently with no warning
+        # tier in between.
+        from factrix._types import (
+            MIN_EVENTS_HARD,
+            MIN_EVENTS_WARN,
+            MIN_PORTFOLIO_PERIODS_HARD,
+            MIN_PORTFOLIO_PERIODS_WARN,
+        )
+        from factrix.metrics.fama_macbeth import (
+            MIN_FM_PERIODS_HARD,
+            MIN_FM_PERIODS_WARN,
+        )
+
+        assert MIN_FM_PERIODS_HARD < MIN_FM_PERIODS_WARN
+        assert MIN_EVENTS_HARD < MIN_EVENTS_WARN
+        assert MIN_PORTFOLIO_PERIODS_HARD < MIN_PORTFOLIO_PERIODS_WARN
 
     def test_auto_bartlett_floor(self) -> None:
         assert auto_bartlett(1) == 1

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -44,8 +44,97 @@ class TestComputeIC:
 
     def test_output_schema(self, noisy_panel):
         result = compute_ic(noisy_panel)
-        assert result.columns == ["date", "ic"]
+        assert result.columns == ["date", "ic", "tie_ratio"]
         assert result["date"].dtype == pl.Datetime("ms")
+
+    def test_tie_ratio_zero_on_unique_factor(self, noisy_panel):
+        result = compute_ic(noisy_panel)
+        # noisy_panel factor is continuous noise — no per-date ties expected.
+        assert result["tie_ratio"].max() == pytest.approx(0.0)
+
+    def test_tie_ratio_detects_bucketed_factor(self):
+        """Bucketed factor → tie_ratio surfaces non-trivially per date."""
+        n_assets = 12
+        dates = [datetime(2024, 1, 1) + timedelta(days=d) for d in range(5)]
+        rows = [
+            {
+                "date": dt,
+                "asset_id": f"A{i}",
+                "factor": float(i % 3),  # 3 buckets → ties
+                "forward_return": float(i) * 0.01,
+            }
+            for dt in dates
+            for i in range(n_assets)
+        ]
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = compute_ic(df)
+        # 12 obs, 3 unique → tie_ratio = 1 - 3/12 = 0.75
+        assert result["tie_ratio"].max() == pytest.approx(0.75)
+        assert result["tie_ratio"].min() == pytest.approx(0.75)
+
+    def test_tie_ratio_propagated_to_metadata(self, noisy_panel):
+        from factrix.metrics.ic import ic, ic_ir, ic_newey_west
+
+        ic_df = compute_ic(noisy_panel)
+        for out in (
+            ic(ic_df, forward_periods=1),
+            ic_newey_west(ic_df, forward_periods=1),
+            ic_ir(ic_df),
+        ):
+            assert "tie_ratio" in out.metadata
+            assert 0.0 <= out.metadata["tie_ratio"] <= 1.0
+
+    def test_high_tie_ratio_emits_warning(self):
+        """ic / ic_newey_west / ic_ir warn when median tie_ratio > threshold."""
+        import warnings
+
+        from factrix.metrics.ic import ic, ic_ir, ic_newey_west
+
+        # 12 assets bucketed into 2 buckets per date → tie_ratio = 1 - 2/12
+        # ≈ 0.83 (well above the 0.3 threshold).
+        n_assets = 12
+        dates = [datetime(2024, 1, 1) + timedelta(days=d) for d in range(40)]
+        rows = [
+            {
+                "date": dt,
+                "asset_id": f"A{i}",
+                "factor": float(i % 2),
+                "forward_return": float(i) * 0.01,
+            }
+            for dt in dates
+            for i in range(n_assets)
+        ]
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        ic_df = compute_ic(df)
+        for fn in (
+            lambda d: ic(d, forward_periods=1),
+            lambda d: ic_newey_west(d, forward_periods=1),
+            ic_ir,
+        ):
+            with pytest.warns(UserWarning, match="tie_ratio"):
+                fn(ic_df)
+
+        # Low-tie panel must not trigger the warning.
+        rng = np.random.default_rng(0)
+        clean_rows = [
+            {
+                "date": dt,
+                "asset_id": f"A{i}",
+                "factor": float(rng.standard_normal()),
+                "forward_return": float(rng.standard_normal()) * 0.01,
+            }
+            for dt in dates
+            for i in range(n_assets)
+        ]
+        clean = pl.DataFrame(clean_rows).with_columns(
+            pl.col("date").cast(pl.Datetime("ms"))
+        )
+        clean_ic = compute_ic(clean)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            ic(clean_ic, forward_periods=1)
+            ic_newey_west(clean_ic, forward_periods=1)
+            ic_ir(clean_ic)
 
 
 class TestIC:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -16,7 +16,7 @@ from factrix._describe import (
     describe_analysis_modes,
     suggest_config,
 )
-from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_RELIABLE
+from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 
 # ---------------------------------------------------------------------------
 # describe_analysis_modes
@@ -287,7 +287,7 @@ class TestSuggestConfigWarnings:
 
     def test_long_timeseries_no_warning(self) -> None:
         ts = _make_timeseries(
-            n_dates=MIN_PERIODS_RELIABLE + 50,
+            n_dates=MIN_PERIODS_WARN + 50,
             sparse=False,
             seed=15,
         )

--- a/tests/test_oos.py
+++ b/tests/test_oos.py
@@ -83,7 +83,9 @@ class TestMultiSplitOOSDecay:
         assert isinstance(result, MetricOutput)
         assert result.name == "oos_decay"
         assert result.stat is None  # descriptive, not hypothesis test
-        assert result.metadata["p_value"] == 1.0
+        # Descriptive-only: no p_value emitted (would invite mis-routing
+        # the diagnostic into BHY / gate logic).
+        assert "p_value" not in result.metadata
         assert result.metadata["method"] == "multi-split OOS decay"
 
     def test_per_split_shape(self, ic_series_positive):

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -37,7 +37,7 @@ class TestQuantileSpread:
 
         import polars as pl
 
-        # 2 dates < MIN_PORTFOLIO_PERIODS=5
+        # 2 dates < MIN_PORTFOLIO_PERIODS_HARD=3
         df = pl.DataFrame(
             {
                 "date": [datetime(2024, 1, 1)] * 5 + [datetime(2024, 1, 2)] * 5,

--- a/tests/test_ts_asymmetry.py
+++ b/tests/test_ts_asymmetry.py
@@ -104,7 +104,8 @@ class TestGateCMethodBSkip:
 
 class TestSampleFloor:
     def test_short_series_short_circuits(self):
-        T = 4
+        # MIN_PORTFOLIO_PERIODS_HARD = 3; T=2 trips the floor.
+        T = 2
         rng = np.random.default_rng(0)
         f = rng.standard_normal(T)
         r = rng.standard_normal(T)

--- a/tests/test_ts_beta_procedure.py
+++ b/tests/test_ts_beta_procedure.py
@@ -24,7 +24,7 @@ from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
 from factrix._stats.constants import (
     MIN_PERIODS_HARD,
-    MIN_PERIODS_RELIABLE,
+    MIN_PERIODS_WARN,
     auto_bartlett,
 )
 
@@ -171,7 +171,7 @@ class TestSampleSizeStratification:
             _TSBetaContTimeseriesProcedure().compute(ts, cfg)
 
     def test_T_in_warning_band_emits_warning(self, cfg: AnalysisConfig) -> None:
-        # MIN_PERIODS_HARD <= T < MIN_PERIODS_RELIABLE → verdict + UNRELIABLE_SE warn.
+        # MIN_PERIODS_HARD <= T < MIN_PERIODS_WARN → verdict + UNRELIABLE_SE warn.
         ts = _make_ts(n_dates=MIN_PERIODS_HARD, seed=2, beta=0.5)
         profile = _TSBetaContTimeseriesProcedure().compute(ts, cfg)
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in profile.warnings
@@ -181,7 +181,7 @@ class TestSampleSizeStratification:
         self,
         cfg: AnalysisConfig,
     ) -> None:
-        ts = _make_ts(n_dates=MIN_PERIODS_RELIABLE, seed=3, beta=0.5)
+        ts = _make_ts(n_dates=MIN_PERIODS_WARN, seed=3, beta=0.5)
         profile = _TSBetaContTimeseriesProcedure().compute(ts, cfg)
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS not in profile.warnings
 

--- a/tests/test_ts_dummy_procedure.py
+++ b/tests/test_ts_dummy_procedure.py
@@ -26,7 +26,7 @@ from factrix._procedures import (
 )
 from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _SCOPE_COLLAPSED, _DispatchKey
-from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_RELIABLE
+from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 
 
 def _make_sparse_ts(
@@ -278,7 +278,7 @@ class TestSampleSizeStratification:
         cfg_individual: AnalysisConfig,
     ) -> None:
         ts = _make_sparse_ts(
-            n_dates=MIN_PERIODS_RELIABLE,
+            n_dates=MIN_PERIODS_WARN,
             seed=3,
             event_positions=list(range(4, 30, 5)),
             beta=1.0,

--- a/tests/test_ts_quantile.py
+++ b/tests/test_ts_quantile.py
@@ -119,8 +119,9 @@ class TestGateAFactorVariation:
 
 class TestSampleFloor:
     def test_short_series_short_circuits(self):
+        # MIN_PORTFOLIO_PERIODS_HARD = 3; T=2 trips the floor.
         rng = np.random.default_rng(0)
-        T = 4
+        T = 2
         f = rng.standard_normal(T)
         r = rng.standard_normal(T)
         out = ts_quantile_spread(_series_panel(f, r), n_groups=5)

--- a/tests/test_two_tier_guards.py
+++ b/tests/test_two_tier_guards.py
@@ -1,0 +1,179 @@
+"""Two-tier sample-size guards for inference primitives (issue #48 D).
+
+Each primitive (``fama_macbeth``, ``caar``, ``top_concentration``)
+must implement three tiers:
+
+1. ``n < HARD`` → short-circuit (NaN ``MetricOutput``).
+2. ``HARD ≤ n < WARN`` → return stat AND emit ``UserWarning`` AND
+   surface the relevant ``WarningCode.value`` in ``metadata["warning_codes"]``.
+3. ``n ≥ WARN`` → silent: stat returned, no warning, no warning_codes.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._codes import WarningCode
+from factrix._types import (
+    MIN_EVENTS_HARD,
+    MIN_EVENTS_WARN,
+    MIN_PORTFOLIO_PERIODS_HARD,
+    MIN_PORTFOLIO_PERIODS_WARN,
+)
+from factrix.metrics.caar import caar
+from factrix.metrics.concentration import top_concentration
+from factrix.metrics.fama_macbeth import (
+    MIN_FM_PERIODS_HARD,
+    MIN_FM_PERIODS_WARN,
+    fama_macbeth,
+)
+
+
+def _beta_df(n: int, *, seed: int = 0) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    betas = rng.normal(0.0, 0.01, n)
+    return pl.DataFrame({"date": dates, "beta": betas}).with_columns(
+        pl.col("date").cast(pl.Datetime("ms"))
+    )
+
+
+def _caar_df(n: int, *, seed: int = 0) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    vals = rng.normal(0.0, 0.01, n)
+    return pl.DataFrame({"date": dates, "caar": vals}).with_columns(
+        pl.col("date").cast(pl.Datetime("ms"))
+    )
+
+
+def _concentration_panel(
+    n_dates: int, n_assets: int = 30, *, seed: int = 0
+) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    rows = []
+    for d in range(n_dates):
+        date = datetime(2024, 1, 1) + timedelta(days=d)
+        factors = rng.normal(0.0, 1.0, n_assets)
+        rets = rng.normal(0.0, 0.02, n_assets)
+        for a in range(n_assets):
+            rows.append(
+                {
+                    "date": date,
+                    "asset_id": f"A{a}",
+                    "factor": float(factors[a]),
+                    "forward_return": float(rets[a]),
+                }
+            )
+    return pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+# ---------------------------------------------------------------------------
+# fama_macbeth
+# ---------------------------------------------------------------------------
+
+
+class TestFamaMacbethTwoTier:
+    def test_below_hard_short_circuits(self) -> None:
+        df = _beta_df(MIN_FM_PERIODS_HARD - 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            out = fama_macbeth(df)
+        assert math.isnan(out.value)
+        assert out.stat is None
+        assert out.metadata["reason"] == "insufficient_fm_periods"
+
+    def test_borderline_warns_and_tags_metadata(self) -> None:
+        n = (MIN_FM_PERIODS_HARD + MIN_FM_PERIODS_WARN) // 2
+        df = _beta_df(n)
+        with pytest.warns(UserWarning, match="MIN_FM_PERIODS_WARN"):
+            out = fama_macbeth(df)
+        assert out.stat is not None
+        assert (
+            WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value
+            in out.metadata["warning_codes"]
+        )
+
+    def test_at_or_above_warn_is_silent(self) -> None:
+        df = _beta_df(MIN_FM_PERIODS_WARN + 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            out = fama_macbeth(df)
+        assert out.stat is not None
+        assert "warning_codes" not in out.metadata
+
+
+# ---------------------------------------------------------------------------
+# caar
+# ---------------------------------------------------------------------------
+
+
+class TestCaarTwoTier:
+    def test_below_hard_short_circuits(self) -> None:
+        # caar uses _scaled_min_periods(MIN_EVENTS_HARD, forward_periods);
+        # forward_periods=1 keeps the scaled floor equal to the raw floor.
+        df = _caar_df(MIN_EVENTS_HARD - 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            out = caar(df, forward_periods=1)
+        assert math.isnan(out.value)
+        assert out.stat is None
+        assert out.metadata["reason"] == "insufficient_event_dates"
+
+    def test_borderline_warns_and_tags_metadata(self) -> None:
+        n = (MIN_EVENTS_HARD + MIN_EVENTS_WARN) // 2
+        df = _caar_df(n)
+        with pytest.warns(UserWarning, match="MIN_EVENTS_WARN"):
+            out = caar(df, forward_periods=1)
+        assert out.stat is not None
+        assert (
+            WarningCode.FEW_EVENTS_BROWN_WARNER.value in out.metadata["warning_codes"]
+        )
+
+    def test_at_or_above_warn_is_silent(self) -> None:
+        df = _caar_df(MIN_EVENTS_WARN + 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            out = caar(df, forward_periods=1)
+        assert out.stat is not None
+        assert "warning_codes" not in out.metadata
+
+
+# ---------------------------------------------------------------------------
+# top_concentration
+# ---------------------------------------------------------------------------
+
+
+class TestTopConcentrationTwoTier:
+    def test_below_hard_short_circuits(self) -> None:
+        # Only 2 dates ⇒ HHI series length 2 < MIN_PORTFOLIO_PERIODS_HARD=3.
+        df = _concentration_panel(MIN_PORTFOLIO_PERIODS_HARD - 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            out = top_concentration(df, forward_periods=1, q_top=0.2)
+        assert math.isnan(out.value)
+        assert out.metadata["reason"] == "insufficient_portfolio_periods"
+
+    def test_borderline_warns_and_tags_metadata(self) -> None:
+        n = (MIN_PORTFOLIO_PERIODS_HARD + MIN_PORTFOLIO_PERIODS_WARN) // 2
+        df = _concentration_panel(n)
+        with pytest.warns(UserWarning, match="MIN_PORTFOLIO_PERIODS_WARN"):
+            out = top_concentration(df, forward_periods=1, q_top=0.2)
+        assert out.stat is not None
+        assert (
+            WarningCode.BORDERLINE_PORTFOLIO_PERIODS.value
+            in out.metadata["warning_codes"]
+        )
+
+    def test_at_or_above_warn_is_silent(self) -> None:
+        df = _concentration_panel(MIN_PORTFOLIO_PERIODS_WARN + 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            out = top_concentration(df, forward_periods=1, q_top=0.2)
+        assert out.stat is not None
+        assert "warning_codes" not in out.metadata

--- a/uv.lock
+++ b/uv.lock
@@ -958,7 +958,7 @@ requires-dist = [
     { name = "polars", specifier = ">=1.38" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==6.1.1" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "scipy", specifier = ">=1.13" },
@@ -3549,15 +3549,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "6.1.1"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
+    { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #48 — four code-side polish items on the metric primitives surfaced by the pre-PR review on #45 / PR #46:

- **A** `compute_ic` surfaces per-date `tie_ratio`; `ic` / `ic_newey_west` / `ic_ir` aggregate the median into `MetricOutput.metadata` and emit a `UserWarning` past the global 0.3 threshold so bucketed-factor bias is visible without inspecting the raw input.
- **B** `bmp_test(include_prediction_error_variance=False)` opts into the strict BMP (1991) denominator $\sigma_i \cdot \sqrt{1 + 1/T_{\mathrm{est}}}$ — a uniform SAR rescaling under mean-adjusted residuals so $z$ is invariant by design; the flag documents the standardiser rather than moving inference.
- **C** `WarningCode.SPARSE_MAGNITUDE_WEIGHTED` flags mixed-sign non-±1 sparse inputs that produce Sefcik-Thompson (1986) magnitude-weighted CAAR rather than textbook MacKinlay (1997) signed CAAR. `compute_caar` emits a Python `UserWarning`; the sparse PANEL procedures attach the structured code to `FactorProfile.warnings` so batch runs silencing Python warnings still see the regime switch.
- **D** Sample-size guards re-tiered to the project's `_HARD` (math floor → short-circuit) / `_WARN` (literature/power floor → return-with-warning) taxonomy:
  - `MIN_FM_PERIODS`: 20 → `_HARD = 4` / `_WARN = 30`
  - `MIN_EVENTS`: 10 → `_HARD = 4` / `_WARN = 30` (Brown-Warner 1985 convention)
  - `MIN_PORTFOLIO_PERIODS`: 5 → `_HARD = 3` / `_WARN = 20`
  - `_RELIABLE` suffix renamed to `_WARN` repo-wide for symmetry.
  - Two new `WarningCode`s: `FEW_EVENTS_BROWN_WARNER`, `BORDERLINE_PORTFOLIO_PERIODS`. FM reuses the existing `UNRELIABLE_SE_SHORT_PERIODS`. The FM and CAAR PANEL procedures propagate borderline codes into `FactorProfile.warnings`.
  - Descriptive metrics (clustering, corrado, event_horizon, event_quality, mfe_mae, quantile, ts_quantile, ts_asymmetry, `bmp_test`) switch to the new `_HARD` constant and accept smaller-`n` inputs they previously refused — the explicit "warn, don't refuse" UX shift.
  - `multi_split_oos_decay` becomes descriptive-only (drops `metadata["p_value"]`); the multi-split decomposition is the message and a $t$-stat at `MIN_OOS_PERIODS = 5` is power-zero.

mkdocs reference (`docs/reference/metric-applicability.md`, `docs/development/architecture.md`) and `factrix/llms-full.txt` updated for the new constants and codes.

## Test plan

- [x] `uv run pytest -q` — 645 passed (was 619; +26 covering the new tier behaviours, dual-emission propagation, IC tie-warn, BMP composition, and the descriptive-only `oos` contract)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mkdocs build --strict` — passes (only unrelated INFO notes)
- [ ] Reviewer sanity-check the borderline test seeds in `test_caar_procedure.py::TestFewEventsBrownWarner` (event-density tuned to land in `[4, 30)`)