### PR TITLE
docs(site): API nav restructure + n_obs/diagnose rationale (#81)

### DIFF
--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -57,6 +57,59 @@ Reading `n_obs` together with `n_assets` disambiguates whether a small
 `n_obs` came from a short series (low `T`) or a thin cross-section
 (low `N`).
 
+#### Inference-stage denominator, not raw `N × T`
+
+`n_obs` reports the **second-stage** sample size — the denominator
+behind the inference test that produces `primary_p`. It is never raw
+`N × T`. factrix procedures aggregate in two stages
+([Architecture § Terminology — aggregation regime](../development/architecture.md#terminology--aggregation-regime)):
+the first stage reduces the panel to a per-date or per-asset series,
+the second stage runs the inferential test over that series.
+
+Concretely, an IC PANEL run with `T = 30` dates and `N = 500` assets
+per date has `n_obs = 30` (the per-date IC series feeding the NW HAC
+`t`-test), not `15000`. Treating `n_obs` as a raw cell count would
+overstate degrees of freedom by orders of magnitude — the warning
+guards (`MIN_PERIODS_HARD`, `UNRELIABLE_SE_SHORT_PERIODS`) and the
+`primary_p` itself read the second-stage value.
+
+#### `n_assets` is the raw panel width
+
+`n_assets = panel["asset_id"].n_unique()` is computed once on the
+input and has fixed semantics across cells — the cross-section width
+of the union over the sample period. It is the test denominator
+**only** in cells where the second stage is a cross-asset aggregation
+(`(common, continuous, None, panel)`, `(common, sparse, None, panel)`);
+elsewhere it is metadata for warnings and routing, not for inference.
+
+#### Consumers
+
+| Consumer | Reads `n_obs` | Reads `n_assets` |
+|---|---|---|
+| `profile.diagnose()` payload | yes | yes |
+| `MIN_PERIODS_HARD` / `UNRELIABLE_SE_SHORT_PERIODS` guards | yes | — |
+| `MIN_ASSETS` guards (`SMALL_CROSS_SECTION_N`, `BORDERLINE_CROSS_SECTION_N`) | — | yes |
+| `InsufficientSampleError.actual_periods` | yes | — |
+| `verdict()` | — | — |
+| `multi_factor.bhy` family partition | — | — |
+
+Neither `verdict()` nor `multi_factor.bhy` reads these fields:
+`verdict()` thresholds on `primary_p`; BHY partitions families on
+`(dispatch cell, forward horizon)` and runs step-up on p-values.
+
+#### Why one polymorphic `n_obs` instead of split `n_periods` + `n_cs`
+
+Every registered cell runs **one** primary test with **one**
+denominator. Splitting `n_obs` into `n_periods` and `n_cs` would
+force every consumer (`diagnose()` printers, warning-code interpreters,
+`InsufficientSampleError` recovery code) to dispatch on cell to pick
+which field to read — and the field that matters is always the test
+denominator. The polymorphic-`n_obs` design surfaces that field
+directly; the per-cell semantic table above resolves "which axis am
+I looking at" in one place when needed. `n_assets` stays as a raw
+panel descriptor for the cross-asset cells and for `MIN_ASSETS`
+guards.
+
 ### `stats` keys by cell
 
 Every cell populates the keys for its primary statistic (`*_MEAN`,

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -59,28 +59,18 @@ Reading `n_obs` together with `n_assets` disambiguates whether a small
 
 #### Inference-stage denominator, not raw `N × T`
 
-`n_obs` reports the **second-stage** sample size — the denominator
-behind the inference test that produces `primary_p`. It is never raw
-`N × T`. factrix procedures aggregate in two stages
-([Architecture § Terminology — aggregation regime](../development/architecture.md#terminology--aggregation-regime)):
-the first stage reduces the panel to a per-date or per-asset series,
-the second stage runs the inferential test over that series.
-
-Concretely, an IC PANEL run with `T = 30` dates and `N = 500` assets
-per date has `n_obs = 30` (the per-date IC series feeding the NW HAC
-`t`-test), not `15000`. Treating `n_obs` as a raw cell count would
-overstate degrees of freedom by orders of magnitude — the warning
-guards (`MIN_PERIODS_HARD`, `UNRELIABLE_SE_SHORT_PERIODS`) and the
+`n_obs` is the second-stage denominator behind `primary_p`, never raw
+`N × T` (factrix procedures aggregate in two stages — see
+[Architecture § Terminology — aggregation regime](../development/architecture.md#terminology--aggregation-regime)).
+An IC PANEL run with `T = 30` and `N = 500` has `n_obs = 30` (the
+per-date IC series feeding the NW HAC `t`-test), not `15000`. The
+`MIN_PERIODS_HARD` / `UNRELIABLE_SE_SHORT_PERIODS` guards and
 `primary_p` itself read the second-stage value.
 
-#### `n_assets` is the raw panel width
-
-`n_assets = panel["asset_id"].n_unique()` is computed once on the
-input and has fixed semantics across cells — the cross-section width
-of the union over the sample period. It is the test denominator
-**only** in cells where the second stage is a cross-asset aggregation
-(`(common, continuous, None, panel)`, `(common, sparse, None, panel)`);
-elsewhere it is metadata for warnings and routing, not for inference.
+`n_assets` is the raw panel width (`panel["asset_id"].n_unique()`)
+with fixed semantics across cells. It is the test denominator **only**
+in cross-asset cells (`(common, *, None, panel)`); elsewhere it is
+metadata for warnings (`MIN_ASSETS` guards) and routing.
 
 #### Consumers
 
@@ -93,22 +83,18 @@ elsewhere it is metadata for warnings and routing, not for inference.
 | `verdict()` | — | — |
 | `multi_factor.bhy` family partition | — | — |
 
-Neither `verdict()` nor `multi_factor.bhy` reads these fields:
-`verdict()` thresholds on `primary_p`; BHY partitions families on
-`(dispatch cell, forward horizon)` and runs step-up on p-values.
+`verdict()` thresholds on `primary_p`; BHY partitions on
+`(dispatch cell, forward horizon)` and runs step-up on p-values —
+neither path reads these fields.
 
 #### Why one polymorphic `n_obs` instead of split `n_periods` + `n_cs`
 
-Every registered cell runs **one** primary test with **one**
-denominator. Splitting `n_obs` into `n_periods` and `n_cs` would
-force every consumer (`diagnose()` printers, warning-code interpreters,
-`InsufficientSampleError` recovery code) to dispatch on cell to pick
-which field to read — and the field that matters is always the test
-denominator. The polymorphic-`n_obs` design surfaces that field
-directly; the per-cell semantic table above resolves "which axis am
-I looking at" in one place when needed. `n_assets` stays as a raw
-panel descriptor for the cross-asset cells and for `MIN_ASSETS`
-guards.
+Every registered cell runs one primary test with one denominator.
+Splitting `n_obs` would force every consumer (`diagnose()` printers,
+warning-code interpreters, `InsufficientSampleError` recovery) to
+dispatch on cell to pick which field is the test denominator. The
+polymorphic field surfaces it directly; the per-cell table above
+resolves the axis when needed.
 
 ### `stats` keys by cell
 
@@ -138,20 +124,16 @@ non-event entries) makes the unit-root null degenerate.
 
 ### `stats` provenance — two paths
 
-`profile.stats` is populated by **one path only**: the procedure that
-ran inside `evaluate()`. The keys above are the full enumeration —
-nothing else is auto-merged.
+`profile.stats` is populated only by the procedure that ran inside
+`evaluate()`; the keys above are the full enumeration.
 
 | Path | Lives in | What it produces | Pluggable? |
 |---|---|---|---|
 | **Procedure-internal** | `factrix/_stats/` helpers (`_newey_west_t_test`, `_adf`, `_ljung_box_p`, …) invoked from `factrix/_procedures.py` | The `StatCode` keys listed above on `profile.stats` | No — the per-cell stat set is hard-coded by the registered procedure. |
 | **Standalone metrics** | `factrix/metrics/*.py`, listed by [`list_metrics`](list-metrics.md) | A separate [`MetricOutput`](metric-output.md) per call, returned to the user | Yes — call any number after `evaluate()` returns. |
 
-The user-invoked path is **independent**: a call like
-`fl.metrics.quantile_spread(...)` returns a `MetricOutput` to the
-caller. It does not mutate `profile.stats`. To layer follow-up metrics
-into a single agent-readable payload, the caller assembles them
-explicitly (typically a `dict` of `MetricOutput` keyed by metric name).
+`fl.metrics.quantile_spread(...)` and friends return a `MetricOutput`
+to the caller; they do not mutate `profile.stats`.
 
 #### `StatCode` → statistical method
 

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -83,6 +83,39 @@ have no `NW_LAGS_USED` entry.
 cells skip it because the `{0, R}` event-trigger signal (zero on
 non-event entries) makes the unit-root null degenerate.
 
+### `stats` provenance — two paths
+
+`profile.stats` is populated by **one path only**: the procedure that
+ran inside `evaluate()`. The keys above are the full enumeration —
+nothing else is auto-merged.
+
+| Path | Lives in | What it produces | Pluggable? |
+|---|---|---|---|
+| **Procedure-internal** | `factrix/_stats/` helpers (`_newey_west_t_test`, `_adf`, `_ljung_box_p`, …) invoked from `factrix/_procedures.py` | The `StatCode` keys listed above on `profile.stats` | No — the per-cell stat set is hard-coded by the registered procedure. |
+| **Standalone metrics** | `factrix/metrics/*.py`, listed by [`list_metrics`](list-metrics.md) | A separate [`MetricOutput`](metric-output.md) per call, returned to the user | Yes — call any number after `evaluate()` returns. |
+
+The user-invoked path is **independent**: a call like
+`fl.metrics.quantile_spread(...)` returns a `MetricOutput` to the
+caller. It does not mutate `profile.stats`. To layer follow-up metrics
+into a single agent-readable payload, the caller assembles them
+explicitly (typically a `dict` of `MetricOutput` keyed by metric name).
+
+#### `StatCode` → statistical method
+
+Each procedure-internal `StatCode` maps to one section of
+[Statistical methods](../reference/statistical-methods.md):
+
+| `StatCode` | Method |
+|---|---|
+| `IC_MEAN`, `IC_T_NW`, `IC_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West HAC `t` on the per-date IC series |
+| `FM_LAMBDA_MEAN`, `FM_LAMBDA_T_NW`, `FM_LAMBDA_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — NW HAC `t` on the per-date Fama-MacBeth λ series |
+| `CAAR_MEAN`, `CAAR_T_NW`, `CAAR_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — non-overlapping `t` / BMP `z` on the per-event-date CAAR series |
+| `TS_BETA`, `TS_BETA_T_NW`, `TS_BETA_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — cross-asset `t` on `E[β]` (PANEL) or NW HAC single-series `t` (TIMESERIES) |
+| `NW_LAGS_USED` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West 1994 auto-lag with Hansen-Hodrick overlap floor |
+| `FACTOR_ADF_P` | [Persistence diagnostics under near-unit-root predictors](../reference/statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors) — ADF unit-root test on the continuous factor |
+| `LJUNG_BOX_P` | [Architecture § Procedure pipelines](../development/architecture.md#-sparse---n1-ts-dummy--time-series-only) — Ljung-Box on the TS-dummy single-asset residual |
+| `EVENT_TEMPORAL_HHI` | [Architecture § Procedure pipelines](../development/architecture.md#-sparse---n1-ts-dummy--time-series-only) — Herfindahl concentration of event dates over the calendar grid |
+
 ### Example
 
 A worked `diagnose()` call with rendered output lives in

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,44 @@
+# API
+
+Reference for every public symbol exported from `factrix`. The pages
+below mirror the user surface in dependency order — start at the
+top if you are new.
+
+## Entry points
+
+| Page | What it is | When to read |
+|---|---|---|
+| [`AnalysisConfig`](analysis-config.md) | Three-axis frozen dataclass selecting the dispatch cell. Four factory methods (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`). | Picking the analysis cell. |
+| [`evaluate`](evaluate.md) | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
+| [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `verdict()`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
+| [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
+| [`Metrics`](metrics/index.md) | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly on a `FactorProfile` / panel. |
+
+## Supporting surface
+
+| Page | What it is |
+|---|---|
+| [`MetricOutput`](metric-output.md) | Common wrapper returned by every standalone metric — `value`, `p_value`, `stats`, `metadata`. |
+| [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. |
+| [`datasets`](datasets.md) | Synthetic panels (`make_cs_panel`, `make_event_panel`) for smoke tests and docs examples. |
+
+The two helpers `describe_analysis_modes` and `suggest_config` are
+documented inline on
+[`AnalysisConfig`](analysis-config.md) and the
+[Concepts](../getting-started/concepts.md) page; both are introspection
+shims, not part of the dispatch surface.
+
+## Naming convention
+
+Sidebar entries mirror the actual Python identifier — the case
+distinction is intentional, not inconsistent:
+
+| Sidebar entry | Identifier kind | Example call |
+|---|---|---|
+| `AnalysisConfig`, `FactorProfile`, `MetricOutput` | Class | `fl.AnalysisConfig.individual_continuous(...)` |
+| `evaluate`, `list_metrics` | Function | `fl.evaluate(panel, cfg)` |
+| `multi_factor`, `datasets`, `Metrics` (and submodules) | Module | `fl.multi_factor.bhy(profiles)` |
+
+Reading the sidebar gives you the import path verbatim — `fl.evaluate`
+is a function, `fl.AnalysisConfig` is a class, `fl.multi_factor` is a
+module you reach into for `bhy`.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,8 +1,6 @@
 # API
 
-Reference for every public symbol exported from `factrix`. The pages
-below mirror the user surface in dependency order — start at the
-top if you are new.
+Reference for every public symbol exported from `factrix`.
 
 ## Entry points
 
@@ -11,6 +9,7 @@ top if you are new.
 | [`AnalysisConfig`](analysis-config.md) | Three-axis frozen dataclass selecting the dispatch cell. Four factory methods (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`). | Picking the analysis cell. |
 | [`evaluate`](evaluate.md) | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
 | [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `verdict()`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
+| [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. | Multi-factor screening. |
 | [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
 | [`Metrics`](metrics/index.md) | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly on a `FactorProfile` / panel. |
 
@@ -19,14 +18,11 @@ top if you are new.
 | Page | What it is |
 |---|---|
 | [`MetricOutput`](metric-output.md) | Common wrapper returned by every standalone metric — `value`, `p_value`, `stats`, `metadata`. |
-| [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. |
 | [`datasets`](datasets.md) | Synthetic panels (`make_cs_panel`, `make_event_panel`) for smoke tests and docs examples. |
 
-The two helpers `describe_analysis_modes` and `suggest_config` are
-documented inline on
-[`AnalysisConfig`](analysis-config.md) and the
-[Concepts](../getting-started/concepts.md) page; both are introspection
-shims, not part of the dispatch surface.
+`describe_analysis_modes` and `suggest_config` are introspection shims,
+documented inline on [`AnalysisConfig`](analysis-config.md) and
+[Concepts](../getting-started/concepts.md).
 
 ## Naming convention
 
@@ -38,7 +34,3 @@ distinction is intentional, not inconsistent:
 | `AnalysisConfig`, `FactorProfile`, `MetricOutput` | Class | `fl.AnalysisConfig.individual_continuous(...)` |
 | `evaluate`, `list_metrics` | Function | `fl.evaluate(panel, cfg)` |
 | `multi_factor`, `datasets`, `Metrics` (and submodules) | Module | `fl.multi_factor.bhy(profiles)` |
-
-Reading the sidebar gives you the import path verbatim — `fl.evaluate`
-is a function, `fl.AnalysisConfig` is a class, `fl.multi_factor` is a
-module you reach into for `bhy`.

--- a/docs/api/metrics/hit_rate.md
+++ b/docs/api/metrics/hit_rate.md
@@ -10,4 +10,4 @@ spread series.
 
 - [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
 - [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Series tools landing page](series-tools.md) — other axis-agnostic series diagnostics.
+- [Series diagnostics landing page](series-tools.md) — other axis-agnostic series diagnostics.

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -55,9 +55,10 @@ modules plus a fourth axis-agnostic group**:
 | `Common × Sparse` | **Individual sparse** (shared metric modules) | Has its own dispatch procedure (`_CommonSparsePanelProcedure`: per-asset OLS β on the broadcast dummy → cross-asset *t*) — not the CAAR per-event flow used by `Individual × Sparse`. The two cells share the SPARSE column contract and the event-quality / clustering / corrado helper metrics, so factrix groups them on this nav. |
 | `Common × Continuous` | **Common continuous** | Single time series broadcast across assets (VIX, USD index, …). |
 
-**Series tools** (`hit_rate`, `trend`, `oos`) are axis-agnostic — they
-operate on any `(date, value)` series produced by the upstream cell
-metrics and are not bound to a specific cell.
+**Series diagnostics** (`hit_rate`, `trend`, `oos`) are axis-agnostic —
+they operate on any `(date, value)` series produced by the upstream
+cell metrics and are not bound to a specific cell. Distinct from
+`Mode.TIMESERIES`, which is the dispatch regime for `n_assets == 1`.
 
 ## How to read a metric page
 

--- a/docs/api/metrics/oos.md
+++ b/docs/api/metrics/oos.md
@@ -10,4 +10,4 @@ descriptive (no formal H₀).
 
 - [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
 - [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Series tools landing page](series-tools.md) — other axis-agnostic series diagnostics.
+- [Series diagnostics landing page](series-tools.md) — other axis-agnostic series diagnostics.

--- a/docs/api/metrics/series-tools.md
+++ b/docs/api/metrics/series-tools.md
@@ -1,9 +1,14 @@
-# Series tools
+# Series diagnostics
 
 Axis-agnostic metrics that operate on any `(date, value)` series
 produced by an upstream cell metric — IC time series, $\beta$ time
 series, CAAR time series, an external factor return, etc. They do not
 care which cell produced the series.
+
+> *Not the same as `Mode.TIMESERIES`.* `Mode.TIMESERIES` is the
+> dispatch regime for `n_assets == 1` (set on `FactorProfile.mode`);
+> the metrics on this page run on a `(date, value)` series regardless
+> of which mode produced it.
 
 | Metric | Role | Page |
 |---|---|---|

--- a/docs/api/metrics/trend.md
+++ b/docs/api/metrics/trend.md
@@ -9,4 +9,4 @@ detection (29.3% breakdown point) on IC or other diagnostic series.
 
 - [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
 - [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Series tools landing page](series-tools.md) — other axis-agnostic series diagnostics.
+- [Series diagnostics landing page](series-tools.md) — other axis-agnostic series diagnostics.

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -6,7 +6,7 @@ Grouping below follows the ``Scope × Signal`` cells defined in
 ``factrix._axis`` — *not* ``Mode`` (which is a derived sample regime,
 ``PANEL`` for ``N ≥ 2`` and ``TIMESERIES`` for ``N == 1``). Every
 cell can run in either Mode; the dispatch registry handles that.
-Series tools are axis-agnostic and operate on any ``(date, value)``
+Series diagnostics are axis-agnostic and operate on any ``(date, value)``
 series produced upstream.
 
 Individual × Continuous:
@@ -30,7 +30,7 @@ Common × Continuous:
     compute_rolling_mean_beta, ts_beta_sign_consistency,
     ts_quantile_spread, ts_asymmetry
 
-Series tools — axis-agnostic on ``(date, value)``:
+Series diagnostics — axis-agnostic on ``(date, value)``:
     hit_rate, ic_trend, multi_split_oos_decay
 """
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - Warning / info / stat codes: reference/warning-codes.md
       - Bibliography: reference/bibliography.md
   - API:
+      - api/index.md
       - AnalysisConfig: api/analysis-config.md
       - evaluate: api/evaluate.md
       - list_metrics: api/list-metrics.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,7 +168,7 @@ nav:
               - ts_beta: api/metrics/ts_beta.md
               - ts_quantile: api/metrics/ts_quantile.md
               - ts_asymmetry: api/metrics/ts_asymmetry.md
-          - Series tools:
+          - Series diagnostics:
               - api/metrics/series-tools.md
               - hit_rate: api/metrics/hit_rate.md
               - trend: api/metrics/trend.md


### PR DESCRIPTION
## Summary

Pure-docs structure & rationale pass for the API tab (Batch 2 of #77). No API change, no behavior change, no schema change.

- **API landing page** at `docs/api/index.md` wired via `navigation.indexes`; removes the visible "API → API" sidebar duplication and documents the PascalCase-vs-snake_case sidebar convention (entry mirrors the actual Python identifier — class vs function vs module — intentional).
- **`Series tools` → `Series diagnostics`** in the metrics sidebar, plus a one-line disambiguation from `Mode.TIMESERIES` on the landing page. Old name introduced "tools" as a category type that appeared nowhere else; "diagnostics" matches the existing Role vocabulary used inside the page.
- **`profile.stats` provenance** — make explicit the procedure-internal (`factrix/_stats/` helpers, hard-coded per cell) vs standalone (`factrix/metrics/*`, user-invoked, returns `MetricOutput`) two-path model, and cross-link every procedure-internal `StatCode` to its underlying section in Statistical methods / Architecture.
- **`n_obs` / `n_assets` rationale** — second-stage inference-test denominator, not raw `N × T` (length-30 IC series with `N=500` has `dof ≈ 30`, not 15000); `n_assets` is the raw panel width with fixed semantics; consumers list (`verdict()` / `bhy` don't read these); design rationale for the polymorphic `n_obs` over split `n_periods` + `n_cs`.

Closes #81

## Test plan

- [x] `mkdocs build --strict` passes
- [x] `pytest` — 668 passed
- [x] Sidebar landing pages work (API tab clickable; Series diagnostics tab clickable)
- [ ] Spot-check rendered pages on the PR preview build

🤖 Generated with [Claude Code](https://claude.com/claude-code)