### PR TITLE
feat(metrics): add per_date_series capability (#176)

### DIFF
--- a/factrix/metrics/_metric_capabilities.py
+++ b/factrix/metrics/_metric_capabilities.py
@@ -1,0 +1,83 @@
+"""Resolver helpers for per-metric capability attributes.
+
+Each metric module declares optional capability attributes at module
+top-level (parallel to the metric callable itself):
+
+- ``per_date_series(input_df) -> pl.DataFrame``: returns ``(date,
+  value)`` long-form per-date series. Required for slice-test
+  consumers (#176).
+- ``min_assets_per_group: int | None``: minimum cross-section bucket
+  size for slice-test ``n_groups`` downscale (#153 §5).
+
+This module centralizes the lookup from a metric callable to its
+declaring module's capabilities so consumers do not grovel
+``sys.modules`` directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import Protocol
+
+import polars as pl
+
+
+class PerDateSeries(Protocol):
+    """Callable contract for ``module.per_date_series``.
+
+    Implementations consume the metric's canonical input DataFrame
+    and return a two-column long-form frame with ``date`` and
+    ``value``. ``value`` is the per-date scalar that the slice tests
+    treat as the metric's time series (per-date IC, per-date Fama-
+    MacBeth lambda, per-date hit indicator, etc.).
+    """
+
+    def __call__(self, df: pl.DataFrame, /) -> pl.DataFrame: ...
+
+
+def per_date_series_rename(source_col: str) -> PerDateSeries:
+    """Factory: ``per_date_series`` for metrics whose input is already
+    a ``(date, source_col)`` per-date frame.
+
+    Returns a callable that projects ``date`` plus ``source_col``
+    aliased to ``value`` and drops null rows. Metrics whose per-date
+    series needs computation (binary cast, cross-section aggregation,
+    etc.) define their own ``per_date_series`` instead.
+    """
+
+    def _per_date(df: pl.DataFrame) -> pl.DataFrame:
+        return df.select(
+            [pl.col("date"), pl.col(source_col).alias("value")]
+        ).drop_nulls()
+
+    return _per_date
+
+
+def resolve_per_date_series(metric: Callable) -> PerDateSeries:
+    """Look up ``per_date_series`` on the module that defines ``metric``.
+
+    Raises ``TypeError`` when the metric's module does not declare the
+    attribute — the metric is not eligible for slice tests / other
+    consumers that need a per-date series.
+    """
+    mod = sys.modules[metric.__module__]
+    fn = getattr(mod, "per_date_series", None)
+    if fn is None:
+        raise TypeError(
+            f"metric {metric.__name__!r} is not slice-test-eligible: "
+            f"module {metric.__module__!r} does not declare a top-level "
+            f"`per_date_series(df) -> pl.DataFrame[(date, value)]` callable."
+        )
+    return fn
+
+
+def resolve_min_assets_per_group(metric: Callable) -> int | None:
+    """Look up ``min_assets_per_group`` on the module that defines ``metric``.
+
+    Returns ``None`` when the attribute is absent or explicitly
+    ``None`` — slice tests treat both as "metric does not bucket
+    cross-section assets, skip ``n_groups`` downscale".
+    """
+    mod = sys.modules[metric.__module__]
+    return getattr(mod, "min_assets_per_group", None)

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -34,14 +34,17 @@ from factrix._stats import (
 )
 from factrix._types import DDOF, EPSILON, MetricOutput, ShankenVarSource
 from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._metric_capabilities import per_date_series_rename
 
-# Layer-B slice-test contract (#153 §5): Fama-MacBeth runs a per-date
+# Slice-test contract (#153 §5): Fama-MacBeth runs a per-date
 # OLS regression on the cross-section, not a bucket sort, so slice
 # tests never need to downscale `n_groups`. Sample-size constraints
 # (T < HARD short-circuit, T < WARN warning) live in the procedure
 # below; the cross-section minimum per regression is enforced inside
 # the per-date OLS rather than via this attribute.
 min_assets_per_group: int | None = None
+per_date_series = per_date_series_rename("beta")
+
 
 # Two-tier sample-size guard on the FM β series. ``T < HARD`` short-
 # circuits — NW HAC SE on a 3-period series is undefined. ``HARD ≤ T <

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -32,6 +32,23 @@ from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_out
 min_assets_per_group: int | None = None
 
 
+def per_date_series(series: pl.DataFrame) -> pl.DataFrame:
+    """Return ``(date, value)`` per-date hit indicator series.
+
+    Casts ``value > 0`` to ``Float64`` per date. Caller is expected to
+    rename a non-default value column upstream; the slice-test
+    capability contract takes no kwargs. Consumed by
+    ``slice_pairwise_test`` / ``slice_joint_test`` (#176) via
+    ``factrix.metrics._metric_capabilities.resolve_per_date_series``.
+    """
+    return series.select(
+        [
+            pl.col("date"),
+            (pl.col("value") > 0).cast(pl.Float64).alias("value"),
+        ]
+    ).drop_nulls()
+
+
 def hit_rate(
     series: pl.DataFrame,
     value_col: str = "value",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -36,9 +36,10 @@ from factrix.metrics._helpers import (
     _scaled_min_periods,
     _short_circuit_output,
 )
+from factrix.metrics._metric_capabilities import per_date_series_rename
 from factrix.stats import bhy_adjusted_p
 
-# Layer-B slice-test contract (#153 §5): IC is per-date Spearman rank
+# Slice-test contract (#153 §5): IC is per-date Spearman rank
 # correlation, not a bucketed metric — slice tests never need to
 # downscale `n_groups`. The min-cross-section-per-date constraint
 # (Spearman ρ asymptotic distribution requires ≥ 30 obs per date,
@@ -46,6 +47,7 @@ from factrix.stats import bhy_adjusted_p
 # `MIN_ASSETS_PER_DATE_IC` short-circuit, parallel to (not exposed
 # via) this attribute.
 min_assets_per_group: int | None = None
+per_date_series = per_date_series_rename("ic")
 
 
 class _RegimeICEntry(TypedDict):

--- a/tests/test_metric_capabilities.py
+++ b/tests/test_metric_capabilities.py
@@ -1,0 +1,60 @@
+"""Resolver + per-metric ``per_date_series`` contract checks."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import polars as pl
+import pytest
+from factrix.metrics import fama_macbeth, hit_rate, ic, monotonicity
+from factrix.metrics._metric_capabilities import (
+    resolve_min_assets_per_group,
+    resolve_per_date_series,
+)
+
+
+def _dates(n: int) -> list[dt.date]:
+    return [dt.date(2024, 1, 1) + dt.timedelta(days=i) for i in range(n)]
+
+
+def test_resolve_per_date_series_ic_shape() -> None:
+    ic_df = pl.DataFrame({"date": _dates(5), "ic": [0.1, 0.2, None, 0.3, 0.0]})
+    out = resolve_per_date_series(ic)(ic_df)
+    assert out.columns == ["date", "value"]
+    assert out.height == 4
+
+
+def test_resolve_per_date_series_fama_macbeth_shape() -> None:
+    beta_df = pl.DataFrame({"date": _dates(3), "beta": [0.01, -0.02, 0.0]})
+    out = resolve_per_date_series(fama_macbeth)(beta_df)
+    assert out.columns == ["date", "value"]
+    assert out.height == 3
+
+
+def test_resolve_per_date_series_hit_rate_binary_cast() -> None:
+    series = pl.DataFrame({"date": _dates(4), "value": [0.5, -0.1, 0.0, 1.2]})
+    out = resolve_per_date_series(hit_rate)(series)
+    assert out.columns == ["date", "value"]
+    assert out["value"].to_list() == [1.0, 0.0, 0.0, 1.0]
+
+
+def test_resolve_per_date_series_raises_for_ineligible_metric() -> None:
+    def fake_metric(df: pl.DataFrame) -> None:
+        return None
+
+    with pytest.raises(TypeError, match="slice-test-eligible"):
+        resolve_per_date_series(fake_metric)
+
+
+def test_resolve_min_assets_per_group_passthrough() -> None:
+    assert resolve_min_assets_per_group(ic) is None
+    assert resolve_min_assets_per_group(fama_macbeth) is None
+    assert resolve_min_assets_per_group(hit_rate) is None
+    assert resolve_min_assets_per_group(monotonicity) == 50
+
+
+def test_resolve_min_assets_per_group_missing_attr_returns_none() -> None:
+    def fake_metric(df: pl.DataFrame) -> None:
+        return None
+
+    assert resolve_min_assets_per_group(fake_metric) is None


### PR DESCRIPTION
## Summary

- New `factrix.metrics._metric_capabilities`: `PerDateSeries` Protocol + `resolve_per_date_series` / `resolve_min_assets_per_group` resolvers + `per_date_series_rename` factory.
- Metric modules `ic` / `fama_macbeth` / `hit_rate` each declare a top-level `per_date_series(df) -> pl.DataFrame[(date, value)]`, parallel to the existing `min_assets_per_group` capability declaration (#153 §5).
- `monotonicity` deferred — its per-date Spearman needs the bucket-aggregation logic refactored out of the summary path; handled in a follow-up so this PR stays atomic on the resolver pattern.

Pre-req for #176 `slice_pairwise_test` / `slice_joint_test`, but the resolver pattern is reusable by any future cross-cell inference verb, so landed independently.

## Test plan

- [x] `tests/test_metric_capabilities.py` covers resolver happy path × 3 metrics, ineligible-metric raise, `min_assets_per_group` passthrough (None × 3, 50 × 1), missing-attr → None.
- [x] Existing `test_ic.py` / `test_fm_procedure.py` / `test_hit_rate.py` pass — capability addition does not touch metric output paths.

Refs #176