### PR TITLE
refactor(metrics): deprecate multi_horizon_* (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
   Downstream consumers of `profile.diagnose()` JSON: the `stats` sub-dict's keys move from `"ic_p"` / `"ic_mean"` / `"caar_p"` / etc. to flat `"p"` / `"mean"` / `"t_nw"`. Filtering / dashboard code that reads keys by their old metric-prefixed string needs the same rename map applied to its own logic. (#187)
 
+### Deprecated
+
+- **`factrix.metrics.multi_horizon_ic` / `multi_horizon_hit_rate`** — sweeping IC / hit-rate across `[1, 5, 10, 20]` forward periods is a dispatcher concern, not a per-cell metric. The in-metric horizon loop conflicted with `FactorProfile.identity` carrying `forward_periods` (#160 anti-shopping defense) and ran a second BHY path inside the metric (`metadata["p_adjusted_bhy"]`) parallel to `multi_factor.bhy(profiles, expand_over=["forward_periods"])`, the FDR SSOT. Both functions remain importable and runnable for one release cycle but emit `DeprecationWarning` on call and are excluded from `list_metrics` output (`_metric_index._DEPRECATED`). `run_metrics` auto-discover already skipped them via `_AUTO_DISCOVER_EXCLUDED` (per #147). Migration: `run_metrics(panel, cfg.replace(forward_periods=h))` per horizon → `compare(bundles)` for descriptive horizon-by-metric view, or `evaluate(...)` per horizon → `multi_factor.bhy(profiles, expand_over=["forward_periods"])` for FDR-controlled inference. Both paths are metric-agnostic — `mfe_mae` / `caar` / `oos` / `monotonicity` inherit horizon-sweep support automatically. Recipes in `docs/api/multi-horizon.md`. Removal version pinned at the next major-bump release-train. (#186)
+
 ### Removed
 
 - **`factrix.multi_factor.bhy(p_stat=StatCode)` path** — replaced by `estimator=Estimator` (see Changed above). (#170)

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -1,0 +1,95 @@
+# Multi-horizon analysis
+
+`factrix.metrics.multi_horizon_ic` and `factrix.metrics.multi_horizon_hit_rate`
+are deprecated. Both functions remain importable and runnable for one
+release cycle, but they emit `DeprecationWarning` on call and no longer
+appear in [`list_metrics`](list-metrics.md) output.
+
+## Why the deprecation
+
+Sweeping a metric across `[1, 5, 10, 20]` forward periods is a
+**dispatcher** concern, not a per-cell metric: it fans the same
+underlying metric across a horizon axis exactly the way
+[`by_regime`](by-regime.md) / [`by_slice`](by-slice.md) fan across a
+date or label axis. Burying the horizon loop inside a metric callable
+created three structural problems:
+
+1. **Cross-cuts the metric registry.** The horizon loop produces one
+   `MetricOutput` aggregating `k` horizons, but the registry is keyed
+   per `(scope, signal, metric)` — so a horizon-loop result has to
+   pretend to be a single metric, hiding the loop in `metadata`.
+2. **Conflicts with the identity-as-family contract** ([#160][i160]).
+   `FactorProfile.identity` carries `forward_periods` precisely to make
+   horizon shopping explicit at the FDR layer; `multi_horizon_*`
+   collapsed `k` horizons into one identity entry, defeating that
+   defense.
+3. **Two BHY paths.** `multi_horizon_ic` ran its own internal BHY
+   adjustment and wrote `metadata["p_adjusted_bhy"]`. The family-verb
+   layer (`multi_factor.bhy(profiles, expand_over=["forward_periods"])`)
+   is the single source of truth for FDR control across horizons.
+
+The dispatcher framing also lets future descriptive metrics
+(`mfe_mae`, `caar`, `oos`, `monotonicity`, ...) inherit horizon-sweep
+support automatically; the previous shape special-cased IC and
+hit-rate.
+
+## Migration recipes
+
+### Descriptive sweep — looking at horizon-by-metric magnitudes
+
+Use [`run_metrics`](run-metrics.md) per horizon and assemble a long
+horizon × metric table from each bundle's `.to_frame()`. No FDR claim
+is made.
+
+```python
+import factrix as fx
+import polars as pl
+
+cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
+horizons = [1, 5, 10, 20]
+bundles = [
+    fx.run_metrics(panel, cfg.replace(forward_periods=h), factor_col="mom_12_1")
+    for h in horizons
+]
+table = pl.concat([b.to_frame() for b in bundles])  # long-form: horizon x metric
+```
+
+Every metric the cell exposes — not just IC — gets a horizon view
+through this single call. A higher-level `compare(bundles)` verb that
+pivots this long-form table is tracked in #148 as a follow-up; today
+the `pl.concat` recipe above is the supported path.
+
+### Inferential sweep — controlling FDR across horizons
+
+Use [`evaluate`](evaluate.md) per horizon and
+[`multi_factor.bhy`][bhy] with `expand_over=["forward_periods"]`. The
+family-verb layer partitions the BHY null per horizon (and per any
+other declared `expand_over` key) so the step-up threshold is correct.
+
+```python
+import factrix as fx
+
+cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
+profiles = [
+    fx.evaluate(panel, cfg.replace(forward_periods=h))
+    for h in horizons
+]
+survivors = fx.multi_factor.bhy(
+    profiles,
+    expand_over=["forward_periods"],
+)
+```
+
+`survivors.profiles` carries the kept rows; `survivors.adj_q` carries
+the bucket-local BHY-adjusted p-values.
+
+## Removal timeline
+
+Removal lands in a future major-bump release-train. The exact version
+is fixed at bump time — see the `BUMP-TIME` markers in
+`factrix/metrics/ic.py` and `factrix/metrics/event_horizon.py`.
+Tracked in [#186][i186].
+
+[i160]: https://github.com/awwesomeman/factrix/issues/160
+[i186]: https://github.com/awwesomeman/factrix/issues/186
+[bhy]: multi-factor.md

--- a/docs/reference/_generated_metric_matrix.md
+++ b/docs/reference/_generated_metric_matrix.md
@@ -5,10 +5,12 @@
 | [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) |
 | [`metrics.corrado`][factrix.metrics.corrado] | `(*, SPARSE, *, PANEL)` | per-event | nonparametric rank |
 | [`metrics.event_horizon`][factrix.metrics.event_horizon] | `(*, SPARSE, *, PANEL)` | per-event | binomial |
+| [`metrics.event_horizon`][factrix.metrics.event_horizon] | `(*, SPARSE, *, PANEL)` | per-event | binomial [deprecated] |
 | [`metrics.event_quality`][factrix.metrics.event_quality] | `(*, SPARSE, *, PANEL)` | per-event | binomial / nonparametric rank |
 | [`metrics.fama_macbeth`][factrix.metrics.fama_macbeth] | `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | cs-first | NW HAC / clustered t |
 | [`metrics.hit_rate`][factrix.metrics.hit_rate] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | binomial |
 | [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | cs-first | NW HAC / cross-asset t |
+| [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | cs-first | NW HAC / cross-asset t [deprecated] |
 | [`metrics.mfe_mae`][factrix.metrics.mfe_mae] | `(*, SPARSE, *, PANEL)` | per-event | no formal H₀ |
 | [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
 | [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | no formal H₀ |

--- a/docs/reference/_generated_metric_name_index.md
+++ b/docs/reference/_generated_metric_name_index.md
@@ -21,8 +21,6 @@
 | `mean_r_squared` | `mean_r_squared` | [`factrix.metrics.ts_beta`][factrix.metrics.ts_beta] | [`mean_r_squared`](../api/metrics/ts_beta.md#factrix.metrics.ts_beta.mean_r_squared) |
 | `mfe_mae_summary` | `mfe_mae_summary` | [`factrix.metrics.mfe_mae`][factrix.metrics.mfe_mae] | [`mfe_mae_summary`](../api/metrics/mfe_mae.md#factrix.metrics.mfe_mae.mfe_mae_summary) |
 | `monotonicity` | `monotonicity` | [`factrix.metrics.monotonicity`][factrix.metrics.monotonicity] | [`monotonicity`](../api/metrics/monotonicity.md#factrix.metrics.monotonicity.monotonicity) |
-| `multi_horizon_hit_rate` | `multi_horizon_hit_rate` | [`factrix.metrics.event_horizon`][factrix.metrics.event_horizon] | [`multi_horizon_hit_rate`](../api/metrics/event_horizon.md#factrix.metrics.event_horizon.multi_horizon_hit_rate) |
-| `multi_horizon_ic` | `multi_horizon_ic` | [`factrix.metrics.ic`][factrix.metrics.ic] | [`multi_horizon_ic`](../api/metrics/ic.md#factrix.metrics.ic.multi_horizon_ic) |
 | `net_spread` | `net_spread` | [`factrix.metrics.tradability`][factrix.metrics.tradability] | [`net_spread`](../api/metrics/tradability.md#factrix.metrics.tradability.net_spread) |
 | `notional_turnover` | `notional_turnover` | [`factrix.metrics.tradability`][factrix.metrics.tradability] | [`notional_turnover`](../api/metrics/tradability.md#factrix.metrics.tradability.notional_turnover) |
 | `oos_decay` | `multi_split_oos_decay` | [`factrix.metrics.oos`][factrix.metrics.oos] | [`multi_split_oos_decay`](../api/metrics/oos.md#factrix.metrics.oos.multi_split_oos_decay) |

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -60,7 +60,6 @@ Min sample*. `MIN_*` constants resolve to values in the
 | [`ic_newey_west`][factrix.metrics.ic.ic_newey_west] | `T` (full series) | `T ≥ MIN_ASSETS_PER_DATE_IC` |
 | [`ic_ir`][factrix.metrics.ic.ic_ir] | `T` | `T ≥ MIN_ASSETS_PER_DATE_IC` |
 | [`regime_ic`][factrix.metrics.ic.regime_ic] | `T` per regime | per-regime `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`multi_horizon_ic`][factrix.metrics.ic.multi_horizon_ic] | `T` per horizon | per-horizon `T/h ≥ MIN_ASSETS_PER_DATE_IC` |
 
 ### FM family — Cell: Individual × Continuous
 
@@ -98,7 +97,6 @@ Min sample*. `MIN_*` constants resolve to values in the
 | [`event_skewness`][factrix.metrics.event_quality.event_skewness] | `K` | `K ≥ MIN_EVENTS_HARD` |
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | `K` | `K ≥ 2` |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | per-offset `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`multi_horizon_hit_rate`][factrix.metrics.event_horizon.multi_horizon_hit_rate] | per-horizon `K` | `K ≥ MIN_EVENTS_HARD` |
 | [`mfe_mae_summary`][factrix.metrics.mfe_mae.mfe_mae_summary] | `K` | `K ≥ MIN_EVENTS_HARD`; `price` column required |
 | [`clustering_diagnostic`][factrix.metrics.clustering.clustering_diagnostic] | `K`, `N` | `N ≥ 2`; `K ≥ MIN_EVENTS_HARD` |
 | [`corrado_rank_test`][factrix.metrics.corrado.corrado_rank_test] | `K` × estimation window | `K ≥ MIN_EVENTS_HARD`; per-asset `T ≥ 30` |

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -76,6 +76,14 @@ _INFRASTRUCTURE: frozenset[str] = frozenset({"by_regime", "by_slice"})
 """Cross-cutting dispatchers published from ``factrix.metrics`` that
 are not per-(scope, signal) cell metrics."""
 
+# Deprecated metrics: still callable from ``factrix.metrics`` for one
+# release cycle but excluded from the user-facing surface
+# (``list_metrics`` / applicability table) so new callers do not adopt
+# them. ``run_metrics`` auto-discover exclusion lives on
+# ``_AUTO_DISCOVER_EXCLUDED`` (orthogonal axis: that set also covers
+# stage-1 consumers which remain user-facing).
+_DEPRECATED: frozenset[str] = frozenset({"multi_horizon_ic", "multi_horizon_hit_rate"})
+
 # Scalar-input metrics: pre-aggregated-scalar utilities that consume
 # scalars (``gross_spread: float``, ``turnover: float``, ...) rather
 # than the standard ``(date-keyed DataFrame, **kwargs) -> MetricOutput``
@@ -371,6 +379,6 @@ def all_rows() -> list[MetricRow]:
 
 @functools.cache
 def user_facing_rows() -> list[MetricRow]:
-    """Return parsed rows excluding stage-1 helpers and cross-cutting infra."""
-    excluded = _STAGE1_HELPERS | _INFRASTRUCTURE
+    """Return parsed rows excluding stage-1 helpers, cross-cutting infra, and deprecated metrics."""
+    excluded = _STAGE1_HELPERS | _INFRASTRUCTURE | _DEPRECATED
     return [r for r in all_rows() if r.name not in excluded]

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -553,6 +553,10 @@ sits outside `config`.
 
 ---
 
+## Deprecations
+
+- **`factrix.metrics.multi_horizon_ic` / `multi_horizon_hit_rate`** (#186). Horizon sweeping is a dispatcher concern, not a per-cell metric: the in-metric horizon loop conflicted with the family-keyed FDR layer (`bhy(expand_over=["forward_periods"])`) and with the identity-as-family contract (`FactorProfile.identity` carries `forward_periods`). Both functions still import and run for one release cycle; calls emit `DeprecationWarning` and the names are excluded from `list_metrics` output. Migration: `run_metrics(panel, cfg.replace(forward_periods=h))` per horizon → `compare(bundles)` for descriptive view, or `evaluate(...)` per horizon → `multi_factor.bhy(profiles, expand_over=["forward_periods"])` for FDR-controlled inference. Recipes in [docs/api/multi-horizon.md](https://awwesomeman.github.io/factrix/api/multi-horizon/).
+
 ## Links
 
 - Docs: https://awwesomeman.github.io/factrix/

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -13,6 +13,7 @@
 - [API — AnalysisConfig](https://awwesomeman.github.io/factrix/api/analysis-config/): four factory methods, from_dict / to_dict
 - [API — evaluate](https://awwesomeman.github.io/factrix/api/evaluate/): single-factor dispatch entry point
 - [API — run_metrics](https://awwesomeman.github.io/factrix/api/run-metrics/): cell-level descriptive batch runner — returns MetricsBundle
+- [API — Multi-horizon](https://awwesomeman.github.io/factrix/api/multi-horizon/): deprecation of multi_horizon_* with run_metrics + compare / evaluate + bhy(expand_over=) migration recipes
 - [API — FactorProfile](https://awwesomeman.github.io/factrix/api/factor-profile/): result schema, verdict(), diagnose()
 - [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() FDR-corrected screening
 - [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode / InfoCode / StatCode / Verdict enums

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -13,10 +13,13 @@ Metrics:
     event_around_return   — return profile summary at each offset
     multi_horizon_hit_rate — win rate at multiple holding periods
 
-Matrix-row: compute_event_returns, event_around_return, multi_horizon_hit_rate | (*, SPARSE, *, PANEL) | per-event | binomial | _short_circuit_output, _significance_marker
+Matrix-row: compute_event_returns, event_around_return | (*, SPARSE, *, PANEL) | per-event | binomial | _short_circuit_output, _significance_marker
+Matrix-row: multi_horizon_hit_rate | (*, SPARSE, *, PANEL) | per-event | binomial [deprecated] | _short_circuit_output, _significance_marker
 """
 
 from __future__ import annotations
+
+import warnings as _warnings
 
 import numpy as np
 import polars as pl
@@ -245,6 +248,14 @@ def multi_horizon_hit_rate(
 ) -> MetricOutput:
     """Win rate at multiple holding periods.
 
+    .. deprecated::
+        Horizon sweeping is a dispatcher concern, not a per-cell metric.
+        Use ``run_metrics(panel, cfg.replace(forward_periods=h))`` per
+        horizon and ``compare(bundles)`` for descriptive view, or
+        ``evaluate(...)`` per horizon and
+        ``multi_factor.bhy(profiles, expand_over=["forward_periods"])``
+        for FDR-controlled inference. Removal tracked in #186.
+
     Answers: "how long do you need to hold for the signal to work?"
 
     For each horizon, computes the fraction of events where the
@@ -271,6 +282,18 @@ def multi_horizon_hit_rate(
         across horizons is left to the caller (the appropriate set of
         sweeps is application-specific).
     """
+    # BUMP-TIME: pin the SemVer cutoff in this string before the next
+    # bump (e.g. "removed in v0.12.0"). Mirror in CHANGELOG `### Deprecated`.
+    _warnings.warn(
+        "multi_horizon_hit_rate is deprecated and will be removed in a "
+        "future release; use run_metrics + compare(bundles[]) for "
+        "descriptive horizon sweep or evaluate + "
+        "bhy(expand_over=['forward_periods']) for FDR-controlled "
+        "inference. See #186.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if horizons is None:
         horizons = [1, 6, 12, 24]
 

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -8,7 +8,8 @@ Input: DataFrame with ``date, asset_id, factor, forward_return``.
 Output: time-indexed IC series (``date, ic``) that can be fed into
 any ``series/`` tool (oos, trend, significance, hit_rate).
 
-Matrix-row: compute_ic, ic, ic_newey_west, ic_ir, regime_ic, multi_horizon_ic | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output
+Matrix-row: compute_ic, ic, ic_newey_west, ic_ir, regime_ic | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output
+Matrix-row: multi_horizon_ic | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t [deprecated] | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output
 """
 
 from __future__ import annotations
@@ -498,6 +499,14 @@ def multi_horizon_ic(
 ) -> MetricOutput:
     """Compute mean IC at multiple forward horizons.
 
+    .. deprecated::
+        Horizon sweeping is a dispatcher concern, not a per-cell metric.
+        Use ``run_metrics(panel, cfg.replace(forward_periods=h))`` per
+        horizon and ``compare(bundles)`` for descriptive view, or
+        ``evaluate(...)`` per horizon and
+        ``multi_factor.bhy(profiles, expand_over=["forward_periods"])``
+        for FDR-controlled inference. Removal tracked in #186.
+
     Args:
         df: Preprocessed panel with ``date``, ``asset_id``, ``close``,
             and ``factor`` columns. Output of ``preprocess_cs_factor``.
@@ -527,6 +536,17 @@ def multi_horizon_ic(
         [Hansen-Hodrick 1980][hansen-hodrick-1980]: per-horizon overlap
         rule motivating the per-horizon stride.
     """
+    # BUMP-TIME: pin the SemVer cutoff in this string before the next
+    # bump (e.g. "removed in v0.12.0"). Mirror in CHANGELOG `### Deprecated`.
+    _warnings.warn(
+        "multi_horizon_ic is deprecated and will be removed in a future "
+        "release; use run_metrics + compare(bundles[]) for descriptive "
+        "horizon sweep or evaluate + bhy(expand_over=['forward_periods']) "
+        "for FDR-controlled inference. See #186.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if periods is None:
         periods = [1, 5, 10, 20]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
       - AnalysisConfig: api/analysis-config.md
       - evaluate: api/evaluate.md
       - run_metrics: api/run-metrics.md
+      - Multi-horizon: api/multi-horizon.md
       - by_slice: api/by-slice.md
       - by_regime: api/by-regime.md
       - list_metrics: api/list-metrics.md

--- a/tests/test_deprecated_multi_horizon.py
+++ b/tests/test_deprecated_multi_horizon.py
@@ -1,0 +1,88 @@
+"""Deprecation surface for multi_horizon_* metrics (#186).
+
+Covers the user-facing contract: DeprecationWarning fires on call,
+``list_metrics`` no longer surfaces the deprecated names, and
+``run_metrics`` auto-discover (already covered by #147) keeps skipping
+them via ``_AUTO_DISCOVER_EXCLUDED``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._metric_index import (
+    _AUTO_DISCOVER_EXCLUDED,
+    _DEPRECATED,
+    user_facing_rows,
+)
+from factrix.metrics.event_horizon import multi_horizon_hit_rate
+from factrix.metrics.ic import multi_horizon_ic
+
+
+def _make_panel(
+    n_assets: int = 10,
+    n_dates: int = 200,
+    seed: int = 0,
+) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+    rows = []
+    for a in range(n_assets):
+        price = 100.0
+        for d in dates:
+            ret = rng.normal(0, 0.01)
+            price *= 1 + ret
+            rows.append(
+                {
+                    "date": d,
+                    "asset_id": f"asset_{a}",
+                    "factor": rng.normal(),
+                    "price": price,
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+class TestDeprecationSurface:
+    def test_deprecated_set_contents(self):
+        assert frozenset({"multi_horizon_ic", "multi_horizon_hit_rate"}) == _DEPRECATED
+
+    def test_list_metrics_excludes_deprecated(self):
+        names = {row.name for row in user_facing_rows()}
+        assert "multi_horizon_ic" not in names
+        assert "multi_horizon_hit_rate" not in names
+
+    def test_run_metrics_auto_discover_excludes_deprecated(self):
+        assert "multi_horizon_ic" in _AUTO_DISCOVER_EXCLUDED
+        assert "multi_horizon_hit_rate" in _AUTO_DISCOVER_EXCLUDED
+
+    def test_multi_horizon_ic_emits_deprecation_warning(self):
+        df = _make_panel(seed=1)
+        with pytest.warns(DeprecationWarning, match=r"#186"):
+            multi_horizon_ic(df, periods=[1, 5])
+
+    def test_multi_horizon_hit_rate_emits_deprecation_warning(self):
+        df = _make_panel(seed=2)
+        with pytest.warns(DeprecationWarning, match=r"#186"):
+            multi_horizon_hit_rate(df, horizons=[1, 5])
+
+
+class TestStillCallable:
+    """Deprecated metrics remain importable and runnable for one cycle."""
+
+    def test_imports(self):
+        from factrix.metrics import multi_horizon_hit_rate, multi_horizon_ic
+
+        assert callable(multi_horizon_ic)
+        assert callable(multi_horizon_hit_rate)
+
+    def test_multi_horizon_ic_still_returns_metric_output(self):
+        df = _make_panel(seed=3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = multi_horizon_ic(df, periods=[1, 5])
+        assert result.name == "multi_horizon_ic"

--- a/tests/test_deprecated_multi_horizon.py
+++ b/tests/test_deprecated_multi_horizon.py
@@ -24,27 +24,28 @@ from factrix.metrics.ic import multi_horizon_ic
 
 
 def _make_panel(
-    n_assets: int = 10,
-    n_dates: int = 200,
+    n_assets: int = 2,
+    n_dates: int = 30,
     seed: int = 0,
 ) -> pl.DataFrame:
     rng = np.random.default_rng(seed)
     dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
-    rows = []
+    n = n_assets * n_dates
+    asset_ids = [f"asset_{a}" for a in range(n_assets) for _ in range(n_dates)]
+    date_col = dates * n_assets
+    rets = rng.normal(0, 0.01, size=n)
+    prices = np.empty(n)
     for a in range(n_assets):
-        price = 100.0
-        for d in dates:
-            ret = rng.normal(0, 0.01)
-            price *= 1 + ret
-            rows.append(
-                {
-                    "date": d,
-                    "asset_id": f"asset_{a}",
-                    "factor": rng.normal(),
-                    "price": price,
-                }
-            )
-    return pl.DataFrame(rows)
+        s = a * n_dates
+        prices[s : s + n_dates] = 100.0 * np.cumprod(1 + rets[s : s + n_dates])
+    return pl.DataFrame(
+        {
+            "date": date_col,
+            "asset_id": asset_ids,
+            "factor": rng.normal(size=n),
+            "price": prices,
+        }
+    )
 
 
 class TestDeprecationSurface:
@@ -86,3 +87,10 @@ class TestStillCallable:
             warnings.simplefilter("ignore", DeprecationWarning)
             result = multi_horizon_ic(df, periods=[1, 5])
         assert result.name == "multi_horizon_ic"
+
+    def test_multi_horizon_hit_rate_still_returns_metric_output(self):
+        df = _make_panel(seed=4)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            result = multi_horizon_hit_rate(df, horizons=[1, 5])
+        assert result.name == "multi_horizon_hit_rate"


### PR DESCRIPTION
## Summary

Stage 1 of #186 — deprecates `factrix.metrics.multi_horizon_ic` and `multi_horizon_hit_rate`. Both functions remain importable and runnable for one release cycle but emit `DeprecationWarning` on call and are excluded from `list_metrics` output via the new `_metric_index._DEPRECATED` set. Stage 2 (function removal) lands at the next major-bump release-train.

The in-metric horizon loop conflicted with #160's identity-as-family contract (`FactorProfile.identity` carries `forward_periods` as anti-shopping defense) and ran a second BHY path inside the metric in parallel to `multi_factor.bhy(expand_over=)`, the FDR SSOT. Horizon sweeping is a dispatcher concern (like `by_regime` / `by_slice`), not a per-cell metric.

`run_metrics` auto-discover exclusion already shipped via `_AUTO_DISCOVER_EXCLUDED` in #147; the new `_DEPRECATED` set is orthogonal — it hides from `list_metrics` while `_AUTO_DISCOVER_EXCLUDED` only governs `run_metrics` fan-out.

Migration recipes in `docs/api/multi-horizon.md`:
- Descriptive: `run_metrics(panel, cfg.replace(forward_periods=h))` per horizon → `pl.concat([b.to_frame() for b in bundles])`. A higher-level `compare(bundles)` verb is tracked in #148.
- Inferential: `evaluate(...)` per horizon → `multi_factor.bhy(profiles, expand_over=["forward_periods"])`.

Both paths are metric-agnostic, so future descriptive metrics inherit horizon-sweep support without per-metric special casing.

## Test plan

- [x] `_DEPRECATED` set + `user_facing_rows()` exclusion verified (`tests/test_deprecated_multi_horizon.py::TestDeprecationSurface`)
- [x] `DeprecationWarning` fires on both `multi_horizon_ic` and `multi_horizon_hit_rate` with `#186` in message
- [x] Both functions still callable and return `MetricOutput` with correct `name` field
- [x] `_AUTO_DISCOVER_EXCLUDED` containment preserved (per #147)
- [x] `list_metrics` no longer surfaces deprecated names; applicability table + generated name index regenerated
- [x] CHANGELOG `### Deprecated` entry added between `### Changed` and `### Removed`
- [x] mkdocs nav + llms.txt + llms-full.txt synced
- [x] Full test suite: 1037 passed, ruff clean

Refs #186 (Stage 1 of two; do not auto-close — Stage 2 removal pending)