### PR TITLE
refactor(scripts): organise scripts/ by purpose (#65)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -539,7 +539,7 @@ matrix. The matrix is generated at build time from machine-readable
 - Each public metric module carries one or more `Matrix-row:` lines at the
   end of its module-level docstring, with five pipe-separated fields:
   `public_functions | cell_scope | aggregation_order | inference_se | primitives`.
-- `scripts/gen_metric_matrix.py` (also a MkDocs `hooks:` entry) parses every
+- `scripts/mkdocs_hooks/gen_metric_matrix.py` (a MkDocs `hooks:` entry) parses every
   public module with `ast`, extracts the tags, and writes
   `docs/reference/_generated_metric_matrix.md` before each docs build.
 - `standalone-metrics.md` includes the generated file via

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -283,9 +283,9 @@ actual（第 6 列）。
 | Source（SSOT） | Docs 目的地 | 機制 |
 |---|---|---|
 | `factrix/**/*.py` docstring | `docs/api/**/*.md` 內 `:::` 指令處 | mkdocstrings plugin |
-| `factrix/metrics/*.py` 的 `Matrix-row:` | `docs/reference/_generated_metric_matrix.md` | hook: `scripts/gen_metric_matrix.py` |
-| `examples/*.ipynb` | `docs/examples/` | hook: `scripts/sync_examples.py` |
-| `factrix/llms*.txt` | site root `llms*.txt` | hook: `scripts/sync_llms_txt.py` |
+| `factrix/metrics/*.py` 的 `Matrix-row:` | `docs/reference/_generated_metric_matrix.md` | hook: `scripts/mkdocs_hooks/gen_metric_matrix.py` |
+| `examples/*.ipynb` | `docs/examples/` | hook: `scripts/mkdocs_hooks/sync_examples.py` |
+| `factrix/llms*.txt` | site root `llms*.txt` | hook: `scripts/mkdocs_hooks/sync_llms_txt.py` |
 
 ### 仍需手動維護的 docs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,11 +36,11 @@ theme:
 
 hooks:
   # factrix/metrics/*.py Matrix-row: -> docs/reference/_generated_metric_matrix.md
-  - scripts/gen_metric_matrix.py
+  - scripts/mkdocs_hooks/gen_metric_matrix.py
   # examples/*.ipynb -> docs/examples/
-  - scripts/sync_examples.py
+  - scripts/mkdocs_hooks/sync_examples.py
   # factrix/llms*.txt -> site root llms*.txt
-  - scripts/sync_llms_txt.py
+  - scripts/mkdocs_hooks/sync_llms_txt.py
 
 watch:
   - factrix

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+# `scripts/` — repo automation
+
+Build-time helpers and one-off utilities. Sub-folders group by **who
+runs them**, not by what they touch.
+
+## Layout
+
+| Path | Who runs | Purpose |
+|------|----------|---------|
+| [`mkdocs_hooks/`](mkdocs_hooks/) | mkdocs (`hooks:` in `mkdocs.yml`) | Build-time content generation for the docs site. Triggered automatically before every `mkdocs build` / `mkdocs serve`. Each script also has a `__main__` guard so it can be run directly for debugging (`uv run python scripts/mkdocs_hooks/<name>.py`), but that path is not part of the normal workflow. |
+| `scripts/` (root) | humans (CLI), one-off | Manual utilities — release helpers, ad-hoc data fixes, anything outside the mkdocs lifecycle. Empty at present; reserved for future additions. |
+
+## Adding a new script
+
+- **It runs as part of `mkdocs build`** → put it in `mkdocs_hooks/` and
+  register it in `mkdocs.yml` under `hooks:`. The hook entry should
+  carry a leading comment describing input → output.
+- **It is invoked by a human or by CI separately from mkdocs** → put
+  it at the `scripts/` root. Include a docstring and a `__main__`
+  guard so it is runnable as `uv run python scripts/<name>.py`.
+
+The split exists so `mkdocs.yml` is not the only place documenting
+which scripts run automatically — drop a script in the wrong folder
+and it either fails to fire (hook not registered) or fires twice
+(human invocation hitting a build hook).

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -6,7 +6,7 @@ Markdown table to ``docs/reference/_generated_metric_matrix.md``.
 
 Usage (manual)::
 
-    python scripts/gen_metric_matrix.py
+    python scripts/mkdocs_hooks/gen_metric_matrix.py
 
 MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
 
@@ -25,7 +25,7 @@ import re
 # when invoked from any working directory, including inside mkdocs).
 # ---------------------------------------------------------------------------
 
-_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _METRICS_DIR = _REPO_ROOT / "factrix" / "metrics"
 _OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_metric_matrix.md"
 

--- a/scripts/mkdocs_hooks/sync_examples.py
+++ b/scripts/mkdocs_hooks/sync_examples.py
@@ -17,7 +17,7 @@ recipe cannot drift from the listing.
 
 Usage (manual)::
 
-    python scripts/sync_examples.py
+    python scripts/mkdocs_hooks/sync_examples.py
 
 MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
 
@@ -33,7 +33,7 @@ import re
 import shutil
 from dataclasses import dataclass
 
-_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _SRC_DIR = _REPO_ROOT / "examples"
 _DST_DIR = _REPO_ROOT / "docs" / "examples"
 

--- a/scripts/mkdocs_hooks/sync_llms_txt.py
+++ b/scripts/mkdocs_hooks/sync_llms_txt.py
@@ -8,7 +8,7 @@ site so they also deploy at the public URL root.
 
 Usage (manual)::
 
-    python scripts/sync_llms_txt.py
+    python scripts/mkdocs_hooks/sync_llms_txt.py
 
 MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
 
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import pathlib
 
-_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _SRC_DIR = _REPO_ROOT / "factrix"
 _DST_DIR = _REPO_ROOT / "docs"
 _FILES = ("llms.txt", "llms-full.txt")
@@ -28,7 +28,7 @@ _FILES = ("llms.txt", "llms-full.txt")
 _BANNER = (
     "<!-- GENERATED FILE — DO NOT EDIT.\n"
     "     SSOT lives at factrix/{name}; regenerated on every mkdocs build\n"
-    "     by scripts/sync_llms_txt.py. Edits here will be overwritten. -->\n"
+    "     by scripts/mkdocs_hooks/sync_llms_txt.py. Edits here will be overwritten. -->\n"
     "\n"
 )
 

--- a/tests/test_docs_matrix.py
+++ b/tests/test_docs_matrix.py
@@ -72,7 +72,7 @@ def test_generated_matrix_exists_and_nonempty() -> None:
     if not GENERATED_MATRIX.exists():
         pytest.skip(
             f"{GENERATED_MATRIX} not found — run "
-            "'python scripts/gen_metric_matrix.py' or 'mkdocs build' first."
+            "'python scripts/mkdocs_hooks/gen_metric_matrix.py' or 'mkdocs build' first."
         )
     lines = [
         ln


### PR DESCRIPTION
## Summary

- Three mkdocs hook scripts (`gen_metric_matrix.py`, `sync_examples.py`, `sync_llms_txt.py`) moved into `scripts/mkdocs_hooks/`. Root `scripts/` reserved for human-run utilities (currently empty after `build_demo.py` was retired in #67).
- `scripts/README.md` documents the layout — adding a script no longer requires reading `mkdocs.yml` to know whether it joins the build-hook lifecycle.
- `_REPO_ROOT = pathlib.Path(__file__).parent.parent` gets one extra `.parent` in each script (deeper nesting). Cross-references updated: `mkdocs.yml` `hooks:`, `tests/test_docs_matrix.py` skip message, `docs/development/architecture.md`, `docs/development/contributing.md`, and the `llms.txt` generated-file banner that ships into the docs site.

Pure file move + path adjustment; no generator behaviour change.

Closes #65.

## Test plan

- [x] `pytest -q` — 650 passed
- [x] `mkdocs build --clean` — 0 warnings, all three hooks fire (gen_metric_matrix / sync_examples / sync_llms_txt)
- [x] `ruff check` / `ruff format --check` clean
- [x] `docs/llms.txt` regenerated banner now points at `scripts/mkdocs_hooks/sync_llms_txt.py`
- [x] No stale references to old script paths in active files (CHANGELOG historical entries describing the prior state intentionally retained)