### PR TITLE
docs(arch): auto-generate registry cell table from _registry (#92)

### DIFF
--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -47,8 +47,11 @@ jobs:
       - name: Strict build
         run: uv run mkdocs build --strict
 
-      - name: Check generated metric matrix is committed
-        run: git diff --exit-code -- docs/reference/_generated_metric_matrix.md
+      - name: Check generated docs files are committed
+        run: |
+          git diff --exit-code -- \
+            docs/reference/_generated_metric_matrix.md \
+            docs/development/_generated_registry_cells.md
 
   build-main:
     if: github.event_name != 'pull_request'
@@ -69,5 +72,8 @@ jobs:
       - name: Strict build
         run: uv run mkdocs build --strict
 
-      - name: Check generated metric matrix is committed
-        run: git diff --exit-code -- docs/reference/_generated_metric_matrix.md
+      - name: Check generated docs files are committed
+        run: |
+          git diff --exit-code -- \
+            docs/reference/_generated_metric_matrix.md \
+            docs/development/_generated_registry_cells.md

--- a/docs/development/_generated_registry_cells.md
+++ b/docs/development/_generated_registry_cells.md
@@ -1,0 +1,9 @@
+| `(scope, signal, metric, mode)` | Procedure class |
+|---|---|
+| `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | `_ICContPanelProcedure` |
+| `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | `_FMContPanelProcedure` |
+| `(INDIVIDUAL, SPARSE, None, PANEL)` | `_CAARSparsePanelProcedure` |
+| `(COMMON, CONTINUOUS, None, PANEL)` | `_CommonContPanelProcedure` |
+| `(COMMON, SPARSE, None, PANEL)` | `_CommonSparsePanelProcedure` |
+| `(COMMON, CONTINUOUS, None, TIMESERIES)` | `_TSBetaContTimeseriesProcedure` |
+| `(_SCOPE_COLLAPSED, SPARSE, None, TIMESERIES)` | `_TSDummySparseTimeseriesProcedure` |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -125,15 +125,7 @@ mapping and per-cell canonical statistic / references, see
 [Concepts §Five analysis scenarios](../getting-started/concepts.md#five-analysis-scenarios) — that
 table is the SSOT for what each procedure computes.
 
-| `(scope, signal, metric, mode)`                         | Procedure class                                  |
-|---------------------------------------------------------|--------------------------------------------------|
-| `(INDIVIDUAL, CONTINUOUS, IC, PANEL)`                    | `_ICContPanelProcedure`                          |
-| `(INDIVIDUAL, CONTINUOUS, FM, PANEL)`                    | `_FMContPanelProcedure`                          |
-| `(INDIVIDUAL, SPARSE, None, PANEL)`                      | `_CAARSparsePanelProcedure`                      |
-| `(COMMON, CONTINUOUS, None, PANEL)`                      | `_CommonContPanelProcedure`                      |
-| `(COMMON, SPARSE, None, PANEL)`                          | `_CommonSparsePanelProcedure`                    |
-| `(COMMON, CONTINUOUS, None, TIMESERIES)`                 | `_TSBetaContTimeseriesProcedure`                 |
-| `(_SCOPE_COLLAPSED, SPARSE, None, TIMESERIES)`           | `_TSDummySparseTimeseriesProcedure`              |
+--8<-- "docs/development/_generated_registry_cells.md"
 
 The two timeseries cells share the NW HAC + auto-Bartlett-with-Hansen-Hodrick-floor
 lag rule from `factrix/_stats/constants.py`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ theme:
 hooks:
   # factrix/metrics/*.py Matrix-row: -> docs/reference/_generated_metric_matrix.md
   - scripts/mkdocs_hooks/gen_metric_matrix.py
+  # factrix/_registry._DISPATCH_REGISTRY -> docs/development/_generated_registry_cells.md
+  - scripts/mkdocs_hooks/gen_registry_cells.py
   # examples/*.ipynb -> docs/examples/
   - scripts/mkdocs_hooks/sync_examples.py
   # factrix/llms*.txt -> site root llms*.txt

--- a/scripts/mkdocs_hooks/gen_registry_cells.py
+++ b/scripts/mkdocs_hooks/gen_registry_cells.py
@@ -1,0 +1,66 @@
+"""Build-time generator for the registry-cell table.
+
+Renders the dispatch cells from ``factrix._registry._DISPATCH_REGISTRY``
+into ``docs/development/_generated_registry_cells.md`` so the
+architecture page stays in lockstep with code. Mirrors the
+``gen_metric_matrix.py`` pattern: code is SSOT, the docs file is a
+generated artifact included via ``pymdownx.snippets``.
+
+Usage (manual)::
+
+    python scripts/mkdocs_hooks/gen_registry_cells.py
+
+MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
+
+    The ``on_pre_build(config)`` function is called by MkDocs before
+    each build.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from factrix._axis import FactorScope
+from factrix._registry import (
+    _DISPATCH_REGISTRY,
+    _DispatchKey,
+    _RegistryEntry,
+    _ScopeCollapsedSentinel,
+)
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+_OUT_FILE = _REPO_ROOT / "docs" / "development" / "_generated_registry_cells.md"
+
+_TABLE_HEADER = "| `(scope, signal, metric, mode)` | Procedure class |\n|---|---|\n"
+
+
+def _scope_name(scope: FactorScope | _ScopeCollapsedSentinel) -> str:
+    if isinstance(scope, _ScopeCollapsedSentinel):
+        return "_SCOPE_COLLAPSED"
+    return scope.name
+
+
+def _render_row(key: _DispatchKey, entry: _RegistryEntry) -> str:
+    scope = _scope_name(key.scope)
+    signal = key.signal.name
+    metric = key.metric.name if key.metric is not None else "None"
+    mode = key.mode.name
+    cls = type(entry.procedure).__name__
+    return f"| `({scope}, {signal}, {metric}, {mode})` | `{cls}` |\n"
+
+
+def generate() -> None:
+    """Generate ``_generated_registry_cells.md`` from the live registry."""
+    rows = [_render_row(k, e) for k, e in _DISPATCH_REGISTRY.items()]
+    _OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _OUT_FILE.write_text(_TABLE_HEADER + "".join(rows), encoding="utf-8")
+    print(f"gen_registry_cells: wrote {len(rows)} row(s) to {_OUT_FILE}")
+
+
+def on_pre_build(config: object) -> None:
+    """MkDocs hook: regenerate the table before every build."""
+    generate()
+
+
+if __name__ == "__main__":
+    generate()

--- a/tests/test_docs_registry_cells.py
+++ b/tests/test_docs_registry_cells.py
@@ -1,0 +1,57 @@
+"""Coverage test: generated registry-cell table tracks the live registry.
+
+Asserts that ``docs/development/_generated_registry_cells.md`` exists,
+contains one data row per ``_DISPATCH_REGISTRY`` entry, and lists every
+registered procedure class. Skipped if the file is absent (only
+meaningful after a build).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+from factrix._registry import _DISPATCH_REGISTRY
+
+GENERATED_TABLE = pathlib.Path("docs/development/_generated_registry_cells.md")
+
+
+def _data_rows(text: str) -> list[str]:
+    return [
+        ln
+        for ln in text.splitlines()
+        if ln.strip().startswith("|") and not ln.strip().startswith("|---")
+    ]
+
+
+def test_generated_table_exists_and_nonempty() -> None:
+    if not GENERATED_TABLE.exists():
+        pytest.skip(
+            f"{GENERATED_TABLE} not found — run "
+            "'python scripts/mkdocs_hooks/gen_registry_cells.py' or 'mkdocs build' first."
+        )
+    rows = _data_rows(GENERATED_TABLE.read_text(encoding="utf-8"))
+    # header + at least one data row
+    assert len(rows) >= 2, f"{GENERATED_TABLE} has no data rows"
+
+
+def test_generated_table_row_count_matches_registry() -> None:
+    if not GENERATED_TABLE.exists():
+        pytest.skip(f"{GENERATED_TABLE} not found")
+    rows = _data_rows(GENERATED_TABLE.read_text(encoding="utf-8"))
+    # rows includes the header row
+    assert len(rows) - 1 == len(_DISPATCH_REGISTRY), (
+        f"{GENERATED_TABLE} has {len(rows) - 1} data row(s) but registry has "
+        f"{len(_DISPATCH_REGISTRY)} entries — regenerate via 'mkdocs build'."
+    )
+
+
+def test_every_procedure_class_appears_in_table() -> None:
+    if not GENERATED_TABLE.exists():
+        pytest.skip(f"{GENERATED_TABLE} not found")
+    text = GENERATED_TABLE.read_text(encoding="utf-8")
+    for entry in _DISPATCH_REGISTRY.values():
+        cls = type(entry.procedure).__name__
+        assert f"`{cls}`" in text, (
+            f"procedure class {cls!r} missing from {GENERATED_TABLE}"
+        )


### PR DESCRIPTION
## Summary

Mirror the metric-matrix pattern so the architecture page's cell table can no longer drift from the live registry. Code is SSOT, the docs fragment is generated.

- New `scripts/mkdocs_hooks/gen_registry_cells.py` iterates `_DISPATCH_REGISTRY` and writes `docs/development/_generated_registry_cells.md` (deterministic, insertion order = register-call order).
- Replaced the hand-typed table in `architecture.md` with a `pymdownx.snippets` include — generator output verified byte-equal to the previous hand-table.
- New `tests/test_docs_registry_cells.py`: row count + per-class presence checks against the live registry.
- Extended the docs-build freshness check (#89) so an uncommitted regeneration of either generated file fails CI.

## Test plan

- [ ] `uv run pytest -q` (677 passed locally including the 3 new tests).
- [ ] `uv run mkdocs build --strict` (clean; rendered HTML contains `<code>_FMContPanelProcedure</code>` etc.).
- [ ] Tampering with the generated file then running the freshness check — fails as expected.

Closes #92