### PR TITLE
feat(api): standalone-metric runner for a cell (#147)

### DIFF
--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -1,0 +1,163 @@
+# run_metrics
+
+Cell-level descriptive batch runner — the descriptive twin of
+[`evaluate`](evaluate.md). Where `evaluate` runs a cell's primary
+inferential procedure and returns a [`FactorProfile`](factor-profile.md),
+`run_metrics` fans out across the cell's standalone descriptive metrics
+in `factrix.metrics.*` and returns a [`MetricsBundle`](#metricsbundle).
+
+The two paths share the `(panel, cfg)` entry contract; their result
+types are disjoint by design.
+
+| Verb | Returns | Use when |
+|---|---|---|
+| [`evaluate`](evaluate.md) | `FactorProfile` (primary p, drives FDR) | you want the single inferential decision for the cell |
+| `run_metrics` | `MetricsBundle` (cell's descriptive surface) | you want every standalone metric the cell exposes for plotting / dashboards / cross-factor comparison |
+
+Both can be called on the same `(panel, cfg)`; neither is a
+prerequisite for the other.
+
+## Call shape
+
+```python
+import factrix as fx
+
+cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
+bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+
+bundle["ic"].value             # dict-style access
+bundle.identity                # ("momentum_12_1", 5) — (factor_id, fwd)
+bundle.to_frame()              # long-form pl.DataFrame
+dict(bundle.skipped)           # metrics that could not auto-run
+```
+
+`panel` follows the same canonical schema as `evaluate`
+(`date, asset_id, factor, forward_return`); `factor_col` renames an
+alternate signal column to `"factor"` internally before dispatch.
+`bundle.identity = (factor_col, cfg.forward_periods)` — when looping
+over candidate signals, pass `factor_col=name` for each so
+`bundle.identity` stays unique across the sweep (otherwise every
+bundle reports `("factor", h)` and concatenated `to_frame()` outputs
+collide).
+
+## What auto-discover runs
+
+`metrics=None` (default) runs every metric `list_metrics(cfg.scope,
+cfg.signal)` exposes for the cell, after three filters:
+
+1. `input_kind == "panel"` — drops scalar-input utilities
+   (`breakeven_cost`, `net_spread`).
+2. `_STAGE1_HELPERS` — drops shared `compute_*` helpers (they produce
+   stage-1 frames consumed by other metrics).
+3. `_AUTO_DISCOVER_EXCLUDED` — drops metrics that need explicit kwargs
+   `run_metrics` does not thread (per-row reason; surfaced on
+   `bundle.skipped`).
+
+In v1 the IC family (`ic`, `ic_newey_west`, `ic_ir`, `regime_ic`)
+shares a single `compute_ic(panel)` per call. Other stage-1 consumers
+(`caar`, `fama_macbeth`, `ts_beta`, `mfe_mae_summary`, plus series /
+spread consumers) live in the auto-discover exclusion set; the bundle's
+`skipped` map carries the explicit-import recipe for each. v1.x will
+extend stage-1 wiring per cell.
+
+## Explicit subset
+
+```python
+fx.run_metrics(panel, cfg, metrics=["ic", "monotonicity"])
+```
+
+Unknown names raise [`UserInputError`](errors.md) with a fuzzy
+suggestion plus the full candidate list. Names registered for the
+cell but in the auto-discover exclusion set raise the same error type with
+the documented reason and the explicit-call recipe — `run_metrics`
+never silently drops a name the caller asked for.
+
+## Cross-horizon and cross-universe analysis
+
+`run_metrics` runs at exactly one horizon — `cfg.forward_periods` — and
+on exactly the panel passed in. Sweeps go through the existing verbs;
+`run_metrics` does not ship a `horizons=[...]` helper because
+cross-horizon analysis is the job of `compare(bundles)` (descriptive,
+v1.x — see #148) or `bhy(expand_over=["forward_periods"])` (FDR
+controlled, anti-shopping defense per #160). Keeping `run_metrics`
+single-horizon preserves the `(panel, cfg) → bundle` contract
+symmetric with `evaluate`.
+
+```python
+horizons = [1, 5, 21]
+
+# Descriptive sweep — no FDR claim
+bundles = [
+    fx.run_metrics(panel, cfg.replace(forward_periods=h))
+    for h in horizons
+]
+# compare(bundles)  # descriptive cross-factor view; v1.x verb, see #148
+
+# Inferential sweep — FDR-controlled
+profiles = [
+    fx.evaluate(panel, cfg.replace(forward_periods=h))
+    for h in horizons
+]
+fx.multi_factor.bhy(profiles, expand_over=["forward_periods"])
+```
+
+Universe / regime works the same way: filter the panel, optionally
+stamp `bundle.context` via `dataclasses.replace`, then concatenate
+through `compare` / `bhy`. See the [Identity / context](identity.md)
+guide.
+
+## MetricsBundle
+
+Frozen dataclass keyed by `identity = (factor_id, forward_periods)`
+(matches `FactorProfile.identity` per #160).
+
+| Member | Type | Description |
+|---|---|---|
+| `identity` | `(str, int)` | hypothesis dimensions |
+| `metrics` | `Mapping[str, MetricOutput]` | every metric that produced a value (incl. short-circuit `NaN` outputs with `metadata["reason"]`) |
+| `skipped` | `Mapping[str, str]` | metric → reason for everything excluded from auto-discover |
+| `context` | `Mapping[str, Any]` | sample-restriction dimensions; v1 always empty, populated by downstream slicers or by user via `dataclasses.replace` after panel-side filtering |
+
+Access patterns:
+
+- `bundle["ic"]` — dict-style metric lookup
+- `"ic" in bundle` / `list(bundle)` / `iter(bundle)` — operate on the
+  metric keys
+- `bundle.to_frame()` — long-form `pl.DataFrame` (one row per metric);
+  fixed 8-column schema for stable `pl.concat([b.to_frame() ...])`
+
+Hashing is disabled (`__hash__ = None`) because the bundle holds
+`MetricOutput` instances whose `metadata` is a mutable dict. Group
+bundles by `identity` (a hashable tuple).
+
+## to_frame schema
+
+| Column | Type | Source |
+|---|---|---|
+| `factor_id` | `str` | `identity[0]` |
+| `forward_periods` | `int` | `identity[1]` |
+| `metric` | `str` | mapping key |
+| `value` | `float` | `MetricOutput.value` |
+| `stat` | `float \| null` | `MetricOutput.stat` |
+| `significance` | `str \| null` | `MetricOutput.significance` |
+| `p_value` | `float \| null` | `metadata["p_value"]` |
+| `short_circuit_reason` | `str \| null` | `metadata["reason"]` |
+
+`metadata` is **not** flattened — its shape is heterogeneous across
+metrics (per-regime dicts, per-horizon entries, KP source labels…).
+Reach into `bundle["name"].metadata` directly. `context.*` is **not**
+flattened in v1 (the column would always be empty).
+
+## Error handling
+
+Three classes, three responses:
+
+| Class | Source | What `run_metrics` does |
+|---|---|---|
+| **A** Sample-floor / data-quality | `InsufficientSampleError`, metric-internal `_short_circuit_output` | Convert to a short-circuit `MetricOutput` (`value=NaN`, `metadata["reason"]=...`) inside the bundle. Other metrics keep running. |
+| **B** User input | unknown / excluded `metrics=[...]`, missing / colliding `factor_col` | Raise [`UserInputError`](errors.md) with fuzzy suggestion + fix path. |
+| **C** Unexpected | bug in a metric callable or stage-1 helper | Raise [`RunMetricsError`](errors.md) wrapping the original exception (chained via `__cause__`); attributes `.cell`, `.metric_name`, `.stage` identify which metric broke. |
+
+A single `logging.info` line at logger name `factrix.run_metrics`
+summarises ran / skipped counts per call (observability hook for
+batch jobs; not the primary user surface — `bundle.skipped` is).

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -61,10 +61,12 @@ from factrix._errors import (
     InsufficientSampleError,
     MissingConfigError,
     ModeAxisError,
+    RunMetricsError,
     UserInputError,
 )
 from factrix._evaluate import _evaluate as _evaluate
 from factrix._profile import FactorProfile
+from factrix._run_metrics import MetricsBundle, run_metrics
 from factrix._types import MetricOutput
 
 
@@ -148,11 +150,14 @@ __all__ = [
     "InsufficientSampleError",
     "MissingConfigError",
     "ModeAxisError",
+    "RunMetricsError",
     "UserInputError",
     # Profile + dispatch
     "FactorProfile",
     "MetricOutput",
+    "MetricsBundle",
     "evaluate",
+    "run_metrics",
     # Introspection
     "SuggestConfigResult",
     "describe_analysis_modes",

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -153,6 +153,42 @@ class ModeAxisError(ConfigError):
     """
 
 
+class RunMetricsError(FactrixError):
+    """Unexpected exception inside ``run_metrics`` dispatch.
+
+    Wraps an unexpected error raised by a stage-1 helper or a metric
+    consumer so the caller can identify which metric / stage failed
+    without parsing tracebacks. The original exception is chained via
+    ``raise ... from exc`` so ``__cause__`` carries the full stack.
+
+    A wrapped exception means the failure is **not** a known
+    sample-floor / data-quality short-circuit — those are converted to
+    short-circuit ``MetricOutput`` entries inside the bundle. Treat
+    ``RunMetricsError`` as a likely factrix bug and report.
+
+    Attributes:
+        cell: ``"<scope>/<signal>"`` of the dispatched cell.
+        metric_name: The metric whose call raised, or the stage-1
+            helper name when ``stage == "stage1"``.
+        stage: Which dispatch stage raised — ``"stage1"`` (shared
+            helper failed; the whole module's consumers are skipped)
+            or ``"consumer"`` (an individual metric raised).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        cell: str,
+        metric_name: str,
+        stage: str,
+    ) -> None:
+        super().__init__(message)
+        self.cell = cell
+        self.metric_name = metric_name
+        self.stage = stage
+
+
 class InsufficientSampleError(ConfigError):
     """``T < MIN_PERIODS_HARD`` for a TIMESERIES procedure.
 

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -85,6 +85,83 @@ are not per-(scope, signal) cell metrics."""
 # it isn't.
 _SCALAR_INPUT_METRICS: frozenset[str] = frozenset({"breakeven_cost", "net_spread"})
 
+# Metrics that ``run_metrics`` cannot auto-discover even though their
+# Matrix-row is user-facing. Each entry carries a short reason rendered
+# into ``MetricsBundle.skipped`` and into the ``UserInputError`` raised
+# when a caller names one explicitly via ``metrics=[...]``. v2 may
+# promote this to a Matrix-row tag once the population is stable.
+_AUTO_DISCOVER_EXCLUDED: dict[str, str] = {
+    # Horizon dispatchers — semantics live at the horizon-loop layer
+    # (#186 deprecation in favour of `compare(bundles[])` /
+    # `bhy(expand_over=["forward_periods"])`).
+    "multi_horizon_ic": (
+        "horizon dispatcher; use compare(bundles[]) or "
+        "bhy(expand_over=['forward_periods'])"
+    ),
+    "multi_horizon_hit_rate": (
+        "horizon dispatcher; use compare(bundles[]) or "
+        "bhy(expand_over=['forward_periods'])"
+    ),
+    # Stage-1 consumers without v1 dispatch wiring. These metrics are
+    # callable directly from ``factrix.metrics`` once the caller has the
+    # stage-1 frame; v1 ``run_metrics`` does not yet thread that wiring.
+    # Tracked as v1.x follow-up; not blocking the IC-cell stage-1 pattern
+    # validated in v1.
+    "caar": (
+        "consumes caar_df; call factrix.metrics.compute_event_returns + "
+        "compute_caar then caar(caar_df) directly"
+    ),
+    "fama_macbeth": (
+        "consumes beta_df; call factrix.metrics.compute_fm_betas then "
+        "fama_macbeth(beta_df) directly"
+    ),
+    "beta_sign_consistency": (
+        "consumes beta_df; call factrix.metrics.compute_fm_betas then "
+        "beta_sign_consistency(beta_df) directly"
+    ),
+    "ts_beta": (
+        "consumes ts_betas_df; call factrix.metrics.compute_ts_betas then "
+        "ts_beta(ts_betas_df) directly"
+    ),
+    "mean_r_squared": (
+        "consumes ts_betas_df; call factrix.metrics.compute_ts_betas then "
+        "mean_r_squared(ts_betas_df) directly"
+    ),
+    "ts_beta_sign_consistency": (
+        "consumes ts_betas_df; call factrix.metrics.compute_ts_betas then "
+        "ts_beta_sign_consistency(ts_betas_df) directly"
+    ),
+    "mfe_mae_summary": (
+        "consumes mfe_mae_df; call factrix.metrics.compute_mfe_mae then "
+        "mfe_mae_summary(mfe_mae_df) directly"
+    ),
+    # Series-input diagnostics — operate on a (date, value) series, not
+    # a panel. Compose explicitly with compute_ic / compute_spread_series.
+    "hit_rate": (
+        "consumes a (date, value) series; e.g. "
+        "hit_rate(compute_ic(panel).rename({'ic': 'value'}))"
+    ),
+    "multi_split_oos_decay": (
+        "consumes a (date, value) series; e.g. "
+        "multi_split_oos_decay(compute_spread_series(panel)"
+        ".rename({'spread': 'value'}))"
+    ),
+    "ic_trend": (
+        "consumes a (date, value) series; e.g. "
+        "ic_trend(compute_ic(panel).rename({'ic': 'value'}))"
+    ),
+    # Multi-factor spread inputs — require a list/dict of factor spreads,
+    # not a single panel.
+    "spanning_alpha": (
+        "consumes factor_spread; call after compute_spread_series on the "
+        "challenger factor"
+    ),
+    "greedy_forward_selection": (
+        "consumes factor_spreads dict; call after compute_spread_series on "
+        "each candidate factor"
+    ),
+}
+
 # Function name → emitted ``MetricOutput.name`` literal, where the two
 # diverge. Most metrics emit ``name=<function_name>``; the entries here
 # are the historical exceptions and the source of truth for the
@@ -266,6 +343,7 @@ def matrix_entries() -> tuple[MatrixEntry, ...]:
     return tuple(out)
 
 
+@functools.cache
 def all_rows() -> list[MetricRow]:
     """Return every parsed ``Matrix-row:`` row, exploded one per metric name.
 
@@ -291,6 +369,7 @@ def all_rows() -> list[MetricRow]:
     return rows
 
 
+@functools.cache
 def user_facing_rows() -> list[MetricRow]:
     """Return parsed rows excluding stage-1 helpers and cross-cutting infra."""
     excluded = _STAGE1_HELPERS | _INFRASTRUCTURE

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -1,0 +1,469 @@
+"""``run_metrics`` — descriptive batch runner parallel to ``evaluate``.
+
+Where ``_evaluate`` dispatches a cell's primary inferential procedure
+into a single ``FactorProfile``, ``run_metrics`` fans out across the
+cell's standalone descriptive metrics into a single ``MetricsBundle``.
+The two paths share the ``(panel, cfg)`` entry contract (#148) and
+keep their result types disjoint.
+
+v1 scope (#147): IC-cell stage-1 cache + panel-direct metrics for every
+cell. Other stage-1 consumers (``caar`` / ``fama_macbeth`` / ``ts_beta``
+/ ``mfe_mae_summary`` / series consumers / spread consumers) are listed
+in :data:`factrix._metric_index._AUTO_DISCOVER_EXCLUDED` with explicit
+import hints; per-cell stage-1 wiring is a v1.x follow-up.
+"""
+
+from __future__ import annotations
+
+import html
+import inspect
+import logging
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+import polars as pl
+
+from factrix._errors import (
+    InsufficientSampleError,
+    RunMetricsError,
+    UserInputError,
+)
+from factrix._metric_index import _AUTO_DISCOVER_EXCLUDED, user_facing_rows
+from factrix._types import MetricOutput
+from factrix.metrics._helpers import _short_circuit_output
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from factrix._analysis_config import AnalysisConfig
+
+_logger = logging.getLogger("factrix.run_metrics")
+
+# Metrics whose first positional argument is the ``compute_ic`` output
+# (the ``(date, ic, tie_ratio)`` frame). v1 wires this single stage-1
+# helper; expanding to ``compute_fm_betas`` / ``compute_ts_betas`` /
+# ``compute_event_returns`` pipelines is tracked as v1.x follow-up.
+_IC_CONSUMERS: frozenset[str] = frozenset({"ic", "ic_newey_west", "ic_ir", "regime_ic"})
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class MetricsBundle:
+    """Cell-level descriptive metrics for one factor at one horizon.
+
+    Parallel to :class:`factrix.FactorProfile` (the primary inferential
+    artifact). The bundle holds every standalone metric ``run_metrics``
+    successfully evaluated for the cell, plus a ``skipped`` map of
+    metrics that could not auto-run (with reason).
+
+    Attributes:
+        identity: ``(factor_id, forward_periods)`` — the hypothesis
+            dimensions per #160. Aligns with ``FactorProfile.identity``
+            so downstream verbs (``compare`` / ``slice_analysis``) can
+            stack profiles and bundles by the same key.
+        metrics: Metric name → ``MetricOutput`` mapping for every
+            metric that produced a value (including short-circuit
+            ``MetricOutput`` entries — ``value=NaN`` with a reason in
+            ``metadata["reason"]``).
+        skipped: Metric name → reason string for metrics that could
+            not auto-run (excluded by the registry, requires explicit
+            kwargs, stage-1 helper failed, …). v1 surfaces this through
+            ``__repr__`` / ``_repr_html_`` and a single ``logging.info``.
+        context: Sample-restriction / conditioning dimensions per #160.
+            v1 always empty; downstream slicers (``slice_analysis`` /
+            ``by_regime``) populate via ``dataclasses.replace`` once
+            available, or callers stamp manually after panel-side
+            filtering.
+
+    Hashing is disabled (``__hash__ = None``) because the bundle holds
+    ``MetricOutput`` instances whose ``metadata`` is a mutable dict.
+    Group bundles by ``identity`` (a hashable tuple), not by the bundle
+    itself.
+    """
+
+    identity: tuple[str, int]
+    metrics: Mapping[str, MetricOutput] = field(default_factory=dict)
+    skipped: Mapping[str, str] = field(default_factory=dict)
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+    __hash__ = None  # type: ignore[assignment]
+
+    @property
+    def factor_id(self) -> str:
+        return self.identity[0]
+
+    @property
+    def forward_periods(self) -> int:
+        return self.identity[1]
+
+    def __getitem__(self, key: str) -> MetricOutput:
+        return self.metrics[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.metrics
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.metrics)
+
+    def __len__(self) -> int:
+        return len(self.metrics)
+
+    def _summary_rows(self) -> list[tuple[str, Any]]:
+        rows: list[tuple[str, Any]] = [
+            ("factor_id", self.factor_id),
+            ("forward_periods", self.forward_periods),
+            ("n_metrics", len(self.metrics)),
+        ]
+        for k in sorted(self.context):
+            rows.append((f"context.{k}", self.context[k]))
+        if self.skipped:
+            rows.append(("n_skipped", len(self.skipped)))
+        return rows
+
+    def __repr__(self) -> str:
+        head = ", ".join(f"{k}={v!r}" for k, v in self._summary_rows())
+        names = ", ".join(sorted(self.metrics))
+        return f"MetricsBundle({head}, metrics=[{names}])"
+
+    def _repr_html_(self) -> str:
+        header = "".join(
+            f"<tr><th style='text-align:left'>{html.escape(str(k))}</th>"
+            f"<td>{html.escape(str(v))}</td></tr>"
+            for k, v in self._summary_rows()
+        )
+        metric_rows = "".join(
+            f"<tr><td>{html.escape(name)}</td>"
+            f"<td style='text-align:right'>{out.value:.4g}</td>"
+            f"<td>{html.escape(out.significance or '')}</td></tr>"
+            for name, out in sorted(self.metrics.items())
+        )
+        skipped_block = ""
+        if self.skipped:
+            skipped_rows = "".join(
+                f"<tr><td>{html.escape(name)}</td><td>{html.escape(reason)}</td></tr>"
+                for name, reason in sorted(self.skipped.items())
+            )
+            skipped_block = (
+                "<details><summary>skipped "
+                f"({len(self.skipped)})</summary>"
+                "<table><thead><tr><th>metric</th><th>reason</th>"
+                "</tr></thead>"
+                f"<tbody>{skipped_rows}</tbody></table></details>"
+            )
+        return (
+            "<div class='factrix-metrics-bundle'>"
+            "<table><caption>MetricsBundle</caption>"
+            f"<tbody>{header}</tbody></table>"
+            "<table><thead><tr><th>metric</th><th>value</th>"
+            "<th>sig</th></tr></thead>"
+            f"<tbody>{metric_rows}</tbody></table>"
+            f"{skipped_block}"
+            "</div>"
+        )
+
+    def to_frame(self) -> pl.DataFrame:
+        """Long-form view of the bundle: one row per metric.
+
+        Schema (8 columns, stable regardless of bundle contents):
+
+        | column | type | source |
+        |---|---|---|
+        | ``factor_id`` | str | ``identity[0]`` |
+        | ``forward_periods`` | int | ``identity[1]`` |
+        | ``metric`` | str | mapping key |
+        | ``value`` | float | ``MetricOutput.value`` |
+        | ``stat`` | float \\| null | ``MetricOutput.stat`` |
+        | ``significance`` | str \\| null | ``MetricOutput.significance`` |
+        | ``p_value`` | float \\| null | ``metadata["p_value"]`` |
+        | ``short_circuit_reason`` | str \\| null | ``metadata["reason"]`` |
+
+        ``metadata`` is **not** flattened — the per-metric shape is
+        heterogeneous (per-regime dicts, per-horizon entries,
+        Kolari-Pynnönen source labels, …) and a flat schema would
+        fight every consumer. Reach into ``bundle["name"].metadata``
+        for the rest.
+
+        ``context.*`` is **not** flattened in v1 — ``context`` is
+        always empty here; downstream slicers populating ``context``
+        is a v1.x extension that may grow the schema.
+
+        ``skipped`` entries do not appear; only successful and
+        short-circuited ``MetricOutput`` rows are emitted.
+        """
+        rows = []
+        for name, out in sorted(self.metrics.items()):
+            meta = out.metadata or {}
+            rows.append(
+                {
+                    "factor_id": self.factor_id,
+                    "forward_periods": self.forward_periods,
+                    "metric": name,
+                    "value": float(out.value),
+                    "stat": (None if out.stat is None else float(out.stat)),
+                    "significance": out.significance,
+                    "p_value": _coerce_optional_float(meta.get("p_value")),
+                    "short_circuit_reason": _coerce_optional_str(meta.get("reason")),
+                }
+            )
+        schema = {
+            "factor_id": pl.String,
+            "forward_periods": pl.Int64,
+            "metric": pl.String,
+            "value": pl.Float64,
+            "stat": pl.Float64,
+            "significance": pl.String,
+            "p_value": pl.Float64,
+            "short_circuit_reason": pl.String,
+        }
+        return pl.DataFrame(rows, schema=schema)
+
+
+def _coerce_optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    return float(value)  # type: ignore[arg-type]
+
+
+def _coerce_optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _candidate_metric_names(scope: Any, signal: Any) -> list[str]:
+    return [
+        r.name
+        for r in user_facing_rows()
+        if r.cell.matches(scope, signal) and r.input_kind == "panel"
+    ]
+
+
+def _accepts_kwarg(fn: Callable[..., Any], name: str) -> bool:
+    return name in inspect.signature(fn).parameters
+
+
+def _cell_label(cfg: AnalysisConfig) -> str:
+    return f"{cfg.scope.value}/{cfg.signal.value}"
+
+
+def _raise_factor_col_error(*, value: str, expected: str) -> None:
+    raise UserInputError(
+        verb="run_metrics",
+        field="factor_col",
+        value=value,
+        expected=expected,
+        docs_path="api/run_metrics#factor_col",
+    )
+
+
+def run_metrics(
+    panel: pl.DataFrame,
+    cfg: AnalysisConfig,
+    *,
+    factor_col: str = "factor",
+    metrics: list[str] | None = None,
+) -> MetricsBundle:
+    """Run every standalone descriptive metric the cell exposes.
+
+    Parallel to :func:`factrix.evaluate`: both consume ``(panel, cfg)``,
+    each produces a disjoint result type. ``run_metrics`` collects the
+    cell's :mod:`factrix.metrics` surface — IC family from one shared
+    ``compute_ic`` (cache), every other panel-direct metric called
+    directly — and returns a :class:`MetricsBundle` keyed by metric name.
+
+    Args:
+        panel: Canonical-column panel (``date, asset_id, factor,
+            forward_return``). Renamed internally if ``factor_col`` is
+            not ``"factor"``, mirroring :func:`factrix.evaluate`.
+        cfg: Validated :class:`AnalysisConfig`. ``cfg.scope`` and
+            ``cfg.signal`` route metric discovery; ``cfg.forward_periods``
+            (a single int) is the horizon every metric sees. Cross-horizon
+            sweeps go through user comprehension into ``compare(bundles)``
+            or ``bhy(profiles, expand_over=["forward_periods"])`` —
+            ``run_metrics`` itself does not loop horizons (#147 §E /
+            #186).
+        factor_col: Name of the signal column on ``panel``. Renamed to
+            ``"factor"`` internally before dispatch so metric callables
+            see the canonical schema.
+        metrics: ``None`` (default) auto-discovers every applicable
+            metric from :func:`factrix.list_metrics`. Pass an explicit
+            list to run a subset; unknown or
+            :data:`~factrix._metric_index._AUTO_DISCOVER_EXCLUDED`
+            names raise :class:`factrix.UserInputError` with a fix
+            path (a fuzzy suggestion plus the explicit-import recipe
+            for stage-1 consumers).
+
+    Returns:
+        A :class:`MetricsBundle` whose ``metrics`` map carries every
+        ``MetricOutput`` produced (including short-circuit outputs for
+        sample-floor failures) and whose ``skipped`` map carries
+        per-metric reasons for metrics that could not auto-run.
+
+    Raises:
+        UserInputError: ``metrics`` contains an unknown name or a name
+            that needs explicit kwargs not threaded by ``run_metrics``
+            v1. Carries a fuzzy suggestion plus the documented reason
+            from :data:`~factrix._metric_index._AUTO_DISCOVER_EXCLUDED`.
+        RunMetricsError: Wraps an unexpected exception raised inside a
+            metric callable or the IC stage-1 helper. Treat as a
+            likely factrix bug; the original exception is chained via
+            ``__cause__``. Sample-floor exceptions
+            (:class:`factrix.InsufficientSampleError`) and metric-internal
+            short-circuits are converted to short-circuit
+            ``MetricOutput`` entries inside the bundle, **not** raised.
+
+    Example:
+        >>> import factrix as fx
+        >>> cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
+        >>> bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+        >>> bundle["ic"].value           # dict-style access
+        >>> bundle.to_frame()            # long-form pl.DataFrame
+        >>> dict(bundle.skipped)         # what we could not auto-run
+    """
+    missing = {"date", "asset_id", factor_col, "forward_return"} - set(panel.columns)
+    if missing:
+        hint = (
+            "factrix.preprocess.compute_forward_return(panel) attaches forward_return"
+            if "forward_return" in missing
+            else f"add column(s) {sorted(missing)!r} to the panel"
+        )
+        _raise_factor_col_error(
+            value=factor_col,
+            expected=(
+                f"panel with canonical columns "
+                f"{{date, asset_id, {factor_col!r}, forward_return}}; "
+                f"missing {sorted(missing)!r} ({hint})"
+            ),
+        )
+
+    if metrics is not None and not metrics:
+        raise UserInputError(
+            verb="run_metrics",
+            field="metrics",
+            value=metrics,
+            expected=(
+                "a non-empty list of metric names, or None for "
+                "auto-discover. An empty list is rejected to surface "
+                "upstream filter mistakes that would otherwise produce "
+                "an empty bundle silently."
+            ),
+            docs_path="api/run_metrics#metrics",
+        )
+
+    if factor_col != "factor":
+        if factor_col not in panel.columns:
+            _raise_factor_col_error(
+                value=factor_col,
+                expected=f"a column on panel; got columns {list(panel.columns)!r}",
+            )
+        if "factor" in panel.columns:
+            _raise_factor_col_error(
+                value=factor_col,
+                expected=(
+                    "panel without an existing 'factor' column when "
+                    "factor_col != 'factor' (drop the unused column "
+                    "before calling)"
+                ),
+            )
+        panel = panel.rename({factor_col: "factor"})
+
+    candidates = _candidate_metric_names(cfg.scope, cfg.signal)
+    runnable = [m for m in candidates if m not in _AUTO_DISCOVER_EXCLUDED]
+    excluded_reasons = {
+        m: _AUTO_DISCOVER_EXCLUDED[m]
+        for m in candidates
+        if m in _AUTO_DISCOVER_EXCLUDED
+    }
+
+    if metrics is None:
+        targets = runnable
+    else:
+        seen: set[str] = set()
+        targets = []
+        for name in metrics:
+            if name in seen:
+                continue
+            seen.add(name)
+            if name in runnable:
+                targets.append(name)
+                continue
+            if name in excluded_reasons:
+                raise UserInputError(
+                    verb="run_metrics",
+                    field="metrics",
+                    value=name,
+                    expected=(
+                        f"a metric run_metrics can dispatch directly. "
+                        f"{name!r} is registered for this cell but "
+                        f"requires explicit handling: "
+                        f"{excluded_reasons[name]}"
+                    ),
+                    docs_path="api/run_metrics#explicit-required-kwargs",
+                )
+            raise UserInputError(
+                verb="run_metrics",
+                field="metrics",
+                value=name,
+                candidates=runnable,
+                docs_path="api/run_metrics#metrics",
+            )
+
+    skipped: dict[str, str] = dict(excluded_reasons) if metrics is None else {}
+    results: dict[str, MetricOutput] = {}
+    ic_df: pl.DataFrame | None = None
+
+    import factrix.metrics as _metrics
+
+    for name in targets:
+        fn = getattr(_metrics, name)
+        stage = "consumer"
+        try:
+            if name in _IC_CONSUMERS:
+                if ic_df is None:
+                    stage = "stage1"
+                    ic_df = _metrics.compute_ic(panel)
+                    stage = "consumer"
+                first_arg: pl.DataFrame = ic_df
+            else:
+                first_arg = panel
+            kwargs: dict[str, Any] = {}
+            if _accepts_kwarg(fn, "forward_periods"):
+                kwargs["forward_periods"] = cfg.forward_periods
+            results[name] = fn(first_arg, **kwargs)
+        except InsufficientSampleError as exc:
+            results[name] = _short_circuit_output(
+                name,
+                "insufficient_sample",
+                actual_periods=exc.actual_periods,
+                required_periods=exc.required_periods,
+            )
+        except RunMetricsError:
+            raise
+        except Exception as exc:
+            raise RunMetricsError(
+                f"run_metrics() failed in metric={name!r} "
+                f"(cell={_cell_label(cfg)}, stage={stage}). "
+                f"Likely a factrix bug — please report.",
+                cell=_cell_label(cfg),
+                metric_name=name,
+                stage=stage,
+            ) from exc
+
+    if skipped:
+        _logger.info(
+            "run_metrics(cell=%s, factor_id=%s, fwd=%d): ran=%d skipped=%d (%s)",
+            _cell_label(cfg),
+            factor_col,
+            cfg.forward_periods,
+            len(results),
+            len(skipped),
+            ", ".join(sorted(skipped)),
+        )
+
+    return MetricsBundle(
+        identity=(factor_col, cfg.forward_periods),
+        metrics=MappingProxyType(results),
+        skipped=MappingProxyType(skipped),
+        context=MappingProxyType({}),
+    )

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -204,6 +204,60 @@ below for the full hierarchy + recovery payloads):
 
 ---
 
+### `run_metrics`
+
+```
+factrix.run_metrics(panel: polars.DataFrame, cfg: AnalysisConfig,
+                    *, factor_col: str = "factor",
+                    metrics: list[str] | None = None) -> MetricsBundle
+```
+
+Cell-level descriptive batch runner — the descriptive twin of
+`evaluate`. Same `(panel, cfg)` entry contract; disjoint result type
+(`evaluate` carries the primary inferential `FactorProfile`,
+`run_metrics` carries the cell's descriptive surface as a
+`MetricsBundle`). `metrics=None` auto-discovers via
+`list_metrics(cfg.scope, cfg.signal)` filtered for `panel`-input
+metrics; `metrics=[...]` validates names and raises
+`UserInputError` (with fuzzy suggestion) for unknown / excluded
+entries. v1 wires the IC stage-1 cache (`compute_ic` shared across
+`ic` / `ic_newey_west` / `ic_ir` / `regime_ic`); other stage-1
+consumers (`caar`, `fama_macbeth`, `ts_beta`, `mfe_mae_summary`,
+plus series / spread consumers) appear in `bundle.skipped` with the
+explicit-import recipe. Cross-horizon / cross-universe sweeps go
+through user comprehension into `compare(bundles[])` (descriptive)
+or `bhy(profiles, expand_over=["forward_periods"])` (FDR-controlled).
+Raises `RunMetricsError` (chained `__cause__`) when a metric or the
+stage-1 helper hits an unexpected exception; sample-floor failures
+are converted to short-circuit `MetricOutput` entries inside the
+bundle, not raised.
+
+### `MetricsBundle`
+
+Frozen dataclass produced by `run_metrics`. Identity / context split
+matches `FactorProfile` per #160.
+
+```
+bundle.identity        : tuple[str, int]               # (factor_id, forward_periods)
+bundle.metrics         : Mapping[str, MetricOutput]    # name → output (incl. NaN short-circuits)
+bundle.skipped         : Mapping[str, str]             # name → reason for excluded metrics
+bundle.context         : Mapping[str, Any]             # v1 always {}; populated downstream
+bundle.factor_id       : str                           # identity[0]
+bundle.forward_periods : int                           # identity[1]
+```
+
+Access: `bundle["ic"]` (dict-style); `"ic" in bundle`,
+`list(bundle)`, `iter(bundle)` operate on metric keys.
+`bundle.to_frame()` returns an 8-column long-form `pl.DataFrame`
+(`factor_id, forward_periods, metric, value, stat, significance,
+p_value, short_circuit_reason`) for stable
+`pl.concat([b.to_frame() ...])` across bundles.
+
+`__hash__ = None` — group bundles by `identity` (a hashable tuple),
+not by the bundle itself.
+
+---
+
 ### `FactorProfile`
 
 Frozen dataclass. All fields are read-only.

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -12,6 +12,7 @@
 - [Guides](https://awwesomeman.github.io/factrix/guides/): PANEL vs TIMESERIES, BHY batch screening, choosing a metric
 - [API — AnalysisConfig](https://awwesomeman.github.io/factrix/api/analysis-config/): four factory methods, from_dict / to_dict
 - [API — evaluate](https://awwesomeman.github.io/factrix/api/evaluate/): single-factor dispatch entry point
+- [API — run_metrics](https://awwesomeman.github.io/factrix/api/run-metrics/): cell-level descriptive batch runner — returns MetricsBundle
 - [API — FactorProfile](https://awwesomeman.github.io/factrix/api/factor-profile/): result schema, verdict(), diagnose()
 - [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() FDR-corrected screening
 - [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode / InfoCode / StatCode / Verdict enums

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -66,6 +66,7 @@ from factrix.metrics.ic import (
     compute_ic,
     ic,
     ic_ir,
+    ic_newey_west,
     multi_horizon_ic,
     regime_ic,
 )
@@ -127,6 +128,7 @@ __all__ = [
     "hit_rate",
     "ic",
     "ic_ir",
+    "ic_newey_west",
     "ic_trend",
     "mean_r_squared",
     "mfe_mae_summary",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
       - api/index.md
       - AnalysisConfig: api/analysis-config.md
       - evaluate: api/evaluate.md
+      - run_metrics: api/run-metrics.md
       - by_slice: api/by-slice.md
       - by_regime: api/by-regime.md
       - list_metrics: api/list-metrics.md

--- a/tests/test_run_metrics.py
+++ b/tests/test_run_metrics.py
@@ -1,0 +1,307 @@
+"""``run_metrics`` v1 — IC-cell stage-1 cache + panel-direct metrics (#147)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._analysis_config import AnalysisConfig
+from factrix._axis import Metric
+from factrix._errors import RunMetricsError, UserInputError
+from factrix._metric_index import _AUTO_DISCOVER_EXCLUDED
+from factrix._run_metrics import (
+    _IC_CONSUMERS,
+    MetricsBundle,
+    run_metrics,
+)
+from factrix._types import MetricOutput
+
+
+def _build_panel(
+    *,
+    n_dates: int = 80,
+    n_assets: int = 25,
+    seed: int = 0,
+    factor_strength: float = 0.2,
+) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    start = dt.date(2024, 1, 1)
+    dates = [start + dt.timedelta(days=i) for i in range(n_dates)]
+    rows: list[dict[str, object]] = []
+    for d in dates:
+        fwd = rng.standard_normal(n_assets)
+        noise = rng.standard_normal(n_assets)
+        factor = factor_strength * fwd + (1.0 - factor_strength) * noise
+        price = rng.uniform(50.0, 150.0, n_assets)
+        for j in range(n_assets):
+            rows.append(
+                {
+                    "date": d,
+                    "asset_id": f"A{j:03d}",
+                    "factor": float(factor[j]),
+                    "forward_return": float(fwd[j]),
+                    "price": float(price[j]),
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+@pytest.fixture
+def panel() -> pl.DataFrame:
+    return _build_panel()
+
+
+@pytest.fixture
+def cfg() -> AnalysisConfig:
+    return AnalysisConfig.individual_continuous(metric=Metric.IC)
+
+
+# ---------------------------------------------------------------------------
+# Default auto-discover
+# ---------------------------------------------------------------------------
+
+
+def test_auto_discover_runs_ic_family_and_panel_direct(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    bundle = run_metrics(panel, cfg)
+    assert _IC_CONSUMERS.issubset(set(bundle.metrics))
+    assert "monotonicity" in bundle.metrics
+    assert "turnover" in bundle.metrics
+
+
+def test_auto_discover_skipped_carries_excluded_reasons(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    bundle = run_metrics(panel, cfg)
+    for name, reason in bundle.skipped.items():
+        assert reason == _AUTO_DISCOVER_EXCLUDED[name]
+
+
+def test_auto_discover_skipped_logs_one_summary(
+    panel: pl.DataFrame,
+    cfg: AnalysisConfig,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("INFO", logger="factrix.run_metrics"):
+        run_metrics(panel, cfg)
+    summaries = [r for r in caplog.records if r.name == "factrix.run_metrics"]
+    assert len(summaries) == 1
+    assert "skipped" in summaries[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Explicit metrics= subset
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_subset_runs_only_named(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    bundle = run_metrics(panel, cfg, metrics=["ic", "ic_ir"])
+    assert set(bundle.metrics) == {"ic", "ic_ir"}
+    assert dict(bundle.skipped) == {}
+
+
+def test_explicit_unknown_raises_user_input_error(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    with pytest.raises(UserInputError) as exc_info:
+        run_metrics(panel, cfg, metrics=["icc"])
+    msg = str(exc_info.value)
+    assert "ic" in msg
+
+
+def test_explicit_excluded_raises_with_reason(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    with pytest.raises(UserInputError) as exc_info:
+        run_metrics(panel, cfg, metrics=["fama_macbeth"])
+    msg = str(exc_info.value)
+    assert "compute_fm_betas" in msg
+
+
+# ---------------------------------------------------------------------------
+# MetricsBundle access pattern
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_dict_style_access(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    bundle = run_metrics(panel, cfg, metrics=["ic"])
+    assert isinstance(bundle["ic"], MetricOutput)
+    assert "ic" in bundle
+    assert list(bundle) == ["ic"]
+    assert len(bundle) == 1
+
+
+def test_bundle_identity_and_default_context(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    bundle = run_metrics(panel, cfg, factor_col="factor", metrics=["ic"])
+    assert bundle.identity == ("factor", cfg.forward_periods)
+    assert dict(bundle.context) == {}
+
+
+def test_bundle_is_unhashable(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    bundle = run_metrics(panel, cfg, metrics=["ic"])
+    with pytest.raises(TypeError):
+        hash(bundle)
+
+
+def test_bundle_repr_html_smoke(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    bundle = run_metrics(panel, cfg)
+    html = bundle._repr_html_()
+    assert "MetricsBundle" in html
+    assert "ic" in html
+    assert "skipped" in html  # the bundle has skipped entries by default
+
+
+# ---------------------------------------------------------------------------
+# to_frame schema
+# ---------------------------------------------------------------------------
+
+_TO_FRAME_SCHEMA = {
+    "factor_id": pl.String,
+    "forward_periods": pl.Int64,
+    "metric": pl.String,
+    "value": pl.Float64,
+    "stat": pl.Float64,
+    "significance": pl.String,
+    "p_value": pl.Float64,
+    "short_circuit_reason": pl.String,
+}
+
+
+def test_to_frame_schema_is_stable(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    bundle = run_metrics(panel, cfg, metrics=["ic"])
+    frame = bundle.to_frame()
+    assert dict(frame.schema) == _TO_FRAME_SCHEMA
+    assert frame.height == 1
+
+
+def test_to_frame_empty_bundle_keeps_schema() -> None:
+    empty = MetricsBundle(identity=("f", 5))
+    frame = empty.to_frame()
+    assert dict(frame.schema) == _TO_FRAME_SCHEMA
+    assert frame.height == 0
+
+
+def test_to_frame_short_circuit_metric_appears_with_reason() -> None:
+    sc_output = MetricOutput(
+        name="ic",
+        value=float("nan"),
+        stat=None,
+        significance="",
+        metadata={"reason": "insufficient_ic_periods", "p_value": 1.0},
+    )
+    bundle = MetricsBundle(identity=("f", 5), metrics={"ic": sc_output})
+    frame = bundle.to_frame()
+    assert frame.height == 1
+    row = frame.row(0, named=True)
+    assert row["short_circuit_reason"] == "insufficient_ic_periods"
+    assert np.isnan(row["value"])
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 cache
+# ---------------------------------------------------------------------------
+
+
+def test_stage1_compute_ic_called_once_for_ic_family(
+    panel: pl.DataFrame, cfg: AnalysisConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import factrix.metrics as metrics_pkg
+
+    counter = {"n": 0}
+    real_compute_ic = metrics_pkg.compute_ic
+
+    def counting_compute_ic(*args: object, **kwargs: object) -> pl.DataFrame:
+        counter["n"] += 1
+        return real_compute_ic(*args, **kwargs)
+
+    monkeypatch.setattr(metrics_pkg, "compute_ic", counting_compute_ic)
+    run_metrics(
+        panel,
+        cfg,
+        metrics=["ic", "ic_newey_west", "ic_ir", "regime_ic"],
+    )
+    assert counter["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Error strategy A / B / C
+# ---------------------------------------------------------------------------
+
+
+def test_class_a_short_circuit_keeps_other_metrics(
+    cfg: AnalysisConfig,
+) -> None:
+    # Tiny panel with too few periods for IC's non-overlap test.
+    tiny = _build_panel(n_dates=5, n_assets=12)
+    bundle = run_metrics(tiny, cfg, metrics=["ic", "monotonicity"])
+    ic_out = bundle["ic"]
+    assert ic_out.metadata.get("reason", "").startswith(("insufficient", "no_"))
+    assert "monotonicity" in bundle.metrics
+
+
+def test_class_c_unexpected_exception_wrapped(
+    panel: pl.DataFrame,
+    cfg: AnalysisConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise KeyError("unexpected")
+
+    monkeypatch.setattr("factrix.metrics.monotonicity", boom)
+    with pytest.raises(RunMetricsError) as exc_info:
+        run_metrics(panel, cfg, metrics=["monotonicity"])
+    assert exc_info.value.metric_name == "monotonicity"
+    assert exc_info.value.cell == "individual/continuous"
+    assert exc_info.value.stage == "consumer"
+    assert isinstance(exc_info.value.__cause__, KeyError)
+
+
+# ---------------------------------------------------------------------------
+# factor_col rename path
+# ---------------------------------------------------------------------------
+
+
+def test_factor_col_renames_and_stamps_identity(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    renamed = panel.rename({"factor": "momentum_12_1"})
+    bundle = run_metrics(renamed, cfg, factor_col="momentum_12_1", metrics=["ic"])
+    assert bundle.identity == ("momentum_12_1", cfg.forward_periods)
+
+
+def test_factor_col_missing_raises_user_input_error(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    with pytest.raises(UserInputError):
+        run_metrics(panel, cfg, factor_col="nonexistent", metrics=["ic"])
+
+
+def test_missing_forward_return_raises_actionable_error(
+    cfg: AnalysisConfig,
+) -> None:
+    panel_no_fwd = _build_panel().drop("forward_return")
+    with pytest.raises(UserInputError) as exc_info:
+        run_metrics(panel_no_fwd, cfg, metrics=["ic"])
+    assert "compute_forward_return" in str(exc_info.value)
+
+
+def test_empty_metrics_list_rejected(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    with pytest.raises(UserInputError) as exc_info:
+        run_metrics(panel, cfg, metrics=[])
+    assert "non-empty" in str(exc_info.value)
+
+
+def test_factor_col_collision_raises_user_input_error(
+    panel: pl.DataFrame, cfg: AnalysisConfig
+) -> None:
+    # both 'factor' (already present) and a new candidate column
+    panel_with_alias = panel.with_columns(pl.col("factor").alias("alt"))
+    with pytest.raises(UserInputError):
+        run_metrics(panel_with_alias, cfg, factor_col="alt", metrics=["ic"])


### PR DESCRIPTION
## Summary

- Add `run_metrics(panel, cfg) -> MetricsBundle`, the descriptive twin of `evaluate`. Same `(panel, cfg)` entry contract; disjoint result type. Auto-discovers panel-input metrics for the cell and shares one `compute_ic` across the IC family.
- New `MetricsBundle`: dict-style access, stable 8-column `to_frame()`, identity / context split per #160, explicit `skipped` map, `__hash__ = None`.
- New `RunMetricsError` (chained `__cause__`) for unexpected metric bugs; sample-floor failures become short-circuit `MetricOutput` entries; user-input mistakes raise `UserInputError` per #165.
- `_AUTO_DISCOVER_EXCLUDED` carries explicit-call recipes for stage-1 consumers (caar, fama_macbeth, ts_beta, mfe_mae_summary, series / spread consumers) deferred to v1.x; `multi_horizon_*` exclusion tracks #186 deprecation.
- Pre-flight schema check catches the common "forgot `compute_forward_return`" case with an actionable message.
- Docs: `docs/api/run-metrics.md` + nav + `llms.txt` / `llms-full.txt` entries.

Cross-horizon stays in `bhy(expand_over=["forward_periods"])` / `compare(bundles)` per #160 anti-shopping defense — no horizon helper on `run_metrics` itself.

## Test plan

- [x] `pytest tests/test_run_metrics.py` — 21 cases (auto-discover / explicit subset / unknown raise / excluded raise / dict-style access / unhashable / `_repr_html_` smoke / `to_frame` schema incl. empty + short-circuit / stage-1 cache counter / class A+C error paths / `factor_col` rename + missing + collision / missing `forward_return` / empty `metrics=[]`)
- [x] Full suite: `pytest` — 975 passed
- [x] `ruff check factrix/ tests/` — clean
- [x] Smoke: open a notebook, call `fx.run_metrics(panel, cfg)`, render `bundle._repr_html_()` (Jupyter only)

## Reviews applied

Simplify backend (3 agents) + quant UX review:
- `@functools.cache` on `all_rows` / `user_facing_rows`
- Drop `importlib` indirection; hoist `factrix.metrics` ref out of dispatch loop
- Extract `_raise_factor_col_error` helper
- Make stage detection explicit (set `stage="stage1"` around `compute_ic` call) instead of `not ic_df_cache`-coupled
- Pre-flight schema check + actionable hint for missing `forward_return`
- Tighten series-consumer explicit-call recipes in `_AUTO_DISCOVER_EXCLUDED` (include the `rename({col: 'value'})` shape)
- Reject empty `metrics=[]` to surface upstream filter mistakes
- Docs: evaluate-vs-run_metrics mini table; factor_col-collision warning for sweep loops; rationale for no horizon helper

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)