### PR TITLE
docs(regime): note v0.9.0 Layer-B coverage is regime_ic only (#116)

### DIFF
--- a/docs/api/by-regime.md
+++ b/docs/api/by-regime.md
@@ -49,6 +49,10 @@ factrix provides Layer B wrappers — see
 `by_regime` directly when no Layer B wrapper exists or when you want
 raw per-regime outputs to compose your own analysis.
 
+**As of v0.9.0, `regime_ic` is the only Layer B wrapper.** `regime_caar`
+and `regime_fama_macbeth` are tracked in
+[#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107).
+
 ## Which metrics work
 
 Any metric whose primary first argument is a DataFrame with a `date`

--- a/docs/guides/regime-analysis.md
+++ b/docs/guides/regime-analysis.md
@@ -13,6 +13,8 @@ Regime analysis asks "is this factor stable across market environments?" — a d
 
 **Use Layer B when:** a curated wrapper exists for your metric and the bundled second-layer test matches your research question.
 
+> **Layer B coverage as of v0.9.0:** only [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) ships. `regime_caar` and `regime_fama_macbeth` are tracked in [#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107). Until then, `by_regime(compute_caar, df, ...)` and `by_regime(fama_macbeth, df, ...)` return per-regime values without a cross-regime statistic — useful for descriptive comparison, not for inference.
+
 ## Why no generic cross-regime test
 
 A single dispatcher carrying a single second-layer test would silently over-claim. The appropriate test depends on the metric family:


### PR DESCRIPTION
## Summary

Adds a one-line caveat at two locations:

- `docs/guides/regime-analysis.md` — block-quote callout right after the two-layer table
- `docs/api/by-regime.md` — bold sentence at the end of the "What it does **not** do" section

Both link to [#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107) so a reader who greps `regime_caar` lands on the tracking thread instead of concluding the docs missed it.

## Why locality > separate "version-specific notes" section

Putting these caveats next to the Layer-B references they qualify means the same PR that lands #107 Phase 2 (regime_caar / regime_fama_macbeth) deletes both lines in the same diff. A separate "as of vX.Y.Z" section drifts because nobody remembers to update it.

## Test plan

- [x] `uv run mkdocs build --strict` — clean
- [x] `uv run pytest tests/test_docs_pages.py tests/test_docs_llms.py -q` — 122 passed
- [x] No code changes; no pytest / mypy / ruff impact

Closes #116