### PR TITLE
docs(reference): split metric matrix by family (#142)

### DIFF
--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -44,52 +44,89 @@ factrix expresses sample size on three axes (see
 procedure in either Mode; the metric's applicability does not change
 across Modes, only the sample axis that constrains it.
 
-## Cross-metric matrix
+## Other metrics by family
 
-`MIN_*` constants in the `Min sample` column resolve to values in the
-[Sample-size constants table](#sample-size-constants) below.
+Primary metrics (`ic`, `fama_macbeth`, `caar`, `ts_beta`) are the SSOT
+in the [primary table](#cell-to-evaluate-metric) above. The remaining
+metrics group by family below; the section heading carries the cell
+context, so each per-row schema reduces to *Metric / Sample axis /
+Min sample*. `MIN_*` constants resolve to values in the
+[Sample-size constants table](#sample-size-constants).
 
-| Metric | Cell | Canonical role | Sample axis | Min sample |
-|---|---|---|---|---|
-| [`ic`][factrix.metrics.ic.ic] | Individual × Continuous | Cell-canonical (IC) | `T/h` (non-overlap) | `T/h ≥ MIN_ASSETS_PER_DATE_IC` via `_scaled_min_periods(MIN_ASSETS_PER_DATE_IC, h)` |
-| [`ic_newey_west`][factrix.metrics.ic.ic_newey_west] | Individual × Continuous | HAC variant of `ic` | `T` (full series) | `T ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`ic_ir`][factrix.metrics.ic.ic_ir] | Individual × Continuous | IR / ICIR | `T` | `T ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`regime_ic`][factrix.metrics.ic.regime_ic] | Individual × Continuous | Regime-stratified IC | `T` per regime | per-regime `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`multi_horizon_ic`][factrix.metrics.ic.multi_horizon_ic] | Individual × Continuous | Per-horizon IC + BHY | `T` per horizon | per-horizon `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`fama_macbeth`][factrix.metrics.fama_macbeth.fama_macbeth] | Individual × Continuous | Cell-canonical (FM) | `T` (λ series) | `T ≥ MIN_FM_PERIODS_HARD`; warn if `T < MIN_FM_PERIODS_WARN` |
-| [`pooled_ols`][factrix.metrics.fama_macbeth.pooled_ols] | Individual × Continuous | Pooled OLS sibling of FM | `N × T` | `N ≥ 10`, effective clusters `G ≥ 3` |
-| [`beta_sign_consistency`][factrix.metrics.fama_macbeth.beta_sign_consistency] | Individual × Continuous | Per-period β-sign hit rate | `T` (β series) | `T ≥ MIN_FM_PERIODS_HARD` |
-| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | Individual × Continuous | Top-minus-bottom spread t | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; per-date `N ≥ n_groups` |
-| [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | Individual × Continuous | Value-weighted spread | `T/h` | as `quantile_spread` |
-| [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | Individual × Continuous | Group-rank monotonicity | `T/h` | per-date `N ≥ n_groups`; series `≥ MIN_MONOTONICITY_PERIODS` |
-| [`top_concentration`][factrix.metrics.concentration.top_concentration] | Individual × Continuous | Top-bucket HHI ratio | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; warn if `T/h < MIN_PORTFOLIO_PERIODS_WARN` |
-| [`turnover`][factrix.metrics.tradability.turnover] | Individual × Continuous | Rank-stability (`1 − ρ`) | `T` | `T ≥ 2·forward_periods + 1` |
-| [`notional_turnover`][factrix.metrics.tradability.notional_turnover] | Individual × Continuous | Q1/Qn replacement fraction | `T` | as `turnover` |
-| [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | Individual × Continuous | bps cost where α → 0 | scalar | `notional_turnover > 0` |
-| [`net_spread`][factrix.metrics.tradability.net_spread] | Individual × Continuous | $\text{spread} - \text{cost} \cdot \tau$ | scalar | spread + cost provided |
-| [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | Spread-series consumer | Single-factor α post base | `T` | aligned spread series |
-| [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | Spread-series consumer | Diagnostic — not for inference | `T` | as `spanning_alpha` |
-| [`caar`][factrix.metrics.caar.caar] | Individual × Sparse | Cell-canonical | `K/h` (non-overlap) | `K/h ≥ MIN_EVENTS_HARD`; warn if `K/h < MIN_EVENTS_WARN` via `_scaled_min_periods(MIN_EVENTS_HARD, h)` |
-| [`bmp_test`][factrix.metrics.caar.bmp_test] | Individual × Sparse | Variance-robust sibling | `K` | `K ≥ MIN_EVENTS_HARD`; `estimation_window` periods per asset |
-| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | Individual × Sparse | Per-event sign hit rate | `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`event_ic`][factrix.metrics.event_quality.event_ic] | Individual × Sparse | Strength → return Spearman | `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`profit_factor`][factrix.metrics.event_quality.profit_factor] | Individual × Sparse | `Σ gains / Σ losses` | `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | Individual × Sparse | Per-event return skewness | `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`signal_density`][factrix.metrics.event_quality.signal_density] | Individual × Sparse | Mean inter-event gap | `K` | `K ≥ 2` |
-| [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | Individual × Sparse | Per-offset return profile | per-offset `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | Individual × Sparse | Per-horizon binomial hit | per-horizon `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`mfe_mae_summary`][factrix.metrics.mfe_mae.mfe_mae_summary] | Individual × Sparse | Path-excursion summary | `K` | `K ≥ MIN_EVENTS_HARD`; `price` column required |
-| [`clustering_diagnostic`][factrix.metrics.clustering.clustering_diagnostic] | Individual × Sparse (`N ≥ 2`) | Event-date HHI | `K`, `N` | `N ≥ 2`; `K ≥ MIN_EVENTS_HARD` |
-| [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test] | Individual × Sparse | Nonparametric rank test | `K` × estimation window | `K ≥ MIN_EVENTS_HARD`; per-asset `T ≥ 30` |
-| [`ts_beta`][factrix.metrics.ts_beta.ts_beta] | Common × Continuous | Cell-canonical | `N` (β distribution) | `N ≥ 2`; per-asset `T ≥ MIN_TS_OBS` |
-| [`mean_r_squared`][factrix.metrics.ts_beta.mean_r_squared] | Common × Continuous | Avg explanatory R² | `N` | as `ts_beta` |
-| [`compute_rolling_mean_beta`][factrix.metrics.ts_beta.compute_rolling_mean_beta] | Common × Continuous | β stability over time | `T` per window | window ≥ `MIN_TS_OBS` |
-| [`ts_beta_sign_consistency`][factrix.metrics.ts_beta.ts_beta_sign_consistency] | Common × Continuous | Cross-asset β-sign rate | `N` | `N ≥ 2` |
-| [`ts_quantile_spread`][factrix.metrics.ts_quantile.ts_quantile_spread] | Common × Continuous | Quantile-bucketed Wald | `T` | `T ≥ MIN_PORTFOLIO_PERIODS_HARD`; factor `n_unique ≥ n_groups × 2` |
-| [`ts_asymmetry`][factrix.metrics.ts_asymmetry.ts_asymmetry] | Common × Continuous | Long/short slope asymmetry | `T` | factor has both signs (Gate B); each side `n_unique ≥ 2` for method B (Gate C) |
-| [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | Series-tools | Binomial hit rate | series length | `T ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`ic_trend`][factrix.metrics.trend.ic_trend] | Series-tools | Theil-Sen slope + ADF flag | `T` | `T ≥ 10` (literal floor) |
-| [`multi_split_oos_decay`][factrix.metrics.oos.multi_split_oos_decay] | Series-tools | Median IS/OOS survival | `T` | `T ≥ 2 × MIN_OOS_PERIODS` |
+### IC family — Cell: Individual × Continuous
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`ic_newey_west`][factrix.metrics.ic.ic_newey_west] | `T` (full series) | `T ≥ MIN_ASSETS_PER_DATE_IC` |
+| [`ic_ir`][factrix.metrics.ic.ic_ir] | `T` | `T ≥ MIN_ASSETS_PER_DATE_IC` |
+| [`regime_ic`][factrix.metrics.ic.regime_ic] | `T` per regime | per-regime `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
+| [`multi_horizon_ic`][factrix.metrics.ic.multi_horizon_ic] | `T` per horizon | per-horizon `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
+
+### FM family — Cell: Individual × Continuous
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`pooled_ols`][factrix.metrics.fama_macbeth.pooled_ols] | `N × T` | `N ≥ 10`, effective clusters `G ≥ 3` |
+| [`beta_sign_consistency`][factrix.metrics.fama_macbeth.beta_sign_consistency] | `T` (β series) | `T ≥ MIN_FM_PERIODS_HARD` |
+
+### Quantile / Monotonicity / Concentration — Cell: Individual × Continuous
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; per-date `N ≥ n_groups` |
+| [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | `T/h` | as `quantile_spread` |
+| [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | `T/h` | per-date `N ≥ n_groups`; series `≥ MIN_MONOTONICITY_PERIODS` |
+| [`top_concentration`][factrix.metrics.concentration.top_concentration] | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; warn if `T/h < MIN_PORTFOLIO_PERIODS_WARN` |
+
+### Tradability — Cell: Individual × Continuous
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`turnover`][factrix.metrics.tradability.turnover] | `T` | `T ≥ 2·forward_periods + 1` |
+| [`notional_turnover`][factrix.metrics.tradability.notional_turnover] | `T` | as `turnover` |
+| [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | scalar | `notional_turnover > 0` |
+| [`net_spread`][factrix.metrics.tradability.net_spread] | scalar | spread + cost provided |
+
+### Event-quality — Cell: Individual × Sparse
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`bmp_test`][factrix.metrics.caar.bmp_test] | `K` | `K ≥ MIN_EVENTS_HARD`; `estimation_window` periods per asset |
+| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`event_ic`][factrix.metrics.event_quality.event_ic] | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`profit_factor`][factrix.metrics.event_quality.profit_factor] | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`signal_density`][factrix.metrics.event_quality.signal_density] | `K` | `K ≥ 2` |
+| [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | per-offset `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | per-horizon `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`mfe_mae_summary`][factrix.metrics.mfe_mae.mfe_mae_summary] | `K` | `K ≥ MIN_EVENTS_HARD`; `price` column required |
+| [`clustering_diagnostic`][factrix.metrics.clustering.clustering_diagnostic] | `K`, `N` | `N ≥ 2`; `K ≥ MIN_EVENTS_HARD` |
+| [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test] | `K` × estimation window | `K ≥ MIN_EVENTS_HARD`; per-asset `T ≥ 30` |
+
+### TS-β family — Cell: Common × Continuous
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`mean_r_squared`][factrix.metrics.ts_beta.mean_r_squared] | `N` | as `ts_beta` |
+| [`compute_rolling_mean_beta`][factrix.metrics.ts_beta.compute_rolling_mean_beta] | `T` per window | window ≥ `MIN_TS_OBS` |
+| [`ts_beta_sign_consistency`][factrix.metrics.ts_beta.ts_beta_sign_consistency] | `N` | `N ≥ 2` |
+| [`ts_quantile_spread`][factrix.metrics.ts_quantile.ts_quantile_spread] | `T` | `T ≥ MIN_PORTFOLIO_PERIODS_HARD`; factor `n_unique ≥ n_groups × 2` |
+| [`ts_asymmetry`][factrix.metrics.ts_asymmetry.ts_asymmetry] | `T` | factor has both signs (Gate B); each side `n_unique ≥ 2` for method B (Gate C) |
+
+### Spread-series consumers — not cell-bound
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | `T` | aligned spread series |
+| [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | `T` | as `spanning_alpha` |
+
+### Series-tools — not cell-bound
+
+| Metric | Sample axis | Min sample |
+|---|---|---|
+| [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | series length | `T ≥ MIN_ASSETS_PER_DATE_IC` |
+| [`ic_trend`][factrix.metrics.trend.ic_trend] | `T` | `T ≥ 10` (literal floor) |
+| [`multi_split_oos_decay`][factrix.metrics.oos.multi_split_oos_decay] | `T` | `T ≥ 2 × MIN_OOS_PERIODS` |
 
 ## Sample-size constants
 [](){ #sample-size-constants }
@@ -187,8 +224,7 @@ A few specific caveats worth flagging:
   single-tier — the metric is now descriptive-only (no `p_value` in
   metadata), so a literature power floor is moot. Treat its output as
   descriptive; the formal `verdict()` reading should rely on the
-  cell-canonical metric until the underlying series is materially
-  longer.
+  primary metric until the underlying series is materially longer.
 
 ## Below-threshold behaviour
 


### PR DESCRIPTION
## Summary

Split the flat 38-row Cross-metric matrix in `docs/reference/metric-applicability.md` into family-grouped H3 subsections. The `Cell` and `Canonical role` columns are pushed into the section headings (e.g. `### Event-quality — Cell: Individual × Sparse`), so the per-row schema reduces to *Metric / Sample axis / Min sample*. Primary metrics (`ic`, `fama_macbeth`, `caar`, `ts_beta`) are excluded — the generated primary table at the top of the page (`_generated_evaluate_metric_table.md` include) remains their SSOT.

## Why

Readers asking "what other metrics apply to cell X" had to scan every row; family membership was implied only by free-form labels in `Canonical role` (e.g. "HAC variant of `ic`", "Top-bucket HHI ratio"). Family grouping makes the cell-axis cut visible at one glance and removes the redundant `Canonical role` column.

## Scope discipline

Only the cross-metric matrix moved. Sample-size constants table, sample-size sensitivity discussion, below-threshold behaviour, and event-study contracts are untouched. One incidental `cell-canonical` → `primary` substitution in the OOS sensitivity paragraph aligns the wording with the page's new framing.

Out of scope: broader `canonical` → `primary` cleanup across the repo. The `tests/test_docs_terminology_ratchet.py` ratchet is the right mechanism — it monotonically decreases as code is touched, and proactive bulk renaming would churn git blame for no behavioural value.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] `pytest tests/test_docs_*` (197 passed) — terminology ratchet, applicability page validators, drift guards all green
- [ ] Reviewer: open `/reference/metric-applicability/` and confirm the eight family subsections render and that the primary table at the top is unchanged

Closes #142