### PR TITLE
docs(docstrings): fence Example code blocks for mkdocstrings rendering

### DIFF
--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -314,12 +314,15 @@ def run_metrics(
             ``MetricOutput`` entries inside the bundle, **not** raised.
 
     Example:
-        >>> import factrix as fx
-        >>> cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
-        >>> bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
-        >>> bundle["ic"].value           # dict-style access
-        >>> bundle.to_frame()            # long-form pl.DataFrame
-        >>> dict(bundle.skipped)         # what we could not auto-run
+        ```python
+        import factrix as fx
+
+        cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
+        bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+        bundle["ic"].value           # dict-style access
+        bundle.to_frame()            # long-form pl.DataFrame
+        dict(bundle.skipped)         # what we could not auto-run
+        ```
     """
     missing = {"date", "asset_id", factor_col, "forward_return"} - set(panel.columns)
     if missing:

--- a/factrix/metrics/_slice.py
+++ b/factrix/metrics/_slice.py
@@ -95,10 +95,13 @@ def by_slice(
         ValueError: ``label`` not in ``df.columns``, or ``df`` is empty.
 
     Example:
-        >>> import polars as pl
-        >>> from factrix.metrics import by_slice, ic, compute_ic
-        >>> ic_df = compute_ic(panel)              # already has 'sector'
-        >>> per_sector = by_slice(ic, ic_df, label="sector")
+        ```python
+        import polars as pl
+        from factrix.metrics import by_slice, ic, compute_ic
+
+        ic_df = compute_ic(panel)              # already has 'sector'
+        per_sector = by_slice(ic, ic_df, label="sector")
+        ```
 
     Universe overlap (superset / multi-membership / hierarchical /
     sliding window / cross-product) is composed by the caller — see

--- a/factrix/metrics/regime.py
+++ b/factrix/metrics/regime.py
@@ -113,9 +113,12 @@ def by_regime(
             the regime-label join.
 
     Example:
-        >>> from factrix.metrics import by_regime, ic, compute_ic
-        >>> ic_df = compute_ic(panel)
-        >>> per_regime = by_regime(ic, ic_df, regime_labels=labels)
+        ```python
+        from factrix.metrics import by_regime, ic, compute_ic
+
+        ic_df = compute_ic(panel)
+        per_regime = by_regime(ic, ic_df, regime_labels=labels)
+        ```
     """
     _warnings.warn(
         "factrix.metrics.by_regime is deprecated since v0.10.0; use "


### PR DESCRIPTION
## Summary
- Google-style `Example:` sections are rendered by Griffe as an admonition whose contents are parsed as raw markdown. Bare doctest `>>>` lines collapsed into a single paragraph in the rendered site (visible on the `by_regime` API page).
- Wrap the example bodies in fenced ```python blocks in `regime.py`, `_slice.py`, and `_run_metrics.py` so mkdocstrings emits a proper highlighted code block inside the Example admonition.

## Test plan
- [x] `mkdocs build --strict` succeeds locally
- [x] Inspected rendered `site/api/by-regime/index.html` — Example admonition now contains a multi-line highlighted Python block instead of a collapsed paragraph