### PR TITLE
feat(api): friendly error when evaluate() called without config (#72)

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -56,11 +56,31 @@ from factrix._errors import (
     FactrixError,
     IncompatibleAxisError,
     InsufficientSampleError,
+    MissingConfigError,
     ModeAxisError,
 )
-from factrix._evaluate import _evaluate as evaluate
+from factrix._evaluate import _evaluate as _evaluate
 from factrix._profile import FactorProfile
 from factrix._types import MetricOutput
+
+
+def evaluate(raw, config=None, /):
+    """Dispatch ``raw`` through the cell selected by ``config``.
+
+    Thin public wrapper around the private ``_evaluate`` dispatcher.
+    Intercepts the common onboarding miss — ``evaluate(panel)`` — with
+    a friendly :class:`MissingConfigError` pointing at
+    :func:`suggest_config` and the Get Started guide.
+    """
+    if config is None:
+        raise MissingConfigError(
+            "evaluate() requires an AnalysisConfig. "
+            "Call factrix.suggest_config(raw) for a recommendation, "
+            "or see the Get Started guide: "
+            "https://awwesomeman.github.io/factrix/getting-started/"
+        )
+    return _evaluate(raw, config)
+
 
 __version__ = "0.7.0"
 
@@ -83,6 +103,7 @@ __all__ = [
     "FactrixError",
     "IncompatibleAxisError",
     "InsufficientSampleError",
+    "MissingConfigError",
     "ModeAxisError",
     # Profile + dispatch
     "FactorProfile",

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -38,6 +38,15 @@ class ConfigError(FactrixError):
         self.suggested_fix = suggested_fix
 
 
+class MissingConfigError(ConfigError):
+    """``evaluate(raw)`` called without an ``AnalysisConfig``.
+
+    Friendly replacement for the bare ``TypeError`` from the private
+    ``_evaluate`` signature. ``suggested_fix`` stays ``None`` — call
+    ``factrix.suggest_config(raw)`` to get a concrete recommendation.
+    """
+
+
 class IncompatibleAxisError(ConfigError):
     """``(scope, signal, metric)`` tuple is not a legal analysis cell.
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -184,7 +184,6 @@ class TestFallbackNoneBranch:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from factrix import _evaluate as evaluate_mod
         from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
 
         # Pop the live (COMMON, CONTINUOUS, PANEL) entry so a real
@@ -202,7 +201,7 @@ class TestFallbackNoneBranch:
         try:
             panel = _build_panel(n_dates=30, n_assets=20, seed=11)
             with pytest.raises(ModeAxisError) as exc:
-                evaluate_mod._evaluate(
+                _evaluate(
                     panel,
                     AnalysisConfig.common_continuous(),
                 )

--- a/tests/test_evaluate_missing_config.py
+++ b/tests/test_evaluate_missing_config.py
@@ -1,0 +1,63 @@
+"""Public ``evaluate`` shim — friendly error on missing config (#72)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import factrix as fl
+import numpy as np
+import polars as pl
+import pytest
+from factrix._errors import ConfigError, FactrixError, MissingConfigError
+
+
+def _build_panel(n_dates: int = 60, n_assets: int = 5, seed: int = 0) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    start = dt.date(2024, 1, 1)
+    rows: list[dict[str, object]] = []
+    for i in range(n_dates):
+        d = start + dt.timedelta(days=i)
+        for j in range(n_assets):
+            rows.append(
+                {
+                    "date": d,
+                    "asset_id": f"A{j:03d}",
+                    "factor": float(rng.standard_normal()),
+                    "forward_return": float(rng.standard_normal()),
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+def test_evaluate_without_config_raises_missing_config_error():
+    panel = _build_panel()
+    with pytest.raises(MissingConfigError):
+        fl.evaluate(panel)
+
+
+def test_missing_config_error_message_points_to_suggest_config_and_docs():
+    panel = _build_panel()
+    with pytest.raises(MissingConfigError) as exc_info:
+        fl.evaluate(panel)
+    msg = str(exc_info.value)
+    assert "suggest_config" in msg
+    assert "https://awwesomeman.github.io/factrix/getting-started/" in msg
+
+
+def test_missing_config_error_is_catchable_as_config_and_factrix_error():
+    panel = _build_panel()
+    with pytest.raises(ConfigError):
+        fl.evaluate(panel)
+    with pytest.raises(FactrixError):
+        fl.evaluate(panel)
+
+
+def test_evaluate_with_config_routes_to_private_dispatcher():
+    panel = _build_panel()
+    cfg = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC)
+    profile = fl.evaluate(panel, cfg)
+    assert isinstance(profile, fl.FactorProfile)
+
+
+def test_missing_config_error_exported_from_top_level():
+    assert fl.MissingConfigError is MissingConfigError


### PR DESCRIPTION
## Summary

`evaluate(panel)` without a config used to surface a bare `TypeError` naming the underscore-prefixed `_evaluate` symbol — worst first impression for the exact users we want to convert. Replace the rename re-export with a thin public shim that raises a new `MissingConfigError(ConfigError)` whose message points at `suggest_config()` and the Get Started guide.

Per the design decision recorded on #63: lazy error path (no `suggest_config(raw)` side-effect inside the exception), single docs URL, positional-only public signature preserves the v0.5 dispatch contract.

## Test plan

- [x] `tests/test_evaluate_missing_config.py` — error type, message contents, hierarchy catchability, happy-path smoke, top-level export
- [x] Full suite passes (655 tests)
- [x] `factrix._evaluate` submodule still importable as a module attribute (existing `tests/test_evaluate.py::TestFallbackNoneBranch` relies on this)

Closes #72