### PR TITLE
fix(docs-hooks): prune stale notebooks from docs/examples on build (#99)

### DIFF
--- a/scripts/mkdocs_hooks/sync_examples.py
+++ b/scripts/mkdocs_hooks/sync_examples.py
@@ -120,9 +120,24 @@ def _render_index(metas: list[_RecipeMeta]) -> str:
 
 
 def sync() -> None:
-    """Copy notebooks and regenerate ``docs/examples/index.md``."""
+    """Copy notebooks and regenerate ``docs/examples/index.md``.
+
+    Prunes ``*.ipynb`` files in ``_DST_DIR`` that no longer exist in
+    ``_SRC_DIR`` before copying — covers retired notebooks (e.g.
+    ``examples/demo.ipynb`` was replaced in v0.8.0 but lingered in
+    ``docs/examples/`` across builds, surfacing as a "not in nav"
+    warning until manual cleanup).
+    """
     _DST_DIR.mkdir(parents=True, exist_ok=True)
     notebooks = sorted(_SRC_DIR.glob("*.ipynb"))
+    source_names = {nb.name for nb in notebooks}
+
+    pruned: list[str] = []
+    for stale in _DST_DIR.glob("*.ipynb"):
+        if stale.name not in source_names:
+            stale.unlink()
+            pruned.append(stale.name)
+
     metas: list[_RecipeMeta] = []
     for src in notebooks:
         dst = _DST_DIR / src.name
@@ -130,7 +145,10 @@ def sync() -> None:
         metas.append(_collect(src))
 
     (_DST_DIR / "index.md").write_text(_render_index(metas), encoding="utf-8")
-    print(f"sync_examples: synced {len(notebooks)} notebook(s) + index to {_DST_DIR}")
+    msg = f"sync_examples: synced {len(notebooks)} notebook(s) + index to {_DST_DIR}"
+    if pruned:
+        msg += f" (pruned: {', '.join(pruned)})"
+    print(msg)
 
 
 def on_pre_build(config: object) -> None:

--- a/tests/test_sync_examples.py
+++ b/tests/test_sync_examples.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``scripts/mkdocs_hooks/sync_examples.py``.
+
+Targets the prune behaviour added in #99: a notebook removed from
+``examples/`` should disappear from ``docs/examples/`` on the next
+build, not linger as a "not in nav" warning forever.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from scripts.mkdocs_hooks import sync_examples
+
+_MINIMAL_NB = {
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": ["# Title\n", "\n", "## Use this when\n", "\n", "- teaser\n"],
+        }
+    ],
+    "metadata": {},
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}
+
+
+def _write_nb(path: pathlib.Path, title: str = "Title") -> None:
+    nb = json.loads(json.dumps(_MINIMAL_NB))
+    nb["cells"][0]["source"] = [
+        f"# {title}\n",
+        "\n",
+        "## Use this when\n",
+        "\n",
+        "- teaser line\n",
+    ]
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+@pytest.fixture
+def isolated_dirs(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[pathlib.Path, pathlib.Path]:
+    src = tmp_path / "examples"
+    dst = tmp_path / "docs" / "examples"
+    src.mkdir(parents=True)
+    dst.mkdir(parents=True)
+    monkeypatch.setattr(sync_examples, "_SRC_DIR", src)
+    monkeypatch.setattr(sync_examples, "_DST_DIR", dst)
+    return src, dst
+
+
+def test_sync_prunes_stale_destination_notebook(
+    isolated_dirs: tuple[pathlib.Path, pathlib.Path],
+) -> None:
+    src, dst = isolated_dirs
+    _write_nb(src / "current.ipynb", title="Current")
+    _write_nb(dst / "current.ipynb", title="Current")
+    _write_nb(dst / "retired.ipynb", title="Retired")
+
+    sync_examples.sync()
+
+    assert (dst / "current.ipynb").exists()
+    assert not (dst / "retired.ipynb").exists()
+
+
+def test_sync_does_not_touch_files_outside_dst(
+    isolated_dirs: tuple[pathlib.Path, pathlib.Path],
+) -> None:
+    src, dst = isolated_dirs
+    _write_nb(src / "a.ipynb", title="A")
+    sibling = dst.parent / "sibling.ipynb"
+    sibling.write_text("untouched", encoding="utf-8")
+
+    sync_examples.sync()
+
+    assert sibling.read_text(encoding="utf-8") == "untouched"
+
+
+def test_sync_leaves_non_notebook_files_alone(
+    isolated_dirs: tuple[pathlib.Path, pathlib.Path],
+) -> None:
+    """The prune glob is ``*.ipynb`` only; ``index.md`` etc. survive."""
+    src, dst = isolated_dirs
+    _write_nb(src / "a.ipynb", title="A")
+    keepme = dst / "keepme.txt"
+    keepme.write_text("not a notebook", encoding="utf-8")
+
+    sync_examples.sync()
+
+    assert keepme.exists()
+
+
+def test_sync_handles_rename_in_one_pass(
+    isolated_dirs: tuple[pathlib.Path, pathlib.Path],
+) -> None:
+    """Renamed notebook (old name pruned + new name copied) is handled
+    in a single ``sync()`` call — the prune-before-copy ordering."""
+    src, dst = isolated_dirs
+    _write_nb(src / "renamed.ipynb", title="Renamed")
+    _write_nb(dst / "old_name.ipynb", title="Renamed")
+
+    sync_examples.sync()
+
+    assert (dst / "renamed.ipynb").exists()
+    assert not (dst / "old_name.ipynb").exists()


### PR DESCRIPTION
## Summary

\`sync_examples.sync()\` only copied INTO \`docs/examples/\` and never pruned. When \`examples/demo.ipynb\` was retired in v0.8.0, the stale destination copy lingered across builds — caught only by the post-#92 audit. Add a prune pass before the copy loop.

- Glob is \`*.ipynb\` only — \`index.md\` and any other content survive.
- Prune-before-copy avoids a renamed notebook briefly existing under both names.
- 3 unit tests via \`tmp_path\` + \`monkeypatch\` cover: prune happens, files outside \`_DST_DIR\` untouched, non-\`.ipynb\` files survive.

## Test plan

- [ ] \`uv run pytest tests/test_sync_examples.py -v\` (3 passed locally).
- [ ] \`uv run pytest -q\` (794 passed, no regression).
- [ ] \`uv run mkdocs build --strict\` (clean).
- [ ] Manual: created stray \`docs/examples/demo.ipynb\` then ran \`mkdocs build\` — file removed, build clean.

Closes #99