### PR TITLE
chore(devx): add scripts/setup_dev.py for .githooks/ activation (#196)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Quick-start guide. Full contributing reference: **[docs/development/contributing
 git clone https://github.com/awwesomeman/factrix.git
 cd factrix
 uv sync --extra dev
-git config core.hooksPath .githooks
-uv run pytest    # must be green before committing
+python scripts/setup_dev.py   # activate .githooks/ (per-clone, idempotent)
+uv run pytest                 # must be green before committing
 ```
 
 ## Development cycle

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -98,12 +98,18 @@ uv lock --upgrade    # upgrade lock to the latest within current pyproject const
 Run once after a fresh clone:
 
 ```bash
-git config core.hooksPath .githooks
+python scripts/setup_dev.py
 ```
 
-This config is per-clone and local—it does not propagate across
-machines, so every clone / new machine must run it once. After that,
-all hooks below activate automatically; no per-hook install needed.
+The script sets `git config core.hooksPath .githooks`. Idempotent —
+re-running is a no-op; aborts (non-zero exit) if `core.hooksPath` is
+already pointed at a different path so a contributor's dotfiles-
+managed hook surface is not silently overwritten. The setting is
+per-clone and local; it does not propagate across machines, so every
+clone / new machine must run the script once. `git worktree`
+instances share `.git/config` with their primary clone, so one run at
+the primary clone covers every worktree under it. After activation,
+all hooks below run automatically; no per-hook install needed.
 
 `pre-commit` — when staged changes include `*.py`, runs `ruff check`
 + `ruff format --check` (mirrors CI's `lint` job). Fail → blocks the

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -1,0 +1,90 @@
+"""One-time local dev setup — point Git at the repo-tracked hooks.
+
+Sets ``core.hooksPath`` to ``.githooks`` so the version-controlled
+pre-commit / pre-push scripts run automatically. The setting is
+per-clone and does not travel with ``git clone``; ``git worktree``
+instances share ``.git/config`` with the primary clone, so one run
+covers every worktree under it.
+
+Idempotent: re-running is a no-op. Aborts (non-zero exit) if
+``core.hooksPath`` is already set to a different path so a
+contributor's dotfiles-managed hook surface is not silently
+overwritten.
+
+Usage::
+
+    python scripts/setup_dev.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_TARGET_PATH = ".githooks"
+
+
+def _run_git(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=check)
+
+
+def _git_config_get(key: str) -> str | None:
+    """Return the value of a git config key, or ``None`` if unset."""
+    result = _run_git("config", "--get", key)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def main() -> int:
+    try:
+        repo_check = _run_git("rev-parse", "--git-dir")
+    except FileNotFoundError:
+        print(
+            "[setup_dev] ERROR: 'git' not found in PATH. "
+            "Install Git, or run this script from a shell where git is available.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if repo_check.returncode != 0:
+        print(
+            "[setup_dev] ERROR: not inside a Git working tree. "
+            "Run this script from the factrix clone root.",
+            file=sys.stderr,
+        )
+        return 1
+
+    current = _git_config_get("core.hooksPath")
+
+    if current == _TARGET_PATH:
+        print(
+            f"[setup_dev] core.hooksPath already set to {_TARGET_PATH!r}; nothing to do."
+        )
+        return 0
+
+    if current is not None:
+        print(
+            f"[setup_dev] ERROR: core.hooksPath is already set to {current!r}, "
+            f"not {_TARGET_PATH!r}.",
+            file=sys.stderr,
+        )
+        print(
+            "[setup_dev] Refusing to overwrite a contributor-managed hook path. "
+            "If you want this clone to use the repo hooks, run "
+            "`git config --unset core.hooksPath` then re-run this script.",
+            file=sys.stderr,
+        )
+        return 1
+
+    _run_git("config", "core.hooksPath", _TARGET_PATH, check=True)
+    print(
+        f"[setup_dev] core.hooksPath -> {_TARGET_PATH}. "
+        "Hooks in .githooks/ are now active for this clone "
+        "(and any worktree sharing its .git/config)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `scripts/setup_dev.py` — idempotent Python script that runs `git config core.hooksPath .githooks`, with a no-op path when already set and a hard abort when pointed elsewhere (so contributors' dotfiles-managed hook surfaces stay intact).
- Update `CONTRIBUTING.md` and `docs/development/contributing.md` to call the script instead of the raw `git config` line; add a note that the setting is per-clone and that `git worktree` instances inherit it via shared `.git/config`.
- Stop-gap by design — #197 will migrate to the `pre-commit` framework; this PR deliberately does not touch `.githooks/pre-commit` or introduce `.pre-commit-config.yaml`.

## Test plan

- [x] Fresh state (`git config --unset core.hooksPath`) → `python scripts/setup_dev.py` → activates and prints confirmation
- [x] Re-run → idempotent no-op, exit 0
- [x] `git config core.hooksPath custom/path` → script aborts with non-zero exit and a clear resolution message
- [x] After activation, the hook fires on this very PR's commit (visible in the local commit log: `[pre-commit] ruff check ... [pre-commit] ruff format --check ...`)
- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest` — 1025 passed

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)