### PR TITLE
test(docs): extend public-surface validator to all docs pages (#98)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,6 @@ validation:
 
 exclude_docs: |
   plans/
-  plan_factorlib.md
 
 nav:
   - Home: index.md

--- a/tests/_doc_validation.py
+++ b/tests/_doc_validation.py
@@ -1,0 +1,106 @@
+"""Shared helpers for doc-validation tests.
+
+Used by ``test_docs_llms.py`` (validates ``factrix/llms-full.txt``) and
+``test_docs_pages.py`` (walks all ``docs/**/*.md``). Pure regex + attribute
+walking; no fixtures, intentionally not in ``conftest.py`` so it stays
+out of the pytest collection path.
+
+The leading underscore in the filename keeps pytest from collecting it
+as a test module.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+
+import factrix
+
+# Negative lookbehind excludes URL paths (`github.com/awwesomeman/factrix`)
+# and dotted continuations from a non-factrix root.
+REF_RE = re.compile(
+    r"(?<![/.:])\b(?:factrix|fl)\."
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)"
+)
+FROM_IMPORT_RE = re.compile(
+    r"^from\s+(factrix(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s+import\s+(.+)$",
+    re.MULTILINE,
+)
+# `import factrix` / `import factrix.metrics [as fl]` — bare-import form.
+BARE_IMPORT_RE = re.compile(
+    r"^import\s+(factrix(?:\.[A-Za-z_][A-Za-z0-9_]*)*)(?:\s+as\s+\w+)?\s*$",
+    re.MULTILINE,
+)
+
+
+def referenced_chains(text: str) -> set[tuple[str, ...]]:
+    """Return the set of `factrix.X.Y...` attribute chains in ``text``."""
+    return {tuple(m.group(1).split(".")) for m in REF_RE.finditer(text)}
+
+
+def imports(text: str) -> list[tuple[str, str | None]]:
+    """Return ``[(module_path, imported_name_or_None), ...]``.
+
+    ``None`` for bare ``import factrix.X`` forms (only the module needs
+    to resolve; no attribute to check).
+    """
+    out: list[tuple[str, str | None]] = []
+    for m in FROM_IMPORT_RE.finditer(text):
+        module = m.group(1)
+        # Strip trailing comments before splitting on commas.
+        names_str = m.group(2).split("#", 1)[0]
+        for raw in names_str.split(","):
+            name = raw.strip().split(" as ")[0].strip()
+            if name:
+                out.append((module, name))
+    for m in BARE_IMPORT_RE.finditer(text):
+        out.append((m.group(1), None))
+    return out
+
+
+def resolves(chain: tuple[str, ...]) -> bool:
+    """Resolve ``factrix.<chain>`` against the live package.
+
+    Tries the longest prefix of ``chain`` as a module path first, then
+    walks the remaining parts as attributes. Going longest-first matters
+    because ``factrix.metrics.__init__`` re-exports symbols like
+    ``caar`` (the function) that shadow the same-named submodule —
+    naive left-to-right ``getattr`` walks land on the function and then
+    fail to look up ``bmp_test`` on it. Mkdocstrings cross-refs like
+    ``factrix.metrics.caar.bmp_test`` mean the module path, not the
+    re-exported function.
+    """
+    for k in range(len(chain), 0, -1):
+        try:
+            obj: object = importlib.import_module("factrix." + ".".join(chain[:k]))
+        except ImportError:
+            continue
+        ok = True
+        for member in chain[k:]:
+            try:
+                obj = getattr(obj, member)
+            except AttributeError:
+                ok = False
+                break
+        if ok:
+            return True
+    # Fallback: chain may live entirely on the top-level ``factrix``
+    # namespace (e.g. ``factrix.AnalysisConfig.individual_continuous``).
+    obj = factrix
+    for part in chain:
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            return False
+    return True
+
+
+def import_resolves(module_path: str, name: str | None) -> bool:
+    """Verify a ``from <module_path> import <name>`` statement resolves."""
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError:
+        return False
+    if name is None:
+        return True
+    return hasattr(module, name)

--- a/tests/test_docs_llms.py
+++ b/tests/test_docs_llms.py
@@ -21,81 +21,34 @@ Three checks:
 Bare references like ``StatCode.IC_MEAN`` (no ``fl.`` / ``factrix.``
 prefix) are intentionally not validated — too many false positives
 against ``profile.X`` style attribute talk in prose.
+
+Sibling test ``test_docs_pages.py`` runs the resolution checks
+against every ``docs/**/*.md`` page; this file remains specific to
+the curated llms snapshot (because of the ``__all__``-coverage check).
 """
 
 from __future__ import annotations
 
-import importlib
 import pathlib
 import re
 
 import factrix
 
+from tests._doc_validation import (
+    import_resolves,
+    imports,
+    referenced_chains,
+    resolves,
+)
+
 LLMS_FULL = pathlib.Path("factrix/llms-full.txt")
 LLMS_INDEX = pathlib.Path("factrix/llms.txt")
-
-# Negative lookbehind excludes URL paths (`github.com/awwesomeman/factrix`)
-# and dotted continuations from a non-factrix root.
-_REF_RE = re.compile(
-    r"(?<![/.:])\b(?:factrix|fl)\."
-    r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)"
-)
-_IMPORT_RE = re.compile(
-    r"^from\s+(factrix(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s+import\s+(.+)$",
-    re.MULTILINE,
-)
-# `import factrix` / `import factrix.metrics [as fl]` — bare-import form.
-_BARE_IMPORT_RE = re.compile(
-    r"^import\s+(factrix(?:\.[A-Za-z_][A-Za-z0-9_]*)*)(?:\s+as\s+\w+)?\s*$",
-    re.MULTILINE,
-)
-
-
-def _referenced_chains(text: str) -> set[tuple[str, ...]]:
-    return {tuple(m.group(1).split(".")) for m in _REF_RE.finditer(text)}
-
-
-def _imports(text: str) -> list[tuple[str, str | None]]:
-    """Return ``[(module_path, imported_name_or_None), ...]``.
-
-    ``None`` for bare ``import factrix.X`` forms (only the module needs
-    to resolve; no attribute to check).
-    """
-    out: list[tuple[str, str | None]] = []
-    for m in _IMPORT_RE.finditer(text):
-        module = m.group(1)
-        # Strip trailing comments before splitting on commas.
-        names_str = m.group(2).split("#", 1)[0]
-        for raw in names_str.split(","):
-            name = raw.strip().split(" as ")[0].strip()
-            if name:
-                out.append((module, name))
-    for m in _BARE_IMPORT_RE.finditer(text):
-        out.append((m.group(1), None))
-    return out
-
-
-def _resolves(chain: tuple[str, ...]) -> bool:
-    """Walk attribute chain from ``factrix``, falling back to submodule
-    import for lazy-loaded subpackages (e.g. ``factrix.metrics``)."""
-    obj: object = factrix
-    walked: list[str] = []
-    for part in chain:
-        try:
-            obj = getattr(obj, part)
-        except AttributeError:
-            try:
-                obj = importlib.import_module("factrix." + ".".join([*walked, part]))
-            except ImportError:
-                return False
-        walked.append(part)
-    return True
 
 
 def test_every_referenced_symbol_resolves() -> None:
     text = LLMS_FULL.read_text(encoding="utf-8")
     failures = sorted(
-        ".".join(chain) for chain in _referenced_chains(text) if not _resolves(chain)
+        ".".join(chain) for chain in referenced_chains(text) if not resolves(chain)
     )
     assert not failures, (
         "Unresolvable factrix.* references in llms-full.txt:\n  "
@@ -105,15 +58,11 @@ def test_every_referenced_symbol_resolves() -> None:
 
 def test_every_imported_name_resolves() -> None:
     text = LLMS_FULL.read_text(encoding="utf-8")
-    failures: list[str] = []
-    for module_path, name in _imports(text):
-        try:
-            module = importlib.import_module(module_path)
-        except ImportError:
-            failures.append(f"{module_path} (module not importable)")
-            continue
-        if name is not None and not hasattr(module, name):
-            failures.append(f"{module_path}.{name}")
+    failures = [
+        f"{module}.{name}" if name else f"{module} (module not importable)"
+        for module, name in imports(text)
+        if not import_resolves(module, name)
+    ]
     assert not failures, (
         "Imports in llms-full.txt that do not resolve:\n  " + "\n  ".join(failures)
     )

--- a/tests/test_docs_pages.py
+++ b/tests/test_docs_pages.py
@@ -1,0 +1,60 @@
+"""Validates every ``docs/**/*.md`` page against the live public surface.
+
+Catches the drift class flagged by PR #97: a stale ``factrix.X.Y``
+reference or a ``from factrix.subpkg import X`` that survived a rename.
+The validator from #90 only inspected ``factrix/llms-full.txt``; this
+sibling extends the same snapshot approach to every authored docs page.
+
+``docs/plans/**`` is excluded — those pages are intentionally fossilised
+historical planning artifacts (also excluded from the published site
+via ``mkdocs.yml`` ``exclude_docs``).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from tests._doc_validation import (
+    import_resolves,
+    imports,
+    referenced_chains,
+    resolves,
+)
+
+DOCS_ROOT = pathlib.Path("docs")
+EXCLUDED_PREFIXES = (DOCS_ROOT / "plans",)
+
+
+def _page_paths() -> list[pathlib.Path]:
+    return sorted(
+        p
+        for p in DOCS_ROOT.rglob("*.md")
+        if not any(p.is_relative_to(prefix) for prefix in EXCLUDED_PREFIXES)
+    )
+
+
+@pytest.mark.parametrize("path", _page_paths(), ids=lambda p: str(p))
+def test_page_references_resolve(path: pathlib.Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    failures = sorted(
+        ".".join(chain) for chain in referenced_chains(text) if not resolves(chain)
+    )
+    assert not failures, (
+        f"Unresolvable factrix.* references in {path}:\n  "
+        + "\n  ".join(f"factrix.{f}" for f in failures)
+    )
+
+
+@pytest.mark.parametrize("path", _page_paths(), ids=lambda p: str(p))
+def test_page_imports_resolve(path: pathlib.Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    failures = [
+        f"{module}.{name}" if name else f"{module} (module not importable)"
+        for module, name in imports(text)
+        if not import_resolves(module, name)
+    ]
+    assert not failures, f"Imports in {path} that do not resolve:\n  " + "\n  ".join(
+        failures
+    )


### PR DESCRIPTION
## Summary

Extends the snapshot validator from #90 to walk every tracked \`docs/**/*.md\` (excluding \`docs/plans/**\`). Closes the drift class that left a stale \`fl.preprocess.returns.X\` import + a wrong-kwarg snippet in \`docs/guides/standalone-metrics.md\` undetected for two months.

- Refactor: regex / resolver helpers extracted from \`tests/test_docs_llms.py\` into \`tests/_doc_validation.py\` (private, not pytest-collected).
- New \`tests/test_docs_pages.py\` parametrizes \`test_page_references_resolve\` and \`test_page_imports_resolve\` per docs page.
- Bug fix in \`resolves()\`: longest-module-prefix-first strategy correctly handles mkdocstrings cross-refs like \`factrix.metrics.caar.bmp_test\` that were previously masked by re-exported same-named functions.

## Test plan

- [ ] \`uv run pytest -q\` (791 passed locally, was 681 — 110 new parametrized cases for ~55 docs pages).
- [ ] Negative test: planted \`fl.bogus_for_test\` in a guide page; \`tests/test_docs_pages.py::test_page_references_resolve[docs/guides/standalone-metrics.md]\` failed as expected; restored, all green.
- [ ] \`tests/test_docs_llms.py\` still passes after the helper extraction (no behaviour change for the llms-specific checks).

Closes #98