### PR TITLE
feat(profile): metadata channel for hyperparameter records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ While the version is below `1.0.0`, the public API should be considered unstable
 - **`factrix.stats.NeweyWest`** — reference Estimator naming the procedure-emitted Newey-West HAC inference path. Carries no compute logic; the underlying NW HAC math stays in `factrix._stats` and is invoked by each cell procedure during `evaluate()`. Constructor takes no arguments in v0.11; `lag` / `kernel` / `overlap_floor` knobs are tracked for a future enhancement. (#170)
 - **`factrix.list_estimators(scope, signal, *, format, with_import)`** — mirrors `list_metrics` shape so the pre-flight pattern ("which scalars and which inference methods does this cell admit") is one API. v0.11 ships only `NeweyWest`; HansenHodrick / GMM follow-ups append to `factrix.stats._ESTIMATOR_REGISTRY` as the #170 sub-issue lands. (#170)
 
+- **`FactorProfile.metadata: Mapping[StatCode, Mapping[str, Any]]`** — new field carrying hyperparameter records for each populated stat (#188). Symmetric with `stats`: for any populated entry, `stats[code]` is the value and `metadata[code]` is the inner dict of hyperparameters that produced it. Examples by cell:
+
+  | Cell | Populated `metadata` keys | Inner |
+  |---|---|---|
+  | IC / FM / CAAR PANEL | `T_NW`, `P` | `{"nw_lags": <resolved bandwidth>}` |
+  | COMMON CONTINUOUS PANEL | `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | `{"lag_order": 0}` |
+  | COMMON CONTINUOUS TIMESERIES | `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | NW lags + ADF lag_order |
+  | TS-dummy SPARSE TIMESERIES | `T_NW`, `P`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` | NW lags + Ljung-Box `lag_h` + HHI `n_bins` |
+
+  Stats with no hyperparameter (`MEAN`) are absent from the mapping rather than mapping to an empty dict. Tests that share a hyperparameter (NW populates `T_NW` + `P` from one bandwidth; Ljung-Box populates `Q` + `P` from one `lag_h`) duplicate the inner dict under both keys to keep single-key lookup honest. `profile.diagnose()["metadata"]` serialises with `StatCode.value` strings as outer keys and plain dicts inside.
+
+  This restores reproducibility for the NW lag count after #187 removed `StatCode.NW_LAGS_USED`, and surfaces previously-discarded hyperparameters (ADF `lag_order`, Ljung-Box `lag_h`, HHI `n_bins`) under the same uniform schema. The `_ljung_box` internal helper now returns `(h, Q, p)` instead of `(Q, p)` so callers receive the resolved lag count alongside the test output. (#188)
+
 ### Changed
 
 - **`factrix.multi_factor.bhy` accepts `estimator: Estimator | None` instead of `p_stat: StatCode | None`** (breaking, #170). The previous `p_stat=` kwarg was a placeholder landed in v0.10 alongside the family-verb refactor and is removed in v0.11. Migration:

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -134,10 +134,27 @@ prefix because their target sits outside `config`. Keys appear in
 cells skip it because the `{0, R}` event-trigger signal (zero on
 non-event entries) makes the unit-root null degenerate.
 
-The Newey-West auto-bandwidth lag count (Bartlett, NW1994 with
-Hansen-Hodrick overlap floor) is no longer surfaced on
-`profile.stats`; reinstating it under a dedicated metadata channel
-is tracked as #188.
+### `profile.metadata` — hyperparameter records
+
+`profile.metadata: Mapping[StatCode, Mapping[str, Any]]` mirrors
+`stats`: for any populated stat, the same key in `metadata` returns
+the inner dict of hyperparameters that produced it. Stats with no
+hyperparameter (`MEAN`) are absent rather than mapping to `{}`. Tests
+that share a hyperparameter populate the inner dict under each key
+the test produced.
+
+| Cell | Populated `metadata` keys | Inner dict |
+|---|---|---|
+| IC / FM / CAAR PANEL | `T_NW`, `P` | `{"nw_lags": <resolved bandwidth>}` |
+| `(common, continuous, None, panel)` | `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | `{"lag_order": 0}` |
+| `(common, continuous, None, timeseries)` | `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | NW `nw_lags` + ADF `lag_order` |
+| `(*, sparse, None, timeseries)` | `T_NW`, `P`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` | NW `nw_lags` + Ljung-Box `lag_h` + HHI `n_bins` |
+| `(common, sparse, None, panel)` | (none — cross-asset t has no hyperparam) | — |
+
+`profile.diagnose()["metadata"]` serialises with `StatCode.value`
+strings as outer keys (e.g. `"p"`) and plain dicts inside. Reading
+order pattern: `profile.stats[StatCode.P]` for the value, then
+`profile.metadata[StatCode.P]` for "how was this computed".
 
 ### `stats` provenance — two paths
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -11,12 +11,55 @@ registry SSOT (§4.4 A1) is queryable as soon as the package loads.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import StatCode
 from factrix._registry import _SCOPE_COLLAPSED, _DispatchKey, register
+
+# ---------------------------------------------------------------------------
+# Metadata helpers (#188)
+# ---------------------------------------------------------------------------
+# Hardcoded hyperparameters surfaced into ``profile.metadata`` so the
+# StatCode they produced can be reproduced / audited without grepping
+# the procedure source. Keep these constants here (not in
+# ``_stats.constants``) so the metadata schema stays co-located with
+# the code that emits it.
+_ADF_LAG_ORDER = 0
+_HHI_N_BINS = 10
+
+
+def _nw_metadata(nw_lags: int) -> dict[StatCode, Mapping[str, Any]]:
+    """NW HAC bandwidth → ``T_NW`` + ``P`` (shared single bandwidth choice).
+
+    Returns a fresh inner dict per StatCode so downstream code that
+    mutates one entry does not silently bleed into the other.
+    """
+    return {
+        StatCode.T_NW: {"nw_lags": nw_lags},
+        StatCode.P: {"nw_lags": nw_lags},
+    }
+
+
+def _adf_metadata() -> dict[StatCode, Mapping[str, Any]]:
+    return {
+        StatCode.FACTOR_ADF_TAU: {"lag_order": _ADF_LAG_ORDER},
+        StatCode.FACTOR_ADF_P: {"lag_order": _ADF_LAG_ORDER},
+    }
+
+
+def _ljung_box_metadata(lag_h: int) -> dict[StatCode, Mapping[str, Any]]:
+    return {
+        StatCode.RESID_LJUNG_BOX_Q: {"lag_h": lag_h},
+        StatCode.RESID_LJUNG_BOX_P: {"lag_h": lag_h},
+    }
+
+
+def _hhi_metadata(n_bins: int) -> dict[StatCode, Mapping[str, Any]]:
+    return {StatCode.EVENT_HHI_VALUE: {"n_bins": n_bins}}
+
 
 if TYPE_CHECKING:
     from factrix._analysis_config import AnalysisConfig
@@ -117,6 +160,7 @@ class _ICContPanelProcedure:
                 StatCode.T_NW: t_stat,
                 StatCode.P: p_value,
             },
+            metadata=_nw_metadata(nw_lags),
         )
 
 
@@ -188,6 +232,7 @@ class _FMContPanelProcedure:
                 StatCode.T_NW: t_stat,
                 StatCode.P: p_value,
             },
+            metadata=_nw_metadata(nw_lags),
         )
 
 
@@ -290,6 +335,7 @@ class _CAARSparsePanelProcedure:
                 StatCode.T_NW: t_stat,
                 StatCode.P: p_value,
             },
+            metadata=_nw_metadata(nw_lags),
         )
 
 
@@ -453,6 +499,7 @@ def _compute_common_panel(
         StatCode.T_NW: t_stat,
         StatCode.P: p_value,
     }
+    metadata: dict[StatCode, Mapping[str, Any]] = {}
     warnings: set[WarningCode] = set(extra_warnings)
     n_tier = cross_section_tier(N)
     if n_tier is not None:
@@ -468,9 +515,10 @@ def _compute_common_panel(
             .drop_nulls()
             .to_numpy()
         )
-        adf_tau, adf_p = _adf(factor_series)
+        adf_tau, adf_p = _adf(factor_series, lags=_ADF_LAG_ORDER)
         stats[StatCode.FACTOR_ADF_TAU] = adf_tau
         stats[StatCode.FACTOR_ADF_P] = adf_p
+        metadata.update(_adf_metadata())
         if adf_p > 0.10:
             warnings.add(WarningCode.PERSISTENT_REGRESSOR)
 
@@ -485,6 +533,7 @@ def _compute_common_panel(
         n_assets=int(raw["asset_id"].n_unique()),
         warnings=frozenset(warnings),
         stats=stats,
+        metadata=metadata,
     )
 
 
@@ -553,7 +602,7 @@ class _TSBetaContTimeseriesProcedure:
         # extra nulls.
         y, x = y[:n_periods], x[:n_periods]
         beta, t_stat, p_value, _ = _ols_nw_slope_t(y, x, lags=nw_lags)
-        adf_tau, adf_p = _adf(x)
+        adf_tau, adf_p = _adf(x, lags=_ADF_LAG_ORDER)
 
         warnings: set[WarningCode] = set()
         if n_periods < MIN_PERIODS_WARN:
@@ -578,6 +627,7 @@ class _TSBetaContTimeseriesProcedure:
                 StatCode.FACTOR_ADF_TAU: adf_tau,
                 StatCode.FACTOR_ADF_P: adf_p,
             },
+            metadata=_nw_metadata(nw_lags) | _adf_metadata(),
         )
 
 
@@ -656,8 +706,8 @@ class _TSDummySparseTimeseriesProcedure:
             config.forward_periods,
         )
         beta, t_stat, p_value, resid = _ols_nw_slope_t(y, d, lags=nw_lags)
-        ljung_box_q, ljung_box_p = _ljung_box(resid)
-        hhi = _event_temporal_hhi(d)
+        ljung_box_h, ljung_box_q, ljung_box_p = _ljung_box(resid)
+        hhi = _event_temporal_hhi(d, n_bins=_HHI_N_BINS)
         overlap = _has_event_window_overlap(d, config.forward_periods)
 
         warnings: set[WarningCode] = set()
@@ -683,6 +733,11 @@ class _TSDummySparseTimeseriesProcedure:
                 StatCode.RESID_LJUNG_BOX_P: ljung_box_p,
                 StatCode.EVENT_HHI_VALUE: hhi,
             },
+            metadata=(
+                _nw_metadata(nw_lags)
+                | _ljung_box_metadata(ljung_box_h)
+                | _hhi_metadata(_HHI_N_BINS)
+            ),
         )
 
 

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -43,6 +43,18 @@ class FactorProfile:
             (``universe_id``, ``regime_id``, future axes). Populated
             by higher-level verbs via ``dataclasses.replace``.
         warnings, info_notes, stats: per-procedure flags / scalars.
+        metadata: Hyperparameter-selection records the procedure made
+            internally, keyed by the ``StatCode`` they produced.
+            Symmetric with ``stats`` — for any populated entry,
+            ``stats[code]`` is the value and ``metadata[code]`` is the
+            inner dict of hyperparameters that produced it (e.g.
+            ``{"nw_lags": 5}`` for ``T_NW`` / ``P`` under an NW HAC
+            test). Stats with no hyperparameter (e.g. plain ``MEAN``)
+            are absent from the mapping rather than mapping to an
+            empty dict. Tests that share a hyperparameter (NW
+            populates both ``T_NW`` and ``P`` from one bandwidth
+            choice) duplicate the inner dict under both keys to keep
+            single-key lookup honest (#188).
 
     Hashing is disabled (``__hash__ = None``) because ``context``
     defaults to ``dict`` (unhashable). Equality is field-by-field via
@@ -60,6 +72,7 @@ class FactorProfile:
     warnings: frozenset[WarningCode] = frozenset()
     info_notes: frozenset[InfoCode] = frozenset()
     stats: Mapping[StatCode, float] = field(default_factory=dict)
+    metadata: Mapping[StatCode, Mapping[str, Any]] = field(default_factory=dict)
 
     __hash__ = None  # type: ignore[assignment]
 
@@ -153,4 +166,5 @@ class FactorProfile:
             "warnings": sorted(w.value for w in self.warnings),
             "info_notes": sorted(i.value for i in self.info_notes),
             "stats": {k.value: v for k, v in self.stats.items()},
+            "metadata": {k.value: dict(v) for k, v in self.metadata.items()},
         }

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -479,31 +479,33 @@ def _ljung_box(
     resid: np.ndarray,
     *,
     lags: int | None = None,
-) -> tuple[float, float]:
-    """Ljung-Box Q statistic and two-sided p-value for residual autocorrelation.
+) -> tuple[int, float, float]:
+    """Resolved lag count, Q statistic, two-sided p-value for residual autocorrelation.
 
     ``Q = n(n+2) Σ_{k=1..h} ρ̂_k² / (n - k)`` evaluated against
     ``χ²_h``; the H₀ is "no autocorrelation up to lag h". Default
     ``lags = min(10, n // 10)`` per plan §5.2.
 
-    Returns ``(NaN, 1.0)`` for ``n < 4`` or zero-variance inputs — Q is
-    undefined in those cases (no autocovariance can be estimated), and
-    the canonical "cannot reject" p of 1.0 is the honest fallback. NaN
-    on Q lets downstream readers distinguish "not computable" from
-    "computed and equal to zero".
+    Returns ``(0, NaN, 1.0)`` for ``n < 4`` or unresolvable lag inputs
+    — Q is undefined when no lag can be applied. ``(h, NaN, 1.0)`` for
+    zero-variance residuals — the lag was resolved but the statistic
+    itself is undefined. NaN on Q lets downstream readers distinguish
+    "not computable" from "computed and equal to zero". The resolved
+    ``h`` lag count is returned so callers can record it as a
+    hyperparameter (#188).
     """
     n = len(resid)
     if n < 4:
-        return np.nan, 1.0
+        return 0, np.nan, 1.0
     h = lags if lags is not None else min(10, n // 10)
     if h < 1:
-        return np.nan, 1.0
+        return 0, np.nan, 1.0
     h = min(h, n - 1)
 
     centred = resid - float(np.mean(resid))
     var = float(np.dot(centred, centred))
     if var < EPSILON:
-        return np.nan, 1.0
+        return h, np.nan, 1.0
 
     q = 0.0
     for k in range(1, h + 1):
@@ -511,4 +513,4 @@ def _ljung_box(
         rho_k = cov_k / var
         q += rho_k * rho_k / (n - k)
     q *= n * (n + 2)
-    return float(q), float(sp_stats.chi2.sf(q, df=h))
+    return h, float(q), float(sp_stats.chi2.sf(q, df=h))

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -220,7 +220,8 @@ profile.identity        : tuple[str, int]            # (factor_id, forward_perio
 profile.context         : Mapping[str, Any]          # universe_id / regime_id / ...
 profile.warnings        : frozenset[WarningCode]
 profile.info_notes      : frozenset[InfoCode]
-profile.stats           : Mapping[StatCode, float]   # cell-specific scalars
+profile.stats           : Mapping[StatCode, float]                 # cell-specific scalars
+profile.metadata        : Mapping[StatCode, Mapping[str, Any]]     # hyperparams that produced each stat (#188)
 
 profile.verdict(*, threshold: float = 0.05, gate: StatCode | None = None) -> Verdict
     # PASS if primary_p (or stats[gate]) < threshold
@@ -231,7 +232,8 @@ profile.diagnose() -> dict[str, Any]
     #  "mode", "n_obs", "n_assets", "primary_p",
     #  "warnings": [str, ...],          # sorted WarningCode .value strings
     #  "info_notes": [str, ...],        # sorted InfoCode .value strings
-    #  "stats": {str: float, ...}}      # StatCode .value → float
+    #  "stats": {str: float, ...},      # StatCode .value → float
+    #  "metadata": {str: {str: Any}}}   # StatCode .value → hyperparams dict
 ```
 
 `identity` and `context` split hypothesis dimensions (factor_id × horizon)

--- a/tests/test_ic_procedure.py
+++ b/tests/test_ic_procedure.py
@@ -120,6 +120,29 @@ class TestStrongFactor:
     def test_primary_p_matches_ic_p_stat(self, profile: FactorProfile) -> None:
         assert profile.primary_p == profile.stats[StatCode.P]
 
+    def test_metadata_records_nw_lags_under_t_nw_and_p(
+        self,
+        profile: FactorProfile,
+        ic_config: AnalysisConfig,
+    ) -> None:
+        # auto_bartlett(60)=3, forward_periods-1=4 → HH overlap floor
+        # binds. Metadata channel surfaces the resolved lag count under
+        # both StatCode keys produced by the same NW call (#188).
+        from factrix._stats.constants import auto_bartlett
+
+        expected = max(auto_bartlett(60), ic_config.forward_periods - 1)
+        assert profile.metadata[StatCode.P] == {"nw_lags": expected}
+        assert profile.metadata[StatCode.T_NW] == {"nw_lags": expected}
+
+    def test_metadata_inner_dicts_are_not_aliased(
+        self,
+        profile: FactorProfile,
+    ) -> None:
+        # Shared hyperparam (NW lag) is duplicated as content but the
+        # inner dicts must be distinct objects so caller mutation of
+        # one entry does not silently bleed into the other (#188).
+        assert profile.metadata[StatCode.T_NW] is not profile.metadata[StatCode.P]
+
 
 class TestRandomFactor:
     @pytest.fixture(scope="class")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -182,6 +182,7 @@ def _make_profile(
     stats: dict[StatCode, float] | None = None,
     warnings: frozenset[WarningCode] = frozenset(),
     info_notes: frozenset[InfoCode] = frozenset(),
+    metadata: dict[StatCode, dict[str, object]] | None = None,
 ) -> FactorProfile:
     return FactorProfile(
         config=AnalysisConfig.individual_continuous(),
@@ -192,6 +193,7 @@ def _make_profile(
         warnings=warnings,
         info_notes=info_notes,
         stats=stats or {},
+        metadata=metadata or {},
     )
 
 
@@ -250,6 +252,7 @@ class TestDiagnose:
             stats={StatCode.MEAN: 0.05, StatCode.T_NW: 1.96},
             warnings=frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS}),
             info_notes=frozenset({InfoCode.SCOPE_AXIS_COLLAPSED}),
+            metadata={StatCode.T_NW: {"nw_lags": 5}, StatCode.P: {"nw_lags": 5}},
         )
         d = prof.diagnose()
         assert d["mode"] == "panel"
@@ -258,6 +261,8 @@ class TestDiagnose:
         assert "unreliable_se_short_periods" in d["warnings"]
         assert "scope_axis_collapsed" in d["info_notes"]
         assert d["stats"]["mean"] == 0.05
+        # metadata uses StatCode.value strings as outer keys, plain dicts inside.
+        assert d["metadata"] == {"t_nw": {"nw_lags": 5}, "p": {"nw_lags": 5}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ts_beta_procedure.py
+++ b/tests/test_ts_beta_procedure.py
@@ -122,6 +122,19 @@ class TestStrongBeta:
         ):
             assert key in profile.stats
 
+    def test_metadata_records_nw_and_adf_hyperparams(
+        self,
+        profile: FactorProfile,
+    ) -> None:
+        # NW lag count under T_NW + P; ADF lag_order under TAU + P (#188).
+        nw_meta = profile.metadata[StatCode.P]
+        assert profile.metadata[StatCode.T_NW] == nw_meta
+        assert "nw_lags" in nw_meta
+
+        adf_meta = profile.metadata[StatCode.FACTOR_ADF_P]
+        assert profile.metadata[StatCode.FACTOR_ADF_TAU] == adf_meta
+        assert adf_meta == {"lag_order": 0}
+
     def test_no_persistent_regressor_warning_on_iid_factor(
         self,
         profile: FactorProfile,

--- a/tests/test_ts_dummy_procedure.py
+++ b/tests/test_ts_dummy_procedure.py
@@ -159,6 +159,22 @@ class TestStrongTrigger:
         ):
             assert key in profile.stats
 
+    def test_metadata_keyed_by_stat_with_test_hyperparams(
+        self,
+        profile: FactorProfile,
+    ) -> None:
+        # NW lag count shared by T_NW + P; Ljung-Box lag h shared by Q + P;
+        # HHI n_bins under EVENT_HHI_VALUE only (#188).
+        nw_meta = profile.metadata[StatCode.P]
+        assert profile.metadata[StatCode.T_NW] == nw_meta
+        assert "nw_lags" in nw_meta and nw_meta["nw_lags"] >= 1
+
+        lb_meta = profile.metadata[StatCode.RESID_LJUNG_BOX_P]
+        assert profile.metadata[StatCode.RESID_LJUNG_BOX_Q] == lb_meta
+        assert "lag_h" in lb_meta and lb_meta["lag_h"] >= 1
+
+        assert profile.metadata[StatCode.EVENT_HHI_VALUE] == {"n_bins": 10}
+
 
 class TestRandomSparse:
     def test_random_dummy_fails_at_default_threshold(


### PR DESCRIPTION
## Summary

- Add `FactorProfile.metadata: Mapping[StatCode, Mapping[str, Any]]` — keyed by the `StatCode` the hyperparam produced, value is the inner dict of hyperparameters used. Symmetric with `stats`: `profile.stats[code]` is the value, `profile.metadata[code]` is the provenance.
- Procedures populate per cell: NW lag count under `T_NW` + `P`; ADF `lag_order` under `FACTOR_ADF_TAU` + `FACTOR_ADF_P`; Ljung-Box `lag_h` under `RESID_LJUNG_BOX_Q` + `RESID_LJUNG_BOX_P`; HHI `n_bins` under `EVENT_HHI_VALUE`. Stats with no hyperparameter (`MEAN`) are absent from the mapping.
- `_ljung_box` returns `(h, Q, p)` instead of `(Q, p)` so the resolved lag count flows into metadata. ADF call sites pass `lags=_ADF_LAG_ORDER` explicitly so what gets recorded matches what the math used.
- Inner dicts are constructed per-key (no aliasing) — shared-hyperparam entries duplicate content but are distinct dict objects, locked in by an aliasing test.

## Test plan

- [x] `pytest tests/` — 975 pass (+4 new)
- [x] `ruff check` clean
- [x] Quant UX review — PASS overall (lookup symmetry / shared-hyperparam duplication / `_ljung_box` ergonomics all clean)
- [x] Backend simplify review — 5 FIX items applied (aliasing, ADF lag passthrough, factory reuse in `_compute_common_panel`, redundant `int()` casts, docstring)

Closes #188
Refs #187 (this PR restores the reproducibility surface that #187's `NW_LAGS_USED` removal opened)