### PR TITLE
feat(mtc): family verb naming + shared family resolution layer (#161)

### DIFF
--- a/docs/api/identity.md
+++ b/docs/api/identity.md
@@ -84,7 +84,7 @@ profiles = [
     for name in factor_cols
 ]
 large_cap = [p for p in profiles if p.context.get("universe_id") == "us_large_cap"]
-fl.multi_factor.bhy(large_cap, threshold=0.05)
+fl.multi_factor.bhy(large_cap, q=0.05)
 ```
 
 When the universe / regime axis IS a hypothesis dimension (e.g., "is

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -10,23 +10,73 @@ that assumes independence over-corrects).
 ## Call shape
 
 ```python
-profiles = [fl.evaluate(panel_i, cfg) for panel_i in candidates]
-adjusted = fl.multi_factor.bhy(profiles)
+import dataclasses
+
+profiles = [
+    dataclasses.replace(
+        fl.evaluate(panel, cfg), factor_id=f"momentum_{lookback}"
+    )
+    for lookback, cfg in candidates
+]
+survivors = fl.multi_factor.bhy(profiles, q=0.05)
 ```
 
-Returns the collection with `p_value_bhy_adjusted` populated on each
-profile; per-factor `verdict()` reads the adjusted $p$ when present.
+The input list **is** the family. `bhy` runs one Benjamini–Yekutieli
+step-up over all profiles by default, returning the surviving subset.
+Set `expand_over=[<context key>]` to declare per-bucket independent
+families (Benjamini & Bogomolov 2014 selective inference); for
+example, `expand_over=["regime_id"]` runs one step-up per regime.
 
-`bhy` implements the Benjamini-Yekutieli (2001) procedure with the
-$c(m) = \sum_{i=1}^{m} 1/i$ dependence correction, valid under
-arbitrary positive or negative dependence at the cost of a $1/\ln m$
-shrinkage relative to plain BH. Plain Benjamini-Hochberg (1995) is
-**not** offered: typical factor-pool dependence violates its PRDS
-assumption.
+`bhy` implements the Benjamini–Yekutieli (2001) procedure with the
+harmonic dependence correction $c(m) = \sum_{i=1}^{m} 1/i$ baked into
+the threshold. **Pass your nominal `q` directly — no manual division.**
+The procedure controls FDR ≤ q under arbitrary positive or negative
+dependence at the cost of a $1/\ln m$ power loss relative to plain BH.
+Plain Benjamini–Hochberg (1995) is **not** offered: typical factor-pool
+dependence violates its Positive Regression Dependency on a Subset
+(PRDS) assumption.
 
-For the design rationale (BHY rather than Bayesian or
-reality-check / SPA bootstraps) see
-[Reference § Statistical methods § Multiple-testing](../reference/statistical-methods.md#2-multiple-testing-under-dependence)
+## Parameters
+
+| Kwarg | Default | Meaning |
+|-------|---------|---------|
+| `expand_over` | `None` | Context keys whose distinct value tuples split the input into independent step-ups. Names must live in `FactorProfile.context` (never identity). |
+| `p_stat` | `None` (= `primary_p`) | Alternate p-value `StatCode` (must satisfy `is_p_value`). Common picks: `IC_P`, `FM_LAMBDA_P`, `CAAR_P`. |
+| `q` | `0.05` | Nominal false discovery rate target. The Benjamini–Yekutieli $c(m)$ correction is applied internally — pass the level you actually want; do not pre-divide. |
+
+### Identity vs context (anti-shopping defense)
+
+Identity = `(factor_id, forward_periods)` — names *which hypothesis*.
+Context = mutable dict of slicing conditions (`universe_id`,
+`regime_id`, …) — names *which slice* of the data the hypothesis was
+tested on. `expand_over` may only name context keys, never identity.
+
+Concretely: if `expand_over=["factor_id"]` were allowed, every factor
+would land in its own size-1 family and pass its own step-up trivially
+— FDR control across the screening universe collapses. Same logic for
+`forward_periods`: per-horizon families would let a candidate "shop"
+the horizon at which its noise happens to clear the threshold. Forcing
+`expand_over` to live in `context` keeps the family axis orthogonal to
+the hypothesis being tested. See [Development § Architecture § Family
+verbs](../development/architecture.md#_resolve_family-four-invariants)
+for the full invariant list.
+
+## Migration from v0.4
+
+| v0.4 | v0.5 |
+|------|------|
+| `bhy(profiles, threshold=0.05)` | `bhy(profiles, q=0.05)` (`threshold=` still accepted with `DeprecationWarning`) |
+| `bhy(profiles, gate=StatCode.X)` | `bhy(profiles, p_stat=StatCode.X)` (`gate=` still accepted with `DeprecationWarning`) |
+| auto-partition by dispatch cell × horizon | caller declares the family; mixed `forward_periods` without `expand_over` emits `RuntimeWarning`. **Fix:** split the call per horizon, or pass `expand_over=[<context key>]` if profiles legitimately co-exist as one family across horizons. |
+| same `factor_id` across cells silently auto-split | raises `UserInputError` (duplicate identity). **Fix:** set unique `factor_id` per profile via `dataclasses.replace(profile, factor_id=...)`, or use `expand_over` if profiles really do share identity but belong in separate test buckets. |
+
+## Design rationale
+
+For why BHY (rather than Bayesian or reality-check / SPA bootstraps)
+see [Reference § Statistical methods § Multiple-testing](../reference/statistical-methods.md#2-multiple-testing-under-dependence)
 and [Development § Design notes § BHY](../development/design-notes.md#5-bhy-rather-than-bayesian-multiple-testing).
+For the architectural place of `_resolve_family` and the closed-form
+vs resampling-based verb classification see [Development §
+Architecture § Family verbs](../development/architecture.md#family-verbs-and-the-resolution-layer).
 
 ::: factrix.multi_factor.bhy

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -10,12 +10,8 @@ that assumes independence over-corrects).
 ## Call shape
 
 ```python
-import dataclasses
-
 profiles = [
-    dataclasses.replace(
-        fl.evaluate(panel, cfg), factor_id=f"momentum_{lookback}"
-    )
+    fl.evaluate(panel_per_lookback[lookback], cfg, factor_col=f"momentum_{lookback}")
     for lookback, cfg in candidates
 ]
 survivors = fl.multi_factor.bhy(profiles, q=0.05)
@@ -23,6 +19,12 @@ survivors = fl.multi_factor.bhy(profiles, q=0.05)
 
 The input list **is** the family. `bhy` runs one Benjamini–Yekutieli
 step-up over all profiles by default, returning the surviving subset.
+Each panel carries its factor under a distinct column name and
+`evaluate(..., factor_col=name)` auto-stamps `factor_id` from that
+name; this is the canonical multi-factor pattern. When you cannot
+rename the column (e.g. an upstream loader fixes it), reach for
+`dataclasses.replace(profile, factor_id=...)` as an escape hatch.
+
 Set `expand_over=[<context key>]` to declare per-bucket independent
 families (Benjamini & Bogomolov 2014 selective inference); for
 example, `expand_over=["regime_id"]` runs one step-up per regime.
@@ -68,7 +70,7 @@ for the full invariant list.
 | `bhy(profiles, threshold=0.05)` | `bhy(profiles, q=0.05)` (`threshold=` still accepted with `DeprecationWarning`) |
 | `bhy(profiles, gate=StatCode.X)` | `bhy(profiles, p_stat=StatCode.X)` (`gate=` still accepted with `DeprecationWarning`) |
 | auto-partition by dispatch cell × horizon | caller declares the family; mixed `forward_periods` without `expand_over` emits `RuntimeWarning`. **Fix:** split the call per horizon, or pass `expand_over=[<context key>]` if profiles legitimately co-exist as one family across horizons. |
-| same `factor_id` across cells silently auto-split | raises `UserInputError` (duplicate identity). **Fix:** set unique `factor_id` per profile via `dataclasses.replace(profile, factor_id=...)`, or use `expand_over` if profiles really do share identity but belong in separate test buckets. |
+| same `factor_id` across cells silently auto-split | raises `UserInputError` (duplicate identity). **Fix (canonical):** name each panel's factor column distinctly and pass `evaluate(..., factor_col=name)`. **Fix (escape hatch):** post-hoc stamp via `dataclasses.replace(profile, factor_id=...)`. **Or:** use `expand_over` if profiles really do share identity but belong in separate test buckets. |
 
 ## Design rationale
 

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -61,10 +61,10 @@ the hypothesis being tested. See [Development § Architecture § Family
 verbs](../development/architecture.md#_resolve_family-four-invariants)
 for the full invariant list.
 
-## Migration from v0.4
+## Behaviour change (#161)
 
-| v0.4 | v0.5 |
-|------|------|
+| Before | After |
+|--------|-------|
 | `bhy(profiles, threshold=0.05)` | `bhy(profiles, q=0.05)` (`threshold=` still accepted with `DeprecationWarning`) |
 | `bhy(profiles, gate=StatCode.X)` | `bhy(profiles, p_stat=StatCode.X)` (`gate=` still accepted with `DeprecationWarning`) |
 | auto-partition by dispatch cell × horizon | caller declares the family; mixed `forward_periods` without `expand_over` emits `RuntimeWarning`. **Fix:** split the call per horizon, or pass `expand_over=[<context key>]` if profiles legitimately co-exist as one family across horizons. |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -527,10 +527,10 @@ All three user-facing raises route through `factrix._errors.UserInputError`
 unique tuple of `context[k] for k in expand_over` is its own step-up batch —
 e.g. `expand_over=["regime_id"]` runs one BHY step-up per regime.
 
-### Caller responsibilities (v0.4 → v0.5 change)
+### Caller responsibilities (#161 contract change)
 
-The v0.4 `bhy` auto-partitioned by `_FamilyKey(_DispatchKey, forward_periods)`.
-v0.5 retired this in favour of explicit family declaration:
+`bhy` previously auto-partitioned by `_FamilyKey(_DispatchKey, forward_periods)`.
+#161 retired the auto-split in favour of explicit family declaration:
 
 - Mixing cells without distinct `factor_id` now raises `UserInputError`
   (duplicate identity) where v0.4 silently auto-split. Set `factor_id` per

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -54,7 +54,7 @@ Three entry points, all in `factrix.__init__`:
 |--------|---------|
 | `fl.AnalysisConfig` | Three-axis frozen dataclass; construct via 4 factory methods |
 | `fl.evaluate(panel, config)` | Dispatch to the registered procedure → `FactorProfile` |
-| `fl.multi_factor.bhy(profiles, *, threshold=0.05)` | Benjamini-Yekutieli FDR correction across a profile batch |
+| `fl.multi_factor.bhy(profiles, *, expand_over=None, p_stat=None, q=0.05)` | Benjamini-Yekutieli FDR correction; one declared family per call (optionally split per-bucket via `expand_over`) |
 
 Plus introspection / error / enum re-exports:
 
@@ -482,26 +482,65 @@ Failure modes:
 
 ---
 
-## BHY family partitioning
+## Family verbs and the resolution layer
 
-`factrix/_multi_factor.py::bhy(profiles, *, threshold=0.05, gate=None)`:
+Multiple-testing verbs (`bhy` today; `bhy_hierarchical` / `partial_conjunction` /
+`bonferroni` / `holm` / `romano_wolf` planned) share a single internal pre-processing
+layer in `factrix/_family.py::_resolve_family`. Each verb's procedure runs *after*
+the family-resolution invariants pass.
 
-1. partitions `profiles` by `_family_key(profile) -> _FamilyKey(dispatch, forward_periods)`:
-   - `dispatch: _DispatchKey` derived from `(scope, signal, metric, mode)` with the
-     `_SCOPE_COLLAPSED` collapse rule applied so PANEL and TIMESERIES sparse profiles
-     aggregate consistently
-   - `forward_periods` from `profile.config.forward_periods` — split into separate families
-     because each horizon carries its own null distribution and effective sample size;
-     pooling horizons dilutes the step-up threshold `q × k / N` and silently inflates FDR
-2. within each family, runs Benjamini-Yekutieli step-up correction at the
-   given FDR threshold and returns the survivors.
+### Two signature classes (#161)
 
-`_FamilyKey` is kept distinct from `_DispatchKey` (the registry SSOT must remain
-horizon-agnostic — one procedure per cell). User does **not** pass a group key —
-same-test-family is enforced mechanically.
+The shared layer admits two verb shapes — important to keep distinct so a
+resampling-based verb cannot retroactively force a kwarg onto the closed-form
+ones:
 
-Cross-family aggregation (e.g. horizon-shopping correction) is the user's
-responsibility — see [Guides § Batch screening (BHY)](../guides/batch-screening.md) for the FWER-then-BHY recipe.
+| Class | Verbs | Signature shape |
+|-------|-------|-----------------|
+| Closed-form (p-value only) | `bhy` / `bhy_hierarchical` / `partial_conjunction` / `bonferroni` / `holm` | `(profiles, *, expand_over, p_stat, ...)` |
+| Resampling-based | `romano_wolf` (planned) | `(profiles, panel, *, expand_over, p_stat, n_bootstrap, ...)` — needs raw return panel for bootstrap step-down |
+
+### `_resolve_family` four invariants
+
+For input `profiles: Sequence[FactorProfile]`, `expand_over: Sequence[str] | None`,
+and `p_stat: StatCode | None`:
+
+1. `expand_over` names must be present in every profile's `context` and must
+   not collide with identity dimensions (`factor_id` / `forward_periods`) —
+   identity names *the hypothesis*, context names *the slicing condition*;
+   confusing the two is the v0.5 anti-shopping defense at the family layer.
+2. partition key per profile = `identity + tuple(context[k] for k in expand_over)`
+   must be unique across the input. `FactorProfile.__hash__ = None`, so dedup
+   walks the tuple, not a hash.
+3. `p_stat` (when supplied) must satisfy `is_p_value` and must be populated
+   on every profile.
+4. Resolved `p_value` per entry: `primary_p` when `p_stat is None`, else
+   `profile.stats[p_stat]`.
+
+All three user-facing raises route through `factrix._errors.UserInputError`
+(#165) so fuzzy suggestions and docs links render uniformly.
+
+### `expand_over` semantics
+
+`expand_over` declares per-bucket independent families (Benjamini & Bogomolov
+2014, *Selective Inference on Multiple Families of Hypotheses*, JRSS-B). Each
+unique tuple of `context[k] for k in expand_over` is its own step-up batch —
+e.g. `expand_over=["regime_id"]` runs one BHY step-up per regime.
+
+### Caller responsibilities (v0.4 → v0.5 change)
+
+The v0.4 `bhy` auto-partitioned by `_FamilyKey(_DispatchKey, forward_periods)`.
+v0.5 retired this in favour of explicit family declaration:
+
+- Mixing cells without distinct `factor_id` now raises `UserInputError`
+  (duplicate identity) where v0.4 silently auto-split. Set `factor_id` per
+  candidate, or use `expand_over` if profiles legitimately share identity.
+- Mixing `forward_periods` without `expand_over` emits a `RuntimeWarning` —
+  different horizons carry different null distributions, and pooling them
+  dilutes the per-rank threshold `q × k / N`.
+- Cross-family aggregation (horizon-shopping correction) remains the
+  user's responsibility — see [Guides § Batch screening (BHY)](../guides/batch-screening.md)
+  for the FWER-then-BHY recipe.
 
 ---
 
@@ -511,7 +550,7 @@ Two-tier metric organisation. Choosing the right tier when adding a new metric:
 
 | Tier | Lives in | Count today | Definition | Surfaces |
 |------|----------|-------------|------------|----------|
-| **Registry procedure** | `factrix/_procedures.py` (`register(...)` at module bottom) | exactly 7 (one per legal cell) | The **canonical PASS/FAIL test** for one `(scope, signal, metric, mode)` cell | `evaluate()` dispatch, `FactorProfile.verdict()`, BHY family key |
+| **Registry procedure** | `factrix/_procedures.py` (`register(...)` at module bottom) | exactly 7 (one per legal cell) | The **canonical PASS/FAIL test** for one `(scope, signal, metric, mode)` cell | `evaluate()` dispatch, `FactorProfile.verdict()`, `primary_p` for family verbs |
 | **Standalone metric** | `factrix/metrics/*.py` | ~19 modules | **Diagnostic / second-look / multi-statistic** decomposition. User imports and calls directly. | `from factrix.metrics import X` returning `MetricOutput` |
 
 ### When to register
@@ -564,7 +603,8 @@ factrix/
 ├── _profile.py              # FactorProfile dataclass + verdict / diagnose
 ├── _evaluate.py             # _derive_mode + _evaluate dispatch wrapper
 ├── _describe.py             # describe_analysis_modes + suggest_config + SuggestConfigResult
-├── _multi_factor.py         # bhy with family partitioning
+├── _family.py               # _resolve_family + FamilyEntry (shared invariants)
+├── _multi_factor.py         # bhy on the resolution layer
 ├── multi_factor.py          # public namespace (re-exports bhy)
 ├── _stats/
 │   ├── __init__.py          # _ols_nw_slope_t, _ljung_box_p, _adf, _newey_west_t_test, _resolve_nw_lags
@@ -586,11 +626,11 @@ Hard constraints — violating these breaks the API contract:
 
 1. `AnalysisConfig` is `frozen=True, slots=True`; every construction path goes through `__post_init__ → _validate_axis_compat` (factory, direct, `from_dict` all hit the same gate).
 2. `FactorProfile` is `frozen=True, slots=True`. One unified type — no per-cell subclass.
-3. The registry is the SSOT for "which cells exist". `_validate_axis_compat`, `describe_analysis_modes`, `suggest_config`, BHY family partitioning all reverse-query it; no parallel rule table.
+3. The registry is the SSOT for "which cells exist". `_validate_axis_compat`, `describe_analysis_modes`, and `suggest_config` all reverse-query it; no parallel rule table.
 4. `_SCOPE_COLLAPSED` is an internal sentinel. It never appears in a user-facing `AnalysisConfig` — `evaluate()` rewrites the routed scope at dispatch time and reports the collapse via `InfoCode.SCOPE_AXIS_COLLAPSED`.
 5. `FactorProfile.primary_p` is a real probability for every legal cell × mode. TIMESERIES never returns a degenerate `primary_p = 1.0`.
 6. `verdict()` reads `primary_p` (or a user-supplied `StatCode` gate); `warnings` and `info_notes` never auto-rebind it.
-7. BHY family key = `_FamilyKey(_DispatchKey, forward_periods)`, derived mechanically from the profile, not user-supplied. Horizons split into separate families to preserve nominal FDR control.
+7. Family declaration is explicit: the `bhy` (and other family-verb) input list is one family, optionally split per-bucket via `expand_over`. `_resolve_family` enforces (a) identity uniqueness across input, (b) `expand_over` ⊂ `context` (never identity), (c) `p_stat` is a probability and populated everywhere. Cell / horizon partitioning is the caller's responsibility; mixed `forward_periods` without `expand_over` warns.
 8. `register(...)` is append-only at import time. Duplicate keys raise `ValueError`.
 9. NW HAC lag selection in panel-aggregation cells uses `max(auto_bartlett(T), forward_periods - 1)` — the Hansen-Hodrick floor must not be skipped under overlapping forward returns.
 10. `T < MIN_PERIODS_HARD` raises `InsufficientSampleError`; procedures never silently produce a result on under-sample data.

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -387,10 +387,11 @@ optimiser.
 ```python
 import factrix as fl
 
-import dataclasses
+# Each panel carries its factor under a distinct column name
+# ("momentum_12" / "value" / ...); evaluate auto-stamps factor_id
+# from factor_col so identities stay unique without manual surgery.
 profiles  = [
-    dataclasses.replace(fl.evaluate(p, cfg), factor_id=f"f{i}")
-    for i, p in enumerate(panels)
+    fl.evaluate(p, cfg, factor_col=name) for name, p in panels.items()
 ]
 survivors = fl.multi_factor.bhy(profiles, q=0.05)
 

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -387,8 +387,12 @@ optimiser.
 ```python
 import factrix as fl
 
-profiles  = [fl.evaluate(p, cfg) for p in panels]
-survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
+import dataclasses
+profiles  = [
+    dataclasses.replace(fl.evaluate(p, cfg), factor_id=f"f{i}")
+    for i, p in enumerate(panels)
+]
+survivors = fl.multi_factor.bhy(profiles, q=0.05)
 
 # survivors is a list[FactorProfile]; pass the underlying factor
 # panels to skfolio / PyPortfolioOpt / riskfolio-lib as Stage 2 input

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -91,10 +91,10 @@
    "id": "ce058d63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T02:15:41.377184Z",
-     "iopub.status.busy": "2026-05-10T02:15:41.377104Z",
-     "iopub.status.idle": "2026-05-10T02:15:42.400699Z",
-     "shell.execute_reply": "2026-05-10T02:15:42.400090Z"
+     "iopub.execute_input": "2026-05-10T02:22:41.971199Z",
+     "iopub.status.busy": "2026-05-10T02:22:41.971102Z",
+     "iopub.status.idle": "2026-05-10T02:22:42.962604Z",
+     "shell.execute_reply": "2026-05-10T02:22:42.962221Z"
     }
    },
    "outputs": [
@@ -141,10 +141,10 @@
    "id": "5b3d27c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T02:15:42.402039Z",
-     "iopub.status.busy": "2026-05-10T02:15:42.401916Z",
-     "iopub.status.idle": "2026-05-10T02:15:42.472856Z",
-     "shell.execute_reply": "2026-05-10T02:15:42.472182Z"
+     "iopub.execute_input": "2026-05-10T02:22:42.964094Z",
+     "iopub.status.busy": "2026-05-10T02:22:42.963977Z",
+     "iopub.status.idle": "2026-05-10T02:22:43.035203Z",
+     "shell.execute_reply": "2026-05-10T02:22:43.034656Z"
     }
    },
    "outputs": [
@@ -215,10 +215,10 @@
    "id": "b8bb4acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T02:15:42.475132Z",
-     "iopub.status.busy": "2026-05-10T02:15:42.475013Z",
-     "iopub.status.idle": "2026-05-10T02:15:42.478210Z",
-     "shell.execute_reply": "2026-05-10T02:15:42.477656Z"
+     "iopub.execute_input": "2026-05-10T02:22:43.036693Z",
+     "iopub.status.busy": "2026-05-10T02:22:43.036571Z",
+     "iopub.status.idle": "2026-05-10T02:22:43.039027Z",
+     "shell.execute_reply": "2026-05-10T02:22:43.038684Z"
     }
    },
    "outputs": [
@@ -270,10 +270,10 @@
    "id": "a0d14937",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T02:15:42.479785Z",
-     "iopub.status.busy": "2026-05-10T02:15:42.479693Z",
-     "iopub.status.idle": "2026-05-10T02:15:42.683186Z",
-     "shell.execute_reply": "2026-05-10T02:15:42.682709Z"
+     "iopub.execute_input": "2026-05-10T02:22:43.040282Z",
+     "iopub.status.busy": "2026-05-10T02:22:43.040191Z",
+     "iopub.status.idle": "2026-05-10T02:22:43.236828Z",
+     "shell.execute_reply": "2026-05-10T02:22:43.236301Z"
     }
    },
    "outputs": [
@@ -283,7 +283,7 @@
      "text": [
       "UserInputError raised as expected:\n",
       "bhy(): invalid profiles=('factor', 5)\n",
-      "  Expected: unique partition key across input; duplicate first seen at index 0, again at 1. Set distinct factor_id per profile via `dataclasses.replace(profile, factor_id=<name>)`, or pass `expand_over=[<context key>]` to declare per-bucket families\n",
+      "  Expected: unique partition key across input; duplicate first seen at index 0, again at 1. Stamp distinct factor_id per profile via `evaluate(..., factor_col=<name>)` (canonical) or `dataclasses.replace(profile, factor_id=<name>)` (escape hatch when the column cannot be renamed); or pass `expand_over=[<context key>]` to declare per-bucket families\n",
       "  Docs: https://awwesomeman.github.io/factrix/api/bhy#partition-key\n"
      ]
     },
@@ -358,10 +358,10 @@
    "id": "395dde39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T02:15:42.684653Z",
-     "iopub.status.busy": "2026-05-10T02:15:42.684553Z",
-     "iopub.status.idle": "2026-05-10T02:15:42.686485Z",
-     "shell.execute_reply": "2026-05-10T02:15:42.686072Z"
+     "iopub.execute_input": "2026-05-10T02:22:43.238272Z",
+     "iopub.status.busy": "2026-05-10T02:22:43.238173Z",
+     "iopub.status.idle": "2026-05-10T02:22:43.240261Z",
+     "shell.execute_reply": "2026-05-10T02:22:43.239822Z"
     }
    },
    "outputs": [

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -22,17 +22,22 @@
     "\n",
     "This recipe uses `multi_factor.bhy(...)` over a list of\n",
     "`FactorProfile` objects. Each profile is produced by\n",
-    "`evaluate(panel, cfg)` for any registered cell — screening is\n",
-    "factor-type-agnostic.\n",
+    "`evaluate(panel, cfg, factor_col=<name>)` for any registered cell —\n",
+    "screening is factor-type-agnostic.\n",
     "\n",
     "The input list **is** the family. Each profile must carry a unique\n",
     "`identity = (factor_id, forward_periods)` (#160 anti-shopping\n",
-    "defense); set distinct `factor_id` per candidate via\n",
-    "`dataclasses.replace`. Pass `expand_over=[<context key>]` to declare\n",
-    "per-bucket independent step-ups (Benjamini & Bogomolov 2014\n",
-    "selective inference). Mixing `forward_periods` without `expand_over`\n",
-    "emits `RuntimeWarning` — different horizons carry different null\n",
-    "distributions and pooling silently inflates FDR.\n",
+    "defense). The recommended path: name the factor column distinctly\n",
+    "per candidate panel and pass it via `factor_col=`; `evaluate`\n",
+    "auto-stamps `factor_id` from that name. `dataclasses.replace(profile,\n",
+    "factor_id=...)` is an escape hatch for cases where you cannot rename\n",
+    "the column.\n",
+    "\n",
+    "Pass `expand_over=[<context key>]` to declare per-bucket independent\n",
+    "step-ups (Benjamini & Bogomolov 2014 selective inference). Mixing\n",
+    "`forward_periods` without `expand_over` emits `RuntimeWarning` —\n",
+    "different horizons carry different null distributions and pooling\n",
+    "silently inflates FDR.\n",
     "\n",
     "Literature: [Benjamini & Yekutieli (2001)](../reference/bibliography.md).\n"
    ]
@@ -86,10 +91,10 @@
    "id": "ce058d63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:55:26.022584Z",
-     "iopub.status.busy": "2026-05-10T01:55:26.022491Z",
-     "iopub.status.idle": "2026-05-10T01:55:27.014958Z",
-     "shell.execute_reply": "2026-05-10T01:55:27.014536Z"
+     "iopub.execute_input": "2026-05-10T02:15:41.377184Z",
+     "iopub.status.busy": "2026-05-10T02:15:41.377104Z",
+     "iopub.status.idle": "2026-05-10T02:15:42.400699Z",
+     "shell.execute_reply": "2026-05-10T02:15:42.400090Z"
     }
    },
    "outputs": [
@@ -124,7 +129,10 @@
     "BHY input where the step-up actually controls FDR.\n",
     "\n",
     "We start from one ground-truth factor and add increasing IID noise\n",
-    "to produce variants with varying signal strengths.\n"
+    "to produce variants with varying signal strengths. Each variant is\n",
+    "materialised under its own column name (`variant_0` … `variant_4`)\n",
+    "so `evaluate(..., factor_col=name)` auto-stamps a distinct\n",
+    "`factor_id` per profile — no post-hoc identity surgery needed.\n"
    ]
   },
   {
@@ -133,10 +141,10 @@
    "id": "5b3d27c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:55:27.016655Z",
-     "iopub.status.busy": "2026-05-10T01:55:27.016510Z",
-     "iopub.status.idle": "2026-05-10T01:55:27.106889Z",
-     "shell.execute_reply": "2026-05-10T01:55:27.106430Z"
+     "iopub.execute_input": "2026-05-10T02:15:42.402039Z",
+     "iopub.status.busy": "2026-05-10T02:15:42.401916Z",
+     "iopub.status.idle": "2026-05-10T02:15:42.472856Z",
+     "shell.execute_reply": "2026-05-10T02:15:42.472182Z"
     }
    },
    "outputs": [
@@ -153,8 +161,6 @@
     }
    ],
    "source": [
-    "import dataclasses\n",
-    "\n",
     "raw = fl.datasets.make_cs_panel(\n",
     "    n_assets=100,\n",
     "    n_dates=500,\n",
@@ -168,24 +174,22 @@
     ")\n",
     "\n",
     "\n",
-    "def with_noise(base: pl.DataFrame, scale: float, seed: int) -> pl.DataFrame:\n",
+    "def variant_panel(\n",
+    "    base: pl.DataFrame, *, name: str, scale: float, seed: int\n",
+    ") -> pl.DataFrame:\n",
+    "    \"\"\"Add IID noise on top of the ground-truth factor and store under a fresh column name.\"\"\"\n",
     "    rng = np.random.default_rng(seed)\n",
-    "    return base.with_columns(\n",
-    "        pl.Series(\n",
-    "            \"factor\",\n",
-    "            base[\"factor\"].to_numpy() + scale * rng.standard_normal(base.height),\n",
-    "        ),\n",
-    "    )\n",
+    "    noisy = base[\"factor\"].to_numpy() + scale * rng.standard_normal(base.height)\n",
+    "    return base.drop(\"factor\").with_columns(pl.Series(name, noisy))\n",
     "\n",
     "\n",
     "candidates = {\n",
-    "    f\"variant_{i}\": with_noise(panel, scale=0.5 + 0.3 * i, seed=100 + i)\n",
+    "    f\"variant_{i}\": variant_panel(\n",
+    "        panel, name=f\"variant_{i}\", scale=0.5 + 0.3 * i, seed=100 + i\n",
+    "    )\n",
     "    for i in range(5)\n",
     "}\n",
-    "profiles = [\n",
-    "    dataclasses.replace(fl.evaluate(p, cfg), factor_id=name)\n",
-    "    for name, p in candidates.items()\n",
-    "]\n",
+    "profiles = [fl.evaluate(p, cfg, factor_col=name) for name, p in candidates.items()]\n",
     "for prof in profiles:\n",
     "    print(\n",
     "        f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}  verdict={prof.verdict()}\"\n",
@@ -211,10 +215,10 @@
    "id": "b8bb4acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:55:27.108475Z",
-     "iopub.status.busy": "2026-05-10T01:55:27.108359Z",
-     "iopub.status.idle": "2026-05-10T01:55:27.110912Z",
-     "shell.execute_reply": "2026-05-10T01:55:27.110432Z"
+     "iopub.execute_input": "2026-05-10T02:15:42.475132Z",
+     "iopub.status.busy": "2026-05-10T02:15:42.475013Z",
+     "iopub.status.idle": "2026-05-10T02:15:42.478210Z",
+     "shell.execute_reply": "2026-05-10T02:15:42.477656Z"
     }
    },
    "outputs": [
@@ -245,16 +249,19 @@
    "source": [
     "## 4. Duplicate-identity defense\n",
     "\n",
-    "`evaluate()` stamps `factor_id=\"factor\"` by default (the source\n",
-    "column name). If you forget to override it before passing the\n",
-    "profiles to `bhy()`, every candidate lands at the same identity\n",
-    "`(\"factor\", forward_periods)` and `bhy` raises `UserInputError`\n",
-    "rather than silently treating distinct candidates as one\n",
-    "hypothesis.\n",
+    "`evaluate()` defaults `factor_col=\"factor\"`, which means every\n",
+    "profile built via the lazy path lands at\n",
+    "`identity = (\"factor\", forward_periods)`. Pass two such profiles to\n",
+    "`bhy()` and the family-resolution layer raises `UserInputError`\n",
+    "rather than silently treating distinct candidates as one hypothesis.\n",
     "\n",
-    "The fix is what we already did in § 2: stamp a unique `factor_id`\n",
-    "per profile via `dataclasses.replace`. Below we deliberately *skip*\n",
-    "that step to surface the error.\n"
+    "The canonical fix is what § 2 already does: distinct column name\n",
+    "per panel + `evaluate(..., factor_col=name)`. When you cannot rename\n",
+    "the column (e.g. because the panel comes from an upstream loader you\n",
+    "do not own), `dataclasses.replace(profile, factor_id=name)` is the\n",
+    "escape hatch.\n",
+    "\n",
+    "Below we deliberately take the lazy path to surface the error.\n"
    ]
   },
   {
@@ -263,10 +270,10 @@
    "id": "a0d14937",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:55:27.112167Z",
-     "iopub.status.busy": "2026-05-10T01:55:27.112075Z",
-     "iopub.status.idle": "2026-05-10T01:55:27.182559Z",
-     "shell.execute_reply": "2026-05-10T01:55:27.182026Z"
+     "iopub.execute_input": "2026-05-10T02:15:42.479785Z",
+     "iopub.status.busy": "2026-05-10T02:15:42.479693Z",
+     "iopub.status.idle": "2026-05-10T02:15:42.683186Z",
+     "shell.execute_reply": "2026-05-10T02:15:42.682709Z"
     }
    },
    "outputs": [
@@ -276,27 +283,60 @@
      "text": [
       "UserInputError raised as expected:\n",
       "bhy(): invalid profiles=('factor', 5)\n",
-      "  Expected: unique partition key across input; duplicate first seen at index 0, again at 1. Set distinct factor_id per profile, or pass expand_over=[<context key>] to declare per-bucket families\n",
+      "  Expected: unique partition key across input; duplicate first seen at index 0, again at 1. Set distinct factor_id per profile via `dataclasses.replace(profile, factor_id=<name>)`, or pass `expand_over=[<context key>]` to declare per-bucket families\n",
       "  Docs: https://awwesomeman.github.io/factrix/api/bhy#partition-key\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "canonical fix → identities: ['ic_var', 'fm_var']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "escape hatch  → identities: ['ic_var', 'fm_var']\n"
      ]
     }
    ],
    "source": [
+    "import dataclasses\n",
+    "\n",
     "cfg_fm = fl.AnalysisConfig.individual_continuous(\n",
     "    metric=fl.Metric.FM,\n",
     "    forward_periods=5,\n",
     ")\n",
     "\n",
-    "# Both profiles default to factor_id=\"factor\" — same identity.\n",
+    "# Lazy path: both calls default factor_col=\"factor\" → identity collide.\n",
     "unstamped = [\n",
-    "    fl.evaluate(panel, cfg),  # IC\n",
-    "    fl.evaluate(panel, cfg_fm),  # FM — different cell, same identity\n",
+    "    fl.evaluate(panel, cfg),  # IC, factor_id=\"factor\"\n",
+    "    fl.evaluate(panel, cfg_fm),  # FM, factor_id=\"factor\" — same identity\n",
     "]\n",
     "try:\n",
     "    fl.multi_factor.bhy(unstamped, q=0.05)\n",
     "except fl.UserInputError as exc:\n",
     "    print(\"UserInputError raised as expected:\")\n",
-    "    print(str(exc))"
+    "    print(str(exc))\n",
+    "\n",
+    "# Canonical fix: pass factor_col= on each evaluate call. Requires distinct\n",
+    "# column names; here we rename the same panel's \"factor\" column upfront.\n",
+    "stamped = [\n",
+    "    fl.evaluate(panel.rename({\"factor\": \"ic_var\"}), cfg, factor_col=\"ic_var\"),\n",
+    "    fl.evaluate(panel.rename({\"factor\": \"fm_var\"}), cfg_fm, factor_col=\"fm_var\"),\n",
+    "]\n",
+    "print(f\"\\ncanonical fix → identities: {[p.factor_id for p in stamped]}\")\n",
+    "\n",
+    "# Escape hatch: when you cannot rename the column, post-hoc stamp via\n",
+    "# dataclasses.replace. Identical end state, slightly more imperative.\n",
+    "escape = [\n",
+    "    dataclasses.replace(fl.evaluate(panel, cfg), factor_id=\"ic_var\"),\n",
+    "    dataclasses.replace(fl.evaluate(panel, cfg_fm), factor_id=\"fm_var\"),\n",
+    "]\n",
+    "print(f\"escape hatch  → identities: {[p.factor_id for p in escape]}\")"
    ]
   },
   {
@@ -318,10 +358,10 @@
    "id": "395dde39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:55:27.184167Z",
-     "iopub.status.busy": "2026-05-10T01:55:27.184035Z",
-     "iopub.status.idle": "2026-05-10T01:55:27.186163Z",
-     "shell.execute_reply": "2026-05-10T01:55:27.185601Z"
+     "iopub.execute_input": "2026-05-10T02:15:42.684653Z",
+     "iopub.status.busy": "2026-05-10T02:15:42.684553Z",
+     "iopub.status.idle": "2026-05-10T02:15:42.686485Z",
+     "shell.execute_reply": "2026-05-10T02:15:42.686072Z"
     }
    },
    "outputs": [

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -8,8 +8,9 @@
     "# Multi-factor screening\n",
     "\n",
     "Apply Benjamini-Hochberg-Yekutieli (BHY) FDR control to a batch of\n",
-    "candidate factors. Demonstrates family partitioning — the behaviour\n",
-    "that is impossible to learn from docstrings alone.\n"
+    "candidate factors. Demonstrates the explicit-family contract and\n",
+    "the duplicate-identity defense (#161) — the behaviour that is\n",
+    "impossible to learn from docstrings alone.\n"
    ]
   },
   {
@@ -22,12 +23,16 @@
     "This recipe uses `multi_factor.bhy(...)` over a list of\n",
     "`FactorProfile` objects. Each profile is produced by\n",
     "`evaluate(panel, cfg)` for any registered cell — screening is\n",
-    "factor-type-agnostic, but BHY families partition on the dispatch\n",
-    "key plus `forward_periods`.\n",
+    "factor-type-agnostic.\n",
     "\n",
-    "Family key = `(scope, signal, metric, mode, forward_periods)`. Two\n",
-    "profiles share a family iff they share all five axes; cross-family\n",
-    "pooling silently inflates FDR and is gated by a runtime warning.\n",
+    "The input list **is** the family. Each profile must carry a unique\n",
+    "`identity = (factor_id, forward_periods)` (#160 anti-shopping\n",
+    "defense); set distinct `factor_id` per candidate via\n",
+    "`dataclasses.replace`. Pass `expand_over=[<context key>]` to declare\n",
+    "per-bucket independent step-ups (Benjamini & Bogomolov 2014\n",
+    "selective inference). Mixing `forward_periods` without `expand_over`\n",
+    "emits `RuntimeWarning` — different horizons carry different null\n",
+    "distributions and pooling silently inflates FDR.\n",
     "\n",
     "Literature: [Benjamini & Yekutieli (2001)](../reference/bibliography.md).\n"
    ]
@@ -42,29 +47,29 @@
     "- You have ≥2 candidate factors and want type-I error control under\n",
     "  multiple testing.\n",
     "- Candidates are evaluable under the same `AnalysisConfig` (same\n",
-    "  scope, signal, metric, forward horizon). Mixed-cell batches still\n",
-    "  run but issue `RuntimeWarning` when most families collapse to\n",
-    "  size 1.\n",
+    "  scope, signal, metric, forward horizon). Mixed cells / horizons\n",
+    "  in one call are caller's responsibility — see § 4 below.\n",
     "- You prefer FDR control (BHY) over family-wise error (Bonferroni)\n",
     "  — appropriate when discoveries can tolerate a known false-positive\n",
     "  rate and power matters.\n",
     "\n",
     "## What it tests\n",
     "\n",
-    "Within each family, BHY step-up keeps profiles whose ranked\n",
-    "p-values satisfy `p_(k) ≤ q · k / (N · c(N))` where `c(N) =\n",
-    "Σ 1/i` (Benjamini-Yekutieli adjustment for arbitrary dependence).\n",
-    "Cross-family aggregation is *not* performed — that is the user's\n",
-    "responsibility and is deliberately out of scope.\n",
+    "For an input family of size `N`, BHY step-up keeps profiles whose\n",
+    "ranked p-values satisfy `p_(k) ≤ q · k / (N · c(N))` where\n",
+    "`c(N) = Σ 1/i` (Benjamini-Yekutieli adjustment for arbitrary\n",
+    "dependence). Pass your nominal `q` directly — the `c(N)` correction\n",
+    "is baked in. Cross-family aggregation is *not* performed; that is\n",
+    "the user's responsibility and is deliberately out of scope.\n",
     "\n",
     "## Output to read\n",
     "\n",
     "1. `len(survivors)` vs `len(profiles)` — coarse hit rate.\n",
-    "2. Per-survivor `profile.primary_p` and `profile.config` — which\n",
+    "2. Per-survivor `profile.primary_p` and `profile.factor_id` — which\n",
     "   factor cleared the family-adjusted bar.\n",
-    "3. Any emitted `RuntimeWarning` about singleton families — a sign\n",
-    "   the batch is mis-grouped (one profile per cell provides no FDR\n",
-    "   correction beyond a raw threshold).\n"
+    "3. Any emitted `RuntimeWarning` — flags mixed `forward_periods`\n",
+    "   without `expand_over` (FDR-inflation foot-gun) or singleton\n",
+    "   `expand_over` buckets (BHY on n=1 is a raw cutoff).\n"
    ]
   },
   {
@@ -81,10 +86,10 @@
    "id": "ce058d63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:43.308236Z",
-     "iopub.status.busy": "2026-05-06T06:25:43.308066Z",
-     "iopub.status.idle": "2026-05-06T06:25:45.244243Z",
-     "shell.execute_reply": "2026-05-06T06:25:45.243775Z"
+     "iopub.execute_input": "2026-05-10T01:55:26.022584Z",
+     "iopub.status.busy": "2026-05-10T01:55:26.022491Z",
+     "iopub.status.idle": "2026-05-10T01:55:27.014958Z",
+     "shell.execute_reply": "2026-05-10T01:55:27.014536Z"
     }
    },
    "outputs": [
@@ -92,14 +97,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "factrix version: 0.7.0\n"
+      "factrix version: 0.10.0\n"
      ]
     }
    ],
    "source": [
     "from __future__ import annotations\n",
-    "\n",
-    "import warnings\n",
     "\n",
     "import factrix as fl\n",
     "import numpy as np\n",
@@ -130,10 +133,10 @@
    "id": "5b3d27c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:45.245576Z",
-     "iopub.status.busy": "2026-05-06T06:25:45.245457Z",
-     "iopub.status.idle": "2026-05-06T06:25:45.357038Z",
-     "shell.execute_reply": "2026-05-06T06:25:45.356573Z"
+     "iopub.execute_input": "2026-05-10T01:55:27.016655Z",
+     "iopub.status.busy": "2026-05-10T01:55:27.016510Z",
+     "iopub.status.idle": "2026-05-10T01:55:27.106889Z",
+     "shell.execute_reply": "2026-05-10T01:55:27.106430Z"
     }
    },
    "outputs": [
@@ -150,6 +153,8 @@
     }
    ],
    "source": [
+    "import dataclasses\n",
+    "\n",
     "raw = fl.datasets.make_cs_panel(\n",
     "    n_assets=100,\n",
     "    n_dates=500,\n",
@@ -177,9 +182,14 @@
     "    f\"variant_{i}\": with_noise(panel, scale=0.5 + 0.3 * i, seed=100 + i)\n",
     "    for i in range(5)\n",
     "}\n",
-    "profiles = [fl.evaluate(p, cfg) for p in candidates.values()]\n",
-    "for name, prof in zip(candidates, profiles, strict=True):\n",
-    "    print(f\"  {name:12s} primary_p={prof.primary_p:.4g}  verdict={prof.verdict()}\")"
+    "profiles = [\n",
+    "    dataclasses.replace(fl.evaluate(p, cfg), factor_id=name)\n",
+    "    for name, p in candidates.items()\n",
+    "]\n",
+    "for prof in profiles:\n",
+    "    print(\n",
+    "        f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}  verdict={prof.verdict()}\"\n",
+    "    )"
    ]
   },
   {
@@ -189,9 +199,10 @@
    "source": [
     "## 3. Apply BHY\n",
     "\n",
-    "`multi_factor.bhy` groups profiles by family key, runs the step-up\n",
-    "within each family, and returns survivors in input order across\n",
-    "families.\n"
+    "The input list **is** the family. `bhy` runs one Benjamini-Yekutieli\n",
+    "step-up over all profiles, returns survivors in input order, and\n",
+    "controls FDR ≤ `q` under arbitrary dependence (the `c(N)` correction\n",
+    "is applied internally — no manual adjustment).\n"
    ]
   },
   {
@@ -200,10 +211,10 @@
    "id": "b8bb4acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:45.358578Z",
-     "iopub.status.busy": "2026-05-06T06:25:45.358477Z",
-     "iopub.status.idle": "2026-05-06T06:25:45.360988Z",
-     "shell.execute_reply": "2026-05-06T06:25:45.360622Z"
+     "iopub.execute_input": "2026-05-10T01:55:27.108475Z",
+     "iopub.status.busy": "2026-05-10T01:55:27.108359Z",
+     "iopub.status.idle": "2026-05-10T01:55:27.110912Z",
+     "shell.execute_reply": "2026-05-10T01:55:27.110432Z"
     }
    },
    "outputs": [
@@ -212,19 +223,19 @@
      "output_type": "stream",
      "text": [
       "BHY survivors: 5 / 5\n",
-      "  primary_p=2.136e-39\n",
-      "  primary_p=4.052e-26\n",
-      "  primary_p=6.682e-22\n",
-      "  primary_p=3.987e-17\n",
-      "  primary_p=7.407e-14\n"
+      "  variant_0    primary_p=2.136e-39\n",
+      "  variant_1    primary_p=4.052e-26\n",
+      "  variant_2    primary_p=6.682e-22\n",
+      "  variant_3    primary_p=3.987e-17\n",
+      "  variant_4    primary_p=7.407e-14\n"
      ]
     }
    ],
    "source": [
-    "survivors = fl.multi_factor.bhy(profiles, threshold=0.05)\n",
+    "survivors = fl.multi_factor.bhy(profiles, q=0.05)\n",
     "print(f\"BHY survivors: {len(survivors)} / {len(profiles)}\")\n",
     "for prof in survivors:\n",
-    "    print(f\"  primary_p={prof.primary_p:.4g}\")"
+    "    print(f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}\")"
    ]
   },
   {
@@ -232,12 +243,18 @@
    "id": "33cf8f6f",
    "metadata": {},
    "source": [
-    "## 4. Cross-family pitfall\n",
+    "## 4. Duplicate-identity defense\n",
     "\n",
-    "Mixing cells in one `bhy()` call partitions into multiple families,\n",
-    "each size 1 in this construction. BHY on a singleton is identical to a raw\n",
-    "threshold and provides *no* FDR correction. factrix flags this\n",
-    "with `RuntimeWarning` so silent mis-grouping fails loud:\n"
+    "`evaluate()` stamps `factor_id=\"factor\"` by default (the source\n",
+    "column name). If you forget to override it before passing the\n",
+    "profiles to `bhy()`, every candidate lands at the same identity\n",
+    "`(\"factor\", forward_periods)` and `bhy` raises `UserInputError`\n",
+    "rather than silently treating distinct candidates as one\n",
+    "hypothesis.\n",
+    "\n",
+    "The fix is what we already did in § 2: stamp a unique `factor_id`\n",
+    "per profile via `dataclasses.replace`. Below we deliberately *skip*\n",
+    "that step to surface the error.\n"
    ]
   },
   {
@@ -246,10 +263,10 @@
    "id": "a0d14937",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:45.362221Z",
-     "iopub.status.busy": "2026-05-06T06:25:45.362127Z",
-     "iopub.status.idle": "2026-05-06T06:25:45.453963Z",
-     "shell.execute_reply": "2026-05-06T06:25:45.453527Z"
+     "iopub.execute_input": "2026-05-10T01:55:27.112167Z",
+     "iopub.status.busy": "2026-05-10T01:55:27.112075Z",
+     "iopub.status.idle": "2026-05-10T01:55:27.182559Z",
+     "shell.execute_reply": "2026-05-10T01:55:27.182026Z"
     }
    },
    "outputs": [
@@ -257,9 +274,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RuntimeWarning: bhy: 3 of 3 families contain a single profile — BHY on n=1 is identical to a raw threshold and provides no FDR correction. Group ≥2 same-family profiles per call for meaningful control.\n",
-      "\n",
-      "survivors across mixed families: 2\n"
+      "UserInputError raised as expected:\n",
+      "bhy(): invalid profiles=('factor', 5)\n",
+      "  Expected: unique partition key across input; duplicate first seen at index 0, again at 1. Set distinct factor_id per profile, or pass expand_over=[<context key>] to declare per-bucket families\n",
+      "  Docs: https://awwesomeman.github.io/factrix/api/bhy#partition-key\n"
      ]
     }
    ],
@@ -268,28 +286,17 @@
     "    metric=fl.Metric.FM,\n",
     "    forward_periods=5,\n",
     ")\n",
-    "ev_raw = fl.datasets.make_event_panel(\n",
-    "    n_assets=80,\n",
-    "    n_dates=400,\n",
-    "    event_rate=0.02,\n",
-    "    post_event_drift_bps=15.0,\n",
-    "    signal_horizon=5,\n",
-    "    seed=42,\n",
-    ")\n",
-    "ev_panel = compute_forward_return(ev_raw, forward_periods=5)\n",
-    "cfg_caar = fl.AnalysisConfig.individual_sparse(forward_periods=5)\n",
     "\n",
-    "mixed = [\n",
-    "    fl.evaluate(panel, cfg),  # IC family\n",
-    "    fl.evaluate(panel, cfg_fm),  # FM family — different metric\n",
-    "    fl.evaluate(ev_panel, cfg_caar),  # sparse family — different signal\n",
+    "# Both profiles default to factor_id=\"factor\" — same identity.\n",
+    "unstamped = [\n",
+    "    fl.evaluate(panel, cfg),  # IC\n",
+    "    fl.evaluate(panel, cfg_fm),  # FM — different cell, same identity\n",
     "]\n",
-    "with warnings.catch_warnings(record=True) as caught:\n",
-    "    warnings.simplefilter(\"always\")\n",
-    "    survivors_mixed = fl.multi_factor.bhy(mixed, threshold=0.05)\n",
-    "for w in caught:\n",
-    "    print(f\"{w.category.__name__}: {w.message}\")\n",
-    "print(f\"\\nsurvivors across mixed families: {len(survivors_mixed)}\")"
+    "try:\n",
+    "    fl.multi_factor.bhy(unstamped, q=0.05)\n",
+    "except fl.UserInputError as exc:\n",
+    "    print(\"UserInputError raised as expected:\")\n",
+    "    print(str(exc))"
    ]
   },
   {
@@ -297,10 +304,9 @@
    "id": "259f7bcf",
    "metadata": {},
    "source": [
-    "## 5. Sample-guard edge cases\n",
+    "## 5. Where to go next\n",
     "\n",
-    "Family partitioning makes BHY fragile to small-batch regimes. For\n",
-    "the broader `n_assets` × factory behaviour matrix see\n",
+    "For the broader `n_assets` × factory behaviour matrix see\n",
     "[Guides § PANEL vs TIMESERIES](../guides/panel-timeseries.md);\n",
     "for the BHY contract specifically see\n",
     "[Guides § Batch screening](../guides/batch-screening.md).\n"
@@ -312,10 +318,10 @@
    "id": "395dde39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:45.455101Z",
-     "iopub.status.busy": "2026-05-06T06:25:45.455024Z",
-     "iopub.status.idle": "2026-05-06T06:25:45.456844Z",
-     "shell.execute_reply": "2026-05-06T06:25:45.456502Z"
+     "iopub.execute_input": "2026-05-10T01:55:27.184167Z",
+     "iopub.status.busy": "2026-05-10T01:55:27.184035Z",
+     "iopub.status.idle": "2026-05-10T01:55:27.186163Z",
+     "shell.execute_reply": "2026-05-10T01:55:27.185601Z"
     }
    },
    "outputs": [

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -75,10 +75,10 @@
    "id": "36a976ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:47.837317Z",
-     "iopub.status.busy": "2026-05-06T06:25:47.837164Z",
-     "iopub.status.idle": "2026-05-06T06:25:48.710816Z",
-     "shell.execute_reply": "2026-05-06T06:25:48.710300Z"
+     "iopub.execute_input": "2026-05-10T01:52:23.868550Z",
+     "iopub.status.busy": "2026-05-10T01:52:23.868375Z",
+     "iopub.status.idle": "2026-05-10T01:52:24.871875Z",
+     "shell.execute_reply": "2026-05-10T01:52:24.871421Z"
     }
    },
    "outputs": [
@@ -86,7 +86,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "factrix version: 0.7.0\n"
+      "factrix version: 0.10.0\n"
      ]
     }
    ],
@@ -117,10 +117,10 @@
    "id": "4475e1b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:48.712429Z",
-     "iopub.status.busy": "2026-05-06T06:25:48.712296Z",
-     "iopub.status.idle": "2026-05-06T06:25:48.724754Z",
-     "shell.execute_reply": "2026-05-06T06:25:48.724316Z"
+     "iopub.execute_input": "2026-05-10T01:52:24.873221Z",
+     "iopub.status.busy": "2026-05-10T01:52:24.873109Z",
+     "iopub.status.idle": "2026-05-10T01:52:24.884999Z",
+     "shell.execute_reply": "2026-05-10T01:52:24.884548Z"
     }
    },
    "outputs": [
@@ -161,10 +161,10 @@
    "id": "50ffb0d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:48.726118Z",
-     "iopub.status.busy": "2026-05-06T06:25:48.726037Z",
-     "iopub.status.idle": "2026-05-06T06:25:48.740405Z",
-     "shell.execute_reply": "2026-05-06T06:25:48.739948Z"
+     "iopub.execute_input": "2026-05-10T01:52:24.886224Z",
+     "iopub.status.busy": "2026-05-10T01:52:24.886143Z",
+     "iopub.status.idle": "2026-05-10T01:52:24.903923Z",
+     "shell.execute_reply": "2026-05-10T01:52:24.903507Z"
     }
    },
    "outputs": [
@@ -214,10 +214,10 @@
    "id": "311e6ff1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:48.741933Z",
-     "iopub.status.busy": "2026-05-06T06:25:48.741812Z",
-     "iopub.status.idle": "2026-05-06T06:25:48.743851Z",
-     "shell.execute_reply": "2026-05-06T06:25:48.743433Z"
+     "iopub.execute_input": "2026-05-10T01:52:24.905031Z",
+     "iopub.status.busy": "2026-05-10T01:52:24.904957Z",
+     "iopub.status.idle": "2026-05-10T01:52:24.906835Z",
+     "shell.execute_reply": "2026-05-10T01:52:24.906457Z"
     }
    },
    "outputs": [
@@ -226,16 +226,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
+      "  \"identity\": {\n",
+      "    \"factor_id\": \"factor\",\n",
+      "    \"forward_periods\": 5\n",
+      "  },\n",
+      "  \"context\": {},\n",
       "  \"mode\": \"panel\",\n",
       "  \"n_obs\": 494,\n",
       "  \"n_assets\": 100,\n",
-      "  \"primary_p\": 2.1286625029236503e-40,\n",
+      "  \"primary_p\": 2.1286625029235276e-40,\n",
       "  \"warnings\": [],\n",
       "  \"info_notes\": [],\n",
       "  \"stats\": {\n",
       "    \"ic_mean\": 0.0722106866557101,\n",
       "    \"ic_t_nw\": 14.6039191698416,\n",
-      "    \"ic_p\": 2.1286625029236503e-40,\n",
+      "    \"ic_p\": 2.1286625029235276e-40,\n",
       "    \"nw_lags_used\": 5.0\n",
       "  }\n",
       "}\n"
@@ -272,10 +277,10 @@
    "id": "0ed123b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-06T06:25:48.745136Z",
-     "iopub.status.busy": "2026-05-06T06:25:48.745046Z",
-     "iopub.status.idle": "2026-05-06T06:25:48.746832Z",
-     "shell.execute_reply": "2026-05-06T06:25:48.746430Z"
+     "iopub.execute_input": "2026-05-10T01:52:24.907907Z",
+     "iopub.status.busy": "2026-05-10T01:52:24.907833Z",
+     "iopub.status.idle": "2026-05-10T01:52:24.909676Z",
+     "shell.execute_reply": "2026-05-10T01:52:24.909256Z"
     }
    },
    "outputs": [

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -19,7 +19,7 @@ Single-factor::
 Batch + BHY::
 
     profiles = [fl.evaluate(panel, cfg) for cfg in candidate_configs]
-    survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
+    survivors = fl.multi_factor.bhy(profiles, q=0.05)
 
 Schema reflection::
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -151,12 +151,12 @@ class StatCode(StrEnum):
       / ``TS_BETA_P`` / ``CAAR_P`` plus the diagnostic-only
       ``FACTOR_ADF_P`` / ``LJUNG_BOX_P``). ``is_p_value`` returns
       ``True``. These are the only codes ``multi_factor.bhy`` will
-      accept as a ``gate=`` override (BHY step-up requires probabilities
-      — feeding it t-stats yields nonsense FDR control).
+      accept as a ``p_stat=`` override (BHY step-up requires
+      probabilities — feeding it t-stats yields nonsense FDR control).
     - **t-stats** / effect-size means / lag counts / HHI: ``is_p_value``
       returns ``False``. ``profile.verdict(gate=...)`` accepts these
       (the comparison is generic ``value < threshold`` — interpretation
-      is the caller's call) but ``bhy(gate=...)`` rejects them.
+      is the caller's call) but ``bhy(p_stat=...)`` rejects them.
     """
 
     IC_MEAN = "ic_mean"
@@ -180,9 +180,10 @@ class StatCode(StrEnum):
     def is_p_value(self) -> bool:
         """``True`` iff this stat is a probability in [0, 1].
 
-        Used by ``multi_factor.bhy`` to gatekeep the ``gate=`` override
-        — BHY step-up math requires p-values, so feeding a t-stat would
-        silently corrupt FDR control.
+        Used by ``multi_factor.bhy`` (and the shared family resolution
+        layer) to gatekeep the ``p_stat=`` override — BHY step-up math
+        requires p-values, so feeding a t-stat would silently corrupt
+        FDR control.
         """
         return self.value.endswith("_p")
 

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -131,10 +131,12 @@ def _resolve_family(
                 expected=(
                     "unique partition key across input; duplicate first "
                     f"seen at index {seen[partition_key]}, again at {idx}. "
-                    "Set distinct factor_id per profile via "
-                    "`dataclasses.replace(profile, factor_id=<name>)`, or "
-                    "pass `expand_over=[<context key>]` to declare per-"
-                    "bucket families"
+                    "Stamp distinct factor_id per profile via "
+                    "`evaluate(..., factor_col=<name>)` (canonical) or "
+                    "`dataclasses.replace(profile, factor_id=<name>)` "
+                    "(escape hatch when the column cannot be renamed); "
+                    "or pass `expand_over=[<context key>]` to declare "
+                    "per-bucket families"
                 ),
                 docs_path=f"api/{verb}#partition-key",
             )

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -93,6 +93,19 @@ def _resolve_family(
             failures (unknown ``expand_over`` / hits identity / duplicate
             partition key / missing ``p_stat``).
     """
+    if p_stat is not None and not p_stat.is_p_value:
+        raise UserInputError(
+            verb=verb,
+            field="p_stat",
+            value=p_stat.name,
+            expected=(
+                f"p-value StatCode (is_p_value=True); {p_stat.name} is "
+                "not a probability and family step-up math would be "
+                "incoherent on it"
+            ),
+            docs_path=f"api/{verb}#p_stat",
+        )
+
     keys = list(expand_over) if expand_over else []
     for name in keys:
         if name in _IDENTITY_FIELDS:
@@ -117,7 +130,10 @@ def _resolve_family(
                 value=partition_key,
                 expected=(
                     "unique partition key across input; duplicate first "
-                    f"seen at index {seen[partition_key]}, again at {idx}"
+                    f"seen at index {seen[partition_key]}, again at {idx}. "
+                    "Set distinct factor_id per profile, or pass "
+                    "expand_over=[<context key>] to declare per-bucket "
+                    "families"
                 ),
                 docs_path=f"api/{verb}#partition-key",
             )

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -1,0 +1,176 @@
+"""Shared family resolution layer for multiple-testing verbs (#161).
+
+Every closed-form family verb (``bhy`` / ``bhy_hierarchical`` /
+``partial_conjunction`` / ``bonferroni`` / ``holm``) and the
+resampling-based ``romano_wolf`` runs through ``_resolve_family`` to
+turn a list of :class:`~factrix._profile.FactorProfile` into flat
+``FamilyEntry`` records ready for the procedure-specific step-up math.
+
+The four invariants enforced here are the family-layer extension of the
+identity / context anti-shopping defense from #160: ``identity``
+dimensions (``factor_id`` / ``forward_periods``) name *the hypothesis*,
+``context`` dimensions name *the slicing condition*, and ``expand_over``
+must stay in the latter — otherwise users would unwittingly let horizon
+or factor name participate in family partitioning.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from factrix._codes import StatCode
+from factrix._errors import UserInputError
+
+if TYPE_CHECKING:
+    from factrix._profile import FactorProfile
+
+
+_IDENTITY_FIELDS: frozenset[str] = frozenset({"factor_id", "forward_periods"})
+
+
+@dataclass(frozen=True, slots=True)
+class FamilyEntry:
+    """Flat record fed to family-verb procedures after invariant checks.
+
+    Attributes:
+        identity: ``(factor_id, forward_periods)`` from
+            :attr:`FactorProfile.identity`.
+        expand_over_values: ``tuple(profile.context[k] for k in expand_over)``
+            in the order the caller passed ``expand_over``; empty tuple
+            when ``expand_over`` is None / empty.
+        p_value: Resolved per the ``p_stat`` selection rule —
+            ``profile.primary_p`` when ``p_stat is None``, else
+            ``profile.stats[p_stat]``.
+        profile: Back-reference for survivor-renderer use; never read by
+            the resolution layer itself.
+    """
+
+    identity: tuple[str, int]
+    expand_over_values: tuple[Any, ...]
+    p_value: float
+    profile: FactorProfile
+
+
+def _resolve_family(
+    profiles: Sequence[FactorProfile],
+    *,
+    verb: str,
+    expand_over: Sequence[str] | None = None,
+    p_stat: StatCode | None = None,
+) -> list[FamilyEntry]:
+    """Validate four invariants and return flat ``FamilyEntry`` records.
+
+    Steps (raise on failure, in order):
+
+    1. ``expand_over`` names must exist in every profile's ``context``
+       and must not collide with identity dimensions
+       (``factor_id`` / ``forward_periods``).
+    2. The partition key
+       ``identity + tuple(profile.context[k] for k in expand_over)``
+       must be unique across the input.
+    3. When ``p_stat`` is supplied, every profile must populate it in
+       ``stats``.
+    4. Resolve ``p_value`` per profile: ``primary_p`` when
+       ``p_stat is None``, else ``profile.stats[p_stat]``.
+
+    Args:
+        profiles: Input profiles. ``__hash__`` is disabled on
+            ``FactorProfile``; dedup uses the partition-key tuple, never
+            profile hashing.
+        verb: Calling verb name for error rendering (e.g. ``"bhy"``).
+        expand_over: Optional context keys to include in the partition
+            key. ``None`` and ``[]`` are equivalent.
+        p_stat: Optional alternate p-value selector. ``None`` falls back
+            to ``primary_p``.
+
+    Returns:
+        One ``FamilyEntry`` per input profile, in input order.
+
+    Raises:
+        UserInputError: On any of the three named-set / availability
+            failures (unknown ``expand_over`` / hits identity / duplicate
+            partition key / missing ``p_stat``).
+    """
+    keys = list(expand_over) if expand_over else []
+    for name in keys:
+        if name in _IDENTITY_FIELDS:
+            raise UserInputError(
+                verb=verb,
+                field="expand_over",
+                value=name,
+                expected="context key, not an identity dimension (see #160)",
+                docs_path=f"api/{verb}#expand_over",
+            )
+
+    entries: list[FamilyEntry] = []
+    seen: dict[tuple[Any, ...], int] = {}
+
+    for idx, profile in enumerate(profiles):
+        values = _expand_over_values(profile, keys=keys, verb=verb)
+        partition_key = (*profile.identity, *values)
+        if partition_key in seen:
+            raise UserInputError(
+                verb=verb,
+                field="profiles",
+                value=partition_key,
+                expected=(
+                    "unique partition key across input; duplicate first "
+                    f"seen at index {seen[partition_key]}, again at {idx}"
+                ),
+                docs_path=f"api/{verb}#partition-key",
+            )
+        seen[partition_key] = idx
+
+        entries.append(
+            FamilyEntry(
+                identity=profile.identity,
+                expand_over_values=values,
+                p_value=_resolve_p_value(profile, p_stat=p_stat, verb=verb),
+                profile=profile,
+            )
+        )
+
+    return entries
+
+
+def _expand_over_values(
+    profile: FactorProfile,
+    *,
+    keys: list[str],
+    verb: str,
+) -> tuple[Any, ...]:
+    values: list[Any] = []
+    for name in keys:
+        if name not in profile.context:
+            raise UserInputError(
+                verb=verb,
+                field="expand_over",
+                value=name,
+                candidates=sorted(profile.context)
+                or ["<no context keys on this profile>"],
+                docs_path=f"api/{verb}#expand_over",
+            )
+        values.append(profile.context[name])
+    return tuple(values)
+
+
+def _resolve_p_value(
+    profile: FactorProfile,
+    *,
+    p_stat: StatCode | None,
+    verb: str,
+) -> float:
+    if p_stat is None:
+        return profile.primary_p
+    try:
+        return profile.stats[p_stat]
+    except KeyError:
+        raise UserInputError(
+            verb=verb,
+            field="p_stat",
+            value=p_stat.name,
+            candidates=sorted(s.name for s in profile.stats),
+            docs_path=f"api/{verb}#p_stat",
+        ) from None

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -131,9 +131,10 @@ def _resolve_family(
                 expected=(
                     "unique partition key across input; duplicate first "
                     f"seen at index {seen[partition_key]}, again at {idx}. "
-                    "Set distinct factor_id per profile, or pass "
-                    "expand_over=[<context key>] to declare per-bucket "
-                    "families"
+                    "Set distinct factor_id per profile via "
+                    "`dataclasses.replace(profile, factor_id=<name>)`, or "
+                    "pass `expand_over=[<context key>]` to declare per-"
+                    "bucket families"
                 ),
                 docs_path=f"api/{verb}#partition-key",
             )

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -7,11 +7,11 @@ v0.4 ``redundancy_matrix`` / ``spanning`` modules.
 
 Family declaration is now explicit: the input list ``profiles`` *is*
 the family, optionally split per-bucket via ``expand_over`` (Benjamini
-& Bogomolov 2014 selective-inference framework). The v0.4-era
+& Bogomolov 2014 selective-inference framework). The previous
 auto-partition by dispatch cell × forward horizon was retired in #161 —
 caller responsibility now, both because the implicit policy was opaque
-and because v0.5 ``identity`` already encodes ``forward_periods`` (and
-would silently flag mixed-cell inputs as duplicate identities).
+and because ``identity`` already encodes ``forward_periods`` (and would
+silently flag mixed-cell inputs as duplicate identities).
 """
 
 from __future__ import annotations

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -5,165 +5,186 @@ Currently exposes ``bhy`` only. ``redundancy_matrix`` /
 land alongside the v0.4 deletion sweep that retires the existing
 v0.4 ``redundancy_matrix`` / ``spanning`` modules.
 
-BHY family key = ``(_DispatchKey, forward_periods)``. The registry
-dispatch key alone is *not* sufficient: pooling profiles across
-horizons inflates family size and dilutes the step-up threshold,
-silently destroying FDR control. PANEL and TIMESERIES never share a
-family — different null distributions and effective sample sizes.
-Sparse TIMESERIES collapses scope into the ``_SCOPE_COLLAPSED``
-sentinel so ``individual_sparse`` and ``common_sparse`` profiles at
-N=1 sit in the same family at matching horizon.
+Family declaration is now explicit: the input list ``profiles`` *is*
+the family, optionally split per-bucket via ``expand_over`` (Benjamini
+& Bogomolov 2014 selective-inference framework). The v0.4-era
+auto-partition by dispatch cell × forward horizon was retired in #161 —
+caller responsibility now, both because the implicit policy was opaque
+and because v0.5 ``identity`` already encodes ``forward_periods`` (and
+would silently flag mixed-cell inputs as duplicate identities).
 """
 
 from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from collections.abc import Iterable
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from factrix._codes import StatCode
-from factrix._registry import _dispatch_key_for, _DispatchKey
+from factrix._family import _resolve_family
 from factrix.stats.multiple_testing import bhy_adjust
 
 if TYPE_CHECKING:
     from factrix._profile import FactorProfile
 
 
-@dataclass(frozen=True, slots=True)
-class _FamilyKey:
-    """BHY family coordinate = procedure cell × forward-return horizon.
-
-    Kept distinct from ``_DispatchKey`` (which the registry uses to
-    route cells to procedures, horizon-agnostic) because BHY family
-    membership *must* split on ``forward_periods``. Each horizon
-    carries its own null distribution and effective sample size; mixing
-    them in one step-up batch dilutes the per-rank threshold
-    (``q × k / N``) and silently inflates FDR above the nominal level.
-    """
-
-    dispatch: _DispatchKey
-    forward_periods: int
-
-
-def _family_key(profile: FactorProfile) -> _FamilyKey:
-    """Derive the BHY family key from a ``FactorProfile``.
-
-    Routes through ``_dispatch_key_for`` so the sparse-N=1 collapse and
-    key construction stay byte-identical to ``_evaluate`` — sharing the
-    helper, not a copy of its body, is what makes
-    ``individual_sparse`` / ``common_sparse`` profiles at N=1 land in the
-    same family at matching ``forward_periods`` (§5.4.1 / §5.6).
-    """
-    dispatch = _dispatch_key_for(
-        profile.config.scope,
-        profile.config.signal,
-        profile.config.metric,
-        profile.mode,
-    )
-    return _FamilyKey(
-        dispatch=dispatch,
-        forward_periods=profile.config.forward_periods,
-    )
-
-
-def _gate_p_value(
-    profile: FactorProfile,
-    gate: StatCode | None,
-) -> float:
-    """Return ``primary_p`` (default) or ``stats[gate]`` for the BHY input.
-
-    ``gate`` must be a p-value ``StatCode`` (``is_p_value`` is True).
-    BHY step-up math requires probabilities; feeding a t-stat or HHI
-    would silently produce incoherent FDR control. Validation lives at
-    the caller (``bhy``) so the error fires once per call, not once per
-    profile.
-    """
-    if gate is None:
-        return profile.primary_p
-    return profile.stats[gate]
+_DEPRECATED_KWARGS = {
+    "threshold": "q",
+    "gate": "p_stat",
+}
+_DEFAULT_Q = 0.05
 
 
 def bhy(
     profiles: Iterable[FactorProfile],
     *,
-    threshold: float = 0.05,
-    gate: StatCode | None = None,
+    expand_over: Sequence[str] | None = None,
+    p_stat: StatCode | None = None,
+    q: float | None = None,
+    **deprecated: Any,
 ) -> list[FactorProfile]:
-    """BHY step-up FDR within each family; return the surviving subset.
+    """BHY step-up FDR within one declared family; return the survivors.
 
-    Profiles are grouped by family key (= dispatch cell × forward
-    horizon); each family runs an independent BHY step-up on its
-    p-values. Cross-family aggregation is the user's responsibility
-    and is deliberately not done here. A warning fires when most
-    families are size-1 (BHY on a singleton is identical to a raw
-    threshold and provides no FDR correction).
+    The input list is treated as a single family. When ``expand_over``
+    is supplied, one independent step-up runs per unique tuple of
+    ``profile.context[k] for k in expand_over`` (Benjamini & Bogomolov
+    2014 selective inference). Cell / horizon partitioning is the
+    caller's responsibility — v0.5 retired the implicit auto-split.
 
     Args:
-        profiles: Iterable of ``FactorProfile`` to screen. Profiles
-            from different cells / horizons partition into separate
-            families automatically.
-        threshold: FDR level (not ``alpha``). Default ``0.05``.
-        gate: ``StatCode`` whose ``is_p_value`` is ``True`` selects
-            an alternate p-value from each profile's ``stats``;
-            ``None`` uses the procedure-canonical ``primary_p``.
+        profiles: Iterable of ``FactorProfile``. The full input is one
+            family unless ``expand_over`` further partitions it.
+        expand_over: Optional context keys whose distinct value tuples
+            split the input into independent BHY step-up batches.
+            ``None`` runs a single step-up over all profiles.
+        p_stat: Alternate p-value :class:`StatCode` (must satisfy
+            ``is_p_value``). ``None`` uses each profile's procedure-
+            canonical ``primary_p`` (e.g. ``IC_P`` for IC,
+            ``FM_LAMBDA_P`` for Fama–MacBeth, ``CAAR_P`` for event
+            studies).
+        q: Nominal false discovery rate target. The BHY step-up
+            controls FDR ≤ q under positive-regression-dependence
+            (PRDS); under arbitrary dependence the effective level is
+            ``q / sum(1/k for k in 1..n)``. Default ``0.05``.
 
     Returns:
-        The subset of ``profiles`` that survive the BHY step-up
-        within their respective families, in input order across
-        families.
+        Survivors in input order.
 
     Raises:
-        ValueError: If ``gate`` is a ``StatCode`` whose
-            ``is_p_value`` is ``False`` (BHY step-up requires
-            probabilities).
-        KeyError: If ``gate`` is set and any profile in a family
-            does not populate that key in ``stats``.
+        UserInputError: On any family-resolution invariant failure
+            (unknown / identity-shadowing ``expand_over`` name; missing
+            or non-probability ``p_stat``; duplicate partition key —
+            typically fixed by setting unique ``factor_id`` per profile
+            or splitting via ``expand_over``).
 
     Warns:
-        RuntimeWarning: If most families contain a single profile —
-            BHY on n=1 provides no correction beyond a raw cutoff.
+        DeprecationWarning: When the v0.4 kwargs ``threshold=`` /
+            ``gate=`` are used.
+        RuntimeWarning: When the input mixes ``forward_periods`` while
+            ``expand_over`` is ``None`` — pooling horizons in one
+            step-up dilutes the per-rank threshold and silently
+            inflates FDR. Or when most ``expand_over`` buckets contain
+            a single profile (BHY on n=1 is a raw cutoff and provides
+            no FDR correction).
     """
-    if gate is not None and not gate.is_p_value:
-        raise ValueError(
-            f"bhy(gate={gate.name}): BHY step-up requires p-value input, "
-            f"but {gate.name} is not a probability. Pass a *_P StatCode "
-            "(e.g. StatCode.IC_P, StatCode.FM_LAMBDA_P) or omit `gate=` "
-            "to use the procedure-canonical primary_p.",
-        )
-    families: dict[_FamilyKey, list[FactorProfile]] = defaultdict(list)
-    for profile in profiles:
-        families[_family_key(profile)].append(profile)
+    expand_over, p_stat, q = _apply_deprecated_kwargs(
+        expand_over=expand_over, p_stat=p_stat, q=q, deprecated=deprecated
+    )
 
-    # UX-2 from review: BHY on a size-1 family is identical to a raw
-    # threshold check — useful diagnostic for the (common bug) of
-    # passing one profile per cell from a sweep and assuming FDR is
-    # being controlled. Warn but do not raise; user may have only one
-    # candidate in a family legitimately.
-    singleton_families = sum(1 for fps in families.values() if len(fps) == 1)
-    if singleton_families and len(families) > 1:
+    profile_list = list(profiles)
+    if not profile_list:
+        return []
+
+    _warn_on_mixed_horizons(profile_list, expand_over=expand_over)
+
+    entries = _resolve_family(
+        profile_list, verb="bhy", expand_over=expand_over, p_stat=p_stat
+    )
+
+    buckets: dict[tuple[Any, ...], list[int]] = defaultdict(list)
+    for idx, entry in enumerate(entries):
+        buckets[entry.expand_over_values].append(idx)
+
+    singleton = sum(1 for ix in buckets.values() if len(ix) == 1)
+    if singleton and len(buckets) > 1:
         warnings.warn(
-            f"bhy: {singleton_families} of {len(families)} families "
+            f"bhy: {singleton} of {len(buckets)} expand_over buckets "
             "contain a single profile — BHY on n=1 is identical to a "
-            "raw threshold and provides no FDR correction. Group ≥2 "
-            "same-family profiles per call for meaningful control.",
+            "raw threshold and provides no FDR correction.",
             RuntimeWarning,
             stacklevel=2,
         )
 
-    survivors: list[FactorProfile] = []
-    for family_profiles in families.values():
-        if not family_profiles:
-            continue
-        p_array = np.array(
-            [_gate_p_value(p, gate) for p in family_profiles],
-            dtype=np.float64,
+    survivor_idxs: list[int] = []
+    for ix in buckets.values():
+        p_array = np.array([entries[i].p_value for i in ix], dtype=np.float64)
+        mask = bhy_adjust(p_array, fdr=q)
+        survivor_idxs.extend(i for i, accept in zip(ix, mask, strict=True) if accept)
+
+    survivor_idxs.sort()
+    return [entries[i].profile for i in survivor_idxs]
+
+
+def _warn_on_mixed_horizons(
+    profiles: list[FactorProfile],
+    *,
+    expand_over: Sequence[str] | None,
+) -> None:
+    if expand_over:
+        return
+    horizons = {p.config.forward_periods for p in profiles}
+    if len(horizons) > 1:
+        warnings.warn(
+            f"bhy: input mixes forward_periods={sorted(horizons)} but "
+            "expand_over is None — different horizons have different "
+            "null distributions; pooling them in one step-up dilutes "
+            "the per-rank threshold and silently inflates FDR. Either "
+            "split the call per horizon, or set expand_over=[<context "
+            "key>] to declare per-bucket families.",
+            RuntimeWarning,
+            stacklevel=3,
         )
-        mask = bhy_adjust(p_array, fdr=threshold)
-        survivors.extend(
-            fp for fp, accept in zip(family_profiles, mask, strict=False) if accept
+
+
+def _apply_deprecated_kwargs(
+    *,
+    expand_over: Sequence[str] | None,
+    p_stat: StatCode | None,
+    q: float | None,
+    deprecated: dict[str, Any],
+) -> tuple[Sequence[str] | None, StatCode | None, float]:
+    unknown = set(deprecated) - _DEPRECATED_KWARGS.keys()
+    if unknown:
+        raise TypeError(
+            f"bhy() got unexpected keyword argument(s): {sorted(unknown)!r}"
         )
-    return survivors
+
+    if "threshold" in deprecated:
+        if q is not None:
+            raise TypeError(
+                "bhy(): pass either `q=` or the deprecated `threshold=`, not both."
+            )
+        q = deprecated["threshold"]
+    if "gate" in deprecated:
+        if p_stat is not None:
+            raise TypeError(
+                "bhy(): pass either `p_stat=` or the deprecated `gate=`, not both."
+            )
+        p_stat = deprecated["gate"]
+
+    if deprecated:
+        renamed = ", ".join(
+            f"{old}= → {new}="
+            for old, new in _DEPRECATED_KWARGS.items()
+            if old in deprecated
+        )
+        warnings.warn(
+            f"bhy(): {renamed} (deprecated, removed next release).",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+
+    return expand_over, p_stat, q if q is not None else _DEFAULT_Q

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -181,8 +181,13 @@ def _apply_deprecated_kwargs(
             for old, new in _DEPRECATED_KWARGS.items()
             if old in deprecated
         )
+        # BUMP-TIME: pin the actual SemVer cutoff in this string before
+        # the next bump (e.g. "removed in v0.12.0"). #161 ships under the
+        # release-train; the train's cz bump on main is where the cutoff
+        # version becomes concrete. Mirror the same version in CHANGELOG
+        # `### Deprecated` so user-facing message and changelog agree.
         warnings.warn(
-            f"bhy(): {renamed} (deprecated, removed next release).",
+            f"bhy(): {renamed} (deprecated, removed in a future release).",
             DeprecationWarning,
             stacklevel=4,
         )

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -39,7 +39,7 @@ class FactorProcedure(Protocol):
     procedure can populate on ``FactorProfile.stats`` (always-emitted ∪
     conditionally-emitted). ``describe_analysis_modes(format="json")``
     surfaces this so agents can pre-validate ``verdict(gate=...)`` /
-    ``bhy(gate=...)`` choices without running the procedure.
+    ``bhy(p_stat=...)`` choices without running the procedure.
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema]

--- a/factrix/_registry.py
+++ b/factrix/_registry.py
@@ -126,10 +126,8 @@ def _dispatch_key_for(
     """Build the routed ``_DispatchKey`` for a user-facing axis at ``mode``.
 
     Folds ``_route_scope`` + ``_DispatchKey`` construction into one call
-    so ``_evaluate``, ``_describe``, and ``_multi_factor`` cannot drift
-    in how they assemble lookup keys (the ``mirrors _evaluate exactly``
-    comment that previously guarded ``_multi_factor._family_key`` was a
-    drift hazard, not a guarantee).
+    so ``_evaluate`` and ``_describe`` cannot drift in how they assemble
+    lookup keys.
     """
     return _DispatchKey(
         scope=_route_scope(scope, signal, mode),

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -94,24 +94,25 @@ print(dict(profile.stats))           # {StatCode: float} — IC mean, t-stat, et
 import factrix as fl
 from factrix.preprocess import compute_forward_return
 
-raw_panels = [
-    fl.datasets.make_cs_panel(n_assets=80, n_dates=400, ic_target=ic, seed=s)
-    for ic, s in [(0.08, 1), (0.06, 2), (0.01, 3), (0.0, 4), (0.05, 5)]
-]
-import dataclasses
+raw_panels = {
+    f"variant_{i}": fl.datasets.make_cs_panel(
+        n_assets=80, n_dates=400, ic_target=ic, seed=s
+    ).rename({"factor": f"variant_{i}"})
+    for i, (ic, s) in enumerate([(0.08, 1), (0.06, 2), (0.01, 3), (0.0, 4), (0.05, 5)])
+}
 cfg       = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
 profiles  = [
-    dataclasses.replace(
-        fl.evaluate(compute_forward_return(p, forward_periods=5), cfg),
-        factor_id=f"f{i}",
-    )
-    for i, p in enumerate(raw_panels)
+    fl.evaluate(compute_forward_return(p, forward_periods=5), cfg, factor_col=name)
+    for name, p in raw_panels.items()
 ]
 
 survivors = fl.multi_factor.bhy(profiles, q=0.05)
 # survivors: list[FactorProfile] passing BHY step-up at FDR 0.05.
-# The input list IS the family. Distinct factor_id per profile keeps identity
-# unique; pass expand_over=[<context key>] to declare per-bucket families
+# The input list IS the family. Each panel carries its factor under a
+# distinct column name; evaluate(..., factor_col=name) auto-stamps factor_id
+# from that name so identities stay unique. dataclasses.replace(profile,
+# factor_id=...) is the escape hatch when you cannot rename the column.
+# Pass expand_over=[<context key>] to declare per-bucket families
 # (Benjamini & Bogomolov 2014 selective inference).
 ```
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -98,14 +98,21 @@ raw_panels = [
     fl.datasets.make_cs_panel(n_assets=80, n_dates=400, ic_target=ic, seed=s)
     for ic, s in [(0.08, 1), (0.06, 2), (0.01, 3), (0.0, 4), (0.05, 5)]
 ]
+import dataclasses
 cfg       = fl.AnalysisConfig.individual_continuous(metric=fl.Metric.IC, forward_periods=5)
-profiles  = [fl.evaluate(compute_forward_return(p, forward_periods=5), cfg)
-             for p in raw_panels]
+profiles  = [
+    dataclasses.replace(
+        fl.evaluate(compute_forward_return(p, forward_periods=5), cfg),
+        factor_id=f"f{i}",
+    )
+    for i, p in enumerate(raw_panels)
+]
 
-survivors = fl.multi_factor.bhy(profiles, threshold=0.05)
-# survivors: list[FactorProfile] passing per-family BHY step-up at FDR 0.05.
-# Profiles are auto-partitioned into families by (dispatch cell, forward horizon);
-# BHY runs independently inside each family.
+survivors = fl.multi_factor.bhy(profiles, q=0.05)
+# survivors: list[FactorProfile] passing BHY step-up at FDR 0.05.
+# The input list IS the family. Distinct factor_id per profile keeps identity
+# unique; pass expand_over=[<context key>] to declare per-bucket families
+# (Benjamini & Bogomolov 2014 selective inference).
 ```
 
 ### 3. Single-asset panel — `ModeAxisError` with `suggested_fix`
@@ -413,7 +420,7 @@ Read live descriptions programmatically:
 ## StatCode reference
 
 `StatCode.is_p_value` is `True` iff the value name ends in `_p` (the only
-codes `bhy(gate=...)` accepts).
+codes `bhy(p_stat=...)` accepts).
 
 | StatCode | Set by | Meaning |
 |---|---|---|

--- a/tests/test_family_resolution.py
+++ b/tests/test_family_resolution.py
@@ -1,0 +1,153 @@
+"""Coverage for the shared family resolution layer (#161)."""
+
+from __future__ import annotations
+
+import pytest
+from factrix import AnalysisConfig, Metric
+from factrix._axis import Mode
+from factrix._codes import StatCode
+from factrix._errors import UserInputError
+from factrix._family import _resolve_family
+from factrix._profile import FactorProfile
+
+
+def _cfg(forward_periods: int = 5) -> AnalysisConfig:
+    return AnalysisConfig.individual_continuous(
+        metric=Metric.IC, forward_periods=forward_periods
+    )
+
+
+def _profile(
+    *,
+    factor_id: str = "f1",
+    forward_periods: int = 5,
+    primary_p: float = 0.04,
+    context: dict[str, object] | None = None,
+    stats: dict[StatCode, float] | None = None,
+) -> FactorProfile:
+    return FactorProfile(
+        config=_cfg(forward_periods),
+        mode=Mode.PANEL,
+        primary_p=primary_p,
+        n_obs=60,
+        n_assets=20,
+        factor_id=factor_id,
+        context=context or {},
+        stats=stats or {},
+    )
+
+
+def test_default_path_no_expand_over_returns_one_entry_per_profile() -> None:
+    profiles = [_profile(factor_id="f1"), _profile(factor_id="f2")]
+    entries = _resolve_family(profiles, verb="bhy")
+    assert [e.identity for e in entries] == [("f1", 5), ("f2", 5)]
+    assert all(e.expand_over_values == () for e in entries)
+    assert [e.p_value for e in entries] == [0.04, 0.04]
+
+
+def test_p_stat_none_falls_back_to_primary_p() -> None:
+    p = _profile(primary_p=0.012, stats={StatCode.IC_P: 0.5})
+    [entry] = _resolve_family([p], verb="bhy")
+    assert entry.p_value == 0.012
+
+
+def test_p_stat_supplied_reads_from_stats_mapping() -> None:
+    p = _profile(primary_p=0.5, stats={StatCode.IC_P: 0.012})
+    [entry] = _resolve_family([p], verb="bhy", p_stat=StatCode.IC_P)
+    assert entry.p_value == 0.012
+
+
+def test_expand_over_single_dim_partitions_per_context_value() -> None:
+    profiles = [
+        _profile(factor_id="f1", context={"universe_id": "tw50"}),
+        _profile(factor_id="f1", context={"universe_id": "tw100"}),
+    ]
+    entries = _resolve_family(profiles, verb="bhy", expand_over=["universe_id"])
+    assert [e.expand_over_values for e in entries] == [("tw50",), ("tw100",)]
+
+
+def test_expand_over_multi_dim_keeps_caller_key_order() -> None:
+    profiles = [
+        _profile(factor_id="f1", context={"universe_id": "tw50", "regime_id": "bull"}),
+        _profile(factor_id="f1", context={"universe_id": "tw50", "regime_id": "bear"}),
+    ]
+    entries = _resolve_family(
+        profiles, verb="bhy", expand_over=["universe_id", "regime_id"]
+    )
+    assert [e.expand_over_values for e in entries] == [
+        ("tw50", "bull"),
+        ("tw50", "bear"),
+    ]
+
+
+def test_unknown_expand_over_raises_with_fuzzy_suggestion() -> None:
+    profiles = [_profile(context={"universe_id": "tw50", "regime_id": "bull"})]
+    with pytest.raises(UserInputError) as exc:
+        _resolve_family(profiles, verb="bhy", expand_over=["univere_id"])
+    err = exc.value
+    assert err.field == "expand_over"
+    assert err.value == "univere_id"
+    assert "universe_id" in err.suggestions
+    assert "api/bhy#expand_over" in err.docs_url
+
+
+def test_expand_over_missing_on_some_profiles_raises() -> None:
+    profiles = [
+        _profile(context={"universe_id": "tw50", "regime_id": "bull"}),
+        _profile(context={"universe_id": "tw50"}),  # no regime_id
+    ]
+    with pytest.raises(UserInputError) as exc:
+        _resolve_family(profiles, verb="bhy", expand_over=["regime_id"])
+    assert exc.value.field == "expand_over"
+    assert exc.value.value == "regime_id"
+
+
+@pytest.mark.parametrize("identity_field", ["factor_id", "forward_periods"])
+def test_expand_over_hitting_identity_raises(identity_field: str) -> None:
+    profiles = [_profile(context={"universe_id": "tw50"})]
+    with pytest.raises(UserInputError) as exc:
+        _resolve_family(profiles, verb="bhy", expand_over=[identity_field])
+    err = exc.value
+    assert err.field == "expand_over"
+    assert err.value == identity_field
+    assert "identity" in (err.expected or "")
+
+
+def test_duplicate_partition_key_raises() -> None:
+    profiles = [
+        _profile(factor_id="f1", forward_periods=5),
+        _profile(factor_id="f1", forward_periods=5),
+    ]
+    with pytest.raises(UserInputError) as exc:
+        _resolve_family(profiles, verb="bhy")
+    assert exc.value.field == "profiles"
+    assert "duplicate" in str(exc.value)
+
+
+def test_duplicate_partition_key_with_expand_over_compares_full_key() -> None:
+    # Same identity but different expand_over values → no duplicate.
+    profiles = [
+        _profile(factor_id="f1", context={"universe_id": "tw50"}),
+        _profile(factor_id="f1", context={"universe_id": "tw100"}),
+    ]
+    entries = _resolve_family(profiles, verb="bhy", expand_over=["universe_id"])
+    assert len(entries) == 2
+
+    # Same identity AND same expand_over value → duplicate.
+    dup = [
+        _profile(factor_id="f1", context={"universe_id": "tw50"}),
+        _profile(factor_id="f1", context={"universe_id": "tw50"}),
+    ]
+    with pytest.raises(UserInputError):
+        _resolve_family(dup, verb="bhy", expand_over=["universe_id"])
+
+
+def test_missing_p_stat_raises_with_available_keys() -> None:
+    p = _profile(stats={StatCode.IC_P: 0.04})
+    with pytest.raises(UserInputError) as exc:
+        _resolve_family([p], verb="bhy", p_stat=StatCode.FM_LAMBDA_P)
+    err = exc.value
+    assert err.field == "p_stat"
+    assert err.value == "FM_LAMBDA_P"
+    assert "IC_P" in err.candidates
+    assert "api/bhy#p_stat" in err.docs_url

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -1,135 +1,48 @@
-"""v0.5 ``multi_factor.bhy`` — family partitioning + step-up FDR."""
+"""v0.5 ``multi_factor.bhy`` — _resolve_family-backed step-up FDR (#161)."""
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 from factrix._analysis_config import AnalysisConfig
-from factrix._axis import FactorScope, Metric, Mode, Signal
+from factrix._axis import Metric, Mode
 from factrix._codes import StatCode
-from factrix._multi_factor import _family_key, _FamilyKey, bhy
+from factrix._errors import UserInputError
+from factrix._multi_factor import bhy
 from factrix._profile import FactorProfile
-from factrix._registry import _SCOPE_COLLAPSED, _DispatchKey
 
 
 def _profile(
     *,
-    config: AnalysisConfig,
-    mode: Mode,
+    factor_id: str = "factor",
+    forward_periods: int = 5,
     primary_p: float,
+    context: dict[str, object] | None = None,
     stats: dict[StatCode, float] | None = None,
+    metric: Metric = Metric.IC,
+    mode: Mode = Mode.PANEL,
 ) -> FactorProfile:
-    """Build a ``FactorProfile`` for BHY testing without running compute."""
+    cfg = AnalysisConfig.individual_continuous(
+        metric=metric, forward_periods=forward_periods
+    )
     base_stats: dict[StatCode, float] = {StatCode.IC_P: primary_p}
     if stats:
         base_stats.update(stats)
     return FactorProfile(
-        config=config,
+        config=cfg,
         mode=mode,
         primary_p=primary_p,
         n_obs=100,
-        n_assets=1 if mode is Mode.TIMESERIES else 30,
+        n_assets=30,
+        factor_id=factor_id,
+        context=context or {},
         stats=base_stats,
     )
 
 
 # ---------------------------------------------------------------------------
-# Family-key derivation (§5.6)
-# ---------------------------------------------------------------------------
-
-
-class TestFamilyKey:
-    def test_panel_ic_family_key(self) -> None:
-        prof = _profile(
-            config=AnalysisConfig.individual_continuous(metric=Metric.IC),
-            mode=Mode.PANEL,
-            primary_p=0.01,
-        )
-        assert _family_key(prof) == _FamilyKey(
-            dispatch=_DispatchKey(
-                FactorScope.INDIVIDUAL,
-                Signal.CONTINUOUS,
-                Metric.IC,
-                Mode.PANEL,
-            ),
-            forward_periods=5,
-        )
-
-    def test_panel_fm_distinct_from_panel_ic(self) -> None:
-        prof_ic = _profile(
-            config=AnalysisConfig.individual_continuous(metric=Metric.IC),
-            mode=Mode.PANEL,
-            primary_p=0.01,
-        )
-        prof_fm = _profile(
-            config=AnalysisConfig.individual_continuous(metric=Metric.FM),
-            mode=Mode.PANEL,
-            primary_p=0.02,
-        )
-        assert _family_key(prof_ic) != _family_key(prof_fm)
-
-    def test_sparse_n1_individual_and_common_share_family(self) -> None:
-        prof_i = _profile(
-            config=AnalysisConfig.individual_sparse(),
-            mode=Mode.TIMESERIES,
-            primary_p=0.03,
-        )
-        prof_c = _profile(
-            config=AnalysisConfig.common_sparse(),
-            mode=Mode.TIMESERIES,
-            primary_p=0.04,
-        )
-        assert _family_key(prof_i) == _family_key(prof_c)
-        assert _family_key(prof_i).dispatch.scope is _SCOPE_COLLAPSED
-
-    def test_panel_sparse_does_not_collapse(self) -> None:
-        prof = _profile(
-            config=AnalysisConfig.individual_sparse(),
-            mode=Mode.PANEL,
-            primary_p=0.05,
-        )
-        assert _family_key(prof).dispatch.scope is FactorScope.INDIVIDUAL
-
-    def test_distinct_horizons_get_distinct_families(self) -> None:
-        # Same dispatch cell, different forward_periods → different
-        # families. Pooling horizons would dilute the BHY step-up
-        # threshold and silently inflate FDR.
-        prof_h5 = _profile(
-            config=AnalysisConfig.individual_continuous(
-                metric=Metric.IC,
-                forward_periods=5,
-            ),
-            mode=Mode.PANEL,
-            primary_p=0.01,
-        )
-        prof_h20 = _profile(
-            config=AnalysisConfig.individual_continuous(
-                metric=Metric.IC,
-                forward_periods=20,
-            ),
-            mode=Mode.PANEL,
-            primary_p=0.01,
-        )
-        assert _family_key(prof_h5) != _family_key(prof_h20)
-        assert _family_key(prof_h5).dispatch == _family_key(prof_h20).dispatch
-        assert _family_key(prof_h5).forward_periods == 5
-        assert _family_key(prof_h20).forward_periods == 20
-
-    def test_panel_and_timeseries_not_same_family(self) -> None:
-        prof_a = _profile(
-            config=AnalysisConfig.common_continuous(),
-            mode=Mode.PANEL,
-            primary_p=0.01,
-        )
-        prof_b = _profile(
-            config=AnalysisConfig.common_continuous(),
-            mode=Mode.TIMESERIES,
-            primary_p=0.01,
-        )
-        assert _family_key(prof_a) != _family_key(prof_b)
-
-
-# ---------------------------------------------------------------------------
-# bhy partitioning + step-up correctness
+# Step-up basics
 # ---------------------------------------------------------------------------
 
 
@@ -139,241 +52,223 @@ class TestBhyEmpty:
 
 
 class TestBhyStepUp:
-    def test_low_p_values_pass_at_default_threshold(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
+    def test_low_p_values_pass_at_default_q(self) -> None:
         profiles = [
-            _profile(config=cfg, mode=Mode.PANEL, primary_p=p)
-            for p in [0.001, 0.002, 0.003]
+            _profile(factor_id=f"f{i}", primary_p=p)
+            for i, p in enumerate([0.001, 0.002, 0.003])
         ]
-        survivors = bhy(profiles)
-        assert len(survivors) == 3
+        assert len(bhy(profiles)) == 3
 
     def test_high_p_values_fail(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
         profiles = [
-            _profile(config=cfg, mode=Mode.PANEL, primary_p=p) for p in [0.5, 0.7, 0.9]
+            _profile(factor_id=f"f{i}", primary_p=p)
+            for i, p in enumerate([0.5, 0.7, 0.9])
         ]
-        survivors = bhy(profiles)
-        assert survivors == []
+        assert bhy(profiles) == []
 
-
-class TestBhyFamilyIsolation:
-    def test_families_evaluated_independently(self) -> None:
-        # Tiny p in family A; only large p in family B. A passes, B fails.
-        cfg_a = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        cfg_b = AnalysisConfig.individual_continuous(metric=Metric.FM)
-        profiles = [
-            _profile(config=cfg_a, mode=Mode.PANEL, primary_p=0.001),
-            _profile(config=cfg_a, mode=Mode.PANEL, primary_p=0.002),
-            _profile(config=cfg_b, mode=Mode.PANEL, primary_p=0.50),
-            _profile(config=cfg_b, mode=Mode.PANEL, primary_p=0.80),
-        ]
-        survivors = bhy(profiles)
-        # Only family A's two profiles survive.
-        assert len(survivors) == 2
-        for s in survivors:
-            assert s.config.metric is Metric.IC
-
-    def test_horizons_isolated_within_same_cell(self) -> None:
-        # Two horizons of the same cell. If pooled, h=20's large p's
-        # would borrow h=5's strong evidence and inflate the survivor
-        # count beyond the per-horizon truth.
-        cfg_h5 = AnalysisConfig.individual_continuous(
-            metric=Metric.IC,
-            forward_periods=5,
-        )
-        cfg_h20 = AnalysisConfig.individual_continuous(
-            metric=Metric.IC,
-            forward_periods=20,
-        )
-        profiles = [
-            _profile(config=cfg_h5, mode=Mode.PANEL, primary_p=0.001),
-            _profile(config=cfg_h5, mode=Mode.PANEL, primary_p=0.002),
-            _profile(config=cfg_h20, mode=Mode.PANEL, primary_p=0.60),
-            _profile(config=cfg_h20, mode=Mode.PANEL, primary_p=0.80),
-        ]
-        survivors = bhy(profiles)
-        assert len(survivors) == 2
-        for s in survivors:
-            assert s.config.forward_periods == 5
-
-    def test_sparse_n1_individual_and_common_pool_into_one_family(self) -> None:
-        # Three profiles sharing the sentinel family; their p-values
-        # are jointly evaluated even though two come from
-        # individual_sparse() and one from common_sparse().
-        profiles = [
-            _profile(
-                config=AnalysisConfig.individual_sparse(),
-                mode=Mode.TIMESERIES,
-                primary_p=0.001,
-            ),
-            _profile(
-                config=AnalysisConfig.individual_sparse(),
-                mode=Mode.TIMESERIES,
-                primary_p=0.002,
-            ),
-            _profile(
-                config=AnalysisConfig.common_sparse(),
-                mode=Mode.TIMESERIES,
-                primary_p=0.003,
-            ),
-        ]
-        keys = {_family_key(p) for p in profiles}
-        assert len(keys) == 1
-        survivors = bhy(profiles)
-        assert len(survivors) == 3
+    def test_q_loosens_decision(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.04)
+        assert bhy([prof], q=0.05) == [prof]
+        assert bhy([prof], q=0.01) == []
 
 
 # ---------------------------------------------------------------------------
-# threshold + gate
+# expand_over: per-bucket independent step-up (BB2014)
 # ---------------------------------------------------------------------------
 
 
-class TestThreshold:
-    def test_threshold_loosens_decision(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        # Single test, p=0.04: passes at threshold=0.05, fails at 0.01.
-        prof = _profile(config=cfg, mode=Mode.PANEL, primary_p=0.04)
-        assert bhy([prof], threshold=0.05) == [prof]
-        assert bhy([prof], threshold=0.01) == []
+class TestExpandOver:
+    def test_buckets_evaluated_independently(self) -> None:
+        # bucket "bull": all tiny p → both pass
+        # bucket "bear": all large p → both fail
+        profiles = [
+            _profile(factor_id="f1", primary_p=0.001, context={"regime": "bull"}),
+            _profile(factor_id="f2", primary_p=0.002, context={"regime": "bull"}),
+            _profile(factor_id="f1", primary_p=0.5, context={"regime": "bear"}),
+            _profile(factor_id="f2", primary_p=0.6, context={"regime": "bear"}),
+        ]
+        survivors = bhy(profiles, expand_over=["regime"])
+        assert len(survivors) == 2
+        assert {s.context["regime"] for s in survivors} == {"bull"}
+
+    def test_no_expand_over_pools_all_into_one_family(self) -> None:
+        # Distinct identities → all pass dedup; one step-up over 4 entries.
+        profiles = [
+            _profile(factor_id=f"f{i}", primary_p=p)
+            for i, p in enumerate([0.001, 0.002, 0.5, 0.6])
+        ]
+        survivors = bhy(profiles)
+        # All 4 in one family; only the small p's survive step-up.
+        assert {s.factor_id for s in survivors} == {"f0", "f1"}
+
+    def test_unknown_expand_over_raises(self) -> None:
+        profiles = [_profile(factor_id="f1", primary_p=0.01, context={"regime": "x"})]
+        with pytest.raises(UserInputError):
+            bhy(profiles, expand_over=["regiem"])
+
+    def test_singleton_buckets_warn(self) -> None:
+        profiles = [
+            _profile(factor_id="f1", primary_p=0.04, context={"regime": "a"}),
+            _profile(factor_id="f1", primary_p=0.04, context={"regime": "b"}),
+            _profile(factor_id="f1", primary_p=0.04, context={"regime": "c"}),
+        ]
+        with pytest.warns(RuntimeWarning, match="single profile"):
+            bhy(profiles, expand_over=["regime"])
 
 
-class TestGateOverride:
-    def test_gate_reads_from_stats_not_primary_p(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        # primary_p=0.99 (would FAIL); stats[FM_LAMBDA_P]=0.001 (would PASS)
+# ---------------------------------------------------------------------------
+# p_stat alternate p-value
+# ---------------------------------------------------------------------------
+
+
+class TestPStat:
+    def test_p_stat_reads_from_stats_not_primary_p(self) -> None:
         prof = _profile(
-            config=cfg,
-            mode=Mode.PANEL,
+            factor_id="f1",
             primary_p=0.99,
             stats={StatCode.FM_LAMBDA_P: 0.001},
         )
-        assert bhy([prof], gate=StatCode.FM_LAMBDA_P) == [prof]
+        assert bhy([prof], p_stat=StatCode.FM_LAMBDA_P) == [prof]
 
-    def test_missing_gate_raises_keyerror(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        prof = _profile(config=cfg, mode=Mode.PANEL, primary_p=0.001)
-        # CAAR_P never populated for an IC profile.
-        with pytest.raises(KeyError):
-            bhy([prof], gate=StatCode.CAAR_P)
-
-
-# ---------------------------------------------------------------------------
-# UX-2 review fix: cross-family no-op warning
-# ---------------------------------------------------------------------------
-
-
-class TestSingletonFamilyWarning:
-    def test_warns_on_multiple_singleton_families(self) -> None:
-        """README's BHY-of-the-day bug: 3 distinct cells × 1 profile each
-        produces 3 size-1 families — BHY ≡ raw threshold, no FDR control."""
-        ic = _profile(
-            config=AnalysisConfig.individual_continuous(metric=Metric.IC),
-            mode=Mode.PANEL,
-            primary_p=0.04,
-        )
-        fm = _profile(
-            config=AnalysisConfig.individual_continuous(metric=Metric.FM),
-            mode=Mode.PANEL,
-            primary_p=0.04,
-        )
-        common = _profile(
-            config=AnalysisConfig.common_continuous(),
-            mode=Mode.PANEL,
-            primary_p=0.04,
-        )
-        with pytest.warns(RuntimeWarning, match="single profile"):
-            bhy([ic, fm, common], threshold=0.05)
-
-    def test_silent_on_single_family(self) -> None:
-        """One family with one profile is the legitimate single-candidate
-        case — the cross-family no-op heuristic does not fire."""
+    def test_non_p_stat_rejected(self) -> None:
         prof = _profile(
-            config=AnalysisConfig.individual_continuous(metric=Metric.IC),
-            mode=Mode.PANEL,
-            primary_p=0.04,
-        )
-        import warnings as _warnings
-
-        with _warnings.catch_warnings():
-            _warnings.simplefilter("error")
-            bhy([prof], threshold=0.05)
-
-    def test_silent_when_all_families_have_two_plus(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        a = _profile(config=cfg, mode=Mode.PANEL, primary_p=0.01)
-        b = _profile(config=cfg, mode=Mode.PANEL, primary_p=0.02)
-        import warnings as _warnings
-
-        with _warnings.catch_warnings():
-            _warnings.simplefilter("error")
-            bhy([a, b], threshold=0.05)
-
-
-# ---------------------------------------------------------------------------
-# bhy gate validation: must be a p-value StatCode
-# ---------------------------------------------------------------------------
-
-
-class TestBhyGateValidation:
-    def test_non_p_gate_rejected(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        prof = _profile(
-            config=cfg,
-            mode=Mode.PANEL,
+            factor_id="f1",
             primary_p=0.04,
             stats={StatCode.IC_T_NW: 2.5},
         )
-        # IC_T_NW is a t-stat, not a probability — BHY step-up math
-        # would silently corrupt if fed t-stats.
-        with pytest.raises(ValueError, match="requires p-value input"):
-            bhy([prof], threshold=0.05, gate=StatCode.IC_T_NW)
+        with pytest.raises(UserInputError, match="not a probability"):
+            bhy([prof], p_stat=StatCode.IC_T_NW)
 
-    def test_p_gate_accepted(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
+    def test_missing_p_stat_raises_user_error(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.001)
+        with pytest.raises(UserInputError):
+            bhy([prof], p_stat=StatCode.CAAR_P)
+
+
+# ---------------------------------------------------------------------------
+# Identity uniqueness (#160 anti-shopping defense, family layer)
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityUniqueness:
+    def test_duplicate_identity_raises(self) -> None:
+        # Default factor_id="factor" on both → same identity → duplicate.
+        # v0.4 auto-cell-split would have hidden this; v0.5 surfaces it.
+        profiles = [
+            _profile(primary_p=0.01, metric=Metric.IC),
+            _profile(primary_p=0.02, metric=Metric.FM),
+        ]
+        with pytest.raises(UserInputError, match="duplicate"):
+            bhy(profiles)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated v0.4 kwargs (threshold= → q=, gate= → p_stat=)
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedKwargs:
+    def test_threshold_alias_warns(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.04)
+        with pytest.warns(DeprecationWarning, match="threshold"):
+            survivors = bhy([prof], threshold=0.05)
+        assert survivors == [prof]
+
+    def test_gate_alias_warns(self) -> None:
         prof = _profile(
-            config=cfg,
-            mode=Mode.PANEL,
+            factor_id="f1",
             primary_p=0.99,
             stats={StatCode.FM_LAMBDA_P: 0.001},
         )
-        survivors = bhy(
-            [prof],
-            threshold=0.05,
-            gate=StatCode.FM_LAMBDA_P,
-        )
+        with pytest.warns(DeprecationWarning, match="gate"):
+            survivors = bhy([prof], gate=StatCode.FM_LAMBDA_P)
         assert survivors == [prof]
 
-    def test_default_gate_uses_primary_p(self) -> None:
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
-        prof = _profile(config=cfg, mode=Mode.PANEL, primary_p=0.01)
-        # No exception even though stats has no *_P; primary_p is used.
-        assert bhy([prof], threshold=0.05) == [prof]
-
-
-class TestStatCodeIsPValue:
-    def test_p_codes_marked(self) -> None:
-        for code in (
-            StatCode.IC_P,
-            StatCode.FM_LAMBDA_P,
-            StatCode.TS_BETA_P,
-            StatCode.CAAR_P,
-            StatCode.FACTOR_ADF_P,
-            StatCode.LJUNG_BOX_P,
+    def test_threshold_and_q_collide(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.04)
+        with (
+            pytest.raises(TypeError, match="not both"),
+            warnings.catch_warnings(),
         ):
-            assert code.is_p_value, f"{code.name} should be flagged as p-value"
+            warnings.simplefilter("ignore", DeprecationWarning)
+            bhy([prof], threshold=0.05, q=0.01)
 
-    def test_non_p_codes_unmarked(self) -> None:
-        for code in (
-            StatCode.IC_MEAN,
-            StatCode.IC_T_NW,
-            StatCode.FM_LAMBDA_MEAN,
-            StatCode.FM_LAMBDA_T_NW,
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.CAAR_MEAN,
-            StatCode.CAAR_T_NW,
-            StatCode.EVENT_TEMPORAL_HHI,
-            StatCode.NW_LAGS_USED,
+    def test_gate_and_p_stat_collide(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.04)
+        with (
+            pytest.raises(TypeError, match="not both"),
+            warnings.catch_warnings(),
         ):
-            assert not code.is_p_value, f"{code.name} should NOT be flagged as p-value"
+            warnings.simplefilter("ignore", DeprecationWarning)
+            bhy([prof], gate=StatCode.IC_P, p_stat=StatCode.IC_P)
+
+    def test_unknown_kwarg_raises(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.04)
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            bhy([prof], wibble=1)
+
+
+# ---------------------------------------------------------------------------
+# Mixed-horizon migration foot-gun (v0.4 → v0.5)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedHorizonWarning:
+    def test_mixed_forward_periods_without_expand_over_warns(self) -> None:
+        # v0.4 auto-isolated horizons; v0.5 caller must split. Warn loud
+        # so a sweep that previously enjoyed implicit isolation does not
+        # silently inflate FDR after upgrade.
+        profiles = [
+            _profile(factor_id="f1", forward_periods=5, primary_p=0.001),
+            _profile(factor_id="f2", forward_periods=20, primary_p=0.001),
+        ]
+        with pytest.warns(RuntimeWarning, match="forward_periods"):
+            bhy(profiles)
+
+    def test_mixed_horizons_silent_when_expand_over_set(self) -> None:
+        # Caller has explicitly declared per-bucket families; mixed-
+        # horizon warning is suppressed even though horizons differ.
+        profiles = [
+            _profile(
+                factor_id="f1",
+                forward_periods=5,
+                primary_p=0.001,
+                context={"regime": "a"},
+            ),
+            _profile(
+                factor_id="f2",
+                forward_periods=20,
+                primary_p=0.001,
+                context={"regime": "a"},
+            ),
+        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            bhy(profiles, expand_over=["regime"])
+
+    def test_uniform_horizon_silent(self) -> None:
+        profiles = [
+            _profile(factor_id="f1", forward_periods=5, primary_p=0.001),
+            _profile(factor_id="f2", forward_periods=5, primary_p=0.001),
+        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            bhy(profiles)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-identity error message includes actionable hint
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateIdentityHint:
+    def test_error_message_suggests_factor_id_or_expand_over(self) -> None:
+        profiles = [
+            _profile(factor_id="factor", primary_p=0.01),
+            _profile(factor_id="factor", primary_p=0.02),
+        ]
+        with pytest.raises(UserInputError) as exc:
+            bhy(profiles)
+        msg = str(exc.value)
+        assert "factor_id" in msg
+        assert "expand_over" in msg

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -153,7 +153,8 @@ class TestPStat:
 class TestIdentityUniqueness:
     def test_duplicate_identity_raises(self) -> None:
         # Default factor_id="factor" on both → same identity → duplicate.
-        # v0.4 auto-cell-split would have hidden this; v0.5 surfaces it.
+        # The previous auto-cell-split would have hidden this; #161
+        # surfaces it.
         profiles = [
             _profile(primary_p=0.01, metric=Metric.IC),
             _profile(primary_p=0.02, metric=Metric.FM),
@@ -209,15 +210,15 @@ class TestDeprecatedKwargs:
 
 
 # ---------------------------------------------------------------------------
-# Mixed-horizon migration foot-gun (v0.4 → v0.5)
+# Mixed-horizon migration foot-gun (#161 contract change)
 # ---------------------------------------------------------------------------
 
 
 class TestMixedHorizonWarning:
     def test_mixed_forward_periods_without_expand_over_warns(self) -> None:
-        # v0.4 auto-isolated horizons; v0.5 caller must split. Warn loud
-        # so a sweep that previously enjoyed implicit isolation does not
-        # silently inflate FDR after upgrade.
+        # bhy used to auto-isolate horizons; caller now must split.
+        # Warn loud so a sweep that previously enjoyed implicit
+        # isolation does not silently inflate FDR after upgrade.
         profiles = [
             _profile(factor_id="f1", forward_periods=5, primary_p=0.001),
             _profile(factor_id="f2", forward_periods=20, primary_p=0.001),


### PR DESCRIPTION
## Summary

- Lands `factrix._family._resolve_family` as the shared pre-processing layer for every multiple-testing verb (`bhy` today; `bhy_hierarchical` / `partial_conjunction` / `bonferroni` / `holm` / `romano_wolf` planned). Four invariants enforced before any procedure-specific math: identity-uniqueness across input, `expand_over` ⊂ `context` (never identity, extending the #160 anti-shopping defense), `p_stat` is a probability and populated everywhere, `p_value` resolves to `primary_p` when `p_stat is None`.
- Refactors `bhy` onto the new layer with the new signature `bhy(profiles, *, expand_over=None, p_stat=None, q=0.05)`. The previous kwargs `threshold=` / `gate=` continue to work for one release cycle with `DeprecationWarning`.
- **Behaviour change (#161 contract):** retires the implicit auto-partition by dispatch cell × forward horizon. Caller now declares the family explicitly. Mixed `forward_periods` without `expand_over` emits `RuntimeWarning` (FDR-inflation foot-gun); duplicate identity raises `UserInputError` with an actionable hint pointing at the canonical `evaluate(..., factor_col=name)` route or `dataclasses.replace(profile, factor_id=...)` escape hatch.
- ARCHITECTURE family-verbs section + `docs/api/multi-factor.md` rewrite covering the closed-form vs resampling-based verb classification, `expand_over` selective-inference semantics (Benjamini & Bogomolov 2014), and a before/after table with concrete fix recipes. Notebook `examples/multi_factor_screening.ipynb` now demos the canonical `factor_col=` sweep pattern; `dataclasses.replace` shown as the escape hatch.

Six atomic commits:

1. `0d435b4` `feat(family)` — greenfield `_resolve_family` + `FamilyEntry` + 12 unit tests
2. `610ae33` `feat(multi_factor)!` — bhy refactor + behaviour change + 17 rewritten tests
3. `3593470` `docs(multi_factor)` — architecture + api page + llms-full + where-factrix-fits
4. `31323a7` `docs(multi_factor)` — align migration wording with SemVer, fix notebook for the new contract, enrich the duplicate-identity error message with the concrete `dataclasses.replace` call site
5. `eefa1fd` `docs(examples)` — switch notebook to `factor_col=` canonical path, demote `dataclasses.replace` to escape hatch
6. `4190b48` `docs` — sync `multi-factor.md` / `where-factrix-fits.md` / `llms-full.txt` / `identity.md` to the canonical-path framing
7. `0734783` `chore(multi_factor)` — soften deprecation message to "removed in a future release"; leave a BUMP-TIME comment beside the warning so the release-train author pins a concrete SemVer at cz-bump time and mirrors it in CHANGELOG `### Deprecated`

Closes #161

## Test plan

- [x] `pytest tests/` — 938 passed (was 941 pre-#161; net −3 from removing obsolete `_FamilyKey` / auto-split tests, +29 from new family / bhy tests)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/test_docs_pages.py tests/test_docs_llms.py` — 136 passed (anchor / cross-link validation)
- [x] `jupyter nbconvert --execute` on both example notebooks — clean
- [x] **Reviewer (self-review): contract change is acceptable for the v0.11.0 train.** Failure modes are loud (`UserInputError` on cross-cell collide; `RuntimeWarning` on mixed horizons), kwarg deprecation is graceful (one cycle), 29 new tests cover the family layer + the bhy behaviour change. Two flags for the bump-time CHANGELOG author are now persisted in `factrix/_multi_factor.py` (BUMP-TIME comment beside the deprecation `warnings.warn`): (a) the auto-partition removal needs an explicit `### Changed` paragraph with the migration recipe, not just `### Added` for `expand_over`; (b) pin the concrete SemVer cutoff in the warning string before the next bump and mirror it in CHANGELOG `### Deprecated`.