### PR TITLE
refactor: prefix internal-only types with underscore (#219)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -603,7 +603,7 @@ factrix/
 ├── _profile.py              # FactorProfile dataclass + verdict / diagnose
 ├── _evaluate.py             # _derive_mode + _evaluate dispatch wrapper
 ├── _describe.py             # describe_analysis_modes + suggest_config + SuggestConfigResult
-├── _family.py               # _resolve_family + FamilyEntry (shared invariants)
+├── _family.py               # _resolve_family + _FamilyEntry (shared invariants)
 ├── _multi_factor.py         # bhy on the resolution layer
 ├── multi_factor.py          # public namespace (re-exports bhy)
 ├── _stats/

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -4,7 +4,7 @@ Every closed-form family verb (``bhy`` / ``bhy_hierarchical`` /
 ``partial_conjunction`` / ``bonferroni`` / ``holm``) and the
 resampling-based ``romano_wolf`` runs through ``_resolve_family`` to
 turn a list of :class:`~factrix._profile.FactorProfile` into flat
-``FamilyEntry`` records ready for the procedure-specific step-up math.
+``_FamilyEntry`` records ready for the procedure-specific step-up math.
 
 The four invariants enforced here are the family-layer extension of the
 identity / context anti-shopping defense from #160: ``identity``
@@ -42,7 +42,7 @@ _ESTIMATOR_DOCS_ANCHOR = "estimator"
 
 
 @dataclass(frozen=True, slots=True)
-class FamilyEntry:
+class _FamilyEntry:
     """Flat record fed to family-verb procedures after invariant checks.
 
     Attributes:
@@ -70,8 +70,8 @@ def _resolve_family(
     verb: str,
     expand_over: Sequence[str] | None = None,
     estimator: Estimator | None = None,
-) -> list[FamilyEntry]:
-    """Validate four invariants and return flat ``FamilyEntry`` records.
+) -> list[_FamilyEntry]:
+    """Validate four invariants and return flat ``_FamilyEntry`` records.
 
     Steps (raise on failure, in order):
 
@@ -99,7 +99,7 @@ def _resolve_family(
             back to ``primary_p``.
 
     Returns:
-        One ``FamilyEntry`` per input profile, in input order.
+        One ``_FamilyEntry`` per input profile, in input order.
 
     Raises:
         UserInputError: On any of the named-set / availability /
@@ -116,7 +116,7 @@ def _resolve_family(
                 docs_path=f"api/{verb}#expand_over",
             )
 
-    entries: list[FamilyEntry] = []
+    entries: list[_FamilyEntry] = []
     seen: dict[tuple[Any, ...], int] = {}
 
     for idx, profile in enumerate(profiles):
@@ -142,7 +142,7 @@ def _resolve_family(
         seen[partition_key] = idx
 
         entries.append(
-            FamilyEntry(
+            _FamilyEntry(
                 identity=profile.identity,
                 expand_over_values=values,
                 p_value=_resolve_p_value(profile, estimator=estimator, verb=verb),

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -201,7 +201,7 @@ class Cell:
 
 
 @dataclass(frozen=True, slots=True)
-class MatrixEntry:
+class _MatrixEntry:
     """One ``Matrix-row:`` tag, un-exploded — drives matrix rendering."""
 
     module: str
@@ -296,8 +296,8 @@ def _extract_matrix_rows(path: pathlib.Path) -> list[str]:
     return [m.group(1).strip() for m in _MATRIX_ROW_RE.finditer(doc)]
 
 
-def _parse_module_entries(path: pathlib.Path) -> list[MatrixEntry]:
-    entries: list[MatrixEntry] = []
+def _parse_module_entries(path: pathlib.Path) -> list[_MatrixEntry]:
+    entries: list[_MatrixEntry] = []
     for raw_value in _extract_matrix_rows(path):
         parts = [p.strip() for p in raw_value.split("|")]
         if len(parts) != 5:
@@ -308,7 +308,7 @@ def _parse_module_entries(path: pathlib.Path) -> list[MatrixEntry]:
         names_csv, cell_str, agg_order, inference_se, _primitives = parts
         names = tuple(n for n in (n.strip() for n in names_csv.split(",")) if n)
         entries.append(
-            MatrixEntry(
+            _MatrixEntry(
                 module=path.stem,
                 names=names,
                 cell=_parse_cell(cell_str),
@@ -320,14 +320,14 @@ def _parse_module_entries(path: pathlib.Path) -> list[MatrixEntry]:
 
 
 @functools.cache
-def matrix_entries() -> tuple[MatrixEntry, ...]:
+def _matrix_entries() -> tuple[_MatrixEntry, ...]:
     """Return one entry per ``Matrix-row:`` tag (un-exploded by name).
 
     Sorted by module. Cached — metric module docstrings do not change
     at runtime, so repeated callers (``list_metrics`` in agentic loops)
     avoid re-parsing every public ``factrix/metrics/*.py``.
     """
-    out: list[MatrixEntry] = []
+    out: list[_MatrixEntry] = []
     for path in _public_metric_modules():
         out.extend(_parse_module_entries(path))
     out.sort(key=lambda e: e.module)
@@ -335,7 +335,7 @@ def matrix_entries() -> tuple[MatrixEntry, ...]:
 
 
 @functools.cache
-def all_rows() -> list[MetricRow]:
+def _all_rows() -> list[MetricRow]:
     """Return every parsed ``Matrix-row:`` row, exploded one per metric name.
 
     Sorted by ``(module, name)``. Includes stage-1 helpers; for the
@@ -353,7 +353,7 @@ def all_rows() -> list[MetricRow]:
             docs_anchor=DOCS_ANCHOR_FMT.format(module=entry.module, name=name),
             emitted_name=_EMITTED_NAME_OVERRIDES.get(name, name),
         )
-        for entry in matrix_entries()
+        for entry in _matrix_entries()
         for name in entry.names
     ]
     rows.sort(key=lambda r: (r.module, r.name))
@@ -364,4 +364,4 @@ def all_rows() -> list[MetricRow]:
 def user_facing_rows() -> list[MetricRow]:
     """Return parsed rows excluding stage-1 helpers and cross-cutting infra."""
     excluded = _STAGE1_HELPERS | _INFRASTRUCTURE
-    return [r for r in all_rows() if r.name not in excluded]
+    return [r for r in _all_rows() if r.name not in excluded]

--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -13,7 +13,7 @@ from factrix._types import EPSILON
 
 
 @dataclass
-class OLSResult:
+class _OLSResult:
     """Result of a single OLS regression."""
 
     alpha: float
@@ -25,15 +25,15 @@ class OLSResult:
 def ols_alpha(
     candidate: np.ndarray,
     base_matrix: np.ndarray,
-) -> OLSResult:
+) -> _OLSResult:
     """OLS regression: candidate = alpha + beta @ base + epsilon.
 
     Returns:
-        OLSResult with alpha, t_stat, betas, and R².
+        _OLSResult with alpha, t_stat, betas, and R².
     """
     n_obs = len(candidate)
     if n_obs < 3:
-        return OLSResult(alpha=0.0, alpha_t=0.0)
+        return _OLSResult(alpha=0.0, alpha_t=0.0)
 
     ones = np.ones((n_obs, 1))
     X = np.hstack([ones, base_matrix]) if base_matrix.shape[1] > 0 else ones
@@ -41,7 +41,7 @@ def ols_alpha(
     try:
         beta, _, _, _ = np.linalg.lstsq(X, candidate, rcond=None)
     except np.linalg.LinAlgError:
-        return OLSResult(alpha=0.0, alpha_t=0.0)
+        return _OLSResult(alpha=0.0, alpha_t=0.0)
 
     alpha = float(beta[0])
     betas = [float(b) for b in beta[1:]]
@@ -55,22 +55,22 @@ def ols_alpha(
 
     dof = n_obs - X.shape[1]
     if dof <= 0:
-        return OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
 
     sigma2 = ss_res / dof
     if sigma2 < EPSILON:
-        return OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
 
     try:
         xtx_inv = np.linalg.inv(X.T @ X)
         se_alpha = float(np.sqrt(sigma2 * xtx_inv[0, 0]))
     except np.linalg.LinAlgError:
-        return OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
 
     if se_alpha < EPSILON:
-        return OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
 
-    return OLSResult(
+    return _OLSResult(
         alpha=alpha,
         alpha_t=alpha / se_alpha,
         betas=betas,

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import pathlib
 
-from factrix._metric_index import MatrixEntry, matrix_entries
+from factrix._metric_index import _matrix_entries, _MatrixEntry
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_metric_matrix.md"
@@ -29,7 +29,7 @@ _TABLE_HEADER = (
 )
 
 
-def _render_row(entry: MatrixEntry) -> str:
+def _render_row(entry: _MatrixEntry) -> str:
     module_cell = f"[`metrics.{entry.module}`][factrix.metrics.{entry.module}]"
     return (
         f"| {module_cell} | `{entry.cell.raw}` | "
@@ -39,7 +39,7 @@ def _render_row(entry: MatrixEntry) -> str:
 
 def generate() -> None:
     """Generate ``_generated_metric_matrix.md`` from module docstrings."""
-    entries = matrix_entries()
+    entries = _matrix_entries()
     lines = [_TABLE_HEADER, *(_render_row(e) for e in entries)]
     _OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     _OUT_FILE.write_text("".join(lines), encoding="utf-8")


### PR DESCRIPTION
## Summary

- Rename `MatrixEntry` / `matrix_entries` / `all_rows` / `OLSResult` / `FamilyEntry` to underscore-prefixed form so symbol visibility matches the already-private hosting module
- Update sole external caller `scripts/mkdocs_hooks/gen_metric_matrix.py`
- No public surface touched → no CHANGELOG entry

## Test plan

- [x] Full pytest suite (1160 passed)
- [x] Repo-wide grep confirms no unprefixed references remain
- [x] ruff check + format clean

Closes #219