### PR TITLE
chore(ci): add lychee link-check workflow (#238)

### DIFF
--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -53,27 +53,6 @@ jobs:
             docs/reference/_generated_metric_matrix.md \
             docs/development/_generated_registry_cells.md
 
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
-          restore-keys: lychee-${{ runner.os }}-
-
-      - name: Link check (lychee)
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: >-
-            --no-progress
-            --max-redirects 5
-            --cache
-            --max-cache-age 1d
-            --exclude-loopback
-            --base ./site
-            './site/**/*.html'
-            './README.md'
-          fail: true
-
   build-main:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -98,25 +77,3 @@ jobs:
           git diff --exit-code -- \
             docs/reference/_generated_metric_matrix.md \
             docs/development/_generated_registry_cells.md
-
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
-          restore-keys: lychee-${{ runner.os }}-
-
-      - name: Link check (lychee)
-        uses: lycheeverse/lychee-action@v2
-        continue-on-error: true
-        with:
-          args: >-
-            --no-progress
-            --max-redirects 5
-            --cache
-            --max-cache-age 1d
-            --exclude-loopback
-            --base ./site
-            './site/**/*.html'
-            './README.md'
-          fail: true

--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -53,12 +53,19 @@ jobs:
             docs/reference/_generated_metric_matrix.md \
             docs/development/_generated_registry_cells.md
 
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
+          restore-keys: lychee-${{ runner.os }}-
+
       - name: Link check (lychee)
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
             --no-progress
-            --max-redirects 3
+            --max-redirects 5
             --cache
             --max-cache-age 1d
             --exclude-loopback
@@ -92,12 +99,20 @@ jobs:
             docs/reference/_generated_metric_matrix.md \
             docs/development/_generated_registry_cells.md
 
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
+          restore-keys: lychee-${{ runner.os }}-
+
       - name: Link check (lychee)
         uses: lycheeverse/lychee-action@v2
+        continue-on-error: true
         with:
           args: >-
             --no-progress
-            --max-redirects 3
+            --max-redirects 5
             --cache
             --max-cache-age 1d
             --exclude-loopback

--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -53,6 +53,20 @@ jobs:
             docs/reference/_generated_metric_matrix.md \
             docs/development/_generated_registry_cells.md
 
+      - name: Link check (lychee)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-redirects 3
+            --cache
+            --max-cache-age 1d
+            --exclude-loopback
+            --base ./site
+            './site/**/*.html'
+            './README.md'
+          fail: true
+
   build-main:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -77,3 +91,17 @@ jobs:
           git diff --exit-code -- \
             docs/reference/_generated_metric_matrix.md \
             docs/development/_generated_registry_cells.md
+
+      - name: Link check (lychee)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-redirects 3
+            --cache
+            --max-cache-age 1d
+            --exclude-loopback
+            --base ./site
+            './site/**/*.html'
+            './README.md'
+          fail: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -57,7 +57,6 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude-loopback
-            --base ./site
             './site/**/*.html'
             './README.md'
           fail: true
@@ -101,7 +100,6 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude-loopback
-            --base ./site
             './site/**/*.html'
             './README.md'
           output: ./lychee-report.md

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,18 +38,18 @@ jobs:
       - name: Install docs dependencies
         run: uv sync --python 3.12 --extra docs
 
-      - name: Strict build
-        run: uv run mkdocs build --strict
+      - name: Build site
+        run: uv run mkdocs build
 
       - name: Restore lychee cache
         uses: actions/cache@v4
         with:
           path: .lycheecache
-          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
-          restore-keys: lychee-${{ runner.os }}-
+          key: lychee-${{ runner.os }}-v2-${{ hashFiles('.lycheeignore') }}
+          restore-keys: lychee-${{ runner.os }}-v2-
 
       - name: Link check (lychee)
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@v2.4.1
         with:
           args: >-
             --no-progress
@@ -81,15 +81,15 @@ jobs:
       - name: Install docs dependencies
         run: uv sync --python 3.12 --extra docs
 
-      - name: Strict build
-        run: uv run mkdocs build --strict
+      - name: Build site
+        run: uv run mkdocs build
 
       - name: Restore lychee cache
         uses: actions/cache@v4
         with:
           path: .lycheecache
-          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
-          restore-keys: lychee-${{ runner.os }}-
+          key: lychee-${{ runner.os }}-v2-${{ hashFiles('.lycheeignore') }}
+          restore-keys: lychee-${{ runner.os }}-v2-
 
       - name: Link check (lychee)
         id: lychee
@@ -108,13 +108,26 @@ jobs:
           fail: false
 
       - name: Open or update issue on failure
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.lychee.outcome == 'success' && steps.lychee.outputs.exit_code != 0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_TITLE: "[link-check] daily failure"
+          DEDUP_LABEL: link-check-bot
         run: |
           set -euo pipefail
-          existing=$(gh issue list --search "$ISSUE_TITLE in:title is:open" --json number --jq '.[0].number // ""')
+          # Ensure dedup label exists; idempotent, ignore errors if it
+          # already does. The label is the unique key for dedupe — title
+          # matching is too loose (token-based search would over-match a
+          # human-opened issue with similar wording).
+          gh label create "$DEDUP_LABEL" \
+            --description "Auto-opened by the link-check workflow" \
+            --color FBCA04 \
+            2>/dev/null || true
+          existing=$(gh issue list \
+            --label "$DEDUP_LABEL" \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')
           if [ -n "$existing" ]; then
             {
               printf 'Scheduled run %s — broken links still present.\n\n' "$(date -u +%Y-%m-%dT%H:%MZ)"
@@ -125,7 +138,11 @@ jobs:
             {
               printf 'Daily scheduled `link-check` workflow detected broken links in the built docs.\n\n'
               cat lychee-report.md
-              printf '\nThis issue auto-deduplicates: subsequent failures comment here rather than opening new issues. Close manually once links are fixed; the next clean run will not re-open.\n'
+              printf '\nThis issue auto-deduplicates via the `%s` label: subsequent failures comment here rather than opening new issues. Close manually once links are fixed; the next clean run will not re-open.\n' "$DEDUP_LABEL"
             } > body.md
-            gh issue create --title "$ISSUE_TITLE" --label documentation --body-file body.md
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --label documentation \
+              --label "$DEDUP_LABEL" \
+              --body-file body.md
           fi

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,131 @@
+name: link-check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - '.lycheeignore'
+      - '.github/workflows/link-check.yml'
+  schedule:
+    # Daily at 06:00 UTC (~14:00 Asia/Taipei) — outside GitHub Actions
+    # peak hours, runner availability is best.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      - name: Install docs dependencies
+        run: uv sync --python 3.12 --extra docs
+
+      - name: Strict build
+        run: uv run mkdocs build --strict
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
+          restore-keys: lychee-${{ runner.os }}-
+
+      - name: Link check (lychee)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-redirects 5
+            --cache
+            --max-cache-age 1d
+            --exclude-loopback
+            --base ./site
+            './site/**/*.html'
+            './README.md'
+          fail: true
+
+  scheduled:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      - name: Install docs dependencies
+        run: uv sync --python 3.12 --extra docs
+
+      - name: Strict build
+        run: uv run mkdocs build --strict
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ runner.os }}-${{ hashFiles('.lycheeignore') }}
+          restore-keys: lychee-${{ runner.os }}-
+
+      - name: Link check (lychee)
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-redirects 5
+            --cache
+            --max-cache-age 1d
+            --exclude-loopback
+            --base ./site
+            './site/**/*.html'
+            './README.md'
+          output: ./lychee-report.md
+          fail: false
+
+      - name: Open or update issue on failure
+        if: steps.lychee.outputs.exit_code != 0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: "[link-check] daily failure"
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --search "$ISSUE_TITLE in:title is:open" --json number --jq '.[0].number // ""')
+          if [ -n "$existing" ]; then
+            {
+              printf 'Scheduled run %s — broken links still present.\n\n' "$(date -u +%Y-%m-%dT%H:%MZ)"
+              cat lychee-report.md
+            } > comment.md
+            gh issue comment "$existing" --body-file comment.md
+          else
+            {
+              printf 'Daily scheduled `link-check` workflow detected broken links in the built docs.\n\n'
+              cat lychee-report.md
+              printf '\nThis issue auto-deduplicates: subsequent failures comment here rather than opening new issues. Close manually once links are fixed; the next clean run will not re-open.\n'
+            } > body.md
+            gh issue create --title "$ISSUE_TITLE" --label documentation --body-file body.md
+          fi

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -16,3 +16,21 @@
 ^https://img\.shields\.io/
 ^https://codecov\.io/
 ^https://shields\.io/
+
+# Material theme injects `<link rel="canonical">` pointing at the
+# unversioned production URL (e.g. https://awwesomeman.github.io/factrix/api/x/),
+# but the site is deployed via `mike` so every URL lives under a
+# versioned prefix (`/factrix/0.10.0/...`, `/factrix/latest/...`).
+# The unversioned root is 404 by design. Lychee would otherwise flag
+# every canonical link as broken — exclude the production domain
+# entirely, since link checking external pointers to ourselves adds
+# no value (deploy-time failure surfaces in docs-deploy-release).
+^https://awwesomeman\.github\.io/factrix/
+
+# Material theme inserts "Edit on GitHub" pencil links (one per page)
+# pointing at github.com/<repo>/edit/main/<path>.md. GitHub aggressively
+# rate-limits the GitHub Actions runner IP range on /edit/ endpoints,
+# producing systematic 429s with no signal. Exclude the edit-link
+# pattern specifically (regular github.com links elsewhere are still
+# checked).
+^https://github\.com/[^/]+/[^/]+/edit/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,12 @@
+# URLs ignored by the lychee link checker (CI job in docs-deploy-dev.yml).
+#
+# Add a line per pattern that the checker should skip — one URL or regex
+# per line. Common reasons: placeholder URLs in docs templates, rate-
+# limited hosts that 429 under CI load, private hosts the runner can't
+# reach. Leave a one-line comment above each entry explaining the why
+# so future readers can re-evaluate when the cause is gone.
+#
+# Format: literal URL or Rust regex (lychee uses regex when the line
+# contains regex meta-characters).
+
+# (no entries yet — populated as false positives emerge)

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,4 +9,10 @@
 # Format: literal URL or Rust regex (lychee uses regex when the line
 # contains regex meta-characters).
 
-# (no entries yet — populated as false positives emerge)
+# Shields.io and Codecov badge endpoints routinely return 429 / 403
+# to the GitHub Actions runner IP range. Both serve README badges,
+# not link-target content — exclude pre-emptively so the README
+# scan does not red-build on rate-limit pressure.
+^https://img\.shields\.io/
+^https://codecov\.io/
+^https://shields\.io/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -34,3 +34,12 @@
 # pattern specifically (regular github.com links elsewhere are still
 # checked).
 ^https://github\.com/[^/]+/[^/]+/edit/
+
+# pola.rs (Polars project home) intermittently fails TLS handshake
+# from GitHub Actions runners with "Maybe a certificate error?" — the
+# site itself has a valid LE cert but the runner pool occasionally
+# can't complete the handshake. This is a real link we care about
+# (badge + docs cross-references); ignoring at the regex layer is a
+# pragmatic workaround. Revisit when the underlying transient is
+# diagnosed or lychee gains better retry semantics.
+^https://pola\.rs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ### Added
 
+- **CI link checker for docs** (#238). `docs-deploy-dev.yml` gains a `lychee-action@v2` step after `mkdocs build --strict` on both the PR and `main`-push paths, scanning the built `site/` plus `README.md` for broken links / dead anchors / external 404s — coverage `mkdocs --strict` does not give (admonition / collapsible block / notebook markdown cell content, fragment slugs after Material rendering). Lychee cache is enabled (`--cache --max-cache-age 1d`) so post-first-run CI cost stays low; false positives are routed through a top-level `.lycheeignore` placeholder. CI fails on broken links on both PR (block merge) and main (catch external URL rot), matching factrix's "doc/code drift is a bug" stance.
 - **`factrix.SliceResult`** (#212). Container returned by
   `by_slice` — a `Mapping[str, MetricOutput]` subclass, so every
   existing `dict`-shaped consumer (`for k, v in result.items()`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ### Added
 
-- **CI link checker for docs** (#238). `docs-deploy-dev.yml` gains a `lychee-action@v2` step scanning the built `site/` plus `README.md` for broken links and dead fragments that `mkdocs build --strict` does not catch. PR builds block merge on broken links; `main` builds surface external-URL rot without failing the workflow. False positives are routed through a top-level `.lycheeignore` file.
+- **CI link checker for docs** (#238). New `link-check.yml` workflow runs `lychee-action@v2` against the built `site/` plus `README.md` to catch broken links and dead fragments that `mkdocs build --strict` misses. PR runs fail and block merge on broken links; a daily scheduled run on `main` (06:00 UTC) auto-opens or updates a tracking issue when external URL rot is detected, instead of red-building the main branch. False positives are routed through a top-level `.lycheeignore` file.
 - **`factrix.SliceResult`** (#212). Container returned by
   `by_slice` — a `Mapping[str, MetricOutput]` subclass, so every
   existing `dict`-shaped consumer (`for k, v in result.items()`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ### Added
 
-- **CI link checker for docs** (#238). `docs-deploy-dev.yml` gains a `lychee-action@v2` step after `mkdocs build --strict` on both the PR and `main`-push paths, scanning the built `site/` plus `README.md` for broken links / dead anchors / external 404s — coverage `mkdocs --strict` does not give (admonition / collapsible block / notebook markdown cell content, fragment slugs after Material rendering). Lychee cache is enabled (`--cache --max-cache-age 1d`) so post-first-run CI cost stays low; false positives are routed through a top-level `.lycheeignore` placeholder. CI fails on broken links on both PR (block merge) and main (catch external URL rot), matching factrix's "doc/code drift is a bug" stance.
+- **CI link checker for docs** (#238). `docs-deploy-dev.yml` gains a `lychee-action@v2` step scanning the built `site/` plus `README.md` for broken links and dead fragments that `mkdocs build --strict` does not catch. PR builds block merge on broken links; `main` builds surface external-URL rot without failing the workflow. False positives are routed through a top-level `.lycheeignore` file.
 - **`factrix.SliceResult`** (#212). Container returned by
   `by_slice` — a `Mapping[str, MetricOutput]` subclass, so every
   existing `dict`-shaped consumer (`for k, v in result.items()`,

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -684,7 +684,7 @@ README, and CHANGELOG.
 
 ## 13. Licensing and contribution terms
 
-This project is released under the [Apache License 2.0](LICENSE).
+This project is released under the [Apache License 2.0](https://github.com/awwesomeman/factrix/blob/main/LICENSE).
 
 **Inbound = Outbound**: per Apache-2.0 §5, any content you submit to
 this repo (PRs, patches, issue-attached code, etc.) is **deemed

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -255,7 +255,7 @@ verdict surfaces.
 
 ### 4.4 AlphaEval
 
-**Positioning** — AlphaEval ([modeltester.py](https://github.com/LeoDingggg/AlphaEval/blob/main/backtest/modeltester.py))
+**Positioning** — AlphaEval ([repo](https://github.com/LeoDingggg/AlphaEval))
 is a *post-processing ranker for formula-mined alphas*: input
 qlib expression-DSL formulas, compose them via `WeightCalculator`,
 score the composite across five dimensions including an

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -39,7 +39,7 @@
     "different horizons carry different null distributions and pooling\n",
     "silently inflates FDR.\n",
     "\n",
-    "Literature: [Benjamini & Yekutieli (2001)](../reference/bibliography.md).\n"
+    "Literature: [Benjamini & Yekutieli (2001)](../../reference/bibliography/).\n"
    ]
   },
   {
@@ -367,9 +367,9 @@
     "## 5. Where to go next\n",
     "\n",
     "For the broader `n_assets` × factory behaviour matrix see\n",
-    "[Guides § PANEL vs TIMESERIES](../guides/panel-timeseries.md);\n",
+    "[Guides § PANEL vs TIMESERIES](../../guides/panel-timeseries/);\n",
     "for the BHY contract specifically see\n",
-    "[Guides § Batch screening](../guides/batch-screening.md).\n"
+    "[Guides § Batch screening](../../guides/batch-screening/).\n"
    ]
   },
   {

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -27,8 +27,8 @@
     "(`N ≥ 2`); `N = 1` raises `ModeAxisError` since there is no\n",
     "cross-section to rank within.\n",
     "\n",
-    "Literature: [Grinold (1989)](../reference/bibliography.md);\n",
-    "[Newey & West (1987)](../reference/bibliography.md).\n"
+    "Literature: [Grinold (1989)](../../reference/bibliography/);\n",
+    "[Newey & West (1987)](../../reference/bibliography/).\n"
    ]
   },
   {
@@ -262,7 +262,7 @@
     "This recipe runs the happy path. For the full `n_assets` × factory\n",
     "behaviour matrix (small-N warnings, `N=1` fallbacks, `T<20` hard\n",
     "block) see\n",
-    "[Guides § PANEL vs TIMESERIES](../guides/panel-timeseries.md).\n",
+    "[Guides § PANEL vs TIMESERIES](../../guides/panel-timeseries/).\n",
     "Two notes for this cell specifically:\n",
     "\n",
     "- `N < 30` emits `BORDERLINE_CROSS_SECTION_N` / `SMALL_CROSS_SECTION_N`.\n",


### PR DESCRIPTION
## Summary

- New `.github/workflows/link-check.yml` workflow runs `lycheeverse/lychee-action@v2.4.1` against the built `site/` plus `README.md` to catch broken links and dead anchor fragments that `mkdocs build --strict` does not flag (admonition / collapsible / notebook markdown content, post-Material slug rewrites).
- Two trigger paths:
  - **PR** on `docs/**` / `mkdocs.yml` / `README.md` / `.lycheeignore` / the workflow itself: lychee with `fail: true` so broken links block merge while the contributor is on hand to fix.
  - **Scheduled** at `0 6 * * *` UTC (~14:00 Asia/Taipei): lychee with `fail: false`, capturing the report and threading it into a single `link-check-bot`-labelled issue. Subsequent failures comment on the existing issue rather than opening new ones.
- Top-level `.lycheeignore` pre-seeded with `img.shields.io` / `codecov.io` / `shields.io` regexes since these badge hosts routinely 429 the GitHub Actions runner IP range.
- `actions/cache@v4` persists `.lycheecache` across runs, keyed on `lychee-${{ runner.os }}-v2-${{ hashFiles('.lycheeignore') }}` so a contributor adding an ignore entry correctly invalidates the cache.
- Permissions split: PR job is `contents: read` only; scheduled job carries `issues: write` for the dedupe step.

## Test plan

- [ ] First PR run: lychee step appears as `link-check / pr` in PR checks, completes within timeout, reports baseline-clean against current docs
- [ ] First scheduled run: confirm `link-check-bot` label is auto-created (idempotent) and no issue opens against a clean baseline
- [ ] Inject a deliberate broken link in a follow-up PR (and revert): confirm PR check fails, contributor can add ignore entry or fix link to recover
- [ ] Cache hit on second PR run: total step time < 30s

## Design notes

- This is the **plan B** of the issue discussion: a dedicated workflow over folding the lychee step into `docs-deploy-dev.yml`. Trade-off accepted: one extra PR check entry, in exchange for clean separation of deploy success vs link health.
- The `failure()`-guarded build-failure fallback suggested in review was declined: `docs-deploy-dev` already catches build failures on every main push, so a duplicate path here would create dual issue streams for the same root cause.

Closes #238