### PR TITLE
docs(batch-screening): drop stale identity-caveat idiom

### DIFF
--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -113,8 +113,8 @@ for s in survivors.profiles:
 
 | Before | After |
 |--------|-------|
-| `bhy(profiles, threshold=0.05)` | `bhy(profiles, q=0.05)` (`threshold=` still accepted with `DeprecationWarning`) |
-| `bhy(profiles, gate=StatCode.X)` | `bhy(profiles, p_stat=StatCode.X)` (`gate=` still accepted with `DeprecationWarning`) |
+| `bhy(profiles, threshold=0.05)` | `bhy(profiles, q=0.05)` (`threshold=` removed in v0.12.0; raises `TypeError`) |
+| `bhy(profiles, gate=StatCode.X)` | `bhy(profiles, p_stat=StatCode.X)` (`gate=` removed in v0.11.0) |
 | auto-partition by dispatch cell × horizon | caller declares the family; mixed `forward_periods` without `expand_over` emits `RuntimeWarning`. **Fix:** split the call per horizon, or pass `expand_over=[<context key>]` if profiles legitimately co-exist as one family across horizons. |
 | same `factor_id` across cells silently auto-split | raises `UserInputError` (duplicate identity). **Fix (canonical):** name each panel's factor column distinctly and pass `evaluate(..., factor_col=name)`. **Fix (escape hatch):** post-hoc stamp via `dataclasses.replace(profile, factor_id=...)`. **Or:** use `expand_over` if profiles really do share identity but belong in separate test buckets. |
 

--- a/docs/guides/batch-screening.md
+++ b/docs/guides/batch-screening.md
@@ -13,13 +13,12 @@ import factrix as fx
 candidates = ["mom_5d", "mom_20d", "mom_60d"]
 cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
 
-by_name = {name: fx.evaluate(panel, cfg, factor_col=name) for name in candidates}
-survivors = fx.multi_factor.bhy(list(by_name.values()), threshold=0.05)
-survivor_names = [n for n, p in by_name.items() if any(p is s for s in survivors)]
+profiles = [fx.evaluate(panel, cfg, factor_col=name) for name in candidates]
+survivors = fx.multi_factor.bhy(profiles, q=0.05)
+survivor_names = [p.factor_id for p in survivors.profiles]
 ```
 
-!!! warning "Identity caveat — survivor → name mapping"
-    `FactorProfile` is a frozen dataclass with no `name` / `label` field; `bhy()` neither accepts nor returns one. Map survivors back to factor names by holding the `name → profile` dict yourself and comparing with `is` (identity), as in the snippet above. Equality (`==`) is unsafe: two factors with coincident stats compare equal.
+`evaluate()` stamps `factor_col` into `profile.factor_id`, so the survivor → name mapping reads off the survivor profiles directly — no external `name → profile` dict, no `is`-comparison idiom. `Survivors.profiles` lists the survivors in their original input order; `Survivors.adj_q` carries the bucket-local BHY-adjusted p in matching order.
 
 Each `evaluate` call repays the per-date cross-section overhead
 (sort / group-by / rank) on its own — that cost is intrinsic to


### PR DESCRIPTION
## Summary

- `docs/guides/batch-screening.md` — Rewrite the basic-usage snippet and identity caveat. Survivor → name mapping now reads off `survivor.profiles[i].factor_id` directly; drop the old `name → profile` dict + `is`-comparison idiom that predates #160's identity/context split. Switch the example from `threshold=0.05` to `q=0.05` (#217 removed `threshold=`).
- `docs/api/multi-factor.md` — Two rows in the "Behaviour change (#161)" table still claimed `threshold=` / `gate=` were live deprecations; both have actually been removed. Reflect the current state (`gate=` removed in v0.11.0, `threshold=` removed in v0.12.0).

## Context

General maintenance cleanup of the docs tail left over after #160's identity/context split. Surfaced while triaging #140 (closed as not planned today — `factor_id` already covers Option A) and #217 (which removed `bhy(threshold=)`). Not a deliverable of either issue.

## Test plan

- [x] `pytest tests/test_docs_pages.py tests/test_docs_llms.py` — 142 passed
- [x] `/simplify` review pass — snippet attributes (`survivors.profiles`, `factor_id`, `q=`) and the `Survivors` input-order claim verified against `factrix/_profile.py` + `factrix/_multi_factor.py`

Refs #140, #160, #217