### PR TITLE
feat(metrics): by_regime regime dispatcher (#107)

### DIFF
--- a/docs/api/by-regime.md
+++ b/docs/api/by-regime.md
@@ -1,0 +1,82 @@
+# by_regime
+
+Cross-cutting research dispatcher. Slices any metric's date-keyed
+input by regime label and runs the metric per slice. Returns
+`dict[regime_label, MetricOutput]`.
+
+## Call shape
+
+```python
+import polars as pl
+from factrix.metrics import by_regime, ic, compute_ic
+
+ic_df = compute_ic(panel)
+labels = pl.DataFrame(
+    {"date": dates, "regime": ["bull", "bull", "bear", "bear"]}
+)
+
+per_regime = by_regime(ic, ic_df, regime_labels=labels)
+# {"bull": MetricOutput(name="ic", ...), "bear": MetricOutput(name="ic", ...)}
+```
+
+The first argument is the **metric callable** (e.g. `ic`, `caar`,
+`fama_macbeth`); the second is the metric's primary date-keyed
+DataFrame; remaining keyword args (`forward_periods=...`, etc.)
+forward unchanged on every per-regime call.
+
+If `regime_labels` is omitted, falls back to time-bisection labelled
+`first_half` / `second_half` and emits a `UserWarning` — that path is
+a structural-break sanity check, not a regime test.
+
+## What it does **not** do
+
+`by_regime` performs **no cross-regime statistical inference**. It
+returns the per-regime outputs and stops. A generic second-layer test
+(BHY adjustment, min-|t|, Sharpe-diff Wald, etc.) cannot be applied
+honestly across the metric matrix — the appropriate test depends on
+the metric family:
+
+| Metric family | Cross-regime test |
+|---------------|-------------------|
+| IC / Fama-MacBeth λ (mean-zero, t-like) | BHY across regimes + min-\|t\| |
+| Sharpe-like ratios | Memmel (2003) / Ledoit-Wolf |
+| CAAR | pooled vs per-regime clustering reconciliation |
+| Turnover, hit_rate, monotonicity ρ | no canonical cross-regime test |
+
+For curated families that have a defensible second-layer test,
+factrix provides Layer B wrappers — see
+[`regime_ic`](metrics/ic.md#factrix.metrics.ic.regime_ic) for the IC family. Use
+`by_regime` directly when no Layer B wrapper exists or when you want
+raw per-regime outputs to compose your own analysis.
+
+## Which metrics work
+
+Any metric whose primary first argument is a DataFrame with a `date`
+column. Discover the eligible set via
+[`list_metrics`](list-metrics.md) — pick a metric that matches your
+`(scope, signal)` cell and pass its callable straight in:
+
+```python
+import factrix as fl
+from factrix.metrics import by_regime, caar, monotonicity, fama_macbeth
+
+fl.list_metrics(fl.FactorScope.INDIVIDUAL, fl.Signal.SPARSE)
+# ['caar', 'event_ic', ...]
+
+per_regime = by_regime(caar, caar_df, regime_labels=labels)
+per_regime = by_regime(monotonicity, spread_df, regime_labels=labels)
+per_regime = by_regime(fama_macbeth, beta_df, regime_labels=labels)
+```
+
+`by_regime` does not police metric-vs-input compatibility — that is
+the metric's own job. Each per-regime call inherits the metric's
+existing guards (sample-size short-circuits, `IncompatibleAxisError`,
+warnings); you see the same signals you would see calling the metric
+directly on each slice.
+
+## API reference
+
+::: factrix.metrics.regime
+    options:
+      members:
+        - by_regime

--- a/docs/api/metrics/ic.md
+++ b/docs/api/metrics/ic.md
@@ -14,8 +14,17 @@ via NW HAC or non-overlapping cross-asset *t*.
         - multi_horizon_ic
         - compute_ic
 
+!!! note "Regime analysis: two layers"
+    `regime_ic` is the **Layer B** wrapper that bundles the IC-specific
+    cross-regime test (BHY adjustment + min-\|t\| + direction
+    consistency). For a generic per-regime dispatcher with no
+    second-layer inference, see [`by_regime`](../by-regime.md) or the
+    [Regime analysis guide](../../guides/regime-analysis.md).
+
 ## See also
 
+- [`by_regime`](../by-regime.md) — Layer A dispatcher for any registered metric.
+- [Regime analysis guide](../../guides/regime-analysis.md) — when to use Layer A vs Layer B.
 - [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
 - [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
 - [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.

--- a/docs/guides/regime-analysis.md
+++ b/docs/guides/regime-analysis.md
@@ -1,0 +1,80 @@
+# Regime Analysis
+
+Regime analysis asks "is this factor stable across market environments?" — a different question from out-of-sample decay (overfitting) and from cross-asset robustness (specification). factrix splits regime analysis into two layers because **slicing by regime** and **testing significance across regimes** are different jobs that need different APIs.
+
+## The two layers
+
+| Layer | Function | What it does | What it does not do |
+|---|---|---|---|
+| A — slicing | [`by_regime(metric, df, *, regime_labels, **kwargs)`](../api/by-regime.md) | Slices `df` by regime label, calls `metric` per slice, returns `dict[regime, MetricOutput]` | **No cross-regime statistical test** |
+| B — bespoke inference | `regime_<metric>` (e.g. [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic)) | Layer A + a metric-appropriate cross-regime test (BHY, min-\|t\|, etc.) | Only exists for curated metrics |
+
+**Use Layer A when:** you want raw per-regime numbers, or you want to compose your own cross-regime test, or no Layer B wrapper exists for the metric you care about.
+
+**Use Layer B when:** a curated wrapper exists for your metric and the bundled second-layer test matches your research question.
+
+## Why no generic cross-regime test
+
+A single dispatcher carrying a single second-layer test would silently over-claim. The appropriate test depends on the metric family:
+
+- **IC, Fama-MacBeth λ** — mean-zero t-tests on per-regime samples → BHY across regimes is defensible.
+- **Sharpe** — variance-stabilised difference (Memmel 2003 / Ledoit-Wolf) is needed; BHY on raw t is wrong.
+- **CAAR** — per-regime clustering interacts with pooled-vs-split SE choice; needs a bespoke reconciliation.
+- **Turnover, hit_rate, monotonicity ρ** — no canonical cross-regime test; differences are descriptive.
+
+Bundling BHY into a generic dispatcher would apply it to all of these, including the cases where it is wrong. We chose explicit Layer B wrappers per metric family instead.
+
+## Constructing regime labels
+
+`regime_labels` is a `(date, regime)` DataFrame. Common constructions:
+
+```python
+import polars as pl
+
+# 1. External classifier (e.g. NBER recession, vol regime, factor return sign)
+vol_labels = pl.DataFrame({"date": dates, "regime": ["bull", "bull", "bear", ...]})
+
+# 2. From a market-vol panel — see lookahead warning below
+vix_thresh = vix["vix"].quantile(0.7)
+vol_labels = vix.with_columns(
+    pl.when(pl.col("vix") > vix_thresh).then(pl.lit("high_vol")).otherwise(pl.lit("low_vol")).alias("regime")
+).select("date", "regime")
+```
+
+!!! warning "Lookahead bias when constructing labels"
+    The `vix.quantile(0.7)` snippet above uses **full-sample** statistics
+    to label every date — that leaks future information into every
+    per-regime IC. For decision-grade analysis, derive thresholds from
+    an expanding or rolling window so each date's label only depends on
+    information available at that date. The full-sample form is fine
+    only for descriptive ex-post analysis.
+
+If `regime_labels=None`, factrix applies a time-bisection fallback
+(`first_half` / `second_half`) and emits a `UserWarning`. This is a
+structural-break check, **not** a regime test — domain-driven labels
+are required for any defensible regime claim.
+
+## Worked example: IC across volatility regimes
+
+```python
+from factrix.metrics import by_regime, compute_ic, ic, regime_ic
+
+ic_df = compute_ic(panel, factor_col="value", return_col="forward_return")
+
+# Layer A — raw per-regime IC summaries
+per_regime = by_regime(ic, ic_df, regime_labels=vol_labels)
+for label, out in per_regime.items():
+    print(label, out.value, out.stat)
+
+# Layer B — IC-specific cross-regime second layer (BHY + min-|t|)
+result = regime_ic(ic_df, regime_labels=vol_labels)
+result.metadata["per_regime"]              # raw + BHY-adjusted p per regime
+result.metadata["p_value_bhy_adjusted"]    # worst adjusted p (aggregate)
+result.metadata["direction_consistent"]    # sign agreement across regimes
+```
+
+## Related
+
+- [`by_regime`](../api/by-regime.md) — Layer A surface and registered metrics.
+- [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) — Layer B wrapper for IC.
+- [Batch screening with BHY](batch-screening.md) — the same BHY family-correction principle, applied to factor candidates rather than regimes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ A Polars-native **factor signal validator** for quantitative finance.
 | Install and run a smoke test | [Get Started](getting-started/index.md) |
 | Understand the three-axis design | [Concepts](getting-started/concepts.md) |
 | Screen a batch of factors with BHY | [Batch screening](guides/batch-screening.md) |
+| Slice any metric by market regime | [Regime analysis](guides/regime-analysis.md) |
 | Look up formulas and applicability | [Reference](reference/metric-applicability.md) |
 | Browse runnable notebooks | [Examples](examples/index.md) |
 | Read the internal architecture | [Architecture](development/architecture.md) |

--- a/docs/reference/_generated_metric_matrix.md
+++ b/docs/reference/_generated_metric_matrix.md
@@ -13,6 +13,7 @@
 | [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
 | [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | no formal H₀ |
 | [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
+| [`metrics.regime`][factrix.metrics.regime] | `(*, *, *, *)` | dispatcher | none (no cross-regime test) |
 | [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | ts-only | NW HAC / OLS t |
 | [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | no formal H₀ |
 | [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ |

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -65,6 +65,16 @@ _STAGE1_HELPERS: frozenset[str] = frozenset(
     }
 )
 
+# Cross-cutting infrastructure published from ``factrix.metrics`` that
+# is **not** a per-(scope, signal) cell metric — e.g. ``by_regime`` is a
+# dispatcher that wraps any registered metric. Listed in ``Matrix-row:``
+# with ``(*, *, *, *)`` so the primitive graph is complete, but excluded
+# from per-cell ``list_metrics`` output and the applicability table
+# (which catalogue per-cell metrics, not infra).
+_INFRASTRUCTURE: frozenset[str] = frozenset({"by_regime"})
+"""Cross-cutting dispatchers published from ``factrix.metrics`` that
+are not per-(scope, signal) cell metrics."""
+
 
 @dataclass(frozen=True, slots=True)
 class Cell:
@@ -225,5 +235,6 @@ def all_rows() -> list[MetricRow]:
 
 
 def user_facing_rows() -> list[MetricRow]:
-    """Return parsed rows excluding stage-1 aggregation helpers."""
-    return [r for r in all_rows() if r.name not in _STAGE1_HELPERS]
+    """Return parsed rows excluding stage-1 helpers and cross-cutting infra."""
+    excluded = _STAGE1_HELPERS | _INFRASTRUCTURE
+    return [r for r in all_rows() if r.name not in excluded]

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -80,6 +80,7 @@ from factrix.metrics.quantile import (
     quantile_spread,
     quantile_spread_vw,
 )
+from factrix.metrics.regime import by_regime
 from factrix.metrics.spanning import greedy_forward_selection, spanning_alpha
 from factrix.metrics.tradability import (
     breakeven_cost,
@@ -102,6 +103,7 @@ __all__ = [
     "beta_sign_consistency",
     "bmp_test",
     "breakeven_cost",
+    "by_regime",
     "caar",
     "clustering_diagnostic",
     "compute_caar",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -389,24 +389,9 @@ def regime_ic(
             min_required=MIN_ASSETS_PER_DATE_IC,
         )
 
-    if regime_labels is not None:
-        merged = ic_df.join(
-            regime_labels.select("date", "regime"), on="date", how="inner"
-        )
-    else:
-        # Fallback: time bisection
-        sorted_ic = ic_df.sort("date")
-        mid = len(sorted_ic) // 2
-        merged = (
-            sorted_ic.with_row_index("_idx")
-            .with_columns(
-                pl.when(pl.col("_idx") < mid)
-                .then(pl.lit("first_half"))
-                .otherwise(pl.lit("second_half"))
-                .alias("regime")
-            )
-            .drop("_idx")
-        )
+    from factrix.metrics.regime import _slice_by_regime
+
+    merged = _slice_by_regime(ic_df, regime_labels)
 
     # Single-pass group_by instead of per-regime Python loop
     regime_stats = (

--- a/factrix/metrics/regime.py
+++ b/factrix/metrics/regime.py
@@ -1,0 +1,139 @@
+"""Regime analysis: Layer A dispatcher (no second-layer inference).
+
+Two-layer split (issue #107):
+
+* Layer A — :func:`by_regime` slices the metric input by regime label
+  and applies a metric callable per slice. Returns
+  ``dict[str, MetricOutput]``. **Performs no cross-regime statistical
+  test.** A generic second-layer test would silently over-claim for
+  non-t-stat metrics (Sharpe, turnover, hit_rate, monotonicity rho) —
+  different metric families need bespoke cross-regime tests, or none
+  at all.
+* Layer B — curated ``regime_<metric>`` wrappers (e.g. ``regime_ic``)
+  add a metric-appropriate second-layer on top of Layer A's slicing
+  primitive. They live in their respective metric modules.
+
+Both layers share :func:`_slice_by_regime` so the time-bisection
+fallback and label-join semantics live in one place.
+
+Matrix-row: by_regime | (*, *, *, *) | dispatcher | none (no cross-regime test) | _slice_by_regime
+"""
+
+from __future__ import annotations
+
+import warnings as _warnings
+from collections.abc import Callable
+from typing import Any
+
+import polars as pl
+
+from factrix._types import MetricOutput
+
+
+def _slice_by_regime(
+    df: pl.DataFrame,
+    regime_labels: pl.DataFrame | None,
+    date_col: str = "date",
+) -> pl.DataFrame:
+    """Annotate ``df`` with a ``regime`` column.
+
+    With ``regime_labels``: inner-join on ``date_col`` (rows without a
+    label are dropped — they cannot be assigned to a regime).
+    Without: time-bisection fallback labelled ``first_half`` /
+    ``second_half`` and a ``UserWarning`` is emitted so callers do not
+    silently rely on what is structurally a break test, not a regime
+    test. The label format is fixed and greppable.
+    """
+    if regime_labels is not None:
+        if "regime" not in regime_labels.columns:
+            raise ValueError(
+                "regime_labels missing required column 'regime'; "
+                f"got columns {regime_labels.columns}"
+            )
+        return df.join(
+            regime_labels.select(date_col, "regime"), on=date_col, how="inner"
+        )
+    _warnings.warn(
+        "by_regime / regime_<metric>: no regime_labels supplied — "
+        "falling back to time-bisection (first_half / second_half). "
+        "This is a structural-break check, not a regime test. Pass "
+        "regime_labels with a domain-driven classification for any "
+        "decision-grade analysis.",
+        UserWarning,
+        stacklevel=3,
+    )
+    sorted_df = df.sort(date_col)
+    mid = len(sorted_df) // 2
+    return (
+        sorted_df.with_row_index("_idx")
+        .with_columns(
+            pl.when(pl.col("_idx") < mid)
+            .then(pl.lit("first_half"))
+            .otherwise(pl.lit("second_half"))
+            .alias("regime")
+        )
+        .drop("_idx")
+    )
+
+
+def by_regime(
+    metric: Callable[..., MetricOutput],
+    df: pl.DataFrame,
+    *,
+    regime_labels: pl.DataFrame | None = None,
+    **kwargs: Any,
+) -> dict[str, MetricOutput]:
+    """Apply a metric to each regime slice of ``df``.
+
+    Convention-based dispatch — pass the metric callable and its
+    primary date-keyed DataFrame; ``by_regime`` slices the DataFrame
+    by regime and forwards the rest of ``kwargs`` to ``metric`` on
+    every call. Works with any metric whose first positional argument
+    is a DataFrame carrying a ``date`` column.
+
+    Args:
+        metric: Callable returning a ``MetricOutput`` (e.g.
+            :func:`factrix.metrics.ic`, :func:`factrix.metrics.caar`).
+        df: The metric's primary date-keyed input.
+        regime_labels: ``(date, regime)`` DataFrame. ``None`` triggers
+            the time-bisection fallback inside :func:`_slice_by_regime`.
+        **kwargs: Forwarded unchanged to ``metric`` on every per-regime
+            call.
+
+    Returns:
+        ``{regime_label: metric(slice, **kwargs)}``. **No cross-regime
+        statistic is computed** — consumers that need one must compose
+        a Layer B wrapper appropriate to the metric family (see e.g.
+        ``regime_ic``).
+
+    Raises:
+        ValueError: ``df`` has no ``date`` column, or no rows survive
+            the regime-label join.
+
+    Example:
+        >>> from factrix.metrics import by_regime, ic, compute_ic
+        >>> ic_df = compute_ic(panel)
+        >>> per_regime = by_regime(ic, ic_df, regime_labels=labels)
+    """
+    if not isinstance(df, pl.DataFrame):
+        raise TypeError(
+            f"by_regime expects a polars DataFrame as the second arg; "
+            f"got {type(df).__name__}. Scalar-input metrics like "
+            f"breakeven_cost / net_spread are not regime-dispatchable — "
+            f"compute their per-regime inputs (gross_spread, turnover) "
+            f"via by_regime first, then combine the scalars."
+        )
+    if "date" not in df.columns:
+        raise ValueError(f"by_regime: df must have a 'date' column; got {df.columns}")
+    annotated = _slice_by_regime(df, regime_labels)
+    if annotated.is_empty():
+        raise ValueError(
+            "by_regime: no rows survived the regime-label join — "
+            "likely a date-range or dtype mismatch between df and regime_labels"
+        )
+    return {
+        str(regime): metric(slice_df, **kwargs)
+        for (regime,), slice_df in annotated.partition_by(
+            "regime", as_dict=True, include_key=False
+        ).items()
+    }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - guides/index.md
       - PANEL vs TIMESERIES: guides/panel-timeseries.md
       - Batch screening (BHY): guides/batch-screening.md
+      - Regime analysis: guides/regime-analysis.md
       - Choosing a metric: guides/choosing-metric.md
       - Standalone metrics: guides/standalone-metrics.md
   - Reference:
@@ -145,6 +146,7 @@ nav:
       - api/index.md
       - AnalysisConfig: api/analysis-config.md
       - evaluate: api/evaluate.md
+      - by_regime: api/by-regime.md
       - list_metrics: api/list-metrics.md
       - FactorProfile: api/factor-profile.md
       - MetricOutput: api/metric-output.md

--- a/tests/test_by_regime.py
+++ b/tests/test_by_regime.py
@@ -1,0 +1,142 @@
+"""Tests for factrix.metrics.regime — Layer A dispatcher."""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._types import MetricOutput
+from factrix.metrics import by_regime, ic, ic_ir
+from factrix.metrics.regime import _slice_by_regime
+
+
+def _ic_series(n: int = 30, mean: float = 0.05, seed: int = 42) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame({"date": dates, "ic": rng.normal(mean, 0.02, n)}).with_columns(
+        pl.col("date").cast(pl.Datetime("ms"))
+    )
+
+
+def _labels(dates: list, partition: list[str]) -> pl.DataFrame:
+    return pl.DataFrame({"date": dates, "regime": partition}).with_columns(
+        pl.col("date").cast(pl.Datetime("ms"))
+    )
+
+
+class TestSliceByRegime:
+    def test_join_with_labels(self):
+        ic_df = _ic_series(10)
+        labels = _labels(ic_df["date"].to_list(), ["a"] * 5 + ["b"] * 5)
+        out = _slice_by_regime(ic_df, labels)
+        assert "regime" in out.columns
+        assert set(out["regime"].unique().to_list()) == {"a", "b"}
+        assert len(out) == 10
+
+    def test_unlabelled_dates_dropped(self):
+        ic_df = _ic_series(10)
+        labels = _labels(ic_df["date"].to_list()[:6], ["a"] * 6)
+        out = _slice_by_regime(ic_df, labels)
+        assert len(out) == 6
+
+    def test_time_bisection_fallback(self):
+        ic_df = _ic_series(11)
+        out = _slice_by_regime(ic_df, regime_labels=None)
+        assert set(out["regime"].unique().to_list()) == {"first_half", "second_half"}
+        counts = out.group_by("regime").len().sort("regime")
+        assert counts.filter(pl.col("regime") == "first_half")["len"][0] == 5
+        assert counts.filter(pl.col("regime") == "second_half")["len"][0] == 6
+
+
+class TestByRegimeDispatcher:
+    def test_returns_dict_per_regime(self):
+        ic_df = _ic_series(40)
+        labels = _labels(ic_df["date"].to_list(), ["bull"] * 20 + ["bear"] * 20)
+        out = by_regime(ic, ic_df, regime_labels=labels)
+        assert isinstance(out, dict)
+        assert set(out) == {"bull", "bear"}
+        for v in out.values():
+            assert isinstance(v, MetricOutput)
+            assert v.name == "ic"
+
+    def test_no_cross_regime_aggregation(self):
+        """Layer A returns per-regime outputs only — no top-level summary."""
+        ic_df = _ic_series(40)
+        out = by_regime(ic, ic_df)
+        for v in out.values():
+            assert "per_regime" not in v.metadata
+            assert "p_value_bhy_adjusted" not in v.metadata
+
+    def test_fallback_when_labels_omitted(self):
+        ic_df = _ic_series(40)
+        out = by_regime(ic, ic_df)
+        assert set(out) == {"first_half", "second_half"}
+
+    def test_kwargs_forwarded(self):
+        """Non-slice kwargs reach the underlying metric on every call."""
+        ic_df = _ic_series(60)
+        out = by_regime(ic, ic_df, forward_periods=3)
+        for v in out.values():
+            assert v.metadata.get("method", "").startswith("non-overlapping")
+
+    def test_works_with_any_metric_callable(self):
+        """No registry — any metric with a date-keyed first arg works."""
+        ic_df = _ic_series(40)
+        out = by_regime(ic_ir, ic_df)
+        assert set(out) == {"first_half", "second_half"}
+        for v in out.values():
+            assert v.name == "ic_ir"
+
+    def test_accepts_arbitrary_callable_matching_contract(self):
+        """The contract is `(df, **kwargs) -> MetricOutput` — nothing factrix-specific.
+
+        This pins the dispatcher's coupling: it must not rely on
+        anything beyond the input being a date-keyed DataFrame and
+        the callable returning a ``MetricOutput``.
+        """
+
+        def fake_metric(df: pl.DataFrame, *, multiplier: float = 1.0) -> MetricOutput:
+            return MetricOutput(
+                name="fake",
+                value=float(df["ic"].mean()) * multiplier,
+            )
+
+        ic_df = _ic_series(40)
+        labels = _labels(ic_df["date"].to_list(), ["a"] * 20 + ["b"] * 20)
+        out = by_regime(fake_metric, ic_df, regime_labels=labels, multiplier=2.0)
+        assert set(out) == {"a", "b"}
+        assert all(o.name == "fake" for o in out.values())
+        # kwarg forwarded to every per-regime call
+        first_half_mean = ic_df.head(20)["ic"].mean()
+        assert out["a"].value == pytest.approx(first_half_mean * 2.0)
+
+    def test_missing_date_column_raises(self):
+        df = pl.DataFrame({"asset_id": [1, 2], "ic": [0.1, 0.2]})
+        with pytest.raises(ValueError, match="must have a 'date' column"):
+            by_regime(ic, df)
+
+    def test_scalar_input_raises_typeerror(self):
+        from factrix.metrics import net_spread
+
+        with pytest.raises(TypeError, match="polars DataFrame"):
+            by_regime(net_spread, 0.001)
+
+    def test_empty_overlap_raises(self):
+        ic_df = _ic_series(10)
+        future_dates = [datetime(2030, 1, 1) + timedelta(days=i) for i in range(5)]
+        labels = _labels(future_dates, ["x"] * 5)
+        with pytest.raises(ValueError, match="no rows survived"):
+            by_regime(ic, ic_df, regime_labels=labels)
+
+    def test_missing_regime_column_raises(self):
+        ic_df = _ic_series(10)
+        bad_labels = pl.DataFrame(
+            {"date": ic_df["date"].to_list(), "label": ["a"] * 10}
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        with pytest.raises(ValueError, match="missing required column 'regime'"):
+            by_regime(ic, ic_df, regime_labels=bad_labels)
+
+    def test_fallback_emits_warning(self):
+        ic_df = _ic_series(40)
+        with pytest.warns(UserWarning, match="time-bisection"):
+            by_regime(ic, ic_df)


### PR DESCRIPTION
## Summary

- New Layer A dispatcher `factrix.metrics.by_regime(metric, df, *, regime_labels, **kwargs)`. Convention-based — pass any metric callable + its date-keyed DataFrame; slices by regime and applies the metric per slice. Returns `dict[regime, MetricOutput]`. No cross-regime statistical inference (a generic second-layer test would silently over-claim for non-t-stat metrics).
- `regime_ic` refactored to share the slicing primitive (`_slice_by_regime`); behaviour preserved.
- Two docs surfaces: `docs/api/by-regime.md` (API contract) and `docs/guides/regime-analysis.md` (concept guide + lookahead-bias warning).

## Test plan

- [x] `pytest tests/test_by_regime.py tests/test_ic.py -q` — 32 passed
- [x] `pytest -q` — 837 passed
- [x] `mkdocs build --strict` — built clean
- [x] Manual smoke: `by_regime(ic, ic_df, regime_labels=labels)` returns `{'bear': ..., 'bull': ...}` with `name='ic'`
- [x] Manual smoke: `by_regime(net_spread, 0.001)` raises `TypeError: by_regime expects a polars DataFrame as the second arg; got float. Scalar-input ...`

Closes #107