### PR TITLE
docs(reference): metric reference consolidation (#144)

### DIFF
--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -79,7 +79,7 @@ fl.list_metrics(
 The JSON form is the single-source-of-truth row produced by parsing
 the `Matrix-row:` tag in each metric module's docstring (the same
 parser MkDocs uses to render
-[the cross-metric matrix](../reference/standalone-metrics.md)). Keys:
+[the cross-metric matrix](../reference/metric-pipelines.md)). Keys:
 
 | Key | Meaning |
 |---|---|

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -523,7 +523,7 @@ Run: `uv run pytest`
 
 ### Docs SSOT strategy (Option B — issue #42)
 
-`docs/reference/standalone-metrics.md` no longer contains a hand-written
+`docs/reference/metric-pipelines.md` no longer contains a hand-written
 matrix. The matrix is generated at build time from machine-readable
 `Matrix-row:` tags embedded in each `factrix/metrics/*.py` module docstring.
 
@@ -535,7 +535,7 @@ matrix. The matrix is generated at build time from machine-readable
 - `scripts/mkdocs_hooks/gen_metric_matrix.py` (a MkDocs `hooks:` entry) parses every
   public module with `ast`, extracts the tags, and writes
   `docs/reference/_generated_metric_matrix.md` before each docs build.
-- `standalone-metrics.md` includes the generated file via
+- `metric-pipelines.md` includes the generated file via
   `--8<-- "docs/reference/_generated_metric_matrix.md"` (pymdownx.snippets).
 
 **CI coverage (`tests/test_docs_matrix.py`):**

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -323,7 +323,7 @@ files auto-update and which need manual maintenance.
   new file plus a `nav:` entry in `mkdocs.yml`
 - `docs/getting-started/`, `docs/guides/`, `docs/development/`, the
   homepage `index.md`, and per-section `index.md`: pure narrative
-- `docs/reference/standalone-metrics.md`, `statistical-methods.md`,
+- `docs/reference/metric-pipelines.md`, `statistical-methods.md`,
   `warning-codes.md`, `bibliography.md`: narrative roll-ups (not
   matrices)
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -71,11 +71,11 @@ Choose by research question, not data shape:
 
 | Factory | Run by `evaluate()` | Procedure | Literature |
 |---------|---------------------|-----------|------------|
-| `individual_continuous(metric=IC)` | [`ic`][factrix.metrics.ic] | per-date Spearman ρ → NW HAC t on E[IC] | [Grinold 1989][grinold-1989]; [Newey-West 1987][newey-west-1987] |
-| `individual_continuous(metric=FM)` | [`fama_macbeth`][factrix.metrics.fama_macbeth] | per-date OLS λₜ → NW HAC t on E[λ] | [Fama-MacBeth 1973][fama-macbeth-1973] |
-| `individual_sparse()` | [`caar`][factrix.metrics.caar] | per-event AR → CAAR → cross-event t | [Brown-Warner 1985][brown-warner-1985] |
-| `common_continuous()` | [`ts_beta`][factrix.metrics.ts_beta] | per-asset TS β → cross-asset t on E[β] | [Black-Jensen-Scholes 1972][black-jensen-scholes-1972] |
-| `common_sparse()` | [`ts_beta`][factrix.metrics.ts_beta] | per-asset TS β on dummy → cross-asset t | TS-β + event-study hybrid |
+| `individual_continuous(metric=IC)` | [`ic`][factrix.metrics.ic.ic] | per-date Spearman ρ → NW HAC t on E[IC] | [Grinold 1989][grinold-1989]; [Newey-West 1987][newey-west-1987] |
+| `individual_continuous(metric=FM)` | [`fama_macbeth`][factrix.metrics.fama_macbeth.fama_macbeth] | per-date OLS λₜ → NW HAC t on E[λ] | [Fama-MacBeth 1973][fama-macbeth-1973] |
+| `individual_sparse()` | [`caar`][factrix.metrics.caar.caar] | per-event AR → CAAR → cross-event t | [Brown-Warner 1985][brown-warner-1985] |
+| `common_continuous()` | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | per-asset TS β → cross-asset t on E[β] | [Black-Jensen-Scholes 1972][black-jensen-scholes-1972] |
+| `common_sparse()` | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | per-asset TS β on dummy → cross-asset t | TS-β + event-study hybrid |
 
 For the cell-keyed (rather than factory-keyed) reverse-index — including
 the dispatch cells single-asset paths route to — see

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -69,13 +69,17 @@ Choose by research question, not data shape:
 
 ## Five analysis scenarios
 
-| Factory | Procedure | Literature |
-|---------|-----------|------------|
-| `individual_continuous(metric=IC)` | per-date Spearman ρ → NW HAC t on E[IC] | [Grinold 1989][grinold-1989]; [Newey-West 1987][newey-west-1987] |
-| `individual_continuous(metric=FM)` | per-date OLS λₜ → NW HAC t on E[λ] | [Fama-MacBeth 1973][fama-macbeth-1973] |
-| `individual_sparse()` | per-event AR → CAAR → cross-event t | [Brown-Warner 1985][brown-warner-1985] |
-| `common_continuous()` | per-asset TS β → cross-asset t on E[β] | [Black-Jensen-Scholes 1972][black-jensen-scholes-1972] |
-| `common_sparse()` | per-asset TS β on dummy → cross-asset t | TS-β + event-study hybrid |
+| Factory | Run by `evaluate()` | Procedure | Literature |
+|---------|---------------------|-----------|------------|
+| `individual_continuous(metric=IC)` | [`ic`][factrix.metrics.ic] | per-date Spearman ρ → NW HAC t on E[IC] | [Grinold 1989][grinold-1989]; [Newey-West 1987][newey-west-1987] |
+| `individual_continuous(metric=FM)` | [`fama_macbeth`][factrix.metrics.fama_macbeth] | per-date OLS λₜ → NW HAC t on E[λ] | [Fama-MacBeth 1973][fama-macbeth-1973] |
+| `individual_sparse()` | [`caar`][factrix.metrics.caar] | per-event AR → CAAR → cross-event t | [Brown-Warner 1985][brown-warner-1985] |
+| `common_continuous()` | [`ts_beta`][factrix.metrics.ts_beta] | per-asset TS β → cross-asset t on E[β] | [Black-Jensen-Scholes 1972][black-jensen-scholes-1972] |
+| `common_sparse()` | [`ts_beta`][factrix.metrics.ts_beta] | per-asset TS β on dummy → cross-asset t | TS-β + event-study hybrid |
+
+For the cell-keyed (rather than factory-keyed) reverse-index — including
+the dispatch cells single-asset paths route to — see
+[Metric applicability § Cell to evaluate-metric](../reference/metric-applicability.md#cell-to-evaluate-metric).
 
 ## Mode: PANEL vs TIMESERIES
 

--- a/docs/guides/choosing-metric.md
+++ b/docs/guides/choosing-metric.md
@@ -36,4 +36,4 @@ For the lookup table — which metrics are supported under which `(scope, signal
 | BHY family input (needs [`FactorProfile`][factrix.FactorProfile]) | Multi-statistic decomposition |
 | Primary screening gate | OOS decay, tradability, concentration |
 
-See [Metric pipelines](../reference/standalone-metrics.md) for the full module list.
+See [Metric pipelines](../reference/metric-pipelines.md) for the full module list.

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -33,7 +33,7 @@ still well-defined; `individual_continuous` at N=1 has no cross-section to
 aggregate over, so it raises. The `cs-first` / `ts-first` / `ts-only` /
 `static-cs` / `per-event` shorthand is the canonical vocabulary used across
 the metric matrix and `list_metrics()` output — see
-[Reference § Metric pipelines § Aggregation vocabulary](../reference/standalone-metrics.md#aggregation-vocabulary).
+[Reference § Metric pipelines § Aggregation vocabulary](../reference/metric-pipelines.md#aggregation-vocabulary).
 
 Full per-procedure pseudocode for all 7 registered pipelines lives in [Development § Procedure pipelines](../development/architecture.md#procedure-pipelines).
 

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -27,7 +27,7 @@ realised returns).
 
 For the cross-module matrix (every module, aggregation pattern,
 inference SE), see
-[Reference § Metric pipelines](../reference/standalone-metrics.md).
+[Reference § Metric pipelines](../reference/metric-pipelines.md).
 For the `(scope, signal)` filter at runtime, see
 [`list_metrics`](../api/list-metrics.md).
 

--- a/docs/reference/_generated_evaluate_metric_table.md
+++ b/docs/reference/_generated_evaluate_metric_table.md
@@ -1,9 +1,9 @@
-| Cell `(scope, signal, metric, mode)` | Run by `evaluate()` | Procedure summary | Literature |
+| Dispatch key `(scope, signal, metric, mode)` | Run by `evaluate()` | Procedure summary | Literature |
 |---|---|---|---|
-| `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | [`ic`][factrix.metrics.ic] | Per-date Spearman IC across the asset cross-section. | Grinold (1989), Newey & West (1987) |
-| `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | [`fama_macbeth`][factrix.metrics.fama_macbeth] | Fama-MacBeth λ on per-date OLS slope. | Fama & MacBeth (1973), Petersen (2009) |
-| `(INDIVIDUAL, SPARSE, *, PANEL)` | [`caar`][factrix.metrics.caar] | Cross-event CAAR with t-test on per-event AR aggregate. | Brown & Warner (1985), MacKinlay (1997) |
-| `(COMMON, CONTINUOUS, *, PANEL)` | [`ts_beta`][factrix.metrics.ts_beta] | Per-asset β on broadcast factor + cross-asset t on E[β]. | Black, Jensen & Scholes (1972), Fama & French (1993) |
-| `(COMMON, SPARSE, *, PANEL)` | [`ts_beta`][factrix.metrics.ts_beta] | Per-asset β on broadcast event dummy + cross-asset t. | MacKinlay (1997) |
-| `(COMMON, CONTINUOUS, *, TIMESERIES)` | [`ts_beta`][factrix.metrics.ts_beta] | Single-asset OLS β on broadcast factor + NW HAC SE. | Newey & West (1987, 1994), Stambaugh (1999) |
-| `(*, SPARSE, *, TIMESERIES)` | [`ts_beta`][factrix.metrics.ts_beta] | Single-asset calendar-time TS dummy regression + NW HAC SE. | Newey & West (1994), Ljung & Box (1978) |
+| `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | [`ic`][factrix.metrics.ic.ic] | Per-date Spearman IC across the asset cross-section. | Grinold (1989), Newey & West (1987) |
+| `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | [`fama_macbeth`][factrix.metrics.fama_macbeth.fama_macbeth] | Fama-MacBeth λ on per-date OLS slope. | Fama & MacBeth (1973), Petersen (2009) |
+| `(INDIVIDUAL, SPARSE, *, PANEL)` | [`caar`][factrix.metrics.caar.caar] | Cross-event CAAR with t-test on per-event AR aggregate. | Brown & Warner (1985), MacKinlay (1997) |
+| `(COMMON, CONTINUOUS, *, PANEL)` | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | Per-asset β on broadcast factor + cross-asset t on E[β]. | Black, Jensen & Scholes (1972), Fama & French (1993) |
+| `(COMMON, SPARSE, *, PANEL)` | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | Per-asset β on broadcast event dummy + cross-asset t. | MacKinlay (1997) |
+| `(COMMON, CONTINUOUS, *, TIMESERIES)` | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | Single-asset OLS β on broadcast factor + NW HAC SE. | Newey & West (1987, 1994), Stambaugh (1999) |
+| `(*, SPARSE, *, TIMESERIES)` | [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | Single-asset calendar-time TS dummy regression + NW HAC SE. | Newey & West (1994), Ljung & Box (1978) |

--- a/docs/reference/_generated_evaluate_metric_table.md
+++ b/docs/reference/_generated_evaluate_metric_table.md
@@ -1,0 +1,9 @@
+| Cell `(scope, signal, metric, mode)` | Run by `evaluate()` | Procedure summary | Literature |
+|---|---|---|---|
+| `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | [`ic`][factrix.metrics.ic] | Per-date Spearman IC across the asset cross-section. | Grinold (1989), Newey & West (1987) |
+| `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | [`fama_macbeth`][factrix.metrics.fama_macbeth] | Fama-MacBeth λ on per-date OLS slope. | Fama & MacBeth (1973), Petersen (2009) |
+| `(INDIVIDUAL, SPARSE, *, PANEL)` | [`caar`][factrix.metrics.caar] | Cross-event CAAR with t-test on per-event AR aggregate. | Brown & Warner (1985), MacKinlay (1997) |
+| `(COMMON, CONTINUOUS, *, PANEL)` | [`ts_beta`][factrix.metrics.ts_beta] | Per-asset β on broadcast factor + cross-asset t on E[β]. | Black, Jensen & Scholes (1972), Fama & French (1993) |
+| `(COMMON, SPARSE, *, PANEL)` | [`ts_beta`][factrix.metrics.ts_beta] | Per-asset β on broadcast event dummy + cross-asset t. | MacKinlay (1997) |
+| `(COMMON, CONTINUOUS, *, TIMESERIES)` | [`ts_beta`][factrix.metrics.ts_beta] | Single-asset OLS β on broadcast factor + NW HAC SE. | Newey & West (1987, 1994), Stambaugh (1999) |
+| `(*, SPARSE, *, TIMESERIES)` | [`ts_beta`][factrix.metrics.ts_beta] | Single-asset calendar-time TS dummy regression + NW HAC SE. | Newey & West (1994), Ljung & Box (1978) |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -108,6 +108,26 @@ specific contracts that apply when factrix routes here.
 
 ## Other terms
 
+### the metric `evaluate()` runs
+
+Every `(scope, signal, metric, mode)` dispatch cell maps to exactly one
+metric callable that [`evaluate()`](../api/evaluate.md) runs internally
+— `ic`, `fama_macbeth`, `caar`, or `ts_beta` — and that metric's
+p-value becomes [`FactorProfile.primary_p`](../api/factor-profile.md).
+Defined by the
+`factrix._registry._DISPATCH_REGISTRY`. Other metrics applicable to
+the same cell are called separately via
+[`list_metrics`](../api/list-metrics.md) and the per-metric callable;
+they do not enter the `FactorProfile`.
+
+The cell-keyed reverse-index lives at
+[Metric applicability § Cell to evaluate-metric](metric-applicability.md#cell-to-evaluate-metric).
+
+**Legacy synonyms** (pre-#144 docs and source comments): `procedure-canonical`,
+`cell-canonical`, `primary metric`, `canonical metric`. New content uses the
+behavioral phrasing above; legacy occurrences are phased out via the ratchet
+test in `tests/test_docs_terminology_ratchet.py` so the count can only decrease.
+
 ### `factor`
 
 The signal column. Same role as Alphalens "factor", Barra "exposure",

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -1,5 +1,10 @@
 # Metric applicability
 
+!!! abstract "Answers"
+    Can my data run this? — applicability gates and sample-size thresholds per metric.
+    For computation pipeline (aggregation order, inference SE), see [Metric pipelines](metric-pipelines.md).
+    For output schema and metadata keys, see [Stat keys by metric](stat-keys-by-metric.md).
+
 A single matrix that maps each public metric to the analysis cell
 where it is in scope, the canonical inferential role it plays in
 that cell, and the sample-size threshold that gates it. Per-metric
@@ -7,9 +12,20 @@ formulae, parameters, and Notes / References live in the
 [Metrics API pages](../api/metrics/index.md); this page is the
 cross-metric overview. For the runtime API that returns the per-cell
 metric list programmatically, see
-[`list_metrics`](../api/list-metrics.md). For the schema of the
-`MetricOutput` each metric returns — primary vs auxiliary
-`metadata` keys — see [Stat keys by metric](stat-keys-by-metric.md).
+[`list_metrics`](../api/list-metrics.md).
+
+## Cell to evaluate-metric
+
+Each `(scope, signal, metric, mode)` cell maps to exactly one metric
+that [`evaluate()`](../api/evaluate.md) runs. This section is the
+cell-keyed reverse-index; the rest of the page is metric-keyed.
+
+--8<-- "docs/reference/_generated_evaluate_metric_table.md"
+
+Cells absent from the table raise `ModeAxisError` (e.g.
+`(INDIVIDUAL, CONTINUOUS) × TIMESERIES`); `(SPARSE × TIMESERIES)`
+collapses scope and tags `InfoCode.SCOPE_AXIS_COLLAPSED` — see
+[TIMESERIES-mode conventions](ts-mode-conventions.md).
 
 ## Sample dimensions
 

--- a/docs/reference/metric-pipelines.md
+++ b/docs/reference/metric-pipelines.md
@@ -1,17 +1,23 @@
 # Metric pipelines
 
+!!! abstract "Answers"
+    How is each metric computed — aggregation order, inference SE machinery.
+    For applicability gates and sample thresholds, see [Metric applicability](metric-applicability.md).
+    For output schema and metadata keys, see [Stat keys by metric](stat-keys-by-metric.md).
+
 Cross-module index of every module under `factrix/metrics/`. Use this
 page to pick the existing aggregation pattern a new metric should
 match, or to mechanically check that a candidate metric satisfies the
 [NW HAC discipline](statistical-methods.md) the rest of the suite
 follows.
 
-The matrix lists **all** metric modules — both the procedure-canonical
-primaries that `evaluate()` invokes internally
-(`ic`, `fama_macbeth`, `caar`, `ts_beta`) and the standalone helpers
-the user calls directly on a `FactorProfile` (`quantile`, `monotonicity`,
-`tradability`, `clustering`, `corrado`, …). The
-[`list_metrics`](../api/list-metrics.md) runtime API filters this same
+The matrix lists **all** metric modules — both the metrics
+[`evaluate()`](../api/evaluate.md) runs for each cell
+(`ic`, `fama_macbeth`, `caar`, `ts_beta`; see the
+[evaluate-metric table](metric-applicability.md#cell-to-evaluate-metric))
+and the standalone helpers the user calls directly on a `FactorProfile`
+(`quantile`, `monotonicity`, `tradability`, `clustering`, `corrado`, …).
+The [`list_metrics`](../api/list-metrics.md) runtime API filters this same
 data to the standalone subset by `(scope, signal)`.
 
 The table below is auto-generated from `Matrix-row:` tags in each module's

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -1,17 +1,19 @@
 # Stat keys by metric
 
-Per-metric schema of the [`MetricOutput`](../api/metric-output.md)
-returned by every public callable in `factrix.metrics` — which
-`metadata` key is the primary inference target, which are auxiliary,
-and what the headline `MetricOutput.stat` carries.
+!!! abstract "Answers"
+    `MetricOutput` schema — which `metadata` key is the primary inference target, which are auxiliary, what the headline `stat` carries.
+    For applicability gates, see [Metric applicability](metric-applicability.md).
+    For computation pipeline, see [Metric pipelines](metric-pipelines.md).
 
-For "is this metric in scope for my cell" see
-[Metric applicability](metric-applicability.md). For the SE / test
-machinery itself see [Statistical methods](statistical-methods.md).
-For the `MetricOutput.name` → docs-page reverse index see
+Per-metric schema of the [`MetricOutput`](../api/metric-output.md)
+returned by every public callable in `factrix.metrics`.
+
+For the SE / test machinery itself see
+[Statistical methods](statistical-methods.md). For the
+`MetricOutput.name` → docs-page reverse index see
 [`MetricOutput`](../api/metric-output.md#name-index). The
-`evaluate()` procedure-canonical equivalent — `FactorProfile.stats`
-keyed by `StatCode` — lives at
+`evaluate()`-side equivalent — `FactorProfile.stats` keyed by
+`StatCode` — lives at
 [`FactorProfile` § `stats` keys by cell](../api/factor-profile.md#stats-keys-by-cell).
 
 `metadata` keys are tagged by role in the per-metric subsections

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -739,40 +739,47 @@ register(
     _ICContPanelProcedure(),
     use_case="Per-date Spearman IC across the asset cross-section.",
     refs=("Grinold (1989)", "Newey & West (1987)"),
+    evaluate_metric_name="ic",
 )
 register(
     _DispatchKey(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.FM, Mode.PANEL),
     _FMContPanelProcedure(),
     use_case="Fama-MacBeth λ on per-date OLS slope.",
     refs=("Fama & MacBeth (1973)", "Petersen (2009)"),
+    evaluate_metric_name="fama_macbeth",
 )
 register(
     _DispatchKey(FactorScope.INDIVIDUAL, Signal.SPARSE, None, Mode.PANEL),
     _CAARSparsePanelProcedure(),
     use_case="Cross-event CAAR with t-test on per-event AR aggregate.",
     refs=("Brown & Warner (1985)", "MacKinlay (1997)"),
+    evaluate_metric_name="caar",
 )
 register(
     _DispatchKey(FactorScope.COMMON, Signal.CONTINUOUS, None, Mode.PANEL),
     _CommonContPanelProcedure(),
     use_case="Per-asset β on broadcast factor + cross-asset t on E[β].",
     refs=("Black, Jensen & Scholes (1972)", "Fama & French (1993)"),
+    evaluate_metric_name="ts_beta",
 )
 register(
     _DispatchKey(FactorScope.COMMON, Signal.SPARSE, None, Mode.PANEL),
     _CommonSparsePanelProcedure(),
     use_case="Per-asset β on broadcast event dummy + cross-asset t.",
     refs=("MacKinlay (1997)",),
+    evaluate_metric_name="ts_beta",
 )
 register(
     _DispatchKey(FactorScope.COMMON, Signal.CONTINUOUS, None, Mode.TIMESERIES),
     _TSBetaContTimeseriesProcedure(),
     use_case="Single-asset OLS β on broadcast factor + NW HAC SE.",
     refs=("Newey & West (1987, 1994)", "Stambaugh (1999)"),
+    evaluate_metric_name="ts_beta",
 )
 register(
     _DispatchKey(_SCOPE_COLLAPSED, Signal.SPARSE, None, Mode.TIMESERIES),
     _TSDummySparseTimeseriesProcedure(),
     use_case="Single-asset calendar-time TS dummy regression + NW HAC SE.",
     refs=("Newey & West (1994)", "Ljung & Box (1978)"),
+    evaluate_metric_name="ts_beta",
 )

--- a/factrix/_registry.py
+++ b/factrix/_registry.py
@@ -52,11 +52,15 @@ class _RegistryEntry:
 
     ``canonical_use_case`` and ``references`` feed
     ``describe_analysis_modes()`` directly — no parallel docs table.
+    ``evaluate_metric_name`` names the standalone metric callable that
+    backs this cell's procedure and powers the build-time
+    evaluate-metric reference table.
     """
 
     key: _DispatchKey
     procedure: FactorProcedure
     canonical_use_case: str
+    evaluate_metric_name: str
     references: tuple[str, ...] = field(default_factory=tuple)
 
 
@@ -69,6 +73,7 @@ def register(
     *,
     use_case: str,
     refs: tuple[str, ...] = (),
+    evaluate_metric_name: str,
 ) -> None:
     """Register a procedure under ``key``.
 
@@ -92,6 +97,7 @@ def register(
         procedure=procedure,
         canonical_use_case=use_case,
         references=refs,
+        evaluate_metric_name=evaluate_metric_name,
     )
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,7 +142,7 @@ nav:
   - Reference:
       - Glossary: reference/glossary.md
       - Metric applicability: reference/metric-applicability.md
-      - Metric pipelines: reference/standalone-metrics.md
+      - Metric pipelines: reference/metric-pipelines.md
       - Stat keys by metric: reference/stat-keys-by-metric.md
       - Statistical methods: reference/statistical-methods.md
       - TIMESERIES-mode conventions: reference/ts-mode-conventions.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ hooks:
   - scripts/mkdocs_hooks/gen_metric_name_index.py
   # factrix/_registry._DISPATCH_REGISTRY -> docs/development/_generated_registry_cells.md
   - scripts/mkdocs_hooks/gen_registry_cells.py
+  # factrix/_registry._DISPATCH_REGISTRY -> docs/reference/_generated_evaluate_metric_table.md
+  - scripts/mkdocs_hooks/gen_evaluate_metric_table.py
   # examples/*.ipynb -> docs/examples/
   - scripts/mkdocs_hooks/sync_examples.py
   # factrix/llms*.txt -> site root llms*.txt

--- a/scripts/mkdocs_hooks/gen_evaluate_metric_table.py
+++ b/scripts/mkdocs_hooks/gen_evaluate_metric_table.py
@@ -1,0 +1,69 @@
+"""Build-time generator for the cell -> ``evaluate()``-metric reference table.
+
+Renders a Markdown table to
+``docs/reference/_generated_evaluate_metric_table.md`` from
+``factrix._registry._DISPATCH_REGISTRY`` and the
+``factrix._metric_index.user_facing_rows`` import-path index.
+
+Usage (manual)::
+
+    python scripts/mkdocs_hooks/gen_evaluate_metric_table.py
+
+MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
+
+    The ``on_pre_build(config)`` function is called by MkDocs before
+    each build.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from factrix._metric_index import user_facing_rows
+from factrix._registry import (
+    _DISPATCH_REGISTRY,
+    _SCOPE_COLLAPSED,
+    _DispatchKey,
+    _RegistryEntry,
+)
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+_OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_evaluate_metric_table.md"
+
+_TABLE_HEADER = (
+    "| Cell `(scope, signal, metric, mode)` | Run by `evaluate()` | "
+    "Procedure summary | Literature |\n|---|---|---|---|\n"
+)
+
+
+def _format_cell(key: _DispatchKey) -> str:
+    scope = "*" if key.scope is _SCOPE_COLLAPSED else key.scope.name
+    metric = key.metric.name if key.metric is not None else "*"
+    return f"({scope}, {key.signal.name}, {metric}, {key.mode.name})"
+
+
+def _render_row(entry: _RegistryEntry, import_path_by_name: dict[str, str]) -> str:
+    cell = _format_cell(entry.key)
+    name = entry.evaluate_metric_name
+    metric = f"[`{name}`][{import_path_by_name[name]}]"
+    refs = ", ".join(entry.references) if entry.references else "—"
+    return f"| `{cell}` | {metric} | {entry.canonical_use_case} | {refs} |\n"
+
+
+def generate() -> None:
+    """Generate ``_generated_evaluate_metric_table.md`` from the registry."""
+    import_path_by_name = {row.name: row.import_path for row in user_facing_rows()}
+    entries = list(_DISPATCH_REGISTRY.values())
+    lines = [_TABLE_HEADER, *(_render_row(e, import_path_by_name) for e in entries)]
+    _OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _OUT_FILE.write_text("".join(lines), encoding="utf-8")
+    print(f"gen_evaluate_metric_table: wrote {len(entries)} row(s) to {_OUT_FILE}")
+
+
+def on_pre_build(config: object) -> None:
+    """MkDocs hook: regenerate the evaluate-metric table before every build."""
+    generate()
+
+
+if __name__ == "__main__":
+    generate()

--- a/scripts/mkdocs_hooks/gen_evaluate_metric_table.py
+++ b/scripts/mkdocs_hooks/gen_evaluate_metric_table.py
@@ -31,7 +31,7 @@ _REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_evaluate_metric_table.md"
 
 _TABLE_HEADER = (
-    "| Cell `(scope, signal, metric, mode)` | Run by `evaluate()` | "
+    "| Dispatch key `(scope, signal, metric, mode)` | Run by `evaluate()` | "
     "Procedure summary | Literature |\n|---|---|---|---|\n"
 )
 
@@ -45,7 +45,10 @@ def _format_cell(key: _DispatchKey) -> str:
 def _render_row(entry: _RegistryEntry, import_path_by_name: dict[str, str]) -> str:
     cell = _format_cell(entry.key)
     name = entry.evaluate_metric_name
-    metric = f"[`{name}`][{import_path_by_name[name]}]"
+    # Function-level mkdocstrings ID lands the cold reader on the metric
+    # callable's API page, not the module index — symmetric with
+    # metric-applicability and stat-keys-by-metric tables.
+    metric = f"[`{name}`][{import_path_by_name[name]}.{name}]"
     refs = ", ".join(entry.references) if entry.references else "—"
     return f"| `{cell}` | {metric} | {entry.canonical_use_case} | {refs} |\n"
 

--- a/tests/test_docs_matrix.py
+++ b/tests/test_docs_matrix.py
@@ -22,6 +22,9 @@ import pytest
 METRICS_DIR = pathlib.Path("factrix/metrics")
 GENERATED_MATRIX = pathlib.Path("docs/reference/_generated_metric_matrix.md")
 GENERATED_NAME_INDEX = pathlib.Path("docs/reference/_generated_metric_name_index.md")
+GENERATED_EVALUATE_METRIC = pathlib.Path(
+    "docs/reference/_generated_evaluate_metric_table.md"
+)
 
 _MATRIX_ROW_RE = re.compile(r"^\s*Matrix-row:\s*(.+)$", re.MULTILINE)
 
@@ -158,5 +161,37 @@ def test_generated_name_index_matches_renderer() -> None:
     assert actual == expected, (
         f"{GENERATED_NAME_INDEX} is stale — re-run "
         "'python scripts/mkdocs_hooks/gen_metric_name_index.py' "
+        "(or 'mkdocs build') to regenerate."
+    )
+
+
+def test_generated_evaluate_metric_table_matches_renderer() -> None:
+    """Generated evaluate-metric table must match what the renderer produces.
+
+    Drift guard for #144: catches a stale checked-in file that no longer
+    reflects ``_DISPATCH_REGISTRY`` (e.g. a cell was added but mkdocs
+    wasn't rerun before commit).
+    """
+    if not GENERATED_EVALUATE_METRIC.exists():
+        pytest.skip(
+            f"{GENERATED_EVALUATE_METRIC} not found — run "
+            "'python scripts/mkdocs_hooks/gen_evaluate_metric_table.py' "
+            "or 'mkdocs build' first."
+        )
+    from factrix._metric_index import user_facing_rows
+    from factrix._registry import _DISPATCH_REGISTRY
+    from scripts.mkdocs_hooks.gen_evaluate_metric_table import (
+        _TABLE_HEADER,
+        _render_row,
+    )
+
+    import_path_by_name = {r.name: r.import_path for r in user_facing_rows()}
+    expected = _TABLE_HEADER + "".join(
+        _render_row(e, import_path_by_name) for e in _DISPATCH_REGISTRY.values()
+    )
+    actual = GENERATED_EVALUATE_METRIC.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"{GENERATED_EVALUATE_METRIC} is stale — re-run "
+        "'python scripts/mkdocs_hooks/gen_evaluate_metric_table.py' "
         "(or 'mkdocs build') to regenerate."
     )

--- a/tests/test_docs_terminology_ratchet.py
+++ b/tests/test_docs_terminology_ratchet.py
@@ -1,0 +1,75 @@
+"""Ratchet on legacy "the metric `evaluate()` runs" tier-name synonyms.
+
+Issue #144 settled the term to a behavioral phrase and listed the older
+synonyms as legacy in ``docs/reference/glossary.md``. The synonyms are
+not big-bang renamed; instead this ratchet asserts that the count can
+only decrease over time, so any PR that touches a file containing one
+must replace the term in that diff.
+
+When the floor reaches a small number (~5), open a follow-up issue for
+a single sweep PR that removes the remainder and deletes the legacy-
+synonyms note in the glossary.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_LEGACY_PATTERN = re.compile(r"procedure-canonical|cell-canonical|canonical metric")
+
+# Files / trees the ratchet ignores.
+#
+# - ``docs/plans/archive/`` is frozen historical drafts.
+# - ``docs/reference/glossary.md`` defines the legacy synonyms for #144;
+#   it must mention them.
+# - This test file itself names the pattern.
+_EXCLUDE_PATHS = (
+    _REPO_ROOT / "docs" / "plans" / "archive",
+    _REPO_ROOT / "docs" / "reference" / "glossary.md",
+    Path(__file__).resolve(),
+)
+
+_SCAN_DIRS = (
+    _REPO_ROOT / "docs",
+    _REPO_ROOT / "factrix",
+)
+
+_SCAN_SUFFIXES = {".md", ".py", ".txt"}
+
+# Frozen baseline at #144 batch 4 merge. PRs may only decrease.
+_BASELINE = 17
+
+
+def _legacy_hits() -> int:
+    total = 0
+    for root in _SCAN_DIRS:
+        for path in root.rglob("*"):
+            if path.suffix not in _SCAN_SUFFIXES:
+                continue
+            if any(
+                path == ex or (ex.is_dir() and ex in path.parents)
+                for ex in _EXCLUDE_PATHS
+            ):
+                continue
+            text = path.read_text(encoding="utf-8")
+            total += len(_LEGACY_PATTERN.findall(text))
+    return total
+
+
+def test_legacy_terminology_ratchet() -> None:
+    hits = _legacy_hits()
+    assert hits <= _BASELINE, (
+        f"legacy 'evaluate()-metric' synonyms increased from {_BASELINE} "
+        f"to {hits}. Replace the new occurrences with the behavioral phrase "
+        f"per docs/reference/glossary.md § the metric `evaluate()` runs."
+    )
+    if hits < _BASELINE:
+        # Soft note (not a failure) so the next PR author sees the floor
+        # to decrement in tests/test_docs_terminology_ratchet.py.
+        print(
+            f"\nLegacy 'evaluate()-metric' synonyms: {hits} (baseline {_BASELINE}). "
+            f"Decrement _BASELINE to {hits} in this PR."
+        )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -123,6 +123,7 @@ class TestRegisterIdempotency:
                 existing_key,
                 _NoopProcedure(),
                 use_case="dup",
+                evaluate_metric_name="dup",
             )
 
 
@@ -435,7 +436,12 @@ class TestRegisterSentinelMetricGuard:
             Mode.TIMESERIES,
         )
         with pytest.raises(ValueError, match="metric=None"):
-            register(bad_key, _Stub(), use_case="illegal — should never land")
+            register(
+                bad_key,
+                _Stub(),
+                use_case="illegal — should never land",
+                evaluate_metric_name="illegal",
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements #144 — restructures the metric reference section so each page answers a distinct cold-reader question, and locks the cell→evaluate-metric mapping to a single SSOT.

- New build-time generator `scripts/mkdocs_hooks/gen_evaluate_metric_table.py` emits `_generated_evaluate_metric_table.md` from `_DISPATCH_REGISTRY`. `_RegistryEntry` gains `evaluate_metric_name` set at registration; registry and docs cannot drift.
- `reference/standalone-metrics.md` → `reference/metric-pipelines.md` (slug ↔ nav title now agree).
- Three reference pages each gain an "Answers: X" admonition: applicability (sample thresholds), pipelines (computation), stat-keys (output schema). Cross-links symmetric.
- `metric-applicability.md` hosts the cell-keyed reverse-index via `--8<--` include.
- `concepts.md` "Five analysis scenarios" table gains a "Run by `evaluate()`" column with function-level mkdocstrings IDs.
- `glossary.md` defines "the metric `evaluate()` runs" behaviorally; lists `procedure-canonical` / `cell-canonical` / `primary metric` / `canonical metric` as legacy synonyms.
- `tests/test_docs_terminology_ratchet.py` freezes the legacy-term count at 17 — PRs may only decrease.
- Drift guard `test_generated_evaluate_metric_table_matches_renderer` added to `test_docs_matrix.py` so the registry-SSOT claim is test-backed.

## Deferred from the original DoD

Two items in #144's DoD were intentionally not implemented in this branch — each warrants its own decision rather than scope creep:

- **`FactorScope.__str__` / `pretty_cell()` helper.** The generator inlines the same `(SCOPE, SIGNAL, METRIC, MODE)` form already used by `Matrix-row:` tags. Extracting a helper now would be premature; revisit if a third generator ever needs cell rendering.
- **Reference dispatch hub `index.md`.** The per-page "Answers: X" admonitions substitute, with the dispatch semantics inline at the point of need rather than centralised. A hub page is still possible later, but the admonitions deliver the cold-reader navigation value with less indirection.

## Test plan

- [x] `pytest tests/` — 873 passed (incl. new ratchet + drift guard)
- [x] `mkdocs build` — no warnings (autorefs resolves all function-level mkdocstrings IDs)
- [x] Drift guard rejects stale generated file (manually verified by reverting one row)
- [ ] Reviewer: visit `/reference/metric-applicability/#cell-to-evaluate-metric` and confirm the 7-row table renders + each metric link lands on the function API page

Closes #144
