### PR TITLE
docs(nav): consolidate metric reference under Reference > Metrics (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ While the version is below `1.0.0`, the public API should be considered unstable
 ### Changed
 
 - **Drop `Layer-A` / `Layer-B` stage labels from code and published docs** (#214). Docstrings, doc pages, and test names now describe behaviour functionally (`slice-test verb`, `slice-test Estimator`, `paired-diff slice test`) instead of by planning tier. The contributing guide gains a Terminology subsection so the rewrite does not regress. No public API or behavioural change.
+- **Regime analysis guide renamed to slice analysis** (#230). `docs/guides/regime-analysis.md` → `docs/guides/slice-analysis.md`, with intro reframed so regime / universe / sector / ADV-bucket are presented as equivalent applications of the same axis-agnostic surface (`by_slice` + `slice_pairwise_test` / `slice_joint_test`). The old URL is intentionally not redirected — external bookmarks to `guides/regime-analysis/` return 404. Inbound references in `docs/index.md`, `docs/api/metrics/ic.md`, `docs/api/list-metrics.md`, and `docs/api/run-metrics.md` updated to the new path and to drop stale `regime_ic` mentions left behind by #217.
+- **Reference nav: metric pages grouped under `Reference > Metrics`** (#231). `Applicability` / `Pipelines` / `Stat keys` move from flat top-level Reference entries to a single sub-section, reducing the flat-Reference page count from 8 to 6 visible entries. `mkdocs.yml` adds `not_in_nav: '**/_generated_*.md'` to silence mkdocs' orphan-page INFO for the four hook-generated tables (`_generated_metric_matrix.md`, `_generated_metric_name_index.md`, `_generated_evaluate_metric_table.md`, `_generated_registry_cells.md`) — all four are already embedded into their host pages via `pymdownx.snippets`, so the orphan listing was a false positive. `reference/metric-applicability.md` gains a back-link to `guides/choosing-metric.md` so the task-oriented decision guide and the lookup table are bidirectionally discoverable.
 
 ### Added
 
@@ -126,10 +128,6 @@ While the version is below `1.0.0`, the public API should be considered unstable
   profiles = [fx.evaluate(panel, cfg.replace(forward_periods=h)) for h in [1, 5, 10, 20]]
   survivors = fx.multi_factor.bhy(profiles, expand_over=["forward_periods"])
   ```
-
-### Changed
-
-- **Regime analysis guide renamed to slice analysis** (#230). `docs/guides/regime-analysis.md` → `docs/guides/slice-analysis.md`, with intro reframed so regime / universe / sector / ADV-bucket are presented as equivalent applications of the same axis-agnostic surface (`by_slice` + `slice_pairwise_test` / `slice_joint_test`). The old URL is intentionally not redirected — external bookmarks to `guides/regime-analysis/` return 404. Inbound references in `docs/index.md`, `docs/api/metrics/ic.md`, `docs/api/list-metrics.md`, and `docs/api/run-metrics.md` updated to the new path and to drop stale `regime_ic` mentions left behind by #217.
 
 ## v0.11.0 (2026-05-11)
 

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -2,9 +2,9 @@
 
 !!! abstract "Answers"
     Can my data run this? — applicability gates and sample-size thresholds per metric.
-    If you are still deciding *which* metric to use, see the task-oriented [Choosing a metric](../guides/choosing-metric.md) guide first.
     For computation pipeline (aggregation order, inference SE), see [Metric pipelines](metric-pipelines.md).
     For output schema and metadata keys, see [Stat keys by metric](stat-keys-by-metric.md).
+    If you are still deciding *which* metric to use, see the task-oriented [Choosing a metric](../guides/choosing-metric.md) guide first.
 
 A single matrix that maps each public metric to the analysis cell
 where it is in scope, the canonical inferential role it plays in

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -2,6 +2,7 @@
 
 !!! abstract "Answers"
     Can my data run this? — applicability gates and sample-size thresholds per metric.
+    If you are still deciding *which* metric to use, see the task-oriented [Choosing a metric](../guides/choosing-metric.md) guide first.
     For computation pipeline (aggregation order, inference SE), see [Metric pipelines](metric-pipelines.md).
     For output schema and metadata keys, see [Stat keys by metric](stat-keys-by-metric.md).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,13 @@ validation:
 exclude_docs: |
   plans/
 
+# Hook-generated tables embedded into host pages via pymdownx.snippets
+# (`--8<-- "docs/reference/_generated_*.md"`). They are not navigable
+# as standalone pages — listing them in `not_in_nav` silences mkdocs'
+# orphan-page INFO without breaking the embed.
+not_in_nav: |
+  **/_generated_*.md
+
 nav:
   - Home: index.md
   - Get Started:
@@ -141,9 +148,10 @@ nav:
       - Standalone metrics: guides/standalone-metrics.md
   - Reference:
       - Glossary: reference/glossary.md
-      - Metric applicability: reference/metric-applicability.md
-      - Metric pipelines: reference/metric-pipelines.md
-      - Stat keys by metric: reference/stat-keys-by-metric.md
+      - Metrics:
+          - Applicability: reference/metric-applicability.md
+          - Pipelines: reference/metric-pipelines.md
+          - Stat keys: reference/stat-keys-by-metric.md
       - Statistical methods: reference/statistical-methods.md
       - TIMESERIES-mode conventions: reference/ts-mode-conventions.md
       - Warning / info / stat codes: reference/warning-codes.md


### PR DESCRIPTION
## Summary

- Groups `metric-applicability` / `metric-pipelines` / `stat-keys-by-metric` into a single `Reference > Metrics` sub-section, reducing flat-Reference visible entries from 8 to 6.
- Adds `not_in_nav: '**/_generated_*.md'` to `mkdocs.yml`. The four hook-generated tables (`_generated_metric_matrix.md`, `_generated_metric_name_index.md`, `_generated_evaluate_metric_table.md`, `_generated_registry_cells.md`) are already embedded into host pages via `pymdownx.snippets`; the mkdocs orphan-page INFO that listed them was a false positive (nav validation runs before snippet resolution). Suppressing the INFO does not change build artefacts.
- Adds reverse cross-link from `reference/metric-applicability.md` to `guides/choosing-metric.md` so the task-oriented decision guide and the lookup table reference are bidirectionally discoverable.
- Side cleanup: merges the duplicate `### Changed` heading inside `[Unreleased]` left behind by the #230 rebase artefact (the #228 entry came in via main while #230's entry was added below; the two now live under one heading).

## Test plan

- [x] `mkdocs build --strict` clean — orphan INFO for `_generated_*.md` is suppressed
- [ ] Spot-check rendered nav: `Reference > Metrics` sub-section expands to the three pages, no duplicate or missing entries
- [ ] Verify reverse cross-link from `metric-applicability.md` resolves to `guides/choosing-metric.md`
- [ ] `[Unreleased]` section has exactly one `### Changed` / `### Added` / `### Removed`

## Scope note

Issue #231 body described the three `_generated_*.md` tables as "orphans the user cannot reach"; in reality all four are embedded into host pages via snippets and are reachable. The remaining real issue was the mkdocs orphan INFO false-positive and the flat Reference nav. PR scope reflects the corrected understanding.

Closes #231