### PR TITLE
feat(stats)!: Estimator protocol + NeweyWest + list_estimators (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,35 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ## [Unreleased]
 
+### Added
+
+- **`factrix.stats.Estimator`** — runtime-checkable Protocol for inference-method instances. Implementations supply `name` / `description` / `applicable_to(scope, signal)` / `emits_for(scope, signal, metric)`; the family-verb resolution layer dispatches via these to a `StatCode` key in `profile.stats`. The protocol is selection-only — no `compute()` method — so cell-internal estimator swap stays a future `ComputableEstimator(Estimator)` extension and the surface does not pre-commit to a return shape that NW (`SE+t+p`) and GMM (`J-stat+df+p`) cannot share. (#170)
+- **`factrix.stats.NeweyWest`** — reference Estimator naming the procedure-emitted Newey-West HAC inference path. Carries no compute logic; the underlying NW HAC math stays in `factrix._stats` and is invoked by each cell procedure during `evaluate()`. Constructor takes no arguments in v0.11; `lag` / `kernel` / `overlap_floor` knobs are tracked for a future enhancement. (#170)
+- **`factrix.list_estimators(scope, signal, *, format, with_import)`** — mirrors `list_metrics` shape so the pre-flight pattern ("which scalars and which inference methods does this cell admit") is one API. v0.11 ships only `NeweyWest`; HansenHodrick / GMM follow-ups append to `factrix.stats._ESTIMATOR_REGISTRY` as the #170 sub-issue lands. (#170)
+
 ### Changed
+
+- **`factrix.multi_factor.bhy` accepts `estimator: Estimator | None` instead of `p_stat: StatCode | None`** (breaking, #170). The previous `p_stat=` kwarg was a placeholder landed in v0.10 alongside the family-verb refactor and is removed in v0.11. Migration:
+
+  ```python
+  # before (v0.10)
+  fx.multi_factor.bhy(profiles, p_stat=fx.StatCode.IC_P)
+
+  # after (v0.11)
+  from factrix.stats import NeweyWest
+  fx.multi_factor.bhy(profiles, estimator=NeweyWest())
+  ```
+
+  Default behaviour (`estimator=None`) is unchanged — each profile's `primary_p` drives the step-up. `StatCode.is_p_value` continues to gate `profile.verdict(gate=...)`; the family-verb path no longer consults it because an `Estimator` instance is implicitly a p-value source by construction (`emits_for` returns a probability `StatCode`). The `_STAT_DESCRIPTIONS[StatCode.*_T_NW]` entries are slimmed: kernel / bandwidth / overlap-floor implementation details now live on `NeweyWest` itself, while enum descriptions retain only cell-specific stat semantics and cross-ref the estimator class. (#170)
 
 - **`factrix.multi_factor.bhy` returns `Survivors` instead of `list[FactorProfile]`** (breaking under v0.x). Migration: replace `survivors` with `survivors.profiles` for downstream list / iteration use. The new container exposes `.profiles` (input order, kept rows only), `.adj_q` (bucket-local BHY-adjusted p-values, aligned to `.profiles`), `.q`, `.expand_over` (tuple of partition keys), and `.n_total` (per-bucket `m`, keyed by `expand_over_values`). Internally `bhy` builds the survivor index as `{i : bhy_adjusted_p(p_array)[i] <= q}` per bucket and slices both `.profiles` and `.adj_q` to that set, so the survivor mask and the adjusted p-values downstream code reads come from the same `bhy_adjusted_p` call (the previous parallel `bhy_adjust` mask path is removed) — tie / boundary cases where two parallel implementations could disagree are eliminated by construction. `Survivors` ships `__repr__` / `_repr_html_` for Jupyter — three-column `identity | primary_p | adj_q` table, plus an `expand_over_values` column when buckets are declared. The container is procedure-agnostic; future Holm / Bonferroni / Romano-Wolf verbs will populate the same shape via their own `*_adjusted_p`. (#171)
 - **Terminology**: rename "Layer A" / "Layer B" to **dispatcher** / **curated wrapper** in module docstrings and user-facing docs. Public API names are unchanged. Older CHANGELOG entries below retain the original wording. (#157)
 - **Docs convention**: switch the recommended import alias from `fl` to `fx` across README, mkdocs pages, notebooks, tests, and `llms-full.txt`. `fl` collided with the FinLab community convention (`import finlab as fl`) and carried no mnemonic tie to `factrix`; `fx` takes the first and last letters in the jax-as-`jnp` / polars-as-`pl` / networkx-as-`nx` style. Public API and importable package name (`factrix`) are unchanged — docs-only convention shift, not a breaking change. (#180)
+
+### Removed
+
+- **`factrix.multi_factor.bhy(p_stat=StatCode)` path** — replaced by `estimator=Estimator` (see Changed above). (#170)
+- **`factrix.multi_factor.bhy(gate=...)` deprecation alias** — the v0.4 alias for `p_stat=` is removed alongside its successor; users still on `gate=` should jump directly to `estimator=NeweyWest()`. (#170)
 
 ---
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -51,6 +51,7 @@ from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
 from factrix._describe import (
     SuggestConfigResult,
     describe_analysis_modes,
+    list_estimators,
     list_metrics,
     suggest_config,
 )
@@ -156,6 +157,7 @@ __all__ = [
     # Introspection
     "SuggestConfigResult",
     "describe_analysis_modes",
+    "list_estimators",
     "list_metrics",
     "suggest_config",
     # Multi-factor namespace

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -150,13 +150,13 @@ class StatCode(StrEnum):
     - **p-values**: identifier ends in ``_p`` (``IC_P`` / ``FM_LAMBDA_P``
       / ``TS_BETA_P`` / ``CAAR_P`` plus the diagnostic-only
       ``FACTOR_ADF_P`` / ``LJUNG_BOX_P``). ``is_p_value`` returns
-      ``True``. These are the only codes ``multi_factor.bhy`` will
-      accept as a ``p_stat=`` override (BHY step-up requires
-      probabilities — feeding it t-stats yields nonsense FDR control).
+      ``True``. The Estimator-based ``estimator=`` override (#170)
+      dispatches to one of these via ``Estimator.emits_for``.
     - **t-stats** / effect-size means / lag counts / HHI: ``is_p_value``
       returns ``False``. ``profile.verdict(gate=...)`` accepts these
       (the comparison is generic ``value < threshold`` — interpretation
-      is the caller's call) but ``bhy(p_stat=...)`` rejects them.
+      is the caller's call) but family-verb ``estimator=`` overrides
+      always dispatch to a probability code.
     """
 
     IC_MEAN = "ic_mean"
@@ -180,10 +180,12 @@ class StatCode(StrEnum):
     def is_p_value(self) -> bool:
         """``True`` iff this stat is a probability in [0, 1].
 
-        Used by ``multi_factor.bhy`` (and the shared family resolution
-        layer) to gatekeep the ``p_stat=`` override — BHY step-up math
-        requires p-values, so feeding a t-stat would silently corrupt
-        FDR control.
+        Used by ``profile.verdict(gate=...)`` and downstream tooling to
+        distinguish probability codes from t-stats / effect-size means.
+        The family-verb ``estimator=`` override (#170) does not consult
+        this gate directly: an :class:`~factrix.stats.Estimator`
+        instance is implicitly a p-value source, and ``emits_for``
+        dispatches to a probability ``StatCode`` by construction.
         """
         return self.value.endswith("_p")
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -201,23 +201,26 @@ class StatCode(StrEnum):
 
 _STAT_DESCRIPTIONS: dict[StatCode, str] = {
     StatCode.IC_MEAN: "Per-date Spearman IC, mean over the time series.",
-    StatCode.IC_T_NW: "NW HAC t-stat on the IC mean (Bartlett kernel, "
-    "auto-bandwidth with Hansen-Hodrick overlap floor).",
+    StatCode.IC_T_NW: "NW HAC t-stat on the IC mean. "
+    "Implementation convention lives in `factrix.stats.NeweyWest`.",
     StatCode.IC_P: "Two-sided p-value from the NW HAC t-test on IC.",
     StatCode.FM_LAMBDA_MEAN: "Fama-MacBeth λ — per-date OLS slope of "
     "forward_return on factor, averaged over time.",
-    StatCode.FM_LAMBDA_T_NW: "NW HAC t-stat on the FM λ mean.",
+    StatCode.FM_LAMBDA_T_NW: "NW HAC t-stat on the FM λ mean. "
+    "Implementation convention lives in `factrix.stats.NeweyWest`.",
     StatCode.FM_LAMBDA_P: "Two-sided p-value from the NW HAC t-test on FM λ.",
     StatCode.TS_BETA: "Per-asset OLS β on the broadcast factor; "
     "PANEL = cross-asset mean of β_i, TIMESERIES = single-series β.",
     StatCode.TS_BETA_T_NW: "PANEL: cross-asset t on E[β]. "
-    "TIMESERIES: NW HAC t on the single-series β.",
+    "TIMESERIES: NW HAC t on the single-series β. "
+    "TIMESERIES convention lives in `factrix.stats.NeweyWest`.",
     StatCode.TS_BETA_P: "Two-sided p-value from the TS_BETA t-test.",
     StatCode.CAAR_MEAN: "Per-event-date weighted abnormal return, "
     "averaged across event dates (event-only mean — see _procedures for "
     "the dense-calendar t-stat).",
     StatCode.CAAR_T_NW: "NW HAC t-stat on the dense-calendar CAAR series "
-    "(zero-fill on non-event dates; Hansen-Hodrick overlap floor).",
+    "(zero-fill on non-event dates). "
+    "Implementation convention lives in `factrix.stats.NeweyWest`.",
     StatCode.CAAR_P: "Two-sided p-value from the NW HAC t-test on CAAR.",
     StatCode.FACTOR_ADF_P: "ADF unit-root test p-value on the factor input "
     "series (MacKinnon 1996 response-surface; constant-only specification). "

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -533,3 +533,71 @@ def list_metrics(
         width = max(len(r.name) for r in rows)
         return [f"{r.name:<{width}} → {r.import_path}" for r in rows]
     return [r.name for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# list_estimators (#170)
+# ---------------------------------------------------------------------------
+
+
+def list_estimators(
+    scope: FactorScope,
+    signal: Signal,
+    *,
+    format: Literal["text", "json"] = "text",
+    with_import: bool = False,
+) -> list[str] | list[dict[str, Any]]:
+    """Return Estimator instances applicable to ``(scope, signal)``.
+
+    Mirrors :func:`list_metrics` shape so callers can build a single
+    pre-flight pattern: ``list_metrics`` says which scalars a cell can
+    emit, ``list_estimators`` says which inference methods can drive
+    family-verb ``estimator=`` for that cell. Mode is intentionally
+    not an input — Estimator applicability is not mode-dependent.
+
+    Parameters
+    ----------
+    scope, signal
+        Cell axes to filter on.
+    format
+        ``"text"`` (default) returns Estimator names sorted
+        alphabetically. ``"json"`` returns ``list[dict]`` rows with
+        keys ``name``, ``description``, ``import_path``.
+    with_import
+        ``"text"`` only. When ``True``, returns ``"name → import_path"``
+        two-column lines so each row is copy-paste-ready into
+        ``from factrix.stats import <name>``. Ignored under JSON
+        (``import_path`` is always present there).
+
+    Raises
+    ------
+    IncompatibleAxisError
+        ``(scope, signal)`` matches no registered Estimator. In v0.11
+        the registry contains only ``NeweyWest`` which applies to every
+        user-facing cell, so this is defensive.
+    """
+    from factrix.stats import _ESTIMATOR_REGISTRY
+
+    matches = [e for e in _ESTIMATOR_REGISTRY if e.applicable_to(scope, signal)]
+    if not matches:
+        raise IncompatibleAxisError(
+            f"no estimators applicable to (scope={scope.value}, signal={signal.value})"
+        )
+
+    matches.sort(key=lambda e: e.name)
+
+    if format == "json":
+        return [
+            {
+                "name": e.name,
+                "description": e.description,
+                "import_path": f"factrix.stats.{type(e).__name__}",
+            }
+            for e in matches
+        ]
+    if with_import:
+        width = max(len(e.name) for e in matches)
+        return [
+            f"{e.name:<{width}} → factrix.stats.{type(e).__name__}" for e in matches
+        ]
+    return [e.name for e in matches]

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -586,18 +586,17 @@ def list_estimators(
 
     matches.sort(key=lambda e: e.name)
 
+    rows = [
+        {
+            "name": e.name,
+            "description": e.description,
+            "import_path": f"factrix.stats.{type(e).__name__}",
+        }
+        for e in matches
+    ]
     if format == "json":
-        return [
-            {
-                "name": e.name,
-                "description": e.description,
-                "import_path": f"factrix.stats.{type(e).__name__}",
-            }
-            for e in matches
-        ]
+        return rows
     if with_import:
-        width = max(len(e.name) for e in matches)
-        return [
-            f"{e.name:<{width}} → factrix.stats.{type(e).__name__}" for e in matches
-        ]
-    return [e.name for e in matches]
+        width = max(len(r["name"]) for r in rows)
+        return [f"{r['name']:<{width}} → {r['import_path']}" for r in rows]
+    return [r["name"] for r in rows]

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -45,7 +45,7 @@ class FactrixError(Exception):
 class UserInputError(FactrixError, ValueError):
     """User-supplied input does not match expected names or types.
 
-    Raised for typos in named-set kwargs (metric / p_stat / context key
+    Raised for typos in named-set kwargs (metric / estimator / context key
     / column name) or input-type mismatches. Multi-inherits from
     :class:`ValueError` so ecosystem code (`pytest.raises(ValueError)`,
     generic `except ValueError`) keeps working.

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -1,4 +1,4 @@
-"""Shared family resolution layer for multiple-testing verbs (#161).
+"""Shared family resolution layer for multiple-testing verbs (#161, #170).
 
 Every closed-form family verb (``bhy`` / ``bhy_hierarchical`` /
 ``partial_conjunction`` / ``bonferroni`` / ``holm``) and the
@@ -12,6 +12,12 @@ dimensions (``factor_id`` / ``forward_periods``) name *the hypothesis*,
 ``context`` dimensions name *the slicing condition*, and ``expand_over``
 must stay in the latter — otherwise users would unwittingly let horizon
 or factor name participate in family partitioning.
+
+The ``estimator=`` override (#170) replaces the v0.10 ``p_stat=StatCode``
+placeholder. An :class:`~factrix.stats.Estimator` instance names *the
+inference method* whose p-value should drive the step-up math; the
+instance reports its applicability per cell and dispatches to the
+appropriate ``StatCode`` key in ``profile.stats``.
 """
 
 from __future__ import annotations
@@ -20,11 +26,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from factrix._codes import StatCode
 from factrix._errors import UserInputError
 
 if TYPE_CHECKING:
     from factrix._profile import FactorProfile
+    from factrix.stats import Estimator
 
 
 _IDENTITY_FIELDS: frozenset[str] = frozenset({"factor_id", "forward_periods"})
@@ -40,9 +46,9 @@ class FamilyEntry:
         expand_over_values: ``tuple(profile.context[k] for k in expand_over)``
             in the order the caller passed ``expand_over``; empty tuple
             when ``expand_over`` is None / empty.
-        p_value: Resolved per the ``p_stat`` selection rule —
-            ``profile.primary_p`` when ``p_stat is None``, else
-            ``profile.stats[p_stat]``.
+        p_value: Resolved per the ``estimator`` selection rule —
+            ``profile.primary_p`` when ``estimator is None``, else the
+            value at ``profile.stats[estimator.emits_for(...)]``.
         profile: Back-reference for survivor-renderer use; never read by
             the resolution layer itself.
     """
@@ -58,7 +64,7 @@ def _resolve_family(
     *,
     verb: str,
     expand_over: Sequence[str] | None = None,
-    p_stat: StatCode | None = None,
+    estimator: Estimator | None = None,
 ) -> list[FamilyEntry]:
     """Validate four invariants and return flat ``FamilyEntry`` records.
 
@@ -70,10 +76,12 @@ def _resolve_family(
     2. The partition key
        ``identity + tuple(profile.context[k] for k in expand_over)``
        must be unique across the input.
-    3. When ``p_stat`` is supplied, every profile must populate it in
-       ``stats``.
+    3. When ``estimator`` is supplied, every profile's cell must be in
+       its applicability set and the dispatched ``StatCode`` must be
+       populated in ``profile.stats``.
     4. Resolve ``p_value`` per profile: ``primary_p`` when
-       ``p_stat is None``, else ``profile.stats[p_stat]``.
+       ``estimator is None``, else
+       ``profile.stats[estimator.emits_for(scope, signal, metric)]``.
 
     Args:
         profiles: Input profiles. ``__hash__`` is disabled on
@@ -82,30 +90,16 @@ def _resolve_family(
         verb: Calling verb name for error rendering (e.g. ``"bhy"``).
         expand_over: Optional context keys to include in the partition
             key. ``None`` and ``[]`` are equivalent.
-        p_stat: Optional alternate p-value selector. ``None`` falls back
-            to ``primary_p``.
+        estimator: Optional inference-method override. ``None`` falls
+            back to ``primary_p``.
 
     Returns:
         One ``FamilyEntry`` per input profile, in input order.
 
     Raises:
-        UserInputError: On any of the three named-set / availability
-            failures (unknown ``expand_over`` / hits identity / duplicate
-            partition key / missing ``p_stat``).
+        UserInputError: On any of the named-set / availability /
+            applicability failures.
     """
-    if p_stat is not None and not p_stat.is_p_value:
-        raise UserInputError(
-            verb=verb,
-            field="p_stat",
-            value=p_stat.name,
-            expected=(
-                f"p-value StatCode (is_p_value=True); {p_stat.name} is "
-                "not a probability and family step-up math would be "
-                "incoherent on it"
-            ),
-            docs_path=f"api/{verb}#p_stat",
-        )
-
     keys = list(expand_over) if expand_over else []
     for name in keys:
         if name in _IDENTITY_FIELDS:
@@ -146,7 +140,7 @@ def _resolve_family(
             FamilyEntry(
                 identity=profile.identity,
                 expand_over_values=values,
-                p_value=_resolve_p_value(profile, p_stat=p_stat, verb=verb),
+                p_value=_resolve_p_value(profile, estimator=estimator, verb=verb),
                 profile=profile,
             )
         )
@@ -178,18 +172,37 @@ def _expand_over_values(
 def _resolve_p_value(
     profile: FactorProfile,
     *,
-    p_stat: StatCode | None,
+    estimator: Estimator | None,
     verb: str,
 ) -> float:
-    if p_stat is None:
+    if estimator is None:
         return profile.primary_p
+
+    cfg = profile.config
+    if not estimator.applicable_to(cfg.scope, cfg.signal):
+        raise UserInputError(
+            verb=verb,
+            field="estimator",
+            value=estimator.name,
+            expected=(
+                f"estimator applicable to (scope={cfg.scope.value}, "
+                f"signal={cfg.signal.value}) cell"
+            ),
+            docs_path=f"api/{verb}#estimator",
+        )
+
+    code = estimator.emits_for(cfg.scope, cfg.signal, cfg.metric)
     try:
-        return profile.stats[p_stat]
+        return profile.stats[code]
     except KeyError:
         raise UserInputError(
             verb=verb,
-            field="p_stat",
-            value=p_stat.name,
+            field="estimator",
+            value=estimator.name,
+            expected=(
+                f"profile.stats to populate {code.name} when {estimator.name} "
+                "is supplied; populated keys listed below"
+            ),
             candidates=sorted(s.name for s in profile.stats),
-            docs_path=f"api/{verb}#p_stat",
+            docs_path=f"api/{verb}#estimator",
         ) from None

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
 
 _IDENTITY_FIELDS: frozenset[str] = frozenset({"factor_id", "forward_periods"})
 
+# Docs fragment anchor for ``estimator=`` error messages. Single source
+# of truth so the family-resolution failure paths and any future docs
+# generation agree on the URL shape.
+_ESTIMATOR_DOCS_ANCHOR = "estimator"
+
 
 @dataclass(frozen=True, slots=True)
 class FamilyEntry:
@@ -188,7 +193,7 @@ def _resolve_p_value(
                 f"estimator applicable to (scope={cfg.scope.value}, "
                 f"signal={cfg.signal.value}) cell"
             ),
-            docs_path=f"api/{verb}#estimator",
+            docs_path=f"api/{verb}#{_ESTIMATOR_DOCS_ANCHOR}",
         )
 
     code = estimator.emits_for(cfg.scope, cfg.signal, cfg.metric)
@@ -204,5 +209,5 @@ def _resolve_p_value(
                 "is supplied; populated keys listed below"
             ),
             candidates=sorted(s.name for s in profile.stats),
-            docs_path=f"api/{verb}#estimator",
+            docs_path=f"api/{verb}#{_ESTIMATOR_DOCS_ANCHOR}",
         ) from None

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -25,17 +25,16 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from factrix._codes import StatCode
 from factrix._family import _resolve_family
 from factrix.stats.multiple_testing import bhy_adjusted_p
 
 if TYPE_CHECKING:
     from factrix._profile import FactorProfile
+    from factrix.stats import Estimator
 
 
 _DEPRECATED_KWARGS = {
     "threshold": "q",
-    "gate": "p_stat",
 }
 _DEFAULT_Q = 0.05
 
@@ -160,7 +159,7 @@ def bhy(
     profiles: Iterable[FactorProfile],
     *,
     expand_over: Sequence[str] | None = None,
-    p_stat: StatCode | None = None,
+    estimator: Estimator | None = None,
     q: float | None = None,
     **deprecated: Any,
 ) -> Survivors:
@@ -178,11 +177,12 @@ def bhy(
         expand_over: Optional context keys whose distinct value tuples
             split the input into independent BHY step-up batches.
             ``None`` runs a single step-up over all profiles.
-        p_stat: Alternate p-value :class:`StatCode` (must satisfy
-            ``is_p_value``). ``None`` uses each profile's procedure-
-            canonical ``primary_p`` (e.g. ``IC_P`` for IC,
-            ``FM_LAMBDA_P`` for Fama–MacBeth, ``CAAR_P`` for event
-            studies).
+        estimator: Optional inference-method override (#170). An
+            :class:`~factrix.stats.Estimator` instance (e.g.
+            ``factrix.stats.NeweyWest()``) names which p-value to feed
+            the step-up; ``None`` uses each profile's ``primary_p``.
+            The instance reports its applicability per cell and
+            dispatches to a ``StatCode`` key in ``profile.stats``.
         q: Nominal false discovery rate target. The BHY step-up
             controls FDR ≤ q under positive-regression-dependence
             (PRDS); under arbitrary dependence the effective level is
@@ -196,14 +196,14 @@ def bhy(
 
     Raises:
         UserInputError: On any family-resolution invariant failure
-            (unknown / identity-shadowing ``expand_over`` name; missing
-            or non-probability ``p_stat``; duplicate partition key —
-            typically fixed by setting unique ``factor_id`` per profile
-            or splitting via ``expand_over``).
+            (unknown / identity-shadowing ``expand_over`` name; an
+            ``estimator`` not applicable to a profile's cell or whose
+            dispatched ``StatCode`` is unpopulated; duplicate partition
+            key — typically fixed by setting unique ``factor_id`` per
+            profile or splitting via ``expand_over``).
 
     Warns:
-        DeprecationWarning: When the v0.4 kwargs ``threshold=`` /
-            ``gate=`` are used.
+        DeprecationWarning: When the v0.4 kwarg ``threshold=`` is used.
         RuntimeWarning: When the input mixes ``forward_periods`` while
             ``expand_over`` is ``None`` — pooling horizons in one
             step-up dilutes the per-rank threshold and silently
@@ -211,8 +211,8 @@ def bhy(
             a single profile (BHY on n=1 is a raw cutoff and provides
             no FDR correction).
     """
-    expand_over, p_stat, q = _apply_deprecated_kwargs(
-        expand_over=expand_over, p_stat=p_stat, q=q, deprecated=deprecated
+    expand_over, q = _apply_deprecated_kwargs(
+        expand_over=expand_over, q=q, deprecated=deprecated
     )
     expand_over_tuple: tuple[str, ...] = tuple(expand_over) if expand_over else ()
 
@@ -229,7 +229,7 @@ def bhy(
     _warn_on_mixed_horizons(profile_list, expand_over=expand_over)
 
     entries = _resolve_family(
-        profile_list, verb="bhy", expand_over=expand_over, p_stat=p_stat
+        profile_list, verb="bhy", expand_over=expand_over, estimator=estimator
     )
 
     buckets: dict[tuple[Any, ...], list[int]] = defaultdict(list)
@@ -287,10 +287,9 @@ def _warn_on_mixed_horizons(
 def _apply_deprecated_kwargs(
     *,
     expand_over: Sequence[str] | None,
-    p_stat: StatCode | None,
     q: float | None,
     deprecated: dict[str, Any],
-) -> tuple[Sequence[str] | None, StatCode | None, float]:
+) -> tuple[Sequence[str] | None, float]:
     unknown = set(deprecated) - _DEPRECATED_KWARGS.keys()
     if unknown:
         raise TypeError(
@@ -303,12 +302,6 @@ def _apply_deprecated_kwargs(
                 "bhy(): pass either `q=` or the deprecated `threshold=`, not both."
             )
         q = deprecated["threshold"]
-    if "gate" in deprecated:
-        if p_stat is not None:
-            raise TypeError(
-                "bhy(): pass either `p_stat=` or the deprecated `gate=`, not both."
-            )
-        p_stat = deprecated["gate"]
 
     if deprecated:
         renamed = ", ".join(
@@ -327,4 +320,4 @@ def _apply_deprecated_kwargs(
             stacklevel=4,
         )
 
-    return expand_over, p_stat, q if q is not None else _DEFAULT_Q
+    return expand_over, q if q is not None else _DEFAULT_Q

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -38,8 +38,9 @@ class FactorProcedure(Protocol):
     ``EMITS_STATS`` is the **possible-set** of ``StatCode`` keys the
     procedure can populate on ``FactorProfile.stats`` (always-emitted ∪
     conditionally-emitted). ``describe_analysis_modes(format="json")``
-    surfaces this so agents can pre-validate ``verdict(gate=...)`` /
-    ``bhy(p_stat=...)`` choices without running the procedure.
+    surfaces this so agents can pre-validate ``verdict(gate=...)`` and
+    cross-check that an ``Estimator`` instance is dispatchable for the
+    cell without running the procedure.
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema]

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -259,7 +259,7 @@ factrix.multi_factor.bhy(
     profiles: Iterable[FactorProfile],
     *,
     expand_over: Sequence[str] | None = None,
-    p_stat: StatCode | None = None,
+    estimator: Estimator | None = None,
     q: float = 0.05,
 ) -> Survivors
 ```
@@ -284,10 +284,15 @@ cases. `Survivors` ships `__repr__` / `_repr_html_` for Jupyter —
 three-column `identity | primary_p | adj_q` text and HTML table, plus
 an `expand_over_values` column when buckets are declared.
 
-`p_stat=` overrides which p-value drives BHY; only `StatCode`s where
-`is_p_value` is `True` are accepted (`UserInputError` on non-probabilities;
-also on missing key per profile). The v0.4 kwargs `threshold=` / `gate=`
-are accepted with `DeprecationWarning` and route to `q=` / `p_stat=`.
+`estimator=` overrides which inference method's p-value drives BHY.
+Pass an `Estimator` instance (e.g. `factrix.stats.NeweyWest()`); the
+instance's `applicable_to(scope, signal)` is checked per profile, and
+its `emits_for(scope, signal, metric)` dispatches to a `StatCode` key
+in `profile.stats`. `UserInputError` raises on cell-not-applicable or
+missing dispatched key per profile. The v0.4 kwarg `threshold=` is
+still accepted with `DeprecationWarning` and routes to `q=`; the
+former `gate=` / `p_stat=` paths were removed in v0.11 alongside this
+breaking change (#170).
 
 Family-resolution invariants raise `UserInputError`:
 - `expand_over` names must exist in every `profile.context` and may not
@@ -310,7 +315,7 @@ via the auto-generated `__eq__`.
 
 ---
 
-### `describe_analysis_modes` / `suggest_config` / `list_metrics`
+### `describe_analysis_modes` / `suggest_config` / `list_metrics` / `list_estimators`
 
 ```
 factrix.describe_analysis_modes(*, format: Literal["text", "json"] = "text"
@@ -350,6 +355,19 @@ factrix.list_metrics(scope: FactorScope, signal: Signal,
     # → fm_beta, etc.). Mode is not an input — applicability does
     # not change across PANEL / TIMESERIES.
     # Raises IncompatibleAxisError if the pair has no registered metrics.
+
+factrix.list_estimators(scope: FactorScope, signal: Signal,
+                        *, format: Literal["text", "json"] = "text",
+                        with_import: bool = False
+                        ) -> list[str] | list[dict[str, Any]]
+    # Estimator instances applicable to a (scope, signal) cell —
+    # mirrors list_metrics shape so the pre-flight pattern is one
+    # API. text → list[str] sorted by name; json → rows with
+    # {name, description, import_path}. with_import (text-only)
+    # returns "name → factrix.stats.<Class>" two-column lines.
+    # v0.11 ships only NeweyWest; HansenHodrick / GMM follow-ups
+    # are tracked under #170. Raises IncompatibleAxisError if the
+    # pair has no applicable estimator.
 ```
 
 ---
@@ -452,8 +470,10 @@ Read live descriptions programmatically:
 
 ## StatCode reference
 
-`StatCode.is_p_value` is `True` iff the value name ends in `_p` (the only
-codes `bhy(p_stat=...)` accepts).
+`StatCode.is_p_value` is `True` iff the value name ends in `_p`. Used by
+`profile.verdict(gate=...)` consumers; the family-verb `estimator=`
+override (#170) dispatches via `Estimator.emits_for` and does not gate
+on `is_p_value` directly.
 
 | StatCode | Set by | Meaning |
 |---|---|---|

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -16,6 +16,13 @@ from factrix.stats.bootstrap import (
 from factrix.stats.multiple_testing import bhy_adjust, bhy_adjusted_p
 from factrix.stats.newey_west import NeweyWest
 
+# Internal registry consumed by `factrix.list_estimators`. Append new
+# Estimator instances here as they land (e.g. HansenHodrick / GMM in
+# the #170 follow-up sub-issue) — `list_estimators` filters by
+# `applicable_to(scope, signal)` so the registry is the single source
+# of truth for "which estimators exist".
+_ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (NeweyWest(),)
+
 __all__ = [
     "Estimator",
     "NeweyWest",

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -1,9 +1,12 @@
 """Statistical tooling shared across the library.
 
+``Estimator`` — inference-method protocol selected via family-verb
+``estimator=`` kwarg (#170).
 ``multiple_testing`` — BHY procedure for FDR control across many factors.
 ``bootstrap`` — stationary-bootstrap resampling + CI for dependent series.
 """
 
+from factrix.stats._estimator import Estimator
 from factrix.stats.bootstrap import (
     bootstrap_mean_ci,
     stationary_bootstrap_resamples,
@@ -11,6 +14,7 @@ from factrix.stats.bootstrap import (
 from factrix.stats.multiple_testing import bhy_adjust, bhy_adjusted_p
 
 __all__ = [
+    "Estimator",
     "bhy_adjust",
     "bhy_adjusted_p",
     "bootstrap_mean_ci",

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -2,6 +2,8 @@
 
 ``Estimator`` — inference-method protocol selected via family-verb
 ``estimator=`` kwarg (#170).
+``NeweyWest`` — reference ``Estimator`` for the procedure-canonical
+NW HAC inference path.
 ``multiple_testing`` — BHY procedure for FDR control across many factors.
 ``bootstrap`` — stationary-bootstrap resampling + CI for dependent series.
 """
@@ -12,9 +14,11 @@ from factrix.stats.bootstrap import (
     stationary_bootstrap_resamples,
 )
 from factrix.stats.multiple_testing import bhy_adjust, bhy_adjusted_p
+from factrix.stats.newey_west import NeweyWest
 
 __all__ = [
     "Estimator",
+    "NeweyWest",
     "bhy_adjust",
     "bhy_adjusted_p",
     "bootstrap_mean_ci",

--- a/factrix/stats/_estimator.py
+++ b/factrix/stats/_estimator.py
@@ -1,0 +1,66 @@
+"""Estimator protocol — `inference_method` interface for family-verb override (#170).
+
+Family verbs (`bhy` / `bhy_hierarchical` / `partial_conjunction` / `bonferroni`
+/ `holm` / `romano_wolf`) accept `estimator: Estimator | None` to select which
+inference method's p-value to feed into the step-up math. The protocol carries
+*selection* semantics only — the procedure has already populated
+``FactorProfile.stats`` with the relevant ``StatCode.*_P`` values; an
+``Estimator`` instance names which one to look up for a given cell.
+
+Cell-internal computation (`evaluate()` / standalone metrics) is out of scope:
+that future axis goes through a `ComputableEstimator(Estimator)` sub-protocol
+that adds a `compute(...)` method.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from factrix._axis import FactorScope, Metric, Signal
+    from factrix._codes import StatCode
+
+
+@runtime_checkable
+class Estimator(Protocol):
+    """Inference-method instance: names the p-value source family verbs select.
+
+    Implementations supply identity (``name``), human-readable summary
+    (``description``), cell-applicability check (``applicable_to``), and a
+    cell → StatCode dispatch (``emits_for``) that ``_resolve_family`` uses to
+    look up the relevant entry in ``FactorProfile.stats``.
+
+    The protocol is deliberately silent on how the value was originally
+    computed — that lives in the procedure that produced the profile.
+    """
+
+    @property
+    def name(self) -> str:
+        """Stable identifier used in error messages and ``list_estimators``."""
+        ...
+
+    @property
+    def description(self) -> str:
+        """One-line summary of the inference method (cell-agnostic).
+
+        Cell-specific stat semantics live in
+        ``factrix._codes._STAT_DESCRIPTIONS`` keyed by ``StatCode``.
+        """
+        ...
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        """Whether this estimator applies to the ``(scope, signal)`` cell."""
+        ...
+
+    def emits_for(
+        self,
+        scope: FactorScope,
+        signal: Signal,
+        metric: Metric | None,
+    ) -> StatCode:
+        """Map a cell to the ``StatCode`` whose value this estimator names.
+
+        Called only after ``applicable_to`` has returned ``True``;
+        implementations may assume the cell is in their applicability set.
+        """
+        ...

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -1,0 +1,70 @@
+"""``NeweyWest`` reference Estimator instance (#170).
+
+Names the Newey-West HAC inference path that v0.5 cells already emit
+into ``FactorProfile.stats``. Carries no compute
+logic — the underlying NW HAC math lives in :mod:`factrix._stats` and is
+invoked by each cell procedure during :func:`factrix.evaluate`.
+
+The Bartlett kernel + NW1994 auto-bandwidth + Hansen-Hodrick overlap
+floor convention applies uniformly across the four primary_p-emitting
+cells; cell-specific sample-size guards (e.g. ``UNRELIABLE_SE_SHORT_PERIODS``)
+are tracked by the procedures and surface via ``FactorProfile.warnings``.
+"""
+
+from __future__ import annotations
+
+from factrix._axis import FactorScope, Metric, Signal
+from factrix._codes import StatCode
+
+# Cell → emitted p-value StatCode for the NW HAC convention.
+# Mode is intentionally absent: the same StatCode is emitted in PANEL
+# and TIMESERIES variants of a given (scope, signal, metric) cell.
+_EMITS: dict[tuple[FactorScope, Signal, Metric | None], StatCode] = {
+    (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC): StatCode.IC_P,
+    (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.FM): StatCode.FM_LAMBDA_P,
+    (FactorScope.INDIVIDUAL, Signal.SPARSE, None): StatCode.CAAR_P,
+    (FactorScope.COMMON, Signal.CONTINUOUS, None): StatCode.TS_BETA_P,
+    (FactorScope.COMMON, Signal.SPARSE, None): StatCode.TS_BETA_P,
+}
+
+
+class NeweyWest:
+    """Newey-West (1987) HAC SE estimator → t-statistic → two-sided p-value.
+
+    The Bartlett-kernel HAC variance estimate uses the NW1994 automatic
+    bandwidth rule with a Hansen-Hodrick overlap floor for forward-return
+    regressions, matching the convention v0.5 procedures already use to
+    populate ``primary_p`` and ``StatCode.*_T_NW`` / ``*_P`` entries.
+
+    Pass an instance to family verbs to make the inference choice
+    explicit::
+
+        fx.bhy(profiles, estimator=NeweyWest())
+
+    Constructor takes no arguments in this release; lag / kernel /
+    overlap-floor knobs are tracked as a future enhancement and would
+    arrive as keyword-only ``__init__`` parameters without changing
+    callers that use the default.
+    """
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+    @property
+    def description(self) -> str:
+        return (
+            "Newey-West HAC SE (Bartlett kernel, NW1994 auto-bandwidth, "
+            "Hansen-Hodrick overlap floor) → t → two-sided p-value."
+        )
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        return any((s, sig) == (scope, signal) for (s, sig, _) in _EMITS)
+
+    def emits_for(
+        self,
+        scope: FactorScope,
+        signal: Signal,
+        metric: Metric | None,
+    ) -> StatCode:
+        return _EMITS[(scope, signal, metric)]

--- a/tests/stats/test_estimator_protocol.py
+++ b/tests/stats/test_estimator_protocol.py
@@ -1,0 +1,65 @@
+"""Estimator protocol surface tests (#170).
+
+Verify the runtime-checkable protocol shape so that downstream `_resolve_family`
+dispatch can rely on `isinstance(obj, Estimator)` and the four required members
+(`name` / `description` / `applicable_to` / `emits_for`).
+"""
+
+from __future__ import annotations
+
+from factrix._axis import FactorScope, Metric, Signal
+from factrix._codes import StatCode
+from factrix.stats import Estimator
+
+
+class _Stub:
+    """Minimal Estimator-conforming class for protocol surface checks."""
+
+    @property
+    def name(self) -> str:
+        return "Stub"
+
+    @property
+    def description(self) -> str:
+        return "Test stub."
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        return scope is FactorScope.INDIVIDUAL and signal is Signal.CONTINUOUS
+
+    def emits_for(
+        self, scope: FactorScope, signal: Signal, metric: Metric | None
+    ) -> StatCode:
+        return StatCode.IC_P
+
+
+class _MissingEmitsFor:
+    @property
+    def name(self) -> str:
+        return "x"
+
+    @property
+    def description(self) -> str:
+        return "x"
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        return True
+
+
+def test_runtime_checkable_accepts_conforming_stub() -> None:
+    assert isinstance(_Stub(), Estimator)
+
+
+def test_runtime_checkable_rejects_missing_member() -> None:
+    assert not isinstance(_MissingEmitsFor(), Estimator)
+
+
+def test_member_calls_route_through_protocol() -> None:
+    e: Estimator = _Stub()
+    assert e.name == "Stub"
+    assert e.description == "Test stub."
+    assert e.applicable_to(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+    assert not e.applicable_to(FactorScope.COMMON, Signal.SPARSE)
+    assert (
+        e.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
+        is StatCode.IC_P
+    )

--- a/tests/stats/test_newey_west_estimator.py
+++ b/tests/stats/test_newey_west_estimator.py
@@ -1,0 +1,71 @@
+"""``NeweyWest`` reference Estimator tests (#170).
+
+Validates the dispatch table that maps each user-facing cell to its
+procedure-canonical NW HAC p-value StatCode. Numerical correctness of
+the underlying NW HAC math is owned by ``tests/stats/test_newey_west.py``;
+this file only exercises the metadata + dispatch surface that
+``_resolve_family`` will rely on.
+"""
+
+from __future__ import annotations
+
+import pytest
+from factrix._axis import FactorScope, Metric, Signal
+from factrix._codes import StatCode
+from factrix.stats import Estimator, NeweyWest
+
+
+def test_satisfies_estimator_protocol() -> None:
+    assert isinstance(NeweyWest(), Estimator)
+
+
+def test_name_uses_class_identifier() -> None:
+    assert NeweyWest().name == "NeweyWest"
+
+
+def test_description_is_cell_agnostic() -> None:
+    desc = NeweyWest().description
+    assert "Bartlett" in desc
+    assert "auto-bandwidth" in desc
+    # Cell semantics ("IC mean", "CAAR series", etc.) belong in
+    # _STAT_DESCRIPTIONS, not on the estimator itself.
+    assert "IC" not in desc and "CAAR" not in desc
+
+
+@pytest.mark.parametrize(
+    ("scope", "signal", "metric", "expected"),
+    [
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC, StatCode.IC_P),
+        (
+            FactorScope.INDIVIDUAL,
+            Signal.CONTINUOUS,
+            Metric.FM,
+            StatCode.FM_LAMBDA_P,
+        ),
+        (FactorScope.INDIVIDUAL, Signal.SPARSE, None, StatCode.CAAR_P),
+        (FactorScope.COMMON, Signal.CONTINUOUS, None, StatCode.TS_BETA_P),
+        (FactorScope.COMMON, Signal.SPARSE, None, StatCode.TS_BETA_P),
+    ],
+)
+def test_emits_for_known_cells(
+    scope: FactorScope,
+    signal: Signal,
+    metric: Metric | None,
+    expected: StatCode,
+) -> None:
+    assert NeweyWest().emits_for(scope, signal, metric) is expected
+
+
+@pytest.mark.parametrize(
+    ("scope", "signal"),
+    [
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS),
+        (FactorScope.INDIVIDUAL, Signal.SPARSE),
+        (FactorScope.COMMON, Signal.CONTINUOUS),
+        (FactorScope.COMMON, Signal.SPARSE),
+    ],
+)
+def test_applicable_to_all_user_facing_cells(
+    scope: FactorScope, signal: Signal
+) -> None:
+    assert NeweyWest().applicable_to(scope, signal)

--- a/tests/stats/test_newey_west_estimator.py
+++ b/tests/stats/test_newey_west_estimator.py
@@ -10,9 +10,11 @@ this file only exercises the metadata + dispatch surface that
 from __future__ import annotations
 
 import pytest
-from factrix._axis import FactorScope, Metric, Signal
+from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import StatCode
+from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
 from factrix.stats import Estimator, NeweyWest
+from factrix.stats.newey_west import _EMITS
 
 
 def test_satisfies_estimator_protocol() -> None:
@@ -69,3 +71,22 @@ def test_applicable_to_all_user_facing_cells(
     scope: FactorScope, signal: Signal
 ) -> None:
     assert NeweyWest().applicable_to(scope, signal)
+
+
+def test_emits_table_stays_in_sync_with_dispatch_registry() -> None:
+    # The _EMITS dispatch table is a hardcoded reverse index from cell
+    # to procedure-emitted p-value StatCode. If a procedure's
+    # EMITS_STATS gains or drops a *_P entry, this test fails so the
+    # estimator side is updated in the same PR (drift would otherwise
+    # surface as a runtime KeyError on bhy(estimator=NeweyWest())).
+    for (scope, signal, metric), code in _EMITS.items():
+        entry = _DISPATCH_REGISTRY.get(_DispatchKey(scope, signal, metric, Mode.PANEL))
+        assert entry is not None, (
+            f"_EMITS lists ({scope.value}, {signal.value}, {metric}) "
+            "but no PANEL procedure is registered for it"
+        )
+        assert code in entry.procedure.EMITS_STATS, (
+            f"NeweyWest dispatches ({scope.value}, {signal.value}, "
+            f"{metric}) → {code.name}, but the procedure's EMITS_STATS "
+            f"does not include it: {sorted(s.name for s in entry.procedure.EMITS_STATS)}"
+        )

--- a/tests/test_family_resolution.py
+++ b/tests/test_family_resolution.py
@@ -1,14 +1,15 @@
-"""Coverage for the shared family resolution layer (#161)."""
+"""Coverage for the shared family resolution layer (#161, #170)."""
 
 from __future__ import annotations
 
 import pytest
 from factrix import AnalysisConfig, Metric
-from factrix._axis import Mode
+from factrix._axis import FactorScope, Mode, Signal
 from factrix._codes import StatCode
 from factrix._errors import UserInputError
 from factrix._family import _resolve_family
 from factrix._profile import FactorProfile
+from factrix.stats import NeweyWest
 
 
 def _cfg(forward_periods: int = 5) -> AnalysisConfig:
@@ -45,16 +46,44 @@ def test_default_path_no_expand_over_returns_one_entry_per_profile() -> None:
     assert [e.p_value for e in entries] == [0.04, 0.04]
 
 
-def test_p_stat_none_falls_back_to_primary_p() -> None:
+def test_estimator_none_falls_back_to_primary_p() -> None:
     p = _profile(primary_p=0.012, stats={StatCode.IC_P: 0.5})
     [entry] = _resolve_family([p], verb="bhy")
     assert entry.p_value == 0.012
 
 
-def test_p_stat_supplied_reads_from_stats_mapping() -> None:
+def test_estimator_supplied_reads_dispatched_stat() -> None:
     p = _profile(primary_p=0.5, stats={StatCode.IC_P: 0.012})
-    [entry] = _resolve_family([p], verb="bhy", p_stat=StatCode.IC_P)
+    [entry] = _resolve_family([p], verb="bhy", estimator=NeweyWest())
     assert entry.p_value == 0.012
+
+
+def test_estimator_not_applicable_to_cell_raises() -> None:
+    class _Picky:
+        @property
+        def name(self) -> str:
+            return "Picky"
+
+        @property
+        def description(self) -> str:
+            return "Rejects every cell."
+
+        def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+            return False
+
+        def emits_for(
+            self, scope: FactorScope, signal: Signal, metric: object
+        ) -> StatCode:
+            raise AssertionError("emits_for must not be called when not applicable")
+
+    p = _profile(stats={StatCode.IC_P: 0.04})
+    with pytest.raises(UserInputError) as exc:
+        _resolve_family([p], verb="bhy", estimator=_Picky())
+    err = exc.value
+    assert err.field == "estimator"
+    assert err.value == "Picky"
+    assert "applicable" in (err.expected or "")
+    assert "api/bhy#estimator" in err.docs_url
 
 
 def test_expand_over_single_dim_partitions_per_context_value() -> None:
@@ -142,12 +171,24 @@ def test_duplicate_partition_key_with_expand_over_compares_full_key() -> None:
         _resolve_family(dup, verb="bhy", expand_over=["universe_id"])
 
 
-def test_missing_p_stat_raises_with_available_keys() -> None:
-    p = _profile(stats={StatCode.IC_P: 0.04})
+def test_missing_dispatched_stat_raises_with_available_keys() -> None:
+    # FM cell profile, but stats only has IC_P populated → NeweyWest
+    # dispatches to FM_LAMBDA_P which is missing.
+    cfg = AnalysisConfig.individual_continuous(metric=Metric.FM, forward_periods=5)
+    p = FactorProfile(
+        config=cfg,
+        mode=Mode.PANEL,
+        primary_p=0.04,
+        n_obs=60,
+        n_assets=20,
+        factor_id="f1",
+        stats={StatCode.IC_P: 0.04},
+    )
     with pytest.raises(UserInputError) as exc:
-        _resolve_family([p], verb="bhy", p_stat=StatCode.FM_LAMBDA_P)
+        _resolve_family([p], verb="bhy", estimator=NeweyWest())
     err = exc.value
-    assert err.field == "p_stat"
-    assert err.value == "FM_LAMBDA_P"
+    assert err.field == "estimator"
+    assert err.value == "NeweyWest"
+    assert "FM_LAMBDA_P" in (err.expected or "")
     assert "IC_P" in err.candidates
-    assert "api/bhy#p_stat" in err.docs_url
+    assert "api/bhy#estimator" in err.docs_url

--- a/tests/test_list_estimators.py
+++ b/tests/test_list_estimators.py
@@ -1,0 +1,62 @@
+"""Tests for ``factrix.list_estimators`` (#170).
+
+Mirrors the `list_metrics` listing pattern: text-format names, JSON
+dict rows, `with_import` two-column form, and `IncompatibleAxisError`
+on the empty cell. v0.11 ships only ``NeweyWest`` so every cell that
+emits a primary p-value resolves to that single entry.
+"""
+
+from __future__ import annotations
+
+import pytest
+from factrix import FactorScope, Signal, list_estimators
+from factrix._errors import IncompatibleAxisError
+
+
+@pytest.mark.parametrize(
+    ("scope", "signal"),
+    [
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS),
+        (FactorScope.INDIVIDUAL, Signal.SPARSE),
+        (FactorScope.COMMON, Signal.CONTINUOUS),
+        (FactorScope.COMMON, Signal.SPARSE),
+    ],
+)
+def test_text_format_returns_name_list(scope: FactorScope, signal: Signal) -> None:
+    rows = list_estimators(scope, signal)
+    assert rows == ["NeweyWest"]
+
+
+def test_json_format_includes_metadata_keys() -> None:
+    [row] = list_estimators(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, format="json")
+    assert row["name"] == "NeweyWest"
+    assert "Bartlett" in row["description"]
+    assert row["import_path"] == "factrix.stats.NeweyWest"
+
+
+def test_with_import_returns_two_column_lines() -> None:
+    rows = list_estimators(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, with_import=True)
+    assert rows == ["NeweyWest → factrix.stats.NeweyWest"]
+
+
+def test_with_import_ignored_under_json() -> None:
+    json_rows = list_estimators(
+        FactorScope.INDIVIDUAL,
+        Signal.CONTINUOUS,
+        format="json",
+        with_import=True,
+    )
+    assert isinstance(json_rows, list)
+    assert json_rows[0]["import_path"] == "factrix.stats.NeweyWest"
+
+
+def test_empty_match_raises_incompatible_axis_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Force an empty registry so we exercise the defensive raise path
+    # even with NeweyWest's universal applicability in v0.11.
+    import factrix.stats as stats_pkg
+
+    monkeypatch.setattr(stats_pkg, "_ESTIMATOR_REGISTRY", ())
+    with pytest.raises(IncompatibleAxisError):
+        list_estimators(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -13,6 +13,7 @@ from factrix._codes import StatCode
 from factrix._errors import UserInputError
 from factrix._multi_factor import Survivors, bhy
 from factrix._profile import FactorProfile
+from factrix.stats import NeweyWest
 
 
 def _profile(
@@ -121,32 +122,35 @@ class TestExpandOver:
 
 
 # ---------------------------------------------------------------------------
-# p_stat alternate p-value
+# estimator override (#170)
 # ---------------------------------------------------------------------------
 
 
-class TestPStat:
-    def test_p_stat_reads_from_stats_not_primary_p(self) -> None:
+class TestEstimatorOverride:
+    def test_estimator_reads_dispatched_stat_not_primary_p(self) -> None:
         prof = _profile(
             factor_id="f1",
+            metric=Metric.FM,
             primary_p=0.99,
             stats={StatCode.FM_LAMBDA_P: 0.001},
         )
-        assert bhy([prof], p_stat=StatCode.FM_LAMBDA_P).profiles == [prof]
+        assert bhy([prof], estimator=NeweyWest()).profiles == [prof]
 
-    def test_non_p_stat_rejected(self) -> None:
-        prof = _profile(
-            factor_id="f1",
-            primary_p=0.04,
-            stats={StatCode.IC_T_NW: 2.5},
-        )
-        with pytest.raises(UserInputError, match="not a probability"):
-            bhy([prof], p_stat=StatCode.IC_T_NW)
+    def test_missing_dispatched_stat_raises_user_error(self) -> None:
+        # FM-cell profile, but default fixture only populates IC_P;
+        # NeweyWest dispatches to FM_LAMBDA_P, which is absent.
+        prof = _profile(factor_id="f1", metric=Metric.FM, primary_p=0.001)
+        with pytest.raises(UserInputError) as exc:
+            bhy([prof], estimator=NeweyWest())
+        err = exc.value
+        assert err.field == "estimator"
+        assert err.value == "NeweyWest"
+        assert "FM_LAMBDA_P" in (err.expected or "")
 
-    def test_missing_p_stat_raises_user_error(self) -> None:
-        prof = _profile(factor_id="f1", primary_p=0.001)
-        with pytest.raises(UserInputError):
-            bhy([prof], p_stat=StatCode.CAAR_P)
+    def test_legacy_p_stat_kwarg_is_unrecognised(self) -> None:
+        prof = _profile(factor_id="f1", primary_p=0.04)
+        with pytest.raises(TypeError, match="p_stat"):
+            bhy([prof], p_stat=StatCode.IC_P)
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +172,7 @@ class TestIdentityUniqueness:
 
 
 # ---------------------------------------------------------------------------
-# Deprecated v0.4 kwargs (threshold= → q=, gate= → p_stat=)
+# Deprecated v0.4 kwargs (threshold= → q=)
 # ---------------------------------------------------------------------------
 
 
@@ -179,16 +183,6 @@ class TestDeprecatedKwargs:
             result = bhy([prof], threshold=0.05)
         assert result.profiles == [prof]
 
-    def test_gate_alias_warns(self) -> None:
-        prof = _profile(
-            factor_id="f1",
-            primary_p=0.99,
-            stats={StatCode.FM_LAMBDA_P: 0.001},
-        )
-        with pytest.warns(DeprecationWarning, match="gate"):
-            result = bhy([prof], gate=StatCode.FM_LAMBDA_P)
-        assert result.profiles == [prof]
-
     def test_threshold_and_q_collide(self) -> None:
         prof = _profile(factor_id="f1", primary_p=0.04)
         with (
@@ -197,15 +191,6 @@ class TestDeprecatedKwargs:
         ):
             warnings.simplefilter("ignore", DeprecationWarning)
             bhy([prof], threshold=0.05, q=0.01)
-
-    def test_gate_and_p_stat_collide(self) -> None:
-        prof = _profile(factor_id="f1", primary_p=0.04)
-        with (
-            pytest.raises(TypeError, match="not both"),
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("ignore", DeprecationWarning)
-            bhy([prof], gate=StatCode.IC_P, p_stat=StatCode.IC_P)
 
     def test_unknown_kwarg_raises(self) -> None:
         prof = _profile(factor_id="f1", primary_p=0.04)


### PR DESCRIPTION
## Summary

- Land `factrix.stats.Estimator` runtime-checkable Protocol — selection-only (`name` / `description` / `applicable_to` / `emits_for`); no `compute()` so the surface stays compatible with future cell-internal `ComputableEstimator` extension and never has to unify NW (`SE+t+p`) with GMM (`J-stat+df+p`) return shapes.
- Ship `factrix.stats.NeweyWest` reference instance — wraps the procedure-emitted NW HAC inference path (no new math; bit-equal `IC_P` / `FM_LAMBDA_P` / `TS_BETA_P` / `CAAR_P` lookups) and serves as the integration target for the breaking change.
- Add `factrix.list_estimators(scope, signal)` mirroring `list_metrics` shape (`format="text" | "json"`, `with_import`, `IncompatibleAxisError` on empty cell).
- **Breaking** — `bhy(p_stat: StatCode | None)` placeholder from v0.10 is replaced by `bhy(estimator: Estimator | None)`. The `gate=` v0.4 alias is dropped alongside its successor; `threshold=` → `q=` deprecation remains live. CHANGELOG migration block points users straight at `estimator=NeweyWest()`.

## Open Decisions (PR review)

Issue body §Open Decisions (now four after dropping the description-SSOT non-issue):

1. Protocol method split (`applicable_to` + `emits_for`) vs merged (`emits_for(...) -> StatCode | None`)
2. `NeweyWest` constructor parameterisation (zero-arg now; `lag` / `kernel` / `overlap_floor` deferred)
3. Sub-issue split — HansenHodrick + GMM bundled (now #184) vs each its own
4. `Estimator` naming final call (vs `PValueEstimator` / `InferenceEstimator` to disambiguate from sklearn `BaseEstimator`)

## Test plan

- [x] `tests/stats/test_estimator_protocol.py` — `runtime_checkable` accepts conforming stub, rejects missing-member, member dispatch round-trip
- [x] `tests/stats/test_newey_west_estimator.py` — protocol satisfaction; `name` / `description` shape; per-cell `emits_for` mapping; universal `applicable_to` for the four user-facing cells
- [x] `tests/test_family_resolution.py` — migrated to `estimator=NeweyWest()`; new `applicable_to=False` + missing-dispatched-key paths
- [x] `tests/test_multi_factor.py` — migrated; legacy `p_stat=` raises `TypeError`; `gate=` deprecation removed
- [x] `tests/test_list_estimators.py` — text / json / `with_import` rows; `monkeypatch` empty registry verifies `IncompatibleAxisError`
- [x] Full suite green: `uv run pytest tests/` — 976 passed
- [x] `mypy` clean on touched modules

Closes #170

Sub-issue tracking HansenHodrick / GMM follow-ups: #184