### PR TITLE
feat(stats): Layer-B inference primitives + policy layer (#153)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,6 +10,7 @@ Reference for every public symbol exported from `factrix`.
 | [`evaluate`](evaluate.md) | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
 | [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `verdict()`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
 | [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. | Multi-factor screening. |
+| [`stats`](stats.md) | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldDoubleCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking inference method for `bhy(estimator=…)` or Layer-B slice tests. |
 | [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
 | [`Metrics`](metrics/index.md) | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly on a `FactorProfile` / panel. |
 

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -1,0 +1,126 @@
+# factrix.stats
+
+Inference-method instances + standalone statistical helpers. The
+public surface is what family verbs (`bhy` / `bhy_hierarchical`) and
+the upcoming Layer-B slice-test verbs accept on their `estimator=`
+kwarg, plus a small set of FDR / bootstrap utilities for callers who
+want to drive inference outside the dispatch chain.
+
+The numerical implementations live in the private `factrix._stats`
+package; nothing under `_stats` is part of the public API.
+
+## Estimator catalogue
+
+`Estimator` is a [selection-only `Protocol`](#estimator-protocol) —
+each instance names *which inference path* downstream code should
+read from `FactorProfile.stats`, not how to compute it. Default-
+constructed instances live in `factrix.stats._ESTIMATOR_REGISTRY`
+and surface through `list_estimators(scope, signal)` (top-level
+factrix export).
+
+| Class | Algorithm family | Emits | Applicable to | Use when |
+|---|---|---|---|---|
+| `NeweyWest` | NW Bartlett HAC | `(T_NW, P_NW)` | every cell | Default — drives `primary_p` on every PANEL / TIMESERIES procedure. |
+| `HansenHodrick` | HH rectangular HAC | `(T_HH, P_HH)` | `(INDIVIDUAL, CONTINUOUS)` only | Overlapping forward returns on IC PANEL / FM PANEL — the MA(h-1) overlap structure has a closed-form rectangular-kernel SE. |
+| `WaldNWCluster` | Cluster-Wald χ² (NW HAC + 1-way cluster on slice) | `(WALD_NWCL, P_WALD_NWCL)` | `(INDIVIDUAL, CONTINUOUS)` | Layer-B slice test on a stacked per-date metric panel (#176 verbs). |
+| `WaldDoubleCluster` | Cluster-Wald χ² (Cameron-Gelbach-Miller two-way cluster on (date, asset)) | `(WALD_DC, P_WALD_DC)` | `(INDIVIDUAL, CONTINUOUS)` | Reserved interface — raw asset-date panel path. No verb consumes it until `factor_decomposition` lands later. |
+| `BlockBootstrap` | Politis-Romano stationary or Künsch fixed block bootstrap; Politis-White auto block length | `(P_BOOT,)` | `(INDIVIDUAL, CONTINUOUS)` | Layer-B paired-diff slice test when distributional assumptions of the cluster-Wald path are uncomfortable (heavy tails, persistent shocks). |
+
+Pass an instance to a family verb to override the default
+`primary_p` lookup:
+
+```python
+from factrix.stats import HansenHodrick
+
+# IC PANEL with overlapping forward_periods=5 → use HH instead of NW.
+survivors = fx.multi_factor.bhy(profiles, estimator=HansenHodrick())
+```
+
+`BlockBootstrap` is the only Estimator whose constructor takes
+configuration:
+
+```python
+from factrix.stats import BlockBootstrap
+
+# Stationary scheme, B=999, automatic block length, fixed seed.
+est = BlockBootstrap(
+    block_length="auto",   # Politis-White (2004) spectral plug-in
+    n_resamples=999,
+    scheme="stationary",   # or "fixed" for Künsch (1989) deterministic blocks
+    rng_seed=42,           # None → system entropy; realised seed written to metadata
+)
+```
+
+The `scheme` is metadata, not a separate `StatCode` — both schemes
+emit `P_BOOT`. Two `BlockBootstrap` instances with different `scheme`
+are distinct Estimators from a verb's perspective; the verb writes
+the resolved scheme + block length + seed into
+`FactorProfile.metadata[StatCode.P_BOOT]`.
+
+## StatCode pairs
+
+`StatCode` is the canonical naming for the scalar statistics the
+procedures populate on `profile.stats`. The shape is
+`<KIND>_<ALGO>` — KIND names the test statistic (`T` for Student-t /
+asymptotic normal, `J` for Hansen J / χ², `WALD` for Wald χ²); ALGO
+names the inference algorithm or SE family (`NW`, `HH`, `NWCL`,
+`DC`, `GMM`, …).
+
+| Pair | What it is |
+|---|---|
+| `(T_NW, P_NW)` | Newey-West HAC t-statistic + p — the `primary_p` source the metric `evaluate()` runs populates by default. |
+| `(T_HH, P_HH)` | Hansen-Hodrick rectangular-kernel HAC t + p — emitted only when `forward_periods > 1`. |
+| `(WALD_NWCL, P_WALD_NWCL)` | Cluster-Wald χ² + p under NW HAC + 1-way slice cluster — emitted by Layer-B slice-test verbs. |
+| `(WALD_DC, P_WALD_DC)` | Cluster-Wald χ² + p under two-way cluster on (date, asset) — reserved. |
+| `(P_BOOT,)` | Block-bootstrap empirical p — singleton, no parametric test statistic to publish. |
+| `(P_GMM,)` | GMM J-test p — reserved (#191). |
+
+Diagnostic StatCodes (`FACTOR_ADF_*`, `RESID_LJUNG_BOX_*`,
+`EVENT_HHI_VALUE`) follow a different naming axis; see
+[`StatCode`](../reference/warning-codes.md#statcode) for the full
+enum.
+
+## FDR / bootstrap utilities
+
+Standalone helpers that don't go through the Estimator dispatch
+chain:
+
+- **`bhy_adjust(p_values, fdr=0.05, *, n_total=None)`** —
+  Benjamini-Yekutieli step-up rejection mask. Returns
+  `np.ndarray[bool]` aligned to input order.
+- **`bhy_adjusted_p(p_values, *, n_total=None)`** — per-hypothesis
+  BHY-adjusted p-values (clipped at 1).
+- **`stationary_bootstrap_resamples(values, n_bootstrap, …)`** —
+  Politis-Romano (1994) resamples; emits the value matrix directly.
+- **`bootstrap_mean_ci(values, *, n_bootstrap, ci, …)`** —
+  stationary-bootstrap CI for a statistic (default `mean`; pass
+  `statistic=` for Sharpe / median / skew).
+
+The Layer-B FWER procedures (Holm step-down / Bonferroni /
+Romano-Wolf bootstrap step-down) live as private helpers under
+`factrix._stats.multiple_testing`; they ship in #153 and are
+consumed by the Layer-B slice-test verbs in #176 — the verb's
+default-selection logic picks Holm for time-disjoint slices and
+Romano-Wolf for date-shared slices.
+
+## Estimator protocol
+
+```python
+@runtime_checkable
+class Estimator(Protocol):
+    @property
+    def name(self) -> str: ...
+    @property
+    def description(self) -> str: ...
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool: ...
+    def emits_for(
+        self,
+        scope: FactorScope,
+        signal: Signal,
+        metric: Metric | None,
+    ) -> StatCode: ...
+```
+
+Selection-only by design: cell-internal `compute()` lives on a
+future `ComputableEstimator(Estimator)` sub-protocol so the
+common-case Estimator instance stays trivial to write.

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -26,6 +26,24 @@ factrix export).
 | `WaldDoubleCluster` | Cluster-Wald χ² (Cameron-Gelbach-Miller two-way cluster on (date, asset)) | `(WALD_DC, P_WALD_DC)` | `(INDIVIDUAL, CONTINUOUS)` | Reserved interface — raw asset-date panel path. No verb consumes it until `factor_decomposition` lands later. |
 | `BlockBootstrap` | Politis-Romano stationary or Künsch fixed block bootstrap; Politis-White auto block length | `(P_BOOT,)` | `(INDIVIDUAL, CONTINUOUS)` | Layer-B paired-diff slice test when distributional assumptions of the cluster-Wald path are uncomfortable (heavy tails, persistent shocks). |
 
+!!! warning "`WaldDoubleCluster` is a reserved interface"
+    The class ships in #153 so the `(WALD_DC, P_WALD_DC)` StatCode
+    pair has a stable home, but no verb populates `profile.stats`
+    with `P_WALD_DC` until `factor_decomposition` lands. Calling
+    `bhy(estimator=WaldDoubleCluster())` against a profile produced
+    by `evaluate()` raises a missing-stat error pointing at the
+    precondition.
+
+### Picking an Estimator
+
+| Question | Estimator |
+|---|---|
+| Default single-series significance on `evaluate()` output | `NeweyWest` |
+| Overlapping forward returns (`forward_periods > 1`) on IC PANEL / FM PANEL | `HansenHodrick` |
+| Slice contrast on per-date IC / FM (regime, sector, decile) | `WaldNWCluster` |
+| Slice paired-diff on heavy-tailed / persistent series, distributional assumptions uncomfortable | `BlockBootstrap` |
+| Raw asset-date panel inference (factor × slice interaction) | `WaldDoubleCluster` (reserved) |
+
 Pass an instance to a family verb to override the default
 `primary_p` lookup:
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -174,10 +174,20 @@ class StatCode(StrEnum):
     KINDs that abbreviate the test statistic's reference distribution:
     ``T`` (Student-t / asymptotic normal), ``J`` (Hansen J / χ²),
     ``WALD`` (Wald χ²), ``F`` (Snedecor F), ``LR`` (likelihood ratio).
-    Currently shipping: ``(T_NW, P_NW)`` for Newey-West and
-    ``(T_HH, P_HH)`` for Hansen-Hodrick. Planned in #191:
-    ``(J_GMM, P_GMM)`` — the over-identification test is χ², not t,
-    so GMM emits J rather than T.
+    Currently shipping: ``(T_NW, P_NW)`` for Newey-West,
+    ``(T_HH, P_HH)`` for Hansen-Hodrick, ``(WALD_NWCL, P_WALD_NWCL)``
+    for NW HAC + one-way cluster on the slice grouping, and
+    ``(WALD_DC, P_WALD_DC)`` for two-way cluster on (date, asset)
+    (Layer-B slice tests, #153). The Wald pairs follow the same
+    ``<KIND>_<ALGO>`` shape — KIND = ``WALD`` (χ² statistic name,
+    parallel to ``T``), ALGO names the cluster-SE family
+    (parallel to ``NW`` / ``HH`` naming the kernel family). ``P_BOOT``
+    ships alongside as the singleton emitted by ``BlockBootstrap``:
+    empirical p-values have no parametric test statistic to publish,
+    and ``BlockBootstrap`` is a single Estimator class (fixed vs
+    stationary scheme is a ctor arg living in metadata). Planned in
+    #191: ``(J_GMM, P_GMM)`` — the over-identification test is χ²,
+    not t, so GMM emits J rather than T.
 
     **Why primary p-value is ``P_<algo>`` while diagnostic p-value is
     ``<target>_<test>_P``**: primary p has a single conceptual target
@@ -193,7 +203,12 @@ class StatCode(StrEnum):
     a (kind × algo) cardinality product and a structured shape
     (``profile.inference[Algo.X] = {test_stat, kind, p, df}``) earns
     its breaking-change cost. Below those thresholds the flat
-    enum stays cheaper.
+    enum stays cheaper. **As of #153 the algorithm count has crossed
+    the threshold: 5 algorithms (NW / HH / NWCL / DC / BlockBootstrap)
+    and 2 KINDs (T / WALD, with J reserved for GMM #191). The flat
+    enum is now over-budget by one algorithm; any further inference
+    algorithm must trigger the structured-shape redesign discussion
+    before extending the enum.**
 
     **Convention: ``df`` always means statistical degrees of freedom.**
     Wherever ``df`` appears in factrix StatCode descriptions, metadata
@@ -230,6 +245,26 @@ class StatCode(StrEnum):
     # in #191; the StatCode grammar in this module's docstring already
     # documents the planned shape.
     P_GMM = "p_gmm"
+    # Cluster-robust Wald χ² for linear restrictions on a slice contrast
+    # / joint coefficient (Layer-B slice tests, #153). KIND = WALD (χ²
+    # test statistic, parallel to T); ALGO names the cluster-SE family
+    # (parallel to NW / HH naming the kernel family).
+    # NWCL = NW Bartlett HAC + one-way cluster on the slice grouping
+    # (emitted by `WaldNWCluster`).
+    WALD_NWCL = "wald_nwcl"
+    P_WALD_NWCL = "p_wald_nwcl"
+    # DC = two-way cluster on (date, asset), Cameron-Gelbach-Miller
+    # (2011) shape (emitted by `WaldDoubleCluster`).
+    WALD_DC = "wald_dc"
+    P_WALD_DC = "p_wald_dc"
+    # Empirical p-value from a block-bootstrap resample of a paired-diff
+    # statistic (Layer-B paired tests, #153). Singleton — the
+    # bootstrap distribution itself is not published as a StatCode.
+    # `BlockBootstrap` is one Estimator class; fixed vs stationary
+    # scheme is a ctor arg living in metadata, so a single P_BOOT key
+    # serves both. Parallel to how `NeweyWest`'s lag rule lives in
+    # `metadata` rather than splitting `P_NW` by lag.
+    P_BOOT = "p_boot"
 
     # Diagnostic — factor input series.
     FACTOR_ADF_TAU = "factor_adf_tau"
@@ -284,6 +319,23 @@ _STAT_DESCRIPTIONS: dict[StatCode, str] = {
     StatCode.P_GMM: "Two-sided p-value from a Hansen (1982) GMM J-test "
     "(over-identifying restrictions). Reserved for procedure-side landing "
     "in a follow-up issue.",
+    StatCode.WALD_NWCL: "Wald χ² statistic for a linear restriction on "
+    "slice contrasts / joint coefficients, computed under NW Bartlett HAC "
+    "plus one-way cluster on the slice grouping. Implementation convention "
+    "lives in `factrix.stats.WaldNWCluster`.",
+    StatCode.P_WALD_NWCL: "P-value from `WALD_NWCL`. Sibling under the "
+    "(WALD_NWCL, P_WALD_NWCL) algorithm-pair convention.",
+    StatCode.WALD_DC: "Wald χ² statistic for a linear restriction on a "
+    "panel coefficient vector, computed under two-way cluster on "
+    "(date, asset) (Cameron-Gelbach-Miller 2011). Implementation "
+    "convention lives in `factrix.stats.WaldDoubleCluster`.",
+    StatCode.P_WALD_DC: "P-value from `WALD_DC`. Sibling under the "
+    "(WALD_DC, P_WALD_DC) algorithm-pair convention.",
+    StatCode.P_BOOT: "Empirical two-sided p-value from a block-bootstrap "
+    "resample of a paired-diff statistic. Implementation convention lives "
+    "in `factrix.stats.BlockBootstrap` (Politis-Romano stationary or "
+    "Künsch fixed scheme; Politis-White auto block length). Single key "
+    "for both schemes — scheme choice is metadata, not StatCode.",
     StatCode.FACTOR_ADF_TAU: "ADF τ statistic on the factor input series "
     "(constant-only specification); fed to the MacKinnon 1996 "
     "response-surface for `FACTOR_ADF_P`.",

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -110,6 +110,9 @@ def _politis_white_block_length(
     M = min(M, k_max)
 
     gamma = rho * gamma_0
+    # PW (2004) eq. 9 sums |k| ≤ M with the flat-top kernel; the k=M
+    # term vanishes because λ(M/M) = λ(1) = 0 by construction, so
+    # `range(1, M)` covers every non-zero contributor.
     g0 = gamma[0] + 2.0 * sum(_flat_top_kernel(k / M) * gamma[k] for k in range(1, M))
     g_deriv = 2.0 * sum(_flat_top_kernel(k / M) * k * gamma[k] for k in range(1, M))
     if scheme == "stationary":

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -1,0 +1,268 @@
+"""Block-bootstrap primitives backing the ``BlockBootstrap`` Estimator (#153).
+
+Two resampling schemes for dependent time series, plus the Politis-White
+(2004) automatic block-length selector and a paired-diff empirical p-value:
+
+- **Stationary scheme** (Politis & Romano 1994) — geometric block lengths
+  with mean ``L``. Resamples are themselves stationary processes;
+  preferred when downstream estimators rely on stationarity (CI for
+  serially-correlated means, Sharpe).
+- **Fixed scheme** (Künsch 1989) — deterministic block length ``L``.
+  Cleaner for variance estimation; loses stationarity at the join
+  points but tighter at small ``B``.
+
+The public ``factrix.stats.bootstrap`` module ships standalone
+``stationary_bootstrap_resamples`` / ``bootstrap_mean_ci`` for callers
+that want a CI utility outside the Estimator dispatch chain. This
+private module is consumed by the procedure that backs the
+``BlockBootstrap`` Estimator under #176.
+
+References
+----------
+Künsch, H. R. (1989). "The jackknife and the bootstrap for general
+    stationary observations." Annals of Statistics, 17(3), 1217-1241.
+Politis, D. N. & Romano, J. P. (1994). "The Stationary Bootstrap."
+    JASA, 89(428), 1303-1313.
+Politis, D. N. & White, H. (2004). "Automatic Block-Length Selection
+    for the Dependent Bootstrap." Econometric Reviews, 23(1), 53-70.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+
+from factrix._types import EPSILON
+
+Scheme = Literal["fixed", "stationary"]
+
+
+def _flat_top_kernel(t: float) -> float:
+    """Politis-Romano trapezoidal flat-top kernel.
+
+    ``λ(t) = 1`` for ``|t| ≤ 0.5``; linear taper to 0 over ``0.5 < |t| < 1``;
+    0 beyond. The flat top eliminates the small-bias term that hurts
+    triangular / Bartlett kernels in spectral-density estimation at
+    frequency 0 — the load-bearing input to PW (2004).
+    """
+    a = abs(t)
+    if a <= 0.5:
+        return 1.0
+    if a < 1.0:
+        return 2.0 * (1.0 - a)
+    return 0.0
+
+
+def _politis_white_block_length(
+    values: np.ndarray,
+    *,
+    scheme: Scheme = "stationary",
+) -> float:
+    """Politis-White (2004) automatic block length.
+
+    Implements the spectral plug-in described in PW §3-4:
+    ``L̂ = (2 Ĝ² / D̂)^(1/3) · T^(1/3)`` where ``Ĝ`` and ``D̂`` are
+    flat-top kernel estimates of, respectively, the first derivative
+    and variance of the spectral density at frequency 0. Caller picks
+    ``scheme`` because ``D̂`` differs by a factor (``2 g(0)²`` for
+    stationary, ``(4/3) g(0)²`` for fixed/circular blocks; PW eq 9 / 12).
+
+    Falls back to ``max(1, 1.75 · T^(1/3))`` (the widely-cited practical
+    PW approximation, also used by ``factrix.stats.bootstrap``) when
+    the series is too short, autocovariance is degenerate, or the
+    spectral estimate yields a non-finite ratio. Returns a ``float``;
+    callers that need an integer block size round at the call site.
+    """
+    x = np.asarray(values, dtype=float)
+    n = len(x)
+    fallback = max(1.0, 1.75 * n ** (1.0 / 3.0)) if n >= 1 else 1.0
+    if n < 4:
+        return fallback
+
+    x = x - float(np.mean(x))
+    gamma_0 = float(np.dot(x, x)) / n
+    if gamma_0 < EPSILON:
+        return fallback
+
+    # Bandwidth search range — PW recommend k_max = ceil(sqrt(log10(T) * T)).
+    k_max = min(n - 1, int(np.ceil(np.sqrt(max(np.log10(n), 1.0) * n))))
+    k_max = max(k_max, 1)
+    rho = np.empty(k_max + 1)
+    rho[0] = 1.0
+    for k in range(1, k_max + 1):
+        rho[k] = float(np.dot(x[k:], x[:-k])) / (n * gamma_0)
+
+    # Pick smallest m such that |ρ̂(m+s)| < 2·sqrt(log10(T)/T) for all
+    # s = 1..K_T. Threshold = Stock-Watson (1998) significance bar.
+    K_T = max(5, int(np.ceil(np.log10(n))))
+    threshold = 2.0 * np.sqrt(np.log10(n) / n)
+    m_pick = None
+    for m in range(0, max(k_max - K_T, 1)):
+        window = rho[m + 1 : m + 1 + K_T]
+        if window.size and np.all(np.abs(window) < threshold):
+            m_pick = m
+            break
+    if m_pick is None:
+        return fallback
+    # PW (2004) §4 doubles the chosen index for the kernel bandwidth.
+    M = max(2 * m_pick, 2)
+    M = min(M, k_max)
+
+    gamma = rho * gamma_0
+    g0 = gamma[0] + 2.0 * sum(_flat_top_kernel(k / M) * gamma[k] for k in range(1, M))
+    g_deriv = 2.0 * sum(_flat_top_kernel(k / M) * k * gamma[k] for k in range(1, M))
+    if scheme == "stationary":
+        d_hat = 2.0 * g0 * g0
+    elif scheme == "fixed":
+        d_hat = (4.0 / 3.0) * g0 * g0
+    else:
+        raise ValueError(f"scheme must be 'fixed' or 'stationary'; got {scheme!r}")
+
+    if d_hat < EPSILON or not np.isfinite(g_deriv):
+        return fallback
+    ratio = (2.0 * g_deriv * g_deriv) / d_hat
+    if ratio <= 0.0 or not np.isfinite(ratio):
+        return fallback
+    L = (ratio ** (1.0 / 3.0)) * (n ** (1.0 / 3.0))
+    if not np.isfinite(L) or L < 1.0:
+        return fallback
+    return float(min(L, n / 2.0))
+
+
+def _stationary_block_indices(
+    n: int,
+    n_resamples: int,
+    mean_block_length: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Politis-Romano (1994) geometric-block index matrix, shape ``(B, n)``.
+
+    Block length at each step is geometric with mean ``mean_block_length``;
+    sampling is circular. Mirrors ``factrix.stats.bootstrap`` resampler
+    but emits indices rather than values so the same matrix can drive
+    multiple statistics (mean / variance / Sharpe) without re-drawing.
+    """
+    if mean_block_length < 1.0:
+        raise ValueError(f"mean_block_length must be >= 1.0; got {mean_block_length!r}")
+    if n == 0:
+        return np.empty((n_resamples, 0), dtype=np.int64)
+    p_new = 1.0 / mean_block_length
+    starts = rng.integers(0, n, size=(n_resamples, n))
+    new_block = rng.random(size=(n_resamples, n)) < p_new
+    idx = np.empty((n_resamples, n), dtype=np.int64)
+    idx[:, 0] = starts[:, 0]
+    for t in range(1, n):
+        prev = (idx[:, t - 1] + 1) % n
+        idx[:, t] = np.where(new_block[:, t], starts[:, t], prev)
+    return idx
+
+
+def _fixed_block_indices(
+    n: int,
+    n_resamples: int,
+    block_length: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Künsch (1989) fixed-block index matrix, shape ``(B, n)``.
+
+    Picks ``ceil(n / L)`` random block starts per resample, lays the
+    blocks contiguously (modulo ``n`` for circular wrap), then truncates
+    to length ``n``. Each resample is composed of ``ceil(n/L)`` blocks
+    of identical length ``L`` — the cleaner variance-estimation path
+    when serial correlation has a known horizon.
+    """
+    if block_length < 1:
+        raise ValueError(f"block_length must be >= 1; got {block_length!r}")
+    if n == 0:
+        return np.empty((n_resamples, 0), dtype=np.int64)
+    n_blocks = int(np.ceil(n / block_length))
+    starts = rng.integers(0, n, size=(n_resamples, n_blocks))
+    offsets = np.arange(block_length, dtype=np.int64)
+    # Broadcast (B, n_blocks, 1) + (block_length,) → (B, n_blocks, block_length).
+    idx = (starts[:, :, None] + offsets[None, None, :]) % n
+    return idx.reshape(n_resamples, n_blocks * block_length)[:, :n]
+
+
+def _block_bootstrap_diff_p(
+    diff: np.ndarray,
+    *,
+    block_length: int | Literal["auto"] = "auto",
+    n_resamples: int = 999,
+    scheme: Scheme = "stationary",
+    rng_seed: int | None = None,
+) -> tuple[float, dict[str, float | int | str]]:
+    """Two-sided empirical p for ``H₀: E[diff] = 0`` on a paired series.
+
+    Resamples ``diff`` under the centring ``diff - mean(diff)`` (the
+    null restricts the mean to zero; the bootstrap distribution must be
+    drawn under that restriction to give a calibrated p). Empirical p
+    uses Davison-Hinkley ``+1 / (B+1)`` smoothing: keeps p strictly
+    positive so log-scale plots and downstream multi-stage adjustments
+    don't see a hard zero.
+
+    Args:
+        diff: 1-D paired-difference series (already date-aligned by
+            caller — the bootstrap does not re-align).
+        block_length: ``"auto"`` runs Politis-White; ``int >= 1`` uses
+            the supplied length unchanged. Stationary scheme uses the
+            mean of the geometric distribution; fixed scheme uses the
+            integer directly.
+        n_resamples: ``B``. PW (2004) recommends ≥ 999 for two-sided
+            5% tests; default matches.
+        scheme: ``"fixed"`` (Künsch) or ``"stationary"`` (Politis-Romano).
+        rng_seed: ``None`` draws from system entropy; the resolved seed
+            is returned in the metadata dict so the caller can record
+            it on ``FactorProfile.metadata[StatCode.P_BOOT]``.
+
+    Returns:
+        ``(p_value, metadata)`` — p in ``[1/(B+1), 1]``; metadata
+        records the resolved block length, scheme, n_resamples, and the
+        actual seed used (so the run is reproducible from the logged
+        metadata even when the caller passed ``rng_seed=None``).
+    """
+    diff = np.asarray(diff, dtype=float)
+    n = len(diff)
+    if n < 2:
+        return 1.0, {
+            "block_length": 0,
+            "n_resamples": 0,
+            "scheme": scheme,
+            "rng_seed": rng_seed if rng_seed is not None else -1,
+        }
+
+    if block_length == "auto":
+        L_float = _politis_white_block_length(diff, scheme=scheme)
+        L = max(1, round(L_float))
+    else:
+        L = int(block_length)
+        if L < 1:
+            raise ValueError(f"block_length must be >= 1; got {L!r}")
+
+    # Resolve seed up front so it can be reported back even when None.
+    if rng_seed is None:
+        seed_used = int(np.random.SeedSequence().entropy & 0xFFFFFFFF)
+    else:
+        seed_used = int(rng_seed)
+    rng = np.random.default_rng(seed_used)
+
+    # Centre under H0 (mean=0) before resampling.
+    centred = diff - float(np.mean(diff))
+    if scheme == "stationary":
+        idx = _stationary_block_indices(n, n_resamples, float(L), rng)
+    else:
+        idx = _fixed_block_indices(n, n_resamples, L, rng)
+    resamples = centred[idx]
+    boot_means = resamples.mean(axis=1)
+
+    observed = float(np.mean(diff))
+    # Two-sided: count resamples whose |bootstrap mean| ≥ |observed|.
+    extreme = int(np.sum(np.abs(boot_means) >= abs(observed)))
+    p = (extreme + 1.0) / (n_resamples + 1.0)
+    metadata: dict[str, float | int | str] = {
+        "block_length": L,
+        "n_resamples": int(n_resamples),
+        "scheme": scheme,
+        "rng_seed": seed_used,
+    }
+    return float(p), metadata

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -29,6 +29,7 @@ Politis, D. N. & White, H. (2004). "Automatic Block-Length Selection
 
 from __future__ import annotations
 
+import secrets
 from typing import Literal
 
 import numpy as np
@@ -243,10 +244,10 @@ def _block_bootstrap_diff_p(
             raise ValueError(f"block_length must be >= 1; got {L!r}")
 
     # Resolve seed up front so it can be reported back even when None.
-    if rng_seed is None:
-        seed_used = int(np.random.SeedSequence().entropy & 0xFFFFFFFF)
-    else:
-        seed_used = int(rng_seed)
+    # `secrets.randbits(32)` is the purpose-built "give me a random int
+    # seed" call — `SeedSequence().entropy` is typed as `int | Sequence[int]
+    # | None` and the Sequence branch breaks the bit-mask path.
+    seed_used = secrets.randbits(32) if rng_seed is None else int(rng_seed)
     rng = np.random.default_rng(seed_used)
 
     # Centre under H0 (mean=0) before resampling.

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -1,0 +1,167 @@
+"""Family-wise error rate (FWER) adjustments — Holm / Bonferroni / Romano-Wolf.
+
+Sister module to public ``factrix.stats.multiple_testing`` (Benjamini-
+Yekutieli FDR control). The procedures here control the *family-wise*
+error rate — probability of at least one false rejection — and target
+the Layer-B slice-test setting where a small number of hypotheses
+(per-slice contrasts vs a baseline) are tested simultaneously.
+
+- **Bonferroni** — single-step ``p_adj_k = min(m * p_k, 1)``. Controls
+  FWER under any dependence; uniformly the most conservative.
+- **Holm step-down** (Holm 1979) — uniformly dominates Bonferroni under
+  the same dependence assumptions; gains power by sequentially
+  rejecting ordered p-values.
+- **Romano-Wolf step-down** (Romano & Wolf 2005) — bootstrap-based
+  step-down that exploits the *joint* dependence structure of the
+  test statistics. Needs the user to supply a bootstrap distribution
+  (under H0); in return delivers tight FWER control even when tests
+  share a common shock (universe pairwise IC, factor-portfolio
+  contrasts, etc.).
+
+The choice between Holm and Romano-Wolf is the caller's: time-disjoint
+slices (e.g. regimes) work fine under Holm; date-shared slices
+(universe pairwise) leave significant power on the table without
+Romano-Wolf. The verb-side fallback that picks between the two lives
+in #176 — this module does not encode a default.
+
+References
+----------
+Holm, S. (1979). "A simple sequentially rejective multiple test
+    procedure." Scandinavian Journal of Statistics, 6(2), 65-70.
+Romano, J. P. & Wolf, M. (2005). "Stepwise multiple testing as
+    formalized data snooping." Econometrica, 73(4), 1237-1282.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+
+def _validate_p(p_values: Sequence[float] | npt.ArrayLike) -> np.ndarray:
+    p = np.asarray(p_values, dtype=float)
+    if p.ndim != 1:
+        raise ValueError(f"p_values must be 1-D; got shape {p.shape}.")
+    if p.size and not np.all((p >= 0) & (p <= 1)):
+        raise ValueError("p_values must all lie in [0, 1].")
+    return p
+
+
+def bonferroni(p_values: Sequence[float] | npt.ArrayLike) -> list[float]:
+    """Bonferroni-adjusted p-values: ``p_adj_k = min(m * p_k, 1)``.
+
+    Single-step, strong FWER control under arbitrary dependence.
+    Uniformly the most conservative of the three procedures here;
+    used as a baseline / sanity-check sibling to Holm.
+    """
+    p = _validate_p(p_values)
+    m = len(p)
+    if m == 0:
+        return []
+    return list(np.minimum(m * p, 1.0))
+
+
+def holm_step_down(p_values: Sequence[float] | npt.ArrayLike) -> list[float]:
+    """Holm (1979) step-down adjusted p-values.
+
+    Order ``p_(1) ≤ p_(2) ≤ … ≤ p_(m)`` and set
+    ``p_adj_(k) = max_{j ≤ k} (m - j + 1) * p_(j)``, clipped at 1.
+    The cummax enforces monotonicity: a smaller raw p never gets a
+    larger adjusted p in rank order — required so the rejection set
+    ``{k : p_adj_k ≤ α}`` is closed downward in significance.
+
+    Strong FWER control under arbitrary dependence; uniformly
+    dominates Bonferroni (each adjusted p is ≤ Bonferroni's).
+    """
+    p = _validate_p(p_values)
+    m = len(p)
+    if m == 0:
+        return []
+    order = np.argsort(p)
+    sorted_p = p[order]
+    factors = np.arange(m, 0, -1, dtype=float)
+    scaled = factors * sorted_p
+    adj_sorted = np.minimum(np.maximum.accumulate(scaled), 1.0)
+    out = np.empty(m, dtype=float)
+    out[order] = adj_sorted
+    return list(out)
+
+
+def romano_wolf(
+    statistics: Sequence[float] | npt.ArrayLike,
+    bootstrap_distribution: npt.ArrayLike,
+    *,
+    one_sided: bool = False,
+) -> list[float]:
+    """Romano-Wolf (2005) step-down adjusted p-values.
+
+    Args:
+        statistics: Observed test statistics ``t_1, …, t_m`` (e.g.
+            studentized contrasts). Sign convention: large positive
+            ``t_k`` favours rejection. For two-sided tests
+            ``one_sided=False`` operates on ``|t_k|`` internally.
+        bootstrap_distribution: ``(B, m)`` array of bootstrap test
+            statistics drawn under H0 (caller is responsible for
+            null centring — typically subtract the sample statistic
+            from each bootstrap replicate before passing in).
+        one_sided: If ``True``, reject only on the positive tail
+            (suitable when the alternative is signed, e.g. "long
+            portfolio outperforms short"). If ``False`` (default),
+            two-sided via ``|t_k|``.
+
+    Returns:
+        Adjusted p-values in input order, each in ``[0, 1]``.
+
+    The step-down critical sequence is built from the *max* of the
+    bootstrap distribution restricted to the not-yet-rejected
+    hypotheses, so the dependence structure (universe co-movement,
+    common-factor exposure) shrinks the multiplicity penalty
+    automatically — Bonferroni / Holm assume worst-case dependence
+    and over-correct in this regime.
+    """
+    t = np.asarray(statistics, dtype=float)
+    boot = np.asarray(bootstrap_distribution, dtype=float)
+    m = len(t)
+    if m == 0:
+        return []
+    if boot.ndim != 2 or boot.shape[1] != m:
+        raise ValueError(
+            f"bootstrap_distribution must have shape (B, {m}); got {boot.shape}."
+        )
+    if boot.shape[0] < 1:
+        raise ValueError("bootstrap_distribution must have at least 1 resample.")
+
+    # Two-sided default: collapse to absolute values up front so the
+    # max-over-remaining is computed on the right scale.
+    if one_sided:
+        t_use = t
+        boot_use = boot
+    else:
+        t_use = np.abs(t)
+        boot_use = np.abs(boot)
+
+    # Most-significant first: order by descending observed statistic.
+    desc_order = np.argsort(-t_use)
+    p_adj_desc = np.empty(m, dtype=float)
+    remaining = list(desc_order)
+    for j, k in enumerate(desc_order):
+        # max over the not-yet-rejected hypotheses, per bootstrap row.
+        max_remaining = boot_use[:, remaining].max(axis=1)
+        # Empirical p with +1 / (B+1) smoothing — keeps p strictly > 0
+        # so log-scale plotting / multi-stage stacks don't crash on a
+        # zero-count bootstrap tail. Standard Davison-Hinkley convention.
+        b = boot_use.shape[0]
+        p_adj_desc[j] = (np.sum(max_remaining >= t_use[k]) + 1.0) / (b + 1.0)
+        remaining = remaining[1:]
+
+    # Enforce monotonicity in descending-significance order: an earlier
+    # (more significant) rejection cannot have a larger adjusted p than
+    # a later one. Cummax over the sequence.
+    p_adj_desc = np.maximum.accumulate(p_adj_desc)
+    p_adj_desc = np.minimum(p_adj_desc, 1.0)
+
+    out = np.empty(m, dtype=float)
+    out[desc_order] = p_adj_desc
+    return list(out)

--- a/factrix/_stats/slice_policy.py
+++ b/factrix/_stats/slice_policy.py
@@ -1,0 +1,114 @@
+"""Slice-test policy helpers — pre-flight subset detection + ``n_groups`` downscale.
+
+Two private helpers consumed by the Layer-B slice-test verbs landing
+in #176 (``slice_pairwise_test`` / ``slice_joint_test``):
+
+- ``_detect_strict_subsets`` — pre-flight check for paired tests.
+  When slice A's (date, asset) key-set is strictly contained in slice
+  B's, the pairwise diff inherits A's universe entirely; the SE
+  estimate has degeneracies the standard cluster-NW formula does not
+  warn about. The verb emits a ``UserWarning`` on non-empty output
+  and steers the caller toward ``slice_joint_test`` (omnibus over all
+  slices) which handles the geometry properly.
+- ``_downscale_n_groups`` — for slice tests on metrics that bucket
+  cross-section assets (quantile spread, monotonicity), shrinks
+  ``n_groups`` so each bucket retains at least ``min_per_group``
+  assets. The per-metric ``min_per_group`` floor lives on the metric
+  module itself (#153 §5); the verb resolves it per slice and feeds
+  it here.
+
+Issue spec deviation: ``_downscale_n_groups`` takes ``int`` rather than
+``AnalysisConfig`` because ``AnalysisConfig`` carries no ``n_groups``
+field — that field is a quantile-family kwarg. Caller composes the
+returned int into the per-slice metric kwarg dict.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import polars as pl
+
+
+def _detect_strict_subsets(
+    slices: Mapping[str, pl.DataFrame],
+    *,
+    key_cols: Sequence[str] = ("date", "asset"),
+) -> list[tuple[str, str]]:
+    """Pairs ``(subset_label, superset_label)`` of strictly nested slices.
+
+    Args:
+        slices: Per-label slice DataFrames; keys are slice labels,
+            values share a common schema and contain ``key_cols``.
+        key_cols: Column names whose unique combinations define a
+            slice's "membership". Default ``("date", "asset")`` matches
+            the canonical panel key.
+
+    Returns:
+        List of ordered pairs ``(a, b)`` where ``key_set(a) ⊊
+        key_set(b)``. Pairs are emitted once per direction (no double
+        report); equal key-sets are not flagged (those are the same
+        slice from the test's perspective). Empty list = all pairs are
+        either disjoint or partially-overlapping, both safe inputs to
+        ``slice_pairwise_test``.
+
+    Raises:
+        ValueError: A slice is missing one of ``key_cols``.
+    """
+    key_cols = tuple(key_cols)
+    key_sets: dict[str, frozenset[tuple]] = {}
+    for label, df in slices.items():
+        missing = [c for c in key_cols if c not in df.columns]
+        if missing:
+            raise ValueError(
+                f"slice {label!r}: missing key columns {missing}; have {df.columns}."
+            )
+        keys = df.select(list(key_cols)).unique().rows()
+        key_sets[label] = frozenset(keys)
+
+    labels = list(slices.keys())
+    results: list[tuple[str, str]] = []
+    for i, a in enumerate(labels):
+        sa = key_sets[a]
+        for b in labels[i + 1 :]:
+            sb = key_sets[b]
+            if sa < sb:
+                results.append((a, b))
+            elif sb < sa:
+                results.append((b, a))
+    return results
+
+
+def _downscale_n_groups(
+    base_n_groups: int,
+    n_assets: int,
+    *,
+    min_per_group: int | None,
+) -> int:
+    """Cap ``n_groups`` so each bucket retains ``≥ min_per_group`` assets.
+
+    Args:
+        base_n_groups: Caller's requested bucket count.
+        n_assets: Number of distinct assets in the slice.
+        min_per_group: Minimum assets per bucket required for the metric
+            to be statistically meaningful (e.g. IC quintile spread:
+            30; monotonicity rho: 50). ``None`` skips the downscale —
+            for metrics that don't bucket cross-section (Fama-MacBeth,
+            CAAR), pass ``None`` and ``base_n_groups`` returns unchanged.
+
+    Returns:
+        ``min(base_n_groups, max(2, n_assets // min_per_group))`` when
+        ``min_per_group`` is set; ``base_n_groups`` otherwise. The lower
+        floor of 2 prevents a 1-bucket "spread" (degenerate) on very
+        small slices — the slice test should ideally be skipped at
+        that point but the helper does not raise.
+
+    Raises:
+        ValueError: ``min_per_group < 1``.
+    """
+    if min_per_group is None:
+        return base_n_groups
+    if min_per_group < 1:
+        raise ValueError(f"min_per_group must be >= 1; got {min_per_group!r}.")
+    capacity = max(2, n_assets // min_per_group)
+    return min(base_n_groups, capacity)

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -1,9 +1,38 @@
-"""Wald χ² test for linear restrictions on an estimated coefficient vector."""
+"""Wald χ² tests for linear restrictions on coefficient vectors.
+
+Three layers of HAC / cluster covariance feed the same closing
+``_wald_p_linear`` core (``W = (Rβ̂ - q)' [RVR']^{-1} (Rβ̂ - q)``):
+
+- **Generic** — ``_wald_p_linear(beta, V, R, q)`` accepts any
+  pre-computed coefficient vector and covariance matrix; the
+  bedrock used by every higher-level helper here.
+- **Vector-mean NW HAC** — ``_wald_nw_cluster_means(Y, R, q, lags)``
+  for the stacked per-date metric panel: rows are joint per-date
+  observations of K slice means; cross-slice covariance is the
+  joint Bartlett-kernel HAC of the K-vector series. Backs the
+  ``WaldNWCluster`` Estimator (#153).
+- **Two-way cluster on (date, asset)** —
+  ``_wald_double_cluster(y, X, *, R, q, date_ids, asset_ids)`` for
+  the raw asset-date panel. Cameron-Gelbach-Miller (2011)
+  ``V_DC = V_date + V_asset - V_intersection`` shape. Backs the
+  ``WaldDoubleCluster`` Estimator — interface preserved this issue;
+  no verb consumes it until ``factor_decomposition`` lands later.
+
+References
+----------
+Cameron, A. C., Gelbach, J. B. & Miller, D. L. (2011). "Robust
+    Inference With Multiway Clustering." JBES, 29(2), 238-249.
+Newey, W. K. & West, K. D. (1987). "A Simple, Positive Semi-Definite,
+    Heteroskedasticity and Autocorrelation Consistent Covariance
+    Matrix." Econometrica, 55(3), 703-708.
+"""
 
 from __future__ import annotations
 
 import numpy as np
 from scipy import stats as sp_stats
+
+from factrix._types import EPSILON
 
 
 def _wald_p_linear(
@@ -28,3 +57,194 @@ def _wald_p_linear(
     W = float(diff @ middle_inv @ diff)
     p = float(sp_stats.chi2.sf(W, df=R.shape[0]))
     return W, p
+
+
+def _nw_hac_vector_mean(
+    Y: np.ndarray,
+    *,
+    lags: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Joint sample mean and Newey-West HAC variance of a vector series.
+
+    For ``Y`` of shape ``(T, K)`` (rows = joint per-date observations
+    of K parallel series), returns ``(mean_K, V_KxK)`` where ``V`` is
+    the Bartlett-kernel HAC variance of the sample mean — handles both
+    serial autocovariance within each column AND cross-column
+    contemporaneous + lagged covariance via the matrix autocovariances
+    ``Γ_j = (1/T) X̃_t' X̃_{t-j}``. Default lag rule
+    ``L = floor(T^(1/3))`` matches ``factrix._stats.hac._newey_west_se``.
+
+    Caller must pre-handle missing data (drop / interpolate) — joint
+    NW HAC requires aligned rows; partial NaN within a row would
+    require pairwise complete-case autocovariances and a different
+    PSD guarantee.
+    """
+    Y = np.asarray(Y, dtype=float)
+    if Y.ndim != 2:
+        raise ValueError(f"Y must be 2-D (T, K); got shape {Y.shape}.")
+    n, k = Y.shape
+    if n < 2:
+        return Y.mean(axis=0) if n else np.zeros(k), np.zeros((k, k))
+
+    L = int(np.floor(n ** (1.0 / 3.0))) if lags is None else lags
+    L = max(0, min(L, n - 1))
+
+    mean = Y.mean(axis=0)
+    centred = Y - mean
+
+    gamma_0 = (centred.T @ centred) / n
+    weighted = gamma_0.copy()
+    for j in range(1, L + 1):
+        gamma_j = (centred[j:].T @ centred[:-j]) / n
+        weight = 1.0 - j / (L + 1)
+        weighted += weight * (gamma_j + gamma_j.T)
+
+    # Symmetrise — floating-point asymmetry from the running sum can
+    # break the strict PSD requirement of `_wald_p_linear`'s inverse.
+    weighted = 0.5 * (weighted + weighted.T)
+    var_of_mean = weighted / n
+    return mean, var_of_mean
+
+
+def _wald_nw_cluster_means(
+    per_date_metric: np.ndarray,
+    *,
+    R: np.ndarray,
+    q: np.ndarray | float = 0.0,
+    lags: int | None = None,
+) -> tuple[float, float]:
+    """Wald χ² for ``R · mean = q`` on a (T, K) per-date metric panel.
+
+    Tests linear restrictions on the K-vector of per-slice means under
+    Newey-West HAC + 1-way cluster on the slice grouping. Equivalent
+    to running OLS on the long-format stacked panel
+    ``y_{t,k} = α + Σ β_j · 1{slice = j}`` with cluster-NW errors,
+    but operating directly on the per-date metric matrix is faster and
+    more numerically stable than rebuilding the design matrix.
+
+    Args:
+        per_date_metric: ``(T, K)`` matrix; ``per_date_metric[t, k]``
+            is the metric value for slice ``k`` on date ``t``.
+        R: Restriction matrix ``(r, K)``. For pairwise contrast
+            "slice 0 vs slice 1": ``[[1, -1, 0, …, 0]]``. For omnibus
+            "all K slices equal" (K-1 contrasts vs the first):
+            ``[[1, -1, 0, …], [1, 0, -1, 0, …], …]``.
+        q: Restriction RHS, scalar or ``(r,)``; default 0.
+        lags: Bartlett-kernel bandwidth; ``None`` → ``floor(T^(1/3))``.
+
+    Returns:
+        ``(W, p)`` with ``W ~ χ²_r`` under H₀. Returns ``(0.0, 1.0)``
+        on degenerate input (T < 2 or singular middle matrix).
+    """
+    Y = np.asarray(per_date_metric, dtype=float)
+    if Y.ndim != 2:
+        raise ValueError(f"per_date_metric must be 2-D (T, K); got shape {Y.shape}.")
+    if Y.shape[0] < 2:
+        return 0.0, 1.0
+    mean, V = _nw_hac_vector_mean(Y, lags=lags)
+    return _wald_p_linear(mean, V, R, q)
+
+
+def _cluster_meat(
+    X: np.ndarray,
+    u: np.ndarray,
+    cluster_ids: np.ndarray,
+) -> np.ndarray:
+    """One-way cluster meat matrix ``Σ_g (X_g' u_g)(X_g' u_g)'``.
+
+    Sandwich pieces are cached at the cluster level; complexity is
+    O(n · k²) regardless of cluster count. Used as the building block
+    for both single-cluster and CGM (2011) two-way cluster covariance.
+    """
+    _, k = X.shape
+    score = X * u[:, None]
+    unique = np.unique(cluster_ids)
+    meat = np.zeros((k, k))
+    for g in unique:
+        mask = cluster_ids == g
+        s_g = score[mask].sum(axis=0)
+        meat += np.outer(s_g, s_g)
+    return meat
+
+
+def _wald_double_cluster(
+    y: np.ndarray,
+    X: np.ndarray,
+    *,
+    R: np.ndarray,
+    q: np.ndarray | float = 0.0,
+    date_ids: np.ndarray,
+    asset_ids: np.ndarray,
+) -> tuple[float, float]:
+    """Wald χ² with two-way cluster covariance on (date, asset).
+
+    Cameron-Gelbach-Miller (2011) construction:
+    ``V_DC = V_date + V_asset - V_intersection``, with each piece a
+    sandwich ``(X'X)^{-1} M_cluster (X'X)^{-1}``. ``V_intersection``
+    clusters by the (date, asset) intersection — for a panel where
+    each row is a unique (date, asset) cell this collapses to the
+    HC0 heteroskedasticity-robust variance ``M = Σ x_i x_i' u_i²``.
+
+    The returned ``V_DC`` is symmetrised before passing to
+    ``_wald_p_linear`` (CGM construction is theoretically symmetric
+    but the subtraction can introduce floating-point asymmetry that
+    breaks the inverse).
+
+    Args:
+        y: ``(n,)`` outcome vector.
+        X: ``(n, k)`` regressor matrix; caller adds intercept column
+            if needed (this routine does not auto-add).
+        R: Restriction matrix ``(r, k)``.
+        q: Restriction RHS; default 0.
+        date_ids: ``(n,)`` date label per observation.
+        asset_ids: ``(n,)`` asset label per observation.
+
+    Returns:
+        ``(W, p)`` with ``W ~ χ²_r`` under H₀. Returns ``(0.0, 1.0)``
+        if ``X'X`` is singular or ``n < k + 1``.
+    """
+    y = np.asarray(y, dtype=float)
+    X = np.asarray(X, dtype=float)
+    date_ids = np.asarray(date_ids)
+    asset_ids = np.asarray(asset_ids)
+    n, k = X.shape
+    if len(y) != n or n < k + 1:
+        return 0.0, 1.0
+    if len(date_ids) != n or len(asset_ids) != n:
+        raise ValueError(
+            f"date_ids / asset_ids length must match X rows ({n}); got "
+            f"{len(date_ids)} / {len(asset_ids)}."
+        )
+
+    XtX = X.T @ X
+    try:
+        XtX_inv = np.linalg.inv(XtX)
+    except np.linalg.LinAlgError:
+        return 0.0, 1.0
+    beta = XtX_inv @ (X.T @ y)
+    resid = y - X @ beta
+
+    M_date = _cluster_meat(X, resid, date_ids)
+    M_asset = _cluster_meat(X, resid, asset_ids)
+    # Intersection cluster = HC0 when each row is a unique (date,
+    # asset) cell. Build a composite scalar ID via np.unique pair-encoding
+    # so panels with repeated (date, asset) cells (e.g. multiple events
+    # per asset-date) still cluster correctly without object-dtype
+    # comparison surprises.
+    _, combined_ids = np.unique(
+        np.column_stack([np.asarray(date_ids), np.asarray(asset_ids)]),
+        axis=0,
+        return_inverse=True,
+    )
+    M_intersection = _cluster_meat(X, resid, combined_ids)
+
+    V_dc = XtX_inv @ (M_date + M_asset - M_intersection) @ XtX_inv
+    V_dc = 0.5 * (V_dc + V_dc.T)
+    # CGM caveat: the subtraction can leave V_DC non-PSD on small
+    # samples. Symmetrising fixes asymmetry but not negative-definite
+    # diagonals; `_wald_p_linear` returns (0, 1) on a singular middle.
+    if not np.all(np.isfinite(V_dc)):
+        return 0.0, 1.0
+    if np.any(np.diag(V_dc) < -EPSILON):
+        return 0.0, 1.0
+    return _wald_p_linear(beta, V_dc, R, q)

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -46,6 +46,14 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
 )
 
+# Layer-B slice-test contract (#153 §5): CAAR is event-driven; the
+# cross-section is the event sample, not a bucketed asset universe,
+# so slice tests skip the `n_groups` downscale step. Minimum event
+# count for the cross-event t-test (FEW_EVENTS_BROWN_WARNER threshold)
+# lives in the procedure short-circuit and is parallel to (not
+# exposed via) this attribute.
+min_assets_per_group: int | None = None
+
 
 def compute_caar(
     df: pl.DataFrame,

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -35,6 +35,14 @@ from factrix._stats import (
 from factrix._types import DDOF, EPSILON, MetricOutput, ShankenVarSource
 from factrix.metrics._helpers import _short_circuit_output
 
+# Layer-B slice-test contract (#153 §5): Fama-MacBeth runs a per-date
+# OLS regression on the cross-section, not a bucket sort, so slice
+# tests never need to downscale `n_groups`. Sample-size constraints
+# (T < HARD short-circuit, T < WARN warning) live in the procedure
+# below; the cross-section minimum per regression is enforced inside
+# the per-date OLS rather than via this attribute.
+min_assets_per_group: int | None = None
+
 # Two-tier sample-size guard on the FM β series. ``T < HARD`` short-
 # circuits — NW HAC SE on a 3-period series is undefined. ``HARD ≤ T <
 # WARN`` returns the stat with ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS``

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -24,6 +24,13 @@ from factrix._stats import (
 from factrix._types import MIN_ASSETS_PER_DATE_IC, MetricOutput
 from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
 
+# Layer-B slice-test contract (#153 §5): hit_rate operates on a
+# pre-aggregated per-date series (no cross-section bucket pass), so
+# slice tests skip the `n_groups` downscale step. Per-date minimum
+# (if any) is the responsibility of the upstream metric that produced
+# the series.
+min_assets_per_group: int | None = None
+
 
 def hit_rate(
     series: pl.DataFrame,

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -38,6 +38,15 @@ from factrix.metrics._helpers import (
 )
 from factrix.stats import bhy_adjusted_p
 
+# Layer-B slice-test contract (#153 §5): IC is per-date Spearman rank
+# correlation, not a bucketed metric — slice tests never need to
+# downscale `n_groups`. The min-cross-section-per-date constraint
+# (Spearman ρ asymptotic distribution requires ≥ 30 obs per date,
+# Hollander-Wolfe-Chicken §8.6) lives in the procedure as
+# `MIN_ASSETS_PER_DATE_IC` short-circuit, parallel to (not exposed
+# via) this attribute.
+min_assets_per_group: int | None = None
+
 
 class _RegimeICEntry(TypedDict):
     mean_ic: float

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -32,6 +32,16 @@ from factrix.metrics._helpers import (
     _warn_high_tie_ratio,
 )
 
+# Layer-B slice-test contract (#153 §5): monotonicity buckets the
+# cross-section into `n_groups` (default 10) and computes Spearman ρ
+# across per-bucket means. Patton & Timmermann (2010) "Monotonicity
+# in Asset Returns" recommend ≥ 50 assets per bucket so the per-date
+# bucket means converge to their cross-sectional expectation; below
+# this floor individual-asset noise dominates the rank statistic.
+# `_downscale_n_groups(base, n_assets, min_per_group=50)` caps
+# `n_groups` accordingly inside the slice-test verb.
+min_assets_per_group: int | None = 50
+
 
 def monotonicity(
     df: pl.DataFrame,

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -6,11 +6,16 @@
 NW HAC inference path.
 ``HansenHodrick`` — rectangular-kernel HAC variant for IC / FM PANEL
 on overlapping forward returns.
+``WaldNWCluster`` / ``WaldDoubleCluster`` — Layer-B cluster-robust
+Wald χ² Estimators for slice contrasts (#153).
+``BlockBootstrap`` — Layer-B block-bootstrap empirical-p Estimator
+for paired-diff slice tests (#153).
 ``multiple_testing`` — BHY procedure for FDR control across many factors.
 ``bootstrap`` — stationary-bootstrap resampling + CI for dependent series.
 """
 
 from factrix.stats._estimator import Estimator
+from factrix.stats.block_bootstrap import BlockBootstrap
 from factrix.stats.bootstrap import (
     bootstrap_mean_ci,
     stationary_bootstrap_resamples,
@@ -18,17 +23,30 @@ from factrix.stats.bootstrap import (
 from factrix.stats.hansen_hodrick import HansenHodrick
 from factrix.stats.multiple_testing import bhy_adjust, bhy_adjusted_p
 from factrix.stats.newey_west import NeweyWest
+from factrix.stats.wald_cluster import WaldDoubleCluster, WaldNWCluster
 
 # Internal registry consumed by `factrix.list_estimators`. Append new
 # Estimator instances here as they land — `list_estimators` filters by
 # `applicable_to(scope, signal)` so the registry is the single source
-# of truth for "which estimators exist".
-_ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (NeweyWest(), HansenHodrick())
+# of truth for "which estimators exist". Layer-B Estimators (#153)
+# enter the registry with default-constructed instances; callers
+# override the defaults by passing an explicitly-constructed instance
+# to the Layer-B verb (#176).
+_ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (
+    NeweyWest(),
+    HansenHodrick(),
+    WaldNWCluster(),
+    WaldDoubleCluster(),
+    BlockBootstrap(),
+)
 
 __all__ = [
+    "BlockBootstrap",
     "Estimator",
     "HansenHodrick",
     "NeweyWest",
+    "WaldDoubleCluster",
+    "WaldNWCluster",
     "bhy_adjust",
     "bhy_adjusted_p",
     "bootstrap_mean_ci",

--- a/factrix/stats/block_bootstrap.py
+++ b/factrix/stats/block_bootstrap.py
@@ -1,0 +1,96 @@
+"""``BlockBootstrap`` Estimator — empirical p via dependent-block resampling (#153).
+
+Names the block-bootstrap inference path for the Layer-B paired-diff
+slice test. Numerics — Politis-Romano stationary scheme, Künsch fixed
+scheme, Politis-White automatic block length — live in
+``factrix._stats.bootstrap``; this module is the dispatch handle
+exposed to family verbs / Layer-B verbs (#176).
+
+Public ``factrix.stats.bootstrap`` standalone helpers
+(``stationary_bootstrap_resamples`` / ``bootstrap_mean_ci``) remain
+in place for callers wanting a CI utility outside the Estimator
+dispatch chain.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from factrix._axis import FactorScope, Metric, Signal
+from factrix._codes import StatCode
+
+
+class BlockBootstrap:
+    """Block-bootstrap empirical p-value Estimator for paired-diff slice tests.
+
+    Resamples a paired-difference series under H₀: ``E[diff] = 0`` using
+    one of two dependent-bootstrap schemes:
+
+    - ``"stationary"`` (Politis & Romano 1994) — geometric block lengths
+      with mean ``L``; each resample is itself a stationary process.
+      Default; preferred when downstream stats (CI, Sharpe) rely on
+      stationarity.
+    - ``"fixed"`` (Künsch 1989) — deterministic block length ``L``;
+      cleaner for variance estimation; loses stationarity at block
+      joins but tighter at small ``B``.
+
+    Block length resolves automatically from the input series via
+    Politis-White (2004) when ``block_length="auto"``; pass an integer
+    to fix it.
+
+    Applicability is restricted to ``(INDIVIDUAL, CONTINUOUS)`` —
+    consistent with the Layer-B verbs that produce paired per-date
+    diffs (slice IC, slice FM-λ, …).
+
+    Constructor parameters are stored on the instance and read by the
+    Layer-B verb procedure when it calls
+    ``factrix._stats.bootstrap._block_bootstrap_diff_p``. Two
+    ``BlockBootstrap`` instances with different ``scheme`` / block
+    length are distinct Estimators from the verb's perspective; the
+    StatCode emitted (``P_BOOT``) does not split on scheme — scheme is
+    metadata, not a separate code (parallel to how ``NeweyWest``'s lag
+    rule lives in ``metadata`` rather than splitting ``P_NW``).
+    """
+
+    def __init__(
+        self,
+        block_length: int | Literal["auto"] = "auto",
+        n_resamples: int = 999,
+        scheme: Literal["fixed", "stationary"] = "stationary",
+        rng_seed: int | None = None,
+    ) -> None:
+        if block_length != "auto" and block_length < 1:
+            raise ValueError(
+                f"block_length must be 'auto' or int >= 1; got {block_length!r}."
+            )
+        if n_resamples < 1:
+            raise ValueError(f"n_resamples must be >= 1; got {n_resamples!r}.")
+        if scheme not in ("fixed", "stationary"):
+            raise ValueError(f"scheme must be 'fixed' or 'stationary'; got {scheme!r}.")
+        self.block_length = block_length
+        self.n_resamples = n_resamples
+        self.scheme = scheme
+        self.rng_seed = rng_seed
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+    @property
+    def description(self) -> str:
+        bl = "auto" if self.block_length == "auto" else f"L={self.block_length}"
+        return (
+            f"Block-bootstrap empirical p-value on a paired-diff series "
+            f"({self.scheme} scheme, {bl}, B={self.n_resamples})."
+        )
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        return scope is FactorScope.INDIVIDUAL and signal is Signal.CONTINUOUS
+
+    def emits_for(
+        self,
+        _scope: FactorScope,
+        _signal: Signal,
+        _metric: Metric | None,
+    ) -> StatCode:
+        return StatCode.P_BOOT

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -64,6 +64,8 @@ def stationary_bootstrap_resamples(
     Returns:
         ``(n_bootstrap, T)`` numpy array of resampled series.
     """
+    from factrix._stats.bootstrap import _stationary_block_indices
+
     values = np.asarray(values, dtype=float)
     n = len(values)
     if n == 0:
@@ -75,18 +77,7 @@ def stationary_bootstrap_resamples(
         raise ValueError(f"block_length must be >= 1.0, got {block_length!r}")
 
     rng = np.random.default_rng(seed)
-    # Probability of starting a new block at each step = 1/L.
-    p_new = 1.0 / block_length
-    # Pre-draw all random decisions — much faster than a Python loop.
-    starts = rng.integers(0, n, size=(n_bootstrap, n))
-    new_block = rng.random(size=(n_bootstrap, n)) < p_new
-    # Build index matrix: when new_block[i, t] is True, take a fresh
-    # random start; else continue by +1 (modulo n) from the previous.
-    idx = np.empty((n_bootstrap, n), dtype=np.int64)
-    idx[:, 0] = starts[:, 0]
-    for t in range(1, n):
-        prev = (idx[:, t - 1] + 1) % n
-        idx[:, t] = np.where(new_block[:, t], starts[:, t], prev)
+    idx = _stationary_block_indices(n, n_bootstrap, float(block_length), rng)
     return values[idx]
 
 

--- a/factrix/stats/wald_cluster.py
+++ b/factrix/stats/wald_cluster.py
@@ -1,0 +1,115 @@
+"""Cluster-robust Wald χ² Estimator instances (#153).
+
+Two ``Estimator`` implementations targeting the Layer-B slice-test
+setting (#176 verbs ``slice_pairwise_test`` / ``slice_joint_test``):
+
+- ``WaldNWCluster`` — NW HAC + 1-way cluster on the slice grouping;
+  consumes the stacked per-date metric panel. Emits
+  ``StatCode.P_WALD_NWCL`` (paired with ``WALD_NWCL`` on the test
+  statistic side).
+- ``WaldDoubleCluster`` — Cameron-Gelbach-Miller (2011) two-way
+  cluster on (date, asset); consumes the raw asset-date panel.
+  Emits ``StatCode.P_WALD_DC``. Interface ships this issue but no
+  verb consumes it until ``factor_decomposition`` lands later;
+  calling ``bhy(estimator=WaldDoubleCluster())`` against a profile
+  produced by ``evaluate()`` lands on a missing-stat error until
+  the verb populates ``profile.stats[StatCode.P_WALD_DC]``.
+
+Numerical implementations live in ``factrix._stats.wald``; this
+module names the inference path the family verbs / Layer-B verbs
+dispatch to.
+"""
+
+from __future__ import annotations
+
+from factrix._axis import FactorScope, Metric, Signal
+from factrix._codes import StatCode
+
+
+class WaldNWCluster:
+    """Cluster-robust Wald χ² with NW Bartlett HAC + 1-way slice cluster.
+
+    Backs the Layer-B slice test on a per-date metric panel: K parallel
+    per-slice metric series (IC, FM λ, etc.) are stacked and a Wald
+    contrast tests the equality of slice means under joint NW HAC of
+    the K-vector. Numerics live in
+    ``factrix._stats.wald._wald_nw_cluster_means``.
+
+    Applicability is restricted to ``(INDIVIDUAL, CONTINUOUS)`` — the
+    PANEL inference cells whose per-date scalars feed the stacked
+    panel. ``COMMON`` cells produce one number per date by definition
+    of the scope and have no within-cell cross-section to slice over.
+
+    Pass an instance to a Layer-B verb to make the inference choice
+    explicit::
+
+        fx.slice_pairwise_test(metric=ic, df=panel, label="sector",
+                                estimator=WaldNWCluster())
+
+    Constructor takes no arguments in this release; the Bartlett-kernel
+    bandwidth is resolved automatically by ``_wald_nw_cluster_means``
+    (``floor(T^(1/3))`` default). Explicit-lag knob is a future
+    enhancement and would arrive as a keyword-only ``__init__``
+    parameter without changing callers using the default.
+    """
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+    @property
+    def description(self) -> str:
+        return (
+            "Cluster-robust Wald χ² (NW Bartlett HAC + 1-way cluster on the "
+            "slice grouping) on a stacked per-date metric panel."
+        )
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        return scope is FactorScope.INDIVIDUAL and signal is Signal.CONTINUOUS
+
+    def emits_for(
+        self,
+        _scope: FactorScope,
+        _signal: Signal,
+        _metric: Metric | None,
+    ) -> StatCode:
+        return StatCode.P_WALD_NWCL
+
+
+class WaldDoubleCluster:
+    """Two-way cluster Wald χ² on (date, asset) — Cameron-Gelbach-Miller (2011).
+
+    Backs the raw asset-date panel inference path (factor × slice
+    interaction with full panel SE). Numerics live in
+    ``factrix._stats.wald._wald_double_cluster``.
+
+    Interface ships this PR; no verb consumes it until
+    ``factor_decomposition`` lands later. ``list_estimators`` surfaces
+    it for ``(INDIVIDUAL, CONTINUOUS)`` cells — calling
+    ``bhy(estimator=WaldDoubleCluster())`` against a profile produced
+    by ``evaluate()`` lands on a missing-stat error pointing at the
+    precondition (same pattern as ``HansenHodrick`` on a non-overlapping
+    profile).
+    """
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+    @property
+    def description(self) -> str:
+        return (
+            "Two-way cluster Wald χ² on (date, asset), Cameron-Gelbach-Miller "
+            "(2011). Reserved interface for the raw asset-date panel path."
+        )
+
+    def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
+        return scope is FactorScope.INDIVIDUAL and signal is Signal.CONTINUOUS
+
+    def emits_for(
+        self,
+        _scope: FactorScope,
+        _signal: Signal,
+        _metric: Metric | None,
+    ) -> StatCode:
+        return StatCode.P_WALD_DC

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
       - Identity / context: api/identity.md
       - MetricOutput: api/metric-output.md
       - multi_factor: api/multi-factor.md
+      - stats: api/stats.md
       - datasets: api/datasets.md
       - preprocess: api/preprocess.md
       - Errors: api/errors.md

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -1,0 +1,178 @@
+"""Tests for ``factrix._stats.bootstrap`` (Künsch / PR / PW)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._stats.bootstrap import (
+    _block_bootstrap_diff_p,
+    _fixed_block_indices,
+    _politis_white_block_length,
+    _stationary_block_indices,
+)
+
+
+class TestPolitisWhiteBlockLength:
+    def test_iid_returns_short_block(self):
+        # IID series: optimal block length should be small (< T^(1/3) * something).
+        rng = np.random.default_rng(seed=0)
+        x = rng.standard_normal(size=500)
+        L = _politis_white_block_length(x, scheme="stationary")
+        assert 1.0 <= L <= 50.0  # generous upper bound for IID
+
+    def test_persistent_returns_longer_block(self):
+        # AR(1) with phi=0.7 should pick a block longer than IID equivalent.
+        rng = np.random.default_rng(seed=1)
+        n = 500
+        x = np.empty(n)
+        x[0] = rng.standard_normal()
+        for t in range(1, n):
+            x[t] = 0.7 * x[t - 1] + rng.standard_normal()
+        L_persist = _politis_white_block_length(x, scheme="stationary")
+        # Generate matched-length IID and compare.
+        x_iid = rng.standard_normal(size=n)
+        L_iid = _politis_white_block_length(x_iid, scheme="stationary")
+        assert L_persist > L_iid
+
+    def test_fixed_smaller_than_stationary(self):
+        # PW eq 9 vs 12: D_CB = (4/3)·g(0)² > D_SB = 2·g(0)²? No — 4/3 < 2,
+        # so fixed L = (2G²/D_CB)^(1/3) > stationary L. Verify direction.
+        rng = np.random.default_rng(seed=2)
+        n = 400
+        x = np.empty(n)
+        x[0] = rng.standard_normal()
+        for t in range(1, n):
+            x[t] = 0.5 * x[t - 1] + rng.standard_normal()
+        L_sb = _politis_white_block_length(x, scheme="stationary")
+        L_cb = _politis_white_block_length(x, scheme="fixed")
+        assert L_cb >= L_sb
+
+    def test_fallback_on_short_series(self):
+        # n=3 < 4 → fallback to 1.75 * n^(1/3).
+        L = _politis_white_block_length(np.array([1.0, 2.0, 3.0]))
+        assert pytest.approx(max(1.0, 1.75 * 3 ** (1.0 / 3.0))) == L
+
+    def test_fallback_on_zero_variance(self):
+        L = _politis_white_block_length(np.zeros(100))
+        assert pytest.approx(max(1.0, 1.75 * 100 ** (1.0 / 3.0))) == L
+
+    def test_rejects_unknown_scheme(self):
+        rng = np.random.default_rng(seed=7)
+        with pytest.raises(ValueError, match="scheme must be"):
+            _politis_white_block_length(rng.standard_normal(200), scheme="other")  # type: ignore[arg-type]
+
+
+class TestFixedBlockIndices:
+    def test_shape_and_range(self):
+        rng = np.random.default_rng(seed=0)
+        idx = _fixed_block_indices(100, 50, block_length=5, rng=rng)
+        assert idx.shape == (50, 100)
+        assert idx.min() >= 0 and idx.max() < 100
+
+    def test_block_contiguity(self):
+        # Within each block of length L, indices should be consecutive
+        # modulo n. Sample one resample.
+        rng = np.random.default_rng(seed=42)
+        n, L = 50, 4
+        idx = _fixed_block_indices(n, 1, block_length=L, rng=rng)[0]
+        # Each block of length L (except maybe last) should have
+        # idx[t+1] = (idx[t] + 1) % n.
+        n_full_blocks = len(idx) // L
+        for b in range(n_full_blocks):
+            block = idx[b * L : (b + 1) * L]
+            diffs = (block[1:] - block[:-1]) % n
+            assert np.all(diffs == 1)
+
+    def test_rejects_zero_block_length(self):
+        rng = np.random.default_rng()
+        with pytest.raises(ValueError, match="block_length must be >= 1"):
+            _fixed_block_indices(10, 5, block_length=0, rng=rng)
+
+    def test_empty(self):
+        rng = np.random.default_rng()
+        idx = _fixed_block_indices(0, 5, block_length=3, rng=rng)
+        assert idx.shape == (5, 0)
+
+
+class TestStationaryBlockIndices:
+    def test_shape_and_range(self):
+        rng = np.random.default_rng(seed=0)
+        idx = _stationary_block_indices(100, 50, mean_block_length=5.0, rng=rng)
+        assert idx.shape == (50, 100)
+        assert idx.min() >= 0 and idx.max() < 100
+
+    def test_geometric_block_length_mean(self):
+        # With p_new = 1/L, the count of new-block events per resample
+        # of length n should average n/L. Statistical sanity (loose).
+        rng = np.random.default_rng(seed=99)
+        n = 1000
+        L_target = 10.0
+        idx = _stationary_block_indices(n, 200, mean_block_length=L_target, rng=rng)
+        # Block boundary count = number of jumps that aren't "+1 mod n".
+        diffs = (idx[:, 1:] - idx[:, :-1]) % n
+        n_jumps = (diffs != 1).sum() + 200  # +1 boundary at t=0 per resample
+        avg_blocks = n_jumps / 200
+        # Expected ≈ n/L = 100.
+        assert 70 < avg_blocks < 130
+
+    def test_rejects_short_block(self):
+        rng = np.random.default_rng()
+        with pytest.raises(ValueError, match=r"mean_block_length must be >= 1\.0"):
+            _stationary_block_indices(10, 5, mean_block_length=0.5, rng=rng)
+
+
+class TestBlockBootstrapDiffP:
+    def test_calibration_under_null(self):
+        # Under H0 (true mean = 0), p should be roughly uniform — in
+        # particular, large p on a series with mean ≈ 0.
+        rng = np.random.default_rng(seed=0)
+        diff = rng.standard_normal(size=200)  # mean ≈ 0
+        p, _meta = _block_bootstrap_diff_p(diff, n_resamples=499, rng_seed=0)
+        assert 0.0 < p <= 1.0
+        # mean ≈ 0 → not significant.
+        assert p > 0.1
+
+    def test_power_under_strong_alt(self):
+        rng = np.random.default_rng(seed=1)
+        diff = rng.standard_normal(size=200) + 0.5  # strong positive shift
+        p, _ = _block_bootstrap_diff_p(diff, n_resamples=499, rng_seed=0)
+        assert p < 0.01
+
+    def test_seed_recorded_when_none(self):
+        diff = np.array([0.1, -0.2, 0.3, -0.1, 0.2, 0.0, -0.05, 0.15])
+        _p, meta = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=None)
+        assert isinstance(meta["rng_seed"], int)
+        assert meta["rng_seed"] >= 0
+        assert meta["n_resamples"] == 199
+
+    def test_explicit_seed_reproducible(self):
+        diff = np.array([0.3, -0.1, 0.4, -0.2, 0.1, 0.05, -0.15, 0.2, 0.0, 0.1])
+        p1, m1 = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=123)
+        p2, m2 = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=123)
+        assert p1 == p2
+        assert m1["rng_seed"] == m2["rng_seed"] == 123
+
+    def test_fixed_scheme(self):
+        rng = np.random.default_rng(seed=2)
+        diff = rng.standard_normal(size=100) + 0.4
+        p_fixed, m_fixed = _block_bootstrap_diff_p(
+            diff,
+            block_length=5,
+            scheme="fixed",
+            n_resamples=499,
+            rng_seed=0,
+        )
+        assert p_fixed < 0.05
+        assert m_fixed["scheme"] == "fixed"
+        assert m_fixed["block_length"] == 5
+
+    def test_short_series_returns_one(self):
+        p, meta = _block_bootstrap_diff_p(np.array([0.5]))
+        assert p == 1.0
+        assert meta["n_resamples"] == 0
+
+    def test_p_floor_smoothing(self):
+        # p should never be exactly 0 (Davison-Hinkley smoothing).
+        diff = np.full(100, 100.0)  # huge mean → all bootstrap means 0
+        p, _ = _block_bootstrap_diff_p(diff, n_resamples=99, rng_seed=0)
+        assert p == pytest.approx(1.0 / 100.0)

--- a/tests/stats/test_layer_b_estimators.py
+++ b/tests/stats/test_layer_b_estimators.py
@@ -1,0 +1,163 @@
+"""Tests for Layer-B Estimators (#153): WaldNWCluster / WaldDoubleCluster / BlockBootstrap."""
+
+from __future__ import annotations
+
+import pytest
+from factrix._axis import FactorScope, Metric, Signal
+from factrix._codes import StatCode
+from factrix.stats import (
+    _ESTIMATOR_REGISTRY,
+    BlockBootstrap,
+    Estimator,
+    WaldDoubleCluster,
+    WaldNWCluster,
+)
+
+
+class TestEstimatorProtocol:
+    def test_all_three_satisfy_protocol(self):
+        for est in (WaldNWCluster(), WaldDoubleCluster(), BlockBootstrap()):
+            assert isinstance(est, Estimator)
+
+    def test_names_distinct(self):
+        names = {e.name for e in _ESTIMATOR_REGISTRY}
+        assert names == {
+            "NeweyWest",
+            "HansenHodrick",
+            "WaldNWCluster",
+            "WaldDoubleCluster",
+            "BlockBootstrap",
+        }
+
+
+class TestWaldNWCluster:
+    def test_emits_p_wald_nwcl(self):
+        est = WaldNWCluster()
+        code = est.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
+        assert code is StatCode.P_WALD_NWCL
+
+    def test_applicable_to_individual_continuous(self):
+        est = WaldNWCluster()
+        assert est.applicable_to(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+
+    def test_not_applicable_to_common(self):
+        est = WaldNWCluster()
+        assert not est.applicable_to(FactorScope.COMMON, Signal.CONTINUOUS)
+
+    def test_not_applicable_to_sparse(self):
+        est = WaldNWCluster()
+        assert not est.applicable_to(FactorScope.INDIVIDUAL, Signal.SPARSE)
+
+    def test_description_mentions_cluster_and_nw(self):
+        d = WaldNWCluster().description.lower()
+        assert "cluster" in d
+        assert "nw" in d or "newey" in d
+
+
+class TestWaldDoubleCluster:
+    def test_emits_p_wald_dc(self):
+        est = WaldDoubleCluster()
+        code = est.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
+        assert code is StatCode.P_WALD_DC
+
+    def test_applicable_to_individual_continuous(self):
+        est = WaldDoubleCluster()
+        assert est.applicable_to(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+
+    def test_description_mentions_two_way(self):
+        d = WaldDoubleCluster().description.lower()
+        assert "two-way" in d or "double" in d or "cgm" in d
+
+
+class TestBlockBootstrap:
+    def test_default_ctor(self):
+        est = BlockBootstrap()
+        assert est.block_length == "auto"
+        assert est.n_resamples == 999
+        assert est.scheme == "stationary"
+        assert est.rng_seed is None
+
+    def test_emits_p_boot(self):
+        est = BlockBootstrap()
+        assert (
+            est.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
+            is StatCode.P_BOOT
+        )
+
+    def test_explicit_config_stored(self):
+        est = BlockBootstrap(
+            block_length=20,
+            n_resamples=499,
+            scheme="fixed",
+            rng_seed=42,
+        )
+        assert est.block_length == 20
+        assert est.n_resamples == 499
+        assert est.scheme == "fixed"
+        assert est.rng_seed == 42
+
+    def test_description_reflects_config(self):
+        est = BlockBootstrap(block_length=10, scheme="fixed", n_resamples=199)
+        d = est.description
+        assert "fixed" in d
+        assert "L=10" in d
+        assert "B=199" in d
+
+    def test_rejects_bad_block_length(self):
+        with pytest.raises(ValueError, match="block_length must be"):
+            BlockBootstrap(block_length=0)
+
+    def test_rejects_bad_n_resamples(self):
+        with pytest.raises(ValueError, match="n_resamples must be >= 1"):
+            BlockBootstrap(n_resamples=0)
+
+    def test_rejects_bad_scheme(self):
+        with pytest.raises(ValueError, match="scheme must be"):
+            BlockBootstrap(scheme="rolling")  # type: ignore[arg-type]
+
+    def test_two_instances_distinct(self):
+        # Same class, different config — caller can pass an explicitly-
+        # constructed instance to override the default in the registry.
+        a = BlockBootstrap(scheme="stationary")
+        b = BlockBootstrap(scheme="fixed")
+        assert a.scheme != b.scheme
+        # Both still emit the same StatCode (scheme is metadata, not
+        # a separate StatCode key).
+        assert a.emits_for(
+            FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC
+        ) == b.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
+
+
+class TestRegistryIntegration:
+    def test_layer_b_estimators_in_registry(self):
+        types_in_registry = {type(e).__name__ for e in _ESTIMATOR_REGISTRY}
+        assert {
+            "WaldNWCluster",
+            "WaldDoubleCluster",
+            "BlockBootstrap",
+        } <= types_in_registry
+
+    def test_existing_estimators_still_in_registry(self):
+        # Regression guard: NW/HH must remain after the Layer-B append.
+        types_in_registry = {type(e).__name__ for e in _ESTIMATOR_REGISTRY}
+        assert "NeweyWest" in types_in_registry
+        assert "HansenHodrick" in types_in_registry
+
+    def test_list_estimators_surfaces_layer_b(self):
+        from factrix import list_estimators
+
+        names = list_estimators(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
+        assert "WaldNWCluster" in names
+        assert "WaldDoubleCluster" in names
+        assert "BlockBootstrap" in names
+
+    def test_list_estimators_excludes_layer_b_for_common(self):
+        from factrix import list_estimators
+
+        names = list_estimators(FactorScope.COMMON, Signal.CONTINUOUS)
+        # NW applies universally; Layer-B + HH restricted to (INDIVIDUAL, CONTINUOUS).
+        assert "NeweyWest" in names
+        assert "WaldNWCluster" not in names
+        assert "WaldDoubleCluster" not in names
+        assert "BlockBootstrap" not in names
+        assert "HansenHodrick" not in names

--- a/tests/stats/test_metric_min_assets_attribute.py
+++ b/tests/stats/test_metric_min_assets_attribute.py
@@ -1,0 +1,44 @@
+"""Contract: each Layer-B-eligible metric module declares ``min_assets_per_group``.
+
+Drift guard for #153 §5 — if a metric module is touched and the
+attribute is dropped (or its type changes from ``int | None``), the
+slice-test verbs in #176 silently treat the metric as non-bucketing
+and skip the downscale step. This test fails loudly instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# (module path, expected attribute value)
+_EXPECTED: list[tuple[str, int | None]] = [
+    ("factrix.metrics.ic", None),
+    ("factrix.metrics.fama_macbeth", None),
+    ("factrix.metrics.hit_rate", None),
+    ("factrix.metrics.caar", None),
+    ("factrix.metrics.monotonicity", 50),
+]
+
+
+@pytest.mark.parametrize(("module_path", "expected"), _EXPECTED)
+def test_metric_declares_min_assets_per_group(
+    module_path: str, expected: int | None
+) -> None:
+    mod = importlib.import_module(module_path)
+    assert hasattr(mod, "min_assets_per_group"), (
+        f"{module_path}.min_assets_per_group is missing — slice-test "
+        f"verbs (#176) cannot resolve the downscale floor."
+    )
+    actual = mod.min_assets_per_group
+    assert actual == expected, (
+        f"{module_path}.min_assets_per_group changed from {expected} to "
+        f"{actual}; update the contract here AND the rationale comment "
+        f"on the metric module + cite the literature anchoring the new value."
+    )
+    if actual is not None:
+        assert isinstance(actual, int) and actual >= 1, (
+            f"{module_path}.min_assets_per_group must be int >= 1 or None; "
+            f"got {actual!r}."
+        )

--- a/tests/stats/test_multiple_testing_fwer.py
+++ b/tests/stats/test_multiple_testing_fwer.py
@@ -38,6 +38,17 @@ class TestHolmStepDown:
         h = np.array(holm_step_down(p))
         assert np.all(h <= b + 1e-12)
 
+    def test_dominates_bonferroni_deterministic(self):
+        # Worst-case sanity: m=3 sorted p = [0.01, 0.02, 0.03].
+        # Holm scaled = [3·0.01, 2·0.02, 1·0.03] = [0.03, 0.04, 0.03];
+        # cummax     = [0.03, 0.04, 0.04].
+        # Bonferroni  = [0.03, 0.06, 0.09].
+        # Holm strictly tighter on the 2nd and 3rd ranks.
+        h = holm_step_down([0.01, 0.02, 0.03])
+        b = bonferroni([0.01, 0.02, 0.03])
+        assert h == pytest.approx([0.03, 0.04, 0.04])
+        assert b == pytest.approx([0.03, 0.06, 0.09])
+
     def test_textbook_example(self):
         # Classic Holm example: p=[0.01, 0.04, 0.03, 0.005], m=4
         # Sorted: [0.005, 0.01, 0.03, 0.04]; factors [4,3,2,1]

--- a/tests/stats/test_multiple_testing_fwer.py
+++ b/tests/stats/test_multiple_testing_fwer.py
@@ -1,0 +1,124 @@
+"""Tests for ``factrix._stats.multiple_testing`` (Holm / Bonferroni / Romano-Wolf)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._stats.multiple_testing import (
+    bonferroni,
+    holm_step_down,
+    romano_wolf,
+)
+
+
+class TestBonferroni:
+    def test_basic(self):
+        # m=4, p=[0.01, 0.04, 0.03, 0.5] → [0.04, 0.16, 0.12, 1.0]
+        out = bonferroni([0.01, 0.04, 0.03, 0.5])
+        assert out == pytest.approx([0.04, 0.16, 0.12, 1.0])
+
+    def test_clipping(self):
+        # p > 1/m → all clipped to 1
+        assert bonferroni([0.5, 0.5, 0.5, 0.5]) == pytest.approx([1.0, 1.0, 1.0, 1.0])
+
+    def test_empty(self):
+        assert bonferroni([]) == []
+
+    def test_validates_range(self):
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            bonferroni([0.5, 1.2])
+
+
+class TestHolmStepDown:
+    def test_dominates_bonferroni(self):
+        # Holm adj p must be ≤ Bonferroni adj p element-wise (uniform dominance).
+        rng = np.random.default_rng(seed=0)
+        p = rng.uniform(0, 1, size=20)
+        b = np.array(bonferroni(p))
+        h = np.array(holm_step_down(p))
+        assert np.all(h <= b + 1e-12)
+
+    def test_textbook_example(self):
+        # Classic Holm example: p=[0.01, 0.04, 0.03, 0.005], m=4
+        # Sorted: [0.005, 0.01, 0.03, 0.04]; factors [4,3,2,1]
+        # Scaled: [0.02, 0.03, 0.06, 0.04]; cummax: [0.02, 0.03, 0.06, 0.06]
+        # Map back to original order:
+        #   idx 0 (raw 0.01, rank 1) → 0.03
+        #   idx 1 (raw 0.04, rank 3) → 0.06
+        #   idx 2 (raw 0.03, rank 2) → 0.06
+        #   idx 3 (raw 0.005, rank 0) → 0.02
+        out = holm_step_down([0.01, 0.04, 0.03, 0.005])
+        assert out == pytest.approx([0.03, 0.06, 0.06, 0.02])
+
+    def test_monotone_in_rank(self):
+        # Adjusted p in rank order is non-decreasing (cummax invariant).
+        p = [0.001, 0.04, 0.02, 0.5, 0.3, 0.1]
+        adj = np.array(holm_step_down(p))
+        adj_sorted = adj[np.argsort(p)]
+        assert np.all(np.diff(adj_sorted) >= -1e-12)
+
+    def test_empty(self):
+        assert holm_step_down([]) == []
+
+    def test_singleton(self):
+        # m=1: Holm = Bonferroni = identity.
+        assert holm_step_down([0.03]) == pytest.approx([0.03])
+
+
+class TestRomanoWolf:
+    def test_independence_close_to_bonferroni_holm(self):
+        # Independent N(0,1) bootstrap: Romano-Wolf should give p ≥ Holm
+        # roughly (it adapts to the actual dependence; under independence
+        # it's not better than Holm). Sanity: all p in [0, 1], monotone.
+        rng = np.random.default_rng(seed=1)
+        m = 5
+        boot = rng.standard_normal(size=(2000, m))
+        # Observed stats — pretend strong tails on first 2 hypotheses.
+        t = np.array([3.5, 3.0, 0.5, 0.2, -0.1])
+        adj = np.array(romano_wolf(t, boot))
+        assert np.all((adj >= 0) & (adj <= 1))
+        # Monotone in descending |t|: order [0, 1, 2, 3, 4] (|t| sorted desc).
+        order = np.argsort(-np.abs(t))
+        adj_desc = adj[order]
+        assert np.all(np.diff(adj_desc) >= -1e-12)
+        # Strong stats should attract small adj p.
+        assert adj[0] < 0.05
+        assert adj[1] < 0.05
+
+    def test_dependence_sharper_than_bonferroni(self):
+        # Perfectly correlated bootstrap: max over k = single column;
+        # Romano-Wolf delivers near-Bonferroni-of-1 = raw-p; should be
+        # MUCH tighter than naive Bonferroni-m on the leading hypothesis.
+        rng = np.random.default_rng(seed=2)
+        m = 10
+        common = rng.standard_normal(size=2000)
+        boot = np.tile(common[:, None], (1, m))  # all columns identical
+        t = np.array([3.5] + [0.0] * (m - 1))
+        adj_rw = np.array(romano_wolf(t, boot))
+        # Naive Bonferroni would be 10 * P(|N|>3.5) ≈ 10 * 0.000465 ≈ 0.0046.
+        # Romano-Wolf with perfect correlation collapses multiplicity:
+        # adj[0] should be close to single-hypothesis p ≈ 0.000465.
+        assert adj_rw[0] < 0.005
+        # Sanity: still in [0,1].
+        assert np.all((adj_rw >= 0) & (adj_rw <= 1))
+
+    def test_one_sided(self):
+        # Observed t = +3 with positive-only alt → small p; with t = -3
+        # under one-sided positive alt, should be near 1.
+        rng = np.random.default_rng(seed=3)
+        boot = rng.standard_normal(size=(2000, 2))
+        adj_pos = romano_wolf([3.0, -3.0], boot, one_sided=True)
+        # +3 → tiny p; -3 → huge p (no rejection on left tail).
+        assert adj_pos[0] < 0.05
+        assert adj_pos[1] > 0.5
+
+    def test_rejects_shape_mismatch(self):
+        with pytest.raises(ValueError, match=r"shape \(B, 3\)"):
+            romano_wolf([1.0, 2.0, 3.0], np.ones((100, 4)))
+
+    def test_rejects_empty_bootstrap(self):
+        with pytest.raises(ValueError, match="at least 1 resample"):
+            romano_wolf([1.0, 2.0], np.ones((0, 2)))
+
+    def test_empty(self):
+        assert romano_wolf([], np.empty((10, 0))) == []

--- a/tests/stats/test_slice_policy.py
+++ b/tests/stats/test_slice_policy.py
@@ -1,0 +1,108 @@
+"""Tests for ``_detect_strict_subsets`` / ``_downscale_n_groups`` (#153 §4 §6)."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from factrix._stats.slice_policy import (
+    _detect_strict_subsets,
+    _downscale_n_groups,
+)
+
+
+def _slice(rows: list[tuple[str, str]]) -> pl.DataFrame:
+    return pl.DataFrame(rows, schema=["date", "asset"], orient="row")
+
+
+class TestDetectStrictSubsets:
+    def test_disjoint_slices_no_pair(self):
+        slices = {
+            "a": _slice([("2020-01-01", "X"), ("2020-01-02", "X")]),
+            "b": _slice([("2020-01-03", "Y"), ("2020-01-04", "Y")]),
+        }
+        assert _detect_strict_subsets(slices) == []
+
+    def test_partial_overlap_no_pair(self):
+        # A and B share some keys but neither is a subset → no warn.
+        slices = {
+            "a": _slice([("d1", "x"), ("d2", "x"), ("d3", "x")]),
+            "b": _slice([("d2", "x"), ("d3", "x"), ("d4", "x")]),
+        }
+        assert _detect_strict_subsets(slices) == []
+
+    def test_strict_subset_emits_pair(self):
+        # Top10 ⊊ Top50 (hierarchical universe pattern).
+        slices = {
+            "top10": _slice([("d1", "a"), ("d1", "b")]),
+            "top50": _slice([("d1", "a"), ("d1", "b"), ("d1", "c"), ("d1", "d")]),
+        }
+        pairs = _detect_strict_subsets(slices)
+        assert pairs == [("top10", "top50")]
+
+    def test_subset_in_either_direction(self):
+        # B contains A; verify flag goes (subset, superset) regardless
+        # of dict insertion order.
+        slices = {
+            "big": _slice([("d1", "a"), ("d1", "b"), ("d1", "c")]),
+            "small": _slice([("d1", "a")]),
+        }
+        pairs = _detect_strict_subsets(slices)
+        assert pairs == [("small", "big")]
+
+    def test_three_way_chain(self):
+        # A ⊊ B ⊊ C → three pairs reported (every nested pair).
+        slices = {
+            "A": _slice([("d1", "x")]),
+            "B": _slice([("d1", "x"), ("d1", "y")]),
+            "C": _slice([("d1", "x"), ("d1", "y"), ("d1", "z")]),
+        }
+        pairs = _detect_strict_subsets(slices)
+        assert sorted(pairs) == [("A", "B"), ("A", "C"), ("B", "C")]
+
+    def test_equal_keysets_not_flagged(self):
+        # Identical key-sets are not strict subsets → not flagged.
+        slices = {
+            "a": _slice([("d1", "x"), ("d2", "y")]),
+            "b": _slice([("d2", "y"), ("d1", "x")]),  # same set, different order
+        }
+        assert _detect_strict_subsets(slices) == []
+
+    def test_custom_key_cols(self):
+        df_a = pl.DataFrame({"event_id": [1, 2], "extra": ["p", "q"]})
+        df_b = pl.DataFrame({"event_id": [1, 2, 3], "extra": ["p", "q", "r"]})
+        pairs = _detect_strict_subsets({"a": df_a, "b": df_b}, key_cols=("event_id",))
+        assert pairs == [("a", "b")]
+
+    def test_missing_key_column_raises(self):
+        df_a = pl.DataFrame({"date": ["d1"], "asset": ["x"]})
+        df_b = pl.DataFrame({"date": ["d1"]})  # missing 'asset'
+        with pytest.raises(ValueError, match="missing key columns"):
+            _detect_strict_subsets({"a": df_a, "b": df_b})
+
+    def test_empty_slices(self):
+        assert _detect_strict_subsets({}) == []
+
+
+class TestDownscaleNGroups:
+    def test_none_passes_through(self):
+        # min_per_group=None → metric doesn't bucket; return base.
+        assert _downscale_n_groups(5, n_assets=20, min_per_group=None) == 5
+
+    def test_capacity_caps_groups(self):
+        # n_assets=60, min_per_group=30 → capacity=2; min(5, 2) = 2.
+        assert _downscale_n_groups(5, n_assets=60, min_per_group=30) == 2
+
+    def test_capacity_above_base_returns_base(self):
+        # n_assets=300, min=30 → capacity=10; base=5 → returns 5.
+        assert _downscale_n_groups(5, n_assets=300, min_per_group=30) == 5
+
+    def test_floor_at_2_when_assets_below_min(self):
+        # n_assets=15, min=30 → 15//30 = 0; floored to 2.
+        assert _downscale_n_groups(5, n_assets=15, min_per_group=30) == 2
+
+    def test_zero_assets_floored_at_2(self):
+        assert _downscale_n_groups(5, n_assets=0, min_per_group=30) == 2
+
+    def test_invalid_min_raises(self):
+        with pytest.raises(ValueError, match="min_per_group must be >= 1"):
+            _downscale_n_groups(5, n_assets=100, min_per_group=0)

--- a/tests/stats/test_wald_cluster.py
+++ b/tests/stats/test_wald_cluster.py
@@ -1,0 +1,170 @@
+"""Tests for cluster-Wald primitives in ``factrix._stats.wald``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._stats.wald import (
+    _nw_hac_vector_mean,
+    _wald_double_cluster,
+    _wald_nw_cluster_means,
+)
+
+
+class TestNWHACVectorMean:
+    def test_iid_diagonal_covariance(self):
+        # IID multivariate normal: V_HAC ≈ Σ / T (no off-diagonal).
+        rng = np.random.default_rng(seed=0)
+        T, K = 1000, 3
+        Y = rng.multivariate_normal(mean=np.zeros(K), cov=np.eye(K), size=T)
+        mean, V = _nw_hac_vector_mean(Y)
+        assert mean.shape == (K,)
+        assert V.shape == (K, K)
+        # Off-diagonals should be small (no cross-corr in DGP).
+        np.testing.assert_allclose(V - np.diag(np.diag(V)), 0.0, atol=2e-3)
+        # Diagonals ≈ 1/T = 0.001.
+        np.testing.assert_allclose(np.diag(V), 1.0 / T, atol=3e-4)
+
+    def test_psd_under_persistence(self):
+        # AR(1) joint series: V_HAC must be PSD even with positive
+        # autocorrelation pumping up the off-diagonals.
+        rng = np.random.default_rng(seed=1)
+        T = 500
+        e = rng.standard_normal(size=(T, 2))
+        Y = np.empty_like(e)
+        Y[0] = e[0]
+        for t in range(1, T):
+            Y[t] = 0.6 * Y[t - 1] + e[t]
+        _, V = _nw_hac_vector_mean(Y)
+        eigvals = np.linalg.eigvalsh(V)
+        assert np.all(eigvals >= -1e-10)
+
+    def test_symmetric(self):
+        rng = np.random.default_rng(seed=2)
+        Y = rng.standard_normal(size=(200, 4))
+        _, V = _nw_hac_vector_mean(Y)
+        np.testing.assert_allclose(V, V.T, atol=1e-14)
+
+    def test_short_sample(self):
+        Y = np.array([[1.0, 2.0]])  # T=1
+        mean, V = _nw_hac_vector_mean(Y)
+        np.testing.assert_array_equal(mean, [1.0, 2.0])
+        np.testing.assert_array_equal(V, np.zeros((2, 2)))
+
+    def test_rejects_1d(self):
+        with pytest.raises(ValueError, match="must be 2-D"):
+            _nw_hac_vector_mean(np.arange(10.0))
+
+    def test_matches_scalar_nw_for_k1(self):
+        # K=1 case: joint NW HAC variance should match the scalar
+        # _newey_west_se² used by the existing HAC module.
+        from factrix._stats.hac import _newey_west_se
+
+        rng = np.random.default_rng(seed=3)
+        x = rng.standard_normal(200)
+        se = _newey_west_se(x)
+        _, V = _nw_hac_vector_mean(x.reshape(-1, 1))
+        assert V[0, 0] == pytest.approx(se * se, rel=1e-12)
+
+
+class TestWaldNWClusterMeans:
+    def test_null_holds_when_means_equal(self):
+        # Two slices with identical IID generation → contrast (1, -1)
+        # should have large p (cannot reject equality).
+        rng = np.random.default_rng(seed=0)
+        T = 500
+        Y = rng.standard_normal(size=(T, 2))
+        _, p = _wald_nw_cluster_means(Y, R=np.array([[1.0, -1.0]]), q=0.0)
+        assert p > 0.1
+
+    def test_alt_detected_when_means_differ(self):
+        rng = np.random.default_rng(seed=1)
+        T = 500
+        Y = np.column_stack([rng.standard_normal(T), rng.standard_normal(T) + 0.5])
+        _, p = _wald_nw_cluster_means(Y, R=np.array([[1.0, -1.0]]), q=0.0)
+        assert p < 0.001
+
+    def test_omnibus_three_slices(self):
+        # K=3, all means equal → joint Wald on R=[[1,-1,0],[1,0,-1]] big p.
+        rng = np.random.default_rng(seed=2)
+        T = 400
+        Y = rng.standard_normal(size=(T, 3))
+        R = np.array([[1.0, -1.0, 0.0], [1.0, 0.0, -1.0]])
+        _, p = _wald_nw_cluster_means(Y, R=R, q=np.zeros(2))
+        assert p > 0.1
+
+    def test_short_sample_returns_unity(self):
+        Y = np.array([[1.0, 2.0]])  # T=1
+        W, p = _wald_nw_cluster_means(Y, R=np.array([[1.0, -1.0]]))
+        assert (W, p) == (0.0, 1.0)
+
+    def test_rejects_1d(self):
+        with pytest.raises(ValueError, match="must be 2-D"):
+            _wald_nw_cluster_means(np.arange(10.0), R=np.array([[1.0]]))
+
+
+class TestWaldDoubleCluster:
+    def _make_panel(self, n_dates=40, n_assets=25, beta=0.0, seed=0):
+        rng = np.random.default_rng(seed=seed)
+        date_ids = np.repeat(np.arange(n_dates), n_assets)
+        asset_ids = np.tile(np.arange(n_assets), n_dates)
+        n = n_dates * n_assets
+        # x and eps both carry date + asset shocks → genuine two-way
+        # cluster structure. Pure-iid x would make CGM ≈ HC0 and the
+        # finite-sample subtraction can flip negative.
+        x_date = rng.standard_normal(n_dates)
+        x_asset = rng.standard_normal(n_assets) * 0.5
+        x = x_date[date_ids] + x_asset[asset_ids] + rng.standard_normal(n) * 0.5
+        e_date = rng.standard_normal(n_dates)
+        e_asset = rng.standard_normal(n_assets) * 0.5
+        eps = e_date[date_ids] + e_asset[asset_ids] + rng.standard_normal(n) * 0.5
+        y = beta * x + eps
+        X = np.column_stack([np.ones(n), x])
+        return y, X, date_ids, asset_ids
+
+    def test_null_holds(self):
+        y, X, d, a = self._make_panel(beta=0.0, seed=0)
+        # Test slope = 0.
+        R = np.array([[0.0, 1.0]])
+        _, p = _wald_double_cluster(y, X, R=R, date_ids=d, asset_ids=a)
+        assert p > 0.05
+
+    def test_alt_detected(self):
+        y, X, d, a = self._make_panel(beta=0.5, seed=1)
+        R = np.array([[0.0, 1.0]])
+        _, p = _wald_double_cluster(y, X, R=R, date_ids=d, asset_ids=a)
+        assert p < 0.01
+
+    def test_symmetric_V(self):
+        # Side-effect check via behaviour: identical (d, a) and (a, d)
+        # cluster orderings → identical p (CGM is symmetric by
+        # construction).
+        y, X, d, a = self._make_panel(beta=0.3, seed=2)
+        R = np.array([[0.0, 1.0]])
+        _, p_da = _wald_double_cluster(y, X, R=R, date_ids=d, asset_ids=a)
+        _, p_ad = _wald_double_cluster(y, X, R=R, date_ids=a, asset_ids=d)
+        assert p_da == pytest.approx(p_ad)
+
+    def test_rejects_id_length_mismatch(self):
+        y, X, d, a = self._make_panel()
+        with pytest.raises(ValueError, match="length must match"):
+            _wald_double_cluster(
+                y,
+                X,
+                R=np.array([[0.0, 1.0]]),
+                date_ids=d[:-1],
+                asset_ids=a,
+            )
+
+    def test_singular_returns_unity(self):
+        # Perfectly collinear regressors → X'X singular → (0, 1).
+        n = 50
+        x = np.arange(n, dtype=float)
+        X = np.column_stack([x, 2 * x])  # collinear
+        y = x + np.random.default_rng(0).standard_normal(n)
+        d = np.repeat(np.arange(10), 5)
+        a = np.tile(np.arange(5), 10)
+        out = _wald_double_cluster(
+            y, X, R=np.array([[1.0, 0.0]]), date_ids=d, asset_ids=a
+        )
+        assert out == (0.0, 1.0)

--- a/tests/test_list_estimators.py
+++ b/tests/test_list_estimators.py
@@ -15,8 +15,19 @@ from factrix._errors import IncompatibleAxisError
 @pytest.mark.parametrize(
     ("scope", "signal", "expected"),
     [
-        # HansenHodrick applies only to (INDIVIDUAL, CONTINUOUS).
-        (FactorScope.INDIVIDUAL, Signal.CONTINUOUS, ["HansenHodrick", "NeweyWest"]),
+        # HansenHodrick + Layer-B Estimators (#153) restrict to
+        # (INDIVIDUAL, CONTINUOUS); NW applies universally.
+        (
+            FactorScope.INDIVIDUAL,
+            Signal.CONTINUOUS,
+            [
+                "BlockBootstrap",
+                "HansenHodrick",
+                "NeweyWest",
+                "WaldDoubleCluster",
+                "WaldNWCluster",
+            ],
+        ),
         (FactorScope.INDIVIDUAL, Signal.SPARSE, ["NeweyWest"]),
         (FactorScope.COMMON, Signal.CONTINUOUS, ["NeweyWest"]),
         (FactorScope.COMMON, Signal.SPARSE, ["NeweyWest"]),
@@ -40,8 +51,11 @@ def test_json_format_includes_metadata_keys() -> None:
 def test_with_import_returns_two_column_lines() -> None:
     rows = list_estimators(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, with_import=True)
     assert rows == [
-        "HansenHodrick → factrix.stats.HansenHodrick",
-        "NeweyWest     → factrix.stats.NeweyWest",
+        "BlockBootstrap    → factrix.stats.BlockBootstrap",
+        "HansenHodrick     → factrix.stats.HansenHodrick",
+        "NeweyWest         → factrix.stats.NeweyWest",
+        "WaldDoubleCluster → factrix.stats.WaldDoubleCluster",
+        "WaldNWCluster     → factrix.stats.WaldNWCluster",
     ]
 
 


### PR DESCRIPTION
## Summary

實作 issue #153 — Layer-B inference primitives 與 policy 層，作為 #176 `slice_pairwise_test` / `slice_joint_test` verb 的前置依賴。

9 個 atomic commit：

| # | Commit | 內容 |
|---|---|---|
| 1 | `9b85bef` | StatCode 加 `WALD_NWCL` / `P_WALD_NWCL` / `WALD_DC` / `P_WALD_DC` / `P_BOOT`；docstring redesign-trigger 註記 |
| 2 | `4f6daf0` | 私有 `_stats/multiple_testing.py`：Holm step-down / Bonferroni / Romano-Wolf bootstrap step-down |
| 3 | `4156358` | 私有 `_stats/bootstrap.py`：Politis-Romano stationary、Künsch fixed、Politis-White (2004) auto block-length spectral plug-in、`_block_bootstrap_diff_p` paired-diff 兩側 empirical p |
| 4 | `2fb6876` | 私有 `_stats/wald.py` 擴張：`_nw_hac_vector_mean`、`_wald_nw_cluster_means`、`_wald_double_cluster` (CGM 2011) |
| 5 | `4337a7c` | 私有 `_stats/slice_policy.py`：`_detect_strict_subsets`、`_downscale_n_groups` |
| 6 | `e83b0e4` | 公開 `WaldNWCluster` / `WaldDoubleCluster` / `BlockBootstrap` Estimators + `_ESTIMATOR_REGISTRY` 註冊 |
| 7 | `9cb74d4` | metric module `min_assets_per_group` 屬性（IC / FM / hit_rate / CAAR = `None`、monotonicity = `50`）+ drift-guard test |
| 8 | `81d932b` | mkdocs `docs/api/stats.md` 新頁面（Estimator catalogue、StatCode 對照表、protocol） |
| 9 | `356fd86` | Cross-batch review fixes：bootstrap kernel dedupe、stats.md decision matrix + reserved-interface admonition、deterministic Holm vs Bonferroni 測、PW flat-top kernel 邊界註記 |

淨變更：+2068 / -12 across 24 files / +212 tests。

## Issue spec deviations（已同步 issue body）

| 項目 | 原 spec | 本 PR | 理由 |
|---|---|---|---|
| StatCode 命名 | `WALD` / `P_WALD` / `P_BOOT` | `WALD_NWCL` / `P_WALD_NWCL` / `WALD_DC` / `P_WALD_DC` / `P_BOOT` | 對齊既有 `T_NW` / `T_HH` 的 `<KIND>_<ALGO>` 慣例；bare `WALD` 把兩種 variance estimator 混淆 |
| `_downscale_n_groups` 簽章 | `AnalysisConfig → AnalysisConfig` | `int → int` | `AnalysisConfig` 並不持有 `n_groups`（quantile-family kwarg）；改為 caller 組裝 |
| §5 IC 範例 | `min_assets_per_group: int = 30` | `None` | IC 是 per-date Spearman 不 bucket；min cross-section 走 procedure 內 `MIN_ASSETS_PER_DATE_IC` short-circuit |
| §5 metric 列表 | IC / FM / monotonicity / Sharpe / hit_rate / turnover / CAAR | 5 個（Sharpe / turnover 不存在 metric module） | 兩者尚未在 codebase；landing 時補 |

## 跨批 quant + senior-backend review — 已採納

- Bootstrap kernel dedupe（公開 `stationary_bootstrap_resamples` 委派私有 `_stationary_block_indices`）
- `stats.md` 加「Picking an Estimator」decision matrix
- `WaldDoubleCluster` reserved-interface 改 admonition
- Deterministic Holm vs Bonferroni 測（補 random-sample 之外的 worst-case pin）
- PW flat-top kernel `range(1, M)` 邊界註記（λ(M/M) = 0）

## Cross-batch review — follow-up 候選（請判斷是否開 issue）

| # | 議題 | 來源 | 建議路徑 |
|---|---|---|---|
| F1 | CGM `V_DC` finite-sample 非 PSD 處理：目前用「diag-negative → 回 (0, 1)」保守 fallback。CGM (2011) §2.3 推薦 eigenvalue projection (V = U·max(Λ,0)·U')，可挽回 power loss | quant logic | 觀察 #176 verb 上線後實測 power 表現再決定；現況不 lie 只 conservative，可接受 |
| F2 | `WaldNWCluster` / `WaldDoubleCluster` class 名選擇 — 從名字看不出 1-way vs 2-way cluster；`WaldSliceCluster` / `WaldTwoWayCluster` 語義較清晰 | quant UX | 是 breaking rename；考慮在 #176 上線前一起改（兩個 verb 也會 reference） |
| F3 | `BlockBootstrap` default `n_resamples=999` 對 α ≤ 0.01 區間 MC error 偏大；考慮預設改 1999 或 docstring 點明 | quant UX | Issue spec 寫 999；改為 docstring 註記較不破壞 spec，dev 自選 |
| F4 | `WALD_DC` 縮寫歧義（double-cluster vs Dimson-correction vs 差分）；`WALD_TWOWAY` 較直觀 | quant UX | 同 F2，考慮一起評估 |
| F5 | Sharpe / turnover metric module 不存在；landing 時須補 `min_assets_per_group` | spec gap | 隨 metric module 加入 |
| F6 | `_cluster_meat` Python loop on cluster IDs — typical 場景毫秒級不需動；極大 cluster 數（≥ 10⁴）才見 hotspot | backend | 出現實際 perf issue 再 profile |

## Test plan

- [x] `python -m pytest -q` → 1122 passed (29 warnings)
- [x] `uv run ruff check` → all clean
- [x] `uv run ruff format --check` → all clean
- [x] `uv run mkdocs build --strict` → exit 0
- [x] CI 全綠（push 後等 GitHub Actions）

Closes #153