### PR TITLE
docs(profile): fix n_obs CAAR docstring (#69)

### DIFF
--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -47,11 +47,11 @@ on any registered cell's output is supported.
 |---------------|------------|
 | `(individual, continuous, ic, panel)` | `T` — number of dates contributing to the per-date IC series |
 | `(individual, continuous, fm, panel)` | `T` — number of dates with a valid OLS slope |
-| `(individual, sparse, None, panel)` | `T` — calendar length after CAAR densification |
+| `(individual, sparse, None, panel)` | `T` — densified panel-period count (unique dates in the panel) after CAAR event-date back-fill |
 | `(common, continuous, None, panel)` | `N` — number of assets entering the cross-asset t-test on `E[β]` |
 | `(common, sparse, None, panel)` | `N` |
 | `(common, continuous, None, timeseries)` | `T` — single-series sample length |
-| `(*, sparse, None, timeseries)` | `T` — calendar length of the dummy regression |
+| `(*, sparse, None, timeseries)` | `T` — period count of the dummy regression |
 
 Reading `n_obs` together with `n_assets` disambiguates whether a small
 `n_obs` came from a short series (low `T`) or a thin cross-section

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -35,8 +35,8 @@ class FactorProfile:
         primary_p: Procedure-canonical p-value used by ``verdict()``
             and ``multi_factor.bhy``.
         n_obs: Cell-canonical effective sample size (T for IC/FM/TS,
-            event count for CAAR, asset count for ``COMMON × *``
-            PANEL).
+            densified panel-period count for CAAR, asset count for
+            ``COMMON × *`` PANEL).
         n_assets: Cross-section width of the raw panel
             (``panel["asset_id"].n_unique()``).
         warnings: ``WarningCode`` flags emitted by the procedure.


### PR DESCRIPTION
## Summary

Align `FactorProfile.n_obs` docstring with the actual CAAR behaviour: `n_obs` is the densified calendar-time portfolio length (Jaffe 1974 / Mandelker 1974), not the raw event count. The recently merged `diagnose()` schema reference (#66) already documents this; the in-source docstring was the diverging copy.

## Test plan

- [x] Pre-commit ruff check / format passes
- [x] Pure docstring change — no behavioural test impact

Closes #69