### PR TITLE
feat: programmatic-consumer symmetry — StatCode.description + SuggestConfigResult.diagnose

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -186,6 +186,49 @@ class StatCode(StrEnum):
         """
         return self.value.endswith("_p")
 
+    @property
+    def description(self) -> str:
+        """Short gloss for ``profile.diagnose()`` consumers.
+
+        Symmetric with ``WarningCode.description`` / ``InfoCode.description``;
+        agents reading ``diagnose()["stats"]`` can resolve a key like
+        ``"factor_adf_p"`` to its statistical meaning without grepping
+        ``_procedures.py``.
+        """
+        return _STAT_DESCRIPTIONS[self]
+
+
+_STAT_DESCRIPTIONS: dict[StatCode, str] = {
+    StatCode.IC_MEAN: "Per-date Spearman IC, mean over the time series.",
+    StatCode.IC_T_NW: "NW HAC t-stat on the IC mean (Bartlett kernel, "
+    "auto-bandwidth with Hansen-Hodrick overlap floor).",
+    StatCode.IC_P: "Two-sided p-value from the NW HAC t-test on IC.",
+    StatCode.FM_LAMBDA_MEAN: "Fama-MacBeth λ — per-date OLS slope of "
+    "forward_return on factor, averaged over time.",
+    StatCode.FM_LAMBDA_T_NW: "NW HAC t-stat on the FM λ mean.",
+    StatCode.FM_LAMBDA_P: "Two-sided p-value from the NW HAC t-test on FM λ.",
+    StatCode.TS_BETA: "Per-asset OLS β on the broadcast factor; "
+    "PANEL = cross-asset mean of β_i, TIMESERIES = single-series β.",
+    StatCode.TS_BETA_T_NW: "PANEL: cross-asset t on E[β]. "
+    "TIMESERIES: NW HAC t on the single-series β.",
+    StatCode.TS_BETA_P: "Two-sided p-value from the TS_BETA t-test.",
+    StatCode.CAAR_MEAN: "Per-event-date weighted abnormal return, "
+    "averaged across event dates (event-only mean — see _procedures for "
+    "the dense-calendar t-stat).",
+    StatCode.CAAR_T_NW: "NW HAC t-stat on the dense-calendar CAAR series "
+    "(zero-fill on non-event dates; Hansen-Hodrick overlap floor).",
+    StatCode.CAAR_P: "Two-sided p-value from the NW HAC t-test on CAAR.",
+    StatCode.FACTOR_ADF_P: "ADF unit-root test p-value on the factor input "
+    "series (MacKinnon 1996 response-surface; constant-only specification). "
+    "p > 0.05 flags persistent regressor regime.",
+    StatCode.LJUNG_BOX_P: "Ljung-Box p-value on residual autocorrelation "
+    "(TS-dummy single-asset path); p < 0.05 flags under-set NW lag.",
+    StatCode.EVENT_TEMPORAL_HHI: "Herfindahl concentration of event dates "
+    "over the calendar grid; high values flag temporal event clustering.",
+    StatCode.NW_LAGS_USED: "NW HAC lag count selected by the auto-bandwidth "
+    "rule for the cell's primary t-test.",
+}
+
 
 class Verdict(StrEnum):
     """Procedure-canonical pass/fail outcome of ``Profile.verdict()``."""

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -248,6 +248,28 @@ class SuggestConfigResult:
     reasoning: dict[str, str]
     warnings: list[WarningCode] = field(default_factory=list)
 
+    def diagnose(self) -> dict[str, Any]:
+        """JSON-shaped view, symmetric with ``FactorProfile.diagnose()``.
+
+        Python callers continue to read ``.warnings`` as a list of
+        ``WarningCode`` enums. Cross-wire / log / agent consumers call
+        ``diagnose()`` to get a fully serialisable dict where
+        ``warnings`` is a sorted list of ``.value`` strings (matching
+        the shape produced by ``FactorProfile.diagnose()``).
+
+        Returns:
+            A plain-Python dict with the suggested config serialised
+            via ``AnalysisConfig.to_dict()``, the detected observations,
+            the per-axis reasoning strings, and warnings as a sorted
+            list of ``.value`` strings.
+        """
+        return {
+            "suggested": self.suggested.to_dict(),
+            "detected": dict(self.detected),
+            "reasoning": dict(self.reasoning),
+            "warnings": sorted(w.value for w in self.warnings),
+        }
+
 
 def _detect_signal(raw: Any) -> tuple[Signal, str, float]:
     """Sparsity ratio in ``factor`` ≥ 0.5 → SPARSE, else CONTINUOUS.

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -170,16 +170,17 @@ factrix.evaluate(raw: polars.DataFrame, config: AnalysisConfig,
                  *, factor_col: str = "factor") -> FactorProfile
 ```
 
-Single dispatch entry. Derives mode from `raw["asset_id"].n_unique()`, applies
-scope-collapse for `SPARSE × TIMESERIES`, and routes to the registered
 procedure. `factor_col=` lets a panel with a non-default signal column
-name (e.g. `"alpha"`) be evaluated without renaming first — single-factor
-convenience only; for multi-signal panels use `factrix.multi_factor`.
-Raises:
+name (e.g. `"alpha"`) be evaluated without renaming first; looping over
+candidates with different `factor_col=` values is the canonical multi-
+factor pattern. Raises (subclasses of `FactrixError`; see `## Errors`
+below for the full hierarchy + recovery payloads):
+- `MissingConfigError` — `evaluate(raw)` called without an `AnalysisConfig`
 - `IncompatibleAxisError` — config axes form an illegal cell
-- `ModeAxisError` — the routed cell has no procedure under the derived mode;
-  the exception carries `.suggested_fix: AnalysisConfig | None` with the
-  nearest-legal config
+- `ModeAxisError` — legal cell has no procedure under the derived mode;
+  carries `.suggested_fix: AnalysisConfig | None`
+- `InsufficientSampleError` — `T` below the procedure's `MIN_PERIODS_HARD`
+  floor; carries `.actual_periods` / `.required_periods`
 - `ValueError` — `factor_col` not present on `raw`, or both `"factor"` and
   `factor_col` present (ambiguous which is the signal)
 
@@ -208,6 +209,12 @@ profile.diagnose() -> dict[str, Any]
     #  "info_notes": [str, ...],        # sorted InfoCode .value strings
     #  "stats": {str: float, ...}}      # StatCode .value → float
 ```
+
+`WarningCode`, `InfoCode`, and `StatCode` each expose a `.description`
+property — agents reading `diagnose()["stats"]` / `["warnings"]` /
+`["info_notes"]` can resolve a key like `"factor_adf_p"` or
+`"persistent_regressor"` to its statistical meaning without grepping
+`_codes.py` or `_procedures.py`.
 
 ---
 
@@ -244,6 +251,22 @@ factrix.describe_analysis_modes(*, format: Literal["text", "json"] = "text"
 factrix.suggest_config(raw, *, forward_periods: int = 5) -> SuggestConfigResult
     # Inspect a panel; propose an AnalysisConfig + structured reasoning + warnings.
     # Suggestion is never auto-applied — caller (or agent) reads .reasoning.
+    # SuggestConfigResult fields:
+    #   .suggested  : AnalysisConfig
+    #   .detected   : dict[str, Any]      # scope/signal/mode/n_assets/n_periods/sparsity
+    #   .reasoning  : dict[str, str]      # per-axis human-readable rationale
+    #   .warnings   : list[WarningCode]   # Python ergonomic — keep enum identity
+    #
+    # SuggestConfigResult.diagnose() -> dict[str, Any]
+    #   # JSON-shape, symmetric with FactorProfile.diagnose():
+    #   # {"suggested": {...to_dict()...},
+    #   #  "detected":  {...},
+    #   #  "reasoning": {...},
+    #   #  "warnings":  [str, ...]}        # sorted WarningCode .value strings
+    #
+    # Wire-format rule: Python callers read .warnings (enum-typed);
+    # cross-wire / JSON / log consumers call .diagnose() — same
+    # convention as FactorProfile.
 
 factrix.list_metrics(scope: FactorScope, signal: Signal,
                      *, format: Literal["text", "json"] = "text"
@@ -290,9 +313,21 @@ FactrixError                       # base — all factrix-raised errors
                                    # carries .actual_periods / .required_periods
 ```
 
-`InsufficientSampleError` and `ModeAxisError` carry recovery payloads
-(numbers / nearest-legal config) so callers can branch programmatically
-without parsing message strings.
+Recovery payloads — what each subclass carries beyond `.args[0]`:
+
+| Exception                | `.suggested_fix` | Extra fields                              |
+|--------------------------|:----------------:|-------------------------------------------|
+| `ConfigError` (base)     | optional         | —                                         |
+| `MissingConfigError`     | always `None`    | (call `factrix.suggest_config(raw)` to recover) |
+| `IncompatibleAxisError`  | optional         | —                                         |
+| `ModeAxisError`          | typically set    | —                                         |
+| `InsufficientSampleError`| optional         | `.actual_periods: int`, `.required_periods: int` |
+
+Agents can branch on these payloads without parsing message strings; the
+canonical pattern is `except fl.FactrixError as exc:` followed by
+`isinstance(exc, …)` dispatch on the subclass. `MissingConfigError` is the
+only subclass with `.suggested_fix` always `None` (the recovery path is
+calling `factrix.suggest_config(raw)`).
 
 ---
 

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -78,6 +78,14 @@ class TestCodeEnums:
         assert StatCode.CAAR_MEAN.value == "caar_mean"
         assert StatCode.NW_LAGS_USED.value == "nw_lags_used"
 
+    def test_stat_descriptions_cover_every_member(self) -> None:
+        # Symmetry with WarningCode / InfoCode: every StatCode has a
+        # human-readable gloss so agents reading diagnose()["stats"]
+        # can resolve a key like "factor_adf_p" without grepping
+        # _procedures.py.
+        for code in StatCode:
+            assert code.description, f"{code} missing description"
+
 
 # ---------------------------------------------------------------------------
 # Stats constants

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -622,3 +622,33 @@ class TestEmitsStatsDrift:
             f"{label}: actual stats {sorted(s.value for s in actual - declared)} "
             f"not in declared EMITS_STATS"
         )
+
+
+class TestSuggestConfigResultDiagnose:
+    def test_diagnose_shape(self) -> None:
+        # Symmetric with FactorProfile.diagnose(): JSON-shape dict with
+        # str-valued warnings for wire / log / agent consumption.
+        result = suggest_config(_make_individual_continuous_panel())
+        d = result.diagnose()
+        assert set(d.keys()) == {"suggested", "detected", "reasoning", "warnings"}
+        assert d["suggested"] == result.suggested.to_dict()
+        assert d["detected"] == result.detected
+        assert d["reasoning"] == result.reasoning
+        assert d["warnings"] == sorted(w.value for w in result.warnings)
+
+    def test_diagnose_warnings_are_strings(self) -> None:
+        # Even when warnings list is non-empty, diagnose() emits .value
+        # strings, not enum members — agents reading JSON should never
+        # see Python enum repr.
+        ts = _make_timeseries(n_dates=80, sparse=False, seed=11)
+        d = suggest_config(ts).diagnose()
+        for w in d["warnings"]:
+            assert isinstance(w, str)
+
+    def test_diagnose_is_jsonable(self) -> None:
+        # End-to-end: diagnose() output round-trips through json.dumps
+        # without a custom encoder (this is the canonical wire format).
+        import json
+
+        result = suggest_config(_make_common_continuous_panel())
+        json.dumps(result.diagnose())


### PR DESCRIPTION
## Summary

PR-C of the #85 persona cross-cuts breakdown. Three commits; all
non-breaking pure additions.

- **`StatCode.description`** — symmetric with `WarningCode.description`
  / `InfoCode.description`. Agents reading
  `FactorProfile.diagnose()["stats"]` can now resolve a key like
  `"factor_adf_p"` to `"ADF unit-root test p-value on the factor
  input series..."` without grepping `_procedures.py`. A coverage
  test enforces the property is non-empty for every member.
- **`SuggestConfigResult.diagnose()`** — mirrors
  `FactorProfile.diagnose()`. Returns a plain-Python dict with the
  suggested config serialised via `to_dict()`, the detected /
  reasoning maps, and warnings as a sorted list of `.value` strings.
  Wire-format rule unified: Python callers read `.warnings`
  (enum-typed); cross-wire / JSON / log consumers call `.diagnose()`
  — same convention across both result types. Round-trips through
  `json.dumps` without a custom encoder.
- **`llms-full.txt` polish** — `evaluate` Raises list expands from 2
  to 4 entries (adds `MissingConfigError`, `InsufficientSampleError`)
  and points at the full hierarchy. Recovery payloads switch from
  prose to a per-subclass table. `SuggestConfigResult` field shape
  and `diagnose()` output are now documented side-by-side with
  `FactorProfile`. `.description` availability mentioned for all
  three code enums.

## Scope

Pure additions. No public-API breakages. No existing tests modified
(only added).

## Verification

- `uv run pytest -x -q` — 803 tests pass, no regressions.
- `uv run mkdocs build --strict` — clean build.
- New tests:
  - `TestStatsAndCodes.test_stat_descriptions_cover_every_member` —
    coverage check on every `StatCode` member.
  - `TestSuggestConfigResultDiagnose` — shape, str-only warnings,
    `json.dumps` round-trip.
- Pre-commit `ruff check` + `ruff format` clean.

## Test plan

- [ ] CI green
- [ ] Manual: `python -c "import factrix; print(factrix.suggest_config(...).diagnose())"`
      yields a JSON-friendly dict with sorted str warnings
- [ ] Manual: `factrix.StatCode.FACTOR_ADF_P.description` returns the
      MacKinnon-1996 gloss

Refs #85