### PR TITLE
docs(site): standalone metrics guide + n_assets clarification & cross_section_tier fix (#83)

### DIFF
--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -68,9 +68,22 @@ per-date IC series feeding the NW HAC `t`-test), not `15000`. The
 `primary_p` itself read the second-stage value.
 
 `n_assets` is the raw panel width (`panel["asset_id"].n_unique()`)
-with fixed semantics across cells. It is the test denominator **only**
-in cross-asset cells (`(common, *, None, panel)`); elsewhere it is
-metadata for warnings (`MIN_ASSETS` guards) and routing.
+with fixed semantics across cells. It is a **sample-period union**,
+not a per-date count, so it does not bias `primary_p` for time-series-
+axis tests where the cross-section is not the test denominator.
+
+In cross-asset cells (`(common, *, None, panel)`) the cross-asset
+t-test reads its own inference-stage `N` — the count of assets
+surviving the `compute_ts_betas` per-asset filter (≥`MIN_TS_OBS`
+non-null observations) — which can be materially smaller than the
+union when assets enter the panel late or with sparse history. The
+`SMALL_CROSS_SECTION_N` / `BORDERLINE_CROSS_SECTION_N` guards in
+`_compute_common_panel` threshold on that filtered N (matching the
+test's actual `dof = N - 1`); reading the warning together with
+`primary_p` is the canonical signal. Reading `n_assets` alone is
+optimistic in this corner — `suggest_config` mirrors the same
+pre-filter so its preview warning agrees with what `evaluate()` will
+emit.
 
 #### Consumers
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,3 +5,4 @@ Step-by-step guides for common factrix workflows.
 - [PANEL vs TIMESERIES](panel-timeseries.md) — sample guards, aggregation order, N=1 paths
 - [Batch screening with BHY](batch-screening.md) — FDR control across factor families
 - [Choosing a metric](choosing-metric.md) — IC vs FM, scenario selection
+- [Standalone metrics](standalone-metrics.md) — input shapes, post-`evaluate()` integration, per-cell examples

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -1,0 +1,132 @@
+# Standalone metrics
+
+[`evaluate()`][factrix.evaluate] runs one canonical procedure per cell
+and returns a [`FactorProfile`][factrix.FactorProfile] with a single
+`primary_p`. Every other module under `factrix.metrics` is a
+**standalone metric** — a `MetricOutput`-returning helper the user
+invokes directly to add diagnostics around the canonical verdict.
+
+This guide covers the three things a user needs to wire them in:
+which metrics apply to a given cell, what input shape each one
+expects, and where they sit in a screening pipeline.
+
+For the cross-module matrix (every module, aggregation pattern,
+inference SE), see
+[Reference § Metric pipelines](../reference/standalone-metrics.md).
+For the `(scope, signal)` filter at runtime, see
+[`list_metrics`](../api/list-metrics.md).
+
+## When to use which
+
+| Want | Reach for |
+|---|---|
+| PASS/FAIL verdict + `primary_p` | [`evaluate()`][factrix.evaluate] |
+| Quintile spread, monotonicity, top concentration | `quantile_spread`, `monotonicity`, `top_concentration` |
+| Tradability / cost break-even | `notional_turnover`, `breakeven_cost`, `net_spread`, `turnover` |
+| Spanning regression vs an existing pool | `spanning_alpha`, `greedy_forward_selection` |
+| Event-side robustness on top of CAAR | `bmp_test`, `corrado_rank_test`, `event_hit_rate`, `clustering_diagnostic` |
+| Per-event return shape | `mfe_mae_summary`, `event_around_return` |
+| Asymmetry / quantile-spread on a broadcast factor | `ts_asymmetry`, `ts_quantile_spread` |
+| OOS decay / trend / hit rate on any `(date, value)` series | `multi_split_oos_decay`, `ic_trend`, `hit_rate` |
+
+`evaluate()` only writes the `StatCode` keys listed for its cell on
+[`FactorProfile`](../api/factor-profile.md#stats-keys-by-cell);
+standalone metrics return their own
+[`MetricOutput`](../api/metric-output.md) and never mutate
+`profile.stats`. The two surfaces compose without coordination.
+
+## Input shapes
+
+Standalone metrics group into three input families:
+
+### 1. Panel `(date, asset_id, factor, forward_return)` — same shape as `evaluate()`
+
+The IC / FM / quantile / Fama-MacBeth / spanning / tradability
+families read the same wide panel `evaluate()` consumes. Pass the
+exact dataframe you handed to `evaluate()`:
+
+```python
+import factrix as fl
+
+raw = fl.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=2024)
+panel = fl.preprocess.returns.compute_forward_return(raw, forward_periods=5)
+profile = fl.evaluate(panel, fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC))
+
+spread = fl.metrics.quantile_spread(panel, forward_periods=5, n_groups=5)
+mono = fl.metrics.monotonicity(panel, forward_periods=5, n_groups=5)
+```
+
+### 2. Event panel `{factor ∈ {0, R}}` — sparse signal cells
+
+`caar`, `event_quality`, `event_horizon`, `mfe_mae`, `clustering`, and
+`corrado` read a panel where `factor` is zero on non-event entries
+and arbitrary real magnitude on event entries (canonical `{-1, 0, +1}`,
+also valid: `{0, R≥0}` or `{-R, 0, +R}`). Build via
+`fl.datasets.make_event_panel` or filter your own panel.
+
+```python
+events = fl.datasets.make_event_panel(n_assets=80, n_dates=500, event_rate=0.05, seed=7)
+events = fl.preprocess.returns.compute_forward_return(events, periods=5)
+
+profile = fl.evaluate(events, fl.AnalysisConfig.individual_sparse(forward_periods=5))
+
+# Robustness on top of the canonical CAAR:
+hit = fl.metrics.event_hit_rate(events)
+rank_p = fl.metrics.corrado_rank_test(events, forward_periods=5)
+```
+
+### 3. Derived `(date, value)` series — series diagnostics
+
+`hit_rate`, `ic_trend`, and `multi_split_oos_decay` are axis-agnostic:
+they take whatever per-date series an upstream cell metric produced.
+This decouples the diagnostic from the cell contract — a per-date IC
+series, a per-date quantile spread, and a per-date FM λ all share the
+same shape and feed the same diagnostics.
+
+```python
+import polars as pl
+
+ic_series: pl.DataFrame = ...  # columns: date, value (per-date IC)
+
+decay = fl.metrics.multi_split_oos_decay(ic_series)
+trend = fl.metrics.ic_trend(ic_series)
+hits = fl.metrics.hit_rate(ic_series, value_col="value")
+```
+
+`Mode.TIMESERIES` (the dispatch regime for `n_assets == 1`) is a
+distinct concept — these diagnostics are series-shaped regardless of
+which Mode the upstream procedure ran in.
+
+## Post-`evaluate()` integration
+
+A typical screening recipe chains `evaluate()` for the verdict, then
+appends standalone metrics for shape and tradability diagnostics. The
+profile and the metric outputs travel together; nothing on either
+side needs to know about the other:
+
+```python
+profile = fl.evaluate(panel, fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC))
+diagnostics = {
+    "verdict": profile.verdict(),
+    "primary_p": profile.primary_p,
+    "spread": fl.metrics.quantile_spread(panel, forward_periods=5).value,
+    "monotonicity_p": fl.metrics.monotonicity(panel, forward_periods=5).p_value,
+    "breakeven_bps": fl.metrics.breakeven_cost(panel).value,
+}
+```
+
+For the BHY family across many factors, `multi_factor.bhy` consumes
+[`FactorProfile`][factrix.FactorProfile] objects only — standalone
+metrics are not in the multiple-testing partition. Run them in a
+separate pass after BHY narrows the candidate set.
+
+## Discovery
+
+[`list_metrics(scope, signal)`](../api/list-metrics.md) returns the
+standalone subset for a given cell, sorted by module then function.
+Use it as the runtime equivalent of the static matrix:
+
+```python
+fl.list_metrics(fl.FactorScope.INDIVIDUAL, fl.Signal.CONTINUOUS)
+# ['concentration.top_concentration', 'fama_macbeth.beta_sign_consistency', ...]
+```

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -99,7 +99,16 @@ _WARNING_DESCRIPTIONS.update(
 
 
 def cross_section_tier(n_assets: int) -> WarningCode | None:
-    """Map ``n_assets`` to the appropriate cross-asset N warning code.
+    """Map an inference-stage cross-asset N to the appropriate warning code.
+
+    The argument is the **inference-stage** N — the count of assets
+    actually entering the cross-asset test, not the panel-union
+    ``FactorProfile.n_assets`` surface field. For ``(COMMON, *, None,
+    PANEL)`` cells the two differ: ``compute_ts_betas`` drops assets
+    with fewer than ``MIN_TS_OBS`` non-null observations, so the union
+    can be materially larger than the post-filter count that drives
+    ``primary_p``'s ``dof = N - 1``. Callers (``suggest_config``,
+    ``_compute_common_panel``) therefore pre-filter before calling.
 
     Tiers are mutually exclusive — SMALL is strictly more severe than
     BORDERLINE — so callers can membership-check the more severe code

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -309,6 +309,28 @@ def _build_suggested(
     return AnalysisConfig.common_continuous(forward_periods=forward_periods)
 
 
+def _estimate_common_panel_inference_n(raw: Any) -> int:
+    """Mirror ``compute_ts_betas``' MIN_TS_OBS filter for the suggest_config preview.
+
+    Row-aligned non-null on ``(factor, forward_return)`` is a close
+    approximation; ``compute_ts_betas`` itself drops nulls per column
+    independently then takes ``min(len)`` positionally — equivalent on
+    aligned panels, mildly tighter when nulls are non-overlapping.
+    Falls back to factor-only if ``forward_return`` is not yet present.
+    """
+    import polars as pl
+
+    from factrix.metrics.ts_beta import MIN_TS_OBS
+
+    cond = pl.col("factor").is_not_null()
+    if "forward_return" in raw.columns:
+        cond = cond & pl.col("forward_return").is_not_null()
+    counts = raw.filter(cond).group_by("asset_id").len()
+    if len(counts) == 0:
+        return 0
+    return int((counts["len"] >= MIN_TS_OBS).sum())
+
+
 def suggest_config(
     raw: Any,
     *,
@@ -331,12 +353,25 @@ def suggest_config(
         f"n_assets = {n_assets} detected → "
         f"{'TIMESERIES' if mode is Mode.TIMESERIES else 'PANEL'}"
     )
-    n_tier = cross_section_tier(n_assets) if mode is Mode.PANEL else None
+    if mode is Mode.PANEL and scope is FactorScope.COMMON:
+        n_inference = _estimate_common_panel_inference_n(raw)
+    else:
+        n_inference = n_assets
+    n_tier = cross_section_tier(n_inference) if mode is Mode.PANEL else None
     if n_tier is not None:
-        mode_reason += (
-            f" (n_assets < MIN_ASSETS_WARN = {MIN_ASSETS_WARN} → "
-            f"cross-asset df low, see WarningCode.{n_tier.name})"
-        )
+        if n_inference != n_assets:
+            mode_reason += (
+                f" (post-MIN_TS_OBS filter n_inference = {n_inference} "
+                f"< MIN_ASSETS_WARN = {MIN_ASSETS_WARN}; union n_assets "
+                f"= {n_assets} would be optimistic — see "
+                f"WarningCode.{n_tier.name})"
+            )
+        else:
+            mode_reason += (
+                f" (n_inference = {n_inference} < MIN_ASSETS_WARN = "
+                f"{MIN_ASSETS_WARN} → cross-asset df low, see "
+                f"WarningCode.{n_tier.name})"
+            )
 
     suggested = _build_suggested(scope, signal, forward_periods=forward_periods)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
       - PANEL vs TIMESERIES: guides/panel-timeseries.md
       - Batch screening (BHY): guides/batch-screening.md
       - Choosing a metric: guides/choosing-metric.md
+      - Standalone metrics: guides/standalone-metrics.md
   - Reference:
       - Metric applicability: reference/metric-applicability.md
       - Metric pipelines: reference/standalone-metrics.md

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -328,6 +328,95 @@ class TestSuggestConfigCrossSectionNWarnings:
         assert "SMALL_CROSS_SECTION_N" in result.reasoning["mode"]
 
 
+class TestSuggestConfigCommonPanelInferenceN:
+    """Issue #83 — COMMON × * PANEL warning must reflect the post-filter
+    inference-stage N, not the panel-union ``n_assets``.
+
+    ``compute_ts_betas`` drops assets with fewer than ``MIN_TS_OBS = 20``
+    non-null factor / forward-return rows. A panel can have a wide union
+    (say 50 assets) but a small inference-stage cross-section if most
+    assets only enter for a short tail. The pre-fix preview optimistically
+    cleared the warning; the fix routes the filtered count to
+    ``cross_section_tier``.
+    """
+
+    @staticmethod
+    def _short_history_panel(
+        *,
+        n_full_history_assets: int,
+        n_short_history_assets: int,
+        n_dates: int = 60,
+        seed: int = 91,
+    ) -> pl.DataFrame:
+        """Broadcast factor; only the first ``n_full_history_assets`` have
+        ≥MIN_TS_OBS rows of valid (factor, forward_return). The rest only
+        enter on the final 5 dates — well below the per-asset filter."""
+        rng = np.random.default_rng(seed)
+        rows: list[dict[str, object]] = []
+        for t in range(n_dates):
+            d = dt.date(2024, 1, 1) + dt.timedelta(days=t)
+            f_t = float(rng.standard_normal())
+            for j in range(n_full_history_assets):
+                rows.append(
+                    {
+                        "date": d,
+                        "asset_id": f"FULL{j:03d}",
+                        "factor": f_t,
+                        "forward_return": float(rng.standard_normal()),
+                    }
+                )
+            if t >= n_dates - 5:
+                for j in range(n_short_history_assets):
+                    rows.append(
+                        {
+                            "date": d,
+                            "asset_id": f"SHORT{j:03d}",
+                            "factor": f_t,
+                            "forward_return": float(rng.standard_normal()),
+                        }
+                    )
+        return pl.DataFrame(rows)
+
+    def test_optimistic_warning_caught_when_union_is_large(self) -> None:
+        # Union n_assets = 5 + 40 = 45 (would be clean at MIN_ASSETS_WARN=30);
+        # inference-stage N = 5 (only FULL assets clear MIN_TS_OBS).
+        panel = self._short_history_panel(
+            n_full_history_assets=5,
+            n_short_history_assets=40,
+        )
+        result = suggest_config(panel)
+        assert result.detected["n_assets"] == 45
+        assert WarningCode.SMALL_CROSS_SECTION_N in result.warnings
+
+    def test_borderline_inference_n_emits_borderline(self) -> None:
+        # Union = 50, inference-stage = 15 → BORDERLINE.
+        panel = self._short_history_panel(
+            n_full_history_assets=15,
+            n_short_history_assets=35,
+        )
+        result = suggest_config(panel)
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N in result.warnings
+        assert WarningCode.SMALL_CROSS_SECTION_N not in result.warnings
+
+    def test_clean_when_inference_n_is_high(self) -> None:
+        # Union = 35, inference-stage = 35 → no tier warning.
+        panel = self._short_history_panel(
+            n_full_history_assets=35,
+            n_short_history_assets=0,
+        )
+        result = suggest_config(panel)
+        assert WarningCode.SMALL_CROSS_SECTION_N not in result.warnings
+        assert WarningCode.BORDERLINE_CROSS_SECTION_N not in result.warnings
+
+    def test_mode_reason_flags_filter_when_union_diverges(self) -> None:
+        panel = self._short_history_panel(
+            n_full_history_assets=5,
+            n_short_history_assets=40,
+        )
+        result = suggest_config(panel)
+        assert "post-MIN_TS_OBS filter" in result.reasoning["mode"]
+
+
 # ---------------------------------------------------------------------------
 # suggest_config — detected (issue #20)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `fix(describe)`: `suggest_config` previewed `cross_section_tier` against panel-union `n_assets`; now mirrors `compute_ts_betas`' `MIN_TS_OBS` filter so the preview warning matches what `evaluate()` will emit for `COMMON × * PANEL`
- `docs(guides)`: new `docs/guides/standalone-metrics.md` — three input-shape families, post-`evaluate()` integration pattern, per-cell worked examples; wired into nav and guides index
- `docs(factor-profile)`: extends `n_assets` prose to flag union-vs-inference-stage gap and the optimistic-warning edge case for `COMMON × * PANEL`

## Test plan

- [ ] 4 new tests in `TestSuggestConfigCommonPanelInferenceN` cover: union-high/inference-small emits SMALL, inference borderline emits BORDERLINE, inference clean emits no warning, reasoning string includes `"post-MIN_TS_OBS filter"` when union diverges
- [ ] Full suite: 672 passed
- [ ] `mkdocs build --strict` passes

Closes #83
Refs #77