### PR TITLE
feat(list_metrics): import_path + input_kind (#111)

### DIFF
--- a/docs/api/by-regime.md
+++ b/docs/api/by-regime.md
@@ -53,14 +53,21 @@ raw per-regime outputs to compose your own analysis.
 
 Any metric whose primary first argument is a DataFrame with a `date`
 column. Discover the eligible set via
-[`list_metrics`](list-metrics.md) — pick a metric that matches your
-`(scope, signal)` cell and pass its callable straight in:
+[`list_metrics`](list-metrics.md) and filter on `input_kind == "panel"`
+— scalar-input utilities like `breakeven_cost` / `net_spread` consume
+pre-aggregated scalars and have no date column to slice on:
 
 ```python
 import factrix as fl
 from factrix.metrics import by_regime, caar, monotonicity, fama_macbeth
 
-fl.list_metrics(fl.FactorScope.INDIVIDUAL, fl.Signal.SPARSE)
+candidates = [
+    r["name"]
+    for r in fl.list_metrics(
+        fl.FactorScope.INDIVIDUAL, fl.Signal.SPARSE, format="json",
+    )
+    if r["input_kind"] == "panel"
+]
 # ['caar', 'event_ic', ...]
 
 per_regime = by_regime(caar, caar_df, regime_labels=labels)

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -27,6 +27,33 @@ across PANEL / TIMESERIES (see
 [Metric applicability](../reference/metric-applicability.md) for the
 underlying matrix).
 
+## Discover-then-import workflow
+
+Pass `with_import=True` to render a copy-paste-ready two-column view
+that pairs each metric with its submodule path:
+
+```python
+print("\n".join(fl.list_metrics(
+    fl.FactorScope.INDIVIDUAL, fl.Signal.CONTINUOUS, with_import=True,
+)))
+# ic                       → factrix.metrics.ic
+# ic_ir                    → factrix.metrics.ic
+# fama_macbeth             → factrix.metrics.fama_macbeth
+# breakeven_cost           → factrix.metrics.tradability
+# ...
+```
+
+Every name on the right is also re-exported from `factrix.metrics`,
+so the canonical wire-up is always:
+
+```python
+from factrix.metrics import ic, fama_macbeth, breakeven_cost
+```
+
+The submodule path is shown so you know *where the implementation
+lives* — useful when reading source, jumping in an IDE, or checking
+the module-level `Matrix-row:` tag.
+
 ## Structured output for tooling
 
 ```python
@@ -42,6 +69,8 @@ fl.list_metrics(
 #         "cell": "(INDIVIDUAL, CONTINUOUS, IC, PANEL)",
 #         "agg_order": "cs-first",
 #         "inference_se": "NW HAC / cross-asset t",
+#         "import_path": "factrix.metrics.ic",
+#         "input_kind": "panel",
 #     },
 #     ...
 # ]
@@ -59,6 +88,29 @@ parser MkDocs uses to render
 | `cell` | Raw cell string from the `Matrix-row:` tag |
 | `agg_order` | Aggregation order (`cs-first`, `ts-first`, `ts-only`, `static-cs`, `per-event`) |
 | `inference_se` | Inference / SE method or `no formal H₀` for descriptive metrics |
+| `import_path` | Fully-qualified submodule (`factrix.metrics.<module>`) — also re-exported from `factrix.metrics` |
+| `input_kind` | `"panel"` for the standard `(date-keyed DataFrame, **kwargs) -> MetricOutput` contract; `"scalar"` for pre-aggregated-scalar utilities |
+
+### `panel` vs `scalar` — and why it matters
+
+Most metrics take a date-keyed DataFrame as their first positional
+argument; a few (`breakeven_cost`, `net_spread` in
+`factrix.metrics.tradability`) consume pre-aggregated scalars
+(`gross_spread: float`, `turnover: float`, …) and return a
+`MetricOutput` directly. Date-slicing dispatchers like
+[`by_regime`](by-regime.md) only accept the `panel` shape — there is
+no date column in a scalar to slice on.
+
+Filter the JSON output to enumerate `by_regime`-eligible metrics:
+
+```python
+panel_metrics = [
+    r for r in fl.list_metrics(
+        fl.FactorScope.INDIVIDUAL, fl.Signal.CONTINUOUS, format="json",
+    )
+    if r["input_kind"] == "panel"
+]
+```
 
 ## Errors
 

--- a/docs/guides/regime-analysis.md
+++ b/docs/guides/regime-analysis.md
@@ -54,6 +54,29 @@ If `regime_labels=None`, factrix applies a time-bisection fallback
 structural-break check, **not** a regime test — domain-driven labels
 are required for any defensible regime claim.
 
+## Discovering eligible metrics
+
+Layer A only accepts metrics whose primary input is a date-keyed
+DataFrame. Use [`list_metrics`](../api/list-metrics.md) with
+`format="json"` and filter on `input_kind == "panel"` to enumerate the
+candidate set for your `(scope, signal)` cell:
+
+```python
+import factrix as fl
+
+panel_metrics = [
+    r["name"]
+    for r in fl.list_metrics(
+        fl.FactorScope.INDIVIDUAL, fl.Signal.CONTINUOUS, format="json",
+    )
+    if r["input_kind"] == "panel"
+]
+```
+
+Scalar-input utilities (`breakeven_cost`, `net_spread`) are excluded —
+they consume pre-aggregated scalars and have no date column to slice
+on.
+
 ## Worked example: IC across volatility regimes
 
 ```python

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -461,6 +461,7 @@ def list_metrics(
     signal: Signal,
     *,
     format: Literal["text", "json"] = "text",
+    with_import: bool = False,
 ) -> list[str] | list[dict[str, Any]]:
     """Return standalone metrics applicable to ``(scope, signal)``.
 
@@ -474,17 +475,31 @@ def list_metrics(
     scope, signal
         Cell axes to filter on.
     format
-        ``"text"`` (default) returns ``list[str]`` of metric names sorted
-        by ``(module, name)``. ``"json"`` returns ``list[dict]`` rows
-        with keys ``name``, ``module``, ``cell``, ``agg_order``,
-        ``inference_se`` — JSON-serialisable, suitable for tooling that
-        needs the structured row.
+        ``"text"`` (default) returns metric names sorted by
+        ``(module, name)``. ``"json"`` returns ``list[dict]`` rows with
+        keys ``name``, ``module``, ``cell``, ``agg_order``,
+        ``inference_se``, ``import_path``, ``input_kind`` —
+        JSON-serialisable, suitable for tooling.
+    with_import
+        ``"text"`` only. When ``True``, returns a two-column
+        ``"name → factrix.metrics.<module>"`` list so each row is
+        copy-paste-ready into ``from factrix.metrics import <name>``.
+        Ignored under ``format="json"`` (the ``import_path`` field is
+        always present there).
 
     Raises
     ------
     IncompatibleAxisError
         ``(scope, signal)`` matches no registered metric. In practice
         all four combos are populated, so this is defensive.
+
+    Notes
+    -----
+    Filter ``input_kind == "panel"`` on the JSON form to find candidates
+    for date-slicing dispatchers like
+    :func:`factrix.metrics.by_regime`; ``"scalar"`` rows
+    (``breakeven_cost``, ``net_spread``) consume pre-aggregated scalars
+    and are not eligible.
     """
     rows = [r for r in user_facing_rows() if r.cell.matches(scope, signal)]
     if not rows:
@@ -500,7 +515,12 @@ def list_metrics(
                 "cell": r.cell.raw,
                 "agg_order": r.agg_order,
                 "inference_se": r.inference_se,
+                "import_path": r.import_path,
+                "input_kind": r.input_kind,
             }
             for r in rows
         ]
+    if with_import:
+        width = max(len(r.name) for r in rows)
+        return [f"{r.name:<{width}} → {r.import_path}" for r in rows]
     return [r.name for r in rows]

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -35,6 +35,7 @@ import functools
 import pathlib
 import re
 from dataclasses import dataclass
+from typing import Literal
 
 from factrix._axis import FactorScope, Metric, Mode, Signal
 
@@ -75,6 +76,15 @@ _INFRASTRUCTURE: frozenset[str] = frozenset({"by_regime"})
 """Cross-cutting dispatchers published from ``factrix.metrics`` that
 are not per-(scope, signal) cell metrics."""
 
+# Scalar-input metrics: pre-aggregated-scalar utilities that consume
+# scalars (``gross_spread: float``, ``turnover: float``, ...) rather
+# than the standard ``(date-keyed DataFrame, **kwargs) -> MetricOutput``
+# panel contract. Not eligible for date-slicing dispatchers like
+# ``by_regime``. Hard-coded exception set rather than a Matrix-row tag
+# extension — the population is small and stable; YAGNI applies until
+# it isn't.
+_SCALAR_INPUT_METRICS: frozenset[str] = frozenset({"breakeven_cost", "net_spread"})
+
 
 @dataclass(frozen=True, slots=True)
 class Cell:
@@ -113,13 +123,23 @@ class MatrixEntry:
 
 @dataclass(frozen=True, slots=True)
 class MetricRow:
-    """One ``(metric_name, module, cell)`` triple parsed from ``Matrix-row:``."""
+    """One ``(metric_name, module, cell)`` triple parsed from ``Matrix-row:``.
+
+    ``import_path`` is the fully-qualified submodule (``factrix.metrics.<module>``)
+    — every public metric is also re-exported from ``factrix.metrics``,
+    so ``from factrix.metrics import <name>`` works regardless. ``input_kind``
+    distinguishes the standard date-keyed-DataFrame contract (``"panel"``)
+    from pre-aggregated-scalar utilities (``"scalar"``); only ``"panel"``
+    metrics are eligible for date-slicing dispatchers like ``by_regime``.
+    """
 
     name: str
     module: str
     cell: Cell
     agg_order: str
     inference_se: str
+    import_path: str
+    input_kind: Literal["panel", "scalar"]
 
 
 def _parse_axis(token: str, enum_cls: type) -> object | None:
@@ -226,6 +246,8 @@ def all_rows() -> list[MetricRow]:
             cell=entry.cell,
             agg_order=entry.agg_order,
             inference_se=entry.inference_se,
+            import_path=f"factrix.metrics.{entry.module}",
+            input_kind="scalar" if name in _SCALAR_INPUT_METRICS else "panel",
         )
         for entry in matrix_entries()
         for name in entry.names

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -126,7 +126,71 @@ def test_json_format_round_trips() -> None:
     decoded = json.loads(text)
     assert decoded == rows
     sample = rows[0]
-    assert set(sample) == {"name", "module", "cell", "agg_order", "inference_se"}
+    assert set(sample) == {
+        "name",
+        "module",
+        "cell",
+        "agg_order",
+        "inference_se",
+        "import_path",
+        "input_kind",
+    }
+
+
+def test_json_carries_import_path_and_input_kind() -> None:
+    rows = fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, format="json")
+    by_name = {r["name"]: r for r in rows}
+
+    # ``ic`` is the canonical panel-input metric.
+    assert by_name["ic"]["import_path"] == "factrix.metrics.ic"
+    assert by_name["ic"]["input_kind"] == "panel"
+
+    # ``breakeven_cost`` / ``net_spread`` are the scalar-input utilities.
+    assert by_name["breakeven_cost"]["import_path"] == "factrix.metrics.tradability"
+    assert by_name["breakeven_cost"]["input_kind"] == "scalar"
+    assert by_name["net_spread"]["input_kind"] == "scalar"
+
+    # Every other row is panel-input.
+    panels = {r["name"] for r in rows if r["input_kind"] == "panel"}
+    scalars = {r["name"] for r in rows if r["input_kind"] == "scalar"}
+    assert scalars == {"breakeven_cost", "net_spread"}
+    assert panels.isdisjoint(scalars)
+
+
+def test_import_path_resolves_for_every_row() -> None:
+    # Walk every cell so the assertion covers cross-cell rows too.
+    import importlib
+
+    seen: set[str] = set()
+    for scope in FactorScope:
+        for signal in Signal:
+            for r in fl.list_metrics(scope, signal, format="json"):
+                if r["name"] in seen:
+                    continue
+                seen.add(r["name"])
+                module = importlib.import_module(r["import_path"])
+                assert hasattr(module, r["name"]), (
+                    f"{r['import_path']} is missing {r['name']}"
+                )
+
+
+def test_with_import_renders_two_column_text() -> None:
+    rendered = fl.list_metrics(
+        FactorScope.INDIVIDUAL, Signal.CONTINUOUS, with_import=True
+    )
+    assert all(" → factrix.metrics." in line for line in rendered)
+    # Same row order as the plain text output — only the rendering changes.
+    plain = fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+    assert [line.split(" → ", 1)[0].rstrip() for line in rendered] == plain
+
+
+def test_with_import_is_ignored_under_json_format() -> None:
+    # ``with_import`` is a text-only knob; JSON always carries the field.
+    a = fl.list_metrics(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, format="json")
+    b = fl.list_metrics(
+        FactorScope.INDIVIDUAL, Signal.CONTINUOUS, format="json", with_import=True
+    )
+    assert a == b
 
 
 def test_json_output_is_stable_across_calls() -> None:
@@ -182,6 +246,8 @@ def test_metric_row_dataclass_fields_are_serialisable() -> None:
             "cell": row.cell.raw,
             "agg_order": row.agg_order,
             "inference_se": row.inference_se,
+            "import_path": row.import_path,
+            "input_kind": row.input_kind,
         }
     )
     assert json.loads(serialised)["name"] == row.name


### PR DESCRIPTION
## Summary

- `MetricRow` carries `import_path` (`factrix.metrics.<module>`) and `input_kind` (`"panel"` | `"scalar"`); JSON output exposes both. Source of truth for `input_kind` is a frozenset of the two known scalar utilities (`breakeven_cost`, `net_spread`) — YAGNI over extending the `Matrix-row:` tag at n=2.
- Text format gains opt-in `with_import=True` for copy-paste-ready `name → factrix.metrics.<module>` two-column rendering.
- Docs: `list-metrics.md` documents the discover-then-import workflow and the panel/scalar split; `by-regime.md` + `regime-analysis.md` switch their discovery snippet to filter `input_kind == "panel"`.

## Test plan

- [x] `pytest tests/test_list_metrics.py` — 17 passed (5 new: import_path + input_kind population, runtime resolvability, two-column rendering, JSON-silently-ignores `with_import`).
- [x] `pytest` — full suite 841 passed.
- [ ] mkdocs render of updated `list-metrics.md` / `by-regime.md` / `regime-analysis.md` looks right locally.

Closes #111