### PR TITLE
docs(api): align evaluate docstring with SSOT (#122)

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -88,7 +88,31 @@ def evaluate(
             ``"factor"``). Renamed to ``"factor"`` internally before
             dispatch. Looping over candidates with different
             ``factor_col=`` values is the canonical multi-factor
-            pattern; see the batch screening guide.
+            pattern; downstream aggregation goes through
+            :func:`factrix.multi_factor.bhy` (auto-partitions families
+            by dispatch cell × ``forward_periods``) — not the low-level
+            ``factrix.stats.bhy_adjusted_p`` primitive. See the batch
+            screening guide.
+
+    Raises:
+        MissingConfigError: ``evaluate(raw)`` called without an
+            ``AnalysisConfig``. Recovery: call
+            :func:`factrix.suggest_config`.
+        IncompatibleAxisError: ``config`` axes form an illegal cell.
+        ModeAxisError: Legal cell has no procedure under the derived
+            ``Mode``. Carries ``.suggested_fix: AnalysisConfig | None``
+            with the nearest-legal config.
+        InsufficientSampleError: ``T`` below the procedure's
+            ``MIN_PERIODS_HARD`` floor. Carries ``.actual_periods`` /
+            ``.required_periods``.
+        ValueError: ``factor_col`` not present on ``raw``, or both
+            ``"factor"`` and ``factor_col`` present (ambiguous which is
+            the signal).
+
+    All factrix-raised errors inherit from :class:`FactrixError`.
+
+    See ``llms-full.txt`` for the full API reference and dispatch
+    table: https://awwesomeman.github.io/factrix/llms-full.txt
     """
     if config is None:
         raise MissingConfigError(

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -173,7 +173,12 @@ factrix.evaluate(raw: polars.DataFrame, config: AnalysisConfig,
 procedure. `factor_col=` lets a panel with a non-default signal column
 name (e.g. `"alpha"`) be evaluated without renaming first; looping over
 candidates with different `factor_col=` values is the canonical multi-
-factor pattern. Raises (subclasses of `FactrixError`; see `## Errors`
+factor pattern. Downstream aggregation goes through
+`factrix.multi_factor.bhy(profiles)`, which auto-partitions families
+by `(dispatch cell, forward_periods)`; do **not** reach into
+`factrix.stats.bhy_adjusted_p` directly — that is a low-level primitive
+that requires re-implementing the family split by hand.
+Raises (subclasses of `FactrixError`; see `## Errors`
 below for the full hierarchy + recovery payloads):
 - `MissingConfigError` — `evaluate(raw)` called without an `AnalysisConfig`
 - `IncompatibleAxisError` — config axes form an illegal cell


### PR DESCRIPTION
## Summary

- `evaluate()` docstring now lists all five exceptions with their recovery payloads (`.suggested_fix`, `.actual_periods`, `.required_periods`) so `help(fl.evaluate)` readers can branch on subclass without parsing message strings.
- `factor_col=` note cross-links downstream to `multi_factor.bhy()` (auto-partitions families by dispatch cell × `forward_periods`) and warns off the low-level `stats.bhy_adjusted_p` primitive. Same anti-pointer mirrored in `factrix/llms-full.txt` §evaluate for-loop note.
- llms-full.txt URL literal pinned in `evaluate` docstring only — `suggest_config` is reached via `MissingConfigError` message, `multi_factor.bhy` via the new `evaluate` cross-link. URL appearance kept to 2 places (module docstring + `evaluate`) for grep-friendly maintenance.

## Test plan

- [x] pre-commit ruff check + format pass
- [x] `python -c "import factrix; help(factrix.evaluate)"` renders new Raises block + URL
- [x] `uv run mkdocs build` regenerates `docs/llms-full.txt` from `factrix/llms-full.txt` SSOT (verified body diff modulo GENERATED banner)
- [x] /simplify review: factual claims (5 exception raise sites, `.suggested_fix` typing, `.actual_periods/.required_periods` fields, `stats.bhy_adjusted_p` public symbol, family-key partition) all confirmed against source

Closes #122