### PR TITLE
refactor(registry): add _dispatch_key_for SSOT helper

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -274,7 +274,28 @@ actual（第 6 列）。
 
 ---
 
-## 6. 測試規範
+## 6. Docs 同步邊界（Source of Truth）
+
+修改 `factrix/` 後，下表告訴你哪些 `docs/` 會自動跟上、哪些需要手動維護。
+
+### 自動同步管道
+
+| Source（SSOT） | Docs 目的地 | 機制 |
+|---|---|---|
+| `factrix/**/*.py` docstring | `docs/api/**/*.md` 內 `:::` 指令處 | mkdocstrings plugin |
+| `factrix/metrics/*.py` 的 `Matrix-row:` | `docs/reference/_generated_metric_matrix.md` | hook: `scripts/gen_metric_matrix.py` |
+| `examples/*.ipynb` | `docs/examples/` | hook: `scripts/sync_examples.py` |
+| `factrix/llms*.txt` | site root `llms*.txt` | hook: `scripts/sync_llms_txt.py` |
+
+### 仍需手動維護的 docs
+
+- `docs/api/**/*.md`（30 支）：每支含手寫 2–5 行敘事 intro + 一行 `:::` 指令；新增公開 metric 需手建檔並更新 `mkdocs.yml` `nav:`
+- `docs/getting-started/`、`docs/guides/`、`docs/development/`、首頁 `index.md`、各區 `index.md`：純敘事
+- `docs/reference/standalone-metrics.md`、`statistical-methods.md`、`warning-codes.md`、`bibliography.md`：敘事性彙整（非 matrix）
+
+---
+
+## 7. 測試規範
 
 ### Synthetic fixtures only
 
@@ -346,7 +367,7 @@ PR 前 self-check：跑過三個 code block、`uv run mkdocs build --strict` 乾
 
 ---
 
-## 7. 版本管理與發布 (SemVer & Release)
+## 8. 版本管理與發布 (SemVer & Release)
 
 目前 factrix 在 **pre-1.0**（v0.x.x）——公開 API **可能在 MINOR bump 裡
 BC 變動**。Consumer（如 `factor-analysis` workspace）應該透過 **git

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -15,8 +15,7 @@ from factrix._codes import WarningCode, cross_section_tier
 from factrix._evaluate import _derive_mode
 from factrix._registry import (
     _DISPATCH_REGISTRY,
-    _DispatchKey,
-    _route_scope,
+    _dispatch_key_for,
     _ScopeCollapsedSentinel,
 )
 from factrix._stats.constants import (
@@ -87,10 +86,7 @@ def _entry_for(
     mode: Mode,
 ) -> Any:
     """Return the registry entry routing this user-facing axis at ``mode``."""
-    routed_scope = _route_scope(scope, signal, mode)
-    return _DISPATCH_REGISTRY.get(
-        _DispatchKey(routed_scope, signal, metric, mode),
-    )
+    return _DISPATCH_REGISTRY.get(_dispatch_key_for(scope, signal, metric, mode))
 
 
 def _row_for_tuple(

--- a/factrix/_evaluate.py
+++ b/factrix/_evaluate.py
@@ -26,8 +26,8 @@ from factrix._codes import InfoCode
 from factrix._errors import ModeAxisError
 from factrix._registry import (
     _DISPATCH_REGISTRY,
-    _DispatchKey,
-    _route_scope,
+    _SCOPE_COLLAPSED,
+    _dispatch_key_for,
 )
 
 if TYPE_CHECKING:
@@ -72,13 +72,12 @@ def _evaluate(raw: Any, config: AnalysisConfig) -> FactorProfile:
             ``suggested_fix``.
     """
     mode = _derive_mode(raw)
-    routed_scope = _route_scope(config.scope, config.signal, mode)
+    key = _dispatch_key_for(config.scope, config.signal, config.metric, mode)
     extra_info: frozenset[InfoCode] = (
         frozenset({InfoCode.SCOPE_AXIS_COLLAPSED})
-        if routed_scope is not config.scope
+        if key.scope is _SCOPE_COLLAPSED
         else frozenset()
     )
-    key = _DispatchKey(routed_scope, config.signal, config.metric, mode)
     entry = _DISPATCH_REGISTRY.get(key)
     if entry is None:
         fallback = _FALLBACK_MAP.get((config.scope, config.signal, mode))

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from factrix._codes import StatCode
-from factrix._registry import _DispatchKey, _route_scope
+from factrix._registry import _dispatch_key_for, _DispatchKey
 from factrix.stats.multiple_testing import bhy_adjust
 
 if TYPE_CHECKING:
@@ -52,21 +52,17 @@ class _FamilyKey:
 def _family_key(profile: FactorProfile) -> _FamilyKey:
     """Derive the BHY family key from a ``FactorProfile``.
 
-    Reuses ``_route_scope`` so the sparse-N=1 collapse mirrors
-    ``_evaluate`` exactly — ``individual_sparse`` and ``common_sparse``
-    profiles at N=1 sit in the same dispatch cell (§5.4.1 / §5.6) and
-    therefore the same family *at matching ``forward_periods``*.
+    Routes through ``_dispatch_key_for`` so the sparse-N=1 collapse and
+    key construction stay byte-identical to ``_evaluate`` — sharing the
+    helper, not a copy of its body, is what makes
+    ``individual_sparse`` / ``common_sparse`` profiles at N=1 land in the
+    same family at matching ``forward_periods`` (§5.4.1 / §5.6).
     """
-    scope = _route_scope(
+    dispatch = _dispatch_key_for(
         profile.config.scope,
         profile.config.signal,
+        profile.config.metric,
         profile.mode,
-    )
-    dispatch = _DispatchKey(
-        scope=scope,
-        signal=profile.config.signal,
-        metric=profile.config.metric,
-        mode=profile.mode,
     )
     return _FamilyKey(
         dispatch=dispatch,

--- a/factrix/_registry.py
+++ b/factrix/_registry.py
@@ -111,6 +111,28 @@ def _route_scope(
     return scope
 
 
+def _dispatch_key_for(
+    scope: FactorScope,
+    signal: Signal,
+    metric: Metric | None,
+    mode: Mode,
+) -> _DispatchKey:
+    """Build the routed ``_DispatchKey`` for a user-facing axis at ``mode``.
+
+    Folds ``_route_scope`` + ``_DispatchKey`` construction into one call
+    so ``_evaluate``, ``_describe``, and ``_multi_factor`` cannot drift
+    in how they assemble lookup keys (the ``mirrors _evaluate exactly``
+    comment that previously guarded ``_multi_factor._family_key`` was a
+    drift hazard, not a guarantee).
+    """
+    return _DispatchKey(
+        scope=_route_scope(scope, signal, mode),
+        signal=signal,
+        metric=metric,
+        mode=mode,
+    )
+
+
 def matches_user_axis(
     scope: FactorScope,
     signal: Signal,
@@ -136,7 +158,8 @@ def matches_user_axis(
 # ``_procedures`` calls ``register(...)`` at module bottom, populating
 # ``_DISPATCH_REGISTRY`` before any first query lands. ``_procedures``
 # imports from us only the names defined above this line (``register``,
-# ``_DispatchKey``, ``_route_scope``, ``_SCOPE_COLLAPSED``,
+# ``_DispatchKey``, ``_route_scope``, ``_dispatch_key_for``,
+# ``_SCOPE_COLLAPSED``,
 # ``_ScopeCollapsedSentinel``). Adding a top-level ``_procedures``
 # usage of any helper defined below would create a circular-import
 # deadlock that will not surface until import time of a downstream

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,8 +35,11 @@ theme:
         name: Switch to light mode
 
 hooks:
+  # factrix/metrics/*.py Matrix-row: -> docs/reference/_generated_metric_matrix.md
   - scripts/gen_metric_matrix.py
+  # examples/*.ipynb -> docs/examples/
   - scripts/sync_examples.py
+  # factrix/llms*.txt -> site root llms*.txt
   - scripts/sync_llms_txt.py
 
 watch:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -314,7 +314,7 @@ class TestMatchesUserAxis:
 # ---------------------------------------------------------------------------
 
 
-from factrix._registry import _route_scope
+from factrix._registry import _dispatch_key_for, _route_scope
 
 
 class TestRouteScope:
@@ -352,6 +352,65 @@ class TestRouteScope:
         # PANEL sparse keeps the user scope — only TIMESERIES collapses.
         for scope in (FactorScope.INDIVIDUAL, FactorScope.COMMON):
             assert _route_scope(scope, Signal.SPARSE, Mode.PANEL) is scope
+
+
+# ---------------------------------------------------------------------------
+# Issue #7: _dispatch_key_for SSOT for routed-scope + key construction
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchKeyFor:
+    def test_panel_continuous_no_collapse(self) -> None:
+        key = _dispatch_key_for(
+            FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC, Mode.PANEL
+        )
+        assert key == _DispatchKey(
+            FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC, Mode.PANEL
+        )
+
+    def test_sparse_timeseries_collapses_both_user_scopes(self) -> None:
+        for user_scope in (FactorScope.INDIVIDUAL, FactorScope.COMMON):
+            key = _dispatch_key_for(user_scope, Signal.SPARSE, None, Mode.TIMESERIES)
+            assert key.scope is _SCOPE_COLLAPSED
+            assert key == _DispatchKey(
+                _SCOPE_COLLAPSED, Signal.SPARSE, None, Mode.TIMESERIES
+            )
+
+    def test_sparse_panel_does_not_collapse(self) -> None:
+        # Only TIMESERIES sparse collapses; PANEL sparse keeps user scope.
+        key = _dispatch_key_for(FactorScope.INDIVIDUAL, Signal.SPARSE, None, Mode.PANEL)
+        assert key.scope is FactorScope.INDIVIDUAL
+
+    def test_routes_to_actual_registry_entries_for_every_legal_axis(
+        self,
+    ) -> None:
+        # Every (scope, signal, metric) the public factories produce must
+        # round-trip through _dispatch_key_for to a registered entry under
+        # at least one mode — the helper *is* the routing.
+        legal = [
+            (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC),
+            (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.FM),
+            (FactorScope.INDIVIDUAL, Signal.SPARSE, None),
+            (FactorScope.COMMON, Signal.CONTINUOUS, None),
+            (FactorScope.COMMON, Signal.SPARSE, None),
+        ]
+        for scope, signal, metric in legal:
+            assert any(
+                _dispatch_key_for(scope, signal, metric, m) in _DISPATCH_REGISTRY
+                for m in (Mode.PANEL, Mode.TIMESERIES)
+            )
+
+    def test_matches_inline_construction(self) -> None:
+        # Helper output is byte-identical to manual construction —
+        # callers swapping in the helper cannot change routing.
+        for scope, signal, metric, mode in [
+            (FactorScope.COMMON, Signal.SPARSE, None, Mode.TIMESERIES),
+            (FactorScope.INDIVIDUAL, Signal.SPARSE, None, Mode.PANEL),
+            (FactorScope.COMMON, Signal.CONTINUOUS, None, Mode.TIMESERIES),
+        ]:
+            assert _dispatch_key_for(scope, signal, metric, mode) == _DispatchKey(
+                _route_scope(scope, signal, mode), signal, metric, mode
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `_dispatch_key_for(scope, signal, metric, mode)` in `factrix/_registry.py` folding `_route_scope` + `_DispatchKey(...)` into one call.
- Migrate three call sites (`_evaluate`, `_describe._entry_for`, `_multi_factor._family_key`) so they share the helper instead of hand-rolling the same boilerplate.
- Replace `_evaluate`'s collapse-detection idiom (`routed_scope is not config.scope`) with the direct `key.scope is _SCOPE_COLLAPSED` check now that the helper returns the routed key.

Pure housekeeping, no behavior change. The "mirrors `_evaluate` exactly" comment in `_multi_factor` was a drift hazard, not a guarantee — structural sharing replaces it.

Closes #7.

## Test plan
- [x] `pytest -q` — 650 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] New `TestDispatchKeyFor` in `tests/test_registry.py` covers pass-through, both-user-scope sparse-TS collapse, panel-sparse non-collapse, registry round-trip on every legal axis, and byte-equivalence vs inline `_DispatchKey(_route_scope(...), ...)` construction