### PR TITLE
ci(release): tag-triggered PyPI publish + GitHub Release (#62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      - name: Build wheel + sdist
+        run: uv build --python 3.12
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    environment: pypi
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fail if release already exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists — refusing to overwrite" >&2
+            exit 1
+          fi
+
+      - name: Extract CHANGELOG section
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          python3 - <<PYEOF
+          import re, os, sys
+          version = os.environ["VERSION"]
+          with open("CHANGELOG.md") as f:
+              content = f.read()
+          pattern = rf"## \[{re.escape(version)}\].*?(?=\n## \[|\Z)"
+          match = re.search(pattern, content, re.DOTALL)
+          if not match:
+              print(f"No CHANGELOG section found for {version}", file=sys.stderr)
+              sys.exit(1)
+          with open("/tmp/release_notes.md", "w") as f:
+              f.write(match.group(0).strip())
+          PYEOF
+        env:
+          VERSION: ${{ github.ref_name }}
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release_notes.md \
+            dist/*

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ A polars-native factor validator. It answers the core question — **Does this f
 ## Installation
 
 ```bash
-uv pip install git+https://github.com/awwesomeman/factrix.git
+pip install factrix
+# or
+uv add factrix
 ```
 
-See the [installation guide](https://awwesomeman.github.io/factrix/latest/getting-started/install/) for `pip` / `conda`, version pinning, and development setup.
+See the [installation guide](https://awwesomeman.github.io/factrix/latest/getting-started/install/) for version pinning and development setup.
 
 ## Typical usage
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,25 +1,25 @@
 # Installation
 
-factrix installs directly from GitHub. The core module depends only on
-`polars` and `numpy`.
+factrix requires Python 3.12+. The core module depends only on `polars` and `numpy`.
+
+## With `pip`
+
+```bash
+pip install factrix
+```
 
 ## With `uv` (recommended)
 
 ```bash
-uv venv --python 3.12 --clear
-source .venv/bin/activate            # Windows: .venv\Scripts\activate
-uv pip install git+https://github.com/awwesomeman/factrix.git
-
-# Pin to a release tag for production
-# uv pip install git+https://github.com/awwesomeman/factrix.git@v0.6.0
+uv add factrix
 ```
 
-## With `pip` / `conda`
+## Version pinning
 
 ```bash
-conda create -n factrix python=3.12 -y
-conda activate factrix
-pip install git+https://github.com/awwesomeman/factrix.git
+pip install factrix==0.7.0
+# or
+uv add factrix==0.7.0
 ```
 
 ## Local development


### PR DESCRIPTION
## Summary

- Add `release.yml` workflow: tag `v*` triggers hermetic build → PyPI OIDC publish → GitHub Release with CHANGELOG body and dist artifacts attached
- Idempotency guard: fails loudly if the tag already has a GitHub Release
- Update `install.md` and README to use `pip install factrix` / `uv add factrix` as primary install method

## Test plan

- [ ] PyPI Trusted Publisher configured at pypi.org (environment: `pypi`, workflow: `release.yml`)
- [ ] GitHub environment `pypi` created in repo Settings
- [ ] Push `v0.7.0` tag after merge; confirm PyPI package appears and GitHub Release is created with correct CHANGELOG section

Closes #62