### PR TITLE
feat(preprocess): expose compute_forward_return as public API (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the [installation guide](https://awwesomeman.github.io/factrix/latest/gettin
 
 ```python
 import factrix as fl
-from factrix.preprocess.returns import compute_forward_return
+from factrix.preprocess import compute_forward_return
 
 raw   = fl.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=2024)
 panel = compute_forward_return(raw, forward_periods=5)

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -2,9 +2,9 @@
 
 Synthetic panel generators for examples, tests, and documentation.
 Both emit raw canonical-column panels (`date, asset_id, price,
-factor`); attach `forward_return` (e.g. via
-`factrix.preprocess.returns.compute_forward_return`) before passing
-to [`evaluate`](evaluate.md).
+factor`); attach `forward_return` via
+[`factrix.preprocess.compute_forward_return`](preprocess.md) before
+passing to [`evaluate`](evaluate.md).
 
 The dataset's `signal_horizon` is a property of the generated
 synthetic signal, not a pipeline parameter. When

--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -1,0 +1,7 @@
+# preprocess
+
+Helpers for attaching `forward_return` to a raw panel. The output
+panel — `(date, asset_id, factor, forward_return)` — is the canonical
+input to [`evaluate`](evaluate.md).
+
+::: factrix.preprocess.compute_forward_return

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -10,7 +10,7 @@
 
 ```python
 import factrix as fl
-from factrix.preprocess.returns import compute_forward_return
+from factrix.preprocess import compute_forward_return
 
 raw   = fl.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=2024)
 panel = compute_forward_return(raw, forward_periods=5)

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -104,7 +104,7 @@
     "import factrix as fl\n",
     "import numpy as np\n",
     "import polars as pl\n",
-    "from factrix.preprocess.returns import compute_forward_return\n",
+    "from factrix.preprocess import compute_forward_return\n",
     "\n",
     "print(\"factrix version:\", fl.__version__)"
    ]

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -94,7 +94,7 @@
     "from __future__ import annotations\n",
     "\n",
     "import factrix as fl\n",
-    "from factrix.preprocess.returns import compute_forward_return\n",
+    "from factrix.preprocess import compute_forward_return\n",
     "\n",
     "print(\"factrix version:\", fl.__version__)"
    ]

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -37,7 +37,7 @@ typical usage patterns in a single fetch. Two access paths::
     text = importlib.resources.files("factrix").joinpath("llms-full.txt").read_text()
 """
 
-from factrix import datasets, multi_factor
+from factrix import datasets, multi_factor, preprocess
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import (  # noqa: F401  Mode re-exported for namespace access; intentionally not in __all__
     FactorScope,
@@ -119,4 +119,6 @@ __all__ = [
     "multi_factor",
     # Synthetic panels
     "datasets",
+    # Forward-return preprocessing
+    "preprocess",
 ]

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -2,13 +2,13 @@
 
 Both generators emit **raw canonical-column panels** (``date, asset_id,
 price, factor``). Callers attach ``forward_return`` (e.g. via
-``factrix.preprocess.returns.compute_forward_return``) before calling
+``factrix.preprocess.compute_forward_return``) before calling
 ``fl.evaluate(panel, cfg)``.
 
 Usage:
 
     import factrix as fl
-    from factrix.preprocess.returns import compute_forward_return
+    from factrix.preprocess import compute_forward_return
 
     raw = fl.datasets.make_cs_panel(n_assets=100, n_dates=500)
     panel = compute_forward_return(raw, forward_periods=5)
@@ -115,7 +115,7 @@ def make_cs_panel(
     Returns:
         Long DataFrame with ``date, asset_id, price, factor`` and
         ``date`` dtype ``pl.Datetime("ms")``. Attach ``forward_return``
-        (e.g. via ``factrix.preprocess.returns.compute_forward_return``)
+        (e.g. via ``factrix.preprocess.compute_forward_return``)
         before passing to ``fl.evaluate``.
     """
     if n_assets < 2:
@@ -204,7 +204,7 @@ def make_event_panel(
         Long DataFrame with ``date, asset_id, price, factor``. Factor
         is ``Float64`` with values in ``{-1.0, 0.0, +1.0}``. Attach
         ``forward_return`` (e.g. via
-        ``factrix.preprocess.returns.compute_forward_return``) before
+        ``factrix.preprocess.compute_forward_return``) before
         passing to ``fl.evaluate``.
     """
     if n_assets < 1:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -73,7 +73,7 @@ Synthetic panels: `fl.datasets.make_cs_panel(...)` for CONTINUOUS,
 
 ```python
 import factrix as fl
-from factrix.preprocess.returns import compute_forward_return
+from factrix.preprocess import compute_forward_return
 
 # raw has columns ["date", "asset_id", "price", "factor"]
 raw   = fl.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=2024)
@@ -92,7 +92,7 @@ print(dict(profile.stats))           # {StatCode: float} — IC mean, t-stat, et
 
 ```python
 import factrix as fl
-from factrix.preprocess.returns import compute_forward_return
+from factrix.preprocess import compute_forward_return
 
 raw_panels = [
     fl.datasets.make_cs_panel(n_assets=80, n_dates=400, ic_target=ic, seed=s)
@@ -254,7 +254,7 @@ factrix.list_metrics(scope: FactorScope, signal: Signal,
 ### Preprocessing
 
 ```python
-from factrix.preprocess.returns import compute_forward_return
+from factrix.preprocess import compute_forward_return
 
 panel = compute_forward_return(
     df,                                # cols: date, asset_id, price (sorted, regular spacing)

--- a/factrix/preprocess/__init__.py
+++ b/factrix/preprocess/__init__.py
@@ -1,1 +1,11 @@
-"""Preprocessing pipeline — Step 1-5 (+ optional Step 6 via tools/regression)."""
+"""Preprocessing helpers for attaching ``forward_return`` to a raw panel.
+
+The public entry point is :func:`compute_forward_return`: given a raw
+``(date, asset_id, price)`` panel, it returns the same panel with a
+``forward_return`` column attached, which is the canonical input to
+:func:`factrix.evaluate`.
+"""
+
+from factrix.preprocess.returns import compute_forward_return
+
+__all__ = ["compute_forward_return"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
       - MetricOutput: api/metric-output.md
       - multi_factor: api/multi-factor.md
       - datasets: api/datasets.md
+      - preprocess: api/preprocess.md
       - Metrics:
           - api/metrics/index.md
           - Individual continuous:

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -1,0 +1,31 @@
+"""Smoke test mirroring the README ``Typical usage`` quickstart.
+
+Guards against silent drift between the README's import path and the
+public surface — if ``compute_forward_return`` is moved or the
+re-export is removed, this test fails before the README does.
+"""
+
+from __future__ import annotations
+
+import factrix as fl
+from factrix.preprocess import compute_forward_return
+
+
+def test_readme_quickstart_runs_end_to_end() -> None:
+    raw = fl.datasets.make_cs_panel(
+        n_assets=100, n_dates=500, ic_target=0.08, seed=2024
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    cfg = fl.AnalysisConfig.individual_continuous(
+        metric=fl.Metric.IC, forward_periods=5
+    )
+    profile = fl.evaluate(panel, cfg)
+
+    assert profile.verdict() in (fl.Verdict.PASS, fl.Verdict.FAIL)
+    assert isinstance(profile.primary_p, float)
+    assert 0.0 <= profile.primary_p <= 1.0
+
+
+def test_compute_forward_return_is_reachable_from_namespace() -> None:
+    assert fl.preprocess.compute_forward_return is compute_forward_return


### PR DESCRIPTION
## Summary

`compute_forward_return` was the only function the README quickstart imported, but it lived behind an undocumented submodule path with no test exercising it. This PR promotes it to first-class public surface and aligns every live reference, so a future rename fails CI instead of silently breaking the most-followed code path.

- Re-exported from `factrix.preprocess`; `preprocess` added to top-level `__all__`.
- New `docs/api/preprocess.md` mkdocstrings page + nav entry.
- README, `docs/getting-started/quickstart.md`, `factrix/datasets.py` docstrings, `factrix/llms-full.txt`, and both example notebooks updated to the new import path.
- New `tests/test_readme_quickstart.py` runs the quickstart end-to-end.

`docs/plans/plan_individual_stock_scoring.md` left as-is — historical planning artifact.

## Test plan

- [ ] `uv run pytest -q` (674 passed locally including the new quickstart test).
- [ ] `uv run mkdocs build --strict` (clean locally).

Closes #91