### PR TITLE
feat(api): list_metrics for per-cell standalone metric discovery (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ CONTRIBUTING §7 (Release workflow).
 
 ### Added
 
+- **`factrix.list_metrics(scope, signal, *, format="text" | "json")`** —
+  programmatic discovery of standalone metrics applicable to a given
+  analysis cell. Closes the gap left by `describe_analysis_modes()`,
+  which only surfaces the cell's primary procedure (IC / FM / CAAR /
+  TS-β); `list_metrics` returns the full set of standalone callables
+  under `factrix.metrics` that the user can additionally invoke (e.g.
+  `monotonicity`, `quantile_spread`, `turnover`, `event_hit_rate`).
+  Source of truth is the `Matrix-row:` tag already parsed by the docs
+  matrix generator — extracted into `factrix._metric_index` so the
+  runtime API and the docs render share one parser. `Mode` is not an
+  input because applicability does not change across PANEL /
+  TIMESERIES. (#76)
 - **`bmp_test(include_prediction_error_variance=False)`** — opt-in
   strict BMP (1991) denominator $\sigma_i \cdot \sqrt{1 + 1/T_{\mathrm{est}}}$
   for the mean-adjusted residual forecast. Default off preserves the

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -1,0 +1,76 @@
+# list_metrics
+
+Programmatic discovery of standalone metrics applicable to a given
+analysis cell. Complements [`describe_analysis_modes`](
+../reference/metric-applicability.md) — that helper enumerates the
+*primary procedure* per cell (IC / FM / CAAR / TS-β); `list_metrics`
+returns the full set of standalone callables under
+[`factrix.metrics`](metrics/index.md) that the user can additionally
+invoke once `evaluate()` has produced a `FactorProfile`.
+
+## Call shape
+
+```python
+import factrix as fl
+
+fl.list_metrics(fl.FactorScope.INDIVIDUAL, fl.Signal.CONTINUOUS)
+# -> ['top_concentration', 'beta_sign_consistency', 'fama_macbeth',
+#     'pooled_ols', 'hit_rate', 'ic', 'ic_ir', 'ic_newey_west',
+#     'multi_horizon_ic', 'regime_ic', 'monotonicity',
+#     'multi_split_oos_decay', 'quantile_spread', 'quantile_spread_vw',
+#     'greedy_forward_selection', 'spanning_alpha', 'breakeven_cost',
+#     'net_spread', 'notional_turnover', 'turnover', 'ic_trend']
+```
+
+`Mode` is intentionally not an input — applicability does not change
+across PANEL / TIMESERIES (see
+[Metric applicability](../reference/metric-applicability.md) for the
+underlying matrix).
+
+## Structured output for tooling
+
+```python
+fl.list_metrics(
+    fl.FactorScope.INDIVIDUAL,
+    fl.Signal.CONTINUOUS,
+    format="json",
+)
+# -> [
+#     {
+#         "name": "ic",
+#         "module": "ic",
+#         "cell": "(INDIVIDUAL, CONTINUOUS, IC, PANEL)",
+#         "agg_order": "CS-first",
+#         "inference_se": "NW HAC / cross-asset t",
+#     },
+#     ...
+# ]
+```
+
+The JSON form is the single-source-of-truth row produced by parsing
+the `Matrix-row:` tag in each metric module's docstring (the same
+parser MkDocs uses to render
+[the cross-metric matrix](../reference/standalone-metrics.md)). Keys:
+
+| Key | Meaning |
+|---|---|
+| `name` | Function name as exported under `factrix.metrics` |
+| `module` | Submodule stem (e.g. `ic`, `fama_macbeth`) |
+| `cell` | Raw cell string from the `Matrix-row:` tag |
+| `agg_order` | Aggregation order (`CS-first`, `TS-first`, `per-event`, `TS-only`, `static CS`) |
+| `inference_se` | Inference / SE method or `no formal H₀` for descriptive metrics |
+
+## Errors
+
+`IncompatibleAxisError` is raised when `(scope, signal)` matches no
+registered metric. All four real combinations are populated, so this
+is defensive — surfaced for symmetry with the rest of the API.
+
+## Source of truth
+
+`list_metrics` and the docs matrix share one parser
+(`factrix._metric_index`). Adding a new metric only requires adding a
+`Matrix-row:` tag to the new module's docstring; both surfaces pick it
+up automatically.
+
+::: factrix.list_metrics

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -5,7 +5,9 @@ where it is in scope, the canonical inferential role it plays in
 that cell, and the sample-size threshold that gates it. Per-metric
 formulae, parameters, and Notes / References live in the
 [Metrics API pages](../api/metrics/index.md); this page is the
-cross-metric overview.
+cross-metric overview. For the runtime API that returns the per-cell
+metric list programmatically, see
+[`list_metrics`](../api/list-metrics.md).
 
 ## Sample dimensions
 

--- a/docs/reference/standalone-metrics.md
+++ b/docs/reference/standalone-metrics.md
@@ -32,4 +32,6 @@ For per-module formula derivations, read each module's top-level
 docstring (linked above); for the underlying paper references and
 inference-SE rationale, see [Statistical methods](statistical-methods.md);
 for `n_obs` / `n_assets` thresholds per metric, see
-[Metric applicability](metric-applicability.md).
+[Metric applicability](metric-applicability.md). For the runtime API
+that returns the same data filtered by `(scope, signal)`, see
+[`list_metrics`](../api/list-metrics.md).

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -49,6 +49,7 @@ from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
 from factrix._describe import (
     SuggestConfigResult,
     describe_analysis_modes,
+    list_metrics,
     suggest_config,
 )
 from factrix._errors import (
@@ -112,6 +113,7 @@ __all__ = [
     # Introspection
     "SuggestConfigResult",
     "describe_analysis_modes",
+    "list_metrics",
     "suggest_config",
     # Multi-factor namespace
     "multi_factor",

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -12,7 +12,9 @@ from typing import Any, Literal
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import WarningCode, cross_section_tier
+from factrix._errors import IncompatibleAxisError
 from factrix._evaluate import _derive_mode
+from factrix._metric_index import user_facing_rows
 from factrix._registry import (
     _DISPATCH_REGISTRY,
     _dispatch_key_for,
@@ -377,3 +379,58 @@ def suggest_config(
         reasoning=reasoning,
         warnings=warnings,
     )
+
+
+# ---------------------------------------------------------------------------
+# list_metrics
+# ---------------------------------------------------------------------------
+
+
+def list_metrics(
+    scope: FactorScope,
+    signal: Signal,
+    *,
+    format: Literal["text", "json"] = "text",
+) -> list[str] | list[dict[str, Any]]:
+    """Return standalone metrics applicable to ``(scope, signal)``.
+
+    Mode is intentionally not an input — applicability does not change
+    across PANEL / TIMESERIES (per ``docs/reference/metric-applicability.md``).
+    Source of truth is the ``Matrix-row:`` tag in each metric module's
+    docstring, parsed by :mod:`factrix._metric_index`.
+
+    Parameters
+    ----------
+    scope, signal
+        Cell axes to filter on.
+    format
+        ``"text"`` (default) returns ``list[str]`` of metric names sorted
+        by ``(module, name)``. ``"json"`` returns ``list[dict]`` rows
+        with keys ``name``, ``module``, ``cell``, ``agg_order``,
+        ``inference_se`` — JSON-serialisable, suitable for tooling that
+        needs the structured row.
+
+    Raises
+    ------
+    IncompatibleAxisError
+        ``(scope, signal)`` matches no registered metric. In practice
+        all four combos are populated, so this is defensive.
+    """
+    rows = [r for r in user_facing_rows() if r.cell.matches(scope, signal)]
+    if not rows:
+        raise IncompatibleAxisError(
+            f"no standalone metrics registered for "
+            f"(scope={scope.value}, signal={signal.value})"
+        )
+    if format == "json":
+        return [
+            {
+                "name": r.name,
+                "module": r.module,
+                "cell": r.cell.raw,
+                "agg_order": r.agg_order,
+                "inference_se": r.inference_se,
+            }
+            for r in rows
+        ]
+    return [r.name for r in rows]

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -1,0 +1,229 @@
+"""Shared parser for ``Matrix-row:`` tags in ``factrix/metrics/*.py``.
+
+Single source of truth for "which standalone metrics live in which
+cell." Consumed by:
+
+- ``scripts/mkdocs_hooks/gen_metric_matrix.py`` — renders the docs
+  matrix in ``docs/reference/_generated_metric_matrix.md``.
+- ``factrix.list_metrics`` — runtime API exposing the same data.
+
+Each metric module's docstring carries one or more ``Matrix-row:``
+lines with the format::
+
+    Matrix-row: {public_functions} | {cell_scope} | {agg_order} | {inference_se} | {primitives}
+
+``public_functions`` is a comma-separated list. ``cell_scope`` is
+either a 4-tuple ``(scope, signal, metric, mode)`` (``*`` denotes
+wildcard) or — uniquely for ``factrix.metrics.spanning`` — the
+literal label ``factor-return-series consumer (post-PANEL pipeline)``,
+which is mapped to ``(INDIVIDUAL, CONTINUOUS, *, *)`` since spanning
+metrics consume the spread series produced by the Individual ×
+Continuous pipeline.
+
+Stage-1 aggregation helpers that produce intermediate panels / series
+(rather than a ``MetricOutput``) are filtered out by ``user_facing``
+rows — they are listed in ``Matrix-row:`` for primitive-graph
+completeness but are not metrics a user would call directly. The
+exclusion set is explicit (not a ``compute_*`` prefix rule) because
+``compute_rolling_mean_beta`` is a genuine user-facing metric.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import pathlib
+import re
+from dataclasses import dataclass
+
+from factrix._axis import FactorScope, Metric, Mode, Signal
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+_METRICS_DIR = _REPO_ROOT / "factrix" / "metrics"
+
+_MATRIX_ROW_RE = re.compile(r"^\s*Matrix-row:\s*(.+)$", re.MULTILINE)
+_TUPLE_RE = re.compile(r"^\((.*)\)$")
+
+_SPANNING_CELL_LABEL = "factor-return-series consumer (post-PANEL pipeline)"
+
+# Stage-1 helpers: produce intermediate panels / series consumed by the
+# user-facing metric in the same module. Listed in ``Matrix-row:`` for
+# primitive-graph completeness; excluded from ``user_facing`` rows.
+_STAGE1_HELPERS: frozenset[str] = frozenset(
+    {
+        "compute_caar",
+        "compute_event_returns",
+        "compute_fm_betas",
+        "compute_group_returns",
+        "compute_ic",
+        "compute_mfe_mae",
+        "compute_spread_series",
+        "compute_ts_betas",
+        # Single-asset fallback wired into the dispatch registry, not a
+        # standalone callable (``ts_beta`` itself dispatches to it).
+        "ts_beta_single_asset_fallback",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Cell:
+    """Parsed ``(scope, signal, metric, mode)`` cell tuple.
+
+    ``None`` represents the ``*`` wildcard along an axis. ``raw``
+    preserves the original string for matrix rendering. ``metric`` and
+    ``mode`` are parsed for completeness — :meth:`matches` only filters
+    on ``scope`` / ``signal`` (the public ``list_metrics`` axes); the
+    matrix renderer reads ``raw`` directly.
+    """
+
+    scope: FactorScope | None
+    signal: Signal | None
+    metric: Metric | None
+    mode: Mode | None
+    raw: str
+
+    def matches(self, scope: FactorScope, signal: Signal) -> bool:
+        """Return True if this cell is applicable to ``(scope, signal)``."""
+        return (self.scope is None or self.scope == scope) and (
+            self.signal is None or self.signal == signal
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixEntry:
+    """One ``Matrix-row:`` tag, un-exploded — drives matrix rendering."""
+
+    module: str
+    names: tuple[str, ...]
+    cell: Cell
+    agg_order: str
+    inference_se: str
+
+
+@dataclass(frozen=True, slots=True)
+class MetricRow:
+    """One ``(metric_name, module, cell)`` triple parsed from ``Matrix-row:``."""
+
+    name: str
+    module: str
+    cell: Cell
+    agg_order: str
+    inference_se: str
+
+
+def _parse_axis(token: str, enum_cls: type) -> object | None:
+    """Map a Matrix-row axis token (``*`` or enum value) to enum or None."""
+    token = token.strip()
+    if token == "*":
+        return None
+    try:
+        return enum_cls(token.lower())
+    except ValueError as exc:
+        raise ValueError(
+            f"unknown {enum_cls.__name__} token {token!r} in Matrix-row cell"
+        ) from exc
+
+
+def _parse_cell(raw: str) -> Cell:
+    raw = raw.strip()
+    if raw == _SPANNING_CELL_LABEL:
+        return Cell(
+            scope=FactorScope.INDIVIDUAL,
+            signal=Signal.CONTINUOUS,
+            metric=None,
+            mode=None,
+            raw=raw,
+        )
+    m = _TUPLE_RE.match(raw)
+    if not m:
+        raise ValueError(f"unparseable Matrix-row cell: {raw!r}")
+    parts = [p.strip() for p in m.group(1).split(",")]
+    if len(parts) != 4:
+        raise ValueError(
+            f"Matrix-row cell tuple has {len(parts)} fields (expected 4): {raw!r}"
+        )
+    return Cell(
+        scope=_parse_axis(parts[0], FactorScope),  # type: ignore[arg-type]
+        signal=_parse_axis(parts[1], Signal),  # type: ignore[arg-type]
+        metric=_parse_axis(parts[2], Metric),  # type: ignore[arg-type]
+        mode=_parse_axis(parts[3], Mode),  # type: ignore[arg-type]
+        raw=raw,
+    )
+
+
+def _public_metric_modules() -> list[pathlib.Path]:
+    return sorted(p for p in _METRICS_DIR.glob("*.py") if not p.stem.startswith("_"))
+
+
+def _extract_matrix_rows(path: pathlib.Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    doc = ast.get_docstring(tree) or ""
+    return [m.group(1).strip() for m in _MATRIX_ROW_RE.finditer(doc)]
+
+
+def _parse_module_entries(path: pathlib.Path) -> list[MatrixEntry]:
+    entries: list[MatrixEntry] = []
+    for raw_value in _extract_matrix_rows(path):
+        parts = [p.strip() for p in raw_value.split("|")]
+        if len(parts) != 5:
+            raise ValueError(
+                f"{path.name}: Matrix-row has {len(parts)} pipe-separated"
+                f" fields (expected 5): {raw_value!r}"
+            )
+        names_csv, cell_str, agg_order, inference_se, _primitives = parts
+        names = tuple(n for n in (n.strip() for n in names_csv.split(",")) if n)
+        entries.append(
+            MatrixEntry(
+                module=path.stem,
+                names=names,
+                cell=_parse_cell(cell_str),
+                agg_order=agg_order,
+                inference_se=inference_se,
+            )
+        )
+    return entries
+
+
+@functools.cache
+def matrix_entries() -> tuple[MatrixEntry, ...]:
+    """Return one entry per ``Matrix-row:`` tag (un-exploded by name).
+
+    Sorted by module. Cached — metric module docstrings do not change
+    at runtime, so repeated callers (``list_metrics`` in agentic loops)
+    avoid re-parsing every public ``factrix/metrics/*.py``.
+    """
+    out: list[MatrixEntry] = []
+    for path in _public_metric_modules():
+        out.extend(_parse_module_entries(path))
+    out.sort(key=lambda e: e.module)
+    return tuple(out)
+
+
+def all_rows() -> list[MetricRow]:
+    """Return every parsed ``Matrix-row:`` row, exploded one per metric name.
+
+    Sorted by ``(module, name)``. Includes stage-1 helpers; for the
+    user-facing subset call :func:`user_facing_rows`.
+    """
+    rows = [
+        MetricRow(
+            name=name,
+            module=entry.module,
+            cell=entry.cell,
+            agg_order=entry.agg_order,
+            inference_se=entry.inference_se,
+        )
+        for entry in matrix_entries()
+        for name in entry.names
+    ]
+    rows.sort(key=lambda r: (r.module, r.name))
+    return rows
+
+
+def user_facing_rows() -> list[MetricRow]:
+    """Return parsed rows excluding stage-1 aggregation helpers."""
+    return [r for r in all_rows() if r.name not in _STAGE1_HELPERS]

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -227,7 +227,7 @@ family lacks the gated key.
 
 ---
 
-### `describe_analysis_modes` / `suggest_config`
+### `describe_analysis_modes` / `suggest_config` / `list_metrics`
 
 ```
 factrix.describe_analysis_modes(*, format: Literal["text", "json"] = "text"
@@ -237,6 +237,15 @@ factrix.describe_analysis_modes(*, format: Literal["text", "json"] = "text"
 factrix.suggest_config(raw, *, forward_periods: int = 5) -> SuggestConfigResult
     # Inspect a panel; propose an AnalysisConfig + structured reasoning + warnings.
     # Suggestion is never auto-applied — caller (or agent) reads .reasoning.
+
+factrix.list_metrics(scope: FactorScope, signal: Signal,
+                     *, format: Literal["text", "json"] = "text"
+                     ) -> list[str] | list[dict[str, Any]]
+    # Standalone metrics applicable to a (scope, signal) cell.
+    # text → list[str] sorted by (module, name); json → rows with
+    # {name, module, cell, agg_order, inference_se}. Mode is not an input —
+    # applicability does not change across PANEL / TIMESERIES.
+    # Raises IncompatibleAxisError if the pair has no registered metrics.
 ```
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
   - API:
       - AnalysisConfig: api/analysis-config.md
       - evaluate: api/evaluate.md
+      - list_metrics: api/list-metrics.md
       - FactorProfile: api/factor-profile.md
       - MetricOutput: api/metric-output.md
       - multi_factor: api/multi-factor.md

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -1,8 +1,9 @@
 """Build-time generator for the standalone-metrics matrix table.
 
-Parses every public ``factrix/metrics/*.py`` module, extracts
-``Matrix-row:`` lines from each module docstring, and writes a
-Markdown table to ``docs/reference/_generated_metric_matrix.md``.
+Renders a Markdown table to ``docs/reference/_generated_metric_matrix.md``
+from the parsed ``Matrix-row:`` tags exposed by
+:mod:`factrix._metric_index` (single source of truth, also consumed at
+runtime by ``factrix.list_metrics``).
 
 Usage (manual)::
 
@@ -16,93 +17,39 @@ MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
 
 from __future__ import annotations
 
-import ast
 import pathlib
-import re
 
-# ---------------------------------------------------------------------------
-# Paths (relative to repo root — resolved at call time so the script works
-# when invoked from any working directory, including inside mkdocs).
-# ---------------------------------------------------------------------------
+from factrix._metric_index import MatrixEntry, matrix_entries
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
-_METRICS_DIR = _REPO_ROOT / "factrix" / "metrics"
 _OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_metric_matrix.md"
 
 _TABLE_HEADER = (
     "| Module | Cell scope | Aggregation order | Inference SE |\n|---|---|---|---|\n"
 )
 
-_MATRIX_ROW_RE = re.compile(r"^\s*Matrix-row:\s*(.+)$", re.MULTILINE)
 
-
-def _public_metric_modules() -> list[pathlib.Path]:
-    """Return sorted list of public metric module paths."""
-    return sorted(p for p in _METRICS_DIR.glob("*.py") if not p.stem.startswith("_"))
-
-
-def _extract_matrix_rows(path: pathlib.Path) -> list[str]:
-    """Return raw Matrix-row values (one per tag) from a module's docstring."""
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return []
-    doc = ast.get_docstring(tree) or ""
-    return [m.group(1).strip() for m in _MATRIX_ROW_RE.finditer(doc)]
-
-
-def _build_table_row(module_path: pathlib.Path, row_value: str) -> str:
-    """Convert one Matrix-row: value into a Markdown table row string.
-
-    Renders 4 user-facing columns (Module | Cell scope | Aggregation order |
-    Inference SE); public_functions and primitives are kept in the docstring
-    for developers but omitted from the overview table.
-    """
-    parts = [p.strip() for p in row_value.split("|")]
-    if len(parts) != 5:
-        raise ValueError(
-            f"{module_path.name}: Matrix-row has {len(parts)} pipe-separated"
-            f" fields (expected 5): {row_value!r}"
-        )
-    _public_fns, cell_scope, agg_order, inference_se, _primitives = parts
-
-    stem = module_path.stem
-    module_cell = f"[`metrics.{stem}`][factrix.metrics.{stem}]"
-
-    return f"| {module_cell} | `{cell_scope}` | {agg_order} | {inference_se} |\n"
+def _render_row(entry: MatrixEntry) -> str:
+    module_cell = f"[`metrics.{entry.module}`][factrix.metrics.{entry.module}]"
+    return (
+        f"| {module_cell} | `{entry.cell.raw}` | "
+        f"{entry.agg_order} | {entry.inference_se} |\n"
+    )
 
 
 def generate() -> None:
     """Generate ``_generated_metric_matrix.md`` from module docstrings."""
-    lines: list[str] = [_TABLE_HEADER]
-
-    for module_path in _public_metric_modules():
-        row_values = _extract_matrix_rows(module_path)
-        if not row_values:
-            # Skip modules with no Matrix-row tags silently; test coverage
-            # in test_docs_matrix.py will catch missing tags.
-            continue
-        for row_value in row_values:
-            lines.append(_build_table_row(module_path, row_value))
-
+    entries = matrix_entries()
+    lines = [_TABLE_HEADER, *(_render_row(e) for e in entries)]
     _OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     _OUT_FILE.write_text("".join(lines), encoding="utf-8")
-    print(f"gen_metric_matrix: wrote {len(lines) - 1} row(s) to {_OUT_FILE}")
-
-
-# ---------------------------------------------------------------------------
-# MkDocs hook entry point (mkdocs 1.4+)
-# ---------------------------------------------------------------------------
+    print(f"gen_metric_matrix: wrote {len(entries)} row(s) to {_OUT_FILE}")
 
 
 def on_pre_build(config: object) -> None:
     """MkDocs hook: regenerate the matrix before every build."""
     generate()
 
-
-# ---------------------------------------------------------------------------
-# CLI entry point
-# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     generate()

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -1,0 +1,187 @@
+"""Tests for ``factrix.list_metrics`` and the shared ``_metric_index`` parser.
+
+Asserts the runtime API agrees with the hand-curated applicability table
+in ``docs/reference/metric-applicability.md`` — the test catches drift
+in either direction (a new metric module that forgets to update the
+doc, or vice versa).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from unittest.mock import patch
+
+import factrix as fl
+import pytest
+from factrix._axis import FactorScope, Signal
+from factrix._errors import IncompatibleAxisError
+from factrix._metric_index import _STAGE1_HELPERS, MetricRow, user_facing_rows
+
+_APPLICABILITY_DOC = pathlib.Path("docs/reference/metric-applicability.md")
+
+
+def _parse_applicability_doc() -> dict[tuple[FactorScope, Signal], set[str]]:
+    """Build per-cell expected name sets from the applicability matrix."""
+    expected: dict[tuple[FactorScope, Signal], set[str]] = {
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS): set(),
+        (FactorScope.COMMON, Signal.CONTINUOUS): set(),
+        (FactorScope.INDIVIDUAL, Signal.SPARSE): set(),
+        (FactorScope.COMMON, Signal.SPARSE): set(),
+    }
+    text = _APPLICABILITY_DOC.read_text(encoding="utf-8")
+    row_re = re.compile(r"^\|\s*\[`([^`]+)`\][^|]*\|\s*([^|]+?)\s*\|", re.MULTILINE)
+    for match in row_re.finditer(text):
+        name, cell = match.group(1), match.group(2)
+        # Drop the leading symbol on the metric name when present
+        # (table syntax already strips backticks).
+        targets: list[tuple[FactorScope, Signal]] = []
+        if cell.startswith("Individual × Continuous") or cell.startswith(
+            "Spread-series consumer"
+        ):
+            targets = [(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)]
+        elif cell.startswith("Common × Continuous"):
+            targets = [(FactorScope.COMMON, Signal.CONTINUOUS)]
+        elif cell.startswith("Individual × Sparse"):
+            # Matrix-row tags use ``(*, SPARSE, *, PANEL)``: wildcard scope.
+            targets = [
+                (FactorScope.INDIVIDUAL, Signal.SPARSE),
+                (FactorScope.COMMON, Signal.SPARSE),
+            ]
+        elif cell.startswith("Series-tools"):
+            # ``(*, CONTINUOUS, *, TIMESERIES)``: wildcard scope.
+            targets = [
+                (FactorScope.INDIVIDUAL, Signal.CONTINUOUS),
+                (FactorScope.COMMON, Signal.CONTINUOUS),
+            ]
+        for t in targets:
+            expected[t].add(name)
+    return expected
+
+
+# ---------------------------------------------------------------------------
+# applicability-doc parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scope", "signal"),
+    [
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS),
+        (FactorScope.COMMON, Signal.CONTINUOUS),
+        (FactorScope.INDIVIDUAL, Signal.SPARSE),
+        (FactorScope.COMMON, Signal.SPARSE),
+    ],
+)
+def test_list_metrics_matches_applicability_doc(
+    scope: FactorScope, signal: Signal
+) -> None:
+    expected = _parse_applicability_doc()[(scope, signal)]
+    assert expected, "applicability doc parser found no rows for this cell"
+    actual = set(fl.list_metrics(scope, signal))
+    assert actual == expected, (
+        f"({scope.value}, {signal.value}) drift\n"
+        f"  only in list_metrics: {sorted(actual - expected)}\n"
+        f"  only in doc table:    {sorted(expected - actual)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# stage-1 helper exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_stage1_helpers_excluded_from_user_facing_rows() -> None:
+    names = {row.name for row in user_facing_rows()}
+    assert _STAGE1_HELPERS.isdisjoint(names)
+
+
+def test_compute_rolling_mean_beta_remains_user_facing() -> None:
+    # Sanity: it starts with ``compute_`` but is a real metric per the doc;
+    # exclusion must be by name set, not prefix.
+    names = {row.name for row in user_facing_rows()}
+    assert "compute_rolling_mean_beta" in names
+
+
+# ---------------------------------------------------------------------------
+# sort stability + format
+# ---------------------------------------------------------------------------
+
+
+def test_text_output_is_sorted_by_module_then_name() -> None:
+    out = fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+    json_rows = fl.list_metrics(
+        FactorScope.INDIVIDUAL, Signal.CONTINUOUS, format="json"
+    )
+    expected_order = [r["name"] for r in json_rows]
+    assert out == expected_order
+    keys = [(r["module"], r["name"]) for r in json_rows]
+    assert keys == sorted(keys)
+
+
+def test_json_format_round_trips() -> None:
+    rows = fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, format="json")
+    text = json.dumps(rows)
+    decoded = json.loads(text)
+    assert decoded == rows
+    sample = rows[0]
+    assert set(sample) == {"name", "module", "cell", "agg_order", "inference_se"}
+
+
+def test_json_output_is_stable_across_calls() -> None:
+    a = fl.list_metrics(FactorScope.COMMON, Signal.CONTINUOUS, format="json")
+    b = fl.list_metrics(FactorScope.COMMON, Signal.CONTINUOUS, format="json")
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# unrepresented (scope, signal) pair
+# ---------------------------------------------------------------------------
+
+
+def test_incompatible_axis_pair_raises() -> None:
+    # All four real (scope, signal) combos are populated; simulate a
+    # genuinely unrepresented pair by monkeypatching the index empty.
+    with (
+        patch("factrix._describe.user_facing_rows", return_value=[]),
+        pytest.raises(IncompatibleAxisError),
+    ):
+        fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+
+
+# ---------------------------------------------------------------------------
+# spanning special-case
+# ---------------------------------------------------------------------------
+
+
+def test_spanning_metrics_appear_for_individual_continuous_only() -> None:
+    ind = set(fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS))
+    com = set(fl.list_metrics(FactorScope.COMMON, Signal.CONTINUOUS))
+    assert {"spanning_alpha", "greedy_forward_selection"}.issubset(ind)
+    assert {"spanning_alpha", "greedy_forward_selection"}.isdisjoint(com)
+
+
+# ---------------------------------------------------------------------------
+# public surface
+# ---------------------------------------------------------------------------
+
+
+def test_list_metrics_in_public_namespace() -> None:
+    assert "list_metrics" in fl.__all__
+    assert callable(fl.list_metrics)
+
+
+def test_metric_row_dataclass_fields_are_serialisable() -> None:
+    row = user_facing_rows()[0]
+    assert isinstance(row, MetricRow)
+    serialised = json.dumps(
+        {
+            "name": row.name,
+            "module": row.module,
+            "cell": row.cell.raw,
+            "agg_order": row.agg_order,
+            "inference_se": row.inference_se,
+        }
+    )
+    assert json.loads(serialised)["name"] == row.name


### PR DESCRIPTION
## Summary

- New `factrix.list_metrics(scope, signal, *, format="text" | "json")` returns the standalone metrics applicable to a `(scope, signal)` cell. Closes the gap left by `describe_analysis_modes()`, which only surfaces each cell's primary procedure (IC / FM / CAAR / TS-β).
- Source of truth is the existing `Matrix-row:` tag in each metric module's docstring — extracted into `factrix/_metric_index` so runtime API and the docs matrix render share one parser. `Mode` is not an input (applicability does not change across PANEL / TIMESERIES).
- `text` returns `list[str]` sorted by `(module, name)`; `json` returns rows with `{name, module, cell, agg_order, inference_se}`.

## Design notes

The original issue draft proposed a richer JSON schema (`role`, `sample_axis`, `min_sample`) and regenerating `metric-applicability.md` from the same parser. Both were dropped after review — those fields live in the hand-curated applicability table, not in `Matrix-row:`, so adopting them as a contract would either silently drop information or force a tag-schema change across every metric module. Plan revision posted on #76 before implementation.

Stage-1 aggregation helpers (`compute_ic`, `compute_caar`, …) are filtered by an explicit name set rather than a `compute_*` prefix — `compute_rolling_mean_beta` is a genuine user-facing metric and must remain. `spanning_alpha` / `greedy_forward_selection` are special-cased to `(INDIVIDUAL, CONTINUOUS)` because their `Matrix-row:` cell label is a free-form "factor-return-series consumer" string rather than a tuple.

## Test plan

- [x] `uv run pytest tests/test_list_metrics.py` — 13 new tests pass (per-cell parity vs `metric-applicability.md`, `compute_*` exclusion + `compute_rolling_mean_beta` allowlist, JSON round-trip, sort stability, spanning special-case, `IncompatibleAxisError` on synthetic unrepresented pair, public-namespace surface).
- [x] `uv run pytest -q` — full suite 668 passed, no regression.
- [x] `uv run mkdocs build --strict` clean; `_generated_metric_matrix.md` byte-identical to pre-change output.

Closes #76