### PR TITLE
docs: persona cross-cuts — equity researcher (input schema + glossary)

### DIFF
--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -30,4 +30,29 @@ flow through.
 For runnable recipes see
 [Examples](../examples/index.md).
 
+## Required columns per cell
+
+Every procedure declared in the dispatch registry imposes the same
+floor at `INPUT_SCHEMA` — `(date, asset_id, factor, forward_return)`.
+Some downstream metrics within a cell consume **optional** columns; if
+the optional column is absent, those specific metrics short-circuit
+gracefully (returning `NaN` with a `reason`) and the rest of the cell
+runs normally.
+
+| Cell | Required | Optional column → enables |
+|---|---|---|
+| Individual × Continuous (`ic`, `fama_macbeth`) | `date, asset_id, factor, forward_return` | `market_cap` (or any column passed as `weight_col=`) → `quantile_spread_vw` value-weighting |
+| Individual × Sparse (event studies) | `date, asset_id, factor, forward_return` | `price` → `event_around_return`, `multi_horizon_hit_rate`, `mfe_mae_summary` (degrade gracefully if absent) |
+| Common × Continuous (broadcast macro factor) | `date, asset_id, factor, forward_return` | — |
+| Common × Sparse (broadcast event dummy) | `date, asset_id, factor, forward_return` | — |
+
+`forward_return` is treated as part of the input contract rather than
+computed inside `evaluate`. Attach it via
+[`compute_forward_return`](preprocess.md) before the call so the
+horizon (`h`) is explicit in the panel and aligned with
+`AnalysisConfig.forward_periods`. The two synthetic dataset
+generators (`make_cs_panel`, `make_event_panel`) emit
+`(date, asset_id, factor, price)` and require the same preprocessing
+step.
+
 ::: factrix.evaluate

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,172 @@
+# Glossary
+
+factrix names its dispatch axes after the structure of the data
+(`Scope × Signal`) and the regression layout (`Mode`). The literature
+this borrows from uses overlapping but **not identical** vocabulary —
+this glossary maps the factrix terms to their nearest industry
+equivalents and flags collisions where the same word means different
+things in factrix vs Alphalens / Barra / standard panel-econometrics.
+
+## Scope axis — `INDIVIDUAL` vs `COMMON`
+
+### `INDIVIDUAL`
+
+Per-asset factor values: each `(date, asset_id)` pair has its own
+factor reading. The cross-section is the unit of inference (per-date
+IC, FM λ, CAAR per event date). This is the regime most equity factor
+research operates in.
+
+**Industry equivalents**:
+
+- **Alphalens**: "characteristic" / "factor". Alphalens panels are
+  always per-asset signals, so the term is implicit.
+- **Standard cross-sectional asset pricing**: "stock characteristic"
+  (size, book-to-market, momentum). Same regime; factrix routes these
+  through `Individual × Continuous`.
+- **MSCI / Axioma**: "factor exposure" of asset `i` to factor `k`.
+
+### `COMMON`
+
+A single broadcast series shared across **all** assets on a given
+date — the same value for every `asset_id` at that `date`. Macro
+factors (VIX, USD index, term spread, monetary-policy shocks) and
+broadcast event dummies (FOMC announcement days) live here.
+
+**Industry equivalents and collisions**:
+
+- **Macro / global factor literature**: "common factor" = a single
+  series that drives multiple assets. **Matches** factrix `COMMON`.
+- **Barra "common factor"**: a shared risk factor *estimated* from
+  cross-sectional regressions on a panel of asset characteristics
+  (Barra style / size / value / momentum factors). Estimation-driven,
+  per-asset latent loadings. **Collides with** factrix `COMMON`,
+  which is a *given* broadcast series with no estimation step on the
+  factor itself.
+- **Alphalens**: no direct equivalent. Closest is "group-neutral" /
+  benchmark series, but Alphalens does not natively dispatch to a
+  `COMMON` cell.
+
+When porting Barra terminology in: a Barra "common factor" with raw
+cross-sectional loadings is a factrix `INDIVIDUAL × CONTINUOUS`
+problem (the loadings *are* the per-asset characteristic). A Barra
+"common factor" treated as a single series shared across assets is a
+factrix `COMMON × CONTINUOUS` problem.
+
+## Signal axis — `CONTINUOUS` vs `SPARSE`
+
+### `CONTINUOUS`
+
+Factor takes a real-valued reading on every observation in the panel.
+Most equity characteristics; macro factors; ML predictor scores.
+
+### `SPARSE`
+
+Factor is non-zero only on event dates and zero elsewhere; the panel
+encodes a discrete event arrival process. Canonical encoding is
+`{−1, 0, +1}` (signed event direction); factrix also accepts
+magnitude-weighted `{0, R}` for continuous-magnitude events
+(see `compute_caar`'s input-form table for the resulting estimator
+distinction).
+
+**Industry equivalents**:
+
+- **MacKinlay (1997) event-study vocabulary**: factrix's `SPARSE`
+  cell is the event-study cell; the factor column is the
+  announcement indicator. factrix's `factor != 0` filter is the
+  event-window selector.
+- **Alphalens**: no direct equivalent — Alphalens assumes continuous
+  characteristics. Event-study workflows live outside Alphalens.
+
+## Mode axis — `PANEL` vs `TIMESERIES`
+
+Mode is **derived from data** at evaluate-time, not configured:
+
+- `N ≥ 2` → `PANEL`.
+- `N == 1` → `TIMESERIES`.
+
+### `PANEL`
+
+Multi-asset panel; cross-section participates in inference (per-date
+aggregation, cross-asset SE).
+
+**Industry equivalents**: panel data; longitudinal data; pooled
+cross-section / time-series. The econometrics literature usually says
+"panel" with no further qualification.
+
+### `TIMESERIES`
+
+Single-asset series. Time axis is the only sample axis; cross-section
+is degenerate.
+
+**Industry equivalents**: time-series regression; single-asset OLS.
+Note that factrix `TIMESERIES` mode does **not** mean Alphalens'
+"time-series of cross-sectional means" (that is per-date aggregation
+of a `PANEL`); the two collide on the word *time-series* and disagree
+on what is aggregated. See
+[TIMESERIES-mode conventions](ts-mode-conventions.md) for the
+specific contracts that apply when factrix routes here.
+
+## Other terms
+
+### `factor`
+
+The signal column. Same role as Alphalens "factor", Barra "exposure",
+or generic "alpha score" / "predictor". factrix expects the column
+literally named `factor`; today this is enforced at procedure-level
+INPUT_SCHEMA (a `factor_col=` argument to `evaluate()` is on the
+roadmap — see #85).
+
+### `forward_return`
+
+The forward return column consumed by every dispatch cell. factrix's
+`compute_forward_return(df, forward_periods=N)` produces a
+**per-period** return with **`t+1` entry**:
+
+```
+forward_return[t] = (price[t+1+N] / price[t+1] − 1) / N
+```
+
+Two non-textbook choices to internalise:
+
+- **`t+1` entry, not `t`**: signal at `t` is computed from data up to
+  and including `price[t]`, so trading at `price[t]` would assume
+  same-bar execution. Entry at `t+1` enforces a causal boundary and
+  cleanly separates the return window from the BMP estimation window.
+- **Divided by `N`**: result is expressed per period rather than as
+  the cumulative `N`-period return, so factor evaluations at
+  different `forward_periods` are directly comparable. If you need
+  the cumulative `N`-period number, multiply by `N`.
+
+Only simple returns are implemented; no log-return option. factrix
+takes `forward_return` as input rather than computing it inside
+`evaluate()` — attach it with
+[`compute_forward_return`](../api/preprocess.md) before dispatch so
+the horizon `N` is explicit and aligned with
+`AnalysisConfig.forward_periods`.
+
+Distinct from "spot return" (contemporaneous one-period return) and
+"realised return" (ex-post return for risk attribution).
+
+### `signal_horizon` (datasets only)
+
+A property of the *synthetic* signal embedded in `make_cs_panel` /
+`make_event_panel` — the horizon at which the generator's nominal IC
+is realised. Aligning `AnalysisConfig.forward_periods` with
+`signal_horizon` is the regime where the synthetic IC / drift is
+calibrated; mismatched horizons induce IC decay (synthetic) and bias
+(in TIMESERIES mode — see
+[TIMESERIES-mode conventions § Non-overlap](ts-mode-conventions.md#non-overlap-convention--forward_periods-vs-signal_horizon)).
+
+### `non-overlapping` returns
+
+Sampling every `h`-th date so consecutive observations are
+independent under the `h`-period forecasting null. factrix's
+`Individual × Continuous` cell defaults to this for `ic` and `caar`;
+NW HAC is the alternative on the full overlapping series. See
+[Statistical methods § HAC SE](statistical-methods.md#1-hac-se-under-overlapping-returns).
+
+### `estimation_window`
+
+Per-asset pre-event sample used to fit the abnormal-return baseline
+for `bmp_test` and `corrado_rank_test`. See
+[Metric applicability § estimation_window](metric-applicability.md#estimation_window).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - Choosing a metric: guides/choosing-metric.md
       - Standalone metrics: guides/standalone-metrics.md
   - Reference:
+      - Glossary: reference/glossary.md
       - Metric applicability: reference/metric-applicability.md
       - Metric pipelines: reference/standalone-metrics.md
       - Statistical methods: reference/statistical-methods.md


### PR DESCRIPTION
## Summary

PR-B of the #85 persona cross-cuts breakdown. Two docs batches, both
non-breaking.

- **Per-cell input schema table** on `evaluate.md` — every dispatch
  cell shares `(date, asset_id, factor, forward_return)` at the
  procedure-level INPUT_SCHEMA; the table now flags the optional
  columns that unlock specific path metrics (`price` for
  event_horizon / mfe_mae on Individual × Sparse; `market_cap` /
  `weight_col=` for `quantile_spread_vw` value-weighting on
  Individual × Continuous). Removes the need to grep
  `_procedures.py`.
- **Glossary** at `reference/glossary.md` — maps factrix
  `INDIVIDUAL` / `COMMON` / `CONTINUOUS` / `SPARSE` / `PANEL` /
  `TIMESERIES` to Alphalens / Barra / standard panel-econometrics
  vocabulary, calling out collisions explicitly: factrix `COMMON`
  (given broadcast series) vs Barra "common factor" (estimated risk
  factor), and factrix `TIMESERIES` mode (single-asset regression)
  vs Alphalens "time-series of cross-sectional means". Also
  documents the two non-textbook `compute_forward_return` choices —
  `t+1` entry and per-period normalisation by `N` — that equity
  researchers otherwise reconstruct from source.

## Scope

Pure docs. No code, no public-API changes. Two atomic commits, one
per gap. `factor_col=` rename idiom (third equity-researcher gap on
#85) is closed by PR-D's `factor_col=` propagation work, not here.

## Verification done

- INPUT_SCHEMA `(date, asset_id, factor, forward_return)` on every
  procedure verified against `_procedures.py` (all 9 procedures).
- `compute_forward_return` formula verified against
  `factrix/preprocess/returns.py:14-63` — corrected from textbook
  `(price[t+h] − price[t]) / price[t]` (incorrect) to actual
  `(price[t+1+N] / price[t+1] − 1) / N` with `t+1` entry rationale
  inlined.
- `quantile_spread_vw` weight column default verified
  (`metrics/quantile.py:229` — default `"market_cap"`, not
  `"weight"`); table corrected.
- `evaluate()` does not auto-compute `forward_return`; reframed as
  user-attached input.
- Mode dispatch rule (`N == 1 → TIMESERIES`, `N ≥ 2 → PANEL`)
  verified against `_evaluate.py:38-45`.

## Test plan

- [ ] `uv run mkdocs build --strict` clean
- [ ] Glossary renders in nav at top of Reference section
- [ ] `evaluate.md` "Required columns per cell" table renders
- [ ] Cross-links from glossary to `ts-mode-conventions.md`,
      `metric-applicability.md`, `statistical-methods.md` resolve

Refs #85