### PR TITLE
feat(metrics): slice_pairwise_test / slice_joint_test verb pair (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ## [Unreleased]
 
+### Added
+
+- **`factrix.metrics.slice_pairwise_test` / `slice_joint_test`** (#176). Cross-slice statistical-test verb pair. `slice_pairwise_test` reports K(K−1)/2 pairwise Wald contrasts with Holm / Romano-Wolf / Bonferroni adjusted p; `slice_joint_test` reports the single omnibus Wald χ² that all slice means are equal. Default estimator `WaldNWCluster` (joint NW HAC over the per-date K-vector panel) covers analytic inference; `BlockBootstrap` triggers the joint bootstrap path with Romano-Wolf as the default multiple-testing adjustment. Both verbs require the metric's module to declare a `per_date_series` capability — `ic` / `fama_macbeth` / `hit_rate` ship with it; metrics without it raise `TypeError`. See `docs/api/slice-test.md`.
+- **`factrix.metrics._metric_capabilities`** (#176). Resolver helpers (`resolve_per_date_series`, `resolve_min_assets_per_group`) plus a `PerDateSeries` Protocol and a `per_date_series_rename` factory. Centralises capability lookup so inference verbs reuse one resolver instead of grovelling `sys.modules` directly.
+
+### Deprecated
+
+- **`factrix.metrics.regime_ic`** (#176). Use `slice_pairwise_test(ic, ic_df.join(regime_labels, on="date"), label="regime")` for the same analysis. The new verb's pairwise contrast frame (Wald χ² + Holm / Romano-Wolf adjusted p) replaces `regime_ic`'s BHY-on-min-|t| summary shape; downstream code consuming `per_regime` metadata should migrate before the function is removed in a future minor. Output shape frozen for one more minor as the migration window.
+
 ### Removed
 
 - **`factrix.metrics.multi_horizon_ic` / `multi_horizon_hit_rate`** (breaking, #186). Deprecated in v0.11.0; the in-metric horizon loop conflicted with `FactorProfile.identity` carrying `forward_periods` (the #160 anti-shopping defense) and ran a second BHY path inside the metric in parallel to `multi_factor.bhy(profiles, expand_over=["forward_periods"])`, the FDR SSOT. Both names are no longer importable from `factrix.metrics`; direct references raise `ImportError`. Code reaching them via `list_metrics` / `run_metrics` was never wired (already excluded via `_AUTO_DISCOVER_EXCLUDED` in v0.11). The `_HorizonICEntry` TypedDict and the `_metric_index._DEPRECATED` set are removed alongside the functions. Migration recipes (descriptive `run_metrics` per horizon + `pl.concat` of `bundle.to_frame()`; inferential `evaluate` per horizon + `bhy(expand_over=["forward_periods"])`) remain in `docs/api/multi-horizon.md` and apply unchanged from the v0.11.0 deprecation window.

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -1,0 +1,116 @@
+# slice_pairwise_test / slice_joint_test
+
+Cross-slice statistical-test verb pair. Both consume a metric callable
+and a date-keyed DataFrame whose `label` column carries the slice
+identifier; the verbs partition by `label`, line up per-date metric
+series across slices, and report inference on whether the slices'
+means differ.
+
+The two verbs answer **different statistical questions**:
+
+| Verb | Question | Output shape |
+|---|---|---|
+| `slice_pairwise_test` | "Which pairs differ?" — K(K−1)/2 contrasts with family-internal multiple-testing correction | One row per pair: `(slice_a, slice_b, n_obs, stat, p_raw, p_adj)` |
+| `slice_joint_test` | "Do any slices differ at all?" — single omnibus Wald χ² | One row: `(n_obs, k_slices, df, stat, p)` |
+
+Both verbs sit in the **View** class (per [#148](https://github.com/awwesomeman/factrix/issues/148)
+verb classification): their headline output is a comparison test
+result. They do **not** participate in BHY family expansion — adjusted
+p is a within-slice-family closure, not a cell-level discovery
+commitment.
+
+## Call shape
+
+```python
+import polars as pl
+from factrix.metrics import compute_ic, ic, slice_joint_test, slice_pairwise_test
+
+ic_df = compute_ic(panel)
+ic_df = ic_df.join(regime_labels, on="date")  # adds 'regime' column
+
+pairwise = slice_pairwise_test(ic, ic_df, label="regime")
+omnibus = slice_joint_test(ic, ic_df, label="regime")
+```
+
+The metric callable's module must declare `per_date_series` (a
+top-level capability function returning a `(date, value)` long-form
+frame); IC, Fama-MacBeth, and hit_rate ship with this declaration.
+A metric without it raises `TypeError` at the verb call site.
+
+## Date alignment is required
+
+Both verbs join all slices on `date` and run inference on the
+intersected rows. Joint NW HAC over the (T, K) per-date metric panel
+needs aligned rows so cross-slice covariance enters through the joint
+kernel. Slices with **disjoint date supports** (e.g. regimes split by
+time period) yield zero aligned rows and the verbs raise `ValueError`.
+
+For genuinely time-disjoint slices, run inference per slice and
+compare summaries upstream (or wait for the future
+`factor_decomposition` verb, which adopts a different SE geometry).
+Date-shared slices — universe, sector, market-cap tier — are the
+intended use case.
+
+## Estimator dispatch
+
+| Estimator | Inference path | `stat` column carries |
+|---|---|---|
+| `WaldNWCluster` (default) | Joint NW HAC over the (T, K) per-date metric panel; per-pair Wald χ² via single-row restriction matrix on the joint variance | Wald χ² |
+| `BlockBootstrap` | Joint block-bootstrap on the same panel; per-pair p from `\|mean diff\|` against the bootstrap null distribution | Signed mean diff |
+
+`BlockBootstrap` shares one set of block indices across all pair diffs
+per draw, so the bootstrap distribution preserves cross-pair
+dependence — the joint structure Romano-Wolf step-down relies on.
+
+`slice_joint_test` accepts only `WaldNWCluster`; the omnibus Wald χ² has
+no canonical bootstrap analogue, so the verb steers callers to
+`slice_pairwise_test` if a bootstrap path is wanted.
+
+## Multiple-testing correction (`slice_pairwise_test` only)
+
+| Method | Default for | Notes |
+|---|---|---|
+| `"holm"` | `WaldNWCluster` (default) | Holm step-down — conservative under arbitrary dependence |
+| `"romano_wolf"` | `BlockBootstrap` | Step-down using the joint bootstrap distribution; near-optimal for date-shared slices (universe / sector) |
+| `"bonferroni"` | Manual opt-in | For literature / cross-tool reproduction |
+
+`multiple_testing="romano_wolf"` with an analytic estimator raises
+`ValueError` — RW needs a bootstrap distribution that analytic
+estimators do not produce.
+
+## Cross-axis composition
+
+The verbs accept a **single** `label` column. For cross-axis slice
+analysis (regime × universe), compose a composite label upstream
+with `pl.concat_str(...)`:
+
+```python
+ic_df = ic_df.with_columns(
+    pl.concat_str(["regime", "universe"], separator="_").alias("regime_x_universe")
+)
+slice_pairwise_test(ic, ic_df, label="regime_x_universe")
+```
+
+Two-way *interaction decomposition* (main effect + interaction with
+double-clustered SE) is a different statistical object and is
+reserved for the future `factor_decomposition` verb.
+
+## Responsibility boundaries
+
+| Need | Use |
+|---|---|
+| Descriptive per-slice metric values (no test) | [`by_slice`](by-slice.md) |
+| Which slice pairs differ statistically | `slice_pairwise_test` |
+| Whether any slice differs (omnibus) | `slice_joint_test` |
+| FDR-adjusted survivor selection across factors | `bhy(profiles, ...)` |
+| Multi-factor leaderboard rendering | `compare(...)` |
+
+## Reference
+
+::: factrix.metrics.slice_test
+    options:
+        members:
+          - slice_pairwise_test
+          - slice_joint_test
+        show_root_heading: false
+        show_source: false

--- a/docs/reference/_generated_metric_matrix.md
+++ b/docs/reference/_generated_metric_matrix.md
@@ -14,6 +14,7 @@
 | [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | no formal H₀ |
 | [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
 | [`metrics.regime`][factrix.metrics.regime] | `(*, *, *, *)` | dispatcher | none (no cross-regime test) |
+| [`metrics.slice_test`][factrix.metrics.slice_test] | `(*, *, *, *)` | inference verb | per-pair Wald χ² + Holm/RW/Bonferroni / joint Wald χ² |
 | [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | ts-only | NW HAC / OLS t |
 | [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | no formal H₀ |
 | [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ |

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -72,7 +72,9 @@ _STAGE1_HELPERS: frozenset[str] = frozenset(
 # with ``(*, *, *, *)`` so the primitive graph is complete, but excluded
 # from per-cell ``list_metrics`` output and the applicability table
 # (which catalogue per-cell metrics, not infra).
-_INFRASTRUCTURE: frozenset[str] = frozenset({"by_regime", "by_slice"})
+_INFRASTRUCTURE: frozenset[str] = frozenset(
+    {"by_regime", "by_slice", "slice_joint_test", "slice_pairwise_test"}
+)
 """Cross-cutting dispatchers published from ``factrix.metrics`` that
 are not per-(scope, signal) cell metrics."""
 

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -270,3 +270,83 @@ def _block_bootstrap_diff_p(
         "rng_seed": seed_used,
     }
     return float(p), metadata
+
+
+def _joint_block_bootstrap_pairwise_distribution(
+    panel: np.ndarray,
+    *,
+    pairs: list[tuple[int, int]],
+    block_length: int | Literal["auto"] = "auto",
+    n_resamples: int = 999,
+    scheme: Scheme = "stationary",
+    rng_seed: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, dict[str, float | int | str]]:
+    """Joint block-bootstrap |mean-diff| distribution for K(K-1)/2 pairs.
+
+    Shares one set of block indices across all pair diffs per draw so
+    the bootstrap distribution preserves cross-pair dependence — the
+    joint structure Romano-Wolf step-down (#176) relies on.
+
+    Args:
+        panel: ``(T, K)`` per-date metric matrix, rows = aligned dates,
+            columns = slices.
+        pairs: Slice index pairs to score; combinations order is the
+            caller's responsibility (matches output column order).
+        block_length, n_resamples, scheme, rng_seed: same semantics as
+            ``_block_bootstrap_diff_p``. ``"auto"`` runs Politis-White
+            on the panel's cross-slice mean as a 1-D proxy.
+
+    Returns:
+        ``(observed, boot, metadata)`` —
+
+        - ``observed``: ``(P,)`` array of ``|mean(panel[:,i]) -
+          mean(panel[:,j])|`` per pair.
+        - ``boot``: ``(B, P)`` matrix of ``|resampled mean diff|`` under
+          null-centred resampling (column means subtracted before
+          drawing, so each resample's column means are zero in
+          expectation).
+        - ``metadata``: resolved block length, n_resamples, scheme, and
+          actual seed used.
+    """
+    panel = np.asarray(panel, dtype=float)
+    if panel.ndim != 2:
+        raise ValueError(f"panel must be 2-D (T, K); got shape {panel.shape}.")
+    T, K = panel.shape
+    if T < 2 or K < 2:
+        raise ValueError(f"panel too small for joint bootstrap; got shape ({T}, {K}).")
+
+    if block_length == "auto":
+        L_float = _politis_white_block_length(panel.mean(axis=1), scheme=scheme)
+        L = max(1, round(L_float))
+    else:
+        L = int(block_length)
+        if L < 1:
+            raise ValueError(f"block_length must be >= 1; got {L!r}")
+
+    seed_used = secrets.randbits(32) if rng_seed is None else int(rng_seed)
+    rng = np.random.default_rng(seed_used)
+
+    col_means = panel.mean(axis=0)
+    centred = panel - col_means
+
+    if scheme == "stationary":
+        idx = _stationary_block_indices(T, n_resamples, float(L), rng)
+    else:
+        idx = _fixed_block_indices(T, n_resamples, L, rng)
+    resampled = centred[idx]
+    resampled_means = resampled.mean(axis=1)
+
+    P = len(pairs)
+    observed = np.empty(P)
+    boot = np.empty((n_resamples, P))
+    for p_idx, (i, j) in enumerate(pairs):
+        observed[p_idx] = abs(col_means[i] - col_means[j])
+        boot[:, p_idx] = np.abs(resampled_means[:, i] - resampled_means[:, j])
+
+    metadata: dict[str, float | int | str] = {
+        "block_length": L,
+        "n_resamples": int(n_resamples),
+        "scheme": scheme,
+        "rng_seed": seed_used,
+    }
+    return observed, boot, metadata

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -81,6 +81,7 @@ from factrix.metrics.quantile import (
     quantile_spread_vw,
 )
 from factrix.metrics.regime import by_regime
+from factrix.metrics.slice_test import slice_pairwise_test
 from factrix.metrics.spanning import greedy_forward_selection, spanning_alpha
 from factrix.metrics.tradability import (
     breakeven_cost,
@@ -140,6 +141,7 @@ __all__ = [
     "quantile_spread_vw",
     "regime_ic",
     "signal_density",
+    "slice_pairwise_test",
     "spanning_alpha",
     "top_concentration",
     "ts_asymmetry",

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -81,7 +81,7 @@ from factrix.metrics.quantile import (
     quantile_spread_vw,
 )
 from factrix.metrics.regime import by_regime
-from factrix.metrics.slice_test import slice_pairwise_test
+from factrix.metrics.slice_test import slice_joint_test, slice_pairwise_test
 from factrix.metrics.spanning import greedy_forward_selection, spanning_alpha
 from factrix.metrics.tradability import (
     breakeven_cost,
@@ -141,6 +141,7 @@ __all__ = [
     "quantile_spread_vw",
     "regime_ic",
     "signal_density",
+    "slice_joint_test",
     "slice_pairwise_test",
     "spanning_alpha",
     "top_concentration",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -359,11 +359,32 @@ def ic_ir(
     )
 
 
+_REGIME_IC_DEPRECATION_MSG = (
+    "factrix.metrics.regime_ic is deprecated since v0.12.0; the same "
+    "analysis runs through slice_pairwise_test (#176) — join your "
+    "regime labels onto the IC frame upstream "
+    "(ic_df.join(regime_labels, on='date')) then call "
+    "slice_pairwise_test(ic, merged, label='regime'). The new verb "
+    "exposes per-pair Wald χ² with Holm/Romano-Wolf adjusted p "
+    "instead of regime_ic's BHY-on-min-|t| summary; downstream code "
+    "depending on regime_ic's `per_regime` metadata dict should be "
+    "updated before this function is removed in a future minor."
+)
+
+
 def regime_ic(
     ic_df: pl.DataFrame,
     regime_labels: pl.DataFrame | None = None,
 ) -> MetricOutput:
-    r"""IC conditioned on regime labels.
+    r"""IC conditioned on regime labels (deprecated since v0.12.0).
+
+    .. deprecated:: 0.12.0
+        Use :func:`factrix.metrics.slice_pairwise_test` with
+        ``ic_df.join(regime_labels, on='date')`` and
+        ``label='regime'`` instead. The new verb returns a
+        long-form pairwise contrast DataFrame with Holm /
+        Romano-Wolf adjusted p, replacing this function's
+        BHY-on-min-|t| summary shape.
 
     Answers "is the factor stable across market environments?"
     unlike OOS decay which tests overfitting.
@@ -403,6 +424,8 @@ def regime_ic(
         [Benjamini-Yekutieli 2001][benjamini-yekutieli-2001]: FDR control
         under arbitrary dependence; the BHY adjustment used here.
     """
+    _warnings.warn(_REGIME_IC_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+
     if len(ic_df) < MIN_ASSETS_PER_DATE_IC:
         return _short_circuit_output(
             "regime_ic",

--- a/factrix/metrics/slice_test.py
+++ b/factrix/metrics/slice_test.py
@@ -1,8 +1,9 @@
 """Cross-slice statistical-test verbs (#176).
 
 ``slice_pairwise_test`` reports K(K-1)/2 cross-slice contrasts as a
-long-form DataFrame of pairwise ``(stat, p_raw, p_adj)``. The
-companion ``slice_joint_test`` (omnibus χ²) lands in a follow-up.
+long-form DataFrame of pairwise ``(stat, p_raw, p_adj)``;
+``slice_joint_test`` reports the single omnibus Wald χ² that all K
+slice means are equal.
 
 The ``_test`` suffix marks "verb whose headline output is a
 comparison test result (stat + p)" — distinct from metrics like
@@ -38,6 +39,56 @@ from factrix.metrics._slice import _slice_by_label
 from factrix.stats import Estimator, WaldNWCluster
 
 MultipleTestingMethod = Literal["holm", "bonferroni"]
+
+
+def _resolve_estimator(estimator: Estimator | None, verb: str) -> WaldNWCluster:
+    if estimator is None:
+        return WaldNWCluster()
+    if not isinstance(estimator, WaldNWCluster):
+        raise NotImplementedError(
+            f"{verb}: estimator {type(estimator).__name__!r} not yet "
+            f"wired; this verb currently supports WaldNWCluster only. "
+            f"BlockBootstrap (Romano-Wolf path) lands in a follow-up batch."
+        )
+    return estimator
+
+
+def _build_per_date_panel(
+    metric: Callable,
+    df: pl.DataFrame,
+    label: str,
+    *,
+    verb: str,
+) -> tuple[list[str], np.ndarray, int]:
+    """Partition ``df`` by ``label``, extract per-date series per slice,
+    inner-join on date, return ``(labels, panel[T, K], n_obs)``.
+
+    Raises ``ValueError`` on <2 slice values or <2 aligned dates;
+    ``TypeError`` (via resolver) if ``metric`` is not slice-test-
+    eligible.
+    """
+    per_date_fn = resolve_per_date_series(metric)
+    slices = _slice_by_label(df, label)
+    if len(slices) < 2:
+        raise ValueError(
+            f"{verb}: need ≥2 slice values on {label!r}; got {len(slices)}."
+        )
+    labels = list(slices.keys())
+    aligned = per_date_fn(slices[labels[0]]).rename({"value": "v_0"})
+    for i, lbl in enumerate(labels[1:], start=1):
+        aligned = aligned.join(
+            per_date_fn(slices[lbl]).rename({"value": f"v_{i}"}),
+            on="date",
+            how="inner",
+        )
+    if aligned.height < 2:
+        raise ValueError(
+            f"{verb}: <2 aligned dates across slices ({aligned.height}); "
+            f"joint HAC inference requires aligned rows. Check that "
+            f"slices share at least 2 common dates."
+        )
+    panel = aligned.drop("date").to_numpy()
+    return labels, panel, aligned.height
 
 
 def slice_pairwise_test(
@@ -76,44 +127,13 @@ def slice_pairwise_test(
         NotImplementedError: Non-``WaldNWCluster`` estimator passed
             before the Romano-Wolf / block-bootstrap batch lands.
     """
-    if estimator is None:
-        estimator = WaldNWCluster()
-    if not isinstance(estimator, WaldNWCluster):
-        raise NotImplementedError(
-            f"slice_pairwise_test: estimator "
-            f"{type(estimator).__name__!r} not yet wired; this verb "
-            f"currently supports WaldNWCluster only. BlockBootstrap "
-            f"(Romano-Wolf path) lands in a follow-up batch."
-        )
+    _resolve_estimator(estimator, "slice_pairwise_test")
     if multiple_testing is None:
         multiple_testing = "holm"
 
-    per_date_fn = resolve_per_date_series(metric)
-
-    slices = _slice_by_label(df, label)
-    if len(slices) < 2:
-        raise ValueError(
-            f"slice_pairwise_test: need ≥2 slice values on {label!r}; "
-            f"got {len(slices)}."
-        )
-
-    labels = list(slices.keys())
-    aligned = per_date_fn(slices[labels[0]]).rename({"value": "v_0"})
-    for i, lbl in enumerate(labels[1:], start=1):
-        aligned = aligned.join(
-            per_date_fn(slices[lbl]).rename({"value": f"v_{i}"}),
-            on="date",
-            how="inner",
-        )
-    if aligned.height < 2:
-        raise ValueError(
-            f"slice_pairwise_test: <2 aligned dates across slices "
-            f"({aligned.height}); joint HAC inference requires aligned "
-            f"rows. Check that slices share at least 2 common dates."
-        )
-
-    panel = aligned.drop("date").to_numpy()
-    n_obs = aligned.height
+    labels, panel, n_obs = _build_per_date_panel(
+        metric, df, label, verb="slice_pairwise_test"
+    )
     k = panel.shape[1]
 
     rows: list[tuple[str, str, float]] = []
@@ -145,5 +165,65 @@ def slice_pairwise_test(
             "stat": [r[2] for r in rows],
             "p_raw": p_raw,
             "p_adj": list(p_adj),
+        }
+    )
+
+
+def slice_joint_test(
+    metric: Callable,
+    df: pl.DataFrame,
+    *,
+    label: str,
+    estimator: Estimator | None = None,
+) -> pl.DataFrame:
+    """Omnibus Wald χ² that all K slice means are equal.
+
+    The joint restriction is ``β_0 = β_1 = … = β_{K-1}``, encoded as
+    ``K-1`` contrasts against the first slice; the Wald statistic
+    follows χ²_{K-1} under H₀.
+
+    Args:
+        metric: Metric callable whose module declares ``per_date_series``.
+        df: Input frame for the metric, containing ``label``.
+        label: Column whose values define the slice partition.
+        estimator: Inference estimator. ``None`` resolves to
+            :class:`WaldNWCluster`. Other estimators raise
+            ``NotImplementedError`` pending follow-up batches.
+
+    Returns:
+        Single-row ``pl.DataFrame`` with columns
+        ``(n_obs, k_slices, df, stat, p)``. ``df`` is the restriction
+        rank (``K-1``); ``stat`` is the joint Wald χ²; ``p`` is the
+        chi-squared survival function. No ``multiple_testing`` kwarg —
+        a single omnibus has no family-internal correction to apply.
+
+    Raises:
+        ValueError: Fewer than two slice values, or fewer than two
+            dates aligned across all slices.
+        TypeError: Metric is not slice-test-eligible (no
+            ``per_date_series`` capability).
+        NotImplementedError: Non-``WaldNWCluster`` estimator passed
+            before the block-bootstrap batch lands.
+    """
+    _resolve_estimator(estimator, "slice_joint_test")
+
+    _, panel, n_obs = _build_per_date_panel(metric, df, label, verb="slice_joint_test")
+    k = panel.shape[1]
+
+    # K-1 contrasts against slice 0: rows are [1, -1, 0, …], [1, 0, -1, …], …
+    restriction = np.zeros((k - 1, k))
+    restriction[:, 0] = 1.0
+    for r in range(k - 1):
+        restriction[r, r + 1] = -1.0
+
+    stat, p = _wald_nw_cluster_means(panel, R=restriction)
+
+    return pl.DataFrame(
+        {
+            "n_obs": [n_obs],
+            "k_slices": [k],
+            "df": [k - 1],
+            "stat": [stat],
+            "p": [p],
         }
     )

--- a/factrix/metrics/slice_test.py
+++ b/factrix/metrics/slice_test.py
@@ -1,0 +1,149 @@
+"""Cross-slice statistical-test verbs (#176).
+
+``slice_pairwise_test`` reports K(K-1)/2 cross-slice contrasts as a
+long-form DataFrame of pairwise ``(stat, p_raw, p_adj)``. The
+companion ``slice_joint_test`` (omnibus χ²) lands in a follow-up.
+
+The ``_test`` suffix marks "verb whose headline output is a
+comparison test result (stat + p)" — distinct from metrics like
+``ic`` / ``fama_macbeth`` whose significance is sidecar to a value,
+and from ``compare`` which renders existing stats without
+recomputing. Convention aligns with scipy (``ttest_ind`` /
+``kruskal``) and R (``t.test`` / ``chisq.test``).
+
+Both consume a metric callable whose module declares
+``per_date_series`` (see
+:mod:`factrix.metrics._metric_capabilities`); the slice partition
+reuses ``_slice_by_label`` so dispatch logic is not duplicated. The
+default estimator is :class:`~factrix.stats.WaldNWCluster` (NW HAC
+Bartlett kernel + 1-way cluster on the slice grouping), which uses
+the joint per-date K-vector panel — cross-slice covariance enters
+through the joint HAC, so paired-diff degeneracies do not arise on
+this path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from itertools import combinations
+from typing import Literal
+
+import numpy as np
+import polars as pl
+
+from factrix._stats.multiple_testing import bonferroni, holm_step_down
+from factrix._stats.wald import _wald_nw_cluster_means
+from factrix.metrics._metric_capabilities import resolve_per_date_series
+from factrix.metrics._slice import _slice_by_label
+from factrix.stats import Estimator, WaldNWCluster
+
+MultipleTestingMethod = Literal["holm", "bonferroni"]
+
+
+def slice_pairwise_test(
+    metric: Callable,
+    df: pl.DataFrame,
+    *,
+    label: str,
+    estimator: Estimator | None = None,
+    multiple_testing: MultipleTestingMethod | None = None,
+) -> pl.DataFrame:
+    """Cross-slice pairwise Wald contrasts on a per-date metric panel.
+
+    Args:
+        metric: Metric callable whose module declares ``per_date_series``.
+        df: Input frame for the metric, containing ``label``.
+        label: Column whose values define the slice partition.
+        estimator: Inference estimator. ``None`` resolves to
+            :class:`WaldNWCluster`. Other estimators raise
+            ``NotImplementedError`` pending follow-up batches.
+        multiple_testing: P-value adjustment family. ``None`` falls
+            back to ``"holm"`` (conservative under arbitrary
+            dependence). Romano-Wolf (block-bootstrap step-down) is
+            scheduled for a follow-up batch.
+
+    Returns:
+        Long-form ``pl.DataFrame`` with columns
+        ``(slice_a, slice_b, n_obs, stat, p_raw, p_adj)``; one row per
+        ordered slice pair ``(a, b)`` with ``a`` before ``b`` in the
+        partition's iteration order.
+
+    Raises:
+        ValueError: Fewer than two slice values, or fewer than two
+            dates aligned across all slices.
+        TypeError: Metric is not slice-test-eligible (no
+            ``per_date_series`` capability).
+        NotImplementedError: Non-``WaldNWCluster`` estimator passed
+            before the Romano-Wolf / block-bootstrap batch lands.
+    """
+    if estimator is None:
+        estimator = WaldNWCluster()
+    if not isinstance(estimator, WaldNWCluster):
+        raise NotImplementedError(
+            f"slice_pairwise_test: estimator "
+            f"{type(estimator).__name__!r} not yet wired; this verb "
+            f"currently supports WaldNWCluster only. BlockBootstrap "
+            f"(Romano-Wolf path) lands in a follow-up batch."
+        )
+    if multiple_testing is None:
+        multiple_testing = "holm"
+
+    per_date_fn = resolve_per_date_series(metric)
+
+    slices = _slice_by_label(df, label)
+    if len(slices) < 2:
+        raise ValueError(
+            f"slice_pairwise_test: need ≥2 slice values on {label!r}; "
+            f"got {len(slices)}."
+        )
+
+    labels = list(slices.keys())
+    aligned = per_date_fn(slices[labels[0]]).rename({"value": "v_0"})
+    for i, lbl in enumerate(labels[1:], start=1):
+        aligned = aligned.join(
+            per_date_fn(slices[lbl]).rename({"value": f"v_{i}"}),
+            on="date",
+            how="inner",
+        )
+    if aligned.height < 2:
+        raise ValueError(
+            f"slice_pairwise_test: <2 aligned dates across slices "
+            f"({aligned.height}); joint HAC inference requires aligned "
+            f"rows. Check that slices share at least 2 common dates."
+        )
+
+    panel = aligned.drop("date").to_numpy()
+    n_obs = aligned.height
+    k = panel.shape[1]
+
+    rows: list[tuple[str, str, float]] = []
+    p_raw: list[float] = []
+    for i, j in combinations(range(k), 2):
+        restriction = np.zeros((1, k))
+        restriction[0, i] = 1.0
+        restriction[0, j] = -1.0
+        stat, p = _wald_nw_cluster_means(panel, R=restriction)
+        rows.append((labels[i], labels[j], stat))
+        p_raw.append(p)
+
+    if multiple_testing == "holm":
+        p_adj = holm_step_down(p_raw)
+    elif multiple_testing == "bonferroni":
+        p_adj = bonferroni(p_raw)
+    else:
+        raise ValueError(
+            f"slice_pairwise_test: multiple_testing="
+            f"{multiple_testing!r} not recognized; expected 'holm' / "
+            f"'bonferroni' / None."
+        )
+
+    return pl.DataFrame(
+        {
+            "slice_a": [r[0] for r in rows],
+            "slice_b": [r[1] for r in rows],
+            "n_obs": [n_obs] * len(rows),
+            "stat": [r[2] for r in rows],
+            "p_raw": p_raw,
+            "p_adj": list(p_adj),
+        }
+    )

--- a/factrix/metrics/slice_test.py
+++ b/factrix/metrics/slice_test.py
@@ -32,23 +32,26 @@ from typing import Literal
 import numpy as np
 import polars as pl
 
-from factrix._stats.multiple_testing import bonferroni, holm_step_down
+from factrix._stats.bootstrap import _joint_block_bootstrap_pairwise_distribution
+from factrix._stats.multiple_testing import bonferroni, holm_step_down, romano_wolf
 from factrix._stats.wald import _wald_nw_cluster_means
 from factrix.metrics._metric_capabilities import resolve_per_date_series
 from factrix.metrics._slice import _slice_by_label
-from factrix.stats import Estimator, WaldNWCluster
+from factrix.stats import BlockBootstrap, Estimator, WaldNWCluster
 
-MultipleTestingMethod = Literal["holm", "bonferroni"]
+MultipleTestingMethod = Literal["holm", "bonferroni", "romano_wolf"]
 
 
-def _resolve_estimator(estimator: Estimator | None, verb: str) -> WaldNWCluster:
+def _resolve_estimator(
+    estimator: Estimator | None, verb: str
+) -> WaldNWCluster | BlockBootstrap:
     if estimator is None:
         return WaldNWCluster()
-    if not isinstance(estimator, WaldNWCluster):
+    if not isinstance(estimator, WaldNWCluster | BlockBootstrap):
         raise NotImplementedError(
             f"{verb}: estimator {type(estimator).__name__!r} not yet "
-            f"wired; this verb currently supports WaldNWCluster only. "
-            f"BlockBootstrap (Romano-Wolf path) lands in a follow-up batch."
+            f"wired; this verb currently supports WaldNWCluster and "
+            f"BlockBootstrap."
         )
     return estimator
 
@@ -106,63 +109,101 @@ def slice_pairwise_test(
         df: Input frame for the metric, containing ``label``.
         label: Column whose values define the slice partition.
         estimator: Inference estimator. ``None`` resolves to
-            :class:`WaldNWCluster`. Other estimators raise
-            ``NotImplementedError`` pending follow-up batches.
-        multiple_testing: P-value adjustment family. ``None`` falls
-            back to ``"holm"`` (conservative under arbitrary
-            dependence). Romano-Wolf (block-bootstrap step-down) is
-            scheduled for a follow-up batch.
+            :class:`WaldNWCluster` (analytic NW HAC + 1-way cluster on
+            slice). :class:`BlockBootstrap` triggers the joint
+            block-bootstrap path and changes the default
+            ``multiple_testing`` to ``"romano_wolf"``.
+        multiple_testing: P-value adjustment family. ``None`` follows
+            the estimator default — ``"holm"`` for ``WaldNWCluster``,
+            ``"romano_wolf"`` for ``BlockBootstrap``. ``"romano_wolf"``
+            with an analytic estimator raises ``ValueError`` (RW
+            requires a bootstrap distribution).
 
     Returns:
         Long-form ``pl.DataFrame`` with columns
         ``(slice_a, slice_b, n_obs, stat, p_raw, p_adj)``; one row per
         ordered slice pair ``(a, b)`` with ``a`` before ``b`` in the
-        partition's iteration order.
+        partition's iteration order. ``stat`` carries the Wald χ² under
+        ``WaldNWCluster`` and the signed mean diff under
+        ``BlockBootstrap`` — bootstrap p-values are based on
+        ``|mean diff|``.
 
     Raises:
-        ValueError: Fewer than two slice values, or fewer than two
-            dates aligned across all slices.
+        ValueError: Fewer than two slice values, fewer than two dates
+            aligned across all slices, or an estimator / multiple-
+            testing combination that has no calibrated p-value path.
         TypeError: Metric is not slice-test-eligible (no
             ``per_date_series`` capability).
-        NotImplementedError: Non-``WaldNWCluster`` estimator passed
-            before the Romano-Wolf / block-bootstrap batch lands.
+        NotImplementedError: Estimator outside ``WaldNWCluster`` /
+            ``BlockBootstrap``.
     """
-    _resolve_estimator(estimator, "slice_pairwise_test")
-    if multiple_testing is None:
-        multiple_testing = "holm"
+    est = _resolve_estimator(estimator, "slice_pairwise_test")
 
     labels, panel, n_obs = _build_per_date_panel(
         metric, df, label, verb="slice_pairwise_test"
     )
     k = panel.shape[1]
+    pairs = list(combinations(range(k), 2))
 
-    rows: list[tuple[str, str, float]] = []
-    p_raw: list[float] = []
-    for i, j in combinations(range(k), 2):
-        restriction = np.zeros((1, k))
-        restriction[0, i] = 1.0
-        restriction[0, j] = -1.0
-        stat, p = _wald_nw_cluster_means(panel, R=restriction)
-        rows.append((labels[i], labels[j], stat))
-        p_raw.append(p)
+    if isinstance(est, BlockBootstrap):
+        observed_abs, boot, _meta = _joint_block_bootstrap_pairwise_distribution(
+            panel,
+            pairs=pairs,
+            block_length=est.block_length,
+            n_resamples=est.n_resamples,
+            scheme=est.scheme,
+            rng_seed=est.rng_seed,
+        )
+        col_means = panel.mean(axis=0)
+        stats = [float(col_means[i] - col_means[j]) for i, j in pairs]
+        b = boot.shape[0]
+        p_raw = [
+            (int(np.sum(boot[:, p_idx] >= observed_abs[p_idx])) + 1) / (b + 1)
+            for p_idx in range(len(pairs))
+        ]
+        if multiple_testing is None:
+            multiple_testing = "romano_wolf"
+    else:
+        stats = []
+        p_raw = []
+        for i, j in pairs:
+            restriction = np.zeros((1, k))
+            restriction[0, i] = 1.0
+            restriction[0, j] = -1.0
+            stat, p = _wald_nw_cluster_means(panel, R=restriction)
+            stats.append(stat)
+            p_raw.append(p)
+        boot = None  # type: ignore[assignment]
+        observed_abs = None  # type: ignore[assignment]
+        if multiple_testing is None:
+            multiple_testing = "holm"
 
     if multiple_testing == "holm":
         p_adj = holm_step_down(p_raw)
     elif multiple_testing == "bonferroni":
         p_adj = bonferroni(p_raw)
+    elif multiple_testing == "romano_wolf":
+        if boot is None:
+            raise ValueError(
+                "slice_pairwise_test: multiple_testing='romano_wolf' "
+                "requires a bootstrap distribution; pair it with "
+                "estimator=BlockBootstrap(). Analytic estimators "
+                "(WaldNWCluster) do not produce one."
+            )
+        p_adj = romano_wolf(observed_abs.tolist(), boot)
     else:
         raise ValueError(
             f"slice_pairwise_test: multiple_testing="
             f"{multiple_testing!r} not recognized; expected 'holm' / "
-            f"'bonferroni' / None."
+            f"'bonferroni' / 'romano_wolf' / None."
         )
 
     return pl.DataFrame(
         {
-            "slice_a": [r[0] for r in rows],
-            "slice_b": [r[1] for r in rows],
-            "n_obs": [n_obs] * len(rows),
-            "stat": [r[2] for r in rows],
+            "slice_a": [labels[i] for i, _ in pairs],
+            "slice_b": [labels[j] for _, j in pairs],
+            "n_obs": [n_obs] * len(pairs),
+            "stat": stats,
             "p_raw": p_raw,
             "p_adj": list(p_adj),
         }
@@ -205,7 +246,14 @@ def slice_joint_test(
         NotImplementedError: Non-``WaldNWCluster`` estimator passed
             before the block-bootstrap batch lands.
     """
-    _resolve_estimator(estimator, "slice_joint_test")
+    est = _resolve_estimator(estimator, "slice_joint_test")
+    if isinstance(est, BlockBootstrap):
+        raise NotImplementedError(
+            "slice_joint_test: BlockBootstrap on the omnibus χ² is not "
+            "implemented; the joint Wald χ² has no canonical bootstrap "
+            "analogue here. Use WaldNWCluster (default) for the omnibus, "
+            "or slice_pairwise_test + BlockBootstrap for pairwise contrasts."
+        )
 
     _, panel, n_obs = _build_per_date_panel(metric, df, label, verb="slice_joint_test")
     k = panel.shape[1]

--- a/factrix/metrics/slice_test.py
+++ b/factrix/metrics/slice_test.py
@@ -21,6 +21,8 @@ Bartlett kernel + 1-way cluster on the slice grouping), which uses
 the joint per-date K-vector panel — cross-slice covariance enters
 through the joint HAC, so paired-diff degeneracies do not arise on
 this path.
+
+Matrix-row: slice_pairwise_test, slice_joint_test | (*, *, *, *) | inference verb | per-pair Wald χ² + Holm/RW/Bonferroni / joint Wald χ² | _build_per_date_panel, _resolve_estimator, _joint_block_bootstrap_pairwise_distribution
 """
 
 from __future__ import annotations
@@ -119,6 +121,15 @@ def slice_pairwise_test(
             with an analytic estimator raises ``ValueError`` (RW
             requires a bootstrap distribution).
 
+    Note:
+        BlockBootstrap reproducibility — pass an explicit ``rng_seed``
+        on the :class:`BlockBootstrap` instance to fix the bootstrap
+        draw. Bootstrap metadata (resolved block length, scheme, seed)
+        is not attached to the returned DataFrame in this release;
+        callers wanting it can either reconstruct from the estimator
+        config or use :func:`factrix._stats.bootstrap._block_bootstrap_diff_p`
+        directly per pair.
+
     Returns:
         Long-form ``pl.DataFrame`` with columns
         ``(slice_a, slice_b, n_obs, stat, p_raw, p_adj)``; one row per
@@ -145,6 +156,8 @@ def slice_pairwise_test(
     k = panel.shape[1]
     pairs = list(combinations(range(k), 2))
 
+    boot: np.ndarray | None
+    observed_abs: np.ndarray | None
     if isinstance(est, BlockBootstrap):
         observed_abs, boot, _meta = _joint_block_bootstrap_pairwise_distribution(
             panel,
@@ -173,8 +186,8 @@ def slice_pairwise_test(
             stat, p = _wald_nw_cluster_means(panel, R=restriction)
             stats.append(stat)
             p_raw.append(p)
-        boot = None  # type: ignore[assignment]
-        observed_abs = None  # type: ignore[assignment]
+        boot = None
+        observed_abs = None
         if multiple_testing is None:
             multiple_testing = "holm"
 
@@ -183,7 +196,7 @@ def slice_pairwise_test(
     elif multiple_testing == "bonferroni":
         p_adj = bonferroni(p_raw)
     elif multiple_testing == "romano_wolf":
-        if boot is None:
+        if boot is None or observed_abs is None:
             raise ValueError(
                 "slice_pairwise_test: multiple_testing='romano_wolf' "
                 "requires a bootstrap distribution; pair it with "

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
       - run_metrics: api/run-metrics.md
       - Multi-horizon (migration): api/multi-horizon.md
       - by_slice: api/by-slice.md
+      - slice_pairwise_test / slice_joint_test: api/slice-test.md
       - by_regime: api/by-regime.md
       - list_metrics: api/list-metrics.md
       - FactorProfile: api/factor-profile.md

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -188,6 +188,11 @@ class TestRegimeIC:
             }
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
 
+    def test_emits_deprecation_warning(self):
+        ic_df = self._make_ic_series(30)
+        with pytest.warns(DeprecationWarning, match="slice_pairwise_test"):
+            regime_ic(ic_df)
+
     def test_time_bisection_fallback(self):
         ic_df = self._make_ic_series(30)
         result = regime_ic(ic_df)

--- a/tests/test_slice_joint_test.py
+++ b/tests/test_slice_joint_test.py
@@ -73,7 +73,7 @@ def test_rejects_non_eligible_metric() -> None:
         slice_joint_test(fake_metric, df, label="regime")
 
 
-def test_rejects_unimplemented_estimator() -> None:
+def test_rejects_block_bootstrap_estimator() -> None:
     df = _ic_panel(n_dates=60, seed=6, means={"a": 0.0, "b": 0.0})
     with pytest.raises(NotImplementedError, match="BlockBootstrap"):
         slice_joint_test(ic, df, label="regime", estimator=BlockBootstrap())

--- a/tests/test_slice_joint_test.py
+++ b/tests/test_slice_joint_test.py
@@ -1,0 +1,112 @@
+"""Omnibus joint Wald χ² cross-slice verb."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.metrics import ic, slice_joint_test
+from factrix.stats import BlockBootstrap, WaldNWCluster
+
+
+def _ic_panel(
+    *,
+    n_dates: int,
+    seed: int,
+    means: dict[str, float],
+) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [dt.date(2024, 1, 1) + dt.timedelta(days=i) for i in range(n_dates)]
+    frames = []
+    for lbl, mu in means.items():
+        frames.append(
+            pl.DataFrame(
+                {
+                    "date": dates,
+                    "ic": rng.normal(mu, 0.05, n_dates),
+                    "regime": [lbl] * n_dates,
+                }
+            )
+        )
+    return pl.concat(frames)
+
+
+def test_two_slice_returns_single_row() -> None:
+    df = _ic_panel(n_dates=120, seed=1, means={"a": 0.02, "b": 0.02})
+    out = slice_joint_test(ic, df, label="regime")
+    assert out.height == 1
+    assert out.columns == ["n_obs", "k_slices", "df", "stat", "p"]
+    assert out["n_obs"][0] == 120
+    assert out["k_slices"][0] == 2
+    assert out["df"][0] == 1
+
+
+def test_three_slice_df_equals_k_minus_one() -> None:
+    df = _ic_panel(n_dates=120, seed=2, means={"a": 0.0, "b": 0.0, "c": 0.0})
+    out = slice_joint_test(ic, df, label="regime")
+    assert out["k_slices"][0] == 3
+    assert out["df"][0] == 2
+
+
+def test_detects_omnibus_signal() -> None:
+    df = _ic_panel(
+        n_dates=240, seed=3, means={"hot": 0.10, "cold": -0.05, "neutral": 0.0}
+    )
+    out = slice_joint_test(ic, df, label="regime")
+    assert out["p"][0] < 0.01
+
+
+def test_null_means_no_omnibus_rejection() -> None:
+    df = _ic_panel(n_dates=240, seed=4, means={"a": 0.0, "b": 0.0, "c": 0.0})
+    out = slice_joint_test(ic, df, label="regime")
+    assert out["p"][0] > 0.10
+
+
+def test_rejects_non_eligible_metric() -> None:
+    def fake_metric(df: pl.DataFrame) -> None:
+        return None
+
+    df = _ic_panel(n_dates=10, seed=5, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(TypeError, match="slice-test-eligible"):
+        slice_joint_test(fake_metric, df, label="regime")
+
+
+def test_rejects_unimplemented_estimator() -> None:
+    df = _ic_panel(n_dates=60, seed=6, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(NotImplementedError, match="BlockBootstrap"):
+        slice_joint_test(ic, df, label="regime", estimator=BlockBootstrap())
+
+
+def test_accepts_default_waldnwcluster_explicit() -> None:
+    df = _ic_panel(n_dates=60, seed=7, means={"a": 0.0, "b": 0.0})
+    out = slice_joint_test(ic, df, label="regime", estimator=WaldNWCluster())
+    assert out.height == 1
+
+
+def test_raises_when_single_slice() -> None:
+    df = _ic_panel(n_dates=60, seed=8, means={"only": 0.0})
+    with pytest.raises(ValueError, match="≥2 slice values"):
+        slice_joint_test(ic, df, label="regime")
+
+
+def test_raises_when_dates_dont_align() -> None:
+    rng = np.random.default_rng(9)
+    base = dt.date(2024, 1, 1)
+    df_a = pl.DataFrame(
+        {
+            "date": [base + dt.timedelta(days=i) for i in range(30)],
+            "ic": rng.normal(0, 0.05, 30),
+            "regime": ["a"] * 30,
+        }
+    )
+    df_b = pl.DataFrame(
+        {
+            "date": [base + dt.timedelta(days=100 + i) for i in range(30)],
+            "ic": rng.normal(0, 0.05, 30),
+            "regime": ["b"] * 30,
+        }
+    )
+    with pytest.raises(ValueError, match="aligned dates"):
+        slice_joint_test(ic, pl.concat([df_a, df_b]), label="regime")

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -102,10 +102,58 @@ def test_rejects_non_eligible_metric() -> None:
         slice_pairwise_test(fake_metric, df, label="universe")
 
 
-def test_rejects_unimplemented_estimator() -> None:
-    df = _ic_panel(n_dates=60, seed=8, means={"a": 0.0, "b": 0.0})
-    with pytest.raises(NotImplementedError, match="BlockBootstrap"):
-        slice_pairwise_test(ic, df, label="universe", estimator=BlockBootstrap())
+def test_block_bootstrap_path_returns_signed_mean_diff_stat() -> None:
+    df = _ic_panel(n_dates=120, seed=8, means={"a": 0.10, "b": -0.05})
+    out = slice_pairwise_test(
+        ic,
+        df,
+        label="universe",
+        estimator=BlockBootstrap(n_resamples=199, rng_seed=42),
+    )
+    assert out.height == 1
+    assert out["stat"][0] == pytest.approx(0.10 - (-0.05), abs=0.05)
+    assert out["p_raw"][0] < 0.05
+
+
+def test_block_bootstrap_defaults_to_romano_wolf() -> None:
+    df = _ic_panel(n_dates=120, seed=80, means={"a": 0.10, "b": -0.05, "c": 0.0})
+    rw_out = slice_pairwise_test(
+        ic,
+        df,
+        label="universe",
+        estimator=BlockBootstrap(n_resamples=199, rng_seed=7),
+    )
+    holm_out = slice_pairwise_test(
+        ic,
+        df,
+        label="universe",
+        estimator=BlockBootstrap(n_resamples=199, rng_seed=7),
+        multiple_testing="holm",
+    )
+    np.testing.assert_array_equal(
+        rw_out["p_raw"].to_numpy(), holm_out["p_raw"].to_numpy()
+    )
+    assert not np.allclose(rw_out["p_adj"].to_numpy(), holm_out["p_adj"].to_numpy())
+
+
+def test_romano_wolf_requires_block_bootstrap() -> None:
+    df = _ic_panel(n_dates=60, seed=81, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(ValueError, match="romano_wolf"):
+        slice_pairwise_test(ic, df, label="universe", multiple_testing="romano_wolf")
+
+
+def test_rejects_unknown_estimator_type() -> None:
+    class FakeEstimator:
+        pass
+
+    df = _ic_panel(n_dates=60, seed=82, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(NotImplementedError, match="FakeEstimator"):
+        slice_pairwise_test(
+            ic,
+            df,
+            label="universe",
+            estimator=FakeEstimator(),  # type: ignore[arg-type]
+        )
 
 
 def test_accepts_default_waldnwcluster_explicit() -> None:

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -1,0 +1,152 @@
+"""Pairwise cross-slice Wald contrast verb."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.metrics import fama_macbeth, ic, slice_pairwise_test
+from factrix.stats import BlockBootstrap, WaldNWCluster
+
+
+def _ic_panel(
+    *,
+    n_dates: int,
+    seed: int,
+    means: dict[str, float],
+) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    dates = [dt.date(2024, 1, 1) + dt.timedelta(days=i) for i in range(n_dates)]
+    frames = []
+    for lbl, mu in means.items():
+        frames.append(
+            pl.DataFrame(
+                {
+                    "date": dates,
+                    "ic": rng.normal(mu, 0.05, n_dates),
+                    "universe": [lbl] * n_dates,
+                }
+            )
+        )
+    return pl.concat(frames)
+
+
+def test_two_slice_returns_one_row() -> None:
+    df = _ic_panel(n_dates=120, seed=1, means={"a": 0.02, "b": 0.02})
+    out = slice_pairwise_test(ic, df, label="universe")
+    assert out.height == 1
+    assert out.columns == ["slice_a", "slice_b", "n_obs", "stat", "p_raw", "p_adj"]
+    assert out["n_obs"][0] == 120
+
+
+def test_three_slice_returns_three_rows() -> None:
+    df = _ic_panel(n_dates=120, seed=2, means={"a": 0.02, "b": 0.02, "c": 0.02})
+    out = slice_pairwise_test(ic, df, label="universe")
+    assert out.height == 3
+    pairs = set(zip(out["slice_a"].to_list(), out["slice_b"].to_list(), strict=False))
+    assert pairs == {("a", "b"), ("a", "c"), ("b", "c")}
+
+
+def test_holm_adjustment_dominates_raw() -> None:
+    df = _ic_panel(n_dates=120, seed=3, means={"a": 0.02, "b": 0.02, "c": 0.02})
+    out = slice_pairwise_test(ic, df, label="universe", multiple_testing="holm")
+    p_raw = out["p_raw"].to_list()
+    p_adj = out["p_adj"].to_list()
+    for raw, adj in zip(p_raw, p_adj, strict=False):
+        assert adj >= raw - 1e-12
+
+
+def test_bonferroni_factor_matches_k() -> None:
+    df = _ic_panel(n_dates=120, seed=4, means={"a": 0.02, "b": 0.02, "c": 0.02})
+    out = slice_pairwise_test(ic, df, label="universe", multiple_testing="bonferroni")
+    p_raw = np.array(out["p_raw"].to_list())
+    p_adj = np.array(out["p_adj"].to_list())
+    expected = np.minimum(p_raw * len(p_raw), 1.0)
+    np.testing.assert_allclose(p_adj, expected)
+
+
+def test_detects_signal_difference() -> None:
+    df = _ic_panel(n_dates=240, seed=5, means={"hot": 0.10, "cold": -0.01})
+    out = slice_pairwise_test(ic, df, label="universe")
+    assert out["p_raw"][0] < 0.01
+
+
+def test_fama_macbeth_metric_accepted() -> None:
+    rng = np.random.default_rng(6)
+    dates = [dt.date(2024, 1, 1) + dt.timedelta(days=i) for i in range(60)]
+    frames = []
+    for lbl, mu in {"x": 0.001, "y": 0.001}.items():
+        frames.append(
+            pl.DataFrame(
+                {
+                    "date": dates,
+                    "beta": rng.normal(mu, 0.01, len(dates)),
+                    "regime": [lbl] * len(dates),
+                }
+            )
+        )
+    df = pl.concat(frames)
+    out = slice_pairwise_test(fama_macbeth, df, label="regime")
+    assert out.height == 1
+    assert out.columns == ["slice_a", "slice_b", "n_obs", "stat", "p_raw", "p_adj"]
+
+
+def test_rejects_non_eligible_metric() -> None:
+    def fake_metric(df: pl.DataFrame) -> None:
+        return None
+
+    df = _ic_panel(n_dates=10, seed=7, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(TypeError, match="slice-test-eligible"):
+        slice_pairwise_test(fake_metric, df, label="universe")
+
+
+def test_rejects_unimplemented_estimator() -> None:
+    df = _ic_panel(n_dates=60, seed=8, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(NotImplementedError, match="BlockBootstrap"):
+        slice_pairwise_test(ic, df, label="universe", estimator=BlockBootstrap())
+
+
+def test_accepts_default_waldnwcluster_explicit() -> None:
+    df = _ic_panel(n_dates=60, seed=9, means={"a": 0.0, "b": 0.0})
+    out = slice_pairwise_test(ic, df, label="universe", estimator=WaldNWCluster())
+    assert out.height == 1
+
+
+def test_raises_when_single_slice() -> None:
+    df = _ic_panel(n_dates=60, seed=10, means={"only": 0.0})
+    with pytest.raises(ValueError, match="≥2 slice values"):
+        slice_pairwise_test(ic, df, label="universe")
+
+
+def test_raises_when_dates_dont_align() -> None:
+    rng = np.random.default_rng(11)
+    base = dt.date(2024, 1, 1)
+    df_a = pl.DataFrame(
+        {
+            "date": [base + dt.timedelta(days=i) for i in range(30)],
+            "ic": rng.normal(0, 0.05, 30),
+            "regime": ["a"] * 30,
+        }
+    )
+    df_b = pl.DataFrame(
+        {
+            "date": [base + dt.timedelta(days=100 + i) for i in range(30)],
+            "ic": rng.normal(0, 0.05, 30),
+            "regime": ["b"] * 30,
+        }
+    )
+    with pytest.raises(ValueError, match="aligned dates"):
+        slice_pairwise_test(ic, pl.concat([df_a, df_b]), label="regime")
+
+
+def test_rejects_unknown_multiple_testing() -> None:
+    df = _ic_panel(n_dates=60, seed=12, means={"a": 0.0, "b": 0.0})
+    with pytest.raises(ValueError, match="not recognized"):
+        slice_pairwise_test(
+            ic,
+            df,
+            label="universe",
+            multiple_testing="fdr",  # type: ignore[arg-type]
+        )

--- a/tests/test_slice_test_reference_cells.py
+++ b/tests/test_slice_test_reference_cells.py
@@ -1,0 +1,107 @@
+"""End-to-end reference cells doubling as docs examples for the
+``slice_pairwise_test`` / ``slice_joint_test`` verb pair (#176).
+
+Each cell runs a realistic pipeline (``compute_ic`` → join labels →
+verb) and asserts the headline result so the file serves both as a
+smoke check and as a copy-paste recipe for users."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import polars as pl
+from factrix.metrics import (
+    compute_ic,
+    ic,
+    slice_joint_test,
+    slice_pairwise_test,
+)
+from factrix.stats import BlockBootstrap
+
+
+def test_pairwise_universe_block_bootstrap_romano_wolf() -> None:
+    """date-shared universe slice → BlockBootstrap + Romano-Wolf default."""
+    rng = np.random.default_rng(11)
+    base = dt.date(2024, 1, 1)
+    n_dates = 200
+    dates = [base + dt.timedelta(days=i) for i in range(n_dates)]
+
+    # Two universes share dates; signal stronger in 'large_cap'
+    rows = []
+    for d in dates:
+        for u, mu in [("large_cap", 0.10), ("small_cap", 0.02)]:
+            for a in range(20):
+                factor = rng.normal()
+                forward_return = mu * factor + rng.normal(scale=0.02)
+                rows.append(
+                    {
+                        "date": d,
+                        "asset_id": f"{u}_{a:03d}",
+                        "factor": factor,
+                        "forward_return": forward_return,
+                        "universe": u,
+                    }
+                )
+    panel = pl.DataFrame(rows)
+
+    per_universe_ic = pl.concat(
+        [
+            compute_ic(panel.filter(pl.col("universe") == u)).with_columns(
+                pl.lit(u).alias("universe")
+            )
+            for u in ["large_cap", "small_cap"]
+        ]
+    )
+
+    out = slice_pairwise_test(
+        ic,
+        per_universe_ic,
+        label="universe",
+        estimator=BlockBootstrap(n_resamples=199, rng_seed=21),
+    )
+    assert out.height == 1
+    assert out["p_adj"][0] < 0.05
+
+
+def test_joint_sector_wald_nw_cluster() -> None:
+    """date-shared sector slice → WaldNWCluster omnibus.
+
+    Joint NW HAC over the (T, K) per-date metric panel requires the K
+    slices to share dates; time-disjoint slices (e.g. regimes with
+    non-overlapping windows) yield zero aligned rows and raise. Use
+    pairwise inference per regime instead, or supply a date-shared
+    classification (sector / market cap tier / universe).
+    """
+    rng = np.random.default_rng(22)
+    base = dt.date(2024, 1, 1)
+    rows = []
+    for d in range(150):
+        for s, mu in [("tech", 0.10), ("finance", 0.0), ("consumer", -0.05)]:
+            for a in range(20):
+                factor = rng.normal()
+                forward_return = mu * factor + rng.normal(scale=0.02)
+                rows.append(
+                    {
+                        "date": base + dt.timedelta(days=d),
+                        "asset_id": f"{s}_{a:03d}",
+                        "factor": factor,
+                        "forward_return": forward_return,
+                        "sector": s,
+                    }
+                )
+    panel = pl.DataFrame(rows)
+
+    per_sector_ic = pl.concat(
+        [
+            compute_ic(panel.filter(pl.col("sector") == s)).with_columns(
+                pl.lit(s).alias("sector")
+            )
+            for s in ["tech", "finance", "consumer"]
+        ]
+    )
+
+    out = slice_joint_test(ic, per_sector_ic, label="sector")
+    assert out.height == 1
+    assert out["df"][0] == 2
+    assert out["p"][0] < 0.05


### PR DESCRIPTION
## Summary

- **`slice_pairwise_test`** — K(K−1)/2 cross-slice Wald contrasts; analytic path (WaldNWCluster + Holm/Bonferroni) and bootstrap path (BlockBootstrap + Romano-Wolf) share output schema.
- **`slice_joint_test`** — single omnibus Wald χ² that all K slice means are equal; WaldNWCluster only.
- Default estimator = WaldNWCluster; BlockBootstrap flips default `multiple_testing` to `romano_wolf`. RW + analytic estimator → ValueError.
- **`regime_ic` deprecated** with full migration recipe pointing at `slice_pairwise_test(ic, ic_df.join(regime_labels, on='date'), label='regime')`. Output shape frozen one minor as migration window.
- Reference cells (`tests/test_slice_test_reference_cells.py`) double as smoke + docs examples; mkdocs page at `docs/api/slice-test.md`.

### Scope deviations from original #176 spec (reflected in updated body)

- **`configs` / `_downscale_n_groups`** deferred — verb extracts per-date series via the `per_date_series` capability instead of calling the metric callable, so per-slice cfg / n_groups have no point of action. Re-enable when a bucketing metric (monotonicity) gains `per_date_series`.
- **Strict-subset detection** deferred — joint K-panel + joint NW HAC absorbs cross-slice covariance through the kernel, so the paired-diff degeneracy the original spec targeted does not arise here. Stays for the future `factor_decomposition` raw-panel verb.
- **Date alignment is required** — joint NW HAC over the (T, K) per-date metric panel needs aligned rows; time-disjoint slices (regimes split by period) yield zero aligned rows and raise. Documented as architectural constraint. Time-disjoint regime inference needs a different SE path (future work).
- **`metric not in list_metrics(cfg)` fuzzy suggest** replaced — verb takes `metric: Callable` not a string, so eligibility is enforced via the `per_date_series` capability resolver (TypeError with capability-contract hint).
- **`_slice_by_regime` retirement** deferred — `regime_ic` shape frozen for migration window means the helper stays until `regime_ic` itself is removed.

## Test plan

- [x] `tests/test_slice_pairwise_test.py` — 14 cases (default / explicit estimator × Holm / Bonferroni / RW × happy and error paths)
- [x] `tests/test_slice_joint_test.py` — 9 cases (df = K-1, omnibus signal/null, error paths)
- [x] `tests/test_slice_test_reference_cells.py` — universe pairwise (BlockBootstrap + RW) + sector joint (WaldNWCluster); both date-shared
- [x] `tests/test_metric_capabilities.py` — landed in #213
- [x] `tests/test_ic.py::TestRegimeIC::test_emits_deprecation_warning` — DeprecationWarning fires
- [x] Full suite: 1160 passing, no regression
- [x] `uv run mypy factrix` clean
- [x] `mkdocs build --strict` clean (verified via pre-push)

Closes #176
