### PR TITLE
docs: enforce english on published surface (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,17 @@ CONTRIBUTING §7 (Release workflow).
   membership-checks `WarningCode.SPARSE_MAGNITUDE_DROPPED`; on `{0, R}`
   inputs, `compute_caar` now does the right thing without warning. (#12)
 
+### Docs
+
+- **English-only convention enforced across the published surface.**
+  `docs/development/contributing.md` translated from mixed Chinese /
+  English to English; `# WHY:` rationale comments in `factrix/`
+  (`_types.py`, `_validators.py`, `metrics/{trend,oos,tradability}.py`,
+  `preprocess/orthogonalize.py`) translated in place. New §11 in
+  contributing documents the single-language rule and the `docs/plans/`
+  exception. Public docstrings, README, CHANGELOG, and examples were
+  already English; no behaviour change. (#74)
+
 ## v0.7.0 (2026-05-04)
 
 Closes the silent-coercion gap in sparse-procedure dispatch. Until now,

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,228 +1,250 @@
 # Contributing to factrix
 
-本文件描述 factrix 的開發流程。主要讀者是**作者本人 + 未來的 AI agent**
-——private repo，所以省略 licensing / DCO / CLA 等 OSS 慣例，聚焦在**實際
-開發模式與陷阱**。
+This document describes the factrix development workflow. The intended
+readers are **the author + future AI agents**—a private repo, so OSS
+conventions like licensing / DCO / CLA are skipped, focusing instead on
+**actual development modes and pitfalls**.
 
 ---
 
-## 1. 兩種開發模式
+## 1. Two development modes
 
-### Mode A — Standalone development（推薦多數情況）
+### Mode A — Standalone development (recommended for most cases)
 
-直接 clone factrix repo，獨立 venv，cycle 最快：
+Clone the factrix repo directly, isolated venv, fastest cycle:
 
 ```bash
 git clone https://github.com/awwesomeman/factrix.git
 cd factrix
 uv sync
-uv run pytest        # 驗證 baseline 綠
+uv run pytest        # confirm baseline is green
 ```
 
-**什麼時候用**：新 feature / 大 refactor / SemVer bump / release。
-隔離環境、不會誤動到下游 research、測試 cycle 最短。
+**When to use**: new feature / large refactor / SemVer bump / release.
+Isolated environment, no risk of accidentally touching downstream
+research, shortest test cycle.
 
-### Mode B — In-workspace development（via submodule）
+### Mode B — In-workspace development (via submodule)
 
-從下游 workspace（`factor-analysis`）的 `external/factorlib/` 編輯——
-可以邊改 factrix、邊在真實 research notebook 看效果：
+Edit from the downstream workspace (`factor-analysis`) under
+`external/factorlib/`—you can change factrix and observe the effect in
+a real research notebook simultaneously:
 
-> **注意**：submodule 的磁碟資料夾名稱取決於 parent workspace 的
-> `.gitmodules` 設定，目前實際路徑仍為 **`external/factorlib/`**。
-> 待 parent workspace 將 submodule path rename 後，路徑才會改為
-> `external/factrix/`。以下指令以當前磁碟路徑為準。
+> **Note**: the submodule directory name on disk depends on the parent
+> workspace's `.gitmodules` setting; the actual path is currently
+> **`external/factorlib/`**. Once the parent workspace renames the
+> submodule path, it will become `external/factrix/`. Commands below
+> follow the current on-disk path.
 
 ```bash
 cd ~/Desktop/dst/code/factor-analysis
 cd external/factorlib
 # edit factrix source
 uv run pytest
-# 回 workspace 跑 notebook 驗證 end-to-end
+# back to workspace and run the notebook for end-to-end verification
 cd ../..
 uv run jupyter notebook
 ```
 
-**什麼時候用**：
-- Debug 「只在 research 環境出現的 bug」——必須真實資料 context 才重現
-- 為某個已知下游需求改 API，想即時驗證
-- 小範圍 tweak（< 10 行），不值得 Mode A 的 setup overhead
+**When to use**:
+- Debugging a "bug that only appears in the research environment"—real
+  data context required to reproduce
+- Changing an API for a known downstream need, with immediate verification
+- Small tweaks (< 10 lines) that don't justify Mode A's setup overhead
 
-**注意**：Mode B 有三個關鍵陷阱，見下方 §4。
+**Caution**: Mode B has three critical pitfalls; see §4 below.
 
 ---
 
-## 2. 環境設置
+## 2. Environment setup
 
-factrix 用 **uv** 管理 Python venv 與 lockfile。`pyproject.toml` 與
-`uv.lock` 是唯一權威——不要用 `pip install` 直接裝任何東西進 `.venv/`。
+factrix uses **uv** to manage the Python venv and lockfile.
+`pyproject.toml` and `uv.lock` are the sole authority—do not use
+`pip install` to drop anything directly into `.venv/`.
 
-Python 版本鎖定在 **3.12+**（定義於 `pyproject.toml` 的 `requires-python`）。
+Python is pinned to **3.12+** (defined by `requires-python` in
+`pyproject.toml`).
 
-### 依賴安裝與 Extras
-根據開發需求，你可以使用 `--extra` 增減所需模組：
+### Dependencies and extras
+Use `--extra` to add or drop modules per development needs:
 
 ```bash
-uv sync                              # 僅安裝 Core 依賴 (polars, numpy, pandera)
-uv sync --extra dev                  # +pytest, commitizen 等開發工具 (寫 Code 必裝)
-uv sync --extra charts               # +plotly 圖表繪製
-uv sync --all-extras                 # charts + mlflow + jupyter（功能 extras）
+uv sync                              # core only (polars, numpy, pandera)
+uv sync --extra dev                  # +pytest, commitizen, etc. (required to write code)
+uv sync --extra charts               # +plotly for charts
+uv sync --all-extras                 # charts + mlflow + jupyter (feature extras)
 ```
 
-> **注意**：`dev` extra 不屬於 `all`（工具鏈與功能 extras 刻意分開），
-> 因此 `--all-extras` **不會**安裝 pytest / commitizen 等開發工具。
-> 開發者請使用：
+> **Note**: the `dev` extra is **not** part of `all` (toolchain and
+> feature extras are deliberately separated), so `--all-extras` does
+> **not** install pytest / commitizen. Developers should use:
 >
 > ```bash
-> uv sync --all-extras --extra dev   # 功能 extras + 開發工具，一次裝齊
+> uv sync --all-extras --extra dev   # feature extras + dev tools in one shot
 > ```
 
-### 常用環境指令
+### Common environment commands
 ```bash
-uv run <cmd>         # 在 venv 內執行（例如: uv run pytest）
-uv add <pkg>         # 新增 dep，同步更新 pyproject + uv.lock
-uv lock --upgrade    # 升 lock 到當前 pyproject constraint 的最新版
+uv run <cmd>         # run inside the venv (e.g. uv run pytest)
+uv add <pkg>         # add dep, sync pyproject + uv.lock
+uv lock --upgrade    # upgrade lock to the latest within current pyproject constraints
 ```
 
-### Git hooks（pre-push CHANGELOG check）
+### Git hooks (pre-push CHANGELOG check)
 
-Repo 根目錄下的 `.githooks/` 收受版控的 hook script。fresh clone 後跑
-一次：
+`.githooks/` at the repo root holds version-controlled hook scripts.
+Run once after a fresh clone:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-這條 config 是 per-clone local，不會跨機器自動同步，所以每個 clone /
-新機器都要跑一次。設好之後下面所有 hook 自動生效，無需個別 install。
+This config is per-clone and local—it does not propagate across
+machines, so every clone / new machine must run it once. After that,
+all hooks below activate automatically; no per-hook install needed.
 
-`pre-commit` — 當 staged changes 含 `*.py` 時，跑 `ruff check` +
-`ruff format --check`（鏡像 CI 的 `lint` job）。失敗 → block commit；
-fix-then-commit 或 `git commit --no-verify` 繞過。Scope 限定 staged
-檔案，touch YAML / Markdown / .txt 的 commit 完全不觸發。
+`pre-commit` — when staged changes include `*.py`, runs `ruff check`
++ `ruff format --check` (mirrors CI's `lint` job). Fail → blocks the
+commit; fix-then-commit, or use `git commit --no-verify` to bypass.
+Scoped to staged files, so commits touching only YAML / Markdown / .txt
+don't trigger.
 
-`pre-push` — 當 push 含 `chore(release): vX.Y.Z`
-（亦即 `cz bump` 產出的 release commit），會檢查 `CHANGELOG.md` 中對
-應 `## vX.Y.Z` section 的非空白行數 ≥ 25。低於門檻 → block push，逼
-你補 WHY narrative（BREAKING migration、行為方向、動機）再 push。
-真要繞過：`git push --no-verify`。
+`pre-push` — when the push includes `chore(release): vX.Y.Z` (i.e. the
+release commit produced by `cz bump`), checks that the `## vX.Y.Z`
+section in `CHANGELOG.md` has ≥ 25 non-blank lines. Below threshold →
+blocks the push, forcing you to add WHY narrative (BREAKING migration,
+behavioural direction, motivation) before pushing. To bypass:
+`git push --no-verify`.
 
-調整門檻（per-shell）：
+Adjust the threshold (per-shell):
 
 ```bash
 CHANGELOG_MIN_LINES=10 git push
 ```
 
-設計理由見 §7 「Release workflow」對 cz auto-CHANGELOG 的限制說明。
+Rationale: see §7 "Release workflow" on the limits of cz's
+auto-CHANGELOG.
 
 ---
 
-## 3. 開發循環（branch → test → commit → push → PR）
+## 3. Development cycle (branch → test → commit → push → PR)
 
 ```bash
-# 1. 從 main 開 branch（不要直接在 main 上 commit）
+# 1. Branch off main (do not commit directly to main)
 git checkout main && git pull
 git checkout -b <type>/<short-desc>     # e.g. feat/redundancy-heatmap
 
-# 2. 開發 + 頻繁跑測試
+# 2. Develop + run tests frequently
 # ...edit...
-uv run pytest                            # 必須全綠才 commit
-uv run pytest tests/test_<file>.py -v   # 聚焦單一 module 快速迭代
+uv run pytest                            # must be all green before commit
+uv run pytest tests/test_<file>.py -v   # focus on a single module for fast iteration
 
-# 3. Commit（Conventional Commits + 互動式生成）
-git add <specific-files>                 # 不用 -A
-cz commit -- -s                          # 使用 Commitizen 產出標準格式並附加簽名檔
+# 3. Commit (Conventional Commits + interactive generation)
+git add <specific-files>                 # avoid -A
+cz commit -- -s                          # Commitizen produces standard format and appends sign-off
 
-# 4. Push + 開 PR
+# 4. Push + open PR
 git push origin feat/redundancy-heatmap
 gh pr create --title "..." --body "..."
 
-# 5. CI 綠後 merge（目前是 solo → squash-merge 或 rebase-merge）
+# 5. After CI is green, merge (currently solo → squash-merge or rebase-merge)
 gh pr merge --squash
 ```
 
-> **重要**：merge 完 **不** 跑 `cz bump`。版號與 tag 走 release-train
-> 節奏（見 §7）——多個 PR 累積後才一次性 release。每個 PR 在自己的
-> 改動寫進 `CHANGELOG.md` 的 `## [Unreleased]` 段（含 `### Added` /
-> `### Changed` / `### Fixed` / `### Migration` 子段，視適用情況），release
-> 時 `cz bump --changelog` 會把該段固化成下一個版本標題。
+> **Important**: do **not** run `cz bump` after merge. Versions and tags
+> follow the release-train cadence (see §7)—a single release fires after
+> several PRs accumulate. Each PR writes its own changes into the
+> `## [Unreleased]` section of `CHANGELOG.md` (under `### Added` /
+> `### Changed` / `### Fixed` / `### Migration` subsections as
+> applicable); at release time, `cz bump --changelog` freezes that
+> section into the next version heading.
 
-### Branch 命名
+### Branch naming
 
-`<type>/<short-desc>`，全小寫連字號：
+`<type>/<short-desc>`, all lowercase with hyphens:
 
-- `feat/...` — 新 feature
+- `feat/...` — new feature
 - `fix/...` — bug fix
-- `refactor/...` — 重構（行為不變）
-- `docs/...` — 文件
-- `chore/...` — 打包 / CI / lock 維護
+- `refactor/...` — refactor (no behavioural change)
+- `docs/...` — documentation
+- `chore/...` — packaging / CI / lockfile maintenance
 
 ### Commit message
 
-專案採用 **Commitizen** 與 **Conventional Commits** 規範。**請一律使用 `cz commit` 進行互動式提交**，程式會自動檢驗標題長短等規則。
+The project follows **Commitizen** + **Conventional Commits**.
+**Always use `cz commit` for interactive commits**—it validates title
+length and other rules automatically.
 
-**規則提醒**：
-- Description 長度 `< 50 字元`
-- Body 採用 `-` 條列式，只寫「為什麼做」+「主要做了什麼」——不複述 diff，每行建議 `< 72 字元`
-- 禁用 AI co-author 署名、emoji、句末句號
-- 透過 `cz commit -- -s` 中的 `-s` 來附加 Signed-off-by
+**Reminders**:
+- Description length `< 50 chars`
+- Body uses `-` bullets, recording only "why" + "what"—do not restate
+  the diff; aim for `< 72 chars` per line
+- No AI co-author signature, no emoji, no trailing period
+- Pass `-s` via `cz commit -- -s` to append Signed-off-by
 
-#### 變更 `Signed-off-by` 簽名名稱與信箱
+#### Changing the `Signed-off-by` name and email
 
-`git commit -s` 生成的簽名是讀取 Git 環境設定中的 `user.name` 和 `user.email` 欄位。如果你需要更改簽名，請執行以下指令：
+`git commit -s` reads `user.name` and `user.email` from your Git
+config. To change the signature, run:
 
 ```bash
-# 僅限當前專案生效
-git config user.name "你的新名字"
-git config user.email "你的新信箱@example.com"
+# project-local only
+git config user.name "Your New Name"
+git config user.email "your-new-email@example.com"
 
-# 全域設定 (所有專案預設生效)
-git config --global user.name "你的新名字"
-git config --global user.email "你的新信箱@example.com"
+# global (default for all projects)
+git config --global user.name "Your New Name"
+git config --global user.email "your-new-email@example.com"
 ```
 
 ---
 
-## 4. Mode B 的三個關鍵陷阱
+## 4. Three critical pitfalls of Mode B
 
-### G1. Submodule = detached HEAD（最大的坑）
+### G1. Submodule = detached HEAD (the biggest trap)
 
-從 workspace 進 `external/factrix/` 時，submodule 預設是 **detached HEAD**。
-在 detached HEAD 上 commit 的 commits **不屬於任何 branch**——下次
-`git submodule update --remote` 會直接覆蓋，commit 消失（reflog 不記）。
+When entering `external/factrix/` from the workspace, the submodule
+defaults to **detached HEAD**. Commits made on a detached HEAD
+**belong to no branch**—the next `git submodule update --remote`
+silently overwrites them and the commits vanish (reflog does not
+record them).
 
 ```bash
-# 丟 commit 的寫法（錯誤示範）
+# Way to lose commits (incorrect)
 cd external/factrix
 # ...edit...
-git commit -am "feat: xxx"              # detached — commit 沒家
+git commit -am "feat: xxx"              # detached — commit has no home
 git submodule update --remote           # GONE
 
-# 正確：先 branch
+# Correct: branch first
 cd external/factrix
-git checkout -b feat/xxx                # 建 branch
+git checkout -b feat/xxx                # create branch
 # ...edit...
 git commit -am "feat: xxx"
 git push origin feat/xxx
-gh pr create                            # 在 factrix repo 開 PR
+gh pr create                            # open PR in the factrix repo
 ```
 
-### G2. Editable install 對 Jupyter 有限制
+### G2. Editable install has Jupyter caveats
 
-Workspace 的 `uv sync` 把 factrix 裝成 editable，所以改 submodule
-source 會立刻反映到 `import factrix`——但 Jupyter kernel 有例外：
+Workspace `uv sync` installs factrix in editable mode, so source
+changes in the submodule reflect in `import factrix` immediately—but
+Jupyter kernels have exceptions:
 
-- Function body 改動 → `%autoreload 2` 能抓到
-- `__init__.py` 的 imports / dataclass 定義 / module-level 常數 → 必須 **restart kernel**
+- Function body changes → caught by `%autoreload 2`
+- `__init__.py` imports / dataclass definitions / module-level
+  constants → must **restart the kernel**
 
-不確定時 restart kernel 是最穩的選擇。
+When in doubt, restart the kernel—the safest option.
 
-### G3. Workspace 不會自動追蹤 factrix 更新
+### G3. Workspace does not auto-track factrix updates
 
-factrix main 合了 PR 之後，workspace 的 submodule 指針**不會自動 bump**。
-這是 feature 不是 bug——workspace 的每個 commit 綁定明確的 factrix SHA，
-研究結果可重現。
+After a PR merges into factrix main, the workspace's submodule pointer
+**does not auto-bump**. This is a feature, not a bug—each workspace
+commit binds an explicit factrix SHA, keeping research results
+reproducible.
 
-手動 bump：
+Manual bump:
 
 ```bash
 cd external/factrix && git fetch && git checkout main && git pull
@@ -234,77 +256,88 @@ git commit -m "chore: bump factrix to <short-sha>: <why>"
 
 ## 5. Submodule sync reference
 
-Mode B 與 consumer workspace 日常操作的指令索引。90% 情境看 cheat sheet
-就夠，看不懂再往下讀心智模型與情境說明。
+Command index for Mode B and consumer-workspace daily ops. The cheat
+sheet covers 90% of cases; read the mental model and scenarios below
+only when the cheat sheet is unclear.
 
 ### 5.1 Cheat sheet
 
-| 想做的事 | 指令 |
-|---------|------|
-| 看 workspace pin 的 SHA | `git submodule status` |
-| 看 submodule actual HEAD | `cd external/factrix && git rev-parse --short HEAD` |
-| 拉 factrix main 最新到 actual | `git submodule update --remote` |
-| 切到特定 tag | `cd external/factrix && git fetch --tags && git checkout vX.Y.Z` |
-| 固化 actual 到 pin | `git add external/factrix && git commit -m "chore: bump..."` |
-| 放棄 actual 改動，reset 回 pin | `git submodule update` |
-| Fresh clone 初始化 submodule | `git submodule update --init --recursive` |
+| Goal | Command |
+|------|---------|
+| See the workspace-pinned SHA | `git submodule status` |
+| See the submodule's actual HEAD | `cd external/factrix && git rev-parse --short HEAD` |
+| Pull factrix main latest into actual | `git submodule update --remote` |
+| Switch to a specific tag | `cd external/factrix && git fetch --tags && git checkout vX.Y.Z` |
+| Freeze actual into the pin | `git add external/factrix && git commit -m "chore: bump..."` |
+| Discard actual changes, reset to pin | `git submodule update` |
+| Initialise submodule on fresh clone | `git submodule update --init --recursive` |
 
-### 5.2 心智模型
+### 5.2 Mental model
 
-workspace 有 `pin`（記在 workspace commit 裡的 SHA），submodule 自己
-有 `actual HEAD`（實際 checkout 的 SHA）。兩者可能不同——`git status`
-會顯示 submodule 是 `modified`。**Python editable install 讀的是 actual
-HEAD**，所以 import 拿到的版本取決於 actual，不是 pin。
+The workspace has a `pin` (the SHA recorded in the workspace commit);
+the submodule has its own `actual HEAD` (the SHA actually checked out).
+The two can differ—`git status` will show the submodule as `modified`.
+**Python editable install reads the actual HEAD**, so the imported
+version follows actual, not pin.
 
-### 5.3 常見情境
+### 5.3 Common scenarios
 
-- **自己改 factrix 要 sync 回 workspace**：走 §3 + §4（dev 流程），完成後
-  cheat sheet 第 5 列固化
-- **別人 push 了 factrix，我要跟上**：cheat sheet 第 3 列 + 第 5 列
-- **Pin 到 tag（推薦，見 §8）**：cheat sheet 第 4 列 + 第 5 列
-- **切 branch 後 submodule 亂掉**：cheat sheet 第 6 列 reset
+- **Editing factrix and syncing back to workspace**: follow §3 + §4
+  (dev workflow), then freeze with cheat sheet row 5
+- **Someone else pushed factrix; I need to catch up**: cheat sheet rows
+  3 + 5
+- **Pinning to a tag (recommended, see §8)**: cheat sheet rows 4 + 5
+- **Submodule looks broken after switching branches**: reset via cheat
+  sheet row 6
 
-### 5.4 搞不清楚時先做兩件事
+### 5.4 When confused, do two things first
 
-1. `git submodule status` 看 pin
-2. `cd external/factrix && git rev-parse HEAD` 看 actual
+1. `git submodule status` — see the pin
+2. `cd external/factrix && git rev-parse HEAD` — see the actual
 
-兩個 SHA 一樣 = 乾淨；不一樣就決定：要 bump pin（第 5 列）還是 reset
-actual（第 6 列）。
+If both SHAs match, you're clean; if not, decide whether to bump the
+pin (row 5) or reset actual (row 6).
 
 ---
 
-## 6. Docs 同步邊界（Source of Truth）
+## 6. Docs sync boundary (Source of Truth)
 
-修改 `factrix/` 後，下表告訴你哪些 `docs/` 會自動跟上、哪些需要手動維護。
+After editing `factrix/`, the table below tells you which `docs/`
+files auto-update and which need manual maintenance.
 
-### 自動同步管道
+### Auto-sync pipelines
 
-| Source（SSOT） | Docs 目的地 | 機制 |
+| Source (SSOT) | Docs target | Mechanism |
 |---|---|---|
-| `factrix/**/*.py` docstring | `docs/api/**/*.md` 內 `:::` 指令處 | mkdocstrings plugin |
-| `factrix/metrics/*.py` 的 `Matrix-row:` | `docs/reference/_generated_metric_matrix.md` | hook: `scripts/mkdocs_hooks/gen_metric_matrix.py` |
+| `factrix/**/*.py` docstrings | `:::` directives in `docs/api/**/*.md` | mkdocstrings plugin |
+| `Matrix-row:` in `factrix/metrics/*.py` | `docs/reference/_generated_metric_matrix.md` | hook: `scripts/mkdocs_hooks/gen_metric_matrix.py` |
 | `examples/*.ipynb` | `docs/examples/` | hook: `scripts/mkdocs_hooks/sync_examples.py` |
 | `factrix/llms*.txt` | site root `llms*.txt` | hook: `scripts/mkdocs_hooks/sync_llms_txt.py` |
 
-### 仍需手動維護的 docs
+### Docs that still need manual maintenance
 
-- `docs/api/**/*.md`（30 支）：每支含手寫 2–5 行敘事 intro + 一行 `:::` 指令；新增公開 metric 需手建檔並更新 `mkdocs.yml` `nav:`
-- `docs/getting-started/`、`docs/guides/`、`docs/development/`、首頁 `index.md`、各區 `index.md`：純敘事
-- `docs/reference/standalone-metrics.md`、`statistical-methods.md`、`warning-codes.md`、`bibliography.md`：敘事性彙整（非 matrix）
+- `docs/api/**/*.md` (30 files): each contains a hand-written 2–5 line
+  narrative intro plus a `:::` directive; new public metrics require a
+  new file plus a `nav:` entry in `mkdocs.yml`
+- `docs/getting-started/`, `docs/guides/`, `docs/development/`, the
+  homepage `index.md`, and per-section `index.md`: pure narrative
+- `docs/reference/standalone-metrics.md`, `statistical-methods.md`,
+  `warning-codes.md`, `bibliography.md`: narrative roll-ups (not
+  matrices)
 
 ---
 
-## 7. 測試規範
+## 7. Testing rules
 
 ### Synthetic fixtures only
 
-**factrix tests 不得 load 真實市場資料**——所有 fixture 必須是
-`tests/conftest.py` 或 test module 內 numpy / polars 程式化構造。
-這個 invariant 讓 tests 可以在任何環境跑（CI / 新機器 / fresh clone），
-也避免 repo 被資料污染。
+**factrix tests must not load real market data**—every fixture must be
+constructed programmatically in `tests/conftest.py` or the test module
+itself, using numpy / polars. This invariant lets tests run in any
+environment (CI / new machine / fresh clone) and prevents the repo
+from being polluted with data.
 
-Pattern（見 `tests/conftest.py`）：
+Pattern (see `tests/conftest.py`):
 
 ```python
 @pytest.fixture
@@ -318,98 +351,116 @@ def clean_panel():
     })
 ```
 
-### 新 feature 必帶測試
+### New features require tests
 
-新的 metric / Profile field / API parameter → 對應的 test case 必須同一個
-PR 加入。PR reviewer（現在是你 + Claude）應 block PR 如果沒測試。
+A new metric / Profile field / API parameter must come with a matching
+test in the same PR. The PR reviewer (you + Claude, today) should
+block the PR if tests are missing.
 
-### CI 必綠
+### CI must be green
 
-`.github/workflows/test.yml` 在每次 push / PR 跑 full pytest。**CI 紅的
-PR 不該 merge**——先 fix 再繼續。
+`.github/workflows/test.yml` runs the full pytest suite on every push
+/ PR. **A red PR must not merge**—fix first, then continue.
 
-### Metric docstring 風格
+### Metric docstring style
 
-`factrix/metrics/*.py` 的 docstring 是各 metric 「精確公式 / 演算法」的
-**authoritative source**。文件整體分工（what goes where）見 README 的
-「下一步看哪裡」表 — 單一來源，此處不複述。格式：
+Docstrings in `factrix/metrics/*.py` are the **authoritative source**
+for each metric's "exact formula / algorithm". Overall doc partitioning
+(what goes where) is in the README "Where to look next" table—single
+source, not restated here. Format:
 
-1. **第一行 tldr** — 一句話說明這個 metric 量什麼，可含簡短公式
-   （例：`IC_IR = mean(IC) / std(IC).`）
-2. **公式**：
-   - **單行公式** → inline 帶過，格式 `value = <expr>`
-   - **多行 algorithm / sandwich SE / 非平凡演算法** → `Formula:` block +
-     縮排等式，讓掃 `help()` 的人可以讀 display math
-3. **Args / Returns** block 保留（Google-style）
-4. **Short-circuit 條件**最後一段說明（哪些 input 會短路成 NaN、
-   對應 `metadata["reason"]` 是什麼）
-5. 引用論文走 `References:` block（選配；複雜方法才需要，簡單診斷
-   指標不用）
+1. **TL;DR first line** — one sentence describing what the metric
+   measures, optionally with a short formula
+   (e.g. `IC_IR = mean(IC) / std(IC).`)
+2. **Formula**:
+   - **Single-line formula** → inline, format `value = <expr>`
+   - **Multi-line algorithms / sandwich SE / non-trivial procedures** →
+     `Formula:` block with indented equations, so anyone scanning
+     `help()` gets readable display math
+3. **Args / Returns** blocks (Google-style)
+4. **Short-circuit conditions** as a final paragraph (which inputs
+   short-circuit to NaN, what `metadata["reason"]` reports)
+5. Paper citations under a `References:` block (optional; only complex
+   methods need it, simple diagnostics don't)
 
-範例（inline 公式）：`ts_beta.ts_beta_sign_consistency`
-範例（Formula block）：`fama_macbeth.pooled_ols`、`_helpers._sample_non_overlapping`
+Examples (inline formula): `ts_beta.ts_beta_sign_consistency`
+Examples (Formula block): `fama_macbeth.pooled_ols`,
+`_helpers._sample_non_overlapping`
 
-### LLM agent reference 同步
+### LLM agent reference sync
 
-SSOT 在 `factrix/llms.txt` 與 `factrix/llms-full.txt`（隨 wheel 出貨；mkdocs
-hook 在 build 時鏡像到 site root）。內容與 mkdocs 站部分重疊但**不互為
-SSOT**——agent 要密度、人類要漸進披露，目標結構性互斥，所以雙軌維護。
+The SSOT lives in `factrix/llms.txt` and `factrix/llms-full.txt`
+(shipped with the wheel; an mkdocs hook mirrors them to the site root
+at build time). Their content overlaps with the mkdocs site partially
+but **neither is the SSOT for the other**—agents need density and
+humans need progressive disclosure; the structural targets are
+mutually exclusive, so both tracks are maintained.
 
-下列任一變更落地時，同 PR 內同步 `factrix/llms*.txt`（無 CI 守門）：
+When any of the following ships, sync `factrix/llms*.txt` in the same
+PR (no CI gate):
 
-- `factrix/__init__.py` `__all__` 增刪
-- 公開 API signature 變更（factory、`evaluate`、`bhy`、`FactorProfile`）
-- `WarningCode` / `InfoCode` / `StatCode` 新增 / 改名 / 描述改寫
-- Mode dispatch 規則或 canonical panel schema 改變
+- Additions / removals to `factrix/__init__.py` `__all__`
+- Public API signature changes (factory, `evaluate`, `bhy`,
+  `FactorProfile`)
+- `WarningCode` / `InfoCode` / `StatCode` additions, renames, or
+  description rewrites
+- Mode dispatch rules or canonical panel schema changes
 
-PR 前 self-check：跑過三個 code block、`uv run mkdocs build --strict` 乾淨、
-`tiktoken` cl100k count < 8000。
+PR self-check: run all three code blocks, `uv run mkdocs build
+--strict` clean, `tiktoken` cl100k count < 8000.
 
 ---
 
-## 8. 版本管理與發布 (SemVer & Release)
+## 8. Versioning and release (SemVer & Release)
 
-目前 factrix 在 **pre-1.0**（v0.x.x）——公開 API **可能在 MINOR bump 裡
-BC 變動**。Consumer（如 `factor-analysis` workspace）應該透過 **git
-submodule SHA pin** 而非 version range，直到 1.0.0 穩定為止。
+factrix is currently in **pre-1.0** (v0.x.x)—the public API **may
+break in MINOR bumps**. Consumers (e.g. the `factor-analysis`
+workspace) should pin via **git submodule SHA**, not version range,
+until 1.0.0 stabilises.
 
-**專案採用 Commitizen 進行全自動升版與 Changelog 生成，搭配 release-train
-節奏：PR 隨時 merge，但 release（bump + tag）獨立排程。**
+**The project uses Commitizen for fully automated bump and changelog
+generation, paired with the release-train cadence: PRs merge whenever,
+but releases (bump + tag) are scheduled independently.**
 
 ### Release cadence — release train
 
-PR 與 release 解耦：
+PRs and releases are decoupled:
 
-- **PR cadence**：高頻、原子。merge 完 **不** bump，**不** tag。
-- **Release cadence**：低頻、彙總。當以下任一條件達到才開 release：
-  - 累積 ≥ 3 個 user-facing `feat:` / `fix:`
-  - 距上一個 tag ≥ 2 週
-  - 有對下游 workspace 的緊急 bug fix（單獨 PATCH 隨時可切）
-  - 為了讓某人 / 某 demo 拉到具名版本
+- **PR cadence**: high-frequency, atomic. Do **not** bump or tag after
+  merge.
+- **Release cadence**: low-frequency, aggregated. A release fires when
+  any of the following holds:
+  - ≥ 3 user-facing `feat:` / `fix:` accumulated
+  - ≥ 2 weeks since the last tag
+  - An urgent downstream-workspace bug fix (a one-off PATCH may ship
+    immediately)
+  - A named version is needed for a person / demo
 
-每個 PR 自己負責把 WHY narrative 寫進 `CHANGELOG.md` 的 `## [Unreleased]`
-段（`### Added` / `### Changed` / `### Fixed` / `### Migration` 子段）。
-這樣 release 時不用回頭重建敘事——`cz bump --changelog` 把整段固化成下
-一個版本標題即可。
+Each PR writes its own WHY narrative into the `## [Unreleased]`
+section of `CHANGELOG.md` (under `### Added` / `### Changed` /
+`### Fixed` / `### Migration` subsections). At release time, no
+narrative reconstruction is needed—`cz bump --changelog` freezes the
+section into the next version heading.
 
 ### Release workflow
 
 ```bash
-# 1. 在 factrix repo main 分支確保最新
+# 1. On main, ensure latest
 git checkout main && git pull
 
-# 2. 驗證 CI 綠 + 本地 pytest 全綠
+# 2. Verify CI is green and local pytest passes
 uv run pytest
 
-# 3. 自動改版與打標籤
-# cz 根據自上一個 tag 以來的 commits 推導 (feat=MINOR, fix=PATCH)，
-# 把 [Unreleased] 段改名為新版本標題，新增空白 [Unreleased] 段，
-# 更新 pyproject.toml，自動 commit + tag。
+# 3. Auto-bump and tag
+# cz derives the level from commits since the last tag (feat=MINOR, fix=PATCH),
+# renames [Unreleased] to the new version heading, adds a fresh empty
+# [Unreleased], updates pyproject.toml, and auto-commits + tags.
 cz bump --changelog
 
-# 4. （選配）手動潤飾 release 段——補 BREAKING migration / 方向 / 動機
-#    至 ≥ 25 非空白行，否則 pre-push 會 block（見 §2 hook）。
-#    潤完用 git commit --amend 收回 release commit，刪舊 tag 重建：
+# 4. (Optional) Manually polish the release section — fill in BREAKING
+#    migration / direction / motivation to ≥ 25 non-blank lines, otherwise
+#    the pre-push hook blocks (see §2). After polishing, amend the release
+#    commit and re-tag:
 git commit --amend --no-edit
 git tag -d v<X.Y.Z> && git tag v<X.Y.Z>
 
@@ -417,7 +468,7 @@ git tag -d v<X.Y.Z> && git tag v<X.Y.Z>
 git push origin main
 git push origin v<X.Y.Z>
 
-# 6. 回 workspace bump submodule
+# 6. Bump the workspace submodule
 cd ~/Desktop/dst/code/factor-analysis
 cd external/factrix && git fetch && git checkout v<X.Y.Z>
 cd ../.. && git add external/factrix
@@ -425,55 +476,92 @@ git commit -m "chore: bump factrix to v<X.Y.Z>"
 git push
 ```
 
-### BC change 特別注意
+### BC change reminders
 
-例：`q1_q5_spread → long_short_spread`（已於 workspace 歷史發生過）
-這種 rename 屬 BC change。開發者在利用 `cz commit` 提交時，必須選擇 Breaking Change，並在 Prompt 中**明確寫出 migration path**（舊名 → 新名、影響哪些欄位）。這樣下游 workspace 才能從自動生成的 CHANGELOG 中找到升級指南。
+Example: `q1_q5_spread → long_short_spread` (this rename actually
+occurred in workspace history). This kind of rename is a BC change.
+When using `cz commit`, the developer must select Breaking Change and
+**explicitly write the migration path** in the prompt (old → new
+names, affected fields). This way, downstream workspaces find the
+upgrade guide directly in the auto-generated CHANGELOG.
 
-### Workspace 不跟最新 main，只跟 tag
+### Workspace pins to tags, not main
 
-下游 research workspace 原則上 **pin 到 tag**（而非 main HEAD），這樣
-每個 workspace commit 對應一個清楚的 factrix 版本、可重現。
+Downstream research workspaces should generally **pin to a tag** (not
+main HEAD), so each workspace commit corresponds to a clear factrix
+version and remains reproducible.
 
-Main HEAD 只在 Mode B 開發中暫時用（debug 流程），完成後 merge 回
-factrix main、打 tag，再讓 workspace bump 到 tag。
-
----
-
-## 9. 架構 / 設計決策
-
-新 feature 或大改動前建議先讀：
-
-- `ARCHITECTURE.md` — 套件現況 snapshot（positioning、public API、
-  4 種 factor types、Profile contract、Artifacts、invariants）
-- `CHANGELOG.md` — 歷史 BC changes + caveats
-
-`ARCHITECTURE.md` 是**當下狀態**描述，不是設計歷程。如果要看「為什麼
-設計成這樣」的過程紀錄，去 `awwesomeman/factor-analysis` workspace 的
-`docs/spike_*.md` / `docs/refactor_*.md`（pre-extraction 歷史保留於彼處）。
+Main HEAD is used only temporarily during Mode B development (debug
+flow); once finished, merge back into factrix main, tag, and let the
+workspace bump to the tag.
 
 ---
 
-## 10. 問問題 / 決策溝通
+## 9. Architecture / design decisions
 
-作者 + AI agent 自用 repo，所以沒有 issue template / discussion board。
-決策記錄管道：
+Before a new feature or large change, read:
 
-- **小改動**：PR description 寫清楚 why + 有無 BC
-- **大改動 / 架構決策**：在 workspace repo 的 `docs/` 下新增 `spike_*.md`
-  設計文件（跟歷史 spike 一致），factrix PR 引用它
-- **Invariant 級規則變更**：更新 `ARCHITECTURE.md` 的 `Invariants` 區塊
+- `docs/development/architecture.md` — current snapshot of the package
+  (positioning, public API, factor types, Profile contract, artifacts,
+  invariants)
+- `CHANGELOG.md` — historical BC changes and caveats
+
+`docs/development/architecture.md` describes the **current state**, not
+the design history. For "why is it designed this way" process records,
+see the `awwesomeman/factor-analysis` workspace under
+`docs/spike_*.md` / `docs/refactor_*.md` (pre-extraction history is
+preserved there).
 
 ---
 
-## 11. 授權與貢獻條款（Licensing）
+## 10. Asking questions / decision communication
 
-本專案採用 [Apache License 2.0](LICENSE)。
+Self-use repo for the author + AI agents, so there is no issue
+template / discussion board. Decision-record channels:
 
-**Inbound = Outbound**：依 Apache-2.0 §5，凡你向本 repo 提交（PR、patch、issue 附帶程式碼等）的內容，**預設視為以 Apache-2.0 同等條款授權回本專案**，除非你在提交時明確聲明其他條款。送 PR 前請確認：
+- **Small changes**: PR description spells out the why and any BC
+- **Large changes / architectural decisions**: add a `spike_*.md`
+  design doc under the workspace repo's `docs/` (matching historical
+  spikes), and reference it from the factrix PR
+- **Invariant-level rule changes**: update the `Invariants` section in
+  `docs/development/architecture.md`
 
-- 你對該段程式碼擁有授權權利（自行撰寫，或來源相容於 Apache-2.0）
-- 引用第三方程式碼時，於檔案 header 或 PR description 標註原始授權
-- 涉及專利的演算法（如：你個人或所屬組織持有專利的方法），請在 PR description 主動揭露
+---
 
-不接受 GPL/AGPL 等具強制 copyleft 的程式碼合併進主程式碼樹（會污染下游使用者的授權義務）。
+## 11. Style — single language
+
+All issue / PR titles + bodies, commit messages, CHANGELOG entries,
+and any content under `factrix/` and `docs/` (excluding `docs/plans/`)
+is written in **English**. Internal planning notes under `docs/plans/`
+may remain bilingual; they are excluded from the published mkdocs site
+via `mkdocs.yml` `exclude_docs`.
+
+Rationale: mixed-language content fragments full-text search
+(`gh issue list`, GitHub search, `git log`), splits visual flow in
+notification emails, and burdens readers who must context-switch
+mid-paragraph. The choice of language is not prescribed by tooling—the
+repo settled on English to align with the public docstring surface,
+README, and CHANGELOG.
+
+---
+
+## 12. Licensing and contribution terms
+
+This project is released under the [Apache License 2.0](LICENSE).
+
+**Inbound = Outbound**: per Apache-2.0 §5, any content you submit to
+this repo (PRs, patches, issue-attached code, etc.) is **deemed
+licensed back to the project under the same Apache-2.0 terms**, unless
+you explicitly state otherwise at submission time. Before opening a
+PR, confirm:
+
+- You hold the right to license that code (self-authored, or sourced
+  under an Apache-2.0-compatible licence)
+- When citing third-party code, mark the original licence in the file
+  header or PR description
+- Patent-encumbered algorithms (e.g. methods you or your organisation
+  hold patents on) must be disclosed proactively in the PR description
+
+Code under strong copyleft (GPL/AGPL etc.) is not accepted into the
+main code tree, since it would propagate licence obligations onto
+downstream users.

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -16,14 +16,15 @@ from typing import Literal, NewType
 # Numerical constants
 # ---------------------------------------------------------------------------
 
-# WHY: 統一除零保護門檻，避免 std ≈ 0 時 t-stat 膨脹至天文數字
+# WHY: shared zero-division floor so std ≈ 0 doesn't inflate t-stat to absurd magnitudes.
 EPSILON: float = 1e-9
 
-# WHY: ddof=1 為樣本標準差（業界主流），全專案統一避免跨指標比較產生系統性偏差
-# Polars .std() 預設 ddof=1，NumPy 需顯式傳入
+# WHY: ddof=1 is the sample-std convention (industry standard); fixing it project-wide
+# avoids systematic bias across cross-metric comparisons.
+# Polars .std() defaults to ddof=1; NumPy requires it explicitly.
 DDOF: int = 1
 
-# WHY: 1.4826 = 1/Φ⁻¹(0.75)，使 MAD 成為常態分佈下 σ 的無偏估計量
+# WHY: 1.4826 = 1/Φ⁻¹(0.75); makes MAD an unbiased estimator of σ under normality.
 MAD_CONSISTENCY_CONSTANT: float = 1.4826
 
 

--- a/factrix/_validators.py
+++ b/factrix/_validators.py
@@ -70,7 +70,7 @@ def validate_n_assets(df: pl.DataFrame, factor_type: str) -> None:
                 f"auto-falls back to per-asset OLS t-test at N=1\n"
                 f"factrix currently has no first-class canonical test for "
                 f"'continuous factor × single asset' (see "
-                f"docs/plan_direction.md §7 待定決策)."
+                f"docs/plan_direction.md §7 — open decision)."
             )
         # macro_panel
         raise ValueError(

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -180,10 +180,12 @@ def multi_split_oos_decay(
         out.metadata.pop("p_value", None)
         return out
 
-    # WHY: 取中位數而非均值，對單一 regime change 落在某 split 點更穩健
+    # WHY: median over mean — robust when a single regime change lands on
+    # one split point.
     median_survival = float(np.median([d.survival_ratio for d in split_details]))
 
-    # WHY: sign flip 任一 split 發生即 VETOED — IC 翻轉代表因子在 OOS 預測反了
+    # WHY: any sign flip across splits → VETOED. IC sign flip means the
+    # factor predicts the wrong direction OOS.
     if any_sign_flip:
         status: GateStatus = "VETOED"
     elif median_survival >= survival_threshold:

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -420,8 +420,8 @@ def breakeven_cost(
             },
         )
 
-    # WHY: ×2 因為 long-short 雙邊交易；×forward_periods 把 per-period spread
-    # 升到 per-rebalance 與 turnover 對齊；×10000 轉 bps。
+    # WHY: ×2 because long-short trades both sides; ×forward_periods lifts the
+    # per-period spread to per-rebalance to align with turnover; ×10000 → bps.
     be_bps = (gross_spread * forward_periods / (2 * turnover)) * 10000
 
     return MetricOutput(

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -105,21 +105,22 @@ def ic_trend(
             min_required=10,
         )
 
-    # WHY: 使用序號而非日期差，因為非重疊取樣後日期間距可能不均
+    # WHY: index by sequence rather than date difference — non-overlapping
+    # sampling can leave irregular gaps between dates.
     x = np.arange(n, dtype=float)
 
     result = sp_stats.theilslopes(vals, x)
     slope = float(result.slope)
-    # WHY: scipy theilslopes 回傳 (slope, intercept, low_slope, high_slope)
+    # WHY: scipy theilslopes returns (slope, intercept, low_slope, high_slope).
     low_slope = float(result.low_slope)
     high_slope = float(result.high_slope)
 
-    # WHY: 如果 CI 不跨零，slope 顯著
+    # WHY: slope is significant when the CI does not cross zero.
     ci_excludes_zero = (low_slope > 0 and high_slope > 0) or (
         low_slope < 0 and high_slope < 0
     )
 
-    # WHY: 從 CI 推導近似 t-stat 供顯著性標記使用
+    # WHY: derive an approximate t-stat from the CI for the significance flag.
     # slope ± margin = CI → margin = (high - low) / 2 → SE ≈ margin / 1.96
     margin = (high_slope - low_slope) / 2
     approx_t = slope / (margin / 1.96) if margin > 0 else 0.0

--- a/factrix/preprocess/orthogonalize.py
+++ b/factrix/preprocess/orthogonalize.py
@@ -68,7 +68,7 @@ def orthogonalize_factor(
         )
         return OrthogonalizeResult(df=factor_df)
 
-    # WHY: join 確保 date × asset_id 對齊
+    # WHY: join enforces date × asset_id alignment.
     merged = factor_df.join(
         base_factors.select(["date", "asset_id", *base_cols]),
         on=["date", "asset_id"],
@@ -93,11 +93,12 @@ def orthogonalize_factor(
         y = chunk[factor_col].to_numpy().astype(np.float64)
         X = chunk.select(base_cols).to_numpy().astype(np.float64)
 
-        # WHY: 加截距項讓回歸去均值
+        # WHY: intercept term de-means the regression.
         ones = np.ones((len(y), 1))
         X_with_intercept = np.hstack([ones, X])
 
-        # WHY: 處理共線性或全零列（某日某產業無觀測）
+        # WHY: handle collinearity or all-zero columns (e.g. a sector with no
+        # observations on that date).
         try:
             beta, _, _, _ = np.linalg.lstsq(X_with_intercept, y, rcond=None)
             residual = y - X_with_intercept @ beta
@@ -125,7 +126,7 @@ def orthogonalize_factor(
 
     residuals_df = pl.concat(residuals_list)
 
-    # WHY: 保留正交化前的原始值供比較分析
+    # WHY: keep the pre-orthogonalisation values for comparison analysis.
     result = (
         factor_df.with_columns(pl.col(factor_col).alias("factor_pre_ortho"))
         .join(residuals_df, on=["date", "asset_id"], how="left")


### PR DESCRIPTION
## Summary

Closes #74. Single-language consistency across the published surface.

- `docs/development/contributing.md` translated fully to English (was 242 lines Chinese + 78 lines English).
- Inline `# WHY:` rationale comments in `factrix/` translated in place across 6 files (`_types.py`, `_validators.py`, `metrics/{trend,oos,tradability}.py`, `preprocess/orthogonalize.py`).
- New §11 in contributing documents the English-only rule; `docs/plans/` excepted (already excluded from the mkdocs publish via `mkdocs.yml exclude_docs`).

Public docstrings, README, CHANGELOG, examples, and `docs/development/architecture.md` were already English; no further changes needed.

## Test plan

- [x] `grep -rP "[\x{4e00}-\x{9fff}]" factrix/ docs/development/contributing.md` returns zero matches
- [x] `uv run mkdocs build --strict` clean
- [x] `uv run pytest -q` — 655 passed
- [x] pre-commit ruff lint/format passes

No behaviour change.