### PR TITLE
refactor(stats)!: flatten StatCode naming + diagnostic grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,9 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
   `StatCode.is_p_value` widened from `value.endswith("_p")` to a tokenised check (`"p" in value.split("_")`) so bare `P` and algorithm variants `P_HH` / `P_GMM` qualify alongside `*_P` diagnostics.
 
-  `Estimator.emits_for` simplified — `NeweyWest` no longer dispatches per-cell to a metric-specific `*_P`; it returns `StatCode.P` cell-agnostically. Future Estimator instances (HansenHodrick / GMM / DriscollKraay) return their own `P_*` value in one line, removing the N-cell × M-algorithm dispatch table the previous shape would have required. (#187)
+  `Estimator.emits_for` simplified — `NeweyWest` no longer dispatches per-cell to a metric-specific `*_P`; it returns `StatCode.P` cell-agnostically. Future Estimator instances (HansenHodrick / GMM / DriscollKraay) return their own `P_*` value in one line, removing the N-cell × M-algorithm dispatch table the previous shape would have required.
+
+  Downstream consumers of `profile.diagnose()` JSON: the `stats` sub-dict's keys move from `"ic_p"` / `"ic_mean"` / `"caar_p"` / etc. to flat `"p"` / `"mean"` / `"t_nw"`. Filtering / dashboard code that reads keys by their old metric-prefixed string needs the same rename map applied to its own logic. (#187)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,32 @@ While the version is below `1.0.0`, the public API should be considered unstable
 - **Terminology**: rename "Layer A" / "Layer B" to **dispatcher** / **curated wrapper** in module docstrings and user-facing docs. Public API names are unchanged. Older CHANGELOG entries below retain the original wording. (#157)
 - **Docs convention**: switch the recommended import alias from `fl` to `fx` across README, mkdocs pages, notebooks, tests, and `llms-full.txt`. `fl` collided with the FinLab community convention (`import finlab as fl`) and carried no mnemonic tie to `factrix`; `fx` takes the first and last letters in the jax-as-`jnp` / polars-as-`pl` / networkx-as-`nx` style. Public API and importable package name (`factrix`) are unchanged — docs-only convention shift, not a breaking change. (#180)
 
+- **`StatCode` naming flattened** (breaking, #187). Primary cell stats lose their metric-name prefix because cell identity already lives on `profile.config` (`scope` / `signal` / `metric`); diagnostics gain explicit prefixes (`FACTOR_` / `RESID_` / `EVENT_`) because their target sits outside `config`. Naming grammar is now `<TARGET>_<KIND>` where TARGET is empty for primary and explicit for diagnostics, KIND is one of `_MEAN` / `_VALUE` / `_<statistic>` / `_P` / `_P_<algorithm>`.
+
+  Rename map (procedure emit + downstream readers):
+
+  | Before | After |
+  |---|---|
+  | `IC_MEAN` / `FM_LAMBDA_MEAN` / `CAAR_MEAN` / `TS_BETA` | `MEAN` |
+  | `IC_T_NW` / `FM_LAMBDA_T_NW` / `TS_BETA_T_NW` / `CAAR_T_NW` | `T_NW` |
+  | `IC_P` / `FM_LAMBDA_P` / `TS_BETA_P` / `CAAR_P` | `P` |
+  | `LJUNG_BOX_P` | `RESID_LJUNG_BOX_P` |
+  | `EVENT_TEMPORAL_HHI` | `EVENT_HHI_VALUE` |
+
+  New StatCodes shipped as part of the refactor:
+
+  - `P_HH` / `P_GMM` — reserved for procedure-side landing of Hansen-Hodrick (#184) and Hansen (1982) GMM J-test inference variants.
+  - `FACTOR_ADF_TAU` / `RESID_LJUNG_BOX_Q` — the underlying ADF τ statistic and Ljung-Box Q statistic are now emitted alongside their existing p-values; the math was already computed inside the procedure but the value was previously discarded.
+
+  `StatCode.is_p_value` widened from `value.endswith("_p")` to a tokenised check (`"p" in value.split("_")`) so bare `P` and algorithm variants `P_HH` / `P_GMM` qualify alongside `*_P` diagnostics.
+
+  `Estimator.emits_for` simplified — `NeweyWest` no longer dispatches per-cell to a metric-specific `*_P`; it returns `StatCode.P` cell-agnostically. Future Estimator instances (HansenHodrick / GMM / DriscollKraay) return their own `P_*` value in one line, removing the N-cell × M-algorithm dispatch table the previous shape would have required. (#187)
+
 ### Removed
 
 - **`factrix.multi_factor.bhy(p_stat=StatCode)` path** — replaced by `estimator=Estimator` (see Changed above). (#170)
 - **`factrix.multi_factor.bhy(gate=...)` deprecation alias** — the v0.4 alias for `p_stat=` is removed alongside its successor; users still on `gate=` should jump directly to `estimator=NeweyWest()`. (#170)
+- **`StatCode.NW_LAGS_USED`** — Newey-West auto-bandwidth lag count is no longer surfaced on `profile.stats`. The lag selection logic in `_resolve_nw_lags` is unchanged; the value just stops being externalised. Reinstating it under a dedicated `profile.metadata` (or sibling) channel is tracked as #188 — `_codes.py` was the wrong home (a hyperparameter-selection record, not a stat). (#187)
 
 ---
 

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -186,10 +186,9 @@ For reference, the JSON shape on the IC PANEL cell is:
   "warnings": [],
   "info_notes": [],
   "stats": {
-    "ic_mean": 0.0722,
-    "ic_t_nw": 14.60,
-    "ic_p": 2.13e-40,
-    "nw_lags_used": 5.0
+    "mean": 0.0722,
+    "t_nw": 14.60,
+    "p": 2.13e-40
   }
 }
 ```

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -113,29 +113,31 @@ resolves the axis when needed.
 
 ### `stats` keys by cell
 
-Every cell populates the keys for its primary statistic (`*_MEAN`,
-`*_T_NW`, `*_P`) plus diagnostic keys specific to its procedure. Keys
-appear in `stats` as `StatCode.value` strings (e.g. `"ic_mean"`).
+After #187's flattening, every cell populates the same primary keys
+(`MEAN`, `T_NW`, `P`); cell identity lives on `profile.config`
+(`scope` / `signal` / `metric`), so the StatCode no longer encodes it.
+Diagnostic keys carry an explicit `FACTOR_` / `RESID_` / `EVENT_`
+prefix because their target sits outside `config`. Keys appear in
+`stats` as `StatCode.value` strings (e.g. `"mean"`, `"factor_adf_p"`).
 
 | Dispatch cell | `stats` keys populated |
 |---------------|------------------------|
-| `(individual, continuous, ic, panel)` | `IC_MEAN`, `IC_T_NW`, `IC_P`, `NW_LAGS_USED` |
-| `(individual, continuous, fm, panel)` | `FM_LAMBDA_MEAN`, `FM_LAMBDA_T_NW`, `FM_LAMBDA_P`, `NW_LAGS_USED` |
-| `(individual, sparse, None, panel)` | `CAAR_MEAN`, `CAAR_T_NW`, `CAAR_P`, `NW_LAGS_USED` |
-| `(common, continuous, None, panel)` | `TS_BETA`, `TS_BETA_T_NW`, `TS_BETA_P`, `FACTOR_ADF_P` |
-| `(common, sparse, None, panel)` | `TS_BETA`, `TS_BETA_T_NW`, `TS_BETA_P` |
-| `(common, continuous, None, timeseries)` | `TS_BETA`, `TS_BETA_T_NW`, `TS_BETA_P`, `FACTOR_ADF_P`, `NW_LAGS_USED` |
-| `(*, sparse, None, timeseries)` (sentinel) | `TS_BETA`, `TS_BETA_T_NW`, `TS_BETA_P`, `LJUNG_BOX_P`, `EVENT_TEMPORAL_HHI`, `NW_LAGS_USED` |
+| `(individual, continuous, ic, panel)` | `MEAN`, `T_NW`, `P` |
+| `(individual, continuous, fm, panel)` | `MEAN`, `T_NW`, `P` |
+| `(individual, sparse, None, panel)` | `MEAN`, `T_NW`, `P` |
+| `(common, continuous, None, panel)` | `MEAN`, `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` |
+| `(common, sparse, None, panel)` | `MEAN`, `T_NW`, `P` |
+| `(common, continuous, None, timeseries)` | `MEAN`, `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` |
+| `(*, sparse, None, timeseries)` (sentinel) | `MEAN`, `T_NW`, `P`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` |
 
-`NW_LAGS_USED` appears whenever a procedure aggregates a time series
-through a Newey-West HAC kernel (Bartlett, Newey-West 1994 auto-lag
-with Hansen-Hodrick overlap floor). Cross-asset aggregations
-(`common_*` PANEL) use a plain cross-section t-test and therefore
-have no `NW_LAGS_USED` entry.
-
-`FACTOR_ADF_P` is a CONTINUOUS-only persistence diagnostic — sparse
+`FACTOR_ADF_*` is a CONTINUOUS-only persistence diagnostic — sparse
 cells skip it because the `{0, R}` event-trigger signal (zero on
 non-event entries) makes the unit-root null degenerate.
+
+The Newey-West auto-bandwidth lag count (Bartlett, NW1994 with
+Hansen-Hodrick overlap floor) is no longer surfaced on
+`profile.stats`; reinstating it under a dedicated metadata channel
+is tracked as #188.
 
 ### `stats` provenance — two paths
 
@@ -144,7 +146,7 @@ non-event entries) makes the unit-root null degenerate.
 
 | Path | Lives in | What it produces | Pluggable? |
 |---|---|---|---|
-| **Procedure-internal** | `factrix/_stats/` helpers (`_newey_west_t_test`, `_adf`, `_ljung_box_p`, …) invoked from `factrix/_procedures.py` | The `StatCode` keys listed above on `profile.stats` | No — the per-cell stat set is hard-coded by the registered procedure. |
+| **Procedure-internal** | `factrix/_stats/` helpers (`_newey_west_t_test`, `_adf`, `_ljung_box`, …) invoked from `factrix/_procedures.py` | The `StatCode` keys listed above on `profile.stats` | No — the per-cell stat set is hard-coded by the registered procedure. |
 | **Standalone metrics** | `factrix/metrics/*.py`, listed by [`list_metrics`](list-metrics.md) | A separate [`MetricOutput`](metric-output.md) per call, returned to the user | Yes — call any number after `evaluate()` returns. |
 
 `fx.metrics.quantile_spread(...)` and friends return a `MetricOutput`
@@ -162,14 +164,12 @@ Each procedure-internal `StatCode` maps to one section of
 
 | `StatCode` | Method |
 |---|---|
-| `IC_MEAN`, `IC_T_NW`, `IC_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West HAC `t` on the per-date IC series |
-| `FM_LAMBDA_MEAN`, `FM_LAMBDA_T_NW`, `FM_LAMBDA_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — NW HAC `t` on the per-date Fama-MacBeth λ series |
-| `CAAR_MEAN`, `CAAR_T_NW`, `CAAR_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — non-overlapping `t` / BMP `z` on the per-event-date CAAR series |
-| `TS_BETA`, `TS_BETA_T_NW`, `TS_BETA_P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — cross-asset `t` on `E[β]` (PANEL) or NW HAC single-series `t` (TIMESERIES) |
-| `NW_LAGS_USED` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West 1994 auto-lag with Hansen-Hodrick overlap floor |
-| `FACTOR_ADF_P` | [Persistence diagnostics under near-unit-root predictors](../reference/statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors) — ADF unit-root test on the continuous factor |
-| `LJUNG_BOX_P` | [Architecture § Procedure pipelines](../development/architecture.md#-sparse---n1-ts-dummy--time-series-only) — Ljung-Box on the TS-dummy single-asset residual |
-| `EVENT_TEMPORAL_HHI` | [Architecture § Procedure pipelines](../development/architecture.md#-sparse---n1-ts-dummy--time-series-only) — Herfindahl concentration of event dates over the calendar grid |
+| `MEAN`, `T_NW`, `P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West HAC `t` on the cell primary series (IC mean / FM λ / CAAR / E[β] / β); convention selected by the procedure dispatched for `profile.config` |
+| `P_HH` | Reserved (#184) — Hansen-Hodrick rectangular-kernel HAC p-value |
+| `P_GMM` | Reserved — Hansen (1982) GMM J-test p-value |
+| `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | [Persistence diagnostics under near-unit-root predictors](../reference/statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors) — ADF τ statistic and unit-root p-value on the continuous factor |
+| `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P` | [Architecture § Procedure pipelines](../development/architecture.md#-sparse---n1-ts-dummy--time-series-only) — Ljung-Box Q statistic and p-value on the TS-dummy single-asset residual |
+| `EVENT_HHI_VALUE` | [Architecture § Procedure pipelines](../development/architecture.md#-sparse---n1-ts-dummy--time-series-only) — Herfindahl concentration of event dates over the calendar grid |
 
 ### Example
 

--- a/docs/api/metrics/common-continuous.md
+++ b/docs/api/metrics/common-continuous.md
@@ -14,7 +14,7 @@ betas.
 
 At `N == 1` the cross-asset $t$ degenerates; factrix auto-routes to a
 TIMESERIES single-series test (null: $\beta = 0$, **not**
-$\mathbb{E}[\beta] = 0$). Same `StatCode.TS_BETA` identifier, different
+$\mathbb{E}[\beta] = 0$). Same `StatCode.MEAN` identifier, different
 statistical meaning — see
 [`profile.mode`](../factor-profile.md) for which path ran.
 

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -52,7 +52,7 @@ dependence violates its Positive Regression Dependency on a Subset
 | Kwarg | Default | Meaning |
 |-------|---------|---------|
 | `expand_over` | `None` | Context keys whose distinct value tuples split the input into independent step-ups. Names must live in `FactorProfile.context` (never identity). |
-| `p_stat` | `None` (= `primary_p`) | Alternate p-value `StatCode` (must satisfy `is_p_value`). Common picks: `IC_P`, `FM_LAMBDA_P`, `CAAR_P`. |
+| `estimator` | `None` (= `primary_p`) | An `Estimator` instance (e.g. `NeweyWest()`) selecting which inference method's p-value to feed into the step-up math. Dispatches via `Estimator.emits_for` to a `StatCode` key on `profile.stats` (see #170, #187). |
 | `q` | `0.05` | Nominal false discovery rate target. The Benjamini–Yekutieli $c(m)$ correction is applied internally — pass the level you actually want; do not pre-divide. |
 
 ### Identity vs context (anti-shopping defense)

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -383,9 +383,9 @@ weighted correctly. Pipeline parity with IC / FM / common-sparse PANEL.
 
 Magnitude is preserved as a weight in `signed_car` (no `.sign()` coercion
 at this layer — `compute_caar`'s docstring carries the input-form
-behaviour table). User-facing `CAAR_MEAN` reports the per-event-date
-mean (the average effect on event days); `n_obs` and `NW_LAGS_USED`
-reflect the dense series.
+behaviour table). User-facing `MEAN` reports the per-event-date
+mean (the average effect on event days); `n_obs` reflects the dense
+series the t-stat is computed on.
 
 Failure modes:
 
@@ -410,7 +410,7 @@ Failure modes:
 - `MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.BORDERLINE_CROSS_SECTION_N`.
 - `n_assets = 1` → degenerate cross-asset test → mode auto-routed to
   TIMESERIES single-series β test (null: β = 0, **not** E[β] = 0). The
-  `StatCode.TS_BETA` identifier is shared across the two modes, so the
+  `StatCode.MEAN` identifier is shared across the two modes, so the
   same field on `FactorProfile` carries different statistical meaning
   depending on `profile.mode`; see §PANEL/TIMESERIES equivalence.
 
@@ -607,7 +607,7 @@ factrix/
 ├── _multi_factor.py         # bhy on the resolution layer
 ├── multi_factor.py          # public namespace (re-exports bhy)
 ├── _stats/
-│   ├── __init__.py          # _ols_nw_slope_t, _ljung_box_p, _adf, _newey_west_t_test, _resolve_nw_lags
+│   ├── __init__.py          # _ols_nw_slope_t, _ljung_box, _adf, _newey_west_t_test, _resolve_nw_lags
 │   └── constants.py         # MIN_PERIODS_HARD / MIN_PERIODS_WARN / auto_bartlett
 ├── _types.py                # MetricOutput, EPSILON, DDOF, MIN_ASSETS_PER_DATE_IC,
 │                            #   MIN_EVENTS_HARD/WARN, MIN_OOS_PERIODS,

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -25,7 +25,7 @@ print(profile.verdict(), '| primary_p =', round(profile.primary_p, 4))
 print(profile.diagnose())
 # {'mode': 'panel', 'n_obs': 494, 'n_assets': 100,
 #  'primary_p': 2.13e-40, 'warnings': [], 'info_notes': [],
-#  'stats': {'ic_mean': 0.0722, 'ic_t_nw': 14.60, ...}}
+#  'stats': {'mean': 0.0722, 't_nw': 14.60, 'p': 2.13e-40}}
 ```
 
 If you are not sure which factory to use, let factrix infer it from the
@@ -65,7 +65,7 @@ when to add standalone metrics), see [Choosing a metric](../guides/choosing-metr
     "primary_p": 0.0001,
     "warnings": ["unreliable_se_short_periods"],
     "info_notes": [],
-    "stats": {"ic_mean": 0.082, "ic_t_nw": 4.21, "nw_lags_used": 5},
+    "stats": {"mean": 0.082, "t_nw": 4.21, "p": 0.0001},
 }
 ```
 

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -54,11 +54,13 @@
     "\n",
     "1. `profile.verdict()` — `pass` / `fail` against `primary_p < 0.05`.\n",
     "2. `profile.primary_p` — directly the IC NW HAC p-value.\n",
-    "3. `profile.stats[StatCode.IC_MEAN]` — sign + magnitude of average IC.\n",
-    "4. `profile.stats[StatCode.IC_T_NW]` — the t-statistic that produced\n",
+    "3. `profile.stats[StatCode.MEAN]` — sign + magnitude of average IC\n",
+    "   (cell identity is on `profile.config.metric`; the StatCode is\n",
+    "   intentionally cell-agnostic — see #187).\n",
+    "4. `profile.stats[StatCode.T_NW]` — the t-statistic that produced\n",
     "   the p-value. Compare to ±2 as a rough sanity check.\n",
     "5. `profile.warnings` — `UNRELIABLE_SE_SHORT_PERIODS` etc. flag risks\n",
-    "   that do *not* enter `verdict()` but should change interpretation.\n"
+    "   that do *not* enter `verdict()` but should change interpretation."
    ]
   },
   {
@@ -75,10 +77,10 @@
    "id": "36a976ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:52:23.868550Z",
-     "iopub.status.busy": "2026-05-10T01:52:23.868375Z",
-     "iopub.status.idle": "2026-05-10T01:52:24.871875Z",
-     "shell.execute_reply": "2026-05-10T01:52:24.871421Z"
+     "iopub.execute_input": "2026-05-10T06:39:37.402095Z",
+     "iopub.status.busy": "2026-05-10T06:39:37.402016Z",
+     "iopub.status.idle": "2026-05-10T06:39:38.394102Z",
+     "shell.execute_reply": "2026-05-10T06:39:38.393611Z"
     }
    },
    "outputs": [
@@ -117,10 +119,10 @@
    "id": "4475e1b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:52:24.873221Z",
-     "iopub.status.busy": "2026-05-10T01:52:24.873109Z",
-     "iopub.status.idle": "2026-05-10T01:52:24.884999Z",
-     "shell.execute_reply": "2026-05-10T01:52:24.884548Z"
+     "iopub.execute_input": "2026-05-10T06:39:38.395411Z",
+     "iopub.status.busy": "2026-05-10T06:39:38.395269Z",
+     "iopub.status.idle": "2026-05-10T06:39:38.460673Z",
+     "shell.execute_reply": "2026-05-10T06:39:38.460194Z"
     }
    },
    "outputs": [
@@ -161,10 +163,10 @@
    "id": "50ffb0d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:52:24.886224Z",
-     "iopub.status.busy": "2026-05-10T01:52:24.886143Z",
-     "iopub.status.idle": "2026-05-10T01:52:24.903923Z",
-     "shell.execute_reply": "2026-05-10T01:52:24.903507Z"
+     "iopub.execute_input": "2026-05-10T06:39:38.461947Z",
+     "iopub.status.busy": "2026-05-10T06:39:38.461863Z",
+     "iopub.status.idle": "2026-05-10T06:39:38.490853Z",
+     "shell.execute_reply": "2026-05-10T06:39:38.490382Z"
     }
    },
    "outputs": [
@@ -176,8 +178,7 @@
       "primary_p    = 2.129e-40\n",
       "mode         = panel\n",
       "ic_mean      = +0.0722\n",
-      "ic_t_nw      = +14.60\n",
-      "nw_lags_used = 5\n"
+      "ic_t_nw      = +14.60\n"
      ]
     }
    ],
@@ -191,9 +192,8 @@
     "print(f\"verdict      = {profile.verdict()}\")\n",
     "print(f\"primary_p    = {profile.primary_p:.4g}\")\n",
     "print(f\"mode         = {profile.mode}\")\n",
-    "print(f\"ic_mean      = {profile.stats[fx.StatCode.IC_MEAN]:+.4f}\")\n",
-    "print(f\"ic_t_nw      = {profile.stats[fx.StatCode.IC_T_NW]:+.2f}\")\n",
-    "print(f\"nw_lags_used = {profile.stats[fx.StatCode.NW_LAGS_USED]:.0f}\")"
+    "print(f\"ic_mean      = {profile.stats[fx.StatCode.MEAN]:+.4f}\")\n",
+    "print(f\"ic_t_nw      = {profile.stats[fx.StatCode.T_NW]:+.2f}\")"
    ]
   },
   {
@@ -214,10 +214,10 @@
    "id": "311e6ff1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:52:24.905031Z",
-     "iopub.status.busy": "2026-05-10T01:52:24.904957Z",
-     "iopub.status.idle": "2026-05-10T01:52:24.906835Z",
-     "shell.execute_reply": "2026-05-10T01:52:24.906457Z"
+     "iopub.execute_input": "2026-05-10T06:39:38.492114Z",
+     "iopub.status.busy": "2026-05-10T06:39:38.492028Z",
+     "iopub.status.idle": "2026-05-10T06:39:38.494040Z",
+     "shell.execute_reply": "2026-05-10T06:39:38.493591Z"
     }
    },
    "outputs": [
@@ -238,10 +238,9 @@
       "  \"warnings\": [],\n",
       "  \"info_notes\": [],\n",
       "  \"stats\": {\n",
-      "    \"ic_mean\": 0.0722106866557101,\n",
-      "    \"ic_t_nw\": 14.6039191698416,\n",
-      "    \"ic_p\": 2.1286625029235276e-40,\n",
-      "    \"nw_lags_used\": 5.0\n",
+      "    \"mean\": 0.0722106866557101,\n",
+      "    \"t_nw\": 14.6039191698416,\n",
+      "    \"p\": 2.1286625029235276e-40\n",
       "  }\n",
       "}\n"
      ]
@@ -277,10 +276,10 @@
    "id": "0ed123b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-10T01:52:24.907907Z",
-     "iopub.status.busy": "2026-05-10T01:52:24.907833Z",
-     "iopub.status.idle": "2026-05-10T01:52:24.909676Z",
-     "shell.execute_reply": "2026-05-10T01:52:24.909256Z"
+     "iopub.execute_input": "2026-05-10T06:39:38.495186Z",
+     "iopub.status.busy": "2026-05-10T06:39:38.495101Z",
+     "iopub.status.idle": "2026-05-10T06:39:38.496849Z",
+     "shell.execute_reply": "2026-05-10T06:39:38.496516Z"
     }
    },
    "outputs": [

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -143,51 +143,58 @@ _INFO_DESCRIPTIONS: dict[InfoCode, str] = {
 class StatCode(StrEnum):
     """Cell-specific scalar stats keyed in ``FactorProfile.stats``.
 
-    Adding a new metric → add an enum value here + populate it in the
-    procedure. Profile schema does not grow. Stats fall in three
-    families:
+    Naming grammar (#187): each code is ``<TARGET>_<KIND>``.
 
-    - **p-values**: identifier ends in ``_p`` (``IC_P`` / ``FM_LAMBDA_P``
-      / ``TS_BETA_P`` / ``CAAR_P`` plus the diagnostic-only
-      ``FACTOR_ADF_P`` / ``LJUNG_BOX_P``). ``is_p_value`` returns
-      ``True``. The Estimator-based ``estimator=`` override (#170)
-      dispatches to one of these via ``Estimator.emits_for``.
-    - **t-stats** / effect-size means / lag counts / HHI: ``is_p_value``
-      returns ``False``. ``profile.verdict(gate=...)`` accepts these
-      (the comparison is generic ``value < threshold`` — interpretation
-      is the caller's call) but family-verb ``estimator=`` overrides
-      always dispatch to a probability code.
+    - ``TARGET`` — what is being measured. **Primary** (cell main
+      effect) carries no prefix because ``FactorProfile.config``
+      (``scope`` / ``signal`` / ``metric``) is the single source of
+      truth for cell identity. **Diagnostic** carries an explicit
+      prefix (``FACTOR_`` / ``RESID_`` / ``EVENT_``) because the
+      target lives outside ``config``.
+    - ``KIND`` — what kind of number. ``_MEAN`` / ``_VALUE`` for point
+      estimates, statistic-named suffixes (``_T_NW`` / ``_TAU`` /
+      ``_Q``) for test statistics, ``_P`` for p-values. Algorithm
+      variants of the same p-value get a further suffix
+      (``_P_HH`` / ``_P_GMM``).
+
+    ``is_p_value`` returns ``True`` for any code whose
+    underscore-separated tokens contain ``"p"``; family-verb
+    ``estimator=`` (#170) dispatches via :class:`Estimator.emits_for`
+    and is implicitly a p-value source by construction.
     """
 
-    IC_MEAN = "ic_mean"
-    IC_T_NW = "ic_t_nw"
-    IC_P = "ic_p"
-    FM_LAMBDA_MEAN = "fm_lambda_mean"
-    FM_LAMBDA_T_NW = "fm_lambda_t_nw"
-    FM_LAMBDA_P = "fm_lambda_p"
-    TS_BETA = "ts_beta"
-    TS_BETA_T_NW = "ts_beta_t_nw"
-    TS_BETA_P = "ts_beta_p"
-    CAAR_MEAN = "caar_mean"
-    CAAR_T_NW = "caar_t_nw"
-    CAAR_P = "caar_p"
+    # Primary (cell main effect) — identity carried by profile.config.
+    MEAN = "mean"
+    T_NW = "t_nw"
+    P = "p"
+    # Algorithm variants reserved for procedure-side landing
+    # (HH-pure: #184; GMM J-test: separate follow-up).
+    P_HH = "p_hh"
+    P_GMM = "p_gmm"
+
+    # Diagnostic — factor input series.
+    FACTOR_ADF_TAU = "factor_adf_tau"
     FACTOR_ADF_P = "factor_adf_p"
-    LJUNG_BOX_P = "ljung_box_p"
-    EVENT_TEMPORAL_HHI = "event_temporal_hhi"
-    NW_LAGS_USED = "nw_lags_used"
+
+    # Diagnostic — regression residual.
+    RESID_LJUNG_BOX_Q = "resid_ljung_box_q"
+    RESID_LJUNG_BOX_P = "resid_ljung_box_p"
+
+    # Diagnostic — event sample distribution.
+    EVENT_HHI_VALUE = "event_hhi_value"
 
     @property
     def is_p_value(self) -> bool:
         """``True`` iff this stat is a probability in [0, 1].
 
         Used by ``profile.verdict(gate=...)`` and downstream tooling to
-        distinguish probability codes from t-stats / effect-size means.
-        The family-verb ``estimator=`` override (#170) does not consult
-        this gate directly: an :class:`~factrix.stats.Estimator`
-        instance is implicitly a p-value source, and ``emits_for``
-        dispatches to a probability ``StatCode`` by construction.
+        distinguish probability codes from test statistics / point
+        estimates. Tokenises the value on ``_`` and checks for a ``p``
+        token, so bare ``P`` and algorithm variants ``P_HH`` / ``P_GMM``
+        all qualify alongside diagnostic ``FACTOR_ADF_P`` /
+        ``RESID_LJUNG_BOX_P``.
         """
-        return self.value.endswith("_p")
+        return "p" in self.value.split("_")
 
     @property
     def description(self) -> str:
@@ -202,38 +209,32 @@ class StatCode(StrEnum):
 
 
 _STAT_DESCRIPTIONS: dict[StatCode, str] = {
-    StatCode.IC_MEAN: "Per-date Spearman IC, mean over the time series.",
-    StatCode.IC_T_NW: "NW HAC t-stat on the IC mean. "
+    StatCode.MEAN: "Cell primary point estimate (interpretation per "
+    "`profile.config.metric`: IC mean, FM λ mean, CAAR event-only mean, "
+    "or TS β / E[β]).",
+    StatCode.T_NW: "Newey-West HAC t-stat on the cell primary estimate. "
     "Implementation convention lives in `factrix.stats.NeweyWest`.",
-    StatCode.IC_P: "Two-sided p-value from the NW HAC t-test on IC.",
-    StatCode.FM_LAMBDA_MEAN: "Fama-MacBeth λ — per-date OLS slope of "
-    "forward_return on factor, averaged over time.",
-    StatCode.FM_LAMBDA_T_NW: "NW HAC t-stat on the FM λ mean. "
-    "Implementation convention lives in `factrix.stats.NeweyWest`.",
-    StatCode.FM_LAMBDA_P: "Two-sided p-value from the NW HAC t-test on FM λ.",
-    StatCode.TS_BETA: "Per-asset OLS β on the broadcast factor; "
-    "PANEL = cross-asset mean of β_i, TIMESERIES = single-series β.",
-    StatCode.TS_BETA_T_NW: "PANEL: cross-asset t on E[β]. "
-    "TIMESERIES: NW HAC t on the single-series β. "
-    "TIMESERIES convention lives in `factrix.stats.NeweyWest`.",
-    StatCode.TS_BETA_P: "Two-sided p-value from the TS_BETA t-test.",
-    StatCode.CAAR_MEAN: "Per-event-date weighted abnormal return, "
-    "averaged across event dates (event-only mean — see _procedures for "
-    "the dense-calendar t-stat).",
-    StatCode.CAAR_T_NW: "NW HAC t-stat on the dense-calendar CAAR series "
-    "(zero-fill on non-event dates). "
-    "Implementation convention lives in `factrix.stats.NeweyWest`.",
-    StatCode.CAAR_P: "Two-sided p-value from the NW HAC t-test on CAAR.",
+    StatCode.P: "Two-sided p-value from the NW HAC t-test on the cell "
+    "primary estimate.",
+    StatCode.P_HH: "Two-sided p-value under Hansen-Hodrick (1980) "
+    "rectangular-kernel HAC. Reserved for procedure-side landing in #184.",
+    StatCode.P_GMM: "Two-sided p-value from a Hansen (1982) GMM J-test "
+    "(over-identifying restrictions). Reserved for procedure-side landing "
+    "in a follow-up issue.",
+    StatCode.FACTOR_ADF_TAU: "ADF τ statistic on the factor input series "
+    "(constant-only specification); fed to the MacKinnon 1996 "
+    "response-surface for `FACTOR_ADF_P`.",
     StatCode.FACTOR_ADF_P: "ADF unit-root test p-value on the factor input "
     "series (MacKinnon 1996 response-surface; constant-only specification). "
     "p > 0.05 flags persistent regressor regime.",
-    StatCode.LJUNG_BOX_P: "Ljung-Box p-value on residual autocorrelation "
+    StatCode.RESID_LJUNG_BOX_Q: "Ljung-Box Q statistic on regression "
+    "residuals (TS-dummy single-asset path); compared against χ²(h) for "
+    "`RESID_LJUNG_BOX_P`.",
+    StatCode.RESID_LJUNG_BOX_P: "Ljung-Box p-value on residual autocorrelation "
     "(TS-dummy single-asset path); p < 0.05 flags under-set NW lag.",
-    StatCode.EVENT_TEMPORAL_HHI: "Herfindahl concentration of event counts "
+    StatCode.EVENT_HHI_VALUE: "Herfindahl concentration of event counts "
     "across calendar bins (cross-sectional / time-axis); high values flag "
     "calendar-time clumping. Does not measure within-asset event clustering.",
-    StatCode.NW_LAGS_USED: "NW HAC lag count selected by the auto-bandwidth "
-    "rule for the cell's primary t-test.",
 }
 
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -66,10 +66,9 @@ class _ICContPanelProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.IC_MEAN,
-            StatCode.IC_T_NW,
-            StatCode.IC_P,
-            StatCode.NW_LAGS_USED,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
         }
     )
 
@@ -114,10 +113,9 @@ class _ICContPanelProcedure:
             n_obs=n_periods,
             n_assets=n_assets,
             stats={
-                StatCode.IC_MEAN: ic_mean,
-                StatCode.IC_T_NW: t_stat,
-                StatCode.IC_P: p_value,
-                StatCode.NW_LAGS_USED: float(nw_lags),
+                StatCode.MEAN: ic_mean,
+                StatCode.T_NW: t_stat,
+                StatCode.P: p_value,
             },
         )
 
@@ -136,10 +134,9 @@ class _FMContPanelProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.FM_LAMBDA_MEAN,
-            StatCode.FM_LAMBDA_T_NW,
-            StatCode.FM_LAMBDA_P,
-            StatCode.NW_LAGS_USED,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
         }
     )
 
@@ -187,10 +184,9 @@ class _FMContPanelProcedure:
             n_assets=n_assets,
             warnings=warning_codes,
             stats={
-                StatCode.FM_LAMBDA_MEAN: lambda_mean,
-                StatCode.FM_LAMBDA_T_NW: t_stat,
-                StatCode.FM_LAMBDA_P: p_value,
-                StatCode.NW_LAGS_USED: float(nw_lags),
+                StatCode.MEAN: lambda_mean,
+                StatCode.T_NW: t_stat,
+                StatCode.P: p_value,
             },
         )
 
@@ -213,12 +209,12 @@ class _CAARSparsePanelProcedure:
     PANEL: same ``_resolve_nw_lags`` + ``_newey_west_t_test`` machinery,
     same dense-series semantics.
 
-    Output contract: ``CAAR_MEAN`` reports the event-only mean
+    Output contract: ``MEAN`` reports the event-only mean
     (user-facing statistic — the average effect on event days);
-    ``n_obs`` and ``NW_LAGS_USED`` reflect the dense series the t-stat
-    is computed on. ``mean_dense × n_total = mean_event × n_event``, so
-    the t-statistic is invariant to the dense reframing in the iid
-    limit (canonical p unchanged when the lag rule was already valid).
+    ``n_obs`` reflects the dense series the t-stat is computed on.
+    ``mean_dense × n_total = mean_event × n_event``, so the t-statistic
+    is invariant to the dense reframing in the iid limit (canonical p
+    unchanged when the lag rule was already valid).
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema] = InputSchema(
@@ -226,10 +222,9 @@ class _CAARSparsePanelProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.CAAR_MEAN,
-            StatCode.CAAR_T_NW,
-            StatCode.CAAR_P,
-            StatCode.NW_LAGS_USED,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
         }
     )
 
@@ -291,10 +286,9 @@ class _CAARSparsePanelProcedure:
             n_assets=n_assets,
             warnings=frozenset(warning_codes),
             stats={
-                StatCode.CAAR_MEAN: event_mean,
-                StatCode.CAAR_T_NW: t_stat,
-                StatCode.CAAR_P: p_value,
-                StatCode.NW_LAGS_USED: float(nw_lags),
+                StatCode.MEAN: event_mean,
+                StatCode.T_NW: t_stat,
+                StatCode.P: p_value,
             },
         )
 
@@ -312,9 +306,10 @@ class _CommonContPanelProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
+            StatCode.FACTOR_ADF_TAU,
             StatCode.FACTOR_ADF_P,
         }
     )
@@ -348,9 +343,9 @@ class _CommonSparsePanelProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
         }
     )
 
@@ -454,9 +449,9 @@ def _compute_common_panel(
         p_value = _p_value_from_t(t_stat, N) if N >= 2 else 1.0
 
     stats: dict[StatCode, float] = {
-        StatCode.TS_BETA: beta_mean,
-        StatCode.TS_BETA_T_NW: t_stat,
-        StatCode.TS_BETA_P: p_value,
+        StatCode.MEAN: beta_mean,
+        StatCode.T_NW: t_stat,
+        StatCode.P: p_value,
     }
     warnings: set[WarningCode] = set(extra_warnings)
     n_tier = cross_section_tier(N)
@@ -473,7 +468,8 @@ def _compute_common_panel(
             .drop_nulls()
             .to_numpy()
         )
-        _, adf_p = _adf(factor_series)
+        adf_tau, adf_p = _adf(factor_series)
+        stats[StatCode.FACTOR_ADF_TAU] = adf_tau
         stats[StatCode.FACTOR_ADF_P] = adf_p
         if adf_p > 0.10:
             warnings.add(WarningCode.PERSISTENT_REGRESSOR)
@@ -507,11 +503,11 @@ class _TSBetaContTimeseriesProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
+            StatCode.FACTOR_ADF_TAU,
             StatCode.FACTOR_ADF_P,
-            StatCode.NW_LAGS_USED,
         }
     )
 
@@ -557,7 +553,7 @@ class _TSBetaContTimeseriesProcedure:
         # extra nulls.
         y, x = y[:n_periods], x[:n_periods]
         beta, t_stat, p_value, _ = _ols_nw_slope_t(y, x, lags=nw_lags)
-        _adf_tau, adf_p = _adf(x)
+        adf_tau, adf_p = _adf(x)
 
         warnings: set[WarningCode] = set()
         if n_periods < MIN_PERIODS_WARN:
@@ -576,11 +572,11 @@ class _TSBetaContTimeseriesProcedure:
             n_assets=int(raw["asset_id"].n_unique()),
             warnings=frozenset(warnings),
             stats={
-                StatCode.TS_BETA: beta,
-                StatCode.TS_BETA_T_NW: t_stat,
-                StatCode.TS_BETA_P: p_value,
+                StatCode.MEAN: beta,
+                StatCode.T_NW: t_stat,
+                StatCode.P: p_value,
+                StatCode.FACTOR_ADF_TAU: adf_tau,
                 StatCode.FACTOR_ADF_P: adf_p,
-                StatCode.NW_LAGS_USED: float(nw_lags),
             },
         )
 
@@ -610,12 +606,12 @@ class _TSDummySparseTimeseriesProcedure:
     )
     EMITS_STATS: ClassVar[frozenset[StatCode]] = frozenset(
         {
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
-            StatCode.LJUNG_BOX_P,
-            StatCode.EVENT_TEMPORAL_HHI,
-            StatCode.NW_LAGS_USED,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
+            StatCode.RESID_LJUNG_BOX_Q,
+            StatCode.RESID_LJUNG_BOX_P,
+            StatCode.EVENT_HHI_VALUE,
         }
     )
 
@@ -628,7 +624,7 @@ class _TSDummySparseTimeseriesProcedure:
         from factrix._errors import InsufficientSampleError
         from factrix._profile import FactorProfile
         from factrix._stats import (
-            _ljung_box_p,
+            _ljung_box,
             _ols_nw_slope_t,
             _resolve_nw_lags,
         )
@@ -660,7 +656,7 @@ class _TSDummySparseTimeseriesProcedure:
             config.forward_periods,
         )
         beta, t_stat, p_value, resid = _ols_nw_slope_t(y, d, lags=nw_lags)
-        ljung_box_p = _ljung_box_p(resid)
+        ljung_box_q, ljung_box_p = _ljung_box(resid)
         hhi = _event_temporal_hhi(d)
         overlap = _has_event_window_overlap(d, config.forward_periods)
 
@@ -680,12 +676,12 @@ class _TSDummySparseTimeseriesProcedure:
             n_assets=int(raw["asset_id"].n_unique()),
             warnings=frozenset(warnings),
             stats={
-                StatCode.TS_BETA: beta,
-                StatCode.TS_BETA_T_NW: t_stat,
-                StatCode.TS_BETA_P: p_value,
-                StatCode.LJUNG_BOX_P: ljung_box_p,
-                StatCode.EVENT_TEMPORAL_HHI: hhi,
-                StatCode.NW_LAGS_USED: float(nw_lags),
+                StatCode.MEAN: beta,
+                StatCode.T_NW: t_stat,
+                StatCode.P: p_value,
+                StatCode.RESID_LJUNG_BOX_Q: ljung_box_q,
+                StatCode.RESID_LJUNG_BOX_P: ljung_box_p,
+                StatCode.EVENT_HHI_VALUE: hhi,
             },
         )
 

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -494,16 +494,16 @@ def _ljung_box(
     """
     n = len(resid)
     if n < 4:
-        return float("nan"), 1.0
+        return np.nan, 1.0
     h = lags if lags is not None else min(10, n // 10)
     if h < 1:
-        return float("nan"), 1.0
+        return np.nan, 1.0
     h = min(h, n - 1)
 
     centred = resid - float(np.mean(resid))
     var = float(np.dot(centred, centred))
     if var < EPSILON:
-        return float("nan"), 1.0
+        return np.nan, 1.0
 
     q = 0.0
     for k in range(1, h + 1):

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -475,32 +475,35 @@ def _wald_p_linear(
     return W, p
 
 
-def _ljung_box_p(
+def _ljung_box(
     resid: np.ndarray,
     *,
     lags: int | None = None,
-) -> float:
-    """Ljung-Box Q-statistic two-sided p-value for residual autocorrelation.
+) -> tuple[float, float]:
+    """Ljung-Box Q statistic and two-sided p-value for residual autocorrelation.
 
     ``Q = n(n+2) Σ_{k=1..h} ρ̂_k² / (n - k)`` evaluated against
     ``χ²_h``; the H₀ is "no autocorrelation up to lag h". Default
     ``lags = min(10, n // 10)`` per plan §5.2.
 
-    Returns ``1.0`` for ``n < 4`` or zero-variance inputs (no
-    autocorrelation can be detected).
+    Returns ``(NaN, 1.0)`` for ``n < 4`` or zero-variance inputs — Q is
+    undefined in those cases (no autocovariance can be estimated), and
+    the canonical "cannot reject" p of 1.0 is the honest fallback. NaN
+    on Q lets downstream readers distinguish "not computable" from
+    "computed and equal to zero".
     """
     n = len(resid)
     if n < 4:
-        return 1.0
+        return float("nan"), 1.0
     h = lags if lags is not None else min(10, n // 10)
     if h < 1:
-        return 1.0
+        return float("nan"), 1.0
     h = min(h, n - 1)
 
     centred = resid - float(np.mean(resid))
     var = float(np.dot(centred, centred))
     if var < EPSILON:
-        return 1.0
+        return float("nan"), 1.0
 
     q = 0.0
     for k in range(1, h + 1):
@@ -508,4 +511,4 @@ def _ljung_box_p(
         rho_k = cov_k / var
         q += rho_k * rho_k / (n - k)
     q *= n * (n + 2)
-    return float(sp_stats.chi2.sf(q, df=h))
+    return float(q), float(sp_stats.chi2.sf(q, df=h))

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -140,7 +140,7 @@ except fx.ModeAxisError as exc:
     profile = fx.evaluate(panel, cfg)
 
 # profile.mode == Mode.TIMESERIES; primary_p is the timeseries-beta p-value
-print(profile.stats[fx.StatCode.TS_BETA])
+print(profile.stats[fx.StatCode.MEAN])
 ```
 
 For `SPARSE × TIMESERIES` the dispatch silently collapses the scope axis
@@ -470,29 +470,28 @@ Read live descriptions programmatically:
 
 ## StatCode reference
 
-`StatCode.is_p_value` is `True` iff the value name ends in `_p`. Used by
-`profile.verdict(gate=...)` consumers; the family-verb `estimator=`
-override (#170) dispatches via `Estimator.emits_for` and does not gate
-on `is_p_value` directly.
+`StatCode.is_p_value` is `True` iff the value tokens (split on `_`)
+contain `"p"`. Used by `profile.verdict(gate=...)` consumers; the
+family-verb `estimator=` override (#170) dispatches via
+`Estimator.emits_for` and does not gate on `is_p_value` directly.
+
+Naming grammar (#187): primary cell stats carry no TARGET prefix
+(cell identity lives on `profile.config`); diagnostics carry an
+explicit `FACTOR_` / `RESID_` / `EVENT_` prefix because the target
+sits outside `config`.
 
 | StatCode | Set by | Meaning |
 |---|---|---|
-| `IC_MEAN`            | IC procedure   | Mean cross-sectional IC |
-| `IC_T_NW`            | IC procedure   | Newey-West t-stat for IC |
-| `IC_P`               | IC procedure   | p-value (= `primary_p` for IC cell) |
-| `FM_LAMBDA_MEAN`     | FM procedure   | Mean Fama-MacBeth lambda |
-| `FM_LAMBDA_T_NW`     | FM procedure   | Newey-West t-stat |
-| `FM_LAMBDA_P`        | FM procedure   | p-value (= `primary_p` for FM cell) |
-| `TS_BETA`            | TS / COMMON    | Timeseries beta |
-| `TS_BETA_T_NW`       | TS / COMMON    | Newey-West t-stat |
-| `TS_BETA_P`          | TS / COMMON    | p-value |
-| `CAAR_MEAN`          | CAAR procedure | Mean cumulative abnormal return |
-| `CAAR_T_NW`          | CAAR procedure | Newey-West t-stat |
-| `CAAR_P`             | CAAR procedure | p-value |
-| `FACTOR_ADF_P`       | all procedures | Diagnostic: factor ADF unit-root p-value |
-| `LJUNG_BOX_P`        | IC / FM        | Diagnostic: residual autocorrelation p-value |
-| `EVENT_TEMPORAL_HHI` | CAAR           | Temporal concentration HHI (0–1) |
-| `NW_LAGS_USED`       | NW-adjusted    | Actual Newey-West lag count used |
+| `MEAN`              | every cell      | Cell primary point estimate (IC mean / FM λ / E[β] / β / CAAR event-only mean) |
+| `T_NW`              | every cell      | NW HAC t-stat on the primary estimate |
+| `P`                 | every cell      | NW HAC p-value (= `primary_p`) |
+| `P_HH`              | reserved (#184) | Hansen-Hodrick p-value (rectangular kernel) |
+| `P_GMM`             | reserved        | GMM J-test p-value |
+| `FACTOR_ADF_TAU`    | COMMON / TS β   | Diagnostic: ADF τ statistic on factor input |
+| `FACTOR_ADF_P`      | COMMON / TS β   | Diagnostic: ADF p-value on factor input |
+| `RESID_LJUNG_BOX_Q` | TS-dummy        | Diagnostic: Ljung-Box Q on residuals |
+| `RESID_LJUNG_BOX_P` | TS-dummy        | Diagnostic: Ljung-Box p-value on residuals |
+| `EVENT_HHI_VALUE`   | TS-dummy        | Diagnostic: temporal concentration HHI (0-1) |
 
 ---
 

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -1,31 +1,24 @@
 """``NeweyWest`` reference Estimator instance (#170).
 
 Names the Newey-West HAC inference path that v0.5 cells already emit
-into ``FactorProfile.stats``. Carries no compute
-logic — the underlying NW HAC math lives in :mod:`factrix._stats` and is
-invoked by each cell procedure during :func:`factrix.evaluate`.
+into ``FactorProfile.stats``. Carries no compute logic — the underlying
+NW HAC math lives in :mod:`factrix._stats` and is invoked by each cell
+procedure during :func:`factrix.evaluate`.
 
 The Bartlett kernel + NW1994 auto-bandwidth + Hansen-Hodrick overlap
 floor convention applies uniformly across the four primary_p-emitting
 cells; cell-specific sample-size guards (e.g. ``UNRELIABLE_SE_SHORT_PERIODS``)
 are tracked by the procedures and surface via ``FactorProfile.warnings``.
+
+After #187's StatCode flattening, ``emits_for`` is cell-agnostic — every
+applicable cell looks up the same ``StatCode.P`` key. Cell identity is
+carried by ``profile.config`` rather than by the StatCode.
 """
 
 from __future__ import annotations
 
 from factrix._axis import FactorScope, Metric, Signal
 from factrix._codes import StatCode
-
-# Cell → emitted p-value StatCode for the NW HAC convention.
-# Mode is intentionally absent: the same StatCode is emitted in PANEL
-# and TIMESERIES variants of a given (scope, signal, metric) cell.
-_EMITS: dict[tuple[FactorScope, Signal, Metric | None], StatCode] = {
-    (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC): StatCode.IC_P,
-    (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.FM): StatCode.FM_LAMBDA_P,
-    (FactorScope.INDIVIDUAL, Signal.SPARSE, None): StatCode.CAAR_P,
-    (FactorScope.COMMON, Signal.CONTINUOUS, None): StatCode.TS_BETA_P,
-    (FactorScope.COMMON, Signal.SPARSE, None): StatCode.TS_BETA_P,
-}
 
 
 class NeweyWest:
@@ -34,7 +27,15 @@ class NeweyWest:
     The Bartlett-kernel HAC variance estimate uses the NW1994 automatic
     bandwidth rule with a Hansen-Hodrick overlap floor for forward-return
     regressions, matching the convention v0.5 procedures already use to
-    populate ``primary_p`` and ``StatCode.*_T_NW`` / ``*_P`` entries.
+    populate ``primary_p`` and ``StatCode.P`` / ``StatCode.T_NW`` entries.
+
+    Cell interpretation comes from ``profile.config`` (``scope`` /
+    ``signal`` / ``metric``) — ``StatCode.P`` is the same key for
+    correlation-mean tests (IC), event-window mean-effect tests (CAAR),
+    cross-asset slope tests (TS β), etc. Downstream readers must consult
+    the config to know which null is being rejected; the StatCode is
+    deliberately cell-agnostic to keep ``Estimator.emits_for`` from
+    re-encoding cell identity.
 
     Pass an instance to family verbs to make the inference choice
     explicit::
@@ -59,7 +60,10 @@ class NeweyWest:
         )
 
     def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
-        return any((s, sig) == (scope, signal) for (s, sig, _) in _EMITS)
+        # NW HAC drives `primary_p` on every user-facing cell, so the
+        # estimator applies universally until a cell opts out.
+        del scope, signal
+        return True
 
     def emits_for(
         self,
@@ -67,4 +71,5 @@ class NeweyWest:
         signal: Signal,
         metric: Metric | None,
     ) -> StatCode:
-        return _EMITS[(scope, signal, metric)]
+        del scope, signal, metric
+        return StatCode.P

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -59,17 +59,15 @@ class NeweyWest:
             "Hansen-Hodrick overlap floor) → t → two-sided p-value."
         )
 
-    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+    def applicable_to(self, _scope: FactorScope, _signal: Signal) -> bool:
         # NW HAC drives `primary_p` on every user-facing cell, so the
         # estimator applies universally until a cell opts out.
-        del scope, signal
         return True
 
     def emits_for(
         self,
-        scope: FactorScope,
-        signal: Signal,
-        metric: Metric | None,
+        _scope: FactorScope,
+        _signal: Signal,
+        _metric: Metric | None,
     ) -> StatCode:
-        del scope, signal, metric
         return StatCode.P

--- a/tests/stats/test_estimator_protocol.py
+++ b/tests/stats/test_estimator_protocol.py
@@ -29,7 +29,7 @@ class _Stub:
     def emits_for(
         self, scope: FactorScope, signal: Signal, metric: Metric | None
     ) -> StatCode:
-        return StatCode.IC_P
+        return StatCode.P
 
 
 class _MissingEmitsFor:
@@ -60,6 +60,5 @@ def test_member_calls_route_through_protocol() -> None:
     assert e.applicable_to(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
     assert not e.applicable_to(FactorScope.COMMON, Signal.SPARSE)
     assert (
-        e.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
-        is StatCode.IC_P
+        e.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC) is StatCode.P
     )

--- a/tests/stats/test_newey_west_estimator.py
+++ b/tests/stats/test_newey_west_estimator.py
@@ -1,10 +1,9 @@
-"""``NeweyWest`` reference Estimator tests (#170).
+"""``NeweyWest`` reference Estimator tests (#170, #187).
 
-Validates the dispatch table that maps each user-facing cell to its
-procedure-canonical NW HAC p-value StatCode. Numerical correctness of
-the underlying NW HAC math is owned by ``tests/stats/test_newey_west.py``;
-this file only exercises the metadata + dispatch surface that
-``_resolve_family`` will rely on.
+Validates the cell-agnostic dispatch surface (`emits_for` always returns
+`StatCode.P`) and applicability across user-facing cells. Numerical
+correctness of the underlying NW HAC math is owned by
+``tests/stats/test_newey_west.py``.
 """
 
 from __future__ import annotations
@@ -12,9 +11,8 @@ from __future__ import annotations
 import pytest
 from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import StatCode
-from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
+from factrix._registry import _DISPATCH_REGISTRY
 from factrix.stats import Estimator, NeweyWest
-from factrix.stats.newey_west import _EMITS
 
 
 def test_satisfies_estimator_protocol() -> None:
@@ -35,27 +33,21 @@ def test_description_is_cell_agnostic() -> None:
 
 
 @pytest.mark.parametrize(
-    ("scope", "signal", "metric", "expected"),
+    ("scope", "signal", "metric"),
     [
-        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC, StatCode.IC_P),
-        (
-            FactorScope.INDIVIDUAL,
-            Signal.CONTINUOUS,
-            Metric.FM,
-            StatCode.FM_LAMBDA_P,
-        ),
-        (FactorScope.INDIVIDUAL, Signal.SPARSE, None, StatCode.CAAR_P),
-        (FactorScope.COMMON, Signal.CONTINUOUS, None, StatCode.TS_BETA_P),
-        (FactorScope.COMMON, Signal.SPARSE, None, StatCode.TS_BETA_P),
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC),
+        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.FM),
+        (FactorScope.INDIVIDUAL, Signal.SPARSE, None),
+        (FactorScope.COMMON, Signal.CONTINUOUS, None),
+        (FactorScope.COMMON, Signal.SPARSE, None),
     ],
 )
-def test_emits_for_known_cells(
+def test_emits_for_returns_flat_p(
     scope: FactorScope,
     signal: Signal,
     metric: Metric | None,
-    expected: StatCode,
 ) -> None:
-    assert NeweyWest().emits_for(scope, signal, metric) is expected
+    assert NeweyWest().emits_for(scope, signal, metric) is StatCode.P
 
 
 @pytest.mark.parametrize(
@@ -73,20 +65,15 @@ def test_applicable_to_all_user_facing_cells(
     assert NeweyWest().applicable_to(scope, signal)
 
 
-def test_emits_table_stays_in_sync_with_dispatch_registry() -> None:
-    # The _EMITS dispatch table is a hardcoded reverse index from cell
-    # to procedure-emitted p-value StatCode. If a procedure's
-    # EMITS_STATS gains or drops a *_P entry, this test fails so the
-    # estimator side is updated in the same PR (drift would otherwise
-    # surface as a runtime KeyError on bhy(estimator=NeweyWest())).
-    for (scope, signal, metric), code in _EMITS.items():
-        entry = _DISPATCH_REGISTRY.get(_DispatchKey(scope, signal, metric, Mode.PANEL))
-        assert entry is not None, (
-            f"_EMITS lists ({scope.value}, {signal.value}, {metric}) "
-            "but no PANEL procedure is registered for it"
-        )
-        assert code in entry.procedure.EMITS_STATS, (
-            f"NeweyWest dispatches ({scope.value}, {signal.value}, "
-            f"{metric}) → {code.name}, but the procedure's EMITS_STATS "
-            f"does not include it: {sorted(s.name for s in entry.procedure.EMITS_STATS)}"
+def test_panel_procedures_emit_the_dispatched_code() -> None:
+    # Every PANEL procedure must populate StatCode.P, since NeweyWest
+    # dispatches there cell-agnostically. Drift would surface as a
+    # runtime KeyError on bhy(estimator=NeweyWest()).
+    for key, entry in _DISPATCH_REGISTRY.items():
+        if key.mode is not Mode.PANEL:
+            continue
+        assert StatCode.P in entry.procedure.EMITS_STATS, (
+            f"PANEL procedure for ({key.scope}, {key.signal}, {key.metric}) "
+            f"does not emit StatCode.P: "
+            f"{sorted(s.name for s in entry.procedure.EMITS_STATS)}"
         )

--- a/tests/test_caar_procedure.py
+++ b/tests/test_caar_procedure.py
@@ -22,7 +22,6 @@ from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _CAARSparsePanelProcedure
 from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
-from factrix._stats.constants import auto_bartlett
 
 
 def _make_event_panel(
@@ -114,22 +113,17 @@ class TestStrongCaar:
 
     def test_caar_mean_close_to_beta(self, profile: FactorProfile) -> None:
         # signed_car ≈ β + noise*sign(factor); cross-event mean ≈ β=1.0.
-        assert 0.7 < profile.stats[StatCode.CAAR_MEAN] < 1.3
+        assert 0.7 < profile.stats[StatCode.MEAN] < 1.3
 
     def test_required_stats(self, profile: FactorProfile) -> None:
-        for key in (
-            StatCode.CAAR_MEAN,
-            StatCode.CAAR_T_NW,
-            StatCode.CAAR_P,
-            StatCode.NW_LAGS_USED,
-        ):
+        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P):
             assert key in profile.stats
 
     def test_primary_p_matches_caar_p_stat(
         self,
         profile: FactorProfile,
     ) -> None:
-        assert profile.primary_p == profile.stats[StatCode.CAAR_P]
+        assert profile.primary_p == profile.stats[StatCode.P]
 
     def test_n_obs_equals_event_dates(self, profile: FactorProfile) -> None:
         # n_obs = number of distinct event-dates feeding the NW test;
@@ -152,24 +146,6 @@ class TestRandomCaar:
         assert profile.verdict() is Verdict.FAIL
 
 
-class TestNwLagFloor:
-    def test_nw_lags_floor_at_forward_periods_minus_one(
-        self,
-        cfg: AnalysisConfig,
-    ) -> None:
-        panel = _make_event_panel(
-            n_dates=80,
-            n_assets=20,
-            seed=4,
-            beta=0.5,
-            event_prob=0.10,
-        )
-        profile = _CAARSparsePanelProcedure().compute(panel, cfg)
-        T = profile.n_obs
-        expected = float(max(auto_bartlett(T), cfg.forward_periods - 1))
-        assert profile.stats[StatCode.NW_LAGS_USED] == expected
-
-
 class TestEndToEndViaEvaluate:
     def test_evaluate_dispatches_to_caar(self, cfg: AnalysisConfig) -> None:
         panel = _make_event_panel(
@@ -180,7 +156,7 @@ class TestEndToEndViaEvaluate:
         )
         profile = _evaluate(panel, cfg)
         assert profile.mode is Mode.PANEL
-        assert StatCode.CAAR_P in profile.stats
+        assert StatCode.P in profile.stats
         assert profile.verdict() is Verdict.PASS
 
 
@@ -255,7 +231,7 @@ class TestCalendarTimeRegimes:
             beta=1.0,
         )
         profile = _CAARSparsePanelProcedure().compute(panel, cfg)
-        assert 0.6 < profile.stats[StatCode.CAAR_MEAN] < 1.4
+        assert 0.6 < profile.stats[StatCode.MEAN] < 1.4
 
     def test_dense_regime_matches_event_only_when_every_date_is_event(
         self,
@@ -283,8 +259,8 @@ class TestCalendarTimeRegimes:
         T = len(event_caar)
         lags = _resolve_nw_lags(T, auto_bartlett(T), cfg.forward_periods)
         ref_t, ref_p, _ = _newey_west_t_test(event_caar, lags=lags)
-        assert profile.stats[StatCode.CAAR_T_NW] == pytest.approx(ref_t)
-        assert profile.stats[StatCode.CAAR_P] == pytest.approx(ref_p)
+        assert profile.stats[StatCode.T_NW] == pytest.approx(ref_t)
+        assert profile.stats[StatCode.P] == pytest.approx(ref_p)
 
     def test_clustered_regime_picks_up_overlap_via_nw_hac(
         self,
@@ -305,7 +281,7 @@ class TestCalendarTimeRegimes:
             beta=0.5,
         )
         profile = _CAARSparsePanelProcedure().compute(panel, cfg)
-        assert 0.0 <= profile.stats[StatCode.CAAR_P] <= 1.0
+        assert 0.0 <= profile.stats[StatCode.P] <= 1.0
         assert profile.n_obs == 60
 
 

--- a/tests/test_common_panel_procedures.py
+++ b/tests/test_common_panel_procedures.py
@@ -153,13 +153,13 @@ class TestContinuousStrong:
 
     def test_beta_mean_close_to_truth(self, profile: FactorProfile) -> None:
         # true β=0.6, dispersion 0.1, N=20 — sample mean SE ≈ 0.022.
-        assert 0.45 < profile.stats[StatCode.TS_BETA] < 0.75
+        assert 0.45 < profile.stats[StatCode.MEAN] < 0.75
 
     def test_required_stats(self, profile: FactorProfile) -> None:
         for key in (
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
             StatCode.FACTOR_ADF_P,
         ):
             assert key in profile.stats
@@ -227,7 +227,7 @@ class TestSparseStrong:
         assert profile.primary_p < 0.001
 
     def test_beta_mean_close_to_truth(self, profile: FactorProfile) -> None:
-        assert 1.0 < profile.stats[StatCode.TS_BETA] < 2.0
+        assert 1.0 < profile.stats[StatCode.MEAN] < 2.0
 
     def test_no_adf_stat_for_sparse(self, profile: FactorProfile) -> None:
         # I6: ADF persistence diagnostic is CONTINUOUS-only.
@@ -318,7 +318,7 @@ class TestEmptyPanelFallback:
         profile = _CommonContPanelProcedure().compute(empty, cfg_continuous)
         assert profile.primary_p == 1.0
         assert profile.n_obs == 0
-        assert profile.stats[StatCode.TS_BETA] == 0.0
+        assert profile.stats[StatCode.MEAN] == 0.0
 
     def test_sparse_empty_raises_insufficient_events(
         self,

--- a/tests/test_docs_llms.py
+++ b/tests/test_docs_llms.py
@@ -18,7 +18,7 @@ Three checks:
    ``llms-full.txt`` — keeps the LLM reference in lockstep when the
    public surface widens.
 
-Bare references like ``StatCode.IC_MEAN`` (no ``fx.`` / ``factrix.``
+Bare references like ``StatCode.MEAN`` (no ``fx.`` / ``factrix.``
 prefix) are intentionally not validated — too many false positives
 against ``profile.X`` style attribute talk in prose.
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -114,7 +114,7 @@ class TestIcPanelEndToEnd:
         assert InfoCode.SCOPE_AXIS_COLLAPSED not in profile.info_notes
 
     def test_ic_p_populated(self, profile: FactorProfile) -> None:
-        assert StatCode.IC_P in profile.stats
+        assert StatCode.P in profile.stats
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +261,7 @@ class TestFactorColumnAlias:
             panel,
             AnalysisConfig.individual_continuous(metric=Metric.IC),
         )
-        assert StatCode.IC_MEAN in profile.stats
+        assert StatCode.MEAN in profile.stats
 
     def test_aliased_factor_col_renamed_internally(self) -> None:
         # Non-default factor_col is renamed to "factor" before dispatch;
@@ -273,7 +273,7 @@ class TestFactorColumnAlias:
             AnalysisConfig.individual_continuous(metric=Metric.IC),
             factor_col="alpha",
         )
-        assert StatCode.IC_MEAN in profile.stats
+        assert StatCode.MEAN in profile.stats
 
     def test_factor_col_missing_raises(self) -> None:
         panel = _build_panel(n_dates=30, n_assets=10, seed=12)
@@ -310,4 +310,4 @@ class TestFactorColumnAlias:
             factor_col="alpha",
         )
         assert isinstance(profile, FactorProfile)
-        assert StatCode.IC_MEAN in profile.stats
+        assert StatCode.MEAN in profile.stats

--- a/tests/test_family_resolution.py
+++ b/tests/test_family_resolution.py
@@ -47,13 +47,13 @@ def test_default_path_no_expand_over_returns_one_entry_per_profile() -> None:
 
 
 def test_estimator_none_falls_back_to_primary_p() -> None:
-    p = _profile(primary_p=0.012, stats={StatCode.IC_P: 0.5})
+    p = _profile(primary_p=0.012, stats={StatCode.P: 0.5})
     [entry] = _resolve_family([p], verb="bhy")
     assert entry.p_value == 0.012
 
 
 def test_estimator_supplied_reads_dispatched_stat() -> None:
-    p = _profile(primary_p=0.5, stats={StatCode.IC_P: 0.012})
+    p = _profile(primary_p=0.5, stats={StatCode.P: 0.012})
     [entry] = _resolve_family([p], verb="bhy", estimator=NeweyWest())
     assert entry.p_value == 0.012
 
@@ -76,7 +76,7 @@ def test_estimator_not_applicable_to_cell_raises() -> None:
         ) -> StatCode:
             raise AssertionError("emits_for must not be called when not applicable")
 
-    p = _profile(stats={StatCode.IC_P: 0.04})
+    p = _profile(stats={StatCode.P: 0.04})
     with pytest.raises(UserInputError) as exc:
         _resolve_family([p], verb="bhy", estimator=_Picky())
     err = exc.value
@@ -172,8 +172,8 @@ def test_duplicate_partition_key_with_expand_over_compares_full_key() -> None:
 
 
 def test_missing_dispatched_stat_raises_with_available_keys() -> None:
-    # FM cell profile, but stats only has IC_P populated → NeweyWest
-    # dispatches to FM_LAMBDA_P which is missing.
+    # NeweyWest dispatches to StatCode.P uniformly; a profile missing P
+    # in stats must surface the available-keys candidate list to the user.
     cfg = AnalysisConfig.individual_continuous(metric=Metric.FM, forward_periods=5)
     p = FactorProfile(
         config=cfg,
@@ -182,13 +182,14 @@ def test_missing_dispatched_stat_raises_with_available_keys() -> None:
         n_obs=60,
         n_assets=20,
         factor_id="f1",
-        stats={StatCode.IC_P: 0.04},
+        stats={StatCode.MEAN: 0.05, StatCode.T_NW: 1.5},
     )
     with pytest.raises(UserInputError) as exc:
         _resolve_family([p], verb="bhy", estimator=NeweyWest())
     err = exc.value
     assert err.field == "estimator"
     assert err.value == "NeweyWest"
-    assert "FM_LAMBDA_P" in (err.expected or "")
-    assert "IC_P" in err.candidates
+    assert "P" in (err.expected or "")
+    assert "MEAN" in err.candidates
+    assert "T_NW" in err.candidates
     assert "api/bhy#estimator" in err.docs_url

--- a/tests/test_fm_procedure.py
+++ b/tests/test_fm_procedure.py
@@ -19,7 +19,6 @@ from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _FMContPanelProcedure
 from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
-from factrix._stats.constants import auto_bartlett
 
 
 def _make_panel(
@@ -108,27 +107,14 @@ class TestStrongFactor:
     ) -> None:
         # factor = 0.95 * fwd + 0.05 * noise → OLS slope of fwd on factor
         # is dominated by the 0.95 component; λ should land in (0.5, 1.5).
-        assert 0.5 < profile.stats[StatCode.FM_LAMBDA_MEAN] < 1.5
+        assert 0.5 < profile.stats[StatCode.MEAN] < 1.5
 
     def test_required_stats_keys_present(self, profile: FactorProfile) -> None:
-        for key in (
-            StatCode.FM_LAMBDA_MEAN,
-            StatCode.FM_LAMBDA_T_NW,
-            StatCode.FM_LAMBDA_P,
-            StatCode.NW_LAGS_USED,
-        ):
+        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P):
             assert key in profile.stats
 
     def test_primary_p_matches_fm_p_stat(self, profile: FactorProfile) -> None:
-        assert profile.primary_p == profile.stats[StatCode.FM_LAMBDA_P]
-
-    def test_nw_lags_floor_at_forward_periods_minus_one(
-        self,
-        profile: FactorProfile,
-        fm_config: AnalysisConfig,
-    ) -> None:
-        expected = float(max(auto_bartlett(60), fm_config.forward_periods - 1))
-        assert profile.stats[StatCode.NW_LAGS_USED] == expected
+        assert profile.primary_p == profile.stats[StatCode.P]
 
 
 class TestRandomFactor:
@@ -152,7 +138,7 @@ class TestRandomFactor:
         assert profile.primary_p > 0.10
 
     def test_lambda_mean_near_zero(self, profile: FactorProfile) -> None:
-        assert abs(profile.stats[StatCode.FM_LAMBDA_MEAN]) < 0.10
+        assert abs(profile.stats[StatCode.MEAN]) < 0.10
 
 
 class TestEndToEndViaEvaluate:
@@ -168,7 +154,7 @@ class TestEndToEndViaEvaluate:
         )
         profile = _evaluate(panel, fm_config)
         assert isinstance(profile, FactorProfile)
-        assert StatCode.FM_LAMBDA_P in profile.stats
+        assert StatCode.P in profile.stats
         assert profile.verdict() is Verdict.PASS
 
 

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -71,12 +71,14 @@ class TestCodeEnums:
             assert code.description, f"{code} missing description"
 
     def test_stat_code_population(self) -> None:
-        # Representative stats for each metric family + diagnostics.
-        assert StatCode.IC_MEAN.value == "ic_mean"
-        assert StatCode.FM_LAMBDA_T_NW.value == "fm_lambda_t_nw"
-        assert StatCode.TS_BETA_P.value == "ts_beta_p"
-        assert StatCode.CAAR_MEAN.value == "caar_mean"
-        assert StatCode.NW_LAGS_USED.value == "nw_lags_used"
+        # Flattened naming (#187): primary cell stats are TARGET-less,
+        # diagnostics carry an explicit prefix.
+        assert StatCode.MEAN.value == "mean"
+        assert StatCode.T_NW.value == "t_nw"
+        assert StatCode.P.value == "p"
+        assert StatCode.FACTOR_ADF_P.value == "factor_adf_p"
+        assert StatCode.RESID_LJUNG_BOX_P.value == "resid_ljung_box_p"
+        assert StatCode.EVENT_HHI_VALUE.value == "event_hhi_value"
 
     def test_stat_descriptions_cover_every_member(self) -> None:
         # Symmetry with WarningCode / InfoCode: every StatCode has a

--- a/tests/test_ic_procedure.py
+++ b/tests/test_ic_procedure.py
@@ -20,7 +20,6 @@ from factrix._codes import StatCode, Verdict
 from factrix._procedures import InputSchema, _ICContPanelProcedure
 from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
-from factrix._stats.constants import auto_bartlett
 
 
 def _make_panel(
@@ -112,28 +111,14 @@ class TestStrongFactor:
         assert profile.primary_p < 0.01
 
     def test_positive_ic_mean(self, profile: FactorProfile) -> None:
-        assert profile.stats[StatCode.IC_MEAN] > 0.5
+        assert profile.stats[StatCode.MEAN] > 0.5
 
     def test_required_stats_keys_present(self, profile: FactorProfile) -> None:
-        for key in (
-            StatCode.IC_MEAN,
-            StatCode.IC_T_NW,
-            StatCode.IC_P,
-            StatCode.NW_LAGS_USED,
-        ):
+        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P):
             assert key in profile.stats
 
     def test_primary_p_matches_ic_p_stat(self, profile: FactorProfile) -> None:
-        assert profile.primary_p == profile.stats[StatCode.IC_P]
-
-    def test_nw_lags_floor_at_forward_periods_minus_one(
-        self,
-        profile: FactorProfile,
-        ic_config: AnalysisConfig,
-    ) -> None:
-        # auto_bartlett(60)=3, forward_periods-1=4 → HH floor binds.
-        expected = float(max(auto_bartlett(60), ic_config.forward_periods - 1))
-        assert profile.stats[StatCode.NW_LAGS_USED] == expected
+        assert profile.primary_p == profile.stats[StatCode.P]
 
 
 class TestRandomFactor:
@@ -160,7 +145,7 @@ class TestRandomFactor:
         assert profile.primary_p > 0.10
 
     def test_ic_mean_near_zero(self, profile: FactorProfile) -> None:
-        assert abs(profile.stats[StatCode.IC_MEAN]) < 0.05
+        assert abs(profile.stats[StatCode.MEAN]) < 0.05
 
 
 class TestProfileConfigPassthrough:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -93,12 +93,13 @@ class TestDescribeAnalysisModes:
             r for r in rows if r["scope"] == "common" and r["signal"] == "continuous"
         )
         # PANEL entry of (COMMON, CONTINUOUS) is _CommonContPanelProcedure
-        # which emits TS_BETA / TS_BETA_T_NW / TS_BETA_P / FACTOR_ADF_P.
+        # which emits MEAN / T_NW / P / FACTOR_ADF_TAU / FACTOR_ADF_P.
         assert "factor_adf_p" in cc_row["panel"]["stats_keys"]
-        assert "ts_beta_p" in cc_row["panel"]["stats_keys"]
+        assert "factor_adf_tau" in cc_row["panel"]["stats_keys"]
+        assert "p" in cc_row["panel"]["stats_keys"]
         # The (COMMON, CONTINUOUS, TIMESERIES) procedure also emits
-        # NW_LAGS_USED in addition to FACTOR_ADF_P.
-        assert "nw_lags_used" in cc_row["timeseries"]["stats_keys"]
+        # FACTOR_ADF_TAU alongside FACTOR_ADF_P.
+        assert "factor_adf_tau" in cc_row["timeseries"]["stats_keys"]
 
     def test_sparse_rows_flag_scope_collapse_at_n1(self) -> None:
         rows = describe_analysis_modes(format="json")

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -29,7 +29,7 @@ def _profile(
     cfg = AnalysisConfig.individual_continuous(
         metric=metric, forward_periods=forward_periods
     )
-    base_stats: dict[StatCode, float] = {StatCode.IC_P: primary_p}
+    base_stats: dict[StatCode, float] = {StatCode.P: primary_p}
     if stats:
         base_stats.update(stats)
     return FactorProfile(
@@ -132,25 +132,34 @@ class TestEstimatorOverride:
             factor_id="f1",
             metric=Metric.FM,
             primary_p=0.99,
-            stats={StatCode.FM_LAMBDA_P: 0.001},
+            stats={StatCode.P: 0.001},
         )
         assert bhy([prof], estimator=NeweyWest()).profiles == [prof]
 
     def test_missing_dispatched_stat_raises_user_error(self) -> None:
-        # FM-cell profile, but default fixture only populates IC_P;
-        # NeweyWest dispatches to FM_LAMBDA_P, which is absent.
-        prof = _profile(factor_id="f1", metric=Metric.FM, primary_p=0.001)
+        # NeweyWest dispatches to StatCode.P; a profile without P in
+        # stats must surface the missing-key error.
+        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC, forward_periods=5)
+        prof = FactorProfile(
+            config=cfg,
+            mode=Mode.PANEL,
+            primary_p=0.001,
+            n_obs=100,
+            n_assets=30,
+            factor_id="f1",
+            stats={StatCode.MEAN: 0.05},
+        )
         with pytest.raises(UserInputError) as exc:
             bhy([prof], estimator=NeweyWest())
         err = exc.value
         assert err.field == "estimator"
         assert err.value == "NeweyWest"
-        assert "FM_LAMBDA_P" in (err.expected or "")
+        assert "P" in (err.expected or "")
 
     def test_legacy_p_stat_kwarg_is_unrecognised(self) -> None:
         prof = _profile(factor_id="f1", primary_p=0.04)
         with pytest.raises(TypeError, match="p_stat"):
-            bhy([prof], p_stat=StatCode.IC_P)
+            bhy([prof], p_stat=StatCode.P)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -212,14 +212,14 @@ class TestVerdict:
     def test_gate_override_uses_stats_value(self) -> None:
         prof = _make_profile(
             primary_p=0.50,  # would FAIL on primary
-            stats={StatCode.IC_P: 0.001},
+            stats={StatCode.P: 0.001},
         )
-        assert prof.verdict(gate=StatCode.IC_P) is Verdict.PASS
+        assert prof.verdict(gate=StatCode.P) is Verdict.PASS
 
     def test_gate_keyerror_when_stat_missing(self) -> None:
         prof = _make_profile(primary_p=0.01, stats={})
         with pytest.raises(KeyError):
-            prof.verdict(gate=StatCode.FM_LAMBDA_P)
+            prof.verdict(gate=StatCode.P)
 
 
 class TestProfileImmutability:
@@ -247,7 +247,7 @@ class TestDiagnose:
     def test_diagnose_serialises_enums_to_strings(self) -> None:
         prof = _make_profile(
             primary_p=0.02,
-            stats={StatCode.IC_MEAN: 0.05, StatCode.NW_LAGS_USED: 4.0},
+            stats={StatCode.MEAN: 0.05, StatCode.T_NW: 1.96},
             warnings=frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS}),
             info_notes=frozenset({InfoCode.SCOPE_AXIS_COLLAPSED}),
         )
@@ -257,7 +257,7 @@ class TestDiagnose:
         assert d["primary_p"] == 0.02
         assert "unreliable_se_short_periods" in d["warnings"]
         assert "scope_axis_collapsed" in d["info_notes"]
-        assert d["stats"]["ic_mean"] == 0.05
+        assert d["stats"]["mean"] == 0.05
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ts_beta_procedure.py
+++ b/tests/test_ts_beta_procedure.py
@@ -22,11 +22,7 @@ from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _TSBetaContTimeseriesProcedure
 from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
-from factrix._stats.constants import (
-    MIN_PERIODS_HARD,
-    MIN_PERIODS_WARN,
-    auto_bartlett,
-)
+from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 
 
 def _make_ts(
@@ -114,15 +110,15 @@ class TestStrongBeta:
 
     def test_beta_close_to_truth(self, profile: FactorProfile) -> None:
         # True β=0.8; finite-sample noise allows a 30% band.
-        assert 0.55 < profile.stats[StatCode.TS_BETA] < 1.05
+        assert 0.55 < profile.stats[StatCode.MEAN] < 1.05
 
     def test_required_stats_keys_present(self, profile: FactorProfile) -> None:
         for key in (
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
+            StatCode.FACTOR_ADF_TAU,
             StatCode.FACTOR_ADF_P,
-            StatCode.NW_LAGS_USED,
         ):
             assert key in profile.stats
 
@@ -150,7 +146,7 @@ class TestRandomFactor:
         assert profile.primary_p > 0.10
 
     def test_beta_near_zero(self, profile: FactorProfile) -> None:
-        assert abs(profile.stats[StatCode.TS_BETA]) < 0.20
+        assert abs(profile.stats[StatCode.MEAN]) < 0.20
 
 
 class TestPersistentRegressor:
@@ -186,17 +182,6 @@ class TestSampleSizeStratification:
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS not in profile.warnings
 
 
-class TestNwLagFloor:
-    def test_nw_lags_floor_at_forward_periods_minus_one(
-        self,
-        cfg: AnalysisConfig,
-    ) -> None:
-        ts = _make_ts(n_dates=60, seed=4, beta=0.5)
-        profile = _TSBetaContTimeseriesProcedure().compute(ts, cfg)
-        expected = float(max(auto_bartlett(60), cfg.forward_periods - 1))
-        assert profile.stats[StatCode.NW_LAGS_USED] == expected
-
-
 class TestEndToEndViaEvaluate:
     def test_evaluate_dispatches_to_ts_beta(
         self,
@@ -205,5 +190,5 @@ class TestEndToEndViaEvaluate:
         ts = _make_ts(n_dates=80, seed=99, beta=0.7)
         profile = _evaluate(ts, cfg)
         assert profile.mode is Mode.TIMESERIES
-        assert StatCode.TS_BETA_P in profile.stats
+        assert StatCode.P in profile.stats
         assert profile.verdict() is Verdict.PASS

--- a/tests/test_ts_dummy_procedure.py
+++ b/tests/test_ts_dummy_procedure.py
@@ -146,16 +146,16 @@ class TestStrongTrigger:
         assert profile.primary_p < 0.001
 
     def test_beta_close_to_truth(self, profile: FactorProfile) -> None:
-        assert 1.5 < profile.stats[StatCode.TS_BETA] < 2.5
+        assert 1.5 < profile.stats[StatCode.MEAN] < 2.5
 
     def test_required_stats_present(self, profile: FactorProfile) -> None:
         for key in (
-            StatCode.TS_BETA,
-            StatCode.TS_BETA_T_NW,
-            StatCode.TS_BETA_P,
-            StatCode.LJUNG_BOX_P,
-            StatCode.EVENT_TEMPORAL_HHI,
-            StatCode.NW_LAGS_USED,
+            StatCode.MEAN,
+            StatCode.T_NW,
+            StatCode.P,
+            StatCode.RESID_LJUNG_BOX_Q,
+            StatCode.RESID_LJUNG_BOX_P,
+            StatCode.EVENT_HHI_VALUE,
         ):
             assert key in profile.stats
 
@@ -195,7 +195,7 @@ class TestSerialCorrelationWarning:
             cfg_individual,
         )
         assert WarningCode.SERIAL_CORRELATION_DETECTED in profile.warnings
-        assert profile.stats[StatCode.LJUNG_BOX_P] < 0.05
+        assert profile.stats[StatCode.RESID_LJUNG_BOX_P] < 0.05
 
 
 # ---------------------------------------------------------------------------
@@ -356,50 +356,3 @@ class TestEventWindowOverlap:
         d[10] = 1.0
         d[30] = 1.0  # gap of 20 > 2*5
         assert _has_event_window_overlap(d, forward_periods=5) is False
-
-
-# ---------------------------------------------------------------------------
-# Review fix TC-Hansen-Hodrick: NW lag floor pin for TS-dummy
-# ---------------------------------------------------------------------------
-
-
-class TestNWLagsFloorTSDummy:
-    """Pins ``max(auto_bartlett(T), forward_periods - 1)`` lag selection
-    on the TS-dummy procedure (mirrors the IC / FM / CAAR / TS-β tests
-    that already pin the same Hansen-Hodrick floor on their cells)."""
-
-    def test_short_series_uses_hh_floor(
-        self,
-        cfg_individual: AnalysisConfig,
-    ) -> None:
-        # T=24 → auto_bartlett(24)=int(4*0.24**(2/9))=int(2.93)=2; the
-        # config's forward_periods=5 → HH floor = 5-1 = 4. Floor wins.
-        ts = _make_sparse_ts(
-            n_dates=24,
-            seed=99,
-            event_density=0.20,
-            beta=2.0,
-        )
-        profile = _TSDummySparseTimeseriesProcedure().compute(
-            ts,
-            cfg_individual,
-        )
-        assert profile.stats[StatCode.NW_LAGS_USED] == 4.0
-
-    def test_long_series_uses_auto_bartlett(
-        self,
-        cfg_individual: AnalysisConfig,
-    ) -> None:
-        # T=400 → auto_bartlett(400)=int(4*4**(2/9))=int(5.34)=5; HH
-        # floor = 5-1 = 4. auto_bartlett wins.
-        ts = _make_sparse_ts(
-            n_dates=400,
-            seed=7,
-            event_density=0.05,
-            beta=1.5,
-        )
-        profile = _TSDummySparseTimeseriesProcedure().compute(
-            ts,
-            cfg_individual,
-        )
-        assert profile.stats[StatCode.NW_LAGS_USED] == 5.0


### PR DESCRIPTION
## Summary

- Flatten primary `StatCode`: `IC_P` / `FM_LAMBDA_P` / `TS_BETA_P` / `CAAR_P` (plus `*_MEAN` / `*_T_NW` siblings) collapse to bare `P` / `MEAN` / `T_NW`. Cell identity now lives only on `profile.config` (`scope` / `signal` / `metric`); the StatCode no longer re-encodes it.
- Diagnostic codes adopt explicit `<TARGET>_<KIND>` grammar: `LJUNG_BOX_P` → `RESID_LJUNG_BOX_P`, `EVENT_TEMPORAL_HHI` → `EVENT_HHI_VALUE`. New emits `FACTOR_ADF_TAU` / `RESID_LJUNG_BOX_Q` surface test statistics the procedures already computed but discarded.
- `Estimator.emits_for` becomes cell-agnostic (`NeweyWest` always returns `StatCode.P`); reserved `P_HH` / `P_GMM` enum slots land for #184 / GMM procedure follow-ups.
- `StatCode.NW_LAGS_USED` removed — it is a hyperparameter-selection record, not a stat. Restoration on a dedicated `profile.metadata` channel is tracked in #188 (raised from quant review of this PR).

## Test plan

- [x] `pytest tests/` — 971 pass
- [x] `ruff check` clean
- [x] Quant correctness review (NW_LAGS_USED gap → #188; Ljung-Box `(NaN, 1.0)` semantics; NeweyWest cell-config docstring)
- [x] Quant UX review (stale `ic_mean` / `ic_p` JSON examples in `docs/api/factor-profile.md` + `docs/getting-started/quickstart.md` corrected; CHANGELOG flags `diagnose()` JSON-key migration)
- [x] Backend simplify review (unused-arg → `_scope` underscore prefix; `float("nan")` → `np.nan`)
- [ ] Manually verify `bhy(estimator=NeweyWest())` end-to-end on a real panel after merge
- [ ] mkdocs build to confirm `docs/examples/` notebook re-sync picks up the regenerated `examples/stock_factor_evaluation.ipynb`

Closes #187
Refs #188 (follow-up: `profile.metadata` channel restoring lag-count surface)