### PR TITLE
docs: hoist high-value gotchas to admonitions

### DIFF
--- a/docs/api/metrics/series-tools.md
+++ b/docs/api/metrics/series-tools.md
@@ -5,10 +5,10 @@ produced by an upstream cell metric — IC time series, $\beta$ time
 series, CAAR time series, an external factor return, etc. They do not
 care which cell produced the series.
 
-> *Not the same as `Mode.TIMESERIES`.* `Mode.TIMESERIES` is the
-> dispatch regime for `n_assets == 1` (set on `FactorProfile.mode`);
-> the metrics on this page run on a `(date, value)` series regardless
-> of which mode produced it.
+!!! warning "Not the same as `Mode.TIMESERIES`"
+    `Mode.TIMESERIES` is the dispatch regime for `n_assets == 1` (set on
+    `FactorProfile.mode`); the metrics on this page run on a
+    `(date, value)` series regardless of which mode produced it.
 
 | Metric | Role | Page |
 |---|---|---|

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -30,11 +30,12 @@ Edit from the downstream workspace (`factor-analysis`) under
 `external/factorlib/`—you can change factrix and observe the effect in
 a real research notebook simultaneously:
 
-> **Note**: the submodule directory name on disk depends on the parent
-> workspace's `.gitmodules` setting; the actual path is currently
-> **`external/factorlib/`**. Once the parent workspace renames the
-> submodule path, it will become `external/factrix/`. Commands below
-> follow the current on-disk path.
+!!! note "Submodule path"
+    The submodule directory name on disk depends on the parent workspace's
+    `.gitmodules` setting; the actual path is currently
+    **`external/factorlib/`**. Once the parent workspace renames the
+    submodule path, it will become `external/factrix/`. Commands below
+    follow the current on-disk path.
 
 ```bash
 cd ~/Desktop/dst/code/factor-analysis
@@ -75,13 +76,14 @@ uv sync --extra charts               # +plotly for charts
 uv sync --all-extras                 # charts + mlflow + jupyter (feature extras)
 ```
 
-> **Note**: the `dev` extra is **not** part of `all` (toolchain and
-> feature extras are deliberately separated), so `--all-extras` does
-> **not** install pytest / commitizen. Developers should use:
->
-> ```bash
-> uv sync --all-extras --extra dev   # feature extras + dev tools in one shot
-> ```
+!!! note "`dev` extra is separate from `all`"
+    The `dev` extra is **not** part of `all` (toolchain and feature extras
+    are deliberately separated), so `--all-extras` does **not** install
+    pytest / commitizen. Developers should use:
+
+    ```bash
+    uv sync --all-extras --extra dev   # feature extras + dev tools in one shot
+    ```
 
 ### Common environment commands
 ```bash
@@ -151,13 +153,13 @@ gh pr create --title "..." --body "..."
 gh pr merge --squash
 ```
 
-> **Important**: do **not** run `cz bump` after merge. Versions and tags
-> follow the release-train cadence (see §9)—a single release fires after
-> several PRs accumulate. Each PR writes its own changes into the
-> `## [Unreleased]` section of `CHANGELOG.md` (under `### Added` /
-> `### Changed` / `### Fixed` / `### Migration` subsections as
-> applicable); at release time, `cz bump --changelog` freezes that
-> section into the next version heading.
+!!! warning "Do not run `cz bump` after merge"
+    Versions and tags follow the release-train cadence (see §9) — a single
+    release fires after several PRs accumulate. Each PR writes its own
+    changes into the `## [Unreleased]` section of `CHANGELOG.md` (under
+    `### Added` / `### Changed` / `### Fixed` / `### Migration` subsections
+    as applicable); at release time, `cz bump --changelog` freezes that
+    section into the next version heading.
 
 **CHANGELOG formatting**: paragraphs and bullets are not hard-wrapped — each paragraph is one line, each bullet one line. The 72-char wrap convention applies to commit messages, not to CHANGELOG prose; GitHub Release notes treat single newlines as `<br>`, so source-level wrapping leaks into the rendered output. Aligns with Polars / ruff / Pydantic.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -505,6 +505,21 @@ PR (no CI gate):
 PR self-check: run all three code blocks, `uv run mkdocs build
 --strict` clean, `tiktoken` cl100k count < 8000.
 
+### Docs callout conventions
+
+Use mkdocs-material admonitions to elevate content that breaks from the
+surrounding flow (different audience or different urgency). Default to
+plain prose; reach for a callout only when the elevation earns it.
+
+- `!!! abstract "Answers"` — top-of-page scope statement on reference pages.
+- `!!! warning` — gotcha / data-validity precondition the reader must check first; surface invariants whose violation breaks the analysis silently.
+- `!!! note` — orthogonal context that helps but isn't required (e.g. mode-axis edge cases).
+- `!!! info` — contract / convention block (e.g. event-study contracts, TS-mode conventions).
+- `!!! example` — minimal worked code that surrounding prose references.
+- `??? note "..."` (collapsible) — long content for a subset of readers (derivations, full enum tables).
+
+Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
+
 ---
 
 ## 9. Versioning and release (SemVer & Release)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,10 +1,10 @@
 # Quickstart
 
-> **`forward_periods` counts rows, not calendar time.** factrix is
-> frequency-agnostic — it only shifts row indices. `forward_periods=5` on a
-> daily panel means 5 trading days; on a weekly panel, 5 weeks. The caller is
-> responsible for ensuring the panel is sorted per asset and has regular time
-> spacing.
+!!! warning "`forward_periods` counts rows, not calendar time"
+    factrix is frequency-agnostic — it only shifts row indices.
+    `forward_periods=5` on a daily panel means 5 trading days; on a
+    weekly panel, 5 weeks. The caller is responsible for ensuring the
+    panel is sorted per asset and has regular time spacing.
 
 ## 30-second smoke test
 
@@ -49,10 +49,10 @@ The five supported research questions and their factory calls live in
 factory. For task-oriented help on **picking** the right factory (IC vs FM,
 when to add standalone metrics), see [Choosing a metric](../guides/choosing-metric.md).
 
-> **N = 1 (single asset / series):** `Mode` auto-switches to `TIMESERIES`. The
-> `common_continuous` and `*_sparse` factories work as-is.
-> `individual_continuous` at N=1 raises `ModeAxisError` with
-> `suggested_fix=common_continuous(...)`.
+!!! note "N = 1 (single asset / series)"
+    `Mode` auto-switches to `TIMESERIES`. The `common_continuous` and
+    `*_sparse` factories work as-is. `individual_continuous` at N=1 raises
+    `ModeAxisError` with `suggested_fix=common_continuous(...)`.
 
 ## `profile.diagnose()` and warnings
 

--- a/docs/guides/batch-screening.md
+++ b/docs/guides/batch-screening.md
@@ -1,6 +1,9 @@
 # Batch Screening with BHY
 
-BHY controls FDR **within a statistical family**: evaluate multiple candidate factors under the same procedure, then apply step-up correction on the resulting p-values. **Do not mix families** — p-values from IC / FM / TS-β carry different null distributions and cannot be pooled.
+BHY controls FDR **within a statistical family**: evaluate multiple candidate factors under the same procedure, then apply step-up correction on the resulting p-values.
+
+!!! warning "Do not mix families"
+    p-values from IC / FM / TS-β carry different null distributions and cannot be pooled. `bhy()` partitions automatically — see below — but if you assemble the input list yourself across procedures, the FDR guarantee breaks.
 
 ## Basic usage
 
@@ -15,7 +18,8 @@ survivors = fl.multi_factor.bhy(list(by_name.values()), threshold=0.05)
 survivor_names = [n for n, p in by_name.items() if any(p is s for s in survivors)]
 ```
 
-`FactorProfile` is a frozen dataclass with no `name` / `label` field — `bhy()` neither accepts nor returns one. Map survivors back to factor names by holding the `name → profile` dict yourself and comparing with `is` (identity), as above. Equality (`==`) is unsafe: two factors with coincident stats compare equal.
+!!! warning "Identity caveat — survivor → name mapping"
+    `FactorProfile` is a frozen dataclass with no `name` / `label` field; `bhy()` neither accepts nor returns one. Map survivors back to factor names by holding the `name → profile` dict yourself and comparing with `is` (identity), as in the snippet above. Equality (`==`) is unsafe: two factors with coincident stats compare equal.
 
 Each `evaluate` call repays the per-date cross-section overhead
 (sort / group-by / rank) on its own — that cost is intrinsic to
@@ -38,6 +42,8 @@ If any family degenerates to size=1 (typical misuse: one factor evaluated across
 | Bonferroni (`p × K`) | K small (≤ 5), horizons approximately independent |
 | Holm (step-down) | K larger, or p-values vary widely in strength |
 
-Do **not** use BHY as the inner procedure: (1) picking one representative p is a FWER problem, not FDR; (2) BHY ∘ BHY has no composition theorem; (3) for small K, BHY's `c(m)` factor makes it more conservative than Bonferroni.
+!!! warning "Do not use BHY as the inner procedure"
+    (1) Picking one representative p is a FWER problem, not FDR. (2) BHY ∘ BHY has no composition theorem. (3) For small K, BHY's `c(m)` factor makes it more conservative than Bonferroni anyway.
 
-> Do not flatten K factors × H horizons into K×H profiles and call `bhy()` directly. BHY partitions by horizon into H families of K — correct for "pick factors within each horizon" — but wrong for "pick best horizon per factor."
+!!! warning "Do not flatten K × H profiles into one `bhy()` call"
+    Flattening K factors × H horizons into K×H profiles and feeding them to `bhy()` directly is wrong. BHY partitions by horizon into H families of K — correct for "pick factors within each horizon" — but wrong for "pick best horizon per factor."

--- a/docs/guides/regime-analysis.md
+++ b/docs/guides/regime-analysis.md
@@ -13,7 +13,8 @@ Regime analysis asks "is this factor stable across market environments?" — a d
 
 **Use Layer B when:** a curated wrapper exists for your metric and the bundled second-layer test matches your research question.
 
-> **Layer B coverage as of v0.9.0:** only [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) ships. `regime_caar` and `regime_fama_macbeth` are tracked in [#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107). Until then, `by_regime(compute_caar, df, ...)` and `by_regime(fama_macbeth, df, ...)` return per-regime values without a cross-regime statistic — useful for descriptive comparison, not for inference.
+!!! info "Layer B coverage as of v0.9.0"
+    Only [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) ships. `regime_caar` and `regime_fama_macbeth` are tracked in [#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107). Until then, `by_regime(compute_caar, df, ...)` and `by_regime(fama_macbeth, df, ...)` return per-regime values without a cross-regime statistic — useful for descriptive comparison, not for inference.
 
 ## Why no generic cross-regime test
 


### PR DESCRIPTION
## Summary

Hoist 9 inline blockquote / bold-prose callouts across the docs to mkdocs-material admonitions. Codify the vocabulary in `CONTRIBUTING § Docs callout conventions` so future content applies the same shapes opportunistically.

## What changed

| Page | Callout | Type |
|---|---|---|
| `quickstart.md` | `forward_periods` row-vs-time | `!!! warning` |
| `quickstart.md` | N=1 mode-switch | `!!! note` |
| `batch-screening.md` | Do not mix families | `!!! warning` |
| `batch-screening.md` | Identity caveat (survivor → name) | `!!! warning` |
| `batch-screening.md` | Do not use BHY as inner | `!!! warning` |
| `batch-screening.md` | Do not flatten K × H profiles | `!!! warning` |
| `regime-analysis.md` | Layer B v0.9.0 coverage | `!!! info` |
| `series-tools.md` | Not the same as `Mode.TIMESERIES` | `!!! warning` |
| `contributing.md` | Submodule path / `dev` extra / `cz bump` after merge | `!!! note` × 2 + `!!! warning` |

`series-tools.md` is the highest-value of the set — the page topic name collides with `Mode.TIMESERIES`, the single most likely thing a reader misreads.

## Scope discipline

Pages where prose was already clear (concepts, choosing-metric, panel-timeseries, all per-metric API pages) were left untouched — adding admonitions there would have been bikeshed. The new CONTRIBUTING entry is explicit that retrofit happens only when a paragraph already qualifies.

## Drift risk

None. `factrix/llms-full.txt` (parallel plain-text track), `_generated_*.md` (registry-driven), `pymdownx.snippets` includes, `_doc_validation.py` (regex on factrix references), and mkdocs autorefs/search all operate independently of the markdown callout syntax. Switching `> ` → `!!!` is a render-layer change with no automation downstream.

## Test plan

- [x] `mkdocs build` clean (no warnings, all autorefs resolve)
- [x] `pytest tests/` — 873 passed
- [x] Zero remaining `> **Note**` / `> **Warning**` / `> **Important**` blockquotes in active docs
- [ ] Reviewer: visit `/getting-started/quickstart/`, `/guides/batch-screening/`, `/api/metrics/series-tools/` and confirm the boxes render as expected
