### PR TITLE
docs: correct SPARSE / n_obs / metric-pipelines wording (#78)

### DIFF
--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -80,8 +80,8 @@ with Hansen-Hodrick overlap floor). Cross-asset aggregations
 have no `NW_LAGS_USED` entry.
 
 `FACTOR_ADF_P` is a CONTINUOUS-only persistence diagnostic — sparse
-cells skip it because the `{−1, 0, +1}`-style signal makes the unit-
-root null degenerate.
+cells skip it because the `{0, R}` event-trigger signal (zero on
+non-event entries) makes the unit-root null degenerate.
 
 ### Example
 

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -45,13 +45,13 @@ on any registered cell's output is supported.
 
 | Dispatch cell | `n_obs` is |
 |---------------|------------|
-| `(individual, continuous, ic, panel)` | `T` — number of dates contributing to the per-date IC series |
-| `(individual, continuous, fm, panel)` | `T` — number of dates with a valid OLS slope |
-| `(individual, sparse, None, panel)` | `T` — densified panel-period count (unique dates in the panel) after CAAR event-date back-fill |
-| `(common, continuous, None, panel)` | `N` — number of assets entering the cross-asset t-test on `E[β]` |
-| `(common, sparse, None, panel)` | `N` |
-| `(common, continuous, None, timeseries)` | `T` — single-series sample length |
-| `(*, sparse, None, timeseries)` | `T` — period count of the dummy regression |
+| `(individual, continuous, ic, panel)` | number of dates contributing to the per-date IC series |
+| `(individual, continuous, fm, panel)` | number of dates with a valid OLS slope |
+| `(individual, sparse, None, panel)` | densified panel-period count (unique dates in the panel) after CAAR event-date back-fill |
+| `(common, continuous, None, panel)` | number of assets entering the cross-asset t-test on `E[β]` |
+| `(common, sparse, None, panel)` | number of assets entering the cross-asset event-dummy t-test |
+| `(common, continuous, None, timeseries)` | single-series sample length |
+| `(*, sparse, None, timeseries)` | period count of the dummy regression |
 
 Reading `n_obs` together with `n_assets` disambiguates whether a small
 `n_obs` came from a short series (low `T`) or a thin cross-section

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -40,7 +40,7 @@ fl.list_metrics(
 #         "name": "ic",
 #         "module": "ic",
 #         "cell": "(INDIVIDUAL, CONTINUOUS, IC, PANEL)",
-#         "agg_order": "CS-first",
+#         "agg_order": "cs-first",
 #         "inference_se": "NW HAC / cross-asset t",
 #     },
 #     ...
@@ -57,7 +57,7 @@ parser MkDocs uses to render
 | `name` | Function name as exported under `factrix.metrics` |
 | `module` | Submodule stem (e.g. `ic`, `fama_macbeth`) |
 | `cell` | Raw cell string from the `Matrix-row:` tag |
-| `agg_order` | Aggregation order (`CS-first`, `TS-first`, `per-event`, `TS-only`, `static CS`) |
+| `agg_order` | Aggregation order (`cs-first`, `ts-first`, `ts-only`, `static-cs`, `per-event`) |
 | `inference_se` | Inference / SE method or `no formal H₀` for descriptive metrics |
 
 ## Errors

--- a/docs/api/metrics/common-continuous.md
+++ b/docs/api/metrics/common-continuous.md
@@ -19,6 +19,6 @@ statistical meaning — see
 [`profile.mode`](../factor-profile.md) for which path ran.
 
 The `Common × Sparse` cell shares the time-series-first aggregation
-shape but with a `{-1, 0, +1}` broadcast dummy in place of the
-continuous regressor; metrics live under
-[Individual sparse](individual-sparse.md).
+shape but with a `{0, R}` broadcast event dummy (canonical
+`{-1, 0, +1}`) in place of the continuous regressor; metrics live
+under [Individual sparse](individual-sparse.md).

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -13,7 +13,7 @@ Reverse index — match your situation to the likely landing page:
 | Continuous factor, ~30+ dates × ~10+ assets, canonical IC test | [`ic`](ic.md) (and `ic_newey_west` for HAC) |
 | Continuous factor, per-date OLS slope test | [`fama_macbeth`](fama_macbeth.md) |
 | Long-short spread sized by factor quintiles | [`quantile`](quantile.md), [`monotonicity`](monotonicity.md) |
-| Sparse `±1` event signal, CAAR / abnormal-return test | [`caar`](caar.md), [`event_quality`](event_quality.md) |
+| Sparse `{0, R}` event signal (canonical `±1`), CAAR / abnormal-return test | [`caar`](caar.md), [`event_quality`](event_quality.md) |
 | Sparse signal, suspect event-induced variance | `caar.bmp_test` (check [`clustering`](clustering.md) first) |
 | Sparse signal, non-parametric robustness check | [`corrado`](corrado.md) |
 | Common time-series factor (one signal × N assets, e.g. VIX) | [`ts_beta`](ts_beta.md), [`ts_quantile`](ts_quantile.md) |
@@ -51,7 +51,7 @@ modules plus a fourth axis-agnostic group**:
 | Cell | Group on this nav | Notes |
 |---|---|---|
 | `Individual × Continuous` | **Individual continuous** | Both `IC` and `FM` primary metrics live in this cell; ancillary metrics (`quantile`, `monotonicity`, `concentration`, `tradability`, `spanning`) are shared across both. |
-| `Individual × Sparse` | **Individual sparse** | Per-event tests on `(date, asset_id, factor ∈ {-1, 0, +1})`. Domain shorthand: *event signal*. |
+| `Individual × Sparse` | **Individual sparse** | Per-event tests on `(date, asset_id, factor)` with sparse `{0, R}` schema (zero on non-event entries; canonical `{-1, 0, +1}`). Domain shorthand: *event signal*. |
 | `Common × Sparse` | **Individual sparse** (shared metric modules) | Has its own dispatch procedure (`_CommonSparsePanelProcedure`: per-asset OLS β on the broadcast dummy → cross-asset *t*) — not the CAAR per-event flow used by `Individual × Sparse`. The two cells share the SPARSE column contract and the event-quality / clustering / corrado helper metrics, so factrix groups them on this nav. |
 | `Common × Continuous` | **Common continuous** | Single time series broadcast across assets (VIX, USD index, …). |
 

--- a/docs/api/metrics/individual-sparse.md
+++ b/docs/api/metrics/individual-sparse.md
@@ -2,8 +2,10 @@
 
 Metrics for the `Individual × Sparse` cell — event signals where most
 `(date, asset_id)` cells carry `factor == 0` and the few non-zero cells
-mark events. The default contract is `factor ∈ {-1, 0, +1}` for signed
-events; magnitude-weighted continuous values also flow through (see
+mark events. The schema is `{0, R}` — zero on non-event entries,
+arbitrary real magnitude otherwise. Canonical example: signed
+`{-1, 0, +1}` ternary; magnitude-weighted continuous values
+(`{0, R≥0}`, `{-R, 0, +R}`) also flow through (see
 [`caar`](caar.md) for the input-form table).
 
 | Metric | Role | Page |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -345,8 +345,9 @@ per-asset OLS R_i = α_i + β_i·D over all n_periods dates   (time-series step)
                                                          →  cross-asset t-test on E[β]   (cross-section step)
 ```
 
-Same shape as `common_continuous`; the broadcast `D ∈ {-1, 0, +1}` dummy
-replaces the continuous regressor. Factor magnitudes are **preserved** in
+Same shape as `common_continuous`; the broadcast `D` carries the
+sparse `{0, R}` schema (canonical `{-1, 0, +1}`) and replaces the
+continuous regressor. Factor magnitudes are **preserved** in
 the OLS (no `.sign()` coercion at this layer — distinct from the
 `individual_sparse` PANEL pipeline). ADF persistence diagnostic is skipped
 per I6 (sparse regressors are not unit-root candidates).

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -9,7 +9,7 @@ specific statistical test.
 | Axis | Values | What it asks |
 |------|--------|--------------|
 | `scope` | `INDIVIDUAL` / `COMMON` | Does each asset have its own factor value, or do all assets share one? |
-| `signal` | `CONTINUOUS` / `SPARSE` | Real-valued signal, or `{−1, 0, +1}` trigger? |
+| `signal` | `CONTINUOUS` / `SPARSE` | Real-valued signal, or `{0, R}` event trigger (zero on non-events; canonical `{−1, 0, +1}`)? |
 | `metric` | `IC` / `FM` / *(N/A)* | Only for `(INDIVIDUAL, CONTINUOUS)` — refines the research question |
 
 ### scope — a factor attribute, not a data shape
@@ -27,7 +27,10 @@ axis, not the panel layout itself:
 ### signal
 
 - **`CONTINUOUS`** — real-valued (z-score, percentile, momentum, …).
-- **`SPARSE`** — `{−1, 0, +1}` trigger; expect ≥ 50% zeros.
+- **`SPARSE`** — `{0, R}` event trigger: zero on non-event entries,
+  arbitrary real magnitude otherwise; expect ≥ 50% zeros. Canonical
+  examples: `{−1, 0, +1}` (signed dummy), `{0, 1}` (event flag),
+  `{0, R≥0}` (intensity).
 
 ### metric (only for `INDIVIDUAL × CONTINUOUS`)
 

--- a/docs/guides/choosing-metric.md
+++ b/docs/guides/choosing-metric.md
@@ -36,4 +36,4 @@ For the lookup table — which metrics are supported under which `(scope, signal
 | BHY family input (needs [`FactorProfile`][factrix.FactorProfile]) | Multi-statistic decomposition |
 | Primary screening gate | OOS decay, tradability, concentration |
 
-See [Standalone metrics](../reference/standalone-metrics.md) for the full module list.
+See [Metric pipelines](../reference/standalone-metrics.md) for the full module list.

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -24,7 +24,16 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 
 ## Aggregation order
 
-PANEL procedures split into **cross-section first** (`individual_continuous` IC / FM, sparse CAAR) and **time-series first** (`common_continuous`, `common_sparse`). The order determines small-sample failure modes and the N=1 collapse behaviour: `common_continuous` at N=1 degenerates to a single-series β test (null: β=0, not E[β]=0), which is still well-defined; `individual_continuous` at N=1 has no cross-section to aggregate over, so it raises.
+PANEL procedures split into **cross-section first** (`cs-first` —
+`individual_continuous` IC / FM, sparse CAAR) and **time-series first**
+(`ts-first` — `common_continuous`, `common_sparse`). The order determines
+small-sample failure modes and the N=1 collapse behaviour: `common_continuous`
+at N=1 degenerates to a single-series β test (null: β=0, not E[β]=0), which is
+still well-defined; `individual_continuous` at N=1 has no cross-section to
+aggregate over, so it raises. The `cs-first` / `ts-first` / `ts-only` /
+`static-cs` / `per-event` shorthand is the canonical vocabulary used across
+the metric matrix and `list_metrics()` output — see
+[Reference § Metric pipelines § Aggregation vocabulary](../reference/standalone-metrics.md#aggregation-vocabulary).
 
 Full per-procedure pseudocode for all 7 registered pipelines lives in [Development § Procedure pipelines](../development/architecture.md#procedure-pipelines).
 

--- a/docs/reference/_generated_metric_matrix.md
+++ b/docs/reference/_generated_metric_matrix.md
@@ -1,22 +1,22 @@
 | Module | Cell scope | Aggregation order | Inference SE |
 |---|---|---|---|
 | [`metrics.caar`][factrix.metrics.caar] | `(*, SPARSE, *, PANEL)` | per-event | non-overlapping t / z |
-| [`metrics.clustering`][factrix.metrics.clustering] | `(*, SPARSE, *, PANEL)` | static CS | no formal H₀ |
-| [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | across-time t (one-sided H₀: ratio ≥ 0.5) |
+| [`metrics.clustering`][factrix.metrics.clustering] | `(*, SPARSE, *, PANEL)` | static-cs | no formal H₀ |
+| [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) |
 | [`metrics.corrado`][factrix.metrics.corrado] | `(*, SPARSE, *, PANEL)` | per-event | nonparametric rank |
 | [`metrics.event_horizon`][factrix.metrics.event_horizon] | `(*, SPARSE, *, PANEL)` | per-event | binomial |
 | [`metrics.event_quality`][factrix.metrics.event_quality] | `(*, SPARSE, *, PANEL)` | per-event | binomial / nonparametric rank |
-| [`metrics.fama_macbeth`][factrix.metrics.fama_macbeth] | `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | CS-first | NW HAC / clustered t |
-| [`metrics.hit_rate`][factrix.metrics.hit_rate] | `(*, CONTINUOUS, *, TIMESERIES)` | TS-only | binomial |
-| [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | CS-first | NW HAC / cross-asset t |
+| [`metrics.fama_macbeth`][factrix.metrics.fama_macbeth] | `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | cs-first | NW HAC / clustered t |
+| [`metrics.hit_rate`][factrix.metrics.hit_rate] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | binomial |
+| [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | cs-first | NW HAC / cross-asset t |
 | [`metrics.mfe_mae`][factrix.metrics.mfe_mae] | `(*, SPARSE, *, PANEL)` | per-event | no formal H₀ |
-| [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | cross-asset t |
-| [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | TS-only | no formal H₀ |
-| [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | cross-asset t |
-| [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | TS-only | NW HAC / OLS t |
-| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | CS-first | no formal H₀ |
-| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | TS-only (rank autocorrelation across consecutive dates) | no formal H₀ |
-| [`metrics.trend`][factrix.metrics.trend] | `(*, CONTINUOUS, *, TIMESERIES)` | TS-only | Theil-Sen rank-based CI |
-| [`metrics.ts_asymmetry`][factrix.metrics.ts_asymmetry] | `(COMMON, CONTINUOUS, *, PANEL)` | CS-first | NW HAC Wald |
-| [`metrics.ts_beta`][factrix.metrics.ts_beta] | `(COMMON, CONTINUOUS, *, PANEL)` | TS-first | cross-asset t |
-| [`metrics.ts_quantile`][factrix.metrics.ts_quantile] | `(COMMON, CONTINUOUS, *, PANEL)` | CS-first | NW HAC Wald |
+| [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
+| [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | no formal H₀ |
+| [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
+| [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | ts-only | NW HAC / OLS t |
+| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | no formal H₀ |
+| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ |
+| [`metrics.trend`][factrix.metrics.trend] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | Theil-Sen rank-based CI |
+| [`metrics.ts_asymmetry`][factrix.metrics.ts_asymmetry] | `(COMMON, CONTINUOUS, *, PANEL)` | cs-first | NW HAC Wald |
+| [`metrics.ts_beta`][factrix.metrics.ts_beta] | `(COMMON, CONTINUOUS, *, PANEL)` | ts-first | cross-asset t |
+| [`metrics.ts_quantile`][factrix.metrics.ts_quantile] | `(COMMON, CONTINUOUS, *, PANEL)` | cs-first | NW HAC Wald |

--- a/docs/reference/standalone-metrics.md
+++ b/docs/reference/standalone-metrics.md
@@ -1,10 +1,18 @@
-# Standalone metric pipelines
+# Metric pipelines
 
 Cross-module index of every module under `factrix/metrics/`. Use this
 page to pick the existing aggregation pattern a new metric should
 match, or to mechanically check that a candidate metric satisfies the
 [NW HAC discipline](statistical-methods.md) the rest of the suite
 follows.
+
+The matrix lists **all** metric modules — both the procedure-canonical
+primaries that `evaluate()` invokes internally
+(`ic`, `fama_macbeth`, `caar`, `ts_beta`) and the standalone helpers
+the user calls directly on a `FactorProfile` (`quantile`, `monotonicity`,
+`tradability`, `clustering`, `corrado`, …). The
+[`list_metrics`](../api/list-metrics.md) runtime API filters this same
+data to the standalone subset by `(scope, signal)`.
 
 The table below is auto-generated from `Matrix-row:` tags in each module's
 docstring. It surfaces the three columns most relevant to understanding
@@ -14,14 +22,20 @@ and internal primitives, click the module link to the source.
 
 ## Aggregation vocabulary
 
-- **CS-first** — aggregate cross-section per date first, then aggregate
-  the resulting time series.
-- **TS-first** — aggregate time-series per asset first, then aggregate
-  across assets.
-- **TS-only** — single-series time-series operation; no cross-section
+The `agg_order` column uses one canonical lowercase-hyphen form across
+the matrix, every `Matrix-row:` tag in `factrix/metrics/*.py`, and the
+`list_metrics()` JSON output:
+
+- **`cs-first`** — aggregate cross-section per date first, then aggregate
+  the resulting time series. Pairs with the
+  [Guides § Aggregation order](../guides/panel-timeseries.md#aggregation-order)
+  *cross-section first* prose.
+- **`ts-first`** — aggregate time-series per asset first, then aggregate
+  across assets. Pairs with the *time-series first* prose.
+- **`ts-only`** — single-series time-series operation; no cross-section
   step.
-- **Static CS** — single cross-section, no time-axis aggregation.
-- **Per-event** — aggregation centred on event dates (per-event-date
+- **`static-cs`** — single cross-section, no time-axis aggregation.
+- **`per-event`** — aggregation centred on event dates (per-event-date
   step), then cross-event aggregation.
 
 ## Matrix

--- a/factrix/_axis.py
+++ b/factrix/_axis.py
@@ -5,7 +5,8 @@ Three orthogonal user-facing axes describe an analysis cell:
 - ``FactorScope``  — does the factor vary per-asset (``INDIVIDUAL``) or
   carry a single value broadcast to every asset (``COMMON``)?
 - ``Signal``       — continuous numeric exposure (``CONTINUOUS``) vs.
-  ``{-1, 0, +1}`` event triggers (``SPARSE``)?
+  ``{0, R}`` event triggers (``SPARSE`` — zero on non-event entries,
+  arbitrary real magnitude otherwise; canonical example ``{-1, 0, +1}``)?
 - ``Metric``       — procedure-canonical scalar (``IC`` or ``FM``).
   Only meaningful for ``INDIVIDUAL × CONTINUOUS``; ``None`` for the
   remaining cells.
@@ -28,7 +29,11 @@ class FactorScope(StrEnum):
 
 
 class Signal(StrEnum):
-    """Continuous numeric exposure vs. ``{-1, 0, +1}`` event trigger."""
+    """Continuous numeric exposure vs. ``{0, R}`` sparse event trigger.
+
+    Sparse columns are zero on non-event entries with arbitrary real
+    magnitude otherwise (canonical example ``{-1, 0, +1}``).
+    """
 
     CONTINUOUS = "continuous"
     SPARSE = "sparse"

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -288,8 +288,9 @@ class _CommonContPanelProcedure:
 class _CommonSparsePanelProcedure:
     """``(COMMON, SPARSE, None, PANEL)`` — broadcast event-dummy β panel.
 
-    Per-asset OLS β_i on a broadcast {-1, 0, +1} dummy, aggregated to
-    a cross-asset t-test on ``E[β]``. Plan §4.3: same per-asset β →
+    Per-asset OLS β_i on a broadcast sparse ``{0, R}`` dummy
+    (canonical ``{-1, 0, +1}``), aggregated to a cross-asset t-test
+    on ``E[β]``. Plan §4.3: same per-asset β →
     cross-asset t-test pattern as COMMON × CONTINUOUS, with the dummy
     replacing the continuous factor. ADF skipped (I6).
 
@@ -331,8 +332,8 @@ class _CommonSparsePanelProcedure:
             if n_events == 0:
                 detail = (
                     "the broadcast factor has no non-zero observations; ensure "
-                    "events are encoded as ±1 on event dates (zero on non-event "
-                    "dates) before dispatching"
+                    "events are encoded with non-zero magnitude on event dates "
+                    "(zero on non-event dates; canonical ±1) before dispatching"
                 )
             else:
                 detail = (

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -162,12 +162,15 @@ def make_event_panel(
     seed: int = 42,
     start_date: str = _DEFAULT_START,
 ) -> pl.DataFrame:
-    """Synthetic event-signal panel (factor ∈ ``{-1, 0, +1}``).
+    """Synthetic event-signal panel — sparse ``{0, R}`` schema, emitted
+    here as the canonical signed ternary ``factor ∈ {-1, 0, +1}``.
 
     Construction:
         1. Baseline returns as in ``make_cs_panel``.
         2. Independent ``Bernoulli(event_rate)`` per ``(t, i)``; sign
-           ``±1`` with equal probability. Non-event cells get ``0``.
+           ``±1`` with equal probability (this generator's chosen
+           magnitude under the broader ``{0, R}`` sparse schema).
+           Non-event cells get ``0``.
         3. Post-event drift: for each event with sign ``s``, add
            ``s · post_event_drift_bps / 1e4 / signal_horizon`` to the
            ``signal_horizon`` bars ``t+2 .. t+1+H`` of that asset — the

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -27,7 +27,8 @@ statistical procedure.
 
 **Signal** — the value type:
 - `CONTINUOUS` — real-valued (returns, z-scores, raw fundamentals)
-- `SPARSE` — categorical trigger in `{-1, 0, +1}` (event flags, regime dummies)
+- `SPARSE` — `{0, R}` event trigger: zero on non-event entries, arbitrary real
+  magnitude otherwise (event flags, regime dummies; canonical `{-1, 0, +1}`)
 
 **Metric** — the statistical procedure. Only meaningful for the
 `(INDIVIDUAL, CONTINUOUS)` cell:

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -56,7 +56,7 @@ def compute_caar(
     r"""Per-event-date weighted abnormal return series.
 
     Aggregation:
-        CS-first. For each event date, take the cross-sectional mean of
+        cs-first. For each event date, take the cross-sectional mean of
         ``signed_car`` $= r \times f$ across event rows where $f \neq 0$;
         the resulting ``n_event_dates``-length CAAR series feeds a
         downstream NW HAC $t$-test on the mean.

--- a/factrix/metrics/clustering.py
+++ b/factrix/metrics/clustering.py
@@ -12,7 +12,7 @@ quantifies this concentration.
 Only meaningful for multi-asset panels (N > 1). For single-asset
 event studies, clustering across assets is not applicable.
 
-Matrix-row: clustering_diagnostic | (*, SPARSE, *, PANEL) | static CS | no formal H₀ | _short_circuit_output
+Matrix-row: clustering_diagnostic | (*, SPARSE, *, PANEL) | static-cs | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -10,7 +10,7 @@ inverse.
 
 Input: DataFrame with ``date, asset_id, factor, forward_return``.
 
-Matrix-row: top_concentration | (INDIVIDUAL, CONTINUOUS, *, PANEL) | CS-first | across-time t (one-sided H₀: ratio ≥ 0.5) | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _compute_tie_ratio
+Matrix-row: top_concentration | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _compute_tie_ratio
 """
 
 from __future__ import annotations

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -15,7 +15,7 @@ References:
     Newey & West (1987), "HAC Covariance Matrix."
     Petersen (2009), "Estimating Standard Errors in Finance Panel Data Sets."
 
-Matrix-row: compute_fm_betas, fama_macbeth, pooled_ols, beta_sign_consistency | (INDIVIDUAL, CONTINUOUS, FM, PANEL) | CS-first | NW HAC / clustered t | _newey_west_t_test, _p_value_from_t, _significance_marker, _short_circuit_output
+Matrix-row: compute_fm_betas, fama_macbeth, pooled_ols, beta_sign_consistency | (INDIVIDUAL, CONTINUOUS, FM, PANEL) | cs-first | NW HAC / clustered t | _newey_west_t_test, _p_value_from_t, _significance_marker, _short_circuit_output
 """
 
 from __future__ import annotations

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -7,7 +7,7 @@ Input: DataFrame with ``date, value`` or a 1-D array.
 Output: proportion of periods where the value satisfies a condition
 (default: value > 0).
 
-Matrix-row: hit_rate | (*, CONTINUOUS, *, TIMESERIES) | TS-only | binomial | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _sample_non_overlapping
+Matrix-row: hit_rate | (*, CONTINUOUS, *, TIMESERIES) | ts-only | binomial | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _sample_non_overlapping
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -8,7 +8,7 @@ Input: DataFrame with ``date, asset_id, factor, forward_return``.
 Output: time-indexed IC series (``date, ic``) that can be fed into
 any ``series/`` tool (oos, trend, significance, hit_rate).
 
-Matrix-row: compute_ic, ic, ic_newey_west, ic_ir, regime_ic, multi_horizon_ic | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | CS-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output
+Matrix-row: compute_ic, ic, ic_newey_west, ic_ir, regime_ic, multi_horizon_ic | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output
 """
 
 from __future__ import annotations

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -10,7 +10,7 @@ Spearman corr between group index and return.
 
 Input: DataFrame with ``date, asset_id, factor, forward_return``.
 
-Matrix-row: monotonicity | (INDIVIDUAL, CONTINUOUS, *, PANEL) | CS-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio
+Matrix-row: monotonicity | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio
 """
 
 from __future__ import annotations

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -10,7 +10,7 @@ detail in ``metadata``.
 This tool is agnostic to what the series represents — it only knows
 about IS/OOS splits on a time-indexed numeric sequence.
 
-Matrix-row: multi_split_oos_decay | (*, CONTINUOUS, *, TIMESERIES) | TS-only | no formal H₀ | _short_circuit_output
+Matrix-row: multi_split_oos_decay | (*, CONTINUOUS, *, TIMESERIES) | ts-only | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -9,7 +9,7 @@ Output: spread series, long/short alpha decomposition.
 All spread series are time-indexed (``date, value``) and can be fed
 into any ``series/`` tool.
 
-Matrix-row: compute_spread_series, quantile_spread, quantile_spread_vw, compute_group_returns | (INDIVIDUAL, CONTINUOUS, *, PANEL) | CS-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio, _lag_within_asset
+Matrix-row: compute_spread_series, quantile_spread, quantile_spread_vw, compute_group_returns | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio, _lag_within_asset
 """
 
 from __future__ import annotations

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -16,7 +16,7 @@ References:
     Barillas & Shanken (2017), "Which Alpha?"
     Feng, Giglio & Xiu (2020), "Taming the Factor Zoo."
 
-Matrix-row: spanning_alpha, greedy_forward_selection | factor-return-series consumer (post-PANEL pipeline) | TS-only | NW HAC / OLS t | _p_value_from_t, _significance_marker, _short_circuit_output, _ols_alpha
+Matrix-row: spanning_alpha, greedy_forward_selection | factor-return-series consumer (post-PANEL pipeline) | ts-only | NW HAC / OLS t | _p_value_from_t, _significance_marker, _short_circuit_output, _ols_alpha
 """
 
 from __future__ import annotations

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -21,8 +21,8 @@ measures — they belong in Profile, not in Gates.
 Input for Turnover: DataFrame with ``date, asset_id, factor``.
 Input for Breakeven/Net Spread: pre-computed spread and turnover values.
 
-Matrix-row: notional_turnover, breakeven_cost, net_spread | (INDIVIDUAL, CONTINUOUS, *, PANEL) | CS-first | no formal H₀ | _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups
-Matrix-row: turnover | (INDIVIDUAL, CONTINUOUS, *, PANEL) | TS-only (rank autocorrelation across consecutive dates) | no formal H₀ | _short_circuit_output
+Matrix-row: notional_turnover, breakeven_cost, net_spread | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | no formal H₀ | _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups
+Matrix-row: turnover | (INDIVIDUAL, CONTINUOUS, *, PANEL) | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -9,7 +9,7 @@ Output: slope + confidence interval for trend detection.
 Theil-Sen is preferred over OLS because it has a breakdown point of 29.3%,
 making it robust to outliers (e.g. COVID-era IC spikes).
 
-Matrix-row: ic_trend | (*, CONTINUOUS, *, TIMESERIES) | TS-only | Theil-Sen rank-based CI | _significance_marker, _short_circuit_output, _adf, _p_value_from_t
+Matrix-row: ic_trend | (*, CONTINUOUS, *, TIMESERIES) | ts-only | Theil-Sen rank-based CI | _significance_marker, _short_circuit_output, _adf, _p_value_from_t
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -32,7 +32,7 @@ Gates (issue #5):
 
 Standalone metric — does not enter the registry.
 
-Matrix-row: ts_asymmetry | (COMMON, CONTINUOUS, *, PANEL) | CS-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear
+Matrix-row: ts_asymmetry | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -13,7 +13,7 @@ each asset's sensitivity (β) to the common factor.
 ``mean_r_squared``: average explanatory power across assets.
 ``compute_rolling_mean_beta``: rolling window mean β for stability analysis.
 
-Matrix-row: compute_ts_betas, ts_beta, mean_r_squared, compute_rolling_mean_beta, ts_beta_sign_consistency, ts_beta_single_asset_fallback | (COMMON, CONTINUOUS, *, PANEL) | TS-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _short_circuit_output
+Matrix-row: compute_ts_betas, ts_beta, mean_r_squared, compute_rolling_mean_beta, ts_beta_sign_consistency, ts_beta_single_asset_fallback | (COMMON, CONTINUOUS, *, PANEL) | ts-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _short_circuit_output
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -15,7 +15,7 @@ Standalone metric — does not enter the registry. See
 distinction. SPARSE / binary signals are out of scope; the input gate
 redirects to `event_quality` helpers.
 
-Matrix-row: ts_quantile_spread | (COMMON, CONTINUOUS, *, PANEL) | CS-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear
+Matrix-row: ts_quantile_spread | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear
 """
 
 from __future__ import annotations

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,7 +131,7 @@ nav:
       - Choosing a metric: guides/choosing-metric.md
   - Reference:
       - Metric applicability: reference/metric-applicability.md
-      - Standalone metrics: reference/standalone-metrics.md
+      - Metric pipelines: reference/standalone-metrics.md
       - Statistical methods: reference/statistical-methods.md
       - Warning / info / stat codes: reference/warning-codes.md
       - Bibliography: reference/bibliography.md


### PR DESCRIPTION
## Summary

Three docs / source-docstring corrections — no API change, no behavior change, no new pages.

- **SPARSE schema** widened from `{-1, 0, +1}` to `{0, R}` (zero on non-event entries, arbitrary real magnitude otherwise) across `Signal` enum docstring, concepts page, `llms-full` SSOT, dataset / procedure docstrings, and the demo notebook. `{-1, 0, +1}` is now demoted to a canonical example.
- **`n_obs` cell table** in `docs/api/factor-profile.md` no longer carries the redundant `T` / `N` prefix on each row, and the `(common, sparse, None, panel)` row gets the missing description.
- **Metric pipelines page**: retitled from "Standalone metric pipelines" (the matrix actually lists every metric module — procedure-canonical primaries plus standalone helpers) and a leading scope note added. The aggregation vocabulary is unified to one canonical lowercase-hyphen form (`cs-first` / `ts-first` / `ts-only` / `static-cs` / `per-event`); all 18 `Matrix-row:` tags in `factrix/metrics/*.py`, the glossary, the `list_metrics` doc example, and the `panel-timeseries.md` cross-link are aligned.

Closes #78

## Test plan

- [x] `mkdocs build --strict` passes
- [x] `pytest` — 668 passed
- [x] Generated metric matrix renders with canonical agg_order vocab
- [ ] Spot-check rendered pages on the PR preview build

🤖 Generated with [Claude Code](https://claude.com/claude-code)