### PR TITLE
feat(metrics): axis-agnostic by_slice + by_regime deprecation (#154)

### DIFF
--- a/docs/api/by-regime.md
+++ b/docs/api/by-regime.md
@@ -1,5 +1,11 @@
 # by_regime
 
+!!! warning "Deprecated since v0.10.0"
+    `by_regime` is superseded by the axis-agnostic
+    [`by_slice`](by-slice.md). Importing or calling `by_regime` emits
+    a `DeprecationWarning`. Behaviour is unchanged for the deprecation
+    window (at least one minor) — see [Migration](#migration) below.
+
 Cross-cutting research dispatcher. Slices any metric's date-keyed
 input by regime label and runs the metric per slice. Returns
 `dict[regime_label, MetricOutput]`.
@@ -102,6 +108,53 @@ the metric's own job. Each per-regime call inherits the metric's
 existing guards (sample-size short-circuits, `IncompatibleAxisError`,
 warnings); you see the same signals you would see calling the metric
 directly on each slice.
+
+## Migration
+
+Replace every `by_regime` call with `by_slice` plus an explicit join
+(or pre-existing column).
+
+```python
+# Before (deprecated since v0.10.0)
+from factrix.metrics import by_regime
+results = by_regime(ic, ic_df, regime_labels=regime_df)
+
+# After
+from factrix.metrics import by_slice
+results = by_slice(
+    ic,
+    ic_df.join(regime_df, on="date", how="inner"),  # match by_regime's inner-join
+    label="regime",
+)
+```
+
+The time-bisection fallback (`regime_labels=None` → `first_half` /
+`second_half`) has **no `by_slice` equivalent**. That path is a
+structural-break sanity check, not a regime test, and the deprecation
+is the right moment to make that explicit. If you still want the
+median-date split, compose the label yourself:
+
+```python
+import polars as pl
+
+mid = df.get_column("date").quantile(0.5)
+df = df.with_columns(
+    pl.when(pl.col("date") < mid).then(pl.lit("first_half"))
+      .otherwise(pl.lit("second_half"))
+      .alias("regime")
+)
+by_slice(ic, df, label="regime")
+```
+
+This is more honest than the old fallback: the caller picks the split
+point and accepts that this is structural-break diagnostics, not
+regime analysis. Genuine regime work needs a domain-driven
+classification (NBER recession dating, volatility-state classifier,
+etc.), which neither `by_regime` nor `by_slice` ships.
+
+Layer-B wrappers (`regime_ic`, `regime_caar`, ...) are unchanged —
+they remain the right entry point when you need a metric-family-aware
+cross-regime test.
 
 ## API reference
 

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -1,0 +1,165 @@
+# by_slice
+
+Axis-agnostic Layer-A research dispatcher. Slices any metric's
+date-keyed input by a column already present in the DataFrame and runs
+the metric per slice. Returns `dict[label_value, MetricOutput]`.
+
+`by_slice` supersedes [`by_regime`](by-regime.md) (deprecated since
+v0.10.0) and generalises it to any cross-section axis — market,
+sector, regime, market-cap tier, ADV bucket — without baking the axis
+name into the API.
+
+## Call shape
+
+```python
+import polars as pl
+from factrix.metrics import by_slice, ic, compute_ic
+
+ic_df = compute_ic(panel)
+ic_df = ic_df.join(regime_labels, on="date")  # adds 'regime' column
+
+per_regime = by_slice(ic, ic_df, label="regime")
+# {"bull": MetricOutput(name="ic", ...), "bear": MetricOutput(name="ic", ...)}
+```
+
+The first argument is the **metric callable** (e.g. `ic`, `caar`,
+`fama_macbeth`); the second is the metric's primary date-keyed
+DataFrame **with the slicing column already present**; `label` names
+that column; remaining keyword args (`forward_periods=...`, etc.)
+forward unchanged on every per-slice call.
+
+## Why "label is a column name"
+
+`by_slice` does not accept a separate labels DataFrame. Users typically
+already carry the partition key (market / sector / regime) on the panel
+or can join it once upstream — splitting that join into the
+dispatcher's signature is redundant and forces a fixed
+`(date, label)` shape that does not generalise across axes (sector
+labels are by-asset, not by-date).
+
+If `label` is not in `df.columns`, `by_slice` raises `ValueError` —
+compose the column upstream with `df.with_columns(...)` or
+`df.join(...)`.
+
+## What it does **not** do
+
+`by_slice` performs **no cross-slice statistical inference**. It
+returns the per-slice outputs and stops. Per-slice t-stats / SE in
+each `MetricOutput` are computed on that slice alone (different `N`,
+different autocorrelation structure per slice) and are **not**
+directly comparable — `max(out.values(), key=lambda m: m.tstat)` is
+not a defensible cross-regime selection rule. A generic second-layer test
+(BHY adjustment, Sharpe-diff Wald, paired-difference NW, etc.) cannot
+be applied honestly across the metric matrix — the appropriate test
+depends on the metric family. Curated families that have a defensible
+second-layer test are exposed as Layer-B wrappers (e.g.
+[`regime_ic`](metrics/ic.md#factrix.metrics.ic.regime_ic) for the IC
+family).
+
+## Universe overlap reference patterns
+
+`by_slice` only partitions on a single column's distinct values. Any
+overlapping-universe scenario — same row needs to count toward
+multiple slices — is composed with three lines of polars upstream.
+The shared idiom: `filter` + `with_columns(label=...)` per target
+slice, then `pl.concat`.
+
+### 1. Superset (subset and full set side-by-side)
+
+`market` is "TWSE" / "OTC"; you want three slices: 上市, 上櫃, 全市場
+(every row also belongs to 全市場).
+
+```python
+import polars as pl
+
+mapping = {"TWSE": "上市", "OTC": "上櫃"}
+expanded = pl.concat([
+    df.with_columns(pl.col("market").replace(mapping).alias("uni")),
+    df.with_columns(pl.lit("全市場").alias("uni")),
+])
+by_slice(ic, expanded, label="uni")
+```
+
+### 2. Multi-membership (one stock in multiple indices)
+
+Each index membership is a separate boolean column; the same row may
+have several `True` values.
+
+```python
+expanded = pl.concat([
+    df.filter(pl.col("in_sp500")).with_columns(pl.lit("SP500").alias("uni")),
+    df.filter(pl.col("in_nasdaq100")).with_columns(pl.lit("N100").alias("uni")),
+])
+by_slice(ic, expanded, label="uni")
+```
+
+### 3. Hierarchical nesting (Top-10 ⊂ Top-50 ⊂ LargeCap ⊂ All)
+
+Nested by market-cap rank; each tier contains every smaller tier.
+
+```python
+tiers = [(10, "Top10"), (50, "Top50"), (200, "LargeCap")]
+expanded = pl.concat([
+    *[
+        df.filter(pl.col("market_cap_rank") <= cutoff)
+          .with_columns(pl.lit(name).alias("tier"))
+        for cutoff, name in tiers
+    ],
+    df.with_columns(pl.lit("All").alias("tier")),
+])
+by_slice(ic, expanded, label="tier")
+```
+
+### 4. Sliding window (overlapping ADV buckets)
+
+Adjacent deciles overlap to smooth boundary noise:
+
+```python
+windows = [(0, 30), (10, 40), (20, 50), (30, 60),
+           (40, 70), (50, 80), (60, 90), (70, 100)]
+expanded = pl.concat([
+    df.filter((pl.col("adv_pct") >= lo) & (pl.col("adv_pct") < hi))
+      .with_columns(pl.lit(f"W[{lo},{hi})").alias("adv_win"))
+    for lo, hi in windows
+])
+by_slice(ic, expanded, label="adv_win")
+```
+
+### 5. Cross-product / multi-axis (universe × sector)
+
+Not an overlap problem — `label` only takes a single column. Compose a
+composite column with `pl.concat_str`:
+
+```python
+df = df.with_columns(
+    pl.concat_str(["market", "sector"], separator="-").alias("uni_sec")
+)
+by_slice(ic, df, label="uni_sec")
+# keys: "TWSE-Tech", "TWSE-Finance", "OTC-Tech", ...
+```
+
+The API does not accept `label: list[str]`: single-column vs
+multi-column semantics would diverge on output dict key type
+(`str` vs `tuple`), breaking the `dict[str, MetricOutput]` convention
+downstream.
+
+### General template
+
+Cases 1–4 share one idiom — per-target-slice `filter` +
+`with_columns(label=...)`, then `pl.concat`. Overlapping rows are
+duplicated naturally by the concat.
+
+```python
+expanded = pl.concat([
+    df.filter(expr).with_columns(pl.lit(name).alias("group"))
+    for name, expr in user_definitions.items()
+])
+by_slice(metric, expanded, label="group")
+```
+
+## API reference
+
+::: factrix.metrics._slice
+    options:
+      members:
+        - by_slice

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -72,7 +72,7 @@ _STAGE1_HELPERS: frozenset[str] = frozenset(
 # with ``(*, *, *, *)`` so the primitive graph is complete, but excluded
 # from per-cell ``list_metrics`` output and the applicability table
 # (which catalogue per-cell metrics, not infra).
-_INFRASTRUCTURE: frozenset[str] = frozenset({"by_regime"})
+_INFRASTRUCTURE: frozenset[str] = frozenset({"by_regime", "by_slice"})
 """Cross-cutting dispatchers published from ``factrix.metrics`` that
 are not per-(scope, signal) cell metrics."""
 

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -34,6 +34,7 @@ Series diagnostics — axis-agnostic on ``(date, value)``:
     hit_rate, ic_trend, multi_split_oos_decay
 """
 
+from factrix.metrics._slice import by_slice
 from factrix.metrics.caar import (
     bmp_test,
     caar,
@@ -104,6 +105,7 @@ __all__ = [
     "bmp_test",
     "breakeven_cost",
     "by_regime",
+    "by_slice",
     "caar",
     "clustering_diagnostic",
     "compute_caar",

--- a/factrix/metrics/_slice.py
+++ b/factrix/metrics/_slice.py
@@ -1,0 +1,109 @@
+"""Axis-agnostic Layer-A slice dispatcher.
+
+Public :func:`by_slice` partitions a metric's date-keyed input on an
+existing column and applies the metric per slice. Private
+:func:`_slice_by_label` is the partition primitive shared with
+Layer-B wrappers. Universe-overlap composition is user-side; see
+``docs/api/by-slice.md`` for reference patterns.
+
+Matrix-row: by_slice | (*, *, *, *) | dispatcher | none (no cross-slice test) | _slice_by_label
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import polars as pl
+
+from factrix._types import MetricOutput
+
+
+def _slice_by_label(
+    df: pl.DataFrame,
+    label: str,
+) -> dict[str, pl.DataFrame]:
+    """Partition ``df`` by the values of an existing column.
+
+    Returns ``{value: sub_df}`` with the label column dropped from each
+    sub-frame (it is constant within a partition and consumers do not
+    need it). Raises ``ValueError`` if ``label`` is not a column of
+    ``df`` or ``df`` is empty.
+    """
+    if not isinstance(df, pl.DataFrame):
+        raise TypeError(
+            f"_slice_by_label expects a polars DataFrame; got {type(df).__name__}."
+        )
+    if label not in df.columns:
+        raise ValueError(
+            f"_slice_by_label: label column {label!r} not found in df; "
+            f"got columns {df.columns}. Compose the label upstream "
+            "(e.g. df.with_columns(pl.lit(...).alias(...)) or a join) "
+            "before calling by_slice."
+        )
+    if df.is_empty():
+        raise ValueError(
+            f"_slice_by_label: df is empty; nothing to slice on {label!r}."
+        )
+    if df.get_column(label).null_count() > 0:
+        raise ValueError(
+            f"_slice_by_label: label column {label!r} contains nulls; "
+            f"drop or impute before slicing (e.g. df.drop_nulls({label!r}))."
+        )
+    return {
+        str(key): sub_df
+        for (key,), sub_df in df.partition_by(
+            label, as_dict=True, include_key=False
+        ).items()
+    }
+
+
+def by_slice(
+    metric: Callable[..., MetricOutput],
+    df: pl.DataFrame,
+    *,
+    label: str,
+    **kwargs: Any,
+) -> dict[str, MetricOutput]:
+    """Apply ``metric`` to each value-partition of ``df`` keyed by ``label``.
+
+    Args:
+        metric: Callable returning a ``MetricOutput`` (e.g.
+            :func:`factrix.metrics.ic`, :func:`factrix.metrics.caar`).
+        df: Metric's primary DataFrame; must already contain ``label``
+            as a column. If you have a separate labels DataFrame, join
+            it in upstream — :func:`by_slice` deliberately does not
+            ingest a separate labels argument.
+        label: Column name in ``df`` whose distinct values define the
+            slices. Must already exist in ``df.columns``; for
+            cross-product slicing (e.g. market × sector) compose a
+            single composite column upstream
+            (``pl.concat_str([...]).alias("...")``).
+        **kwargs: Forwarded unchanged to ``metric`` on every per-slice
+            call.
+
+    Returns:
+        ``{label_value: metric(slice, **kwargs)}``. Keys are
+        stringified (an ``Int64`` decile column yields ``"1".."10"``);
+        dict order matches polars ``partition_by(as_dict=True)``. No
+        cross-slice statistical inference — see API page.
+
+    Raises:
+        TypeError: ``df`` is not a polars DataFrame.
+        ValueError: ``label`` not in ``df.columns``, or ``df`` is empty.
+
+    Example:
+        >>> import polars as pl
+        >>> from factrix.metrics import by_slice, ic, compute_ic
+        >>> ic_df = compute_ic(panel)              # already has 'sector'
+        >>> per_sector = by_slice(ic, ic_df, label="sector")
+
+    Universe overlap (superset / multi-membership / hierarchical /
+    sliding window / cross-product) is composed by the caller — see
+    the API page for reference patterns. ``by_slice`` does no
+    cross-slice statistical inference; for IC use
+    :func:`factrix.metrics.regime_ic` (or a future ``by_<scope>_<metric>``
+    Layer-B wrapper) instead.
+    """
+    sliced = _slice_by_label(df, label)
+    return {key: metric(sub_df, **kwargs) for key, sub_df in sliced.items()}

--- a/factrix/metrics/regime.py
+++ b/factrix/metrics/regime.py
@@ -115,6 +115,16 @@ def by_regime(
         >>> ic_df = compute_ic(panel)
         >>> per_regime = by_regime(ic, ic_df, regime_labels=labels)
     """
+    _warnings.warn(
+        "factrix.metrics.by_regime is deprecated since v0.10.0; use "
+        "factrix.metrics.by_slice instead. With regime_labels, replace "
+        "by_regime(metric, df, regime_labels=labels) with "
+        "by_slice(metric, df.join(labels, on='date'), label='regime'). "
+        "Without regime_labels (time-bisection fallback), compose the "
+        "label yourself — see docs/api/by-regime.md migration block.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not isinstance(df, pl.DataFrame):
         raise TypeError(
             f"by_regime expects a polars DataFrame as the second arg; "
@@ -131,9 +141,6 @@ def by_regime(
             "by_regime: no rows survived the regime-label join — "
             "likely a date-range or dtype mismatch between df and regime_labels"
         )
-    return {
-        str(regime): metric(slice_df, **kwargs)
-        for (regime,), slice_df in annotated.partition_by(
-            "regime", as_dict=True, include_key=False
-        ).items()
-    }
+    from factrix.metrics._slice import by_slice
+
+    return by_slice(metric, annotated, label="regime", **kwargs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
       - api/index.md
       - AnalysisConfig: api/analysis-config.md
       - evaluate: api/evaluate.md
+      - by_slice: api/by-slice.md
       - by_regime: api/by-regime.md
       - list_metrics: api/list-metrics.md
       - FactorProfile: api/factor-profile.md

--- a/tests/test_by_regime.py
+++ b/tests/test_by_regime.py
@@ -9,6 +9,10 @@ from factrix._types import MetricOutput
 from factrix.metrics import by_regime, ic, ic_ir
 from factrix.metrics.regime import _slice_by_regime
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:factrix.metrics.by_regime is deprecated:DeprecationWarning"
+)
+
 
 def _ic_series(n: int = 30, mean: float = 0.05, seed: int = 42) -> pl.DataFrame:
     rng = np.random.default_rng(seed)
@@ -140,3 +144,12 @@ class TestByRegimeDispatcher:
         ic_df = _ic_series(40)
         with pytest.warns(UserWarning, match="time-bisection"):
             by_regime(ic, ic_df)
+
+
+class TestByRegimeDeprecation:
+    @pytest.mark.filterwarnings("default")
+    def test_emits_deprecation_warning(self):
+        ic_df = _ic_series(40)
+        labels = _labels(ic_df["date"].to_list(), ["bull"] * 20 + ["bear"] * 20)
+        with pytest.warns(DeprecationWarning, match="by_slice"):
+            by_regime(ic, ic_df, regime_labels=labels)

--- a/tests/test_by_slice.py
+++ b/tests/test_by_slice.py
@@ -1,0 +1,119 @@
+"""Tests for factrix.metrics.by_slice — axis-agnostic Layer-A dispatcher."""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._types import MetricOutput
+from factrix.metrics import by_slice, ic
+from factrix.metrics._slice import _slice_by_label
+
+
+def _ic_series_with_label(
+    n: int = 40, label_col: str = "regime", seed: int = 42
+) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    half = n // 2
+    return pl.DataFrame(
+        {
+            "date": dates,
+            "ic": rng.normal(0.05, 0.02, n),
+            label_col: ["bull"] * half + ["bear"] * (n - half),
+        }
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+class TestSliceByLabel:
+    def test_partitions_on_existing_column(self):
+        df = _ic_series_with_label(20)
+        out = _slice_by_label(df, "regime")
+        assert set(out) == {"bull", "bear"}
+        assert all(isinstance(v, pl.DataFrame) for v in out.values())
+        assert sum(len(v) for v in out.values()) == 20
+
+    def test_drops_label_column_from_partitions(self):
+        df = _ic_series_with_label(20)
+        out = _slice_by_label(df, "regime")
+        for sub in out.values():
+            assert "regime" not in sub.columns
+
+    def test_missing_label_raises(self):
+        df = _ic_series_with_label(10)
+        with pytest.raises(ValueError, match="not found in df"):
+            _slice_by_label(df, "sector")
+
+    def test_empty_df_raises(self):
+        df = _ic_series_with_label(0)
+        with pytest.raises(ValueError, match="empty"):
+            _slice_by_label(df, "regime")
+
+    def test_null_label_values_raise(self):
+        df = _ic_series_with_label(10).with_columns(
+            pl.when(pl.int_range(0, 10) < 3)
+            .then(None)
+            .otherwise(pl.col("regime"))
+            .alias("regime")
+        )
+        with pytest.raises(ValueError, match="contains nulls"):
+            _slice_by_label(df, "regime")
+
+    def test_numeric_label_stringified(self):
+        df = _ic_series_with_label(20).with_columns(
+            pl.Series("decile", [1, 2] * 10, dtype=pl.Int64)
+        )
+        out = _slice_by_label(df, "decile")
+        assert set(out) == {"1", "2"}
+
+    def test_non_dataframe_raises(self):
+        with pytest.raises(TypeError, match="polars DataFrame"):
+            _slice_by_label([1, 2, 3], "regime")  # type: ignore[arg-type]
+
+
+class TestBySlice:
+    def test_returns_dict_per_slice(self):
+        df = _ic_series_with_label(40)
+        out = by_slice(ic, df, label="regime")
+        assert isinstance(out, dict)
+        assert set(out) == {"bull", "bear"}
+        for v in out.values():
+            assert isinstance(v, MetricOutput)
+            assert v.name == "ic"
+
+    def test_kwargs_forwarded(self):
+        df = _ic_series_with_label(60)
+        out = by_slice(ic, df, label="regime", forward_periods=3)
+        for v in out.values():
+            assert v.metadata.get("method", "").startswith("non-overlapping")
+
+    def test_missing_label_raises(self):
+        df = _ic_series_with_label(10)
+        with pytest.raises(ValueError, match="not found in df"):
+            by_slice(ic, df, label="sector")
+
+    def test_arbitrary_label_column(self):
+        """``label`` is just a column name — sector / market / anything works."""
+        df = _ic_series_with_label(30, label_col="sector")
+        out = by_slice(ic, df, label="sector")
+        assert set(out) == {"bull", "bear"}
+
+    def test_accepts_arbitrary_callable(self):
+        def fake(df: pl.DataFrame, *, mult: float = 1.0) -> MetricOutput:
+            return MetricOutput(name="fake", value=float(df["ic"].mean()) * mult)
+
+        df = _ic_series_with_label(20)
+        out = by_slice(fake, df, label="regime", mult=2.0)
+        assert set(out) == {"bull", "bear"}
+        assert all(o.name == "fake" for o in out.values())
+
+    def test_cross_product_via_composite_column(self):
+        """Cross-product slicing: caller composes the composite column."""
+        df = _ic_series_with_label(40).with_columns(
+            pl.Series("market", ["TWSE", "OTC"] * 20)
+        )
+        df = df.with_columns(
+            pl.concat_str(["market", "regime"], separator="-").alias("uni_reg")
+        )
+        out = by_slice(ic, df, label="uni_reg")
+        assert set(out) <= {"TWSE-bull", "TWSE-bear", "OTC-bull", "OTC-bear"}


### PR DESCRIPTION
## Summary

Implements #154 (sub-issue of #152). Three atomic commits:

1. **`feat(metrics): add by_slice axis-agnostic dispatcher`** — new public `factrix.metrics.by_slice(metric, df, *, label, **kwargs)` plus private `_slice_by_label` partition primitive. `label` is an existing column on the metric input — no separate labels DataFrame, no overlap helpers in the API.
2. **`feat(metrics)!: deprecate by_regime in favor of by_slice`** — `by_regime` now emits `DeprecationWarning` and delegates partition to `by_slice` (one shared primitive over the deprecation window). Time-bisection fallback preserved for behavioural compat. Layer-B `regime_ic` / `regime_caar` unaffected.
3. **`docs(api): by_slice page + by_regime migration`** — new API page with five universe-overlap reference patterns (superset / multi-membership / hierarchical / sliding window / cross-product) + deprecation banner and migration block on `by-regime.md`.

Reviewed via parallel quant-UX and backend agents before /simplify; null-label rejection, `how="inner"` migration recipe, per-slice t-stat non-comparability caveat, and shortened error messages all came out of that pass.

## Test plan

- [x] `pytest tests/test_by_slice.py tests/test_by_regime.py tests/test_ic.py` (46 passed)
- [x] Pre-commit ruff check + format on every commit
- [ ] mkdocs build smoke-check (reviewer: visual scan of new by-slice.md and updated by-regime.md)
- [ ] Verify Layer-B `regime_ic` does not trigger the new `DeprecationWarning` in user pipelines (it consumes `_slice_by_regime` directly)

Closes #154
Refs #152 #107