### PR TITLE
feat(slicing): add SliceResult container with .to_frame() renderer (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ### Added
 
+- **`factrix.SliceResult`** (#212). Container returned by
+  `by_slice` — a `Mapping[str, MetricOutput]` subclass, so every
+  existing `dict`-shaped consumer (`for k, v in result.items()`,
+  `result["bull"]`, `len(result)`) keeps working unchanged. Adds
+  `.to_frame()`, a fixed-schema long-form `pl.DataFrame` renderer
+  (`slice`, `name`, `value`, `stat`, `p_value`) for plotting,
+  leaderboards, and Notebook rendering, plus a `_repr_html_` that
+  delegates to the same frame so `SliceResult` shows as a table in
+  Jupyter. `slice_col=` renames the label column. See
+  `docs/api/by-slice.md` for the schema rationale (why a fixed
+  projection instead of a configurable `cols=` argument).
 - **`factrix.slice_pairwise_test` / `factrix.slice_joint_test`** (#176, #215). Cross-slice statistical-test verb pair, hosted in the new `factrix.slicing` subpackage and re-exported at top level (`from factrix import by_slice, slice_pairwise_test, slice_joint_test`). `slice_pairwise_test` reports K(K−1)/2 pairwise Wald contrasts with Holm / Romano-Wolf / Bonferroni adjusted p; `slice_joint_test` reports the single omnibus Wald χ² that all slice means are equal. Default estimator `WaldNWCluster` (joint NW HAC over the per-date K-vector panel) covers analytic inference; `BlockBootstrap` triggers the joint bootstrap path with Romano-Wolf as the default multiple-testing adjustment. Both verbs require the metric's module to declare a `per_date_series` capability — `ic` / `fama_macbeth` / `hit_rate` ship with it; metrics without it raise `TypeError`. See `docs/api/slice-test.md`.
 - **`factrix.slicing` subpackage** (#215). Hosts `by_slice` (axis-agnostic dispatcher) plus the verb pair above. The move makes `factrix.metrics` a pure cell-metric registry — every public `*.py` under `factrix/metrics/` is a per-(scope, signal) metric, and `run_metrics` auto-discovery is now structural rather than maintained via a denylist.
 - **`factrix.metrics._metric_capabilities`** (#176). Resolver helpers (`resolve_per_date_series`, `resolve_min_assets_per_group`) plus a `PerDateSeries` Protocol and a `per_date_series_rename` factory. Centralises capability lookup so inference verbs reuse one resolver instead of grovelling `sys.modules` directly.

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -2,7 +2,8 @@
 
 Axis-agnostic research dispatcher. Slices any metric's date-keyed
 input by a column already present in the DataFrame and runs the metric
-per slice. Returns `dict[label_value, MetricOutput]`.
+per slice. Returns a [`SliceResult`](#sliceresult) — a
+`Mapping[str, MetricOutput]` with a `.to_frame()` long-form renderer.
 
 The axis name does not bake into the API — market, sector, regime,
 market-cap tier, ADV bucket all share the same dispatcher.
@@ -18,7 +19,10 @@ ic_df = compute_ic(panel)
 ic_df = ic_df.join(regime_labels, on="date")  # adds 'regime' column
 
 per_regime = by_slice(ic, ic_df, label="regime")
-# {"bull": MetricOutput(name="ic", ...), "bear": MetricOutput(name="ic", ...)}
+# SliceResult({"bull": MetricOutput(name="ic", ...), "bear": MetricOutput(name="ic", ...)})
+
+per_regime["bull"].value          # Mapping access — unchanged
+per_regime.to_frame()             # long-form pl.DataFrame for plotting
 ```
 
 The first argument is the **metric callable** (e.g. `ic`, `caar`,
@@ -158,9 +162,97 @@ expanded = pl.concat([
 by_slice(metric, expanded, label="group")
 ```
 
+## SliceResult
+
+`by_slice` returns a `SliceResult`, a `Mapping[str, MetricOutput]`
+subclass — every `dict`-shaped consumer (`for k, v in result.items()`,
+`result["bull"]`, `len(result)`) keeps working unchanged. The added
+value is `.to_frame()`, which flattens per-slice `MetricOutput` rows
+into a fixed-schema long-form `pl.DataFrame` for plotting,
+leaderboards, and Notebook rendering.
+
+```python
+result = by_slice(ic, ic_df, label="regime")
+result.to_frame().sort("slice")           # plot-ready, lexicographic order
+# shape: (2, 5)
+# ┌────────┬──────┬───────┬───────┬──────────┐
+# │ slice  │ name │ value │ stat  │ p_value  │
+# │ ---    │ ---  │ ---   │ ---   │ ---      │
+# │ str    │ str  │ f64   │ f64   │ f64      │
+# ╞════════╪══════╪═══════╪═══════╪══════════╡
+# │ bear   │ ic   │ -0.02 │ -0.41 │ 0.683    │
+# │ bull   │ ic   │ 0.07  │ 2.31  │ 0.024    │
+# └────────┴──────┴───────┴───────┴──────────┘
+
+# leaderboard: rank slices by t-stat magnitude
+result.to_frame().sort(pl.col("stat").abs(), descending=True)
+```
+
+!!! warning "p_value is **per-slice**, not cross-slice-adjusted"
+
+    Each row's `p_value` tests that slice alone against its own null
+    (e.g. `ic` mean = 0). Filtering `df.filter(pl.col("p_value") < 0.05)`
+    across K parallel slices inflates the family-wise error rate —
+    under H0, K=10 sectors yields ≈ 0.4 expected "significant" slices
+    by pure chance. The container is for **exploration**; for
+    inference claims with FWER / FDR control, use
+    [`slice_pairwise_test`](slice-test.md#factrix.slicing.inference.slice_pairwise_test)
+    (Holm / Romano-Wolf / Bonferroni) or
+    [`slice_joint_test`](slice-test.md#factrix.slicing.inference.slice_joint_test)
+    (omnibus χ²).
+
+### Schema
+
+`to_frame()` always returns the same five columns in the same order:
+
+| Column      | Source                     | `None` when                                  |
+|-------------|----------------------------|----------------------------------------------|
+| `slice`     | mapping key (rename via `slice_col=`) | never                              |
+| `name`      | `MetricOutput.name`        | never                                        |
+| `value`     | `MetricOutput.value`       | never                                        |
+| `stat`      | `MetricOutput.stat`        | descriptive metric / short-circuit failure   |
+| `p_value`   | `metadata["p_value"]`      | descriptive metric / short-circuit failure   |
+
+`stat` and `p_value` semantics follow the underlying metric (`stat` may
+be a *t*, *z*, *F*, or *χ²* — see `metadata["stat_type"]`; `p_value`
+may be one- or two-sided per the metric's null hypothesis). When
+concatenating frames from multiple metrics
+(`pl.concat([by_slice(ic, ...).to_frame(), by_slice(hit_rate, ...).to_frame()])`),
+the `stat` column mixes statistic types and is not directly comparable
+across rows of different `name`.
+
+Row order matches iteration order of the result, which matches the
+upstream `polars.DataFrame.partition_by` order (insertion order of
+distinct values, **not** lexicographic). For plotting and
+leaderboards, sort explicitly downstream (`.sort("slice")` for
+deterministic axis order, `.sort("value")` / `.sort("stat")` for
+ranking). The example block above shows the plot-ready idiom.
+
+### Why a fixed schema instead of `cols=...`?
+
+Quant exploration overwhelmingly wants the same five columns — slice,
+metric name, effect size, test statistic, p-value. A configurable
+`cols=` parameter would have to choose between (a) a fixed lookup set
+that excludes p-value (which lives in `metadata`) or (b) per-slice
+metadata key discovery, whose candidate set drifts across metrics and
+even across success vs. short-circuit paths within one metric. Fixed
+schema avoids both failure modes; for metric-specific metadata
+(`tie_ratio`, `shanken_correction`, ...), build the frame directly:
+
+```python
+pl.DataFrame(
+    [{"slice": k, **m.metadata} for k, m in result.items()]
+)
+```
+
 ## API reference
 
 ::: factrix.slicing.dispatcher
     options:
       members:
         - by_slice
+
+::: factrix.slicing.result
+    options:
+      members:
+        - SliceResult

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -69,7 +69,12 @@ from factrix._evaluate import _evaluate as _evaluate
 from factrix._profile import FactorProfile
 from factrix._run_metrics import MetricsBundle, run_metrics
 from factrix._types import MetricOutput
-from factrix.slicing import by_slice, slice_joint_test, slice_pairwise_test
+from factrix.slicing import (
+    SliceResult,
+    by_slice,
+    slice_joint_test,
+    slice_pairwise_test,
+)
 
 
 def evaluate(
@@ -167,6 +172,7 @@ __all__ = [
     "list_metrics",
     "suggest_config",
     # Slicing dispatcher + cross-slice inference verbs
+    "SliceResult",
     "by_slice",
     "slice_joint_test",
     "slice_pairwise_test",

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -313,7 +313,11 @@ property — agents reading `diagnose()["stats"]` / `["warnings"]` /
 Cross-slice analysis lives in `factrix.slicing` and is re-exported at
 top-level. `by_slice(metric, df, *, label)` partitions a metric's
 date-keyed input by an existing column and applies the metric per
-slice — pure dispatcher, no cross-slice inference. For inferential
+slice — pure dispatcher, no cross-slice inference. Returns a
+`SliceResult`, a `Mapping[str, MetricOutput]` with a `.to_frame()`
+long-form renderer (fixed schema:
+`slice / name / value / stat / p_value`) for plotting, leaderboards,
+and Notebook display. For inferential
 contrasts, `slice_pairwise_test(metric, df, *, label, estimator,
 multiple_testing)` reports K(K-1)/2 pairwise Wald contrasts with
 Holm / Romano-Wolf / Bonferroni adjusted p; `slice_joint_test(metric,

--- a/factrix/slicing/__init__.py
+++ b/factrix/slicing/__init__.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 from factrix.slicing.dispatcher import by_slice
 from factrix.slicing.inference import slice_joint_test, slice_pairwise_test
+from factrix.slicing.result import SliceResult
 
 __all__ = [
+    "SliceResult",
     "by_slice",
     "slice_joint_test",
     "slice_pairwise_test",

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -17,6 +17,7 @@ import polars as pl
 
 from factrix._types import MetricOutput
 from factrix.slicing._primitive import _slice_by_label
+from factrix.slicing.result import SliceResult
 
 
 def by_slice(
@@ -25,7 +26,7 @@ def by_slice(
     *,
     label: str,
     **kwargs: Any,
-) -> dict[str, MetricOutput]:
+) -> SliceResult:
     """Apply ``metric`` to each value-partition of ``df`` keyed by ``label``.
 
     Args:
@@ -44,10 +45,13 @@ def by_slice(
             call.
 
     Returns:
-        ``{label_value: metric(slice, **kwargs)}``. Keys are
+        :class:`SliceResult` — ``Mapping[str, MetricOutput]`` (so every
+        ``dict``-shaped consumer keeps working) plus a
+        :meth:`SliceResult.to_frame` long-form renderer. Keys are
         stringified (an ``Int64`` decile column yields ``"1".."10"``);
-        dict order matches polars ``partition_by(as_dict=True)``. No
-        cross-slice statistical inference — see API page.
+        iteration order matches polars
+        ``partition_by(as_dict=True)``. No cross-slice statistical
+        inference — see API page.
 
     Raises:
         TypeError: ``df`` is not a polars DataFrame.
@@ -70,4 +74,6 @@ def by_slice(
     :func:`factrix.slice_pairwise_test` / :func:`factrix.slice_joint_test`.
     """
     sliced = _slice_by_label(df, label)
-    return {key: metric(sub_df, **kwargs) for key, sub_df in sliced.items()}
+    return SliceResult(
+        {key: metric(sub_df, **kwargs) for key, sub_df in sliced.items()}
+    )

--- a/factrix/slicing/result.py
+++ b/factrix/slicing/result.py
@@ -1,0 +1,99 @@
+"""Container returned by :func:`factrix.slicing.by_slice`.
+
+``SliceResult`` is a ``Mapping[str, MetricOutput]`` — every existing
+``dict``-shaped consumer (``for k, v in result.items()``,
+``result["bull"]``, ``len(result)``) keeps working. The added value is
+:meth:`SliceResult.to_frame`: a fixed-schema long-form ``pl.DataFrame``
+that flattens per-slice ``MetricOutput`` rows for plotting,
+leaderboards, and Notebook rendering.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+
+import polars as pl
+
+from factrix._types import MetricOutput
+
+
+class SliceResult(Mapping[str, MetricOutput]):
+    """Mapping of slice label → :class:`MetricOutput` with a frame renderer.
+
+    Returned by :func:`factrix.slicing.by_slice`. Iteration order matches
+    the upstream ``polars.DataFrame.partition_by`` order (insertion-order
+    of distinct values, not lexicographic) — call ``.sort("slice")`` on
+    the rendered frame if a stable order is needed downstream.
+
+    The container deliberately exposes only the universal projection
+    (``name``, ``value``, ``stat``, ``p_value``). For metric-specific
+    metadata (``tie_ratio``, ``shanken_correction``, ...), build the
+    DataFrame directly from ``[(k, m.metadata) for k, m in result.items()]``.
+
+    Warning:
+        ``p_value`` in the rendered frame is the **per-slice** marginal
+        p-value computed by the metric on that slice alone — *not*
+        adjusted for the K parallel tests across slices. Filtering
+        ``df.filter(pl.col("p_value") < 0.05)`` across K=10 sectors
+        inflates the family-wise error rate; under H0 you expect
+        ≈ 0.4 "significant" slices by chance. For cross-slice
+        inference with FWER / FDR control, use
+        :func:`factrix.slice_pairwise_test` (Holm / Romano-Wolf /
+        Bonferroni) or :func:`factrix.slice_joint_test` (omnibus χ²)
+        instead. The container is for exploration; the inference
+        verbs are for claims.
+    """
+
+    def __init__(self, data: Mapping[str, MetricOutput]) -> None:
+        self._data: dict[str, MetricOutput] = dict(data)
+
+    def __getitem__(self, key: str) -> MetricOutput:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return f"SliceResult({self._data!r})"
+
+    def to_frame(self, *, slice_col: str = "slice") -> pl.DataFrame:
+        """Render slices as a long-form ``pl.DataFrame``.
+
+        Schema (always, in order): ``slice_col``, ``name``, ``value``,
+        ``stat``, ``p_value``. ``stat`` and ``p_value`` are ``None``
+        when the underlying ``MetricOutput`` does not carry them
+        (descriptive metric, short-circuit failure path, etc.).
+
+        Args:
+            slice_col: Output column name for the slice label. Default
+                ``"slice"``; override when the caller needs to avoid a
+                clash with an existing identity column they intend to
+                join in upstream.
+
+        Returns:
+            ``pl.DataFrame`` with one row per slice. Row order follows
+            iteration order of ``self``.
+        """
+        cols = (slice_col, "name", "value", "stat", "p_value")
+        rows: dict[str, list[object]] = {c: [] for c in cols}
+        for key, m in self._data.items():
+            rows[slice_col].append(key)
+            rows["name"].append(m.name)
+            rows["value"].append(m.value)
+            rows["stat"].append(m.stat)
+            p = m.metadata.get("p_value")
+            rows["p_value"].append(float(p) if isinstance(p, (int, float)) else None)
+        schema: dict[str, type[pl.DataType]] = {
+            slice_col: pl.Utf8,
+            "name": pl.Utf8,
+            "value": pl.Float64,
+            "stat": pl.Float64,
+            "p_value": pl.Float64,
+        }
+        return pl.DataFrame(rows, schema=schema)
+
+    def _repr_html_(self) -> str:
+        return self.to_frame()._repr_html_()

--- a/tests/test_by_slice.py
+++ b/tests/test_by_slice.py
@@ -1,11 +1,12 @@
 """Tests for factrix.by_slice — axis-agnostic dispatcher."""
 
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 
 import numpy as np
 import polars as pl
 import pytest
-from factrix import by_slice
+from factrix import SliceResult, by_slice
 from factrix._types import MetricOutput
 from factrix.metrics import ic
 from factrix.slicing._primitive import _slice_by_label
@@ -73,10 +74,11 @@ class TestSliceByLabel:
 
 
 class TestBySlice:
-    def test_returns_dict_per_slice(self):
+    def test_returns_slice_result_per_slice(self):
         df = _ic_series_with_label(40)
         out = by_slice(ic, df, label="regime")
-        assert isinstance(out, dict)
+        assert isinstance(out, SliceResult)
+        assert isinstance(out, Mapping)
         assert set(out) == {"bull", "bear"}
         for v in out.values():
             assert isinstance(v, MetricOutput)

--- a/tests/test_slice_result.py
+++ b/tests/test_slice_result.py
@@ -1,0 +1,92 @@
+"""Tests for the SliceResult container returned by by_slice (#212)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import polars as pl
+import pytest
+from factrix import SliceResult
+from factrix._types import MetricOutput
+
+
+def _make_outputs() -> dict[str, MetricOutput]:
+    return {
+        "bull": MetricOutput(
+            name="ic",
+            value=0.07,
+            stat=2.31,
+            significance="*",
+            metadata={"p_value": 0.024, "method": "non-overlapping t-test"},
+        ),
+        "bear": MetricOutput(
+            name="ic",
+            value=-0.02,
+            stat=-0.41,
+            significance="",
+            metadata={"p_value": 0.683, "method": "non-overlapping t-test"},
+        ),
+    }
+
+
+class TestMappingBehaviour:
+    def test_basic_wiring(self):
+        r = SliceResult(_make_outputs())
+        assert isinstance(r, Mapping)
+        assert r["bull"].value == pytest.approx(0.07)
+        assert list(r) == ["bull", "bear"]
+        assert len(r) == 2
+
+    def test_iteration_order_preserved(self):
+        # Insertion order, not lexicographic — matches polars partition_by behaviour.
+        r = SliceResult({"z": _make_outputs()["bull"], "a": _make_outputs()["bear"]})
+        assert list(r) == ["z", "a"]
+
+
+class TestToFrame:
+    def test_default_schema(self):
+        df = SliceResult(_make_outputs()).to_frame()
+        assert df.columns == ["slice", "name", "value", "stat", "p_value"]
+        assert df.schema["slice"] == pl.Utf8
+        assert df.schema["name"] == pl.Utf8
+        assert df.schema["value"] == pl.Float64
+        assert df.schema["stat"] == pl.Float64
+        assert df.schema["p_value"] == pl.Float64
+
+    def test_row_count_and_order(self):
+        df = SliceResult(_make_outputs()).to_frame()
+        assert df.height == 2
+        assert df["slice"].to_list() == ["bull", "bear"]
+        assert df["value"].to_list() == pytest.approx([0.07, -0.02])
+        assert df["stat"].to_list() == pytest.approx([2.31, -0.41])
+        assert df["p_value"].to_list() == pytest.approx([0.024, 0.683])
+
+    def test_custom_slice_col(self):
+        df = SliceResult(_make_outputs()).to_frame(slice_col="regime")
+        assert df.columns == ["regime", "name", "value", "stat", "p_value"]
+        assert df["regime"].to_list() == ["bull", "bear"]
+
+    def test_missing_stat_and_p_value_become_null(self):
+        # Descriptive metric without stat or p_value (e.g. event count summary).
+        outputs = {
+            "g1": MetricOutput(name="counts", value=42.0),
+            "g2": MetricOutput(name="counts", value=17.0, metadata={"note": "x"}),
+        }
+        df = SliceResult(outputs).to_frame()
+        assert df["stat"].to_list() == [None, None]
+        assert df["p_value"].to_list() == [None, None]
+        assert df["value"].to_list() == pytest.approx([42.0, 17.0])
+
+    def test_empty_result(self):
+        df = SliceResult({}).to_frame()
+        assert df.columns == ["slice", "name", "value", "stat", "p_value"]
+        assert df.height == 0
+
+
+class TestReprHtml:
+    def test_repr_html_non_empty(self):
+        html = SliceResult(_make_outputs())._repr_html_()
+        assert isinstance(html, str)
+        assert html  # non-empty
+        # Delegates to polars DataFrame._repr_html_, which renders <table>.
+        assert "<table" in html


### PR DESCRIPTION
## Summary

- `by_slice` 回傳型別由 `dict[str, MetricOutput]` → `SliceResult`（Mapping[str, MetricOutput] 子類，dict-shaped consumer 零修改）。容器加 `.to_frame()` 固定 schema `[slice, name, value, stat, p_value]` 長表渲染 + `_repr_html_` delegate 給 polars。
- 拍掉 issue body 預設 `cols=("value", "stat", "n_obs")` —— `n_obs` 跨 metric 不一致（`ic`→`n_periods`、`fama_macbeth`→`n_obs`、short-circuit→`n_observed`），spec 預設對示範 metric 直接 raise。固定 schema 同時拔掉 `cols=` / fuzzy-suggest / `UserInputError` 整條測試路徑與耦合。
- Quant-UX：docstring + docs admonition 警告 `to_frame().filter(p_value<0.05)` 跨 K 切片是 FWER 陷阱（quant skill `multiple-testing/SKILL.md §1`「隱形多重檢定」），cross-link 到 `slice_pairwise_test` / `slice_joint_test`。Plotting example 補 `.sort("slice")` 避免 `partition_by` insertion-order 對 sector / regime 切片產生隨機 bar order。
- Top-level re-export `factrix.SliceResult`（與 `MetricOutput` 對稱，type hint 友善）。

完整設計偏離與 review 軌跡見 [#212 implementation comment](https://github.com/awwesomeman/factrix/issues/212#issuecomment-4419390886)。

## Test plan

- [x] `pytest`：1158 passed（砍 4 個冗餘 stdlib `Mapping` ABC 測試後）；新增 `tests/test_slice_result.py` 8 cases 覆蓋 wiring / schema / 缺 stat & p_value 變 null / 自訂 `slice_col=` / 空容器 / `_repr_html_`
- [x] `uv run mypy factrix`：0 errors
- [x] `uv run mkdocs build --strict`：clean
- [x] 既有 `tests/test_by_slice.py` / `tests/test_by_regime.py` 的 `isinstance(out, dict)` → `Mapping` / `SliceResult`
- [ ] reviewer 確認：固定 schema vs `cols=` 的取捨（看 commit body / issue comment 的 `n_obs` 跨 metric 不一致論述）是否同意；若需保留 cols 彈性請 push back

## Coordination

- 與 #217（進行中）正交：本 PR 只順手把 `factrix/metrics/regime.py::by_regime` 的回傳型別 annotation 從 `dict[str, MetricOutput]` 改為 `SliceResult`（語意不變、符合新 dispatcher 回傳）。#217 整檔刪除時無 conflict。
- #215 已 merge，落點檔案改在 `factrix/slicing/result.py`（非 issue body 寫的 `factrix/metrics/_slice.py`）。

Closes #212