### PR TITLE
docs(scope): clarify signal-validity vs portfolio (#127)

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,5 +1,12 @@
 # Concepts
 
+## What factrix is for
+
+factrix evaluates factor **signal validity**, not portfolio
+performance — see
+[Guides § Standalone metrics — Scope](../guides/standalone-metrics.md#scope)
+for the full boundary (what is in, what is downstream).
+
 ## Three orthogonal axes
 
 [`AnalysisConfig`][factrix.AnalysisConfig] is defined by three user-facing

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -10,6 +10,21 @@ This guide covers the three things a user needs to wire them in:
 which metrics apply to a given cell, what input shape each one
 expects, and where they sit in a screening pipeline.
 
+## Scope
+
+factrix evaluates **factor signal validity** — predictive power
+(IC, FM λ), robustness (NW HAC, BHY, regime stability), and event
+shape (CAAR, BMP, Corrado). It does **not** compute portfolio-level
+performance: no Sharpe / drawdown / Sortino / Calmar / return
+attribution. Those metrics belong downstream of factor selection
+and live in dedicated backtest libraries (e.g.
+[`vectorbt`](https://vectorbt.dev/) or an internal framework).
+
+The closest crossover inside factrix is `ic_ir` — the information
+ratio of the per-date IC series. It is explicitly a *signal-quality*
+IR (mean / std of IC), **not** a portfolio Sharpe (mean / std of
+realised returns).
+
 For the cross-module matrix (every module, aggregation pattern,
 inference SE), see
 [Reference § Metric pipelines](../reference/standalone-metrics.md).


### PR DESCRIPTION
## Summary
- Add Scope section to `guides/standalone-metrics.md` stating factrix evaluates factor signal validity (IC / FM λ / NW HAC / BHY / CAAR / BMP / Corrado), not portfolio performance (Sharpe / drawdown / Sortino / Calmar / return attribution).
- Note `ic_ir` is the closest crossover and is explicitly a *signal-quality* IR (mean / std of IC), not a portfolio Sharpe.
- One-line pointer from `getting-started/concepts.md` so the boundary surfaces during the first concepts read; canonical wording stays in standalone-metrics.md (SSOT).

Refs #130. Closes #127.

## Test plan
- [x] mkdocs strict build passes
- [x] cross-link `../guides/standalone-metrics.md#scope` resolves
- [x] no code change