### PR TITLE
feat(errors): user-facing error UX contract (#165)

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -43,7 +43,7 @@ FactrixError                       # base
 | `IncompatibleAxisError` | `(scope, signal, metric)` is not a legal cell | optional `.suggested_fix` |
 | `ModeAxisError` | Legal cell has no procedure at the runtime `Mode` | typically `.suggested_fix: AnalysisConfig` |
 | `InsufficientSampleError` | `T` below the procedure floor | `.actual_periods`, `.required_periods` |
-| `UserInputError` | Unknown metric / `p_stat` / context key, column not in panel, wrong type | message rendered via `format_user_error` |
+| `UserInputError` | Unknown metric / `p_stat` / context key, column not in panel, wrong type | structured `.field`, `.value`, `.candidates`, `.suggestions`, `.expected`, `.docs_url` |
 
 ## Reading a `UserInputError`
 
@@ -68,36 +68,52 @@ For type / shape mismatches the second line reads `Expected: <shape>`
 instead of `Did you mean: ...` — same three-part structure, different
 diagnostic.
 
-## Building error messages programmatically
+## Programmatic recovery
 
-If you raise your own user-facing errors on top of factrix verbs, use
-the same renderer for visual consistency:
+The structured attributes are the contract — read them, do not parse
+the rendered message:
+
+```python
+import factrix as fl
+
+bad: dict[str, object] = {}
+for cfg in candidates:
+    try:
+        profiles.append(fl.evaluate(panel, cfg))
+    except fl.UserInputError as exc:
+        bad[exc.field] = exc.value
+        # exc.suggestions carries top-3 fuzzy matches when applicable
+```
+
+| Attribute | Meaning |
+|---|---|
+| `verb` | The calling verb (e.g. `"bhy"`, `"evaluate"`). |
+| `field` | The kwarg / column name that failed validation. |
+| `value` | The value the caller passed in. |
+| `candidates` | Sorted tuple of legal names (named-set branch); `()` otherwise. |
+| `suggestions` | `difflib` top-3 matches against `candidates`; `()` when none. |
+| `expected` | Human-readable shape (mismatch branch); `None` otherwise. |
+| `docs_url` | Resolved deployed-docs URL for the verb. |
+
+## Raising your own `UserInputError`
+
+If you build verbs on top of factrix and want the same canonical
+format, construct a `UserInputError` directly — it is keyword-only and
+renders its own message:
 
 ```python
 import factrix as fl
 
 if metric_name not in fl.list_metrics(cfg):
     raise fl.UserInputError(
-        fl.format_user_error(
-            verb="run_metrics",
-            field="metrics",
-            value=metric_name,
-            candidates=fl.list_metrics(cfg),
-            docs_path="api/run_metrics#metrics",
-        )
+        verb="run_metrics",
+        field="metrics",
+        value=metric_name,
+        candidates=fl.list_metrics(cfg),
+        docs_path="api/run_metrics#metrics",
     )
 ```
 
-`format_user_error` is keyword-only:
-
-| Parameter | Use |
-|---|---|
-| `verb` | Name of the calling verb (no parens). |
-| `field` | The kwarg / column name that failed validation. |
-| `value` | The value the caller passed in. Rendered with `repr`. |
-| `candidates` | Sequence of legal names (named-set typo branch). |
-| `expected` | Human-readable shape / type description (mismatch branch). |
-| `docs_path` | Suffix appended to `https://awwesomeman.github.io/factrix/`. |
-
-Pass exactly one of `candidates` / `expected`; if both are passed,
-`candidates` wins.
+Pass exactly one of `candidates` / `expected`. The rendered message is
+human-readable output; downstream code should rely on the attributes
+above, not on substring matches against `str(exc)`.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,103 @@
+# Errors
+
+How to read factrix errors and which exception class to catch.
+
+## TL;DR
+
+```python
+import factrix as fl
+
+try:
+    profile = fl.evaluate(panel, cfg)
+except fl.UserInputError as exc:
+    # User typed the wrong thing — typo, unknown name, wrong column.
+    # The message carries a fuzzy suggestion + a docs link.
+    print(exc)
+except fl.ConfigError as exc:
+    # AnalysisConfig validation / dispatch failure.
+    # exc.suggested_fix may carry a nearest-legal AnalysisConfig.
+    ...
+except fl.FactrixError as exc:
+    # Catch-all for anything else factrix raises.
+    ...
+```
+
+All factrix-raised exceptions inherit from `FactrixError`, so a single
+`except fl.FactrixError` blocks every library-raised failure.
+
+## Exception hierarchy
+
+```
+FactrixError                       # base
+├── ConfigError                    # AnalysisConfig validation / dispatch
+│   ├── MissingConfigError         # evaluate(raw) called without a config
+│   ├── IncompatibleAxisError      # (scope, signal, metric) is not a legal cell
+│   ├── ModeAxisError              # legal cell, no procedure at runtime mode
+│   └── InsufficientSampleError    # T below MIN_PERIODS_HARD on a TIMESERIES procedure
+└── UserInputError                 # named-set typo / type mismatch
+```
+
+| Exception | When you see it | What it carries |
+|---|---|---|
+| `MissingConfigError` | `evaluate(raw)` called without an `AnalysisConfig` | — (call `fl.suggest_config(raw)` to recover) |
+| `IncompatibleAxisError` | `(scope, signal, metric)` is not a legal cell | optional `.suggested_fix` |
+| `ModeAxisError` | Legal cell has no procedure at the runtime `Mode` | typically `.suggested_fix: AnalysisConfig` |
+| `InsufficientSampleError` | `T` below the procedure floor | `.actual_periods`, `.required_periods` |
+| `UserInputError` | Unknown metric / `p_stat` / context key, column not in panel, wrong type | message rendered via `format_user_error` |
+
+## Reading a `UserInputError`
+
+Every user-facing raise that takes a named input renders the same
+three-part message:
+
+```
+bhy(): unknown expand_over='univere_id'
+  Did you mean: "universe_id"?
+  Available: ['regime_id', 'sector', 'universe_id']
+  Docs: https://awwesomeman.github.io/factrix/api/bhy#expand_over
+```
+
+| Line | What to look at |
+|---|---|
+| `verb(): unknown <field>=<value>` | Which kwarg / column triggered the raise, and what value was received. |
+| `Did you mean: "..."` | Top-3 fuzzy candidates (omitted when nothing matches above the cutoff). |
+| `Available: [...]` | The full legal set — sorted, so the same set always renders identically. |
+| `Docs: https://...` | The verb's deployed-docs anchor. |
+
+For type / shape mismatches the second line reads `Expected: <shape>`
+instead of `Did you mean: ...` — same three-part structure, different
+diagnostic.
+
+## Building error messages programmatically
+
+If you raise your own user-facing errors on top of factrix verbs, use
+the same renderer for visual consistency:
+
+```python
+import factrix as fl
+
+if metric_name not in fl.list_metrics(cfg):
+    raise fl.UserInputError(
+        fl.format_user_error(
+            verb="run_metrics",
+            field="metrics",
+            value=metric_name,
+            candidates=fl.list_metrics(cfg),
+            docs_path="api/run_metrics#metrics",
+        )
+    )
+```
+
+`format_user_error` is keyword-only:
+
+| Parameter | Use |
+|---|---|
+| `verb` | Name of the calling verb (no parens). |
+| `field` | The kwarg / column name that failed validation. |
+| `value` | The value the caller passed in. Rendered with `repr`. |
+| `candidates` | Sequence of legal names (named-set typo branch). |
+| `expected` | Human-readable shape / type description (mismatch branch). |
+| `docs_path` | Suffix appended to `https://awwesomeman.github.io/factrix/`. |
+
+Pass exactly one of `candidates` / `expected`; if both are passed,
+`candidates` wins.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -63,7 +63,7 @@ Plus introspection / error / enum re-exports:
 - `fl.FactorProfile` — single unified result type
 - `fl.describe_analysis_modes(format="text"|"json")` — registry-reflected cell catalogue
 - `fl.suggest_config(panel)` — heuristic factory call from a raw panel
-- `fl.ConfigError`, `fl.IncompatibleAxisError`, `fl.ModeAxisError`, `fl.InsufficientSampleError` — exception hierarchy
+- `fl.FactrixError`, `fl.ConfigError`, `fl.MissingConfigError`, `fl.IncompatibleAxisError`, `fl.ModeAxisError`, `fl.InsufficientSampleError`, `fl.UserInputError` — exception hierarchy (see § Error UX contract)
 
 `__version__` is sourced from `pyproject.toml` (Commitizen-managed).
 
@@ -250,30 +250,48 @@ Every user-facing raise that takes a named input must carry:
    expected-shape string (type error)
 3. **Docs link**: deployed-docs anchor for the verb
 
-### Helper
+### Constructor
 
-`factrix.format_user_error(...)` renders the canonical string:
+`UserInputError` is keyword-only and renders its own message:
 
 ```python
-format_user_error(
+UserInputError(
     *,
     verb: str,
     field: str,
     value: object,
-    candidates: Sequence[str] | None = None,   # named-set typo
-    expected: str | None = None,               # type / shape mismatch
-    docs_path: str,                            # "api/<verb>#<anchor>"
-) -> str
+    candidates: Iterable[object] | None = None,   # named-set typo
+    expected: str | None = None,                  # type / shape mismatch
+    docs_path: str,                               # "api/<verb>#<anchor>"
+)
 ```
 
-- Exactly one of `candidates` / `expected` carries the diagnostic;
-  `candidates` wins when both are passed.
-- Fuzzy match: `difflib.get_close_matches(value, candidates, n=3, cutoff=0.6)`.
+- Exactly one of `candidates` / `expected` carries the diagnostic.
+- Fuzzy match: `difflib.get_close_matches(str(value), candidates, n=3, cutoff=0.6)`.
+- Non-string candidates are coerced via `str(...)` so `Enum` members or
+  type objects work without pre-conversion at the call site.
 - `docs_path` is appended to `https://awwesomeman.github.io/factrix/`
   so the deployed base URL lives in one place
   (`factrix._errors._DOCS_BASE`).
+- Long candidate lists truncate to the first 15 with a
+  `Available (15 of N, see Docs):` header; long `value` reprs cap at
+  120 chars to keep messages readable when callers pass DataFrames or
+  polars expressions.
 - Language: English (consistent with docstrings; errors land in
   stack traces / CI output).
+
+### Structured attributes
+
+Sub-issues and downstream consumers (LLM agents, screening loops)
+recover via attributes, not message substrings:
+
+- `.verb`, `.field`, `.value`, `.expected`, `.docs_url`
+- `.candidates: tuple[str, ...]` — sorted, `()` in the type-mismatch branch
+- `.suggestions: tuple[str, ...]` — difflib top-3, `()` when none above cutoff
+
+`UserInputError` multi-inherits from `ValueError` so generic ecosystem
+code (`pytest.raises(ValueError)`, broad `except ValueError`) still
+catches it.
 
 ### Adoption
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -217,6 +217,73 @@ runs; the warning surfaces the inflation so callers can read p ≈ 0.04 as
 
 ---
 
+## Error UX contract
+
+User-facing raises follow a single canonical message format so callers
+learn to read factrix errors once and recover programmatically across
+all verbs.
+
+### Hierarchy
+
+```
+FactrixError                       # base — all factrix-raised errors
+├── ConfigError                    # AnalysisConfig validation / dispatch
+│   ├── MissingConfigError
+│   ├── IncompatibleAxisError
+│   ├── ModeAxisError              # carries .suggested_fix
+│   └── InsufficientSampleError    # carries .actual_periods / .required_periods
+└── UserInputError                 # named-set typo / type mismatch
+```
+
+`UserInputError` is the marker for "user typed the wrong thing"
+(unknown metric / `p_stat` / `expand_over` key, column not in panel,
+wrong type). Catch it separately from `ConfigError` (axis miswire) and
+`InsufficientSampleError` (data limitation) when those branches need
+different recovery.
+
+### Three required fields
+
+Every user-facing raise that takes a named input must carry:
+
+1. **Trigger**: the kwarg / column name and the value received
+2. **Diagnostic**: either fuzzy candidates (named-set error) or an
+   expected-shape string (type error)
+3. **Docs link**: deployed-docs anchor for the verb
+
+### Helper
+
+`factrix.format_user_error(...)` renders the canonical string:
+
+```python
+format_user_error(
+    *,
+    verb: str,
+    field: str,
+    value: object,
+    candidates: Sequence[str] | None = None,   # named-set typo
+    expected: str | None = None,               # type / shape mismatch
+    docs_path: str,                            # "api/<verb>#<anchor>"
+) -> str
+```
+
+- Exactly one of `candidates` / `expected` carries the diagnostic;
+  `candidates` wins when both are passed.
+- Fuzzy match: `difflib.get_close_matches(value, candidates, n=3, cutoff=0.6)`.
+- `docs_path` is appended to `https://awwesomeman.github.io/factrix/`
+  so the deployed base URL lives in one place
+  (`factrix._errors._DOCS_BASE`).
+- Language: English (consistent with docstrings; errors land in
+  stack traces / CI output).
+
+### Adoption
+
+The contract is opt-in for new user-facing raises. Each v1 verb
+sub-issue (#147 / #160 / #161 / #162) declares conformance in its
+own DoD; retrofit of pre-contract raise sites is tracked separately
+so the helper itself can land without forcing a sweep.
+
+---
+
 ## Procedure pipelines
 
 The 7 registered procedures differ in **aggregation order** — which axis is

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -62,7 +62,6 @@ from factrix._errors import (
     MissingConfigError,
     ModeAxisError,
     UserInputError,
-    format_user_error,
 )
 from factrix._evaluate import _evaluate as _evaluate
 from factrix._profile import FactorProfile
@@ -150,7 +149,6 @@ __all__ = [
     "MissingConfigError",
     "ModeAxisError",
     "UserInputError",
-    "format_user_error",
     # Profile + dispatch
     "FactorProfile",
     "MetricOutput",

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -61,6 +61,8 @@ from factrix._errors import (
     InsufficientSampleError,
     MissingConfigError,
     ModeAxisError,
+    UserInputError,
+    format_user_error,
 )
 from factrix._evaluate import _evaluate as _evaluate
 from factrix._profile import FactorProfile
@@ -147,6 +149,8 @@ __all__ = [
     "InsufficientSampleError",
     "MissingConfigError",
     "ModeAxisError",
+    "UserInputError",
+    "format_user_error",
     # Profile + dispatch
     "FactorProfile",
     "MetricOutput",

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -9,7 +9,7 @@ so the user — or a calling AI agent — can recover programmatically.
 from __future__ import annotations
 
 import difflib
-from collections.abc import Sequence
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,59 +17,92 @@ if TYPE_CHECKING:
 
 
 _DOCS_BASE = "https://awwesomeman.github.io/factrix/"
+_VALUE_REPR_CAP = 120
+_AVAILABLE_PREVIEW = 15
+
+
+def _truncate_repr(value: object) -> str:
+    text = repr(value)
+    if len(text) <= _VALUE_REPR_CAP:
+        return text
+    return text[: _VALUE_REPR_CAP - 3] + "..."
+
+
+def _render_available(candidates: tuple[str, ...]) -> str:
+    if len(candidates) <= _AVAILABLE_PREVIEW:
+        return f"  Available: {list(candidates)!r}"
+    preview = list(candidates[:_AVAILABLE_PREVIEW])
+    return (
+        f"  Available ({_AVAILABLE_PREVIEW} of {len(candidates)}, "
+        f"see Docs): {preview!r}"
+    )
 
 
 class FactrixError(Exception):
     """Base for all factrix-raised errors."""
 
 
-class UserInputError(FactrixError):
+class UserInputError(FactrixError, ValueError):
     """User-supplied input does not match expected names or types.
 
     Raised for typos in named-set kwargs (metric / p_stat / context key
-    / column name) or input-type mismatches. Distinct from
-    :class:`ConfigError` (axis miswire) and :class:`InsufficientSampleError`
-    (data limitation): catch ``UserInputError`` to handle the
-    "user typed the wrong thing" branch separately from internal
-    config / sample failures.
+    / column name) or input-type mismatches. Multi-inherits from
+    :class:`ValueError` so ecosystem code (`pytest.raises(ValueError)`,
+    generic `except ValueError`) keeps working.
+
+    Structured attributes carry the diagnostic so callers (sub-issue
+    raises, LLM agents) do not parse the rendered message:
+
+    - ``verb``: the calling verb name (no parens)
+    - ``field``: the kwarg / column name that failed validation
+    - ``value``: the value the caller passed in
+    - ``candidates``: tuple of legal names (named-set branch); empty otherwise
+    - ``suggestions``: difflib top-3 fuzzy matches against ``candidates``
+    - ``expected``: human-readable shape (type-mismatch branch); ``None`` otherwise
+    - ``docs_url``: deployed-docs URL for the verb
     """
 
-
-def format_user_error(
-    *,
-    verb: str,
-    field: str,
-    value: object,
-    candidates: Sequence[str] | None = None,
-    expected: str | None = None,
-    docs_path: str,
-) -> str:
-    """Render the canonical user-facing error message.
-
-    Exactly one of ``candidates`` (named-set typo) or ``expected``
-    (type / shape mismatch) carries the diagnostic; ``candidates`` wins
-    when both are passed. ``docs_path`` is appended to
-    ``https://awwesomeman.github.io/factrix/`` so the deployed base URL
-    is configured in one place.
-    """
-    if not candidates and not expected:
-        raise ValueError("format_user_error requires candidates= or expected=")
-
-    lines: list[str] = []
-    if candidates:
-        lines.append(f"{verb}(): unknown {field}={value!r}")
-        suggestions = difflib.get_close_matches(
-            str(value), list(candidates), n=3, cutoff=0.6
+    def __init__(
+        self,
+        *,
+        verb: str,
+        field: str,
+        value: object,
+        candidates: Iterable[object] | None = None,
+        expected: str | None = None,
+        docs_path: str,
+    ) -> None:
+        if not candidates and not expected:
+            raise ValueError("UserInputError requires candidates= or expected=")
+        ordered = tuple(sorted(str(c) for c in candidates)) if candidates else ()
+        suggestions = (
+            tuple(difflib.get_close_matches(str(value), ordered, n=3, cutoff=0.6))
+            if ordered
+            else ()
         )
-        if suggestions:
-            quoted = ", ".join(f'"{s}"' for s in suggestions)
-            lines.append(f"  Did you mean: {quoted}?")
-        lines.append(f"  Available: {sorted(candidates)!r}")
-    else:
-        lines.append(f"{verb}(): invalid {field}={value!r}")
-        lines.append(f"  Expected: {expected}")
-    lines.append(f"  Docs: {_DOCS_BASE}{docs_path.lstrip('/')}")
-    return "\n".join(lines)
+        self.verb = verb
+        self.field = field
+        self.value = value
+        self.candidates: tuple[str, ...] = ordered
+        self.suggestions: tuple[str, ...] = suggestions
+        self.expected = expected
+        self.docs_url = f"{_DOCS_BASE}{docs_path.lstrip('/')}"
+        super().__init__(self._render())
+
+    def _render(self) -> str:
+        value_repr = _truncate_repr(self.value)
+        lines: list[str] = []
+        if self.candidates:
+            lines.append(f"{self.verb}(): unknown {self.field}={value_repr}")
+            if self.suggestions:
+                quoted = ", ".join(f'"{s}"' for s in self.suggestions)
+                lines.append(f"  Did you mean: {quoted}?")
+            lines.append(_render_available(self.candidates))
+        else:
+            lines.append(f"{self.verb}(): invalid {self.field}={value_repr}")
+            lines.append(f"  Expected: {self.expected}")
+        lines.append(f"  Docs: {self.docs_url}")
+        return "\n".join(lines)
 
 
 class ConfigError(FactrixError):

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -8,14 +8,68 @@ so the user — or a calling AI agent — can recover programmatically.
 
 from __future__ import annotations
 
+import difflib
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from factrix._analysis_config import AnalysisConfig
 
 
+_DOCS_BASE = "https://awwesomeman.github.io/factrix/"
+
+
 class FactrixError(Exception):
     """Base for all factrix-raised errors."""
+
+
+class UserInputError(FactrixError):
+    """User-supplied input does not match expected names or types.
+
+    Raised for typos in named-set kwargs (metric / p_stat / context key
+    / column name) or input-type mismatches. Distinct from
+    :class:`ConfigError` (axis miswire) and :class:`InsufficientSampleError`
+    (data limitation): catch ``UserInputError`` to handle the
+    "user typed the wrong thing" branch separately from internal
+    config / sample failures.
+    """
+
+
+def format_user_error(
+    *,
+    verb: str,
+    field: str,
+    value: object,
+    candidates: Sequence[str] | None = None,
+    expected: str | None = None,
+    docs_path: str,
+) -> str:
+    """Render the canonical user-facing error message.
+
+    Exactly one of ``candidates`` (named-set typo) or ``expected``
+    (type / shape mismatch) carries the diagnostic; ``candidates`` wins
+    when both are passed. ``docs_path`` is appended to
+    ``https://awwesomeman.github.io/factrix/`` so the deployed base URL
+    is configured in one place.
+    """
+    if not candidates and not expected:
+        raise ValueError("format_user_error requires candidates= or expected=")
+
+    lines: list[str] = []
+    if candidates:
+        lines.append(f"{verb}(): unknown {field}={value!r}")
+        suggestions = difflib.get_close_matches(
+            str(value), list(candidates), n=3, cutoff=0.6
+        )
+        if suggestions:
+            quoted = ", ".join(f'"{s}"' for s in suggestions)
+            lines.append(f"  Did you mean: {quoted}?")
+        lines.append(f"  Available: {sorted(candidates)!r}")
+    else:
+        lines.append(f"{verb}(): invalid {field}={value!r}")
+        lines.append(f"  Expected: {expected}")
+    lines.append(f"  Docs: {_DOCS_BASE}{docs_path.lstrip('/')}")
+    return "\n".join(lines)
 
 
 class ConfigError(FactrixError):

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -320,14 +320,23 @@ All factrix exceptions inherit from `FactrixError`, so agents can write
 
 ```
 FactrixError                       # base — all factrix-raised errors
-└── ConfigError                    # AnalysisConfig validation / dispatch
-    ├── MissingConfigError         # evaluate(raw) called without a config
-    ├── IncompatibleAxisError      # (scope, signal, metric) is not a legal cell
-    ├── ModeAxisError              # legal cell, no procedure at runtime mode;
-    │                              # carries .suggested_fix: AnalysisConfig | None
-    └── InsufficientSampleError    # T < MIN_PERIODS_HARD on a TIMESERIES procedure;
-                                   # carries .actual_periods / .required_periods
+├── ConfigError                    # AnalysisConfig validation / dispatch
+│   ├── MissingConfigError         # evaluate(raw) called without a config
+│   ├── IncompatibleAxisError      # (scope, signal, metric) is not a legal cell
+│   ├── ModeAxisError              # legal cell, no procedure at runtime mode;
+│   │                              # carries .suggested_fix: AnalysisConfig | None
+│   └── InsufficientSampleError    # T < MIN_PERIODS_HARD on a TIMESERIES procedure;
+│                                  # carries .actual_periods / .required_periods
+└── UserInputError                 # user-supplied input does not match expected
+                                   # names or types (typo in named-set kwarg,
+                                   # column not in panel, wrong type)
 ```
+
+User-facing raises that take a named input render their message via
+`factrix.format_user_error(...)` — keyword-only helper that returns a
+canonical string (verb / field / value, fuzzy suggestion via
+`difflib.get_close_matches`, sorted candidate list, docs URL). Used
+in conjunction with `UserInputError`.
 
 Recovery payloads — what each subclass carries beyond `.args[0]`:
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -332,11 +332,12 @@ FactrixError                       # base — all factrix-raised errors
                                    # column not in panel, wrong type)
 ```
 
-User-facing raises that take a named input render their message via
-`factrix.format_user_error(...)` — keyword-only helper that returns a
-canonical string (verb / field / value, fuzzy suggestion via
-`difflib.get_close_matches`, sorted candidate list, docs URL). Used
-in conjunction with `UserInputError`.
+`UserInputError` is keyword-constructed and renders its own canonical
+message; structured attributes (`.verb`, `.field`, `.value`,
+`.candidates`, `.suggestions`, `.expected`, `.docs_url`) carry the
+diagnostic so callers (LLM agents, screening loops) recover without
+parsing `.args[0]`. Multi-inherits from `ValueError` for ecosystem
+compatibility.
 
 Recovery payloads — what each subclass carries beyond `.args[0]`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
       - multi_factor: api/multi-factor.md
       - datasets: api/datasets.md
       - preprocess: api/preprocess.md
+      - Errors: api/errors.md
       - Metrics:
           - api/metrics/index.md
           - Individual continuous:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,107 +2,143 @@
 
 from __future__ import annotations
 
+import enum
+
 import pytest
-from factrix._errors import (
-    FactrixError,
-    UserInputError,
-    format_user_error,
-)
+from factrix._errors import FactrixError, UserInputError
 
 
-def test_user_input_error_subclasses_factrix_error() -> None:
+def test_subclasses_factrix_error_and_value_error() -> None:
     assert issubclass(UserInputError, FactrixError)
+    assert issubclass(UserInputError, ValueError)
 
 
-def test_candidates_with_close_match_emits_suggestion() -> None:
-    msg = format_user_error(
+def test_caught_by_generic_value_error() -> None:
+    with pytest.raises(ValueError):
+        raise UserInputError(
+            verb="x",
+            field="f",
+            value="a",
+            candidates=["aa"],
+            docs_path="api/x",
+        )
+
+
+def test_candidates_branch_renders_suggestion() -> None:
+    err = UserInputError(
         verb="bhy",
         field="expand_over",
         value="univere_id",
         candidates=["universe_id", "regime_id", "sector"],
         docs_path="api/bhy#expand_over",
     )
+    msg = str(err)
     assert "bhy(): unknown expand_over='univere_id'" in msg
     assert 'Did you mean: "universe_id"' in msg
     assert "Available:" in msg
     assert "https://awwesomeman.github.io/factrix/api/bhy#expand_over" in msg
 
 
-def test_candidates_no_close_match_omits_suggestion_line() -> None:
-    msg = format_user_error(
+def test_attributes_exposed_for_programmatic_recovery() -> None:
+    err = UserInputError(
+        verb="bhy",
+        field="expand_over",
+        value="univere_id",
+        candidates=["universe_id", "regime_id", "sector"],
+        docs_path="api/bhy#expand_over",
+    )
+    assert err.verb == "bhy"
+    assert err.field == "expand_over"
+    assert err.value == "univere_id"
+    assert err.candidates == ("regime_id", "sector", "universe_id")
+    assert err.suggestions == ("universe_id",)
+    assert err.expected is None
+    assert err.docs_url == ("https://awwesomeman.github.io/factrix/api/bhy#expand_over")
+
+
+def test_no_close_match_omits_suggestion() -> None:
+    err = UserInputError(
         verb="run_metrics",
         field="metrics",
         value="completely_unrelated_xyz",
         candidates=["ic", "fm_lambda", "caar"],
         docs_path="api/run_metrics",
     )
-    assert "Did you mean" not in msg
-    assert "Available:" in msg
+    assert err.suggestions == ()
+    assert "Did you mean" not in str(err)
+    assert "Available:" in str(err)
 
 
-def test_expected_only_renders_type_branch() -> None:
-    msg = format_user_error(
+def test_expected_branch_for_type_mismatch() -> None:
+    err = UserInputError(
         verb="evaluate",
         field="factor_col",
         value="alpha_x",
         expected="column present in panel",
         docs_path="api/evaluate#factor_col",
     )
-    assert "evaluate(): invalid factor_col='alpha_x'" in msg
-    assert "Expected: column present in panel" in msg
-    assert "Available" not in msg
-
-
-def test_candidates_take_priority_when_both_passed() -> None:
-    msg = format_user_error(
-        verb="x",
-        field="f",
-        value="a",
-        candidates=["aa", "bb"],
-        expected="should not appear",
-        docs_path="api/x",
-    )
-    assert "Expected" not in msg
-    assert "Available" in msg
+    assert err.candidates == ()
+    assert err.expected == "column present in panel"
+    assert "evaluate(): invalid factor_col='alpha_x'" in str(err)
+    assert "Expected: column present in panel" in str(err)
+    assert "Available" not in str(err)
 
 
 def test_neither_candidates_nor_expected_raises() -> None:
     with pytest.raises(ValueError, match="candidates= or expected="):
-        format_user_error(verb="x", field="f", value=1, docs_path="api/x")
+        UserInputError(verb="x", field="f", value=1, docs_path="api/x")
 
 
 def test_docs_path_leading_slash_normalized() -> None:
-    msg = format_user_error(
+    err = UserInputError(
         verb="x",
         field="f",
         value="a",
         candidates=["aa"],
         docs_path="/api/x",
     )
-    assert "https://awwesomeman.github.io/factrix/api/x" in msg
-    assert "factrix/.api" not in msg
-    assert "factrix//api" not in msg
+    assert err.docs_url == "https://awwesomeman.github.io/factrix/api/x"
 
 
-def test_available_list_is_sorted_for_stable_output() -> None:
-    msg = format_user_error(
+def test_available_truncates_when_long() -> None:
+    cands = [f"m{i:03d}" for i in range(50)]
+    err = UserInputError(
         verb="x",
-        field="f",
-        value="a",
-        candidates=["zeta", "alpha", "mu"],
+        field="metric",
+        value="bad",
+        candidates=cands,
         docs_path="api/x",
     )
-    assert "['alpha', 'mu', 'zeta']" in msg
+    msg = str(err)
+    assert "Available (15 of 50, see Docs):" in msg
+    assert "m000" in msg
+    assert "m049" not in msg
 
 
-def test_userinputerror_can_carry_helper_message() -> None:
-    msg = format_user_error(
-        verb="bhy",
-        field="expand_over",
-        value="univere_id",
-        candidates=["universe_id", "regime_id"],
-        docs_path="api/bhy#expand_over",
+def test_value_repr_truncated_for_huge_value() -> None:
+    huge = "x" * 500
+    err = UserInputError(
+        verb="x",
+        field="f",
+        value=huge,
+        candidates=["aa"],
+        docs_path="api/x",
     )
-    err = UserInputError(msg)
-    assert "Did you mean" in str(err)
-    assert isinstance(err, FactrixError)
+    msg = str(err)
+    assert "..." in msg
+    assert len(msg.splitlines()[0]) < 200
+
+
+def test_non_string_candidates_coerced() -> None:
+    class Mode(enum.Enum):
+        A = "alpha"
+        B = "beta"
+
+    err = UserInputError(
+        verb="x",
+        field="mode",
+        value="alfa",
+        candidates=list(Mode),
+        docs_path="api/x",
+    )
+    assert err.candidates == tuple(sorted(str(m) for m in Mode))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,108 @@
+"""Coverage for the user-facing error contract (#165)."""
+
+from __future__ import annotations
+
+import pytest
+from factrix._errors import (
+    FactrixError,
+    UserInputError,
+    format_user_error,
+)
+
+
+def test_user_input_error_subclasses_factrix_error() -> None:
+    assert issubclass(UserInputError, FactrixError)
+
+
+def test_candidates_with_close_match_emits_suggestion() -> None:
+    msg = format_user_error(
+        verb="bhy",
+        field="expand_over",
+        value="univere_id",
+        candidates=["universe_id", "regime_id", "sector"],
+        docs_path="api/bhy#expand_over",
+    )
+    assert "bhy(): unknown expand_over='univere_id'" in msg
+    assert 'Did you mean: "universe_id"' in msg
+    assert "Available:" in msg
+    assert "https://awwesomeman.github.io/factrix/api/bhy#expand_over" in msg
+
+
+def test_candidates_no_close_match_omits_suggestion_line() -> None:
+    msg = format_user_error(
+        verb="run_metrics",
+        field="metrics",
+        value="completely_unrelated_xyz",
+        candidates=["ic", "fm_lambda", "caar"],
+        docs_path="api/run_metrics",
+    )
+    assert "Did you mean" not in msg
+    assert "Available:" in msg
+
+
+def test_expected_only_renders_type_branch() -> None:
+    msg = format_user_error(
+        verb="evaluate",
+        field="factor_col",
+        value="alpha_x",
+        expected="column present in panel",
+        docs_path="api/evaluate#factor_col",
+    )
+    assert "evaluate(): invalid factor_col='alpha_x'" in msg
+    assert "Expected: column present in panel" in msg
+    assert "Available" not in msg
+
+
+def test_candidates_take_priority_when_both_passed() -> None:
+    msg = format_user_error(
+        verb="x",
+        field="f",
+        value="a",
+        candidates=["aa", "bb"],
+        expected="should not appear",
+        docs_path="api/x",
+    )
+    assert "Expected" not in msg
+    assert "Available" in msg
+
+
+def test_neither_candidates_nor_expected_raises() -> None:
+    with pytest.raises(ValueError, match="candidates= or expected="):
+        format_user_error(verb="x", field="f", value=1, docs_path="api/x")
+
+
+def test_docs_path_leading_slash_normalized() -> None:
+    msg = format_user_error(
+        verb="x",
+        field="f",
+        value="a",
+        candidates=["aa"],
+        docs_path="/api/x",
+    )
+    assert "https://awwesomeman.github.io/factrix/api/x" in msg
+    assert "factrix/.api" not in msg
+    assert "factrix//api" not in msg
+
+
+def test_available_list_is_sorted_for_stable_output() -> None:
+    msg = format_user_error(
+        verb="x",
+        field="f",
+        value="a",
+        candidates=["zeta", "alpha", "mu"],
+        docs_path="api/x",
+    )
+    assert "['alpha', 'mu', 'zeta']" in msg
+
+
+def test_userinputerror_can_carry_helper_message() -> None:
+    msg = format_user_error(
+        verb="bhy",
+        field="expand_over",
+        value="univere_id",
+        candidates=["universe_id", "regime_id"],
+        docs_path="api/bhy#expand_over",
+    )
+    err = UserInputError(msg)
+    assert "Did you mean" in str(err)
+    assert isinstance(err, FactrixError)


### PR DESCRIPTION
## Summary

Lands the v1 user-facing error contract from #165: a single canonical
format for "user typed the wrong thing" failures, with structured
attributes so sub-issue raises and downstream agents recover without
parsing message strings.

- `UserInputError(FactrixError, ValueError)` — keyword-only constructor
  (`verb`, `field`, `value`, `candidates` | `expected`, `docs_path`)
  rendering the canonical three-part message and exposing `.verb /
  .field / .value / .candidates / .suggestions / .expected / .docs_url`
- `Iterable[object]` candidates (Enum / class-set friendly), `difflib`
  fuzzy top-3, sorted Available list capped at 15 with `(15 of N, see
  Docs)` indicator, `value` repr capped at 120 chars
- Multi-inherits `ValueError` so `except ValueError` /
  `pytest.raises(ValueError)` keep working
- Adoption is opt-in for new raises (#147 / #160 / #161 / #162);
  retrofit of pre-contract sites is tracked separately so this lands
  without forcing a sweep
- Docs: `docs/api/errors.md` (user view), `docs/development/architecture.md`
  §Error UX contract (engineering view), `factrix/llms-full.txt`
  hierarchy refresh

## Test plan

- [x] `uv run pytest` — 902 passed
- [x] `tests/test_errors.py` covers both branches, attribute exposure,
  `ValueError` catch, value/Available truncation, Enum-coercion
- [x] `tests/test_docs_pages.py` and `tests/test_docs_llms.py` resolve
  every referenced symbol
- [ ] mkdocs build (manual smoke) — Errors entry renders under API tab

Closes #165