### PR TITLE
docs(metrics): deep-link metric pages to stat-methods anchors (#126)

### DIFF
--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -4,6 +4,12 @@ Cumulative Average Abnormal Return tests for event signals. CAAR
 *t*-test (parametric) and BMP standardised AR *z*-test (robust to
 event-induced variance).
 
+→ Formula and references:
+[CAAR cross-event t](../../reference/statistical-methods.md#caar-cross-event-t)
+(`caar`),
+[BMP standardised AR](../../reference/statistical-methods.md#bmp-standardised-ar)
+(`bmp_test`).
+
 !!! info "Event-study contracts"
     `signed_car`, the `estimation_window` consumed by `bmp_test`, and
     factrix's confounded-event handling are documented in

--- a/docs/api/metrics/corrado.md
+++ b/docs/api/metrics/corrado.md
@@ -4,6 +4,9 @@ Corrado (1989) nonparametric rank test on event abnormal returns.
 Robust to extreme returns, non-normality, and cross-asset
 heteroscedasticity. Direction-adjusted for two-sided signals.
 
+→ Formula and references:
+[Corrado nonparametric rank](../../reference/statistical-methods.md#corrado-rank).
+
 !!! info "Event-study contracts"
     Corrado's primitive is `signed_rank = uniform_rank(forward_return) ×
     sign(factor)` — note that the direction adjustment is on the rank,

--- a/docs/api/metrics/fama_macbeth.md
+++ b/docs/api/metrics/fama_macbeth.md
@@ -4,6 +4,11 @@ Per-date cross-sectional OLS slope λ then NW HAC *t* on the λ series
 (Fama-MacBeth 1973). Pooled OLS variant with date-clustered SE; β-sign
 consistency check.
 
+→ Formula and references: stage-2 HAC SE on E[λ] —
+[NW HAC](../../reference/statistical-methods.md#nw-hac)
+(includes the Kan-Zhang / Shanken EIV correction invoked by
+`is_estimated_factor=True`).
+
 ::: factrix.metrics.fama_macbeth
     options:
       members:

--- a/docs/api/metrics/ic.md
+++ b/docs/api/metrics/ic.md
@@ -4,6 +4,12 @@ Information Coefficient (Spearman rank correlation between factor and
 forward return) and its variants. Cross-sectional first; significance
 via NW HAC or non-overlapping cross-asset *t*.
 
+→ Formula and references:
+[NW HAC](../../reference/statistical-methods.md#nw-hac)
+(`ic_newey_west`),
+[BHY across regimes](../../reference/statistical-methods.md#bhy)
+(`regime_ic`, `multi_horizon_ic`).
+
 ::: factrix.metrics.ic
     options:
       members:

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -11,7 +11,7 @@ For per-metric formulae and signatures see the
 behind which disciplines factrix does *not* implement, see
 [Development § Design notes](../development/design-notes.md).
 
-The four sections are the only first-class disciplines in factrix:
+The five sections are the only first-class disciplines in factrix:
 
 1. **HAC SE under overlapping returns** — Newey-West with a
    deterministic bandwidth rule.
@@ -21,10 +21,13 @@ The four sections are the only first-class disciplines in factrix:
    with the consistency factor; Theil-Sen for slope.
 4. **Persistence diagnostics under near-unit-root predictors** —
    ADF flag, no auto-correction.
+5. **Event-study cross-sectional inference** — CAAR cross-event $t$,
+   BMP-style standardised AR, Corrado rank.
 
 ---
 
 ## 1. HAC SE under overlapping returns
+[](){ #nw-hac }
 
 When forward returns span `h > 1` periods, consecutive observations
 inherit MA(`h − 1`) structure. Two standard responses, with different
@@ -122,6 +125,7 @@ Practical rule of thumb:
 ---
 
 ## 2. Multiple-testing under dependence
+[](){ #bhy }
 
 Factor pools are dependent by construction: 200 momentum variants on
 the same return panel correlate, and a Bonferroni step that assumes
@@ -241,3 +245,50 @@ deliberately retains plain OLS SE rather than HAC: the Stambaugh bias
 arises from the predictor's persistence, not from SE estimation, and
 HAC fixes only the SE while leaving the coefficient bias untouched.
 Adding HAC there would advertise robustness factrix does not deliver.
+
+---
+
+## 5. Event-study cross-sectional inference
+
+The `individual_sparse` cell aggregates per-event abnormal returns
+across assets. Three estimators are exposed, each making a different
+assumption about the cross-event distribution:
+
+### CAAR cross-event t
+[](){ #caar-cross-event-t }
+
+Default for `caar`. Per event date, take the cross-sectional mean of
+$\text{return} \times \text{factor}$ across event rows; the resulting
+CAAR series feeds a downstream NW HAC $t$ on the mean. Specification
+follows [Brown-Warner 1985][brown-warner-1985]; the
+[Hansen-Hodrick 1980][hansen-hodrick-1980] overlap floor in §1
+governs the NW lag when the event window induces overlap. The test is
+correctly sized under no event-induced variance; under variance
+inflation around the event date it is mis-specified — the documented
+motivation for switching to the BMP-style estimator below.
+
+### BMP standardised AR
+[](){ #bmp-standardised-ar }
+
+`bmp_test`. Standardises each event's abnormal return by its
+estimation-window standard deviation before taking the cross-event
+mean, restoring size under event-induced variance
+([Boehmer-Musumeci-Poulsen 1991][boehmer-musumeci-poulsen-1991]).
+factrix's implementation is a **BMP-style simplification**: by
+default it uses mean-adjusted abnormal returns and omits the original
+BMP prediction-error correction, so results do not match a textbook
+BMP implementation byte-for-byte. The strict denominator is
+available via `bmp_test(..., include_prediction_error_variance=True)`
+when the textbook form is required.
+
+### Corrado nonparametric rank
+[](){ #corrado-rank }
+
+`corrado_rank_test`. Replaces returns with their uniform rank within
+the (estimation ∪ event) window, then runs the cross-event $t$ on the
+ranks ([Corrado 1989][corrado-1989]). Robust to extreme returns,
+non-normality, and cross-asset heteroscedasticity. factrix adds the
+direction adjustment of [Corrado-Zivney 1992][corrado-zivney-1992]
+for two-sided signed signals — the rank itself is signed by
+$\text{sign}(\text{factor})$ before the cross-event aggregation, not
+the underlying return.


### PR DESCRIPTION
## Summary
- Add a top-of-page \`→ Formula and references\` line on \`ic\`, \`fama_macbeth\`, \`caar\`, \`corrado\` deep-linking the matching anchor in \`statistical-methods.md\`. Covers the seven metrics listed in #126 (\`ic_newey_west\`, \`multi_horizon_ic\`, \`regime_ic\` via \`ic.md\`; \`fama_macbeth\`; \`caar\`, \`bmp_test\` via \`caar.md\`; \`corrado_rank_test\`).
- Add a new \`## 5. Event-study cross-sectional inference\` section to \`statistical-methods.md\` with subsections for CAAR cross-event t / BMP standardised AR / Corrado rank — these methods were previously only described inline in metric pages, now consolidated as the SSOT.
- Make per-section anchors explicit (\`#nw-hac\`, \`#bhy\`, \`#caar-cross-event-t\`, \`#bmp-standardised-ar\`, \`#corrado-rank\`) so deep links survive future heading edits — addresses the DoD requirement "stable anchors (no rename without redirect)".

Refs #130. Closes #126.

## Test plan
- [x] mkdocs strict build passes
- [x] all five new anchors render with expected \`id\` attributes (verified in built HTML)
- [x] all bibliography reference IDs (\`brown-warner-1985\`, \`hansen-hodrick-1980\`, \`boehmer-musumeci-poulsen-1991\`, \`corrado-1989\`, \`corrado-zivney-1992\`) exist
- [x] BMP description includes \`include_prediction_error_variance=True\` opt-in for SSOT symmetry with docstring
- [x] no code change