### PR TITLE
refactor!: remove FactorProfile.verdict() (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ---
 
+## [Unreleased]
+
+### Removed
+
+- **`FactorProfile.verdict()` and `Verdict` enum** (breaking, #243). `verdict(*, threshold=0.05, gate=None)` was a `primary_p < threshold` wrapper. Removed because (a) for N candidate factors, iterating `profile.verdict()` and counting passes is the spec-search anti-pattern factrix explicitly avoids — multi-factor decisions belong to `multi_factor.bhy` survivors, not per-factor threshold gates; (b) the `Verdict` `PASS / FAIL` outcome ignored emitted `WarningCode` (e.g. `UNRELIABLE_SE_SHORT_PERIODS`), letting unreliable inference report `PASS`. The `Verdict` enum is removed alongside the method.
+
+  ```python
+  # before (v0.12.0)
+  if profile.verdict() is fx.Verdict.PASS:
+      ...
+
+  # after — single-factor pre-registered analysis only
+  if profile.primary_p < 0.05:
+      ...
+
+  # after — N candidate factors: route through BHY, read survivors
+  survivors = fx.multi_factor.bhy(profiles, q=0.05)
+  for prof, adj_q in zip(survivors.profiles, survivors.adj_q, strict=True):
+      ...
+  ```
+
+  The `gate=StatCode.X` kwarg (read alternative stat instead of `primary_p`) has no direct replacement; reach `profile.stats[StatCode.X]` and compare to your chosen threshold inline. The `examples/multi_factor_screening.ipynb` per-factor verdict loop is rewritten to demonstrate the BHY path instead.
+
+---
+
 ## v0.12.0 (2026-05-11)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ common factor — each gets the tests that fit its data-generating
 process.
 
 ```
-factor construction  →  factrix (verdict)  →  strategy construction  →  backtest  →  live trading
+factor construction  →  factrix (inference)  →  strategy construction  →  backtest  →  live trading
                             ▲ you are here
 ```
 
@@ -68,7 +68,7 @@ at scale. Kill fakes before they cost you a backtest.
 - **Polars-native** — modern Polars alternative to the pandas-based
   alphalens.
 
-factrix stops at the verdict — primary test plus diagnostic battery.
+factrix stops at the inference — primary test plus diagnostic battery.
 It does not size positions, model slippage, optimise weights, or
 compose alphas; those belong to the later stages of the pipeline above.
 
@@ -76,7 +76,7 @@ compose alphas; those belong to the later stages of the pipeline above.
 
 | You want to… | Use this |
 |---|---|
-| Verdict on a factor (cross-sectional / event / common factor) | **factrix** |
+| Inference on a factor (cross-sectional / event / common factor) | **factrix** |
 | Screen many factors with multiple-testing correction | **factrix** |
 | Backtest with positions / slippage / margin | [zipline-reloaded][zipline], [backtrader][backtrader], [bt][bt], [vectorbt][vectorbt], [nautilus_trader][nautilus] |
 | Optimise portfolio weights | [skfolio][skfolio], [riskfolio-lib][riskfolio] |
@@ -125,7 +125,7 @@ panel = compute_forward_return(raw, forward_periods=5)
 cfg     = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
 profile = fx.evaluate(panel, cfg)
 
-print(profile.verdict(), '| primary_p =', round(profile.primary_p, 4))
+print('primary_p =', round(profile.primary_p, 4))
 print(profile.diagnose())   # WarningCode / InfoCode list
 ```
 

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -12,7 +12,6 @@ and `n_assets` thresholds per procedure.
     options:
       show_root_heading: false
       members:
-        - verdict
         - diagnose
 
 ## `diagnose()` return schema
@@ -30,7 +29,7 @@ registered cell; the `stats` sub-dict varies by procedure.
 | `mode` | `str` | `profile.mode.value` | `"panel"` or `"timeseries"` |
 | `n_obs` | `int` | `profile.n_obs` | Cell-canonical effective sample size — see [§ `n_obs` semantics](#n_obs-semantics-by-cell) |
 | `n_assets` | `int` | `profile.n_assets` | `panel["asset_id"].n_unique()` of the input |
-| `primary_p` | `float` | `profile.primary_p` | Procedure-canonical p-value used by `verdict()` and `multi_factor.bhy` |
+| `primary_p` | `float` | `profile.primary_p` | Procedure-canonical p-value consumed by `multi_factor.bhy` |
 | `warnings` | `list[str]` | `sorted(w.value for w in profile.warnings)` | Sorted [`WarningCode`](../reference/warning-codes.md#warningcode) string values |
 | `info_notes` | `list[str]` | `sorted(i.value for i in profile.info_notes)` | Sorted [`InfoCode`](../reference/warning-codes.md#infocode) string values |
 | `stats` | `dict[str, float]` | `{k.value: v for k, v in profile.stats.items()}` | [`StatCode`](../reference/warning-codes.md#statcode) string keys; per-cell content varies |
@@ -95,12 +94,10 @@ emit.
 | `MIN_PERIODS_HARD` / `UNRELIABLE_SE_SHORT_PERIODS` guards | yes | — |
 | `MIN_ASSETS` guards (`SMALL_CROSS_SECTION_N`, `BORDERLINE_CROSS_SECTION_N`) | — | yes |
 | `InsufficientSampleError.actual_periods` | yes | — |
-| `verdict()` | — | — |
 | `multi_factor.bhy` family partition | — | — |
 
-`verdict()` thresholds on `primary_p`; BHY partitions on
-`(dispatch cell, forward horizon)` and runs step-up on p-values —
-neither path reads these fields.
+BHY partitions on `(dispatch cell, forward horizon)` and runs step-up
+on p-values — it does not read `n_obs` / `n_assets`.
 
 #### Why one polymorphic `n_obs` instead of split `n_periods` + `n_cs`
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,7 +55,7 @@ Click any node to jump to its API page.
 
 | Goal | Pipeline |
 |---|---|
-| Single-factor inference verdict | `evaluate(panel, cfg)` → read `FactorProfile.verdict()` |
+| Single-factor inference | `evaluate(panel, cfg)` → read `FactorProfile.primary_p` |
 | Single-factor descriptive scan | `run_metrics(panel, cfg, factor_col=...)` → read `MetricsBundle` |
 | Slice exploration (single axis) | `by_slice(metric, df, label="...")` → `SliceResult` |
 | Slice statistical test | `slice_pairwise_test(metric, df, label="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
@@ -70,7 +70,7 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 |---|---|---|
 | [`AnalysisConfig`](analysis-config.md) | Three-axis frozen dataclass selecting the dispatch cell. Four factory methods (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`). | Picking the analysis cell. |
 | [`evaluate`](evaluate.md) | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
-| [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `verdict()`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
+| [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
 | [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. | Multi-factor screening. |
 | [`stats`](stats.md) | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking inference method for `bhy(estimator=…)` or cross-slice tests. |
 | [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |

--- a/docs/api/metrics/individual-continuous.md
+++ b/docs/api/metrics/individual-continuous.md
@@ -16,7 +16,7 @@ aggregated over time.
 
 `ic` and `fama_macbeth` are the two **inferential** entry points; the
 rest are **profile / risk** diagnostics that describe the same factor
-without contributing to the verdict.
+without contributing to the primary inference.
 
 For when each applies see
 [Reference § Metric applicability](../../reference/metric-applicability.md).

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -24,7 +24,7 @@ flowchart TD
     REG["Registry<br/>_registry.py SSOT (7 cells)"]
     MODE{"Mode<br/>N = panel.asset_id.n_unique()"}
     PROC["FactorProcedure<br/>cell-dispatched"]
-    FP["FactorProfile<br/>primary_p · verdict() · diagnose()"]
+    FP["FactorProfile<br/>primary_p · diagnose()"]
     BHY["multi_factor.bhy()<br/>BHY FDR correction"]
 
     User -->|"AnalysisConfig.factory(...)"| AC
@@ -61,7 +61,7 @@ Three entry points, all in `factrix.__init__`:
 Plus introspection / error / enum re-exports:
 
 - `fx.FactorScope`, `fx.Signal`, `fx.Metric`, `fx.Mode` — three user-facing axes + the evaluate-time-derived fourth
-- `fx.WarningCode`, `fx.InfoCode`, `fx.StatCode`, `fx.Verdict` — structured codes carried on `FactorProfile`
+- `fx.WarningCode`, `fx.InfoCode`, `fx.StatCode` — structured codes carried on `FactorProfile`
 - `fx.FactorProfile` — single unified result type
 - `fx.describe_analysis_modes(format="text"|"json")` — registry-reflected cell catalogue
 - `fx.suggest_config(panel)` — heuristic factory call from a raw panel
@@ -156,7 +156,6 @@ CAAR, asset count for COMMON×* PANEL. `n_assets` is always
 `raw["asset_id"].n_unique()`; reading both side by side disambiguates
 "small effective sample" between short series vs thin cross-section.
 
-- `verdict(*, threshold=0.05, gate=None) -> Verdict` — `gate=None` uses `primary_p`; supplying a `StatCode` swaps the gate (raises `KeyError` if not populated)
 - `diagnose() -> dict[str, Any]` — flatten `mode / n_obs / primary_p / warnings / info_notes / stats` for human or AI agent triage
 
 Single dataclass, no per-cell subclass proliferation. Cell-specific scalars live
@@ -552,7 +551,7 @@ Two-tier metric organisation. Choosing the right tier when adding a new metric:
 
 | Tier | Lives in | Count today | Definition | Surfaces |
 |------|----------|-------------|------------|----------|
-| **Registry procedure** | `factrix/_procedures.py` (`register(...)` at module bottom) | exactly 7 (one per legal cell) | The **canonical PASS/FAIL test** for one `(scope, signal, metric, mode)` cell | `evaluate()` dispatch, `FactorProfile.verdict()`, `primary_p` for family verbs |
+| **Registry procedure** | `factrix/_procedures.py` (`register(...)` at module bottom) | exactly 7 (one per legal cell) | The **canonical PASS/FAIL test** for one `(scope, signal, metric, mode)` cell | `evaluate()` dispatch, `primary_p` for family verbs |
 | **Standalone metric** | `factrix/metrics/*.py` | ~19 modules | **Diagnostic / second-look / multi-statistic** decomposition. User imports and calls directly. | `from factrix.metrics import X` returning `MetricOutput` |
 
 ### When to register
@@ -572,7 +571,7 @@ Everything else. Specifically:
   `event_quality.py` (hit_rate / profit_factor / event_skewness / signal_density) all
   supplement the registered CAAR procedure for `(INDIVIDUAL, SPARSE, None, PANEL)`.
 - **Descriptive diagnostic without a formal H₀** (concentration HHI, tradability, OOS decay).
-- **Multi-factor relationship** outside the single-factor verdict frame (`spanning.py`).
+- **Multi-factor relationship** outside the single-factor inference frame (`spanning.py`).
 
 ### Standalone metric contract
 
@@ -597,12 +596,12 @@ themselves if FDR control is needed across a batch of standalone runs.
 factrix/
 ├── __init__.py              # public surface
 ├── _axis.py                 # FactorScope / Signal / Metric / Mode StrEnums
-├── _codes.py                # WarningCode / InfoCode / StatCode / Verdict StrEnums
+├── _codes.py                # WarningCode / InfoCode / StatCode StrEnums
 ├── _errors.py               # FactrixError → ConfigError → {IncompatibleAxisError, ModeAxisError, InsufficientSampleError}
 ├── _analysis_config.py      # AnalysisConfig + 4 factories + _FALLBACK_MAP
 ├── _registry.py             # _DispatchKey, _RegistryEntry, _SCOPE_COLLAPSED, register()
 ├── _procedures.py           # 7 FactorProcedure classes; bootstrap-registered at import
-├── _profile.py              # FactorProfile dataclass + verdict / diagnose
+├── _profile.py              # FactorProfile dataclass + diagnose
 ├── _evaluate.py             # _derive_mode + _evaluate dispatch wrapper
 ├── _describe.py             # describe_analysis_modes + suggest_config + SuggestConfigResult
 ├── _family.py               # _resolve_family + _FamilyEntry (shared invariants)
@@ -631,7 +630,7 @@ Hard constraints — violating these breaks the API contract:
 3. The registry is the SSOT for "which cells exist". `_validate_axis_compat`, `describe_analysis_modes`, and `suggest_config` all reverse-query it; no parallel rule table.
 4. `_SCOPE_COLLAPSED` is an internal sentinel. It never appears in a user-facing `AnalysisConfig` — `evaluate()` rewrites the routed scope at dispatch time and reports the collapse via `InfoCode.SCOPE_AXIS_COLLAPSED`.
 5. `FactorProfile.primary_p` is a real probability for every legal cell × mode. TIMESERIES never returns a degenerate `primary_p = 1.0`.
-6. `verdict()` reads `primary_p` (or a user-supplied `StatCode` gate); `warnings` and `info_notes` never auto-rebind it.
+6. `primary_p` is the procedure-canonical p-value; `warnings` and `info_notes` flag interpretation risks but never auto-rebind it.
 7. Family declaration is explicit: the `bhy` (and other family-verb) input list is one family, optionally split per-bucket via `expand_over`. `_resolve_family` enforces (a) identity uniqueness across input, (b) `expand_over` ⊂ `context` (never identity), (c) `p_stat` is a probability and populated everywhere. Cell / horizon partitioning is the caller's responsibility; mixed `forward_periods` without `expand_over` warns.
 8. `register(...)` is append-only at import time. Duplicate keys raise `ValueError`.
 9. NW HAC lag selection in panel-aggregation cells uses `max(auto_bartlett(T), forward_periods - 1)` — the Hansen-Hodrick floor must not be skipped under overlapping forward returns.

--- a/docs/development/design-notes.md
+++ b/docs/development/design-notes.md
@@ -21,7 +21,7 @@ The seven sections below correspond to the seven structural
 
 factrix evaluates each factor through a list of separately reported
 metrics — IC, FM-λ, quantile spread, monotonicity, OOS decay,
-turnover, etc. — and renders a binary `verdict()`. It deliberately
+turnover, etc. — and renders the cell primary p-value. It deliberately
 does **not** collapse these into a single weighted score.
 
 - A composite score becomes a target to be optimised against. Once
@@ -39,8 +39,8 @@ does **not** collapse these into a single weighted score.
   parameter uncertainty ([DeMiguel-Garlappi-Uppal
   2009][demiguel-garlappi-uppal-2009]).
 - Per-metric pass/fail keeps the user in the inference loop. A score
-  can hide which dimension failed; a binary verdict per metric makes
-  it explicit.
+  can hide which dimension failed; per-metric pass/fail makes it
+  explicit.
 
 ---
 
@@ -74,7 +74,7 @@ factrix's outputs).
 
 factrix reports `notional_turnover`, `breakeven_cost`, `net_spread`,
 and `top_concentration` as **profile diagnostics** — values the user
-inspects, not gates that affect the verdict.
+inspects, not gates that affect the inference.
 
 - Capacity is a property of the portfolio implementation, not of the
   factor signal. A factor with concentrated long-leg α can be
@@ -205,6 +205,6 @@ or χ² of the form "is anything in this profile significant?".
   pre-registered analysis plans more broadly
   ([Harvey 2017][harvey-2017]).
 - The cost is that factrix produces a vector of evidence rather than
-  one number. The verdict layer reduces the vector to a binary — but
-  the vector remains accessible for users who need to inspect the
-  components.
+  one number. The user can reduce the vector to a binary at the
+  threshold they choose, while the vector itself remains accessible
+  for inspection.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,7 +19,7 @@ panel = compute_forward_return(raw, forward_periods=5)
 cfg     = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
 profile = fx.evaluate(panel, cfg)
 
-print(profile.verdict(), '| primary_p =', round(profile.primary_p, 4))
+print('primary_p =', round(profile.primary_p, 4))
 # → pass | primary_p = 0.0
 
 print(profile.diagnose())
@@ -78,9 +78,9 @@ The most common warnings:
 - `SERIAL_CORRELATION_DETECTED` — Ljung-Box *p* < 0.05 on residuals.
 
 For the full enum and the trigger conditions for each `WarningCode`,
-`InfoCode`, `StatCode`, and `Verdict`, see
+`InfoCode`, and `StatCode`, see
 [Reference § Warning / info / stat codes](../reference/warning-codes.md).
 
-`warnings` does **not** affect [`verdict()`][factrix.FactorProfile.verdict] —
+`warnings` does **not** affect `primary_p` —
 it is a risk flag. The user decides whether to filter on warnings before
-BHY. `verdict()` reads only `primary_p < threshold`.
+BHY. For single-factor pre-registered analysis compare `primary_p` against your nominal threshold directly.

--- a/docs/guides/choosing-metric.md
+++ b/docs/guides/choosing-metric.md
@@ -28,11 +28,11 @@ For the lookup table — which metrics are supported under which `(scope, signal
 
 ## Standalone metrics vs `evaluate()`
 
-[`evaluate()`][factrix.evaluate] runs the canonical PASS/FAIL procedure for a cell. Standalone metrics in `factrix.metrics` provide supplementary diagnostics without a formal PASS/FAIL verdict:
+[`evaluate()`][factrix.evaluate] runs the canonical inference procedure for a cell. Standalone metrics in `factrix.metrics` provide supplementary diagnostics without a formal PASS/FAIL outcome:
 
 | When to use `evaluate()` | When to use standalone metrics |
 |---|---|
-| Canonical signal validity verdict | Diagnose shape, asymmetry, regime splits |
+| Canonical signal validity inference | Diagnose shape, asymmetry, regime splits |
 | BHY family input (needs [`FactorProfile`][factrix.FactorProfile]) | Multi-statistic decomposition |
 | Primary screening gate | OOS decay, tradability, concentration |
 

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -4,7 +4,7 @@
 and returns a [`FactorProfile`][factrix.FactorProfile] with a single
 `primary_p`. Every other module under `factrix.metrics` is a
 **standalone metric** — a `MetricOutput`-returning helper the user
-invokes directly to add diagnostics around the canonical verdict.
+invokes directly to add diagnostics around the canonical inference.
 
 This guide covers the three things a user needs to wire them in:
 which metrics apply to a given cell, what input shape each one
@@ -35,7 +35,7 @@ For the `(scope, signal)` filter at runtime, see
 
 | Want | Reach for |
 |---|---|
-| PASS/FAIL verdict + `primary_p` | [`evaluate()`][factrix.evaluate] |
+| `primary_p` + diagnose | [`evaluate()`][factrix.evaluate] |
 | Quintile spread, monotonicity, top concentration | `quantile_spread`, `monotonicity`, `top_concentration` |
 | Tradability / cost break-even | `notional_turnover`, `breakeven_cost`, `net_spread`, `turnover` |
 | Spanning regression vs an existing pool | `spanning_alpha`, `greedy_forward_selection` |
@@ -114,7 +114,7 @@ which Mode the upstream procedure ran in.
 
 ## Post-`evaluate()` integration
 
-A typical screening recipe chains `evaluate()` for the verdict, then
+A typical screening recipe chains `evaluate()` for the canonical inference, then
 appends standalone metrics for shape and tradability diagnostics. The
 profile and the metric outputs travel together; nothing on either
 side needs to know about the other:
@@ -122,7 +122,6 @@ side needs to know about the other:
 ```python
 profile = fx.evaluate(panel, fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC))
 diagnostics = {
-    "verdict": profile.verdict(),
     "primary_p": profile.primary_p,
     "spread": fx.metrics.quantile_spread(panel, forward_periods=5).value,
     "monotonicity_p": fx.metrics.monotonicity(panel, forward_periods=5).p_value,

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -387,7 +387,7 @@ Harvey, C. R., Liu, Y. & Zhu, H. (2016). "…and the Cross-Section of
 Expected Returns." *Review of Financial Studies* 29(1), 5–68.
 
 Empirical case for raising t-thresholds in factor research; backs
-the `verdict()` default of `t ≥ 2.0` and the BHY-first multi-factor
+the single-factor `t ≥ 2.0` threshold and the BHY-first multi-factor
 discipline in `greedy_forward_selection`.
 
 ### Harvey (2017)

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -221,7 +221,7 @@ A few specific caveats worth flagging:
   **`MIN_OOS_PERIODS = 5`** in `multi_split_oos_decay` remains
   single-tier — the metric is now descriptive-only (no `p_value` in
   metadata), so a literature power floor is moot. Treat its output as
-  descriptive; the formal `verdict()` reading should rely on the
+  descriptive; the formal inference reading should rely on the
   primary metric until the underlying series is materially longer.
 
 ## Below-threshold behaviour
@@ -232,7 +232,7 @@ returns a meaningful-looking result. Three deterministic outcomes:
 - **Short-circuit** — the metric returns
   `MetricOutput(value=NaN, metadata={"reason": "..."})` and
   `FactorProfile.primary_p` is conservatively pinned to `1.0` so
-  `verdict()` reports `FAILED`.
+  `primary_p` is at or above the user's chosen threshold.
 - **Fallback** — the dispatch registry routes to a degraded but
   semantically distinct procedure (e.g. `Common × Continuous` at
   `N == 1` falls back to single-asset OLS without HAC). `diagnose()`

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -147,7 +147,7 @@ Three positions on multiple testing that the literature has converged
 on and factrix takes:
 
 - The [Harvey-Liu-Zhu 2016][harvey-liu-zhu-2016] case for raising
-  t-thresholds is taken seriously. `verdict()` defaults to $t \geq 2.0$
+  t-thresholds is taken seriously. Single-factor pre-registered comparisons default to $t \geq 2.0$
   but exposes the BHY-adjusted `q` so users can apply a stricter
   threshold for new factor proposals.
 - The [Harvey 2017][harvey-2017] case against ad-hoc p-hacking is the

--- a/docs/reference/warning-codes.md
+++ b/docs/reference/warning-codes.md
@@ -1,23 +1,20 @@
-# Warning, info, stat, and verdict codes
+# Warning, info, and stat codes
 
 Structured enum payloads attached to every
 [`FactorProfile`](../api/factor-profile.md). Use these as the SSOT
 when you need to filter, route, or trigger downstream behaviour from
 factrix output without parsing free-text strings.
 
-The four enums:
+The three enums:
 
 - **`WarningCode`** — risk flags surfaced by `profile.diagnose()`.
-  Does **not** affect [`verdict()`][factrix.FactorProfile.verdict];
+  Does **not** affect `primary_p`;
   the user decides whether to pre-filter on warnings before
   multi-factor BHY.
 - **`InfoCode`** — information-severity diagnose annotations (e.g.
   scope-axis collapsed under `Mode = TIMESERIES`).
 - **`StatCode`** — canonical names for the scalar statistics that
   populate `FactorProfile.metrics`.
-- **`Verdict`** — `pass` / `fail` outcome from
-  [`profile.verdict()`][factrix.FactorProfile.verdict] given a
-  `primary_p` threshold.
 
 For the per-metric mapping of `WarningCode` to the procedure that
 emits it, see
@@ -34,7 +31,3 @@ emits it, see
 ## StatCode
 
 ::: factrix.StatCode
-
-## Verdict
-
-::: factrix.Verdict

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -7,7 +7,7 @@ weaknesses.
 
 ## 1. What factrix is
 
-factrix is a **factor verdict surface**: given a candidate factor and
+factrix is a **factor inference surface**: given a candidate factor and
 a forward return, it answers *is the predictive power real?* and
 returns a structured profile of evidence — rather than applying one
 uniform formula to every factor.
@@ -50,7 +50,7 @@ tools — it sits upstream of them and produces the input they assume.
 ```mermaid
 flowchart LR
     DATA[Raw data] --> CONSTR[Factor construction<br/>zipline Pipeline · self-roll]
-    CONSTR --> FX[<b>factrix verdict</b><br/>Stage 1 — kill fakes]
+    CONSTR --> FX[<b>factrix inference</b><br/>Stage 1 — kill fakes]
     FX --> PORT[Strategy construction<br/>skfolio · PyPortfolioOpt · riskfolio-lib]
     PORT --> BT[Backtest<br/>vectorbt · zipline-reloaded · bt]
     BT --> LIVE[Live trading<br/>lumibot · nautilus_trader]
@@ -75,7 +75,7 @@ flowchart LR
     DISP -->|individual_continuous| CS[IC + FM<br/>+ diagnostics]
     DISP -->|individual_sparse| EV[CAAR<br/>+ diagnostics]
     DISP -->|common_continuous| CO[ts_beta<br/>+ diagnostics]
-    CS --> PROF[FactorProfile<br/>stats · primary_p · verdict]
+    CS --> PROF[FactorProfile<br/>stats · primary_p · diagnose]
     EV --> PROF
     CO --> PROF
     PROF --> BHY[multi_factor.bhy<br/>FDR within family]
@@ -126,7 +126,7 @@ inference loop. See
 **ML signal layer** — out of scope as a deliberate boundary. The
 signal-generation problem is well served by xgboost + shap, and
 folding model fit into factrix would change the page's hero claim
-from "verdict on a hypothesised factor" to "verdict on a fitted
+from "inference on a hypothesised factor" to "inference on a fitted
 model" — those need different statistical machinery (cross-validation
 schemes, leakage tests). qlib already covers the integrated
 pipeline; we leave that branch to qlib.
@@ -248,7 +248,7 @@ second-stage SE. It is a primitive, not a framework.
 **When to pick linearmodels instead** — you only need correct
 Fama-MacBeth standard errors on a panel you have already
 constructed, and you do not need IC, CAAR, BHY, or any of the
-verdict surfaces.
+inference surfaces.
 
 ### 4.4 AlphaEval
 
@@ -279,7 +279,7 @@ and
   explicit null and surfaces per-metric pass/fail rather than a
   weighted scalar. The two libraries answer different questions.
 - Composite scoring becomes its own optimisation target the
-  moment it ships (Goodhart 1984); per-metric verdict keeps the
+  moment it ships (Goodhart 1984); per-metric inference keeps the
   null distributions distinct.
 
 **When to pick AlphaEval instead** — you mine formula alphas
@@ -303,8 +303,8 @@ alpha-quality with a frequently-changing API.
 - factrix integrates event CAAR with NW HAC and an overlap
   diagnostic on the dense event-time calendar; eventstudy treats
   events in isolation.
-- Event verdict lives in the same `FactorProfile` shape as CS and
-  common-factor verdicts; one pipeline screens all three with
+- Event inference lives in the same `FactorProfile` shape as CS and
+  common-factor inferences; one pipeline screens all three with
   shared FDR control.
 
 **When to pick eventstudy instead** — you only do M&A or
@@ -375,7 +375,7 @@ cfg = fx.AnalysisConfig.individual_continuous(
     metric=fx.Metric.IC, forward_periods=5,
 )
 profile = fx.evaluate(panel, cfg)
-verdict = profile.verdict()
+primary_p = profile.primary_p
 ```
 
 factrix → Stage 2: surviving profiles after BHY feed a portfolio
@@ -397,12 +397,12 @@ survivors = fx.multi_factor.bhy(profiles, q=0.05)
 ```
 
 The integration story matters because it answers the implicit
-"what do I do with the verdict" question — factrix is an
+"what do I do with the inference" question — factrix is an
 intermediate stage, not an endpoint.
 
 ## 6. When factrix is NOT the right tool
 
-If you are not at the verdict / screening stage, factrix is the
+If you are not at the inference / screening stage, factrix is the
 wrong tool. The chart below routes you to the canonical
 alternative for each adjacent stage. Construction (upstream) is
 intentionally not branched: readers reach this chart asking
@@ -411,7 +411,7 @@ one*.
 
 ```mermaid
 flowchart TD
-    A[What stage of the alpha pipeline?] --> F[Verdict / screening on a factor]
+    A[What stage of the alpha pipeline?] --> F[Inference / screening on a factor]
     A --> W[Optimise weights for trusted factors]
     A --> E[Backtest or deploy a strategy]
     A --> R[Returns-level tear-sheet on a P&L series]
@@ -447,7 +447,7 @@ self-defeating once they read the source.
   project with fewer Stack Overflow answers. Expect to read source
   for edge cases that alphalens has been asked about for six years.
 - **No published replication of a canonical anomaly study yet** —
-  a factor-zoo skeptic will ask whether factrix's verdicts agree
+  a factor-zoo skeptic will ask whether factrix's conclusions agree
   with the published record on a known-good factor. That
   replication is on the roadmap and is a credibility gap until it
   ships.

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5b3d27c0",
    "metadata": {
     "execution": {
@@ -155,54 +155,8 @@
      "shell.execute_reply": "2026-05-10T03:06:39.923705Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  variant_0    primary_p=2.136e-39  verdict=pass\n",
-      "  variant_1    primary_p=4.052e-26  verdict=pass\n",
-      "  variant_2    primary_p=6.682e-22  verdict=pass\n",
-      "  variant_3    primary_p=3.987e-17  verdict=pass\n",
-      "  variant_4    primary_p=7.407e-14  verdict=pass\n"
-     ]
-    }
-   ],
-   "source": [
-    "raw = fx.datasets.make_cs_panel(\n",
-    "    n_assets=100,\n",
-    "    n_dates=500,\n",
-    "    ic_target=0.08,\n",
-    "    seed=2024,\n",
-    ")\n",
-    "panel = compute_forward_return(raw, forward_periods=5)\n",
-    "cfg = fx.AnalysisConfig.individual_continuous(\n",
-    "    metric=fx.Metric.IC,\n",
-    "    forward_periods=5,\n",
-    ")\n",
-    "\n",
-    "\n",
-    "def variant_panel(\n",
-    "    base: pl.DataFrame, *, name: str, scale: float, seed: int\n",
-    ") -> pl.DataFrame:\n",
-    "    \"\"\"Add IID noise on top of the ground-truth factor and store under a fresh column name.\"\"\"\n",
-    "    rng = np.random.default_rng(seed)\n",
-    "    noisy = base[\"factor\"].to_numpy() + scale * rng.standard_normal(base.height)\n",
-    "    return base.drop(\"factor\").with_columns(pl.Series(name, noisy))\n",
-    "\n",
-    "\n",
-    "candidates = {\n",
-    "    f\"variant_{i}\": variant_panel(\n",
-    "        panel, name=f\"variant_{i}\", scale=0.5 + 0.3 * i, seed=100 + i\n",
-    "    )\n",
-    "    for i in range(5)\n",
-    "}\n",
-    "profiles = [fx.evaluate(p, cfg, factor_col=name) for name, p in candidates.items()]\n",
-    "for prof in profiles:\n",
-    "    print(\n",
-    "        f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}  verdict={prof.verdict()}\"\n",
-    "    )"
-   ]
+   "outputs": [],
+   "source": "raw = fx.datasets.make_cs_panel(\n    n_assets=100,\n    n_dates=500,\n    ic_target=0.08,\n    seed=2024,\n)\npanel = compute_forward_return(raw, forward_periods=5)\ncfg = fx.AnalysisConfig.individual_continuous(\n    metric=fx.Metric.IC,\n    forward_periods=5,\n)\n\n\ndef variant_panel(\n    base: pl.DataFrame, *, name: str, scale: float, seed: int\n) -> pl.DataFrame:\n    \"\"\"Add IID noise on top of the ground-truth factor and store under a fresh column name.\"\"\"\n    rng = np.random.default_rng(seed)\n    noisy = base[\"factor\"].to_numpy() + scale * rng.standard_normal(base.height)\n    return base.drop(\"factor\").with_columns(pl.Series(name, noisy))\n\n\ncandidates = {\n    f\"variant_{i}\": variant_panel(\n        panel, name=f\"variant_{i}\", scale=0.5 + 0.3 * i, seed=100 + i\n    )\n    for i in range(5)\n}\nprofiles = [fx.evaluate(p, cfg, factor_col=name) for name, p in candidates.items()]\n# Raw primary_p only — FDR-controlled decisions wait for BHY in §3.\n# Per-factor `primary_p < 0.05` thresholding on N candidates is the\n# spec-search anti-pattern factrix explicitly avoids.\nfor prof in profiles:\n    print(f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}\")"
   },
   {
    "cell_type": "markdown",

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -35,33 +35,7 @@
    "cell_type": "markdown",
    "id": "8e66de9e",
    "metadata": {},
-   "source": [
-    "## Use this when\n",
-    "\n",
-    "- Factor varies across assets at each date (per-stock signal, e.g.\n",
-    "  momentum, value, quality).\n",
-    "- Cross-section is wide (`N ≥ 30` for clean inference; `10 ≤ N < 30`\n",
-    "  emits `BORDERLINE_CROSS_SECTION_N`).\n",
-    "- Time series is at least 30 periods (`T < 20` is hard-blocked).\n",
-    "\n",
-    "## What it tests\n",
-    "\n",
-    "Null hypothesis `E[IC] = 0` — the factor has no rank-based\n",
-    "predictive ordering of forward returns across assets, on average\n",
-    "across dates. Standard error is NW HAC over the per-date IC series.\n",
-    "\n",
-    "## Output to read\n",
-    "\n",
-    "1. `profile.verdict()` — `pass` / `fail` against `primary_p < 0.05`.\n",
-    "2. `profile.primary_p` — directly the IC NW HAC p-value.\n",
-    "3. `profile.stats[StatCode.MEAN]` — sign + magnitude of average IC\n",
-    "   (cell identity is on `profile.config.metric`; the StatCode is\n",
-    "   intentionally cell-agnostic — see #187).\n",
-    "4. `profile.stats[StatCode.T_NW]` — the t-statistic that produced\n",
-    "   the p-value. Compare to ±2 as a rough sanity check.\n",
-    "5. `profile.warnings` — `UNRELIABLE_SE_SHORT_PERIODS` etc. flag risks\n",
-    "   that do *not* enter `verdict()` but should change interpretation."
-   ]
+   "source": "## Use this when\n\n- Factor varies across assets at each date (per-stock signal, e.g.\n  momentum, value, quality).\n- Cross-section is wide (`N ≥ 30` for clean inference; `10 ≤ N < 30`\n  emits `BORDERLINE_CROSS_SECTION_N`).\n- Time series is at least 30 periods (`T < 20` is hard-blocked).\n\n## What it tests\n\nNull hypothesis `E[IC] = 0` — the factor has no rank-based\npredictive ordering of forward returns across assets, on average\nacross dates. Standard error is NW HAC over the per-date IC series.\n\n## Output to read\n\n1. `profile.primary_p` — IC NW HAC p-value. For single-factor\n   pre-registered analysis, compare against your nominal `α`\n   directly; for N candidate factors, route through\n   `multi_factor.bhy` to control FDR.\n2. `profile.stats[StatCode.MEAN]` — sign + magnitude of average IC\n   (cell identity is on `profile.config.metric`; the StatCode is\n   intentionally cell-agnostic — see #187).\n3. `profile.stats[StatCode.T_NW]` — the t-statistic that produced\n   the p-value. Compare to ±2 as a rough sanity check.\n4. `profile.warnings` — `UNRELIABLE_SE_SHORT_PERIODS` etc. flag\n   data-quality risks that should change interpretation regardless\n   of `primary_p`."
   },
   {
    "cell_type": "markdown",
@@ -159,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "50ffb0d0",
    "metadata": {
     "execution": {
@@ -169,44 +143,14 @@
      "shell.execute_reply": "2026-05-10T06:39:38.490382Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "verdict      = pass\n",
-      "primary_p    = 2.129e-40\n",
-      "mode         = panel\n",
-      "ic_mean      = +0.0722\n",
-      "ic_t_nw      = +14.60\n"
-     ]
-    }
-   ],
-   "source": [
-    "cfg = fx.AnalysisConfig.individual_continuous(\n",
-    "    metric=fx.Metric.IC,\n",
-    "    forward_periods=5,\n",
-    ")\n",
-    "profile = fx.evaluate(panel, cfg)\n",
-    "\n",
-    "print(f\"verdict      = {profile.verdict()}\")\n",
-    "print(f\"primary_p    = {profile.primary_p:.4g}\")\n",
-    "print(f\"mode         = {profile.mode}\")\n",
-    "print(f\"ic_mean      = {profile.stats[fx.StatCode.MEAN]:+.4f}\")\n",
-    "print(f\"ic_t_nw      = {profile.stats[fx.StatCode.T_NW]:+.2f}\")"
-   ]
+   "outputs": [],
+   "source": "cfg = fx.AnalysisConfig.individual_continuous(\n    metric=fx.Metric.IC,\n    forward_periods=5,\n)\nprofile = fx.evaluate(panel, cfg)\n\nprint(f\"primary_p    = {profile.primary_p:.4g}\")\nprint(f\"mode         = {profile.mode}\")\nprint(f\"ic_mean      = {profile.stats[fx.StatCode.MEAN]:+.4f}\")\nprint(f\"ic_t_nw      = {profile.stats[fx.StatCode.T_NW]:+.2f}\")"
   },
   {
    "cell_type": "markdown",
    "id": "613ef289",
    "metadata": {},
-   "source": [
-    "## 4. Inspect the full diagnose dict\n",
-    "\n",
-    "`diagnose()` is the structured triage interface — same content the\n",
-    "verdict and individual-stat reads above derive from, in one dict\n",
-    "for human inspection or AI agent consumption.\n"
-   ]
+   "source": "## 4. Inspect the full diagnose dict\n\n`diagnose()` is the structured triage interface — same content the\nindividual-stat reads above derive from, in one dict for human\ninspection or AI agent consumption."
   },
   {
    "cell_type": "code",

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -13,7 +13,7 @@ Single-factor::
 
     cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
     profile = fx.evaluate(panel, cfg)
-    print(profile.verdict(), profile.primary_p)
+    print(profile.primary_p)
     print(profile.diagnose())
 
 Batch + BHY::
@@ -47,7 +47,7 @@ from factrix._axis import (  # noqa: F401  Mode re-exported for namespace access
     Mode,
     Signal,
 )
-from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
+from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._describe import (
     SuggestConfigResult,
     describe_analysis_modes,
@@ -148,7 +148,6 @@ __all__ = [
     # Code enums
     "InfoCode",
     "StatCode",
-    "Verdict",
     "WarningCode",
     # Errors
     "ConfigError",

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -1,4 +1,4 @@
-"""v0.5 enum codes for warnings, info notes, cell stats, and verdicts.
+"""v0.5 enum codes for warnings, info notes, and cell stats.
 
 ``WarningCode`` / ``InfoCode`` / ``StatCode`` follow the ``*Code`` suffix
 invariant (§7.5).
@@ -281,12 +281,11 @@ class StatCode(StrEnum):
     def is_p_value(self) -> bool:
         """``True`` iff this stat is a probability in [0, 1].
 
-        Used by ``profile.verdict(gate=...)`` and downstream tooling to
-        distinguish probability codes from test statistics / point
-        estimates. Tokenises the value on ``_`` and checks for a ``p``
-        token, so primary-inference variants ``P_NW`` / ``P_HH`` /
-        ``P_GMM`` all qualify alongside diagnostic ``FACTOR_ADF_P`` /
-        ``RESID_LJUNG_BOX_P``.
+        Downstream tooling uses this to distinguish probability codes
+        from test statistics / point estimates. Tokenises the value on
+        ``_`` and checks for a ``p`` token, so primary-inference
+        variants ``P_NW`` / ``P_HH`` / ``P_GMM`` all qualify alongside
+        diagnostic ``FACTOR_ADF_P`` / ``RESID_LJUNG_BOX_P``.
         """
         return "p" in self.value.split("_")
 
@@ -351,10 +350,3 @@ _STAT_DESCRIPTIONS: dict[StatCode, str] = {
     "across calendar bins (cross-sectional / time-axis); high values flag "
     "calendar-time clumping. Does not measure within-asset event clustering.",
 }
-
-
-class Verdict(StrEnum):
-    """Procedure-canonical pass/fail outcome of ``Profile.verdict()``."""
-
-    PASS = "pass"
-    FAIL = "fail"

--- a/factrix/_logging.py
+++ b/factrix/_logging.py
@@ -3,9 +3,9 @@
 Two logger namespaces, by layer of responsibility:
 
 - ``factrix.evaluation`` — orchestration / decision layer. Emits one-line
-  INFO per explicit user decision (e.g. ``multiple_testing_correct`` call,
-  ``verdict()`` returning ``PASS_WITH_WARNINGS``), and WARNING when a
-  diagnose rule fires but the user has not switched ``p_source``.
+  INFO per explicit user decision (e.g. ``multiple_testing_correct``
+  call), and WARNING when a diagnose rule fires but the user has not
+  switched ``p_source``.
 - ``factrix.metrics`` — per-metric correction layer. Emits DEBUG on every
   public metric call (sampling interval, NW lags, n_before/n_after), and
   WARNING when a correction produces a degenerate sample (e.g. non-overlap
@@ -30,7 +30,7 @@ _METRICS_LOGGER_NAME = "factrix.metrics"
 
 
 def get_evaluation_logger() -> logging.Logger:
-    """Orchestration-layer logger (BHY, verdict, diagnose warnings)."""
+    """Orchestration-layer logger (BHY, diagnose warnings)."""
     return logging.getLogger(_EVALUATION_LOGGER_NAME)
 
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -134,9 +134,9 @@ class FactorProcedure(Protocol):
     ``EMITS_STATS`` is the **possible-set** of ``StatCode`` keys the
     procedure can populate on ``FactorProfile.stats`` (always-emitted ∪
     conditionally-emitted). ``describe_analysis_modes(format="json")``
-    surfaces this so agents can pre-validate ``verdict(gate=...)`` and
-    cross-check that an ``Estimator`` instance is dispatchable for the
-    cell without running the procedure.
+    surfaces this so agents can cross-check that an ``Estimator``
+    instance is dispatchable for the cell without running the
+    procedure.
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema]
@@ -624,7 +624,7 @@ class _TSBetaContTimeseriesProcedure:
     NW HAC SE on β; ADF on factor surfaces persistence (CONTINUOUS-only
     diagnostic per I6). n_periods-stratified per I5: below ``MIN_PERIODS_HARD`` raise
     ``InsufficientSampleError``; in ``[MIN_PERIODS_HARD, MIN_PERIODS_WARN)``
-    emit verdict + ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS``.
+    emit result tagged with ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS``.
     """
 
     INPUT_SCHEMA: ClassVar[InputSchema] = InputSchema(

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from factrix._axis import Mode
-from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
+from factrix._codes import InfoCode, StatCode, WarningCode
 
 if TYPE_CHECKING:
     from factrix._analysis_config import AnalysisConfig
@@ -32,8 +32,8 @@ class FactorProfile:
     Attributes:
         config: The ``AnalysisConfig`` that produced this profile.
         mode: Evaluation mode (``PANEL`` / ``TIMESERIES``).
-        primary_p: Procedure-canonical p-value driving ``verdict()``
-            and ``multi_factor.bhy``.
+        primary_p: Procedure-canonical p-value driving
+            ``multi_factor.bhy``.
         n_obs: Cell-canonical effective sample size.
         n_assets: Cross-section width of the raw panel.
         factor_id: User-supplied factor name; stamped by ``_evaluate``
@@ -83,35 +83,6 @@ class FactorProfile:
     @property
     def identity(self) -> tuple[str, int]:
         return (self.factor_id, self.forward_periods)
-
-    def verdict(
-        self,
-        *,
-        threshold: float = 0.05,
-        gate: StatCode | None = None,
-    ) -> Verdict:
-        """Pass/fail at ``threshold`` against ``primary_p`` (or ``gate``).
-
-        ``threshold`` is a generic cutoff — not tied to Type-I-error
-        semantics, because ``gate`` may name a non-p stat (t-stat,
-        HHI, etc.). The comparison ``value < threshold`` is
-        interpreted by the caller.
-
-        Args:
-            threshold: Cutoff applied to the gated value. Default
-                ``0.05``.
-            gate: ``StatCode`` whose value is read from ``stats``;
-                ``None`` uses the procedure-canonical ``primary_p``.
-
-        Returns:
-            ``Verdict.PASS`` if the gated value is below ``threshold``,
-            otherwise ``Verdict.FAIL``.
-
-        Raises:
-            KeyError: If ``gate`` is not populated in ``stats``.
-        """
-        p = self.primary_p if gate is None else self.stats[gate]
-        return Verdict.PASS if p < threshold else Verdict.FAIL
 
     def _summary_rows(self) -> list[tuple[str, Any]]:
         rows: list[tuple[str, Any]] = [

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -7,11 +7,11 @@ Centralised per refactor_api.md §5.2 (A3): no literal ``20`` / ``30`` /
 from __future__ import annotations
 
 # ``T < MIN_PERIODS_HARD`` → :class:`factrix._errors.InsufficientSampleError`
-# (no verdict — NW HAC SE biased beyond the floor where verdict can be
-# trusted at all).
+# (no result — NW HAC SE biased beyond the floor where inference can
+# be trusted at all).
 MIN_PERIODS_HARD: int = 20
 
-# ``MIN_PERIODS_HARD <= T < MIN_PERIODS_WARN`` → verdict still emitted, but
+# ``MIN_PERIODS_HARD <= T < MIN_PERIODS_WARN`` → result still emitted, but
 # tagged with :attr:`factrix._codes.WarningCode.UNRELIABLE_SE_SHORT_PERIODS`.
 MIN_PERIODS_WARN: int = 30
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -82,7 +82,6 @@ panel = compute_forward_return(raw, forward_periods=5)   # appends `forward_retu
 cfg     = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
 profile = fx.evaluate(panel, cfg)
 
-print(profile.verdict())             # Verdict.PASS | Verdict.FAIL
 print(profile.primary_p)             # procedure-canonical p-value (float)
 print(profile.diagnose())            # dict — see FactorProfile below
 print(dict(profile.stats))           # {StatCode: float} — IC mean, t-stat, etc.
@@ -276,9 +275,6 @@ profile.warnings        : frozenset[WarningCode]
 profile.info_notes      : frozenset[InfoCode]
 profile.stats           : Mapping[StatCode, float]                 # cell-specific scalars
 profile.metadata        : Mapping[StatCode, Mapping[str, Any]]     # hyperparams that produced each stat (#188)
-
-profile.verdict(*, threshold: float = 0.05, gate: StatCode | None = None) -> Verdict
-    # PASS if primary_p (or stats[gate]) < threshold
 
 profile.diagnose() -> dict[str, Any]
     # {"identity": {"factor_id", "forward_periods"},
@@ -551,9 +547,9 @@ Read live descriptions programmatically:
 `StatCode.is_p_value` is `True` iff the value tokens (split on `_`)
 contain the token `p` (so `P_NW` → `["p", "nw"]` qualifies, as do
 `P_HH` / `P_GMM` / `FACTOR_ADF_P` / `RESID_LJUNG_BOX_P`). Used by
-`profile.verdict(gate=...)` consumers; the
-family-verb `estimator=` override (#170) dispatches via
-`Estimator.emits_for` and does not gate on `is_p_value` directly.
+downstream tooling to distinguish probability codes from test
+statistics. The family-verb `estimator=` override (#170) dispatches
+via `Estimator.emits_for` and does not gate on `is_p_value` directly.
 
 Naming grammar (#187): primary cell stats carry no TARGET prefix
 (cell identity lives on `profile.config`); diagnostics carry an

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -14,8 +14,8 @@
 - [API — evaluate](https://awwesomeman.github.io/factrix/api/evaluate/): single-factor dispatch entry point
 - [API — run_metrics](https://awwesomeman.github.io/factrix/api/run-metrics/): cell-level descriptive batch runner — returns MetricsBundle
 - [API — Multi-horizon](https://awwesomeman.github.io/factrix/api/multi-horizon/): migration recipes after multi_horizon_* removal — run_metrics + compare / evaluate + bhy(expand_over=)
-- [API — FactorProfile](https://awwesomeman.github.io/factrix/api/factor-profile/): result schema, verdict(), diagnose()
+- [API — FactorProfile](https://awwesomeman.github.io/factrix/api/factor-profile/): result schema, diagnose()
 - [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() FDR-corrected screening
-- [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode / InfoCode / StatCode / Verdict enums
+- [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode / InfoCode / StatCode enums
 - [Reference — metric applicability](https://awwesomeman.github.io/factrix/reference/metric-applicability/): which metrics apply to which axis combinations
 - [Full LLM reference](https://awwesomeman.github.io/factrix/llms-full.txt): single-fetch file covering concepts + API + usage patterns

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -171,7 +171,8 @@ def ts_beta_single_asset_fallback(ts_betas_df: pl.DataFrame) -> MetricOutput:
         factrix centralises the degenerate-case output here so
         Profile / Factor paths produce bit-identical metadata —
         otherwise each entry point would coerce the single-asset row
-        differently and the verdict surface would diverge.
+        differently and the downstream inference surface would
+        diverge.
     """
     row = ts_betas_df.row(0, named=True)
     return MetricOutput(
@@ -400,7 +401,7 @@ def ts_beta_sign_consistency(ts_betas_df: pl.DataFrame) -> MetricOutput:
     itself" (the max collapses to 1.0 for any nonzero β), which would
     read as strong evidence on a dashboard but carries zero information.
     Short-circuits to NaN in that case so the degenerate value never
-    leaks into verdict decisions.
+    leaks into downstream inference.
 
     Notes:
         ``pos = mean_i 1{beta_i > 0}``; ``value = max(pos, 1 - pos)``.
@@ -408,8 +409,8 @@ def ts_beta_sign_consistency(ts_betas_df: pl.DataFrame) -> MetricOutput:
         beta or all negative.
 
         factrix gates this metric at ``N >= 2`` so a single-asset
-        ``max(pos, 1-pos) = 1.0`` cannot leak into verdict surfaces as
-        spurious "perfect agreement". Pair with
+        ``max(pos, 1-pos) = 1.0`` cannot leak into downstream
+        inference as spurious "perfect agreement". Pair with
         ``fama_macbeth.beta_sign_consistency`` when a directional prior
         is available.
     """

--- a/tests/test_caar_procedure.py
+++ b/tests/test_caar_procedure.py
@@ -17,7 +17,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Mode, Signal
-from factrix._codes import StatCode, Verdict, WarningCode
+from factrix._codes import StatCode, WarningCode
 from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _CAARSparsePanelProcedure
 from factrix._profile import FactorProfile
@@ -105,9 +105,6 @@ class TestStrongCaar:
     def test_mode_panel(self, profile: FactorProfile) -> None:
         assert profile.mode is Mode.PANEL
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.001
 
@@ -143,7 +140,7 @@ class TestRandomCaar:
             beta=0.0,
         )
         profile = _CAARSparsePanelProcedure().compute(panel, cfg)
-        assert profile.verdict() is Verdict.FAIL
+        assert profile.primary_p >= 0.05
 
 
 class TestEndToEndViaEvaluate:
@@ -157,7 +154,7 @@ class TestEndToEndViaEvaluate:
         profile = _evaluate(panel, cfg)
         assert profile.mode is Mode.PANEL
         assert StatCode.P_NW in profile.stats
-        assert profile.verdict() is Verdict.PASS
+        assert profile.primary_p < 0.05
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_common_panel_procedures.py
+++ b/tests/test_common_panel_procedures.py
@@ -16,7 +16,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Mode, Signal
-from factrix._codes import StatCode, Verdict, WarningCode
+from factrix._codes import StatCode, WarningCode
 from factrix._evaluate import _evaluate
 from factrix._procedures import (
     InputSchema,
@@ -145,9 +145,6 @@ class TestContinuousStrong:
     def test_n_obs_equals_n_assets(self, profile: FactorProfile) -> None:
         assert profile.n_obs == 20
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.001
 
@@ -179,7 +176,7 @@ class TestContinuousRandom:
             factor_kind="iid",
         )
         profile = _CommonContPanelProcedure().compute(panel, cfg_continuous)
-        assert profile.verdict() is Verdict.FAIL
+        assert profile.primary_p >= 0.05
 
 
 class TestContinuousPersistentFactor:
@@ -220,9 +217,6 @@ class TestSparseStrong:
     def test_mode_panel(self, profile: FactorProfile) -> None:
         assert profile.mode is Mode.PANEL
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.001
 
@@ -249,7 +243,7 @@ class TestSparseRandom:
             sparse_event_density=0.08,
         )
         profile = _CommonSparsePanelProcedure().compute(panel, cfg_sparse)
-        assert profile.verdict() is Verdict.FAIL
+        assert profile.primary_p >= 0.05
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +263,7 @@ class TestEndToEndViaEvaluate:
         )
         profile = _evaluate(panel, cfg_continuous)
         assert profile.mode is Mode.PANEL
-        assert profile.verdict() is Verdict.PASS
+        assert profile.primary_p < 0.05
 
     def test_sparse_panel_does_not_collapse(
         self,

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -9,7 +9,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import InfoCode, StatCode, Verdict
+from factrix._codes import InfoCode, StatCode
 from factrix._errors import ModeAxisError
 from factrix._evaluate import _derive_mode, _evaluate
 from factrix._profile import FactorProfile
@@ -107,8 +107,8 @@ class TestIcPanelEndToEnd:
     def test_mode_is_panel(self, profile: FactorProfile) -> None:
         assert profile.mode is Mode.PANEL
 
-    def test_pass_verdict_on_strong_factor(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
+    def test_low_primary_p_on_strong_factor(self, profile: FactorProfile) -> None:
+        assert profile.primary_p < 0.05
 
     def test_no_collapse_info_note(self, profile: FactorProfile) -> None:
         assert InfoCode.SCOPE_AXIS_COLLAPSED not in profile.info_notes

--- a/tests/test_fm_procedure.py
+++ b/tests/test_fm_procedure.py
@@ -14,7 +14,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import StatCode, Verdict, WarningCode
+from factrix._codes import StatCode, WarningCode
 from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _FMContPanelProcedure
 from factrix._profile import FactorProfile
@@ -95,9 +95,6 @@ class TestStrongFactor:
     def test_n_obs_equals_date_count(self, profile: FactorProfile) -> None:
         assert profile.n_obs == 60
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.01
 
@@ -130,11 +127,10 @@ class TestRandomFactor:
         )
         return _FMContPanelProcedure().compute(panel, fm_config)
 
-    def test_random_factor_fails_at_default_threshold(
+    def test_random_factor_primary_p_above_threshold(
         self,
         profile: FactorProfile,
     ) -> None:
-        assert profile.verdict() is Verdict.FAIL
         assert profile.primary_p > 0.10
 
     def test_lambda_mean_near_zero(self, profile: FactorProfile) -> None:
@@ -155,7 +151,7 @@ class TestEndToEndViaEvaluate:
         profile = _evaluate(panel, fm_config)
         assert isinstance(profile, FactorProfile)
         assert StatCode.P_NW in profile.stats
-        assert profile.verdict() is Verdict.PASS
+        assert profile.primary_p < 0.05
 
 
 class TestFMShortPeriodsWarning:

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -7,7 +7,7 @@ import dataclasses
 import pytest
 from factrix._analysis_config import _FALLBACK_MAP, AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
+from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._errors import (
     ConfigError,
     FactrixError,
@@ -45,10 +45,6 @@ class TestAxisEnums:
 
 
 class TestCodeEnums:
-    def test_verdict_values(self) -> None:
-        assert Verdict.PASS.value == "pass"
-        assert Verdict.FAIL.value == "fail"
-
     def test_warning_codes_present(self) -> None:
         # Spot-check the four live codes (§7.3) — each is raised by at
         # least one procedure in factrix/_procedures.py.

--- a/tests/test_ic_procedure.py
+++ b/tests/test_ic_procedure.py
@@ -4,7 +4,7 @@ Synthetic panel: ``T`` dates × ``N`` assets. ``forward_return`` is
 i.i.d. standard normal; the strong-factor scenario builds the factor
 as ``forward_return + small_noise`` so per-date Spearman IC is
 near-perfect, the random-factor scenario builds it as independent
-noise. Verdict / primary_p / stats keys are the contract.
+noise. primary_p / stats keys are the contract.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import StatCode, Verdict
+from factrix._codes import StatCode
 from factrix._procedures import InputSchema, _ICContPanelProcedure
 from factrix._profile import FactorProfile
 from factrix._registry import _DISPATCH_REGISTRY, _DispatchKey
@@ -104,9 +104,6 @@ class TestStrongFactor:
     def test_n_obs_equals_date_count(self, profile: FactorProfile) -> None:
         assert profile.n_obs == 60
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.01
 
@@ -164,7 +161,7 @@ class TestRandomFactor:
         self,
         profile: FactorProfile,
     ) -> None:
-        assert profile.verdict() is Verdict.FAIL
+        assert profile.primary_p >= 0.05
         assert profile.primary_p > 0.10
 
     def test_ic_mean_near_zero(self, profile: FactorProfile) -> None:

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -72,8 +72,8 @@ class TestDescribeAnalysisModes:
 
     def test_stats_keys_present_per_mode(self) -> None:
         # Every PANEL / TIMESERIES sub-row carries a sorted list of
-        # StatCode .value strings; agents pre-validate verdict(gate=...)
-        # / bhy(gate=...) reachability against this set.
+        # StatCode .value strings; agents pre-validate Estimator
+        # dispatch reachability against this set.
         rows = describe_analysis_modes(format="json")
         for r in rows:
             for mode_dict in (r["panel"], r["timeseries"]):
@@ -545,7 +545,7 @@ class TestSuggestConfigResultImmutability:
 # ---------------------------------------------------------------------------
 # EMITS_STATS drift guard — every procedure's actually-emitted stats keys
 # must be a subset of its declared EMITS_STATS, otherwise describe_*'s
-# stats_keys field lies to agents pre-validating verdict()/bhy() gates.
+# stats_keys field lies to agents pre-validating Estimator dispatch.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -22,7 +22,6 @@ def test_readme_quickstart_runs_end_to_end() -> None:
     )
     profile = fx.evaluate(panel, cfg)
 
-    assert profile.verdict() in (fx.Verdict.PASS, fx.Verdict.FAIL)
     assert isinstance(profile.primary_p, float)
     assert 0.0 <= profile.primary_p <= 1.0
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,8 +1,8 @@
 """v0.5 registry SSOT + procedure stubs + FactorProfile semantics.
 
 Covers refactor_api.md §4.4 (registry as SSOT, A1), §4.4.2 (Profile
-shape + verdict policy), §5.4.1 (TIMESERIES sparse collapse), §7.5
-(naming-consistency invariants).
+shape), §5.4.1 (TIMESERIES sparse collapse), §7.5 (naming-consistency
+invariants).
 """
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from typing import ClassVar
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Metric, Mode, Signal
-from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
+from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._errors import IncompatibleAxisError
 from factrix._procedures import FactorProcedure, InputSchema
 from factrix._profile import FactorProfile
@@ -171,11 +171,6 @@ class TestProcedureProtocol:
             assert isinstance(entry.procedure.INPUT_SCHEMA, InputSchema)
 
 
-# ---------------------------------------------------------------------------
-# FactorProfile.verdict (§4.4.2 / §7.5 naming invariants)
-# ---------------------------------------------------------------------------
-
-
 def _make_profile(
     *,
     primary_p: float,
@@ -195,33 +190,6 @@ def _make_profile(
         stats=stats or {},
         metadata=metadata or {},
     )
-
-
-class TestVerdict:
-    def test_pass_below_default_threshold(self) -> None:
-        assert _make_profile(primary_p=0.01).verdict() is Verdict.PASS
-
-    def test_fail_at_or_above_default_threshold(self) -> None:
-        # Strict `<` per §4.4.2; equality fails.
-        assert _make_profile(primary_p=0.05).verdict() is Verdict.FAIL
-        assert _make_profile(primary_p=0.10).verdict() is Verdict.FAIL
-
-    def test_threshold_override(self) -> None:
-        prof = _make_profile(primary_p=0.07)
-        assert prof.verdict(threshold=0.10) is Verdict.PASS
-        assert prof.verdict(threshold=0.05) is Verdict.FAIL
-
-    def test_gate_override_uses_stats_value(self) -> None:
-        prof = _make_profile(
-            primary_p=0.50,  # would FAIL on primary
-            stats={StatCode.P_NW: 0.001},
-        )
-        assert prof.verdict(gate=StatCode.P_NW) is Verdict.PASS
-
-    def test_gate_keyerror_when_stat_missing(self) -> None:
-        prof = _make_profile(primary_p=0.01, stats={})
-        with pytest.raises(KeyError):
-            prof.verdict(gate=StatCode.P_NW)
 
 
 class TestProfileImmutability:

--- a/tests/test_ts_beta_procedure.py
+++ b/tests/test_ts_beta_procedure.py
@@ -16,7 +16,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import FactorScope, Mode, Signal
-from factrix._codes import StatCode, Verdict, WarningCode
+from factrix._codes import StatCode, WarningCode
 from factrix._errors import InsufficientSampleError
 from factrix._evaluate import _evaluate
 from factrix._procedures import InputSchema, _TSBetaContTimeseriesProcedure
@@ -102,9 +102,6 @@ class TestStrongBeta:
     def test_n_obs_equals_T(self, profile: FactorProfile) -> None:
         assert profile.n_obs == 120
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.001
 
@@ -155,7 +152,7 @@ class TestRandomFactor:
         return _TSBetaContTimeseriesProcedure().compute(ts, cfg)
 
     def test_random_factor_fails(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.FAIL
+        assert profile.primary_p >= 0.05
         assert profile.primary_p > 0.10
 
     def test_beta_near_zero(self, profile: FactorProfile) -> None:
@@ -180,7 +177,7 @@ class TestSampleSizeStratification:
             _TSBetaContTimeseriesProcedure().compute(ts, cfg)
 
     def test_T_in_warning_band_emits_warning(self, cfg: AnalysisConfig) -> None:
-        # MIN_PERIODS_HARD <= T < MIN_PERIODS_WARN → verdict + UNRELIABLE_SE warn.
+        # MIN_PERIODS_HARD <= T < MIN_PERIODS_WARN → result + UNRELIABLE_SE warn.
         ts = _make_ts(n_dates=MIN_PERIODS_HARD, seed=2, beta=0.5)
         profile = _TSBetaContTimeseriesProcedure().compute(ts, cfg)
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in profile.warnings
@@ -204,4 +201,4 @@ class TestEndToEndViaEvaluate:
         profile = _evaluate(ts, cfg)
         assert profile.mode is Mode.TIMESERIES
         assert StatCode.P_NW in profile.stats
-        assert profile.verdict() is Verdict.PASS
+        assert profile.primary_p < 0.05

--- a/tests/test_ts_dummy_procedure.py
+++ b/tests/test_ts_dummy_procedure.py
@@ -15,7 +15,7 @@ import polars as pl
 import pytest
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import Mode, Signal
-from factrix._codes import InfoCode, StatCode, Verdict, WarningCode
+from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._errors import InsufficientSampleError
 from factrix._evaluate import _evaluate
 from factrix._procedures import (
@@ -139,9 +139,6 @@ class TestStrongTrigger:
             cfg_individual,
         )
 
-    def test_passes_verdict(self, profile: FactorProfile) -> None:
-        assert profile.verdict() is Verdict.PASS
-
     def test_low_primary_p(self, profile: FactorProfile) -> None:
         assert profile.primary_p < 0.001
 
@@ -191,7 +188,7 @@ class TestRandomSparse:
             ts,
             cfg_individual,
         )
-        assert profile.verdict() is Verdict.FAIL
+        assert profile.primary_p >= 0.05
 
 
 class TestSerialCorrelationWarning:


### PR DESCRIPTION
## Summary

- `profile.verdict(threshold=0.05)` 為 `primary_p < threshold` 薄包裝，鼓勵 user 對 N candidate factor 逐一 `verdict()` 數通過——這正是 factrix 在 `[set-ops]` 契約禁止 BHY survivors `set` ops 的同根 spec-search anti-pattern。
- `verdict()` 忽略 `WarningCode`（例：`UNRELIABLE_SE_SHORT_PERIODS`），讓不可靠的推論回 `PASS`——又一個 footgun。
- factrix internal 調用：**零**。
- `Verdict` enum 一併移除（無其他 consumer）。

單因子 pre-registered 走 `primary_p < α`；多因子走 `multi_factor.bhy` survivors。

## Test plan

- [x] `uv run pytest -q` — 1122 / 1122 passed
- [x] `uv run mkdocs build --strict` — clean
- [x] `grep -rln "verdict\|Verdict"` 在非 `plans/archive/` 路徑為零
- [x] `/simplify` review：抓到 `test_low_primary_p` 命名碰撞（5 個 test 檔的新 `< 0.05` 斷言被既有更嚴 `< 0.001` shadow，Python 靜默 override），同 commit 修掉
- [ ] Reviewer 確認 CHANGELOG `[Unreleased] ### Removed` 條目的 migration recipe 涵蓋足夠（`gate=StatCode.X` use case 走 `profile.stats[StatCode.X]`）
- [ ] Reviewer 確認 `examples/multi_factor_screening.ipynb` 改寫後的「raw primary_p only → §3 BHY」流程是合適的 anti-pattern 替代範例

Closes #243