### PR TITLE
refactor(stats): rename WaldDoubleCluster / WALD_DC -> TwoWay (#208)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,7 +10,7 @@ Reference for every public symbol exported from `factrix`.
 | [`evaluate`](evaluate.md) | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
 | [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `verdict()`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
 | [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. | Multi-factor screening. |
-| [`stats`](stats.md) | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldDoubleCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking inference method for `bhy(estimator=…)` or Layer-B slice tests. |
+| [`stats`](stats.md) | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking inference method for `bhy(estimator=…)` or Layer-B slice tests. |
 | [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
 | [`Metrics`](metrics/index.md) | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly on a `FactorProfile` / panel. |
 

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -23,14 +23,14 @@ factrix export).
 | `NeweyWest` | NW Bartlett HAC | `(T_NW, P_NW)` | every cell | Default — drives `primary_p` on every PANEL / TIMESERIES procedure. |
 | `HansenHodrick` | HH rectangular HAC | `(T_HH, P_HH)` | `(INDIVIDUAL, CONTINUOUS)` only | Overlapping forward returns on IC PANEL / FM PANEL — the MA(h-1) overlap structure has a closed-form rectangular-kernel SE. |
 | `WaldNWCluster` | Cluster-Wald χ² (NW HAC + 1-way cluster on slice) | `(WALD_NWCL, P_WALD_NWCL)` | `(INDIVIDUAL, CONTINUOUS)` | Layer-B slice test on a stacked per-date metric panel (#176 verbs). |
-| `WaldDoubleCluster` | Cluster-Wald χ² (Cameron-Gelbach-Miller two-way cluster on (date, asset)) | `(WALD_DC, P_WALD_DC)` | `(INDIVIDUAL, CONTINUOUS)` | Reserved interface — raw asset-date panel path. No verb consumes it until `factor_decomposition` lands later. |
+| `WaldTwoWayCluster` | Cluster-Wald χ² (Cameron-Gelbach-Miller two-way cluster on (date, asset)) | `(WALD_TWOWAY, P_WALD_TWOWAY)` | `(INDIVIDUAL, CONTINUOUS)` | Reserved interface — raw asset-date panel path. No verb consumes it until `factor_decomposition` lands later. |
 | `BlockBootstrap` | Politis-Romano stationary or Künsch fixed block bootstrap; Politis-White auto block length | `(P_BOOT,)` | `(INDIVIDUAL, CONTINUOUS)` | Layer-B paired-diff slice test when distributional assumptions of the cluster-Wald path are uncomfortable (heavy tails, persistent shocks). |
 
-!!! warning "`WaldDoubleCluster` is a reserved interface"
-    The class ships in #153 so the `(WALD_DC, P_WALD_DC)` StatCode
+!!! warning "`WaldTwoWayCluster` is a reserved interface"
+    The class ships in #153 so the `(WALD_TWOWAY, P_WALD_TWOWAY)` StatCode
     pair has a stable home, but no verb populates `profile.stats`
-    with `P_WALD_DC` until `factor_decomposition` lands. Calling
-    `bhy(estimator=WaldDoubleCluster())` against a profile produced
+    with `P_WALD_TWOWAY` until `factor_decomposition` lands. Calling
+    `bhy(estimator=WaldTwoWayCluster())` against a profile produced
     by `evaluate()` raises a missing-stat error pointing at the
     precondition.
 
@@ -42,7 +42,7 @@ factrix export).
 | Overlapping forward returns (`forward_periods > 1`) on IC PANEL / FM PANEL | `HansenHodrick` |
 | Slice contrast on per-date IC / FM (regime, sector, decile) | `WaldNWCluster` |
 | Slice paired-diff on heavy-tailed / persistent series, distributional assumptions uncomfortable | `BlockBootstrap` |
-| Raw asset-date panel inference (factor × slice interaction) | `WaldDoubleCluster` (reserved) |
+| Raw asset-date panel inference (factor × slice interaction) | `WaldTwoWayCluster` (reserved) |
 
 Pass an instance to a family verb to override the default
 `primary_p` lookup:
@@ -89,7 +89,7 @@ names the inference algorithm or SE family (`NW`, `HH`, `NWCL`,
 | `(T_NW, P_NW)` | Newey-West HAC t-statistic + p — the `primary_p` source the metric `evaluate()` runs populates by default. |
 | `(T_HH, P_HH)` | Hansen-Hodrick rectangular-kernel HAC t + p — emitted only when `forward_periods > 1`. |
 | `(WALD_NWCL, P_WALD_NWCL)` | Cluster-Wald χ² + p under NW HAC + 1-way slice cluster — emitted by Layer-B slice-test verbs. |
-| `(WALD_DC, P_WALD_DC)` | Cluster-Wald χ² + p under two-way cluster on (date, asset) — reserved. |
+| `(WALD_TWOWAY, P_WALD_TWOWAY)` | Cluster-Wald χ² + p under two-way cluster on (date, asset) — reserved. |
 | `(P_BOOT,)` | Block-bootstrap empirical p — singleton, no parametric test statistic to publish. |
 | `(P_GMM,)` | GMM J-test p — reserved (#191). |
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -177,7 +177,7 @@ class StatCode(StrEnum):
     Currently shipping: ``(T_NW, P_NW)`` for Newey-West,
     ``(T_HH, P_HH)`` for Hansen-Hodrick, ``(WALD_NWCL, P_WALD_NWCL)``
     for NW HAC + one-way cluster on the slice grouping, and
-    ``(WALD_DC, P_WALD_DC)`` for two-way cluster on (date, asset)
+    ``(WALD_TWOWAY, P_WALD_TWOWAY)`` for two-way cluster on (date, asset)
     (Layer-B slice tests, #153). The Wald pairs follow the same
     ``<KIND>_<ALGO>`` shape — KIND = ``WALD`` (χ² statistic name,
     parallel to ``T``), ALGO names the cluster-SE family
@@ -254,9 +254,9 @@ class StatCode(StrEnum):
     WALD_NWCL = "wald_nwcl"
     P_WALD_NWCL = "p_wald_nwcl"
     # DC = two-way cluster on (date, asset), Cameron-Gelbach-Miller
-    # (2011) shape (emitted by `WaldDoubleCluster`).
-    WALD_DC = "wald_dc"
-    P_WALD_DC = "p_wald_dc"
+    # (2011) shape (emitted by `WaldTwoWayCluster`).
+    WALD_TWOWAY = "wald_twoway"
+    P_WALD_TWOWAY = "p_wald_twoway"
     # Empirical p-value from a block-bootstrap resample of a paired-diff
     # statistic (Layer-B paired tests, #153). Singleton — the
     # bootstrap distribution itself is not published as a StatCode.
@@ -325,12 +325,12 @@ _STAT_DESCRIPTIONS: dict[StatCode, str] = {
     "lives in `factrix.stats.WaldNWCluster`.",
     StatCode.P_WALD_NWCL: "P-value from `WALD_NWCL`. Sibling under the "
     "(WALD_NWCL, P_WALD_NWCL) algorithm-pair convention.",
-    StatCode.WALD_DC: "Wald χ² statistic for a linear restriction on a "
+    StatCode.WALD_TWOWAY: "Wald χ² statistic for a linear restriction on a "
     "panel coefficient vector, computed under two-way cluster on "
     "(date, asset) (Cameron-Gelbach-Miller 2011). Implementation "
-    "convention lives in `factrix.stats.WaldDoubleCluster`.",
-    StatCode.P_WALD_DC: "P-value from `WALD_DC`. Sibling under the "
-    "(WALD_DC, P_WALD_DC) algorithm-pair convention.",
+    "convention lives in `factrix.stats.WaldTwoWayCluster`.",
+    StatCode.P_WALD_TWOWAY: "P-value from `WALD_TWOWAY`. Sibling under the "
+    "(WALD_TWOWAY, P_WALD_TWOWAY) algorithm-pair convention.",
     StatCode.P_BOOT: "Empirical two-sided p-value from a block-bootstrap "
     "resample of a paired-diff statistic. Implementation convention lives "
     "in `factrix.stats.BlockBootstrap` (Politis-Romano stationary or "

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -12,10 +12,10 @@ Three layers of HAC / cluster covariance feed the same closing
   joint Bartlett-kernel HAC of the K-vector series. Backs the
   ``WaldNWCluster`` Estimator (#153).
 - **Two-way cluster on (date, asset)** —
-  ``_wald_double_cluster(y, X, *, R, q, date_ids, asset_ids)`` for
+  ``_wald_two_way_cluster(y, X, *, R, q, date_ids, asset_ids)`` for
   the raw asset-date panel. Cameron-Gelbach-Miller (2011)
   ``V_DC = V_date + V_asset - V_intersection`` shape. Backs the
-  ``WaldDoubleCluster`` Estimator — interface preserved this issue;
+  ``WaldTwoWayCluster`` Estimator — interface preserved this issue;
   no verb consumes it until ``factor_decomposition`` lands later.
 
 References
@@ -167,7 +167,7 @@ def _cluster_meat(
     return meat
 
 
-def _wald_double_cluster(
+def _wald_two_way_cluster(
     y: np.ndarray,
     X: np.ndarray,
     *,

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -6,7 +6,7 @@
 NW HAC inference path.
 ``HansenHodrick`` — rectangular-kernel HAC variant for IC / FM PANEL
 on overlapping forward returns.
-``WaldNWCluster`` / ``WaldDoubleCluster`` — Layer-B cluster-robust
+``WaldNWCluster`` / ``WaldTwoWayCluster`` — Layer-B cluster-robust
 Wald χ² Estimators for slice contrasts (#153).
 ``BlockBootstrap`` — Layer-B block-bootstrap empirical-p Estimator
 for paired-diff slice tests (#153).
@@ -23,7 +23,7 @@ from factrix.stats.bootstrap import (
 from factrix.stats.hansen_hodrick import HansenHodrick
 from factrix.stats.multiple_testing import bhy_adjust, bhy_adjusted_p
 from factrix.stats.newey_west import NeweyWest
-from factrix.stats.wald_cluster import WaldDoubleCluster, WaldNWCluster
+from factrix.stats.wald_cluster import WaldNWCluster, WaldTwoWayCluster
 
 # Internal registry consumed by `factrix.list_estimators`. Append new
 # Estimator instances here as they land — `list_estimators` filters by
@@ -36,7 +36,7 @@ _ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (
     NeweyWest(),
     HansenHodrick(),
     WaldNWCluster(),
-    WaldDoubleCluster(),
+    WaldTwoWayCluster(),
     BlockBootstrap(),
 )
 
@@ -45,8 +45,8 @@ __all__ = [
     "Estimator",
     "HansenHodrick",
     "NeweyWest",
-    "WaldDoubleCluster",
     "WaldNWCluster",
+    "WaldTwoWayCluster",
     "bhy_adjust",
     "bhy_adjusted_p",
     "bootstrap_mean_ci",

--- a/factrix/stats/wald_cluster.py
+++ b/factrix/stats/wald_cluster.py
@@ -7,13 +7,13 @@ setting (#176 verbs ``slice_pairwise_test`` / ``slice_joint_test``):
   consumes the stacked per-date metric panel. Emits
   ``StatCode.P_WALD_NWCL`` (paired with ``WALD_NWCL`` on the test
   statistic side).
-- ``WaldDoubleCluster`` — Cameron-Gelbach-Miller (2011) two-way
+- ``WaldTwoWayCluster`` — Cameron-Gelbach-Miller (2011) two-way
   cluster on (date, asset); consumes the raw asset-date panel.
-  Emits ``StatCode.P_WALD_DC``. Interface ships this issue but no
+  Emits ``StatCode.P_WALD_TWOWAY``. Interface ships this issue but no
   verb consumes it until ``factor_decomposition`` lands later;
-  calling ``bhy(estimator=WaldDoubleCluster())`` against a profile
+  calling ``bhy(estimator=WaldTwoWayCluster())`` against a profile
   produced by ``evaluate()`` lands on a missing-stat error until
-  the verb populates ``profile.stats[StatCode.P_WALD_DC]``.
+  the verb populates ``profile.stats[StatCode.P_WALD_TWOWAY]``.
 
 Numerical implementations live in ``factrix._stats.wald``; this
 module names the inference path the family verbs / Layer-B verbs
@@ -76,17 +76,17 @@ class WaldNWCluster:
         return StatCode.P_WALD_NWCL
 
 
-class WaldDoubleCluster:
+class WaldTwoWayCluster:
     """Two-way cluster Wald χ² on (date, asset) — Cameron-Gelbach-Miller (2011).
 
     Backs the raw asset-date panel inference path (factor × slice
     interaction with full panel SE). Numerics live in
-    ``factrix._stats.wald._wald_double_cluster``.
+    ``factrix._stats.wald._wald_two_way_cluster``.
 
     Interface ships this PR; no verb consumes it until
     ``factor_decomposition`` lands later. ``list_estimators`` surfaces
     it for ``(INDIVIDUAL, CONTINUOUS)`` cells — calling
-    ``bhy(estimator=WaldDoubleCluster())`` against a profile produced
+    ``bhy(estimator=WaldTwoWayCluster())`` against a profile produced
     by ``evaluate()`` lands on a missing-stat error pointing at the
     precondition (same pattern as ``HansenHodrick`` on a non-overlapping
     profile).
@@ -112,4 +112,4 @@ class WaldDoubleCluster:
         _signal: Signal,
         _metric: Metric | None,
     ) -> StatCode:
-        return StatCode.P_WALD_DC
+        return StatCode.P_WALD_TWOWAY

--- a/tests/stats/test_layer_b_estimators.py
+++ b/tests/stats/test_layer_b_estimators.py
@@ -1,4 +1,4 @@
-"""Tests for Layer-B Estimators (#153): WaldNWCluster / WaldDoubleCluster / BlockBootstrap."""
+"""Tests for Layer-B Estimators (#153): WaldNWCluster / WaldTwoWayCluster / BlockBootstrap."""
 
 from __future__ import annotations
 
@@ -9,14 +9,14 @@ from factrix.stats import (
     _ESTIMATOR_REGISTRY,
     BlockBootstrap,
     Estimator,
-    WaldDoubleCluster,
     WaldNWCluster,
+    WaldTwoWayCluster,
 )
 
 
 class TestEstimatorProtocol:
     def test_all_three_satisfy_protocol(self):
-        for est in (WaldNWCluster(), WaldDoubleCluster(), BlockBootstrap()):
+        for est in (WaldNWCluster(), WaldTwoWayCluster(), BlockBootstrap()):
             assert isinstance(est, Estimator)
 
     def test_names_distinct(self):
@@ -25,7 +25,7 @@ class TestEstimatorProtocol:
             "NeweyWest",
             "HansenHodrick",
             "WaldNWCluster",
-            "WaldDoubleCluster",
+            "WaldTwoWayCluster",
             "BlockBootstrap",
         }
 
@@ -54,18 +54,18 @@ class TestWaldNWCluster:
         assert "nw" in d or "newey" in d
 
 
-class TestWaldDoubleCluster:
-    def test_emits_p_wald_dc(self):
-        est = WaldDoubleCluster()
+class TestWaldTwoWayCluster:
+    def test_emits_p_wald_twoway(self):
+        est = WaldTwoWayCluster()
         code = est.emits_for(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, Metric.IC)
-        assert code is StatCode.P_WALD_DC
+        assert code is StatCode.P_WALD_TWOWAY
 
     def test_applicable_to_individual_continuous(self):
-        est = WaldDoubleCluster()
+        est = WaldTwoWayCluster()
         assert est.applicable_to(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
 
     def test_description_mentions_two_way(self):
-        d = WaldDoubleCluster().description.lower()
+        d = WaldTwoWayCluster().description.lower()
         assert "two-way" in d or "double" in d or "cgm" in d
 
 
@@ -133,7 +133,7 @@ class TestRegistryIntegration:
         types_in_registry = {type(e).__name__ for e in _ESTIMATOR_REGISTRY}
         assert {
             "WaldNWCluster",
-            "WaldDoubleCluster",
+            "WaldTwoWayCluster",
             "BlockBootstrap",
         } <= types_in_registry
 
@@ -148,7 +148,7 @@ class TestRegistryIntegration:
 
         names = list_estimators(FactorScope.INDIVIDUAL, Signal.CONTINUOUS)
         assert "WaldNWCluster" in names
-        assert "WaldDoubleCluster" in names
+        assert "WaldTwoWayCluster" in names
         assert "BlockBootstrap" in names
 
     def test_list_estimators_excludes_layer_b_for_common(self):
@@ -158,6 +158,6 @@ class TestRegistryIntegration:
         # NW applies universally; Layer-B + HH restricted to (INDIVIDUAL, CONTINUOUS).
         assert "NeweyWest" in names
         assert "WaldNWCluster" not in names
-        assert "WaldDoubleCluster" not in names
+        assert "WaldTwoWayCluster" not in names
         assert "BlockBootstrap" not in names
         assert "HansenHodrick" not in names

--- a/tests/stats/test_wald_cluster.py
+++ b/tests/stats/test_wald_cluster.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytest
 from factrix._stats.wald import (
     _nw_hac_vector_mean,
-    _wald_double_cluster,
     _wald_nw_cluster_means,
+    _wald_two_way_cluster,
 )
 
 
@@ -103,7 +103,7 @@ class TestWaldNWClusterMeans:
             _wald_nw_cluster_means(np.arange(10.0), R=np.array([[1.0]]))
 
 
-class TestWaldDoubleCluster:
+class TestWaldTwoWayCluster:
     def _make_panel(self, n_dates=40, n_assets=25, beta=0.0, seed=0):
         rng = np.random.default_rng(seed=seed)
         date_ids = np.repeat(np.arange(n_dates), n_assets)
@@ -126,13 +126,13 @@ class TestWaldDoubleCluster:
         y, X, d, a = self._make_panel(beta=0.0, seed=0)
         # Test slope = 0.
         R = np.array([[0.0, 1.0]])
-        _, p = _wald_double_cluster(y, X, R=R, date_ids=d, asset_ids=a)
+        _, p = _wald_two_way_cluster(y, X, R=R, date_ids=d, asset_ids=a)
         assert p > 0.05
 
     def test_alt_detected(self):
         y, X, d, a = self._make_panel(beta=0.5, seed=1)
         R = np.array([[0.0, 1.0]])
-        _, p = _wald_double_cluster(y, X, R=R, date_ids=d, asset_ids=a)
+        _, p = _wald_two_way_cluster(y, X, R=R, date_ids=d, asset_ids=a)
         assert p < 0.01
 
     def test_symmetric_V(self):
@@ -141,14 +141,14 @@ class TestWaldDoubleCluster:
         # construction).
         y, X, d, a = self._make_panel(beta=0.3, seed=2)
         R = np.array([[0.0, 1.0]])
-        _, p_da = _wald_double_cluster(y, X, R=R, date_ids=d, asset_ids=a)
-        _, p_ad = _wald_double_cluster(y, X, R=R, date_ids=a, asset_ids=d)
+        _, p_da = _wald_two_way_cluster(y, X, R=R, date_ids=d, asset_ids=a)
+        _, p_ad = _wald_two_way_cluster(y, X, R=R, date_ids=a, asset_ids=d)
         assert p_da == pytest.approx(p_ad)
 
     def test_rejects_id_length_mismatch(self):
         y, X, d, a = self._make_panel()
         with pytest.raises(ValueError, match="length must match"):
-            _wald_double_cluster(
+            _wald_two_way_cluster(
                 y,
                 X,
                 R=np.array([[0.0, 1.0]]),
@@ -164,7 +164,7 @@ class TestWaldDoubleCluster:
         y = x + np.random.default_rng(0).standard_normal(n)
         d = np.repeat(np.arange(10), 5)
         a = np.tile(np.arange(5), 10)
-        out = _wald_double_cluster(
+        out = _wald_two_way_cluster(
             y, X, R=np.array([[1.0, 0.0]]), date_ids=d, asset_ids=a
         )
         assert out == (0.0, 1.0)

--- a/tests/test_list_estimators.py
+++ b/tests/test_list_estimators.py
@@ -24,8 +24,8 @@ from factrix._errors import IncompatibleAxisError
                 "BlockBootstrap",
                 "HansenHodrick",
                 "NeweyWest",
-                "WaldDoubleCluster",
                 "WaldNWCluster",
+                "WaldTwoWayCluster",
             ],
         ),
         (FactorScope.INDIVIDUAL, Signal.SPARSE, ["NeweyWest"]),
@@ -54,8 +54,8 @@ def test_with_import_returns_two_column_lines() -> None:
         "BlockBootstrap    → factrix.stats.BlockBootstrap",
         "HansenHodrick     → factrix.stats.HansenHodrick",
         "NeweyWest         → factrix.stats.NeweyWest",
-        "WaldDoubleCluster → factrix.stats.WaldDoubleCluster",
         "WaldNWCluster     → factrix.stats.WaldNWCluster",
+        "WaldTwoWayCluster → factrix.stats.WaldTwoWayCluster",
     ]
 
 


### PR DESCRIPTION
## Summary

依 #208（已縮 scope）只改 two-way 軸命名，與 panel-econometrics 文獻對齊：

| 從 | 到 |
|---|---|
| `WaldDoubleCluster` | `WaldTwoWayCluster` |
| `StatCode.WALD_DC` | `StatCode.WALD_TWOWAY` |
| `StatCode.P_WALD_DC` | `StatCode.P_WALD_TWOWAY` |
| `_wald_double_cluster` | `_wald_two_way_cluster` |

文獻錨：Cameron-Gelbach-Miller 2011；Petersen 2009；Stata `vce(cluster, cluster)`。

## Why narrower than original spec

原 issue #208 還提案 `WaldNWCluster → WaldSliceCluster` / `WALD_NWCL → WALD_SLICE_CL`，砍掉理由：

1. **`Slice` 丟 kernel 資訊** — 原名 `NW` 載 Newey-West Bartlett kernel 訊息；改 Slice 把 NW vs HC0 vs HH 這層藏掉。未來 HH-kernel 變體照 Slice 模式叫 `WaldHHSliceCluster` 與 `WaldSliceCluster` 不對稱；保 NW 命名則自然延伸 `WaldHHCluster`。
2. **`Slice` 綁 verb context** — 是 factrix 的 `by_slice` / `slice_*_test` verb 命名。Estimator class 對「cluster on what」應 agnostic（caller 餵 cluster IDs）。
3. **F2「兩個並列分不清」自動解** — 只改 two-way 一側後，`WaldNWCluster`（1-way 隱含） vs `WaldTwoWayCluster`（2-way 顯式）變對稱清晰。

issue #208 body 已同步縮 scope。

## 為什麼不是 PR #210 的 retarget

PR #210 base 是 `feat/153-layer-b-primitives`，當時想 stack on top of #206。但 #206 先 merge 並刪 base 後 #210 把 commits merge 進失效 branch、沒落到 main。Stacked PR 只在 base 還會持續演進時才有意義；本案 base 是一次性 land，應一開始就 `--base main`。本 PR 把 rebase 到 main 的 single commit 直接 target main 修正路徑。

## Test plan

- [x] `python -m pytest -q` → 1122 passed
- [x] `uv run ruff check` → all clean
- [x] `uv run mypy factrix` → 0 issues
- [x] `uv run mkdocs build --strict` → exit 0（pre-push 已驗）
- [ ] CI 全綠

Closes #208