### PR TITLE
refactor(stats)!: rename StatCode.P to P_NW (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,23 +23,31 @@ While the version is below `1.0.0`, the public API should be considered unstable
 - **`factrix.stats.HansenHodrick`** — Hansen-Hodrick (1980) rectangular-kernel HAC `Estimator` for the IC PANEL / FM PANEL cells where overlapping h-period forward returns induce MA(h-1) structure. Closed-form `Var(mean) = (γ₀ + 2 Σ_{j=1..h-1} γⱼ) / n`. Cell-agnostic dispatch via `StatCode.P_HH`; `applicable_to` restricted to `(INDIVIDUAL, CONTINUOUS)`. Procedure-side gate skips the emission when `forward_periods == 1` (no overlap → HH collapses to iid SE), so `bhy(estimator=HansenHodrick())` on a non-overlapping profile lands on a missing-stat error instead of aliasing NW. (#184)
 - **`StatCode.T_HH`** — Hansen-Hodrick t-statistic, sibling of `T_NW`. Emitted as a pair with `P_HH` so HH inference reproducibility is symmetric with NW. (#184)
 - **`WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`** — fired by HH (and any future rectangular-kernel HAC variant) when the variance estimate `γ₀ + 2 Σγⱼ` comes out negative on short / mildly anti-correlated samples (no PSD guarantee, Andrews 1991 §3). The primitive clamps variance to 0 → SE=0 → t=0 → p=1.0 (the conservative "cannot reject" direction); the procedure surfaces the flag in `profile.warnings` and mirrors `{"variance_clamped": True}` under both `metadata[StatCode.T_HH]` and `metadata[StatCode.P_HH]`. Generic name (rather than `HH_*`) so future rectangular-kernel HAC variants can reuse it. (#184)
-- **IC PANEL / FM PANEL procedures emit the `(T_HH, P_HH)` pair when `forward_periods > 1`** — populates HH-pure t-stat + p-value alongside the existing NW-derived `(T_NW, P)`, with shared `metadata = {"kernel": "rectangular", "variance_clamped": <bool>}` mirrored under both StatCode keys. `EMITS_STATS` lists both as conditionally emitted; downstream readers should consult `profile.stats` membership rather than assume universal presence. (#184)
+- **IC PANEL / FM PANEL procedures emit the `(T_HH, P_HH)` pair when `forward_periods > 1`** — populates HH-pure t-stat + p-value alongside the existing NW-derived `(T_NW, P_NW)`, with shared `metadata = {"kernel": "rectangular", "variance_clamped": <bool>}` mirrored under both StatCode keys. `EMITS_STATS` lists both as conditionally emitted; downstream readers should consult `profile.stats` membership rather than assume universal presence. (#184)
 - **`StatCode` grammar locked in for inference primary stats** — module docstring now spells out the `<TEST_STAT_KIND>_<ALGO>` / `P_<ALGO>` shape (`T_NW` / `T_HH`, `P_NW` / `P_HH` / `P_GMM`, future `J_GMM` / `WALD` / `F` / `LR`) and a redesign trigger: when ≥ 4 inference algorithms ship concurrently or ≥ 3 distinct test-statistic KINDs coexist, the flat enum yields to a structured `profile.inference[Algo.X]` shape. Below those thresholds the flat enum stays cheaper. (#184)
 
 - **`FactorProfile.metadata: Mapping[StatCode, Mapping[str, Any]]`** — new field carrying hyperparameter records for each populated stat (#188). Symmetric with `stats`: for any populated entry, `stats[code]` is the value and `metadata[code]` is the inner dict of hyperparameters that produced it. Examples by cell:
 
   | Cell | Populated `metadata` keys | Inner |
   |---|---|---|
-  | IC / FM / CAAR PANEL | `T_NW`, `P` | `{"nw_lags": <resolved bandwidth>}` |
+  | IC / FM / CAAR PANEL | `T_NW`, `P_NW` | `{"nw_lags": <resolved bandwidth>}` |
   | COMMON CONTINUOUS PANEL | `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | `{"lag_order": 0}` |
-  | COMMON CONTINUOUS TIMESERIES | `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | NW lags + ADF lag_order |
-  | TS-dummy SPARSE TIMESERIES | `T_NW`, `P`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` | NW lags + Ljung-Box `lag_h` + HHI `n_bins` |
+  | COMMON CONTINUOUS TIMESERIES | `T_NW`, `P_NW`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | NW lags + ADF lag_order |
+  | TS-dummy SPARSE TIMESERIES | `T_NW`, `P_NW`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` | NW lags + Ljung-Box `lag_h` + HHI `n_bins` |
 
-  Stats with no hyperparameter (`MEAN`) are absent from the mapping rather than mapping to an empty dict. Tests that share a hyperparameter (NW populates `T_NW` + `P` from one bandwidth; Ljung-Box populates `Q` + `P` from one `lag_h`) duplicate the inner dict under both keys to keep single-key lookup honest. `profile.diagnose()["metadata"]` serialises with `StatCode.value` strings as outer keys and plain dicts inside.
+  Stats with no hyperparameter (`MEAN`) are absent from the mapping rather than mapping to an empty dict. Tests that share a hyperparameter (NW populates `T_NW` + `P_NW` from one bandwidth; Ljung-Box populates `Q` + `P` from one `lag_h`) duplicate the inner dict under both keys to keep single-key lookup honest. `profile.diagnose()["metadata"]` serialises with `StatCode.value` strings as outer keys and plain dicts inside.
 
   This restores reproducibility for the NW lag count after #187 removed `StatCode.NW_LAGS_USED`, and surfaces previously-discarded hyperparameters (ADF `lag_order`, Ljung-Box `lag_h`, HHI `n_bins`) under the same uniform schema. The `_ljung_box` internal helper now returns `(h, Q, p)` instead of `(Q, p)` so callers receive the resolved lag count alongside the test output. (#188)
 
 ### Changed
+
+- **`StatCode.P` renamed to `StatCode.P_NW`** (breaking, #192). Primary inference codes are now uniformly `P_<algo>` (`P_NW` / `P_HH` / `P_GMM`), parallel to the existing `T_<algo>` convention (`T_NW` / `T_HH`). The bare `P` was the odd one out — algorithm provenance was implicit in the name and only carried by the description string, which fails grep / IDE auto-complete and rots silently. Migration: replace every `StatCode.P` lookup with `StatCode.P_NW`; `profile.diagnose()` JSON keys move from `"p"` to `"p_nw"`. Family verbs (`bhy(profiles)` without explicit `estimator=`) drive off `primary_p` and are unaffected; `bhy(profiles, estimator=NeweyWest())` continues to work because `NeweyWest.emits_for` was retargeted to `P_NW`.
+
+  | Before | After |
+  |---|---|
+  | `StatCode.P` (value `"p"`) | `StatCode.P_NW` (value `"p_nw"`) |
+
+  Out of scope (unchanged): `StatCode.MEAN` (no algorithm axis), `StatCode.T_NW` (already correctly named), diagnostic codes `FACTOR_ADF_P` / `RESID_LJUNG_BOX_P` (grammar `<TARGET>_<TEST>_P` is structural — TARGET distinguishes factor input / residual / event distribution; the asymmetry with primary `P_<algo>` is documented in the `StatCode` module docstring). (#192)
 
 - **`factrix.multi_factor.bhy` accepts `estimator: Estimator | None` instead of `p_stat: StatCode | None`** (breaking, #170). The previous `p_stat=` kwarg was a placeholder landed in v0.10 alongside the family-verb refactor and is removed in v0.11. Migration:
 

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -114,7 +114,7 @@ resolves the axis when needed.
 ### `stats` keys by cell
 
 After #187's flattening, every cell populates the same primary keys
-(`MEAN`, `T_NW`, `P`); cell identity lives on `profile.config`
+(`MEAN`, `T_NW`, `P_NW`); cell identity lives on `profile.config`
 (`scope` / `signal` / `metric`), so the StatCode no longer encodes it.
 Diagnostic keys carry an explicit `FACTOR_` / `RESID_` / `EVENT_`
 prefix because their target sits outside `config`. Keys appear in
@@ -122,13 +122,13 @@ prefix because their target sits outside `config`. Keys appear in
 
 | Dispatch cell | `stats` keys populated |
 |---------------|------------------------|
-| `(individual, continuous, ic, panel)` | `MEAN`, `T_NW`, `P` |
-| `(individual, continuous, fm, panel)` | `MEAN`, `T_NW`, `P` |
-| `(individual, sparse, None, panel)` | `MEAN`, `T_NW`, `P` |
-| `(common, continuous, None, panel)` | `MEAN`, `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` |
-| `(common, sparse, None, panel)` | `MEAN`, `T_NW`, `P` |
-| `(common, continuous, None, timeseries)` | `MEAN`, `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` |
-| `(*, sparse, None, timeseries)` (sentinel) | `MEAN`, `T_NW`, `P`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` |
+| `(individual, continuous, ic, panel)` | `MEAN`, `T_NW`, `P_NW` |
+| `(individual, continuous, fm, panel)` | `MEAN`, `T_NW`, `P_NW` |
+| `(individual, sparse, None, panel)` | `MEAN`, `T_NW`, `P_NW` |
+| `(common, continuous, None, panel)` | `MEAN`, `T_NW`, `P_NW`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` |
+| `(common, sparse, None, panel)` | `MEAN`, `T_NW`, `P_NW` |
+| `(common, continuous, None, timeseries)` | `MEAN`, `T_NW`, `P_NW`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` |
+| `(*, sparse, None, timeseries)` (sentinel) | `MEAN`, `T_NW`, `P_NW`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` |
 
 `FACTOR_ADF_*` is a CONTINUOUS-only persistence diagnostic — sparse
 cells skip it because the `{0, R}` event-trigger signal (zero on
@@ -145,16 +145,16 @@ the test produced.
 
 | Cell | Populated `metadata` keys | Inner dict |
 |---|---|---|
-| IC / FM / CAAR PANEL | `T_NW`, `P` | `{"nw_lags": <resolved bandwidth>}` |
+| IC / FM / CAAR PANEL | `T_NW`, `P_NW` | `{"nw_lags": <resolved bandwidth>}` |
 | `(common, continuous, None, panel)` | `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | `{"lag_order": 0}` |
-| `(common, continuous, None, timeseries)` | `T_NW`, `P`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | NW `nw_lags` + ADF `lag_order` |
-| `(*, sparse, None, timeseries)` | `T_NW`, `P`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` | NW `nw_lags` + Ljung-Box `lag_h` + HHI `n_bins` |
+| `(common, continuous, None, timeseries)` | `T_NW`, `P_NW`, `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | NW `nw_lags` + ADF `lag_order` |
+| `(*, sparse, None, timeseries)` | `T_NW`, `P_NW`, `RESID_LJUNG_BOX_Q`, `RESID_LJUNG_BOX_P`, `EVENT_HHI_VALUE` | NW `nw_lags` + Ljung-Box `lag_h` + HHI `n_bins` |
 | `(common, sparse, None, panel)` | (none — cross-asset t has no hyperparam) | — |
 
 `profile.diagnose()["metadata"]` serialises with `StatCode.value`
-strings as outer keys (e.g. `"p"`) and plain dicts inside. Reading
-order pattern: `profile.stats[StatCode.P]` for the value, then
-`profile.metadata[StatCode.P]` for "how was this computed".
+strings as outer keys (e.g. `"p_nw"`) and plain dicts inside. Reading
+order pattern: `profile.stats[StatCode.P_NW]` for the value, then
+`profile.metadata[StatCode.P_NW]` for "how was this computed".
 
 ### `stats` provenance — two paths
 
@@ -181,7 +181,7 @@ Each procedure-internal `StatCode` maps to one section of
 
 | `StatCode` | Method |
 |---|---|
-| `MEAN`, `T_NW`, `P` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West HAC `t` on the cell primary series (IC mean / FM λ / CAAR / E[β] / β); convention selected by the procedure dispatched for `profile.config` |
+| `MEAN`, `T_NW`, `P_NW` | [HAC SE under overlapping returns](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns) — Newey-West HAC `t` on the cell primary series (IC mean / FM λ / CAAR / E[β] / β); convention selected by the procedure dispatched for `profile.config` |
 | `P_HH` | Reserved (#184) — Hansen-Hodrick rectangular-kernel HAC p-value |
 | `P_GMM` | Reserved — Hansen (1982) GMM J-test p-value |
 | `FACTOR_ADF_TAU`, `FACTOR_ADF_P` | [Persistence diagnostics under near-unit-root predictors](../reference/statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors) — ADF τ statistic and unit-root p-value on the continuous factor |
@@ -205,7 +205,7 @@ For reference, the JSON shape on the IC PANEL cell is:
   "stats": {
     "mean": 0.0722,
     "t_nw": 14.60,
-    "p": 2.13e-40
+    "p_nw": 2.13e-40
   }
 }
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -25,7 +25,7 @@ print(profile.verdict(), '| primary_p =', round(profile.primary_p, 4))
 print(profile.diagnose())
 # {'mode': 'panel', 'n_obs': 494, 'n_assets': 100,
 #  'primary_p': 2.13e-40, 'warnings': [], 'info_notes': [],
-#  'stats': {'mean': 0.0722, 't_nw': 14.60, 'p': 2.13e-40}}
+#  'stats': {'mean': 0.0722, 't_nw': 14.60, 'p_nw': 2.13e-40}}
 ```
 
 If you are not sure which factory to use, let factrix infer it from the
@@ -65,7 +65,7 @@ when to add standalone metrics), see [Choosing a metric](../guides/choosing-metr
     "primary_p": 0.0001,
     "warnings": ["unreliable_se_short_periods"],
     "info_notes": [],
-    "stats": {"mean": 0.082, "t_nw": 4.21, "p": 0.0001},
+    "stats": {"mean": 0.082, "t_nw": 4.21, "p_nw": 0.0001},
 }
 ```
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -163,9 +163,10 @@ class StatCode(StrEnum):
       target lives outside ``config``.
     - ``KIND`` — what kind of number. ``_MEAN`` / ``_VALUE`` for point
       estimates, statistic-named suffixes (``_T_NW`` / ``_TAU`` /
-      ``_Q``) for test statistics, ``_P`` for p-values. Algorithm
-      variants of the same p-value get a further suffix
-      (``_P_HH`` / ``_P_GMM``).
+      ``_Q``) for test statistics, ``_P_<algo>`` for p-values
+      (``_P_NW`` / ``_P_HH`` / ``_P_GMM``). Diagnostic p-values keep
+      their ``<TARGET>_<TEST>_P`` shape (``FACTOR_ADF_P`` /
+      ``RESID_LJUNG_BOX_P``) — the asymmetry is structural, see below.
 
     **Inference primary stats — algorithm-suffixed pair shape**
 
@@ -173,10 +174,18 @@ class StatCode(StrEnum):
     KINDs that abbreviate the test statistic's reference distribution:
     ``T`` (Student-t / asymptotic normal), ``J`` (Hansen J / χ²),
     ``WALD`` (Wald χ²), ``F`` (Snedecor F), ``LR`` (likelihood ratio).
-    Currently shipping: ``(T_NW, P)`` for Newey-West and ``(T_HH, P_HH)``
-    for Hansen-Hodrick. Planned in #191: ``(J_GMM, P_GMM)`` — the
-    over-identification test is χ², not t, so GMM emits J rather than T.
-    The bare ``P`` alias for ``P_NW`` is tracked for rename in #192.
+    Currently shipping: ``(T_NW, P_NW)`` for Newey-West and
+    ``(T_HH, P_HH)`` for Hansen-Hodrick. Planned in #191:
+    ``(J_GMM, P_GMM)`` — the over-identification test is χ², not t,
+    so GMM emits J rather than T.
+
+    **Why primary p-value is ``P_<algo>`` while diagnostic p-value is
+    ``<target>_<test>_P``**: primary p has a single conceptual target
+    (the cell's primary estimate, identified by ``profile.config``) so
+    the prefix slot carries the algorithm choice. Diagnostic p has
+    multiple non-primary targets (factor input / residual / event
+    distribution) so the prefix slot carries the target axis and the
+    test name floats with KIND. Both grammars co-exist deliberately.
 
     **Redesign trigger** — when (a) ≥ 4 inference algorithms ship
     concurrently or (b) ≥ 3 distinct test-statistic KINDs (T / J /
@@ -204,11 +213,15 @@ class StatCode(StrEnum):
 
     # Primary (cell main effect) — identity carried by profile.config.
     MEAN = "mean"
+    # Newey-West HAC (Bartlett kernel): t-statistic + p-value pair.
+    # Every primary-inference cell currently emits these two; algorithm
+    # is named explicitly so the pair stays symmetric with future
+    # P_<algo> / T_<algo> variants.
     T_NW = "t_nw"
-    P = "p"
-    # HH-pure rectangular-kernel HAC: t-statistic + p-value emitted as
-    # a pair, parallel to the (T_NW, P) NW pair. Conditionally emitted by
-    # IC / FM PANEL when forward_periods > 1 (overlap exists).
+    P_NW = "p_nw"
+    # HH-pure rectangular-kernel HAC: t-statistic + p-value pair, parallel
+    # to (T_NW, P_NW). Conditionally emitted by IC / FM PANEL when
+    # forward_periods > 1 (overlap exists).
     T_HH = "t_hh"
     P_HH = "p_hh"
     # GMM J-test (Hansen 1982): J statistic is chi-square distributed
@@ -236,8 +249,8 @@ class StatCode(StrEnum):
         Used by ``profile.verdict(gate=...)`` and downstream tooling to
         distinguish probability codes from test statistics / point
         estimates. Tokenises the value on ``_`` and checks for a ``p``
-        token, so bare ``P`` and algorithm variants ``P_HH`` / ``P_GMM``
-        all qualify alongside diagnostic ``FACTOR_ADF_P`` /
+        token, so primary-inference variants ``P_NW`` / ``P_HH`` /
+        ``P_GMM`` all qualify alongside diagnostic ``FACTOR_ADF_P`` /
         ``RESID_LJUNG_BOX_P``.
         """
         return "p" in self.value.split("_")
@@ -260,8 +273,8 @@ _STAT_DESCRIPTIONS: dict[StatCode, str] = {
     "or TS β / E[β]).",
     StatCode.T_NW: "Newey-West HAC t-stat on the cell primary estimate. "
     "Implementation convention lives in `factrix.stats.NeweyWest`.",
-    StatCode.P: "Two-sided p-value from the NW HAC t-test on the cell "
-    "primary estimate.",
+    StatCode.P_NW: "Two-sided p-value from the Newey-West HAC t-test on "
+    "the cell primary estimate. Sibling of `T_NW`.",
     StatCode.T_HH: "Hansen-Hodrick (1980) rectangular-kernel HAC t-stat "
     "on the cell primary estimate. Sibling of `T_NW`; uses `Var(mean) = "
     "(γ₀ + 2 Σ_{j=1..h-1} γⱼ) / n` instead of NW's Bartlett kernel.",

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -39,7 +39,7 @@ def _nw_metadata(nw_lags: int) -> dict[StatCode, Mapping[str, Any]]:
     """
     return {
         StatCode.T_NW: {"nw_lags": nw_lags},
-        StatCode.P: {"nw_lags": nw_lags},
+        StatCode.P_NW: {"nw_lags": nw_lags},
     }
 
 
@@ -164,7 +164,7 @@ class _ICContPanelProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             # (T_HH, P_HH) pair, conditionally emitted when forward_periods > 1.
             StatCode.T_HH,
             StatCode.P_HH,
@@ -208,7 +208,7 @@ class _ICContPanelProcedure:
         stats: dict[StatCode, float] = {
             StatCode.MEAN: ic_mean,
             StatCode.T_NW: t_stat,
-            StatCode.P: p_value,
+            StatCode.P_NW: p_value,
         }
         metadata = _nw_metadata(nw_lags)
         warnings = _emit_hh_p(
@@ -247,7 +247,7 @@ class _FMContPanelProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             # (T_HH, P_HH) pair, conditionally emitted when forward_periods > 1.
             StatCode.T_HH,
             StatCode.P_HH,
@@ -293,7 +293,7 @@ class _FMContPanelProcedure:
         stats: dict[StatCode, float] = {
             StatCode.MEAN: lambda_mean,
             StatCode.T_NW: t_stat,
-            StatCode.P: p_value,
+            StatCode.P_NW: p_value,
         }
         metadata = _nw_metadata(nw_lags)
         warning_codes = _emit_hh_p(
@@ -349,7 +349,7 @@ class _CAARSparsePanelProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
         }
     )
 
@@ -413,7 +413,7 @@ class _CAARSparsePanelProcedure:
             stats={
                 StatCode.MEAN: event_mean,
                 StatCode.T_NW: t_stat,
-                StatCode.P: p_value,
+                StatCode.P_NW: p_value,
             },
             metadata=_nw_metadata(nw_lags),
         )
@@ -434,7 +434,7 @@ class _CommonContPanelProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             StatCode.FACTOR_ADF_TAU,
             StatCode.FACTOR_ADF_P,
         }
@@ -471,7 +471,7 @@ class _CommonSparsePanelProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
         }
     )
 
@@ -577,7 +577,7 @@ def _compute_common_panel(
     stats: dict[StatCode, float] = {
         StatCode.MEAN: beta_mean,
         StatCode.T_NW: t_stat,
-        StatCode.P: p_value,
+        StatCode.P_NW: p_value,
     }
     metadata: dict[StatCode, Mapping[str, Any]] = {}
     warnings: set[WarningCode] = set(extra_warnings)
@@ -634,7 +634,7 @@ class _TSBetaContTimeseriesProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             StatCode.FACTOR_ADF_TAU,
             StatCode.FACTOR_ADF_P,
         }
@@ -703,7 +703,7 @@ class _TSBetaContTimeseriesProcedure:
             stats={
                 StatCode.MEAN: beta,
                 StatCode.T_NW: t_stat,
-                StatCode.P: p_value,
+                StatCode.P_NW: p_value,
                 StatCode.FACTOR_ADF_TAU: adf_tau,
                 StatCode.FACTOR_ADF_P: adf_p,
             },
@@ -738,7 +738,7 @@ class _TSDummySparseTimeseriesProcedure:
         {
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             StatCode.RESID_LJUNG_BOX_Q,
             StatCode.RESID_LJUNG_BOX_P,
             StatCode.EVENT_HHI_VALUE,
@@ -808,7 +808,7 @@ class _TSDummySparseTimeseriesProcedure:
             stats={
                 StatCode.MEAN: beta,
                 StatCode.T_NW: t_stat,
-                StatCode.P: p_value,
+                StatCode.P_NW: p_value,
                 StatCode.RESID_LJUNG_BOX_Q: ljung_box_q,
                 StatCode.RESID_LJUNG_BOX_P: ljung_box_p,
                 StatCode.EVENT_HHI_VALUE: hhi,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -473,7 +473,9 @@ Read live descriptions programmatically:
 ## StatCode reference
 
 `StatCode.is_p_value` is `True` iff the value tokens (split on `_`)
-contain `"p"`. Used by `profile.verdict(gate=...)` consumers; the
+contain the token `p` (so `P_NW` → `["p", "nw"]` qualifies, as do
+`P_HH` / `P_GMM` / `FACTOR_ADF_P` / `RESID_LJUNG_BOX_P`). Used by
+`profile.verdict(gate=...)` consumers; the
 family-verb `estimator=` override (#170) dispatches via
 `Estimator.emits_for` and does not gate on `is_p_value` directly.
 
@@ -486,9 +488,9 @@ sits outside `config`.
 |---|---|---|
 | `MEAN`              | every cell      | Cell primary point estimate (IC mean / FM λ / E[β] / β / CAAR event-only mean) |
 | `T_NW`              | every cell      | NW HAC t-stat on the primary estimate |
-| `P`                 | every cell      | NW HAC p-value (= `primary_p`) |
-| `P_HH`              | reserved (#184) | Hansen-Hodrick p-value (rectangular kernel) |
-| `P_GMM`             | reserved        | GMM J-test p-value |
+| `P_NW`              | every cell      | NW HAC p-value (= `primary_p`) |
+| `T_HH` / `P_HH`     | IC / FM PANEL when `forward_periods > 1` | Hansen-Hodrick rectangular-kernel HAC pair |
+| `P_GMM`             | reserved (#191) | GMM J-test p-value (paired with `J_GMM` chi-square statistic, lands in #191) |
 | `FACTOR_ADF_TAU`    | COMMON / TS β   | Diagnostic: ADF τ statistic on factor input |
 | `FACTOR_ADF_P`      | COMMON / TS β   | Diagnostic: ADF p-value on factor input |
 | `RESID_LJUNG_BOX_Q` | TS-dummy        | Diagnostic: Ljung-Box Q on residuals |

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -10,9 +10,10 @@ floor convention applies uniformly across the four primary_p-emitting
 cells; cell-specific sample-size guards (e.g. ``UNRELIABLE_SE_SHORT_PERIODS``)
 are tracked by the procedures and surface via ``FactorProfile.warnings``.
 
-After #187's StatCode flattening, ``emits_for`` is cell-agnostic — every
-applicable cell looks up the same ``StatCode.P`` key. Cell identity is
-carried by ``profile.config`` rather than by the StatCode.
+``emits_for`` is cell-agnostic — every applicable cell looks up the
+same ``StatCode.P_NW`` key (#187 flattened the prefix; #192 added the
+``_NW`` algorithm suffix for symmetry with ``T_NW`` / ``P_HH``). Cell
+identity is carried by ``profile.config`` rather than by the StatCode.
 """
 
 from __future__ import annotations
@@ -27,10 +28,10 @@ class NeweyWest:
     The Bartlett-kernel HAC variance estimate uses the NW1994 automatic
     bandwidth rule with a Hansen-Hodrick overlap floor for forward-return
     regressions, matching the convention v0.5 procedures already use to
-    populate ``primary_p`` and ``StatCode.P`` / ``StatCode.T_NW`` entries.
+    populate ``primary_p`` and ``StatCode.P_NW`` / ``StatCode.T_NW`` entries.
 
     Cell interpretation comes from ``profile.config`` (``scope`` /
-    ``signal`` / ``metric``) — ``StatCode.P`` is the same key for
+    ``signal`` / ``metric``) — ``StatCode.P_NW`` is the same key for
     correlation-mean tests (IC), event-window mean-effect tests (CAAR),
     cross-asset slope tests (TS β), etc. Downstream readers must consult
     the config to know which null is being rejected; the StatCode is
@@ -70,4 +71,4 @@ class NeweyWest:
         _signal: Signal,
         _metric: Metric | None,
     ) -> StatCode:
-        return StatCode.P
+        return StatCode.P_NW

--- a/tests/stats/test_estimator_protocol.py
+++ b/tests/stats/test_estimator_protocol.py
@@ -29,7 +29,7 @@ class _Stub:
     def emits_for(
         self, scope: FactorScope, signal: Signal, metric: Metric | None
     ) -> StatCode:
-        return StatCode.P
+        return StatCode.P_NW
 
 
 class _MissingEmitsFor:
@@ -60,5 +60,6 @@ def test_member_calls_route_through_protocol() -> None:
     assert e.applicable_to(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
     assert not e.applicable_to(FactorScope.COMMON, Signal.SPARSE)
     assert (
-        e.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC) is StatCode.P
+        e.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
+        is StatCode.P_NW
     )

--- a/tests/stats/test_newey_west_estimator.py
+++ b/tests/stats/test_newey_west_estimator.py
@@ -1,7 +1,7 @@
 """``NeweyWest`` reference Estimator tests (#170, #187).
 
 Validates the cell-agnostic dispatch surface (`emits_for` always returns
-`StatCode.P`) and applicability across user-facing cells. Numerical
+`StatCode.P_NW`) and applicability across user-facing cells. Numerical
 correctness of the underlying NW HAC math is owned by
 ``tests/stats/test_newey_west.py``.
 """
@@ -47,7 +47,7 @@ def test_emits_for_returns_flat_p(
     signal: Signal,
     metric: Metric | None,
 ) -> None:
-    assert NeweyWest().emits_for(scope, signal, metric) is StatCode.P
+    assert NeweyWest().emits_for(scope, signal, metric) is StatCode.P_NW
 
 
 @pytest.mark.parametrize(
@@ -66,14 +66,14 @@ def test_applicable_to_all_user_facing_cells(
 
 
 def test_panel_procedures_emit_the_dispatched_code() -> None:
-    # Every PANEL procedure must populate StatCode.P, since NeweyWest
+    # Every PANEL procedure must populate StatCode.P_NW, since NeweyWest
     # dispatches there cell-agnostically. Drift would surface as a
     # runtime KeyError on bhy(estimator=NeweyWest()).
     for key, entry in _DISPATCH_REGISTRY.items():
         if key.mode is not Mode.PANEL:
             continue
-        assert StatCode.P in entry.procedure.EMITS_STATS, (
+        assert StatCode.P_NW in entry.procedure.EMITS_STATS, (
             f"PANEL procedure for ({key.scope}, {key.signal}, {key.metric}) "
-            f"does not emit StatCode.P: "
+            f"does not emit StatCode.P_NW: "
             f"{sorted(s.name for s in entry.procedure.EMITS_STATS)}"
         )

--- a/tests/test_caar_procedure.py
+++ b/tests/test_caar_procedure.py
@@ -116,14 +116,14 @@ class TestStrongCaar:
         assert 0.7 < profile.stats[StatCode.MEAN] < 1.3
 
     def test_required_stats(self, profile: FactorProfile) -> None:
-        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P):
+        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P_NW):
             assert key in profile.stats
 
     def test_primary_p_matches_caar_p_stat(
         self,
         profile: FactorProfile,
     ) -> None:
-        assert profile.primary_p == profile.stats[StatCode.P]
+        assert profile.primary_p == profile.stats[StatCode.P_NW]
 
     def test_n_obs_equals_event_dates(self, profile: FactorProfile) -> None:
         # n_obs = number of distinct event-dates feeding the NW test;
@@ -156,7 +156,7 @@ class TestEndToEndViaEvaluate:
         )
         profile = _evaluate(panel, cfg)
         assert profile.mode is Mode.PANEL
-        assert StatCode.P in profile.stats
+        assert StatCode.P_NW in profile.stats
         assert profile.verdict() is Verdict.PASS
 
 
@@ -260,7 +260,7 @@ class TestCalendarTimeRegimes:
         lags = _resolve_nw_lags(T, auto_bartlett(T), cfg.forward_periods)
         ref_t, ref_p, _ = _newey_west_t_test(event_caar, lags=lags)
         assert profile.stats[StatCode.T_NW] == pytest.approx(ref_t)
-        assert profile.stats[StatCode.P] == pytest.approx(ref_p)
+        assert profile.stats[StatCode.P_NW] == pytest.approx(ref_p)
 
     def test_clustered_regime_picks_up_overlap_via_nw_hac(
         self,
@@ -281,7 +281,7 @@ class TestCalendarTimeRegimes:
             beta=0.5,
         )
         profile = _CAARSparsePanelProcedure().compute(panel, cfg)
-        assert 0.0 <= profile.stats[StatCode.P] <= 1.0
+        assert 0.0 <= profile.stats[StatCode.P_NW] <= 1.0
         assert profile.n_obs == 60
 
 

--- a/tests/test_common_panel_procedures.py
+++ b/tests/test_common_panel_procedures.py
@@ -159,7 +159,7 @@ class TestContinuousStrong:
         for key in (
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             StatCode.FACTOR_ADF_P,
         ):
             assert key in profile.stats

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -114,7 +114,7 @@ class TestIcPanelEndToEnd:
         assert InfoCode.SCOPE_AXIS_COLLAPSED not in profile.info_notes
 
     def test_ic_p_populated(self, profile: FactorProfile) -> None:
-        assert StatCode.P in profile.stats
+        assert StatCode.P_NW in profile.stats
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_family_resolution.py
+++ b/tests/test_family_resolution.py
@@ -47,13 +47,13 @@ def test_default_path_no_expand_over_returns_one_entry_per_profile() -> None:
 
 
 def test_estimator_none_falls_back_to_primary_p() -> None:
-    p = _profile(primary_p=0.012, stats={StatCode.P: 0.5})
+    p = _profile(primary_p=0.012, stats={StatCode.P_NW: 0.5})
     [entry] = _resolve_family([p], verb="bhy")
     assert entry.p_value == 0.012
 
 
 def test_estimator_supplied_reads_dispatched_stat() -> None:
-    p = _profile(primary_p=0.5, stats={StatCode.P: 0.012})
+    p = _profile(primary_p=0.5, stats={StatCode.P_NW: 0.012})
     [entry] = _resolve_family([p], verb="bhy", estimator=NeweyWest())
     assert entry.p_value == 0.012
 
@@ -76,7 +76,7 @@ def test_estimator_not_applicable_to_cell_raises() -> None:
         ) -> StatCode:
             raise AssertionError("emits_for must not be called when not applicable")
 
-    p = _profile(stats={StatCode.P: 0.04})
+    p = _profile(stats={StatCode.P_NW: 0.04})
     with pytest.raises(UserInputError) as exc:
         _resolve_family([p], verb="bhy", estimator=_Picky())
     err = exc.value
@@ -172,7 +172,7 @@ def test_duplicate_partition_key_with_expand_over_compares_full_key() -> None:
 
 
 def test_missing_dispatched_stat_raises_with_available_keys() -> None:
-    # NeweyWest dispatches to StatCode.P uniformly; a profile missing P
+    # NeweyWest dispatches to StatCode.P_NW uniformly; a profile missing P
     # in stats must surface the available-keys candidate list to the user.
     cfg = AnalysisConfig.individual_continuous(metric=Metric.FM, forward_periods=5)
     p = FactorProfile(

--- a/tests/test_fm_procedure.py
+++ b/tests/test_fm_procedure.py
@@ -110,11 +110,11 @@ class TestStrongFactor:
         assert 0.5 < profile.stats[StatCode.MEAN] < 1.5
 
     def test_required_stats_keys_present(self, profile: FactorProfile) -> None:
-        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P):
+        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P_NW):
             assert key in profile.stats
 
     def test_primary_p_matches_fm_p_stat(self, profile: FactorProfile) -> None:
-        assert profile.primary_p == profile.stats[StatCode.P]
+        assert profile.primary_p == profile.stats[StatCode.P_NW]
 
 
 class TestRandomFactor:
@@ -154,7 +154,7 @@ class TestEndToEndViaEvaluate:
         )
         profile = _evaluate(panel, fm_config)
         assert isinstance(profile, FactorProfile)
-        assert StatCode.P in profile.stats
+        assert StatCode.P_NW in profile.stats
         assert profile.verdict() is Verdict.PASS
 
 

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -72,10 +72,12 @@ class TestCodeEnums:
 
     def test_stat_code_population(self) -> None:
         # Flattened naming (#187): primary cell stats are TARGET-less,
-        # diagnostics carry an explicit prefix.
+        # diagnostics carry an explicit prefix. Algorithm suffix on
+        # primary inference codes (#192) — `(T_NW, P_NW)` pair, parallel
+        # to `(T_HH, P_HH)`.
         assert StatCode.MEAN.value == "mean"
         assert StatCode.T_NW.value == "t_nw"
-        assert StatCode.P.value == "p"
+        assert StatCode.P_NW.value == "p_nw"
         assert StatCode.FACTOR_ADF_P.value == "factor_adf_p"
         assert StatCode.RESID_LJUNG_BOX_P.value == "resid_ljung_box_p"
         assert StatCode.EVENT_HHI_VALUE.value == "event_hhi_value"

--- a/tests/test_hansen_hodrick_procedure.py
+++ b/tests/test_hansen_hodrick_procedure.py
@@ -72,7 +72,7 @@ class TestProcedureEmitsPHh:
         profile = evaluate(panel, cfg)
         assert StatCode.P_HH not in profile.stats
         assert StatCode.T_HH not in profile.stats
-        assert StatCode.P in profile.stats
+        assert StatCode.P_NW in profile.stats
 
     def test_bhy_dispatches_hh_p_value(self, metric: Metric) -> None:
         panel = _build_panel(n_dates=80, n_assets=15, seed=3)

--- a/tests/test_ic_procedure.py
+++ b/tests/test_ic_procedure.py
@@ -114,11 +114,11 @@ class TestStrongFactor:
         assert profile.stats[StatCode.MEAN] > 0.5
 
     def test_required_stats_keys_present(self, profile: FactorProfile) -> None:
-        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P):
+        for key in (StatCode.MEAN, StatCode.T_NW, StatCode.P_NW):
             assert key in profile.stats
 
     def test_primary_p_matches_ic_p_stat(self, profile: FactorProfile) -> None:
-        assert profile.primary_p == profile.stats[StatCode.P]
+        assert profile.primary_p == profile.stats[StatCode.P_NW]
 
     def test_metadata_records_nw_lags_under_t_nw_and_p(
         self,
@@ -131,7 +131,7 @@ class TestStrongFactor:
         from factrix._stats.constants import auto_bartlett
 
         expected = max(auto_bartlett(60), ic_config.forward_periods - 1)
-        assert profile.metadata[StatCode.P] == {"nw_lags": expected}
+        assert profile.metadata[StatCode.P_NW] == {"nw_lags": expected}
         assert profile.metadata[StatCode.T_NW] == {"nw_lags": expected}
 
     def test_metadata_inner_dicts_are_not_aliased(
@@ -141,7 +141,7 @@ class TestStrongFactor:
         # Shared hyperparam (NW lag) is duplicated as content but the
         # inner dicts must be distinct objects so caller mutation of
         # one entry does not silently bleed into the other (#188).
-        assert profile.metadata[StatCode.T_NW] is not profile.metadata[StatCode.P]
+        assert profile.metadata[StatCode.T_NW] is not profile.metadata[StatCode.P_NW]
 
 
 class TestRandomFactor:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -93,10 +93,10 @@ class TestDescribeAnalysisModes:
             r for r in rows if r["scope"] == "common" and r["signal"] == "continuous"
         )
         # PANEL entry of (COMMON, CONTINUOUS) is _CommonContPanelProcedure
-        # which emits MEAN / T_NW / P / FACTOR_ADF_TAU / FACTOR_ADF_P.
+        # which emits MEAN / T_NW / P_NW / FACTOR_ADF_TAU / FACTOR_ADF_P.
         assert "factor_adf_p" in cc_row["panel"]["stats_keys"]
         assert "factor_adf_tau" in cc_row["panel"]["stats_keys"]
-        assert "p" in cc_row["panel"]["stats_keys"]
+        assert "p_nw" in cc_row["panel"]["stats_keys"]
         # The (COMMON, CONTINUOUS, TIMESERIES) procedure also emits
         # FACTOR_ADF_TAU alongside FACTOR_ADF_P.
         assert "factor_adf_tau" in cc_row["timeseries"]["stats_keys"]

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -29,7 +29,7 @@ def _profile(
     cfg = AnalysisConfig.individual_continuous(
         metric=metric, forward_periods=forward_periods
     )
-    base_stats: dict[StatCode, float] = {StatCode.P: primary_p}
+    base_stats: dict[StatCode, float] = {StatCode.P_NW: primary_p}
     if stats:
         base_stats.update(stats)
     return FactorProfile(
@@ -132,12 +132,12 @@ class TestEstimatorOverride:
             factor_id="f1",
             metric=Metric.FM,
             primary_p=0.99,
-            stats={StatCode.P: 0.001},
+            stats={StatCode.P_NW: 0.001},
         )
         assert bhy([prof], estimator=NeweyWest()).profiles == [prof]
 
     def test_missing_dispatched_stat_raises_user_error(self) -> None:
-        # NeweyWest dispatches to StatCode.P; a profile without P in
+        # NeweyWest dispatches to StatCode.P_NW; a profile without P in
         # stats must surface the missing-key error.
         cfg = AnalysisConfig.individual_continuous(metric=Metric.IC, forward_periods=5)
         prof = FactorProfile(
@@ -159,7 +159,7 @@ class TestEstimatorOverride:
     def test_legacy_p_stat_kwarg_is_unrecognised(self) -> None:
         prof = _profile(factor_id="f1", primary_p=0.04)
         with pytest.raises(TypeError, match="p_stat"):
-            bhy([prof], p_stat=StatCode.P)
+            bhy([prof], p_stat=StatCode.P_NW)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -214,14 +214,14 @@ class TestVerdict:
     def test_gate_override_uses_stats_value(self) -> None:
         prof = _make_profile(
             primary_p=0.50,  # would FAIL on primary
-            stats={StatCode.P: 0.001},
+            stats={StatCode.P_NW: 0.001},
         )
-        assert prof.verdict(gate=StatCode.P) is Verdict.PASS
+        assert prof.verdict(gate=StatCode.P_NW) is Verdict.PASS
 
     def test_gate_keyerror_when_stat_missing(self) -> None:
         prof = _make_profile(primary_p=0.01, stats={})
         with pytest.raises(KeyError):
-            prof.verdict(gate=StatCode.P)
+            prof.verdict(gate=StatCode.P_NW)
 
 
 class TestProfileImmutability:
@@ -252,7 +252,7 @@ class TestDiagnose:
             stats={StatCode.MEAN: 0.05, StatCode.T_NW: 1.96},
             warnings=frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS}),
             info_notes=frozenset({InfoCode.SCOPE_AXIS_COLLAPSED}),
-            metadata={StatCode.T_NW: {"nw_lags": 5}, StatCode.P: {"nw_lags": 5}},
+            metadata={StatCode.T_NW: {"nw_lags": 5}, StatCode.P_NW: {"nw_lags": 5}},
         )
         d = prof.diagnose()
         assert d["mode"] == "panel"
@@ -262,7 +262,7 @@ class TestDiagnose:
         assert "scope_axis_collapsed" in d["info_notes"]
         assert d["stats"]["mean"] == 0.05
         # metadata uses StatCode.value strings as outer keys, plain dicts inside.
-        assert d["metadata"] == {"t_nw": {"nw_lags": 5}, "p": {"nw_lags": 5}}
+        assert d["metadata"] == {"t_nw": {"nw_lags": 5}, "p_nw": {"nw_lags": 5}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ts_beta_procedure.py
+++ b/tests/test_ts_beta_procedure.py
@@ -116,7 +116,7 @@ class TestStrongBeta:
         for key in (
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             StatCode.FACTOR_ADF_TAU,
             StatCode.FACTOR_ADF_P,
         ):
@@ -127,7 +127,7 @@ class TestStrongBeta:
         profile: FactorProfile,
     ) -> None:
         # NW lag count under T_NW + P; ADF lag_order under TAU + P (#188).
-        nw_meta = profile.metadata[StatCode.P]
+        nw_meta = profile.metadata[StatCode.P_NW]
         assert profile.metadata[StatCode.T_NW] == nw_meta
         assert "nw_lags" in nw_meta
 
@@ -203,5 +203,5 @@ class TestEndToEndViaEvaluate:
         ts = _make_ts(n_dates=80, seed=99, beta=0.7)
         profile = _evaluate(ts, cfg)
         assert profile.mode is Mode.TIMESERIES
-        assert StatCode.P in profile.stats
+        assert StatCode.P_NW in profile.stats
         assert profile.verdict() is Verdict.PASS

--- a/tests/test_ts_dummy_procedure.py
+++ b/tests/test_ts_dummy_procedure.py
@@ -152,7 +152,7 @@ class TestStrongTrigger:
         for key in (
             StatCode.MEAN,
             StatCode.T_NW,
-            StatCode.P,
+            StatCode.P_NW,
             StatCode.RESID_LJUNG_BOX_Q,
             StatCode.RESID_LJUNG_BOX_P,
             StatCode.EVENT_HHI_VALUE,
@@ -165,7 +165,7 @@ class TestStrongTrigger:
     ) -> None:
         # NW lag count shared by T_NW + P; Ljung-Box lag h shared by Q + P;
         # HHI n_bins under EVENT_HHI_VALUE only (#188).
-        nw_meta = profile.metadata[StatCode.P]
+        nw_meta = profile.metadata[StatCode.P_NW]
         assert profile.metadata[StatCode.T_NW] == nw_meta
         assert "nw_lags" in nw_meta and nw_meta["nw_lags"] >= 1
 


### PR DESCRIPTION
## Summary

- Rename `StatCode.P` (value `"p"`) → `StatCode.P_NW` (value `"p_nw"`) so primary inference codes are uniformly `P_<algo>` (`P_NW` / `P_HH` / `P_GMM`), parallel to `T_<algo>` (`T_NW` / `T_HH`). Algorithm provenance now lives in the name, not in description prose.
- Mass-rename across 22 files: 7 procedure emit sites, `NeweyWest.emits_for`, 16 test files, docs (`factor-profile.md`, `quickstart.md`, `llms-full.txt`), CHANGELOG, module docstring + `is_p_value` docstring + `_STAT_DESCRIPTIONS[P_NW]` tightened.
- Module docstring now justifies the deliberate primary-vs-diagnostic asymmetry: primary p has one target (cell's headline estimate, identified by `profile.config`) so prefix encodes algorithm; diagnostic p has multiple targets (factor / residual / event) so prefix encodes target axis.

Breaking. `profile.diagnose()` JSON keys move from `"p"` to `"p_nw"` — dashboard / reporting code grepping the old key will silently break (CHANGELOG entry calls this out explicitly). Family verbs without explicit estimator drive off `primary_p` field and are unaffected.

## Test plan

- [x] 1004 tests pass (`pytest -q`)
- [x] `grep -rn 'StatCode\.P\b' factrix tests docs` — empty (no leftover bare-P references)
- [x] `grep -rn '"p":\|'"'"'p'"'"':' factrix tests docs` — empty after fixing the 2 stale doc references caught by simplify review
- [x] `tests/test_foundation.py::test_stat_code_population` updated to assert `P_NW.value == "p_nw"`
- [x] `tests/test_registry.py::test_diagnose_serialises_enums_to_strings` + `tests/test_introspection.py::test_stats_keys_match_emits_stats` updated for new JSON key
- [ ] Reviewer attention: `factrix.llms-full.txt` `is_p_value` description was rewritten to say "contain the token `p`" instead of `contain "p"` — flag if you prefer different phrasing
- [ ] Reviewer attention: `StatCode` module docstring's "Why primary p-value is `P_<algo>` while diagnostic is `<target>_<test>_P`" rationale paragraph — flag if the asymmetry justification reads as post-hoc rather than structural

Closes #192

Stacked on #193 (just merged) — no rebase needed.