### PR TITLE
chore(devx): pre-push mkdocs strict check (#201)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,28 +1,41 @@
 #!/usr/bin/env bash
-# pre-push: enforce CHANGELOG polish on release commits.
+# pre-push: enforce CHANGELOG polish on release commits + mkdocs
+# strict build when the push touches docs-relevant paths.
 #
 # When the push includes a ``chore(release): vX.Y.Z`` commit, the
 # corresponding ``## vX.Y.Z`` section in CHANGELOG.md (as committed
 # at that release) must have at least CHANGELOG_MIN_LINES non-blank
-# lines. Bypass with ``git push --no-verify`` when you really mean it.
+# lines.
 #
-# Threshold rationale: cz auto-generated section is ~17 lines; a
-# polished BREAKING release runs 50+. 25 is the cliff between "just
-# bullets" and "has WHY narrative".
+# When the push touches any path that mkdocs cares about
+# (``docs/`` / ``mkdocs.yml`` / ``factrix/`` / ``scripts/`` /
+# ``examples/``, mirroring ``.github/workflows/docs-deploy-dev.yml``),
+# run ``mkdocs build --strict`` so local catches the same drift CI
+# would block on (broken relative link, missing nav target, unresolved
+# cross-ref, generated-file drift). Bypass either gate with
+# ``git push --no-verify`` when you really mean it.
+#
+# Threshold rationale (CHANGELOG): cz auto-generated section is ~17
+# lines; a polished BREAKING release runs 50+. 25 is the cliff between
+# "just bullets" and "has WHY narrative".
 
 set -euo pipefail
 
 CHANGELOG="CHANGELOG.md"
 CHANGELOG_MIN_LINES=${CHANGELOG_MIN_LINES:-25}
 ZERO="0000000000000000000000000000000000000000"
+DOCS_PATH_RE='^(docs/|mkdocs\.yml$|factrix/|scripts/|examples/)'
+
+needs_mkdocs=0
 
 while read -r local_ref local_sha remote_ref remote_sha; do
     [ "$local_sha" = "$ZERO" ] && continue
     if [ "$remote_sha" = "$ZERO" ]; then
-        # New branch — scan all reachable commits.
-        range="$local_sha"
+        # New branch — restrict to commits not yet on any remote so we
+        # do not re-scan ancient history.
+        range_args=("$local_sha" "--not" "--remotes")
     else
-        range="$remote_sha..$local_sha"
+        range_args=("$remote_sha..$local_sha")
     fi
 
     # WHY: process substitution (not pipe) so the loop runs in this
@@ -53,7 +66,31 @@ while read -r local_ref local_sha remote_ref remote_sha; do
                 fi
                 ;;
         esac
-    done < <(git rev-list "$range")
+    done < <(git rev-list "${range_args[@]}")
+
+    # mkdocs path-touched detection — once a qualifying file appears
+    # in any pushed ref the build runs regardless of remaining refs.
+    if [ "$needs_mkdocs" -eq 0 ]; then
+        if git log --name-only --pretty=format: "${range_args[@]}" 2>/dev/null \
+            | grep -qE "$DOCS_PATH_RE"; then
+            needs_mkdocs=1
+        fi
+    fi
 done
+
+if [ "$needs_mkdocs" -eq 1 ]; then
+    tmp=$(mktemp -d)
+    # WHY: ``--site-dir`` to a tempdir keeps the working tree clean
+    # and avoids any race with a running ``mkdocs serve``.
+    trap 'rm -rf "$tmp"' EXIT
+    printf 'pre-push: running mkdocs build --strict (docs-relevant paths touched)...\n' >&2
+    if ! uv run mkdocs build --strict --site-dir "$tmp" >/dev/null 2>&1; then
+        printf '\n' >&2
+        printf 'pre-push blocked: mkdocs build --strict failed.\n' >&2
+        printf 'Re-run for the full error: uv run mkdocs build --strict\n' >&2
+        printf 'Bypass: git push --no-verify\n\n' >&2
+        exit 1
+    fi
+fi
 
 exit 0


### PR DESCRIPTION
## Summary

Closes the local-vs-CI parity gap that let PR #200 push a broken CHANGELOG markdown link through. Extends `.githooks/pre-push` with a path-gated `mkdocs build --strict` so docs strict-mode failures land before `git push` instead of after CI starts.

Path filter mirrors `.github/workflows/docs-deploy-dev.yml` (`docs/` / `mkdocs.yml` / `factrix/` / `scripts/` / `examples/`); pushes that touch none of these stay free.

Rationale for hook over pytest fixture or Makefile is on #201 — short version: pre-push frequency matches the natural enforcement point (push, not commit iteration); keeping mkdocs out of pytest avoids muddling Python unit-test failure signal with docs-build failure signal; the docs CI workflow already lives separately from `test.yml` for exactly this reason.

## Test plan

| # | Check | How | Result |
|---|---|---|---|
| 1 | Bash syntax | `bash -n .githooks/pre-push` | OK |
| 2 | Baseline build | `uv run mkdocs build --strict --site-dir <tmp>` on main | rc=0 (clean baseline; hook would not block) |
| 3 | Negative test (strict catches drift) | Wrote a deliberate broken markdown link to `docs/api/_smoke.md`, ran the same command, cleaned up | rc=1 (gate would block, mkdocs caught it) |
| 4a | Path filter — non-docs commit | `git log --name-only --pretty=format: HEAD~1..HEAD` (this PR's hook commit, only `.githooks/`) against `DOCS_PATH_RE` | no match → would skip mkdocs build |
| 4b | Path filter — docs-relevant commit | Same against `HEAD~2..HEAD~1` (the v0.11.0 release commit, touches `factrix/__init__.py`) | match → would trigger mkdocs build |
| 5 | Hook end-to-end | Simulated a new-branch push via stdin (`local_sha = HEAD`, `remote_sha = ZERO`), this PR's commit only touches `.githooks/` | hook exits 0 silently (correct — path filter excludes `.githooks/`) |
| 6 | Test suite | `python -m pytest tests/ -q` | 1037 passed |

Side effect: the existing CHANGELOG-polish branch's range for new-branch pushes tightens from `git rev-list $local_sha` (walks back to root) to `git rev-list $local_sha --not --remotes` (only new commits). The check is idempotent on released CHANGELOGs so functionally unchanged; just less wasted scanning.

Bypass for either gate: `git push --no-verify` (already documented in the hook's failure message).

Closes #201