### PR TITLE
docs(guides): rename regime-analysis guide to slice-analysis (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ While the version is below `1.0.0`, the public API should be considered unstable
   survivors = fx.multi_factor.bhy(profiles, expand_over=["forward_periods"])
   ```
 
+### Changed
+
+- **Regime analysis guide renamed to slice analysis** (#230). `docs/guides/regime-analysis.md` → `docs/guides/slice-analysis.md`, with intro reframed so regime / universe / sector / ADV-bucket are presented as equivalent applications of the same axis-agnostic surface (`by_slice` + `slice_pairwise_test` / `slice_joint_test`). The old URL is intentionally not redirected — external bookmarks to `guides/regime-analysis/` return 404. Inbound references in `docs/index.md`, `docs/api/metrics/ic.md`, `docs/api/list-metrics.md`, and `docs/api/run-metrics.md` updated to the new path and to drop stale `regime_ic` mentions left behind by #217.
+
 ## v0.11.0 (2026-05-11)
 
 ### Added

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -16,10 +16,10 @@ import factrix as fx
 fx.list_metrics(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS)
 # -> ['top_concentration', 'beta_sign_consistency', 'fama_macbeth',
 #     'pooled_ols', 'hit_rate', 'ic', 'ic_ir', 'ic_newey_west',
-#     'regime_ic', 'monotonicity',
-#     'multi_split_oos_decay', 'quantile_spread', 'quantile_spread_vw',
-#     'greedy_forward_selection', 'spanning_alpha', 'breakeven_cost',
-#     'net_spread', 'notional_turnover', 'turnover', 'ic_trend']
+#     'monotonicity', 'multi_split_oos_decay', 'quantile_spread',
+#     'quantile_spread_vw', 'greedy_forward_selection', 'spanning_alpha',
+#     'breakeven_cost', 'net_spread', 'notional_turnover', 'turnover',
+#     'ic_trend']
 ```
 
 `Mode` is intentionally not an input — applicability does not change

--- a/docs/api/metrics/ic.md
+++ b/docs/api/metrics/ic.md
@@ -16,19 +16,20 @@ via NW HAC or non-overlapping cross-asset *t*.
         - ic_ir
         - compute_ic
 
-!!! note "Cross-regime IC analysis"
-    For per-regime IC summaries, use [`by_slice`](../by-slice.md) on an
-    IC frame joined with regime labels. For inferential contrasts
-    (pairwise Wald χ² + Holm / Romano-Wolf adjusted p), use
+!!! note "Cross-slice IC analysis"
+    For per-slice IC summaries (regime / universe / sector / ...), use
+    [`by_slice`](../by-slice.md) on an IC frame joined with slice
+    labels. For inferential contrasts (pairwise Wald χ² + Holm /
+    Romano-Wolf adjusted p), use
     [`slice_pairwise_test`](../slice-test.md). The metric-specific
     `regime_ic` callable and `by_regime` dispatcher were removed in
-    v0.12.0; see the [Regime analysis guide](../../guides/regime-analysis.md).
+    v0.12.0; see the [Slice analysis guide](../../guides/slice-analysis.md).
 
 ## See also
 
 - [`by_slice`](../by-slice.md) — axis-agnostic slice dispatcher.
 - [`slice_pairwise_test` / `slice_joint_test`](../slice-test.md) — cross-slice inference verb pair.
-- [Regime analysis guide](../../guides/regime-analysis.md) — slicing and cross-slice inference end-to-end.
+- [Slice analysis guide](../../guides/slice-analysis.md) — slicing and cross-slice inference end-to-end.
 - [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
 - [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
 - [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -53,8 +53,8 @@ cfg.signal)` exposes for the cell, after three filters:
    `run_metrics` does not thread (per-row reason; surfaced on
    `bundle.skipped`).
 
-In v1 the IC family (`ic`, `ic_newey_west`, `ic_ir`, `regime_ic`)
-shares a single `compute_ic(panel)` per call. Other stage-1 consumers
+In v1 the IC family (`ic`, `ic_newey_west`, `ic_ir`) shares a single
+`compute_ic(panel)` per call. Other stage-1 consumers
 (`caar`, `fama_macbeth`, `ts_beta`, `mfe_mae_summary`, plus series /
 spread consumers) live in the auto-discover exclusion set; the bundle's
 `skipped` map carries the explicit-import recipe for each. v1.x will

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -1,14 +1,14 @@
 # Slice Analysis
 
-Slice analysis asks "is this factor stable across a partition of the panel?" The partition can be a market regime (bull / bear, high-vol / low-vol), a universe (large-cap / small-cap, listed-board / OTC), a sector, an ADV bucket, or any other column you can attach to the panel. The statistical question is the same regardless of axis, so factrix exposes one axis-agnostic surface rather than one verb per slice dimension.
+Slice analysis asks "is this factor stable across a partition of the panel?" The partition can be a market regime (bull / bear, high-vol / low-vol), a universe (large-cap / small-cap, listed-board / OTC), a sector, an ADV bucket, or any other column you can attach to the panel. The statistical question is the same regardless of axis, so factrix exposes one axis-agnostic surface rather than one verb per slice dimension. Concretely: `by_slice` is the dispatcher, `slice_pairwise_test` / `slice_joint_test` are the inference verb pair.
 
-factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs.
+factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs. The legacy regime-specific surface (`by_regime`, `regime_ic`) was removed in v0.12.0 — see the CHANGELOG migration recipe.
 
 ## The two roles
 
 | Role | Verb | What it does | What it does not do |
 |---|---|---|---|
-| Dispatcher | [`by_slice(metric, df, *, label)`](../api/by-slice.md) | Partitions `df` on an existing column, calls `metric` per slice, returns `dict[label, MetricOutput]` | **No cross-slice statistical test** |
+| Dispatcher | [`by_slice(metric, df, *, label)`](../api/by-slice.md) | Partitions `df` on an existing column, calls `metric` per slice, returns [`SliceResult`](../api/by-slice.md) — a `Mapping[str, MetricOutput]` subclass with `.to_frame()` for long-form rendering | **No cross-slice statistical test** |
 | Inference | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | Pairwise contrasts (Wald χ² + Holm / Romano-Wolf / Bonferroni) or omnibus χ² that all slice means are equal | Only accepts metrics with a `per_date_series` capability (`ic`, `fama_macbeth`, `hit_rate`) |
 
 **Use the dispatcher when:** you want raw per-slice numbers, or you want to compose your own cross-slice test.
@@ -81,13 +81,18 @@ Scalar-input utilities (`breakeven_cost`, `net_spread`) are excluded — they co
 from factrix import by_slice, slice_pairwise_test
 from factrix.metrics import compute_ic, ic
 
+# compute_ic builds the per-date IC frame consumed by the ic metric;
+# see docs/api/metrics/ic.md for the schema.
 ic_df = compute_ic(panel, factor_col="value", return_col="forward_return")
 merged = ic_df.join(vol_labels, on="date", how="inner")
 
-# Dispatcher — raw per-regime IC summaries
+# Dispatcher — raw per-regime IC summaries (SliceResult is dict-shaped)
 per_regime = by_slice(ic, merged, label="regime")
 for label, out in per_regime.items():
     print(label, out.value, out.stat)
+
+# Long-form for plotting / leaderboards
+per_regime.to_frame()  # columns: slice, name, value, stat, p_value
 
 # Inference — pairwise Wald contrasts with Holm-adjusted p (analytic default)
 pairs = slice_pairwise_test(ic, merged, label="regime")

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -1,6 +1,8 @@
-# Regime Analysis
+# Slice Analysis
 
-Regime analysis asks "is this factor stable across market environments?" — a different question from out-of-sample decay (overfitting) and from cross-asset robustness (specification). factrix splits regime analysis into two roles because **slicing by regime** and **testing significance across regimes** are different jobs that need different APIs.
+Slice analysis asks "is this factor stable across a partition of the panel?" The partition can be a market regime (bull / bear, high-vol / low-vol), a universe (large-cap / small-cap, listed-board / OTC), a sector, an ADV bucket, or any other column you can attach to the panel. The statistical question is the same regardless of axis, so factrix exposes one axis-agnostic surface rather than one verb per slice dimension.
+
+factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs.
 
 ## The two roles
 
@@ -26,7 +28,7 @@ A single dispatcher carrying a single built-in cross-slice test would silently o
 
 ## Constructing slice labels
 
-The label is just a column on `df`. Common constructions (for regime analysis, the label values are regime names):
+The label is just a column on `df`. The constructions below use regime labels as the running example; the same pattern works for any partition (universe id, sector code, ADV bucket index):
 
 ```python
 import polars as pl
@@ -50,7 +52,7 @@ ic_df = compute_ic(panel).join(vol_labels, on="date", how="inner")
 !!! warning "Lookahead bias when constructing labels"
     The `vix.quantile(0.7)` snippet above uses **full-sample** statistics
     to label every date — that leaks future information into every
-    per-regime IC. For decision-grade analysis, derive thresholds from
+    per-slice IC. For decision-grade analysis, derive thresholds from
     an expanding or rolling window so each date's label only depends on
     information available at that date. The full-sample form is fine
     only for descriptive ex-post analysis.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A Polars-native **factor signal validator** for quantitative finance.
 | Install and run a smoke test | [Get Started](getting-started/index.md) |
 | Understand the three-axis design | [Concepts](getting-started/concepts.md) |
 | Screen a batch of factors with BHY | [Batch screening](guides/batch-screening.md) |
-| Slice any metric by market regime | [Regime analysis](guides/regime-analysis.md) |
+| Slice any metric across a panel partition (regime / universe / sector / ...) | [Slice analysis](guides/slice-analysis.md) |
 | Look up formulas and applicability | [Reference](reference/metric-applicability.md) |
 | Browse runnable notebooks | [Examples](examples/index.md) |
 | Read the internal architecture | [Architecture](development/architecture.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ A Polars-native **factor signal validator** for quantitative finance.
 | Install and run a smoke test | [Get Started](getting-started/index.md) |
 | Understand the three-axis design | [Concepts](getting-started/concepts.md) |
 | Screen a batch of factors with BHY | [Batch screening](guides/batch-screening.md) |
-| Slice any metric across a panel partition (regime / universe / sector / ...) | [Slice analysis](guides/slice-analysis.md) |
+| Slice any metric by regime / universe / sector | [Slice analysis](guides/slice-analysis.md) |
 | Look up formulas and applicability | [Reference](reference/metric-applicability.md) |
 | Browse runnable notebooks | [Examples](examples/index.md) |
 | Read the internal architecture | [Architecture](development/architecture.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,7 +136,7 @@ nav:
       - guides/index.md
       - PANEL vs TIMESERIES: guides/panel-timeseries.md
       - Batch screening (BHY): guides/batch-screening.md
-      - Regime analysis: guides/regime-analysis.md
+      - Slice analysis: guides/slice-analysis.md
       - Choosing a metric: guides/choosing-metric.md
       - Standalone metrics: guides/standalone-metrics.md
   - Reference:


### PR DESCRIPTION
## Summary

- Renames `docs/guides/regime-analysis.md` → `slice-analysis.md` and reframes the intro so slice analysis is presented as axis-agnostic (regime is one application alongside universe / sector / ADV bucket). The page content was already on the slice surface since #217; this PR aligns the framing, file name, nav label, and inbound links with the actual capability.
- Updates `mkdocs.yml` nav label (`Regime analysis` → `Slice analysis`) and inbound links in `docs/index.md`, `docs/api/metrics/ic.md`, `docs/api/list-metrics.md`, `docs/api/run-metrics.md`.
- Drops the stale `regime_ic` entry from `ic.md`'s mkdocstrings member list (function was removed in v0.12.0, member would fail to render) and prunes stale `regime_ic` mentions in `list-metrics.md` example output and `run-metrics.md` IC-family enumeration. The v0.12.0 deprecation note in `ic.md` is kept intentionally as a migration pointer.
- No `mkdocs-redirects` plugin added — factrix is pre-1.0, external inbound link surface is low, plugin maintenance cost exceeded the benefit. Old URL returns 404 by design.
- Self-review follow-up commit (`79fd68c`) plugs the freshly-landed `SliceResult.to_frame()` in the dispatcher row and worked example, names the legacy `by_regime` / `regime_ic` once for SEO anchoring, and tightens the lede + landing-card cadence.

## Test plan

- [x] `mkdocs build --strict` clean (verified locally, pre-push hook re-runs it)
- [ ] Spot-check `Slice analysis` nav entry on rendered site
- [ ] `grep -rn 'regime-analysis\|regime_ic' docs/ mkdocs.yml` — all surviving hits are intentional (CHANGELOG migration recipes, `ic.md` deprecation note, `docs/plans/archive/*` historical)

Closes #230