### PR TITLE
docs(bhy): identity caveat for survivor → name mapping

### DIFF
--- a/docs/guides/batch-screening.md
+++ b/docs/guides/batch-screening.md
@@ -10,9 +10,12 @@ import factrix as fl
 candidates = ["mom_5d", "mom_20d", "mom_60d"]
 cfg = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
 
-profiles = [fl.evaluate(panel, cfg, factor_col=name) for name in candidates]
-survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
+by_name = {name: fl.evaluate(panel, cfg, factor_col=name) for name in candidates}
+survivors = fl.multi_factor.bhy(list(by_name.values()), threshold=0.05)
+survivor_names = [n for n, p in by_name.items() if any(p is s for s in survivors)]
 ```
+
+`FactorProfile` is a frozen dataclass with no `name` / `label` field — `bhy()` neither accepts nor returns one. Map survivors back to factor names by holding the `name → profile` dict yourself and comparing with `is` (identity), as above. Equality (`==`) is unsafe: two factors with coincident stats compare equal.
 
 Each `evaluate` call repays the per-date cross-section overhead
 (sort / group-by / rank) on its own — that cost is intrinsic to

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -244,6 +244,12 @@ the caller's responsibility (deliberately not done here).
 `ValueError` fires for non-p-value gates; a `KeyError` fires if a profile in a
 family lacks the gated key.
 
+Identity caveat: `FactorProfile` has no `name` / `label` field, and `bhy()`
+returns surviving profiles only — not their source labels. To map survivors
+back to factor names, hold a `dict[name, profile]` yourself and compare with
+`is` (identity), e.g. `[n for n, p in by_name.items() if any(p is s for s in survivors)]`.
+Equality is unsafe: two factors with coincident stats compare equal.
+
 ---
 
 ### `describe_analysis_modes` / `suggest_config` / `list_metrics`


### PR DESCRIPTION
## Summary
- Quant audit (#130 follow-up) flagged that `multi_factor.bhy()` returns surviving `FactorProfile`s with no name/label — and `FactorProfile.__eq__` (frozen dataclass auto-eq) compares stats fields, so two factors with coincident stats are indistinguishable. Users have to use `is` (identity), but the docs didn't say so.
- Updates the `batch-screening.md` basic-usage block to the canonical `dict[name, profile]` + identity pattern, and mirrors a 5-line caveat into `factrix/llms-full.txt` (SSOT) so agents inlining llms-full.txt get the warning without following links.
- `docs/llms-full.txt` is generated via `scripts/mkdocs_hooks/sync_llms_txt.py`; SSOT lives under `factrix/`.

## Test plan
- [x] `pytest tests/ -k "docs or llms"` — 193 passed
- [ ] mkdocs build sanity-check on review

Refs #130