### PR TITLE
chore(precommit): include .ipynb in staged ruff sweep

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,26 +5,28 @@
 # would fail CI fail locally instead. Bypass with ``git commit
 # --no-verify`` when you really mean it (e.g. WIP, partial reformat).
 #
-# Scoped to staged .py files for speed — at factrix's size whole-repo
-# would be sub-second, but the staged scope keeps the hook silent on
-# commits that touch only YAML / Markdown / .txt.
+# Scoped to staged .py / .ipynb files for speed — at factrix's size
+# whole-repo would be sub-second, but the staged scope keeps the hook
+# silent on commits that touch only YAML / Markdown / .txt. Notebooks
+# are in scope because their Python cells run through the same ruff
+# pass in CI (.github/workflows/test.yml `ruff check .`).
 
 set -e
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.py$' || true)
+staged=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(py|ipynb)$' || true)
 if [ -z "$staged" ]; then
     exit 0
 fi
 
 # shellcheck disable=SC2086
-echo "[pre-commit] ruff check on staged .py files..."
+echo "[pre-commit] ruff check on staged .py / .ipynb files..."
 echo "$staged" | xargs uv run ruff check || {
     echo "[pre-commit] FAIL — fix with: uv run ruff check --fix <files>"
     echo "[pre-commit] bypass:        git commit --no-verify"
     exit 1
 }
 
-echo "[pre-commit] ruff format --check on staged .py files..."
+echo "[pre-commit] ruff format --check on staged .py / .ipynb files..."
 echo "$staged" | xargs uv run ruff format --check || {
     echo "[pre-commit] FAIL — fix with: uv run ruff format <files>"
     echo "[pre-commit] bypass:        git commit --no-verify"


### PR DESCRIPTION
## Summary

- Pre-commit hook (`.githooks/pre-commit`) only matched `.py`, so notebook lint regressions slipped through to CI. Extend the staged-file regex to `\.(py|ipynb)$` so `ruff check` / `ruff format --check` cover notebooks locally too.
- Encountered concretely on #171 batch 3 — `examples/multi_factor_screening.ipynb` had `zip()` without `strict=` (B905) which only surfaced in CI.
- Staged-only scoping is preserved (hook still mute on YAML / Markdown / .txt commits).

## Test plan

- [x] `uv run ruff check examples/multi_factor_screening.ipynb` — clean (no regression on existing notebooks).
- [x] Sanity: a sandbox `.ipynb` with `zip(a, b)` triggers B905, confirming ruff is wired through.
- [x] No-op for commits that touch only YAML / Markdown / .txt (unchanged early-exit branch).