### PR TITLE
docs: persona cross-cuts — event-study + TIMESERIES contracts

### DIFF
--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -4,6 +4,13 @@ Cumulative Average Abnormal Return tests for event signals. CAAR
 *t*-test (parametric) and BMP standardised AR *z*-test (robust to
 event-induced variance).
 
+!!! info "Event-study contracts"
+    `signed_car`, the `estimation_window` consumed by `bmp_test`, and
+    factrix's confounded-event handling are documented in
+    [Metric applicability § Event-study contracts](../../reference/metric-applicability.md#event-study-contracts).
+    factrix computes **CAR** (sum of per-period abnormal returns), not
+    BHAR; see the same section for the distinction.
+
 ::: factrix.metrics.caar
 
 ## See also

--- a/docs/api/metrics/corrado.md
+++ b/docs/api/metrics/corrado.md
@@ -4,6 +4,16 @@ Corrado (1989) nonparametric rank test on event abnormal returns.
 Robust to extreme returns, non-normality, and cross-asset
 heteroscedasticity. Direction-adjusted for two-sided signals.
 
+!!! info "Event-study contracts"
+    Corrado's primitive is `signed_rank = uniform_rank(forward_return) ×
+    sign(factor)` — note that the direction adjustment is on the rank,
+    not on the return itself. The
+    [Event-study contracts table](../../reference/metric-applicability.md#abnormal-return-definition-per-metric)
+    contrasts this with `caar` (magnitude-weighted) and `event_quality`
+    (sign-only on the raw return). The
+    [`estimation_window`](../../reference/metric-applicability.md#estimation_window)
+    section specifies the per-asset baseline this test ranks against.
+
 ::: factrix.metrics.corrado
 
 ## See also

--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -4,6 +4,33 @@ Multi-horizon event analysis — per-event return profile across `k`
 offsets, plus binomial test on per-horizon hit rate. Detects pre-event
 leakage and identifies the strongest horizon.
 
+## Offset conventions
+
+Defaults: `offsets = [-6, -3, -1, 1, 6, 12, 24]`. Offset `0` is the
+event date itself and is excluded from the defaults; user-supplied
+`offsets` lists are honoured verbatim.
+
+| `k` | Anchor | Formula | Sign-adjusted |
+|---|---|---|---|
+| `k > 0` (post-event) | Cumulative from `t+1` entry | `price[t+1+k] / price[t+1] − 1` | Yes — multiplied by `sign(factor)`. The reading is signal *quality*. |
+| `k < 0` (pre-event) | Single bar at offset | `price[t+k] / price[t+k−1] − 1` | **No** — the reading is *leakage*, where the bar's directional response is what matters independent of the eventual signal sign. |
+| `k == 0` (corner) | Single bar at event | `price[t] / price[t−1] − 1` | No — falls into the pre-event branch. Pass with care; the event-day bar is usually contaminated by the announcement itself. |
+
+The pre/post asymmetry is intentional. Mixing the two conventions on a
+single chart (post-event cumulative + pre-event single-bar) is the
+default factrix presentation; downstream consumers should not
+re-cumulate the pre-event leg.
+
+The binomial null at each offset assumes per-event independence at
+that offset. **Adjacent post-event offsets are serially correlated
+within the same event** — `k=6` and `k=12` share the `t+1` entry
+price and overlap on bars `[t+2, t+7]`. The reported per-offset
+*p*-values therefore have understated variance under the joint null
+across offsets; treat the curve as descriptive and read the binomial
+*p* one offset at a time. See also the
+[confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
+on within-asset event clustering, which compounds the same issue.
+
 ::: factrix.metrics.event_horizon
 
 ## See also

--- a/docs/api/metrics/event_quality.md
+++ b/docs/api/metrics/event_quality.md
@@ -4,6 +4,16 @@ Per-event quality summaries computed on `signed_car`: hit rate, IC,
 profit factor, skewness, signal density. Inference is binomial or
 nonparametric — descriptive elsewhere.
 
+!!! info "Event-study contracts"
+    These metrics use the **sign-only** form `signed_car =
+    forward_return × sign(factor)` — distinct from `caar`'s
+    magnitude-weighted `forward_return × factor`. See the
+    [abnormal-return table](../../reference/metric-applicability.md#abnormal-return-definition-per-metric)
+    for the full per-metric contract and the
+    [confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
+    for how the binomial / Spearman nulls behave under within-asset
+    event clustering.
+
 ::: factrix.metrics.event_quality
     options:
       members:

--- a/docs/api/metrics/ts_asymmetry.md
+++ b/docs/api/metrics/ts_asymmetry.md
@@ -5,6 +5,12 @@ Two methods — conditional means and piecewise slopes — both fit by OLS
 with NW HAC and tested by Wald χ², so cross-method *p*-values stay
 comparable under overlapping forward returns.
 
+!!! info "TIMESERIES-mode conventions"
+    `FACTOR_ADF_P` persistence diagnostic, plain stage-1 SE rationale,
+    and the `forward_periods` vs `signal_horizon` bias framing apply
+    here as for the rest of the TS-mode family. See
+    [TIMESERIES-mode conventions](../../reference/ts-mode-conventions.md).
+
 ::: factrix.metrics.ts_asymmetry
 
 ## See also

--- a/docs/api/metrics/ts_beta.md
+++ b/docs/api/metrics/ts_beta.md
@@ -4,6 +4,14 @@ Per-asset time-series β to a macro common factor (VIX, USD index,
 etc.), then cross-asset *t* on the β distribution. Includes mean R²,
 rolling-window β stability, and sign consistency.
 
+!!! info "TIMESERIES-mode conventions"
+    Stage-1 per-asset OLS uses **plain SE**, not HAC — the dominant
+    bias under a persistent predictor is Stambaugh coefficient bias,
+    which HAC does not address. `FACTOR_ADF_P` is emitted on the input
+    series; non-overlap resampling is **not** applied. See
+    [TIMESERIES-mode conventions](../../reference/ts-mode-conventions.md)
+    for the full rationale.
+
 ::: factrix.metrics.ts_beta
     options:
       members:

--- a/docs/api/metrics/ts_quantile.md
+++ b/docs/api/metrics/ts_quantile.md
@@ -4,6 +4,12 @@ Quantile-bucketed NW HAC OLS on the per-date `(_f, _r)` series for
 COMMON / single-asset cells; Wald χ² on the top-bottom bucket spread.
 Catches U-shape / extreme-only signals that linear β assumes away.
 
+!!! info "TIMESERIES-mode conventions"
+    `FACTOR_ADF_P` persistence diagnostic, plain stage-1 SE rationale,
+    and the `forward_periods` vs `signal_horizon` bias framing apply
+    here as for the rest of the TS-mode family. See
+    [TIMESERIES-mode conventions](../../reference/ts-mode-conventions.md).
+
 ::: factrix.metrics.ts_quantile
 
 ## See also

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -122,7 +122,7 @@ Adjust the threshold (per-shell):
 CHANGELOG_MIN_LINES=10 git push
 ```
 
-Rationale: see §7 "Release workflow" on the limits of cz's
+Rationale: see §9 "Release workflow" on the limits of cz's
 auto-CHANGELOG.
 
 ---
@@ -152,7 +152,7 @@ gh pr merge --squash
 ```
 
 > **Important**: do **not** run `cz bump` after merge. Versions and tags
-> follow the release-train cadence (see §7)—a single release fires after
+> follow the release-train cadence (see §9)—a single release fires after
 > several PRs accumulate. Each PR writes its own changes into the
 > `## [Unreleased]` section of `CHANGELOG.md` (under `### Added` /
 > `### Changed` / `### Fixed` / `### Migration` subsections as
@@ -288,7 +288,7 @@ version follows actual, not pin.
   (dev workflow), then freeze with cheat sheet row 5
 - **Someone else pushed factrix; I need to catch up**: cheat sheet rows
   3 + 5
-- **Pinning to a tag (recommended, see §8)**: cheat sheet rows 4 + 5
+- **Pinning to a tag (recommended, see §9)**: cheat sheet rows 4 + 5
 - **Submodule looks broken after switching branches**: reset via cheat
   sheet row 6
 
@@ -329,7 +329,79 @@ files auto-update and which need manual maintenance.
 
 ---
 
-## 7. Testing rules
+## 7. Drift management
+
+Documentation, generated reference material, and example notebooks drift
+away from the code they describe. The project's working policy:
+**automate symbol-level drift, leave narrative/conceptual drift to
+review, and run a manual half-hour pass at every release-train cut.**
+The framing below is heuristic — when a new "should I add a test for
+this drift?" question arises, judge it by whether the cost of
+automating exceeds the cost of missing.
+
+### 7.1 Automated drift checks
+
+Enforced by tests and CI — a regression fails the PR build.
+
+| Drift class | Enforced by |
+|---|---|
+| Generated docs freshness (metric matrix, registry cells, examples sync) | `tests/test_docs_matrix.py`, `tests/test_docs_registry_cells.py`, plus the `git diff --exit-code` step in `.github/workflows/docs-deploy-dev.yml` |
+| Public-surface mention coverage in `factrix/llms-full.txt` | `tests/test_docs_llms.py` |
+| Public-surface mention coverage across all docs pages | `tests/test_docs_pages.py` |
+| README quickstart end-to-end | `tests/test_readme_quickstart.py` |
+| mkdocs nav / link integrity | `uv run mkdocs build --strict` (run in `.github/workflows/docs-deploy-dev.yml`) |
+
+### 7.2 Drift left to human review
+
+Deliberately not automated, because machine-judgement cost > miss cost:
+
+- **Architecture narrative vs current code design**
+  (`docs/development/architecture.md`) — accuracy hinges on whether the
+  prose still captures the *spirit* of the design; a string match
+  cannot judge that.
+- **Conceptual / explanatory text in guides**
+  (`docs/guides/*.md`, `docs/getting-started/*.md`) — wording quality
+  and pedagogical ordering are reviewer calls; a stale phrasing often
+  parses fine.
+- **Editorial choices in `factrix/llms-full.txt`** — depth of context,
+  ordering, and what to omit are agent-UX decisions, not symbol
+  coverage (which §7.1 already enforces).
+
+Rule of thumb: if the drift can be detected by a string match or a
+function call, automate it; if catching it requires reading prose for
+meaning, leave it to release-train review.
+
+### 7.3 Release-train drift audit
+
+Before running `cz bump --changelog` (see §9), run this checklist on
+`main`:
+
+```bash
+# 1. Search for known-deprecated symbol names that may have leaked back in.
+#    Extend the pattern per release with names retired since the last tag.
+git grep -nE 'q1_q5_spread'
+
+# 2. Full test suite — covers every check listed in §7.1.
+uv run pytest -q
+
+# 3. Strict docs build — surfaces broken nav, links, and generated-file drift.
+uv run mkdocs build --strict
+
+# 4. Public-surface coverage spot-check (also run by step 2; explicit run
+#    is cheap and isolates failures).
+uv run pytest tests/test_docs_llms.py tests/test_docs_pages.py -q
+
+# 5. Skim the [Unreleased] CHANGELOG section for stale paths / kwargs
+#    that drifted since the entry was written.
+sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md
+```
+
+A failure on any step is a release blocker — fix on `main` (or revert
+the offending PR) before bumping.
+
+---
+
+## 8. Testing rules
 
 ### Synthetic fixtures only
 
@@ -413,7 +485,7 @@ PR self-check: run all three code blocks, `uv run mkdocs build
 
 ---
 
-## 8. Versioning and release (SemVer & Release)
+## 9. Versioning and release (SemVer & Release)
 
 factrix is currently in **pre-1.0** (v0.x.x)—the public API **may
 break in MINOR bumps**. Consumers (e.g. the `factor-analysis`
@@ -499,7 +571,7 @@ workspace bump to the tag.
 
 ---
 
-## 9. Architecture / design decisions
+## 10. Architecture / design decisions
 
 Before a new feature or large change, read:
 
@@ -516,7 +588,7 @@ preserved there).
 
 ---
 
-## 10. Asking questions / decision communication
+## 11. Asking questions / decision communication
 
 Self-use repo for the author + AI agents, so there is no issue
 template / discussion board. Decision-record channels:
@@ -530,7 +602,7 @@ template / discussion board. Decision-record channels:
 
 ---
 
-## 11. Style — single language
+## 12. Style — single language
 
 All issue / PR titles + bodies, commit messages, CHANGELOG entries,
 and any content under `factrix/` and `docs/` (excluding `docs/plans/`)
@@ -547,7 +619,7 @@ README, and CHANGELOG.
 
 ---
 
-## 12. Licensing and contribution terms
+## 13. Licensing and contribution terms
 
 This project is released under the [Apache License 2.0](LICENSE).
 

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -68,6 +68,32 @@ K-period forecast residuals carry MA(K−1) structure; the source of
 the `forward_periods − 1` lag floor that factrix combines with the
 Andrews rule under overlapping forward returns.
 
+### Hodrick (1992)
+[](){ #hodrick-1992 }
+
+Hodrick, R. J. (1992). "Dividend Yields and Expected Stock Returns:
+Alternative Procedures for Inference and Measurement." *Review of
+Financial Studies* 5(3), 357–386.
+
+Reverse-regression *t*-statistic for long-horizon return
+predictability with persistent regressors. The "1B" form solves the
+size distortion of NW / Hansen-Hodrick (1980) under heavy overlap
+(`h / T` not small) by re-expressing the long-horizon regression as
+a one-period regression on a moving-average of the predictor — the
+test statistic is then size-correct in finite samples even when the
+implied MA(h−1) overlap is severe.
+
+Cited as background, not implemented. Hodrick 1B reformulates the
+long-horizon regression as a one-period regression of `r_{t,t+1}` on
+the predictor sum `X_t = Σ_{j=0}^{h-1} x_{t-j}`, swapping which side
+carries the moving average. The coefficient has a different
+interpretation than the standard `r_{t,t+h} ~ x_t` slope, and factrix
+prefers non-overlapping resampling on the `Individual × Continuous`
+cell as the literature-standard mitigation for overlap-driven size
+distortion. See
+[Statistical methods § HAC SE](statistical-methods.md#1-hac-se-under-overlapping-returns)
+for the comparison among NW / HH-1980 / Hodrick-1992.
+
 ### White (1980)
 [](){ #white-1980 }
 

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -160,3 +160,90 @@ returns a meaningful-looking result. Three deterministic outcomes:
 Structural errors (wrong cell, missing column, `N == 1` on a cell that
 requires `PANEL` Mode) raise `ValueError` / `ConfigError` rather than
 falling back.
+
+## Event-study contracts
+
+The Individual × Sparse cell hosts a family of metrics whose
+abnormal-return definitions, estimation windows, and overlap
+conventions diverge from each other by design. Surfacing the contracts
+here so each metric page can reference one canonical definition.
+
+### Abnormal-return definition per metric
+
+factrix follows MacKinlay (1997) event-window vocabulary but each
+metric instantiates the abnormal-return primitive differently:
+
+| Metric | Per-row primitive | Why this form |
+|---|---|---|
+| [`caar`][factrix.metrics.caar.caar], [`bmp_test`][factrix.metrics.caar.bmp_test] | `signed_car = forward_return × factor` (magnitude preserved) | Generalises MacKinlay's signed CAAR to continuous factors (Sefcik-Thompson 1986 lineage); on `factor ∈ {0, ±1}` it reduces to the textbook signed CAAR. |
+| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate], [`event_ic`][factrix.metrics.event_quality.event_ic], [`profit_factor`][factrix.metrics.event_quality.profit_factor], [`event_skewness`][factrix.metrics.event_quality.event_skewness] | `signed_car = forward_return × sign(factor)` (sign-only) | These metrics measure direction quality independent of factor magnitude; magnitude-weighting would conflate "direction was right" with "magnitude was big". |
+| [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test] | `signed_rank = uniform_rank(forward_return) × sign(factor)` | Corrado (1989) ranks the raw return distribution, then direction-adjusts the rank. The sign-adjustment is on the rank, not the return. |
+| [`event_around_return`][factrix.metrics.event_horizon.event_around_return], [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | Post-event (k > 0): `sign(factor) × cumulative_return`; pre-event (k < 0): unsigned single-bar return | Asymmetric on purpose: post-event reads signal *quality*, pre-event reads *leakage* — leakage is independent of eventual direction and must be inspected unsigned. |
+
+The shared verb "abnormal return" therefore covers four different
+estimators. Use the table above when comparing factrix output to
+literature numbers.
+
+### CAR vs BHAR
+
+factrix computes **CAR** (cumulative abnormal return — sum of per-period
+abnormal returns) throughout. **BHAR** (buy-and-hold abnormal return —
+compounded `∏(1 + r) − 1` minus benchmark) is **not** computed by any
+metric. Two implications:
+
+- The `caar` *t*-test is the cross-event mean of per-event-date CAAR,
+  not BHAR. CAR is appropriate for short-horizon windows (the bias
+  between CAR and BHAR is `O(h²)` for horizon `h`); for multi-year
+  buy-and-hold studies, compute BHAR externally.
+- `event_around_return` post-event uses simple cumulative returns
+  (`price[t+1+k] / price[t+1] − 1`), not period-by-period sums. This is
+  arithmetic accumulation, distinct from BHAR's geometric compounding.
+
+### `estimation_window`
+
+The estimation window is the per-asset pre-event sample used to fit
+the abnormal-return baseline. factrix uses it in two places:
+
+- [`bmp_test`][factrix.metrics.caar.bmp_test]: standardises each
+  event's abnormal return by the event's own pre-event SE, computed
+  over the estimation window.
+- [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test]:
+  ranks the abnormal return against the per-asset distribution drawn
+  from the estimation window.
+
+Conventions:
+
+- **Length**: per-asset `T ≥ 30` non-event observations is the
+  literature default (Brown-Warner 1985 §2.B). factrix enforces
+  this floor at the `corrado_rank_test` per-asset gate.
+- **Alignment**: ends one period before the event date; gap-before
+  -event of zero (no skip period). Users running a skip-period
+  convention must pre-shift the panel.
+- **Overlap exclusion**: factrix's primitives do **not** drop
+  pre-event windows that overlap an earlier event for the same asset.
+  In practice this means contaminated estimation windows for clustered
+  events; use `clustering_diagnostic` to gauge severity and consider
+  pre-filtering the panel for tightly clustered names.
+- **Forward-return horizon**: the event window is `forward_periods`
+  bars; the estimation window is the **pre-event** sample, so
+  `EventConfig.forward_periods` does not affect estimation-window
+  length.
+
+### Confounded-event handling
+
+When two events for the same `asset_id` fall within each other's
+forward window, factrix's procedures **do not deduplicate or skip**
+the inner event. The chosen mitigation depends on the metric:
+
+| Metric | Behaviour under within-asset overlap |
+|---|---|
+| [`caar`][factrix.metrics.caar.caar] | Per-event-date CS-mean is computed first, then NW HAC is applied to the calendar-time CAAR series. The `forward_periods − 1` floor on the lag (Hansen-Hodrick 1980) absorbs MA(h−1) overlap structure. Within-asset clustering on the same date inflates the per-date variance; the calendar reindex + HAC handles the time-axis component but not the asset-axis component. |
+| [`bmp_test`][factrix.metrics.caar.bmp_test] | The Kolari-Pynnönen adjustment (`kolari_pynnonen_adjust=True`) corrects the BMP statistic for cross-sectional dependence on the same event date. It does **not** correct same-asset event clustering. |
+| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate], [`event_ic`][factrix.metrics.event_quality.event_ic] | Each event row is counted independently; same-asset overlapping events double-contribute to the binomial / Spearman statistic. The null implicitly assumes independence — under heavy clustering the variance is understated. |
+| [`event_around_return`][factrix.metrics.event_horizon.event_around_return], [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | Same: each `(asset, event_date)` row is independent in the binomial null at every offset. Adjacent-offset hit rates are also serially correlated within the same event (k=6 and k=12 share the t+1 entry price), which the binomial null does not adjust for. |
+| [`clustering_diagnostic`][factrix.metrics.clustering.clustering_diagnostic] | Quantifies cross-sectional concentration on event dates only. Does not detect within-asset temporal clustering — pair with `signal_density` for the asset-axis view. |
+
+Operationally: trust `caar` *p*-values when `clustering_diagnostic`
+HHI is low and `signal_density` shows events well-spaced per asset;
+otherwise downweight the parametric *p* and lean on `corrado_rank_test`
+or external block-bootstrap.

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -97,6 +97,28 @@ the advantage of exact rather than asymptotic-Gaussian inference at
 the cost of a factor of `h` in effective sample size; users with long
 panels often prefer NW.
 
+### NW vs HH-1980 vs Hodrick-1992 — when to use which
+
+The three procedures all target overlap-induced SE distortion but at
+different points in the bias-variance trade-off:
+
+| Procedure | Mechanism | Strengths | Weaknesses | Where factrix uses it |
+|---|---|---|---|---|
+| **Newey-West (1987)** | Bartlett-kernel HAC on the full overlapping series, bandwidth `L = max(⌊T^{1/3}⌋, h−1)`. | Simple, deterministic, asymptotically valid for arbitrary autocorrelation up to `L`. | Asymptotic Gaussian — finite-sample size distortion when `h/T` is non-trivial; bandwidth rule is conservative. | `ic_newey_west`, `fama_macbeth` stage 2, `pooled_ols`, `ts_quantile_spread`, `ts_asymmetry`. |
+| **Hansen-Hodrick (1980)** | MA(`h−1`) overlap-aware lag floor on NW. | Guarantees the kernel covers the residual structure; cheap addition to NW. | Still asymptotic; the rule itself does not solve size distortion under `h/T → 1`. | Embedded inside the NW bandwidth rule above (`h − 1` floor). |
+| **Hodrick (1992) "1B"** | Reverse-regression: regress one-period return on the predictor sum `X_t = Σ x_{t-j}` over the last `h` periods. | Size-correct in finite samples even at large `h/T`; no bandwidth choice. | Coefficient interpretation differs — `β` is the response to a cumulative-predictor stimulus (MA on the RHS) rather than a long-horizon forecast slope (MA on the LHS in the standard form); not a drop-in replacement for the canonical `β`. | **Not implemented**. Cited as the right tool when overlap is severe; the `Individual × Continuous` cell side-steps the issue with non-overlapping resampling instead. |
+
+Practical rule of thumb:
+
+- `h ≤ 1`: NW with the Andrews rule is fine; the HH-1980 floor is
+  inactive.
+- `1 < h, h/T ≤ 0.05`: NW + HH-1980 floor is the factrix default; the
+  finite-sample bias is small enough.
+- `h/T > 0.05`: prefer non-overlapping resampling (`ic`, `caar`
+  defaults) over NW. If a slope estimate is needed and resampling
+  burns too much sample, Hodrick-1992 1B is the literature-preferred
+  alternative; pre-compute externally.
+
 ---
 
 ## 2. Multiple-testing under dependence

--- a/docs/reference/ts-mode-conventions.md
+++ b/docs/reference/ts-mode-conventions.md
@@ -1,0 +1,92 @@
+# TIMESERIES-mode conventions
+
+`Common × Continuous` evaluations on a single time series (`ts_beta`,
+`ts_quantile`, `ts_asymmetry` and their variants) inherit four shared
+conventions that are not visible from the per-metric API page. Each
+metric page links here so the rationale is reachable without
+source-diving.
+
+## Plain SE in stage-1 per-asset OLS
+
+`ts_beta` is a two-stage estimator: stage 1 is a per-asset OLS of
+`forward_return ~ factor`, stage 2 is the cross-asset distribution of
+the resulting β. **Stage 1 deliberately retains plain OLS SE rather
+than NW / HAC** in TIMESERIES mode even when `forward_periods > 1`
+introduces overlap.
+
+Reasoning summarised in
+[Statistical methods § HAC SE](statistical-methods.md#1-hac-se-under-overlapping-returns)
+(last paragraph): the dominant bias under a persistent predictor is
+[Stambaugh 1999][stambaugh-1999] coefficient bias, which HAC does not
+address. Stage 2 cross-asset inference handles whatever residual
+time-axis structure leaks through the β distribution.
+
+If overlap-induced SE inflation is the binding concern, prefer
+`ic_newey_west` on the same series (Individual × Continuous cell)
+where the HAC adjustment is the canonical inferential primitive.
+
+[stambaugh-1999]: bibliography.md#stambaugh-1999
+
+## `FACTOR_ADF_P` persistence diagnostic
+
+Every TIMESERIES-mode procedure emits `FACTOR_ADF_P` on the input
+factor series (see `_procedures.py`). A failed unit-root rejection
+(`FACTOR_ADF_P > 0.05`) does not short-circuit the metric — the slope
+is still returned — but the diagnostic surfaces on the profile and
+slope significance should be read with that caveat.
+
+Full derivation, threshold rationale, and interpolation accuracy live
+in
+[Statistical methods § Persistence diagnostics](statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors).
+The
+[`FactorProfile` StatCode → method table](../api/factor-profile.md#statcode--statistical-method)
+maps `FACTOR_ADF_P` to that section directly. The
+`unit_root_suspected=True` flag is `ic_trend` metadata only — the
+TIMESERIES-mode cells expose the raw `FACTOR_ADF_P` *p*-value and
+leave the threshold call to the caller.
+
+The diagnostic is on the *input* factor, not the regression residual.
+
+## Non-overlap convention — `forward_periods` vs `signal_horizon`
+
+The cell-canonical `Individual × Continuous` metrics (`ic`, `caar`)
+use **non-overlapping resampling** as the inferential default
+([Statistical methods § HAC SE](statistical-methods.md#1-hac-se-under-overlapping-returns)).
+TIMESERIES mode inverts this: the per-asset stage-1 regression runs
+on the **full** overlapping series — TIMESERIES lacks the
+cross-section axis to "burn" `h` periods of samples, so
+non-overlapping resampling at stage 1 would leave inadequate `T` for
+the per-asset OLS at typical horizons.
+
+When the dataset's `signal_horizon` differs from
+`AnalysisConfig.forward_periods`
+([`datasets.md`](../api/datasets.md) frames the *decay* side of this),
+the realised TIMESERIES-mode signal is also **biased**, not only
+decayed. Two distinct sources compound:
+
+- **Overlap structure**: `h ≠ signal_horizon` produces an MA(h−1)
+  residual whose autocovariance is no longer the simple Bartlett
+  approximation HAC assumes. The Hansen-Hodrick floor in NW absorbs
+  this for HAC-using metrics; the plain-SE stage-1 in `ts_beta` does
+  not.
+- **Stambaugh-style coefficient bias**: when the predictor is
+  persistent (the typical regime flagged by `FACTOR_ADF_P`),
+  `forward_periods ≠ signal_horizon` shifts the OLS coefficient
+  itself, not only its SE.
+
+Treat `forward_periods == signal_horizon` as the regime where
+TIMESERIES-mode inference is calibrated; other horizons are
+exploratory and the reported *p*-values should be discounted
+accordingly. This is a **bias** caveat distinct from the IC-decay
+framing on the synthetic datasets page.
+
+## Single-series null
+
+TIMESERIES dispatch routes `Common × Continuous` to a single-asset β
+whose null is `H₀: β = 0` for the one series — **not** the PANEL null
+`H₀: E[β] = 0` over the cross-section. The two tests answer different
+questions and their *p*-values are not comparable.
+`describe_analysis_modes(format="text")` annotates the routing
+distinction inline ("`single-series test (null differs from PANEL)`")
+when listing the TIMESERIES side of a `Common × Continuous` cell, so
+callers comparing PANEL and TIMESERIES outputs do not assume parity.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - Metric applicability: reference/metric-applicability.md
       - Metric pipelines: reference/standalone-metrics.md
       - Statistical methods: reference/statistical-methods.md
+      - TIMESERIES-mode conventions: reference/ts-mode-conventions.md
       - Warning / info / stat codes: reference/warning-codes.md
       - Bibliography: reference/bibliography.md
   - API:


### PR DESCRIPTION
## Summary

PR-A of the #85 persona cross-cuts breakdown. Three docs batches, all
non-breaking.

- **Event-study contracts** — `metric-applicability.md` gains a single
  canonical "Event-study contracts" section covering the four
  abnormal-return primitives (caar / event_quality / corrado /
  event_horizon) and how they differ, CAR vs BHAR, `estimation_window`
  spec, and confounded-event handling per metric. caar / corrado /
  event_quality / event_horizon pages cross-link via short
  admonitions; event_horizon also gains an offset-conventions section
  (asymmetric pre/post sign, k=0 corner, adjacent-offset serial
  dependence).
- **TIMESERIES-mode conventions** — new `ts-mode-conventions.md` is a
  thin reader's index pointing at the existing plain-SE / FACTOR_ADF_P
  / non-overlap derivations in `statistical-methods.md`, plus two
  pieces of new framing that did not previously have a home:
  `forward_periods != signal_horizon` as a *bias* caveat (overlap
  structure + Stambaugh) distinct from the IC-decay framing on
  `datasets.md`, and the single-series-null distinction. `ts_beta` /
  `ts_quantile` / `ts_asymmetry` cross-link via admonitions.
- **Hodrick-1992 + decision table** — bibliography entry for
  Hodrick-1992 1B with honest "not implemented, here's why";
  `statistical-methods.md` § 1 gains a NW / HH-1980 / Hodrick-1992
  decision table with practical h/T thresholds.

## Scope

Pure docs. No code, no public-API changes. Three atomic commits, one
per batch. mkdocs `--strict` build passes.

## Verification done

- `signed_car` formulae per metric verified against code (caar.py,
  _helpers.py `_signed_car`, corrado.py, event_horizon.py).
- event_horizon offset table verified against
  `event_horizon.py:108-128` line-by-line; adjacent-offset overlap
  arithmetic checked (k=6 vs k=12 → bars [t+2, t+7]).
- `unit_root_suspected=True` confirmed `ic_trend`-only (`trend.py:144`)
  — TIMESERIES-mode wording corrected to "raw FACTOR_ADF_P, caller's
  threshold call".
- `describe_analysis_modes()` JSON shape confirmed — corrected from
  "timeseries.note JSON field" to "text-mode inline annotation"
  (`_describe.py:173-179`).
- Hodrick-1992 1B mechanics double-checked — corrected from "requires
  higher-frequency predictor" (incorrect) to "MA on RHS predictor sum,
  not LHS return — coefficient interpretation differs".

## Test plan

- [ ] `uv run mkdocs build --strict` clean
- [ ] Render new section anchors in browser:
      `metric-applicability.md#event-study-contracts`,
      `metric-applicability.md#abnormal-return-definition-per-metric`,
      `metric-applicability.md#estimation_window`,
      `metric-applicability.md#confounded-event-handling`
- [ ] `ts-mode-conventions.md` cross-links resolve
- [ ] Admonitions render on caar / corrado / event_quality /
      event_horizon / ts_beta / ts_quantile / ts_asymmetry pages
- [ ] Bibliography Hodrick-1992 anchor `#hodrick-1992` resolves
- [ ] Decision table renders correctly in
      `statistical-methods.md#1-hac-se-under-overlapping-returns`

Refs #85