### PR TITLE
docs(regime): rename Layer-A/B terms (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Terminology**: rename "Layer A" / "Layer B" to **dispatcher** / **curated wrapper** in module docstrings and user-facing docs. Public API names are unchanged. Older CHANGELOG entries below retain the original wording. (#157)
+
+---
+
 ## v0.10.0 (2026-05-09)
 
 Generalises v0.9.0's regime-only dispatch primitive into an axis-agnostic `by_slice` (market / sector / decile / regime / any user-defined column), and demotes `by_regime` to a thin deprecation wrapper. The shape of the partition primitive turned out to be axis-independent — the only thing the regime layer added was an inner-join + time-bisection annotation step — so generalising preserved the v0.9.0 behaviour while opening up cross-section axes that previously required hand-rolled `partition_by` loops.

--- a/docs/api/by-regime.md
+++ b/docs/api/by-regime.md
@@ -66,14 +66,19 @@ the metric family:
 | Turnover, hit_rate, monotonicity ρ | no canonical cross-regime test |
 
 For curated families that have a defensible second-layer test,
-factrix provides Layer B wrappers — see
+factrix provides curated wrappers — see
 [`regime_ic`](metrics/ic.md#factrix.metrics.ic.regime_ic) for the IC family. Use
-`by_regime` directly when no Layer B wrapper exists or when you want
+`by_regime` directly when no curated wrapper exists or when you want
 raw per-regime outputs to compose your own analysis.
 
-**As of v0.9.0, `regime_ic` is the only Layer B wrapper.** `regime_caar`
+**As of v0.9.0, `regime_ic` is the only curated wrapper.** `regime_caar`
 and `regime_fama_macbeth` are tracked in
 [#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107).
+
+> Earlier docs called the dispatcher "Layer A" and curated wrappers
+> "Layer B"; renamed in
+> [#157](https://github.com/awwesomeman/factrix/issues/157). Roles
+> unchanged.
 
 ## Which metrics work
 
@@ -152,7 +157,7 @@ regime analysis. Genuine regime work needs a domain-driven
 classification (NBER recession dating, volatility-state classifier,
 etc.), which neither `by_regime` nor `by_slice` ships.
 
-Layer-B wrappers (`regime_ic`, `regime_caar`, ...) are unchanged —
+Curated wrappers (`regime_ic`, `regime_caar`, ...) are unchanged —
 they remain the right entry point when you need a metric-family-aware
 cross-regime test.
 

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -1,8 +1,13 @@
 # by_slice
 
-Axis-agnostic Layer-A research dispatcher. Slices any metric's
-date-keyed input by a column already present in the DataFrame and runs
-the metric per slice. Returns `dict[label_value, MetricOutput]`.
+Axis-agnostic research dispatcher. Slices any metric's date-keyed
+input by a column already present in the DataFrame and runs the metric
+per slice. Returns `dict[label_value, MetricOutput]`.
+
+> Earlier docs called this role "Layer A" and curated wrappers
+> "Layer B"; renamed in
+> [#157](https://github.com/awwesomeman/factrix/issues/157). Roles
+> unchanged.
 
 `by_slice` supersedes [`by_regime`](by-regime.md) (deprecated since
 v0.10.0) and generalises it to any cross-section axis — market,
@@ -52,7 +57,7 @@ not a defensible cross-regime selection rule. A generic second-layer test
 (BHY adjustment, Sharpe-diff Wald, paired-difference NW, etc.) cannot
 be applied honestly across the metric matrix — the appropriate test
 depends on the metric family. Curated families that have a defensible
-second-layer test are exposed as Layer-B wrappers (e.g.
+second-layer test are exposed as curated wrappers (e.g.
 [`regime_ic`](metrics/ic.md#factrix.metrics.ic.regime_ic) for the IC
 family).
 

--- a/docs/api/metrics/ic.md
+++ b/docs/api/metrics/ic.md
@@ -20,17 +20,19 @@ via NW HAC or non-overlapping cross-asset *t*.
         - multi_horizon_ic
         - compute_ic
 
-!!! note "Regime analysis: two layers"
-    `regime_ic` is the **Layer B** wrapper that bundles the IC-specific
+!!! note "Regime analysis: two roles"
+    `regime_ic` is the **curated wrapper** that bundles the IC-specific
     cross-regime test (BHY adjustment + min-\|t\| + direction
     consistency). For a generic per-regime dispatcher with no
     second-layer inference, see [`by_regime`](../by-regime.md) or the
     [Regime analysis guide](../../guides/regime-analysis.md).
+    (Older docs called these roles "Layer A" / "Layer B"; renamed in
+    [#157](https://github.com/awwesomeman/factrix/issues/157).)
 
 ## See also
 
-- [`by_regime`](../by-regime.md) — Layer A dispatcher for any registered metric.
-- [Regime analysis guide](../../guides/regime-analysis.md) — when to use Layer A vs Layer B.
+- [`by_regime`](../by-regime.md) — dispatcher for any registered metric.
+- [Regime analysis guide](../../guides/regime-analysis.md) — when to use the dispatcher vs a curated wrapper.
 - [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
 - [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
 - [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.

--- a/docs/guides/regime-analysis.md
+++ b/docs/guides/regime-analysis.md
@@ -1,19 +1,22 @@
 # Regime Analysis
 
-Regime analysis asks "is this factor stable across market environments?" — a different question from out-of-sample decay (overfitting) and from cross-asset robustness (specification). factrix splits regime analysis into two layers because **slicing by regime** and **testing significance across regimes** are different jobs that need different APIs.
+Regime analysis asks "is this factor stable across market environments?" — a different question from out-of-sample decay (overfitting) and from cross-asset robustness (specification). factrix splits regime analysis into two roles because **slicing by regime** and **testing significance across regimes** are different jobs that need different APIs.
 
-## The two layers
+!!! note "Terminology"
+    These two roles were called **Layer A** and **Layer B** in #107 / #152 / #154 / #153 design discussions. They are now called **dispatcher** and **curated wrapper** ([#157](https://github.com/awwesomeman/factrix/issues/157)). Public API names (`by_regime`, `by_slice`, `regime_ic`, ...) are unchanged.
 
-| Layer | Function | What it does | What it does not do |
+## The two roles
+
+| Role | Function | What it does | What it does not do |
 |---|---|---|---|
-| A — slicing | [`by_regime(metric, df, *, regime_labels, **kwargs)`](../api/by-regime.md) | Slices `df` by regime label, calls `metric` per slice, returns `dict[regime, MetricOutput]` | **No cross-regime statistical test** |
-| B — bespoke inference | `regime_<metric>` (e.g. [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic)) | Layer A + a metric-appropriate cross-regime test (BHY, min-\|t\|, etc.) | Only exists for curated metrics |
+| Dispatcher | [`by_regime(metric, df, *, regime_labels, **kwargs)`](../api/by-regime.md) | Slices `df` by regime label, calls `metric` per slice, returns `dict[regime, MetricOutput]` | **No cross-regime statistical test** |
+| Curated wrapper | `regime_<metric>` (e.g. [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic)) | Dispatcher + a metric-appropriate cross-regime test (BHY, min-\|t\|, etc.) | Only exists for curated metrics |
 
-**Use Layer A when:** you want raw per-regime numbers, or you want to compose your own cross-regime test, or no Layer B wrapper exists for the metric you care about.
+**Use the dispatcher when:** you want raw per-regime numbers, or you want to compose your own cross-regime test, or no curated wrapper exists for the metric you care about.
 
-**Use Layer B when:** a curated wrapper exists for your metric and the bundled second-layer test matches your research question.
+**Use a curated wrapper when:** one exists for your metric and the bundled second-layer test matches your research question.
 
-!!! info "Layer B coverage as of v0.9.0"
+!!! info "Curated wrapper coverage as of v0.9.0"
     Only [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) ships. `regime_caar` and `regime_fama_macbeth` are tracked in [#107 Phase 2](https://github.com/awwesomeman/factrix/issues/107). Until then, `by_regime(compute_caar, df, ...)` and `by_regime(fama_macbeth, df, ...)` return per-regime values without a cross-regime statistic — useful for descriptive comparison, not for inference.
 
 ## Why no generic cross-regime test
@@ -25,7 +28,7 @@ A single dispatcher carrying a single second-layer test would silently over-clai
 - **CAAR** — per-regime clustering interacts with pooled-vs-split SE choice; needs a bespoke reconciliation.
 - **Turnover, hit_rate, monotonicity ρ** — no canonical cross-regime test; differences are descriptive.
 
-Bundling BHY into a generic dispatcher would apply it to all of these, including the cases where it is wrong. We chose explicit Layer B wrappers per metric family instead.
+Bundling BHY into a generic dispatcher would apply it to all of these, including the cases where it is wrong. We chose explicit curated wrappers per metric family instead.
 
 ## Constructing regime labels
 
@@ -59,7 +62,7 @@ are required for any defensible regime claim.
 
 ## Discovering eligible metrics
 
-Layer A only accepts metrics whose primary input is a date-keyed
+The dispatcher only accepts metrics whose primary input is a date-keyed
 DataFrame. Use [`list_metrics`](../api/list-metrics.md) with
 `format="json"` and filter on `input_kind == "panel"` to enumerate the
 candidate set for your `(scope, signal)` cell:
@@ -87,12 +90,12 @@ from factrix.metrics import by_regime, compute_ic, ic, regime_ic
 
 ic_df = compute_ic(panel, factor_col="value", return_col="forward_return")
 
-# Layer A — raw per-regime IC summaries
+# Dispatcher — raw per-regime IC summaries
 per_regime = by_regime(ic, ic_df, regime_labels=vol_labels)
 for label, out in per_regime.items():
     print(label, out.value, out.stat)
 
-# Layer B — IC-specific cross-regime second layer (BHY + min-|t|)
+# Curated wrapper — IC-specific cross-regime second layer (BHY + min-|t|)
 result = regime_ic(ic_df, regime_labels=vol_labels)
 result.metadata["per_regime"]              # raw + BHY-adjusted p per regime
 result.metadata["p_value_bhy_adjusted"]    # worst adjusted p (aggregate)
@@ -101,6 +104,6 @@ result.metadata["direction_consistent"]    # sign agreement across regimes
 
 ## Related
 
-- [`by_regime`](../api/by-regime.md) — Layer A surface and registered metrics.
-- [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) — Layer B wrapper for IC.
+- [`by_regime`](../api/by-regime.md) — dispatcher surface and registered metrics.
+- [`regime_ic`](../api/metrics/ic.md#factrix.metrics.ic.regime_ic) — curated wrapper for IC.
 - [Batch screening with BHY](batch-screening.md) — the same BHY family-correction principle, applied to factor candidates rather than regimes.

--- a/factrix/metrics/_slice.py
+++ b/factrix/metrics/_slice.py
@@ -1,10 +1,12 @@
-"""Axis-agnostic Layer-A slice dispatcher.
+"""Axis-agnostic slice dispatcher.
 
 Public :func:`by_slice` partitions a metric's date-keyed input on an
 existing column and applies the metric per slice. Private
 :func:`_slice_by_label` is the partition primitive shared with
-Layer-B wrappers. Universe-overlap composition is user-side; see
+curated wrappers. Universe-overlap composition is user-side; see
 ``docs/api/by-slice.md`` for reference patterns.
+
+(Previously called Layer-A; renamed per #157.)
 
 Matrix-row: by_slice | (*, *, *, *) | dispatcher | none (no cross-slice test) | _slice_by_label
 """
@@ -103,7 +105,7 @@ def by_slice(
     the API page for reference patterns. ``by_slice`` does no
     cross-slice statistical inference; for IC use
     :func:`factrix.metrics.regime_ic` (or a future ``by_<scope>_<metric>``
-    Layer-B wrapper) instead.
+    curated wrapper) instead.
     """
     sliced = _slice_by_label(df, label)
     return {key: metric(sub_df, **kwargs) for key, sub_df in sliced.items()}

--- a/factrix/metrics/regime.py
+++ b/factrix/metrics/regime.py
@@ -1,19 +1,21 @@
-"""Regime analysis: Layer A dispatcher (no second-layer inference).
+"""Regime analysis: dispatcher (no second-layer inference).
 
-Two-layer split (issue #107):
+Two roles (issue #107; previously called Layer-A / Layer-B, renamed
+per #157):
 
-* Layer A — :func:`by_regime` slices the metric input by regime label
-  and applies a metric callable per slice. Returns
+* **Dispatcher** — :func:`by_regime` slices the metric input by regime
+  label and applies a metric callable per slice. Returns
   ``dict[str, MetricOutput]``. **Performs no cross-regime statistical
   test.** A generic second-layer test would silently over-claim for
   non-t-stat metrics (Sharpe, turnover, hit_rate, monotonicity rho) —
   different metric families need bespoke cross-regime tests, or none
   at all.
-* Layer B — curated ``regime_<metric>`` wrappers (e.g. ``regime_ic``)
-  add a metric-appropriate second-layer on top of Layer A's slicing
-  primitive. They live in their respective metric modules.
+* **Curated wrapper** — ``regime_<metric>`` wrappers (e.g.
+  ``regime_ic``) add a metric-appropriate second-layer on top of the
+  dispatcher's slicing primitive. They live in their respective metric
+  modules.
 
-Both layers share :func:`_slice_by_regime` so the time-bisection
+Both roles share :func:`_slice_by_regime` so the time-bisection
 fallback and label-join semantics live in one place.
 
 Matrix-row: by_regime | (*, *, *, *) | dispatcher | none (no cross-regime test) | _slice_by_regime
@@ -103,7 +105,7 @@ def by_regime(
     Returns:
         ``{regime_label: metric(slice, **kwargs)}``. **No cross-regime
         statistic is computed** — consumers that need one must compose
-        a Layer B wrapper appropriate to the metric family (see e.g.
+        a curated wrapper appropriate to the metric family (see e.g.
         ``regime_ic``).
 
     Raises:

--- a/tests/test_by_regime.py
+++ b/tests/test_by_regime.py
@@ -1,4 +1,4 @@
-"""Tests for factrix.metrics.regime — Layer A dispatcher."""
+"""Tests for factrix.metrics.regime — dispatcher."""
 
 from datetime import datetime, timedelta
 
@@ -64,7 +64,7 @@ class TestByRegimeDispatcher:
             assert v.name == "ic"
 
     def test_no_cross_regime_aggregation(self):
-        """Layer A returns per-regime outputs only — no top-level summary."""
+        """Dispatcher returns per-regime outputs only — no top-level summary."""
         ic_df = _ic_series(40)
         out = by_regime(ic, ic_df)
         for v in out.values():

--- a/tests/test_by_slice.py
+++ b/tests/test_by_slice.py
@@ -1,4 +1,4 @@
-"""Tests for factrix.metrics.by_slice — axis-agnostic Layer-A dispatcher."""
+"""Tests for factrix.metrics.by_slice — axis-agnostic dispatcher."""
 
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
## Summary

- Rename "Layer A" / "Layer B" to **dispatcher** / **curated wrapper** in module docstrings, user-facing docs, and test docstrings.
- "Layer A/B" suggested a global factrix layering, but the split only describes two roles inside regime/slice analysis (per-slice run vs cross-slice inference). New names point at the role directly.
- Public API names (`by_regime`, `by_slice`, `regime_ic`, ...) and runtime behaviour are unchanged. Older CHANGELOG entries keep original wording.
- Affected docs each carry a brief "previously called Layer A/B" note so readers landing from older issue discussions can map terms.

## Test plan

- [x] `pytest tests/test_by_regime.py tests/test_by_slice.py` — 28 passed
- [x] `grep -rn "Layer.A\|Layer.B"` — only intentional historical-CHANGELOG entries and prior-naming notes remain
- [ ] mkdocs build of guides + API pages renders the new admonitions correctly

Closes #157