### PR TITLE
refactor!: Survivors.adj_q -> adj_p (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ## [Unreleased]
 
+### Changed
+
+- **`Survivors.adj_q` → `Survivors.adj_p`** (breaking, #245). Aligned the adjusted-p-value column name with statistical-software conventions (R `p.adjust`, statsmodels `multipletests`) where adjusted p-values are uniformly named `adj_p` / `p_adj` regardless of whether the underlying procedure controls FWER (Bonferroni / Holm) or FDR (BH / BHY). The previous `adj_q` reflected an internal-consistency goal with the `bhy(q=0.05)` kwarg, but read awkwardly in FWER contexts (where the threshold is α, not q) and required first-time users to ask "what is `adj_q`?". The `q=` kwarg name is **kept** (it remains the API-uniform threshold name across procedure families); only the output column renames. `bhy_adjusted_p()` function name was already `_p` — this change extends the same convention to the survivor container field.
+
+  ```python
+  # before (v0.12.0)
+  survivors = fx.multi_factor.bhy(profiles, q=0.05)
+  for prof, adj in zip(survivors.profiles, survivors.adj_q, strict=True):
+      ...
+
+  # after (v0.13.0)
+  survivors = fx.multi_factor.bhy(profiles, q=0.05)
+  for prof, adj in zip(survivors.profiles, survivors.adj_p, strict=True):
+      ...
+  ```
+
 ### Removed
 
 - **`FactorProfile.verdict()` and `Verdict` enum** (breaking, #243). `verdict(*, threshold=0.05, gate=None)` was a `primary_p < threshold` wrapper. Removed because (a) for N candidate factors, iterating `profile.verdict()` and counting passes is the spec-search anti-pattern factrix explicitly avoids — multi-factor decisions belong to `multi_factor.bhy` survivors, not per-factor threshold gates; (b) the `Verdict` `PASS / FAIL` outcome ignored emitted `WarningCode` (e.g. `UNRELIABLE_SE_SHORT_PERIODS`), letting unreliable inference report `PASS`. The `Verdict` enum is removed alongside the method.
@@ -29,7 +45,7 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
   # after — N candidate factors: route through BHY, read survivors
   survivors = fx.multi_factor.bhy(profiles, q=0.05)
-  for prof, adj_q in zip(survivors.profiles, survivors.adj_q, strict=True):
+  for prof, adj_p in zip(survivors.profiles, survivors.adj_p, strict=True):
       ...
   ```
 

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -20,7 +20,7 @@ profiles = [
 survivors = fx.multi_factor.bhy(profiles, q=0.05)
 
 survivors.profiles   # list[FactorProfile] in input order
-survivors.adj_q      # numpy array — bucket-local BHY-adjusted p-value, aligned
+survivors.adj_p      # numpy array — bucket-local BHY-adjusted p-value, aligned
 survivors.q          # 0.05 — the nominal target you passed
 survivors.expand_over     # () for a single family; ("regime_id",) etc. otherwise
 survivors.n_total    # {(): N} or {bucket_key: m_per_bucket}
@@ -29,7 +29,7 @@ survivors.n_total    # {(): N} or {bucket_key: m_per_bucket}
 The input list **is** the family. `bhy` runs one Benjamini–Yekutieli
 step-up over all profiles by default, returning the surviving subset
 wrapped in a `Survivors` container with rich Jupyter rendering
-(three-column text / HTML table of `identity | primary_p | adj_q`,
+(three-column text / HTML table of `identity | primary_p | adj_p`,
 plus an `expand_over_values` column when buckets are declared).
 Each panel carries its factor under a distinct column name and
 `evaluate(..., factor_col=name)` auto-stamps `factor_id` from that
@@ -119,20 +119,20 @@ inspecting the adjusted p-values it produces.
 ## Return type: `Survivors` (#171)
 
 `bhy` returns a `Survivors` container, not a bare list. The container
-is procedure-agnostic — `adj_q` carries the verb's procedure-canonical
+is procedure-agnostic — `adj_p` carries the verb's procedure-canonical
 adjusted p-value (BHY here; future Holm / Bonferroni / Romano-Wolf
 verbs populate the same shape via their own `*_adjusted_p`).
 
 `Survivors` carries only the kept rows. The construction rule **inside
-`bhy`** is: compute `adj_q_all` over the full bucket-local input via
-`bhy_adjusted_p`, then keep `{i : adj_q_all[i] <= q}` and slice both
-`profiles` and `adj_q` to that index set. The survivor mask is derived
+`bhy`** is: compute `adj_p_all` over the full bucket-local input via
+`bhy_adjusted_p`, then keep `{i : adj_p_all[i] <= q}` and slice both
+`profiles` and `adj_p` to that index set. The survivor mask is derived
 from the same adjusted p-values that downstream code reads — not a
 separate rejection-mask path — so tie / boundary edge cases where two
 parallel step-up implementations could disagree are eliminated by
 construction.
 
-`adj_q[i]` is computed within `profiles[i]`'s **own** `expand_over`
+`adj_p[i]` is computed within `profiles[i]`'s **own** `expand_over`
 bucket — bucket-local `n` and `p_array`, never pooled across buckets.
 This is the per-family adjustment that selective-inference theory
 (Benjamini & Bogomolov 2014) requires; `n_total[bucket_key]` records

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -77,7 +77,7 @@ survivors = fx.multi_factor.bhy(
 )
 ```
 
-`survivors.profiles` carries the kept rows; `survivors.adj_q` carries
+`survivors.profiles` carries the kept rows; `survivors.adj_p` carries
 the bucket-local BHY-adjusted p-values.
 
 [i160]: https://github.com/awwesomeman/factrix/issues/160

--- a/docs/guides/batch-screening.md
+++ b/docs/guides/batch-screening.md
@@ -23,7 +23,7 @@ survivors = fx.multi_factor.bhy(profiles, q=0.05)
 survivor_names = [p.factor_id for p in survivors.profiles]
 ```
 
-`evaluate()` stamps `factor_col` into `profile.factor_id`, so the survivor → name mapping reads off the survivor profiles directly — no external `name → profile` dict, no `is`-comparison idiom. `Survivors.profiles` lists the survivors in their original input order; `Survivors.adj_q` carries the bucket-local BHY-adjusted p in matching order.
+`evaluate()` stamps `factor_col` into `profile.factor_id`, so the survivor → name mapping reads off the survivor profiles directly — no external `name → profile` dict, no `is`-comparison idiom. `Survivors.profiles` lists the survivors in their original input order; `Survivors.adj_p` carries the bucket-local BHY-adjusted p in matching order.
 
 Each `evaluate` call repays the per-date cross-section overhead
 (sort / group-by / rank) on its own — that cost is intrinsic to

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -75,8 +75,8 @@
     "   — coarse hit rate.\n",
     "2. `survivors.profiles[i].primary_p` and `.factor_id` — which factor\n",
     "   cleared the family-adjusted bar.\n",
-    "3. `survivors.adj_q[i]` — the BHY-adjusted p-value driving the\n",
-    "   survivor decision (`survivor[i] iff adj_q[i] <= q`). Computed\n",
+    "3. `survivors.adj_p[i]` — the BHY-adjusted p-value driving the\n",
+    "   survivor decision (`survivor[i] iff adj_p[i] <= q`). Computed\n",
     "   bucket-locally when `expand_over` is set.\n",
     "4. `survivors.n_total` — per-bucket `m` fed into each step-up;\n",
     "   audit trail for two-stage screening.\n",
@@ -167,9 +167,9 @@
     "\n",
     "The input list **is** the family. `bhy` runs one Benjamini-Yekutieli\n",
     "step-up over all profiles and returns a `Survivors` container —\n",
-    "`.profiles` in input order, `.adj_q` aligned, `.q` / `.expand_over` /\n",
+    "`.profiles` in input order, `.adj_p` aligned, `.q` / `.expand_over` /\n",
     "`.n_total` for audit. Survivor membership is definitionally\n",
-    "`adj_q <= q`. The `c(N)` correction is applied internally; pass your\n",
+    "`adj_p <= q`. The `c(N)` correction is applied internally; pass your\n",
     "nominal `q`."
    ]
   },
@@ -191,21 +191,21 @@
      "output_type": "stream",
      "text": [
       "BHY survivors: 5 / 5\n",
-      "  variant_0    primary_p=2.136e-39  adj_q=2.439e-38\n",
-      "  variant_1    primary_p=4.052e-26  adj_q=2.313e-25\n",
-      "  variant_2    primary_p=6.682e-22  adj_q=2.543e-21\n",
-      "  variant_3    primary_p=3.987e-17  adj_q=1.138e-16\n",
-      "  variant_4    primary_p=7.407e-14  adj_q=1.691e-13\n"
+      "  variant_0    primary_p=2.136e-39  adj_p=2.439e-38\n",
+      "  variant_1    primary_p=4.052e-26  adj_p=2.313e-25\n",
+      "  variant_2    primary_p=6.682e-22  adj_p=2.543e-21\n",
+      "  variant_3    primary_p=3.987e-17  adj_p=1.138e-16\n",
+      "  variant_4    primary_p=7.407e-14  adj_p=1.691e-13\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<table class='factrix-survivors'><caption>Survivors (n=5, q=0.05, n_total=5)</caption><thead><tr><th style='text-align:left'>identity</th><th style='text-align:left'>primary_p</th><th style='text-align:left'>adj_q</th></tr></thead><tbody><tr><td>(&#x27;variant_0&#x27;, 5)</td><td>2.136e-39</td><td>2.439e-38</td></tr><tr><td>(&#x27;variant_1&#x27;, 5)</td><td>4.052e-26</td><td>2.313e-25</td></tr><tr><td>(&#x27;variant_2&#x27;, 5)</td><td>6.682e-22</td><td>2.543e-21</td></tr><tr><td>(&#x27;variant_3&#x27;, 5)</td><td>3.987e-17</td><td>1.138e-16</td></tr><tr><td>(&#x27;variant_4&#x27;, 5)</td><td>7.407e-14</td><td>1.691e-13</td></tr></tbody></table>"
+       "<table class='factrix-survivors'><caption>Survivors (n=5, q=0.05, n_total=5)</caption><thead><tr><th style='text-align:left'>identity</th><th style='text-align:left'>primary_p</th><th style='text-align:left'>adj_p</th></tr></thead><tbody><tr><td>(&#x27;variant_0&#x27;, 5)</td><td>2.136e-39</td><td>2.439e-38</td></tr><tr><td>(&#x27;variant_1&#x27;, 5)</td><td>4.052e-26</td><td>2.313e-25</td></tr><tr><td>(&#x27;variant_2&#x27;, 5)</td><td>6.682e-22</td><td>2.543e-21</td></tr><tr><td>(&#x27;variant_3&#x27;, 5)</td><td>3.987e-17</td><td>1.138e-16</td></tr><tr><td>(&#x27;variant_4&#x27;, 5)</td><td>7.407e-14</td><td>1.691e-13</td></tr></tbody></table>"
       ],
       "text/plain": [
        "Survivors(n=5, q=0.05, n_total=5)\n",
-       "identity          primary_p  adj_q    \n",
+       "identity          primary_p  adj_p    \n",
        "('variant_0', 5)  2.136e-39  2.439e-38\n",
        "('variant_1', 5)  4.052e-26  2.313e-25\n",
        "('variant_2', 5)  6.682e-22  2.543e-21\n",
@@ -221,8 +221,8 @@
    "source": [
     "survivors = fx.multi_factor.bhy(profiles, q=0.05)\n",
     "print(f\"BHY survivors: {len(survivors)} / {len(profiles)}\")\n",
-    "for prof, adj in zip(survivors.profiles, survivors.adj_q, strict=True):\n",
-    "    print(f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}  adj_q={adj:.4g}\")\n",
+    "for prof, adj in zip(survivors.profiles, survivors.adj_p, strict=True):\n",
+    "    print(f\"  {prof.factor_id:12s} primary_p={prof.primary_p:.4g}  adj_p={adj:.4g}\")\n",
     "\n",
     "# Survivors also renders as a table in Jupyter — see repr output.\n",
     "survivors"

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -37,22 +37,22 @@ if TYPE_CHECKING:
 class Survivors:
     """Family-verb survivor container with rich Jupyter rendering.
 
-    Procedure-agnostic: ``adj_q`` carries the verb's procedure-canonical
+    Procedure-agnostic: ``adj_p`` carries the verb's procedure-canonical
     adjusted p-value (BHY ``bhy_adjusted_p``, Holm step-down, Bonferroni
     ``min(p*m, 1)``, Romano-Wolf resampling, ...). The contract is
-    ``survivor[i] iff adj_q[i] <= q`` — a duality every step-up /
+    ``survivor[i] iff adj_p[i] <= q`` — a duality every step-up /
     step-down family procedure satisfies.
 
     Invariants:
-        ``len(profiles) == len(adj_q)`` and entries align in input
+        ``len(profiles) == len(adj_p)`` and entries align in input
         order. Per-bucket independent step-up uses bucket-local ``n``
-        and ``p_array``; ``adj_q[i]`` reflects ``profiles[i]``'s own
+        and ``p_array``; ``adj_p[i]`` reflects ``profiles[i]``'s own
         bucket only (Benjamini & Bogomolov 2014 selective inference),
         not a global cross-bucket adjustment.
 
     Attributes:
         profiles: Survivors in input order.
-        adj_q: Bucket-local adjusted p-values aligned with ``profiles``.
+        adj_p: Bucket-local adjusted p-values aligned with ``profiles``.
         q: Nominal FDR (or family-wise) target shared across all
             buckets.
         expand_over: Context keys used to partition the input into
@@ -65,7 +65,7 @@ class Survivors:
     """
 
     profiles: list[FactorProfile]
-    adj_q: np.ndarray
+    adj_p: np.ndarray
     q: float
     expand_over: tuple[str, ...]
     n_total: Mapping[tuple[Any, ...], int]
@@ -82,12 +82,12 @@ class Survivors:
         """
         headers: tuple[str, ...]
         if self.expand_over:
-            headers = ("expand_over_values", "identity", "primary_p", "adj_q")
+            headers = ("expand_over_values", "identity", "primary_p", "adj_p")
         else:
-            headers = ("identity", "primary_p", "adj_q")
+            headers = ("identity", "primary_p", "adj_p")
 
         rows: list[tuple[str, ...]] = []
-        for profile, adj in zip(self.profiles, self.adj_q, strict=True):
+        for profile, adj in zip(self.profiles, self.adj_p, strict=True):
             cells = (
                 repr(profile.identity),
                 f"{profile.primary_p:.4g}",
@@ -182,9 +182,9 @@ def bhy(
             ``q / sum(1/k for k in 1..n)``. Default ``0.05``.
 
     Returns:
-        ``Survivors`` container in input order; ``adj_q`` carries the
+        ``Survivors`` container in input order; ``adj_p`` carries the
         bucket-local BHY-adjusted p-value and the survivor set is
-        defined as ``adj_q <= q`` (single source of truth — no separate
+        defined as ``adj_p <= q`` (single source of truth — no separate
         rejection mask path).
 
     Raises:
@@ -209,7 +209,7 @@ def bhy(
     if not profile_list:
         return Survivors(
             profiles=[],
-            adj_q=np.zeros(0, dtype=np.float64),
+            adj_p=np.zeros(0, dtype=np.float64),
             q=q,
             expand_over=expand_over_tuple,
             n_total={},
@@ -235,17 +235,17 @@ def bhy(
             stacklevel=2,
         )
 
-    adj_q_all = np.full(len(entries), np.nan, dtype=np.float64)
+    adj_p_all = np.full(len(entries), np.nan, dtype=np.float64)
     n_total: dict[tuple[Any, ...], int] = {}
     for bucket_key, ix in buckets.items():
         p_array = np.array([entries[i].p_value for i in ix], dtype=np.float64)
-        adj_q_all[ix] = bhy_adjusted_p(p_array)
+        adj_p_all[ix] = bhy_adjusted_p(p_array)
         n_total[bucket_key] = len(ix)
 
-    survivor_idxs = np.flatnonzero(adj_q_all <= q)
+    survivor_idxs = np.flatnonzero(adj_p_all <= q)
     return Survivors(
         profiles=[entries[i].profile for i in survivor_idxs],
-        adj_q=adj_q_all[survivor_idxs],
+        adj_p=adj_p_all[survivor_idxs],
         q=q,
         expand_over=expand_over_tuple,
         n_total=n_total,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -108,7 +108,7 @@ profiles  = [
 survivors = fx.multi_factor.bhy(profiles, q=0.05)
 # survivors: Survivors container.
 #   .profiles    : list[FactorProfile] passing BHY at FDR 0.05 (input order)
-#   .adj_q       : np.ndarray of bucket-local BHY-adjusted p-values, aligned
+#   .adj_p       : np.ndarray of bucket-local BHY-adjusted p-values, aligned
 #   .q           : nominal target you passed
 #   .expand_over : tuple of context keys used to split families ((), or e.g. ("regime_id",))
 #   .n_total     : Mapping[bucket_key, m_per_bucket] for two-stage screening audit
@@ -345,17 +345,17 @@ in expand_over` (Benjamini & Bogomolov 2014 selective inference). Cell
 / horizon partitioning is the caller's responsibility (#161 retired
 the implicit `(dispatch cell, forward_periods)` auto-split).
 
-Returns a `Survivors` container with `.profiles` (input order), `.adj_q`
+Returns a `Survivors` container with `.profiles` (input order), `.adj_p`
 (bucket-local BHY-adjusted p-values, same length as `.profiles`), `.q`,
 `.expand_over` (tuple), and `.n_total` (Mapping keyed by each bucket's
 expand_over_values tuple — `()` in the single-family case). `Survivors`
 carries only the kept rows; `bhy` constructs the survivor index set as
 `{i : bhy_adjusted_p(p_array)[i] <= q}` per bucket, then slices both
-`.profiles` and `.adj_q` to that set. Survivor membership and the
+`.profiles` and `.adj_p` to that set. Survivor membership and the
 adjusted p-values downstream code reads come from the same
 `bhy_adjusted_p` call, so they cannot disagree on ties or boundary
 cases. `Survivors` ships `__repr__` / `_repr_html_` for Jupyter —
-three-column `identity | primary_p | adj_q` text and HTML table, plus
+three-column `identity | primary_p | adj_p` text and HTML table, plus
 an `expand_over_values` column when buckets are declared.
 
 `estimator=` overrides which inference method's p-value drives BHY.

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -53,7 +53,7 @@ class TestBhyEmpty:
     def test_empty_input_returns_empty(self) -> None:
         result = bhy([])
         assert result.profiles == []
-        assert len(result.adj_q) == 0
+        assert len(result.adj_p) == 0
 
 
 class TestBhyStepUp:
@@ -278,9 +278,9 @@ class TestBhyReturnsSurvivors:
         prof = _profile(factor_id="f1", primary_p=0.001)
         assert isinstance(bhy([prof]), Survivors)
 
-    def test_adj_q_matches_bhy_adjusted_p_and_mask_definitional(self) -> None:
-        # Single contract: survivor set == {i: adj_q[i] <= q}, and
-        # adj_q values come from bhy_adjusted_p of the bucket-local
+    def test_adj_p_matches_bhy_adjusted_p_and_mask_definitional(self) -> None:
+        # Single contract: survivor set == {i: adj_p[i] <= q}, and
+        # adj_p values come from bhy_adjusted_p of the bucket-local
         # p_array. Both halves of the duality in one assertion block.
         from factrix.stats.multiple_testing import bhy_adjusted_p
 
@@ -292,14 +292,14 @@ class TestBhyReturnsSurvivors:
         expected_ids = [profiles[i].factor_id for i, a in enumerate(full_adj) if a <= q]
         assert [p.factor_id for p in result.profiles] == expected_ids
         np.testing.assert_allclose(
-            result.adj_q,
+            result.adj_p,
             [full_adj[i] for i in range(len(ps)) if full_adj[i] <= q],
             rtol=1e-12,
         )
-        assert (result.adj_q <= q).all()
+        assert (result.adj_p <= q).all()
 
-    def test_n_total_and_adj_q_per_bucket(self) -> None:
-        # Multi-bucket: n_total per bucket AND adj_q per surviving
+    def test_n_total_and_adj_p_per_bucket(self) -> None:
+        # Multi-bucket: n_total per bucket AND adj_p per surviving
         # profile equals bhy_adjusted_p of that profile's own bucket
         # slice (not pooled across buckets).
         from factrix.stats.multiple_testing import bhy_adjusted_p
@@ -318,13 +318,13 @@ class TestBhyReturnsSurvivors:
         assert result.n_total == {("bull",): 3, ("bear",): 1}
 
         bull_adj = bhy_adjusted_p(np.array(bull_ps))
-        for prof, adj in zip(result.profiles, result.adj_q, strict=True):
+        for prof, adj in zip(result.profiles, result.adj_p, strict=True):
             assert prof.context["regime"] == "bull"  # bear bucket fails
             bull_idx = ["f1", "f2", "f3"].index(prof.factor_id)
             assert adj == pytest.approx(bull_adj[bull_idx], rel=1e-12)
 
     def test_ties_in_p_handled(self) -> None:
-        # Tied p-values are a known step-up edge: adj_q stays a
+        # Tied p-values are a known step-up edge: adj_p stays a
         # function of bhy_adjusted_p only — no separate tie-handling
         # path drift.
         from factrix.stats.multiple_testing import bhy_adjusted_p
@@ -334,7 +334,7 @@ class TestBhyReturnsSurvivors:
         result = bhy(profiles, q=0.05)
         full_adj = bhy_adjusted_p(np.array(ps))
         np.testing.assert_allclose(
-            result.adj_q,
+            result.adj_p,
             [full_adj[i] for i in range(len(ps)) if full_adj[i] <= 0.05],
             rtol=1e-12,
         )
@@ -362,7 +362,7 @@ def surv_single_bucket() -> Survivors:
     ]
     return Survivors(
         profiles=profiles,
-        adj_q=np.array([0.002, 0.024]),
+        adj_p=np.array([0.002, 0.024]),
         q=0.05,
         expand_over=(),
         n_total={(): 2},
@@ -377,7 +377,7 @@ def surv_multi_bucket() -> Survivors:
     ]
     return Survivors(
         profiles=profiles,
-        adj_q=np.array([0.002, 0.040]),
+        adj_p=np.array([0.002, 0.040]),
         q=0.05,
         expand_over=("universe_id",),
         n_total={("tw50",): 1, ("tw100",): 1},
@@ -398,7 +398,7 @@ class TestSurvivorsReprText:
         text = repr(surv_single_bucket)
         assert "Survivors(" in text
         assert "n=2" in text and "q=0.05" in text
-        assert "identity" in text and "primary_p" in text and "adj_q" in text
+        assert "identity" in text and "primary_p" in text and "adj_p" in text
         assert "expand_over_values" not in text
         assert "'f1'" in text and "'f2'" in text
 
@@ -413,7 +413,7 @@ class TestSurvivorsReprText:
     def test_empty_survivors_renders_header_only(self) -> None:
         empty = Survivors(
             profiles=[],
-            adj_q=np.array([]),
+            adj_p=np.array([]),
             q=0.05,
             expand_over=(),
             n_total={(): 0},
@@ -451,7 +451,7 @@ class TestSurvivorsReprHtml:
         )
         surv = Survivors(
             profiles=[profile],
-            adj_q=np.array([0.02]),
+            adj_p=np.array([0.02]),
             q=0.05,
             expand_over=("universe_id",),
             n_total={("<x>",): 1},
@@ -472,7 +472,7 @@ class TestSurvivorsBackRefIdentity:
         ]
         surv = Survivors(
             profiles=original,
-            adj_q=np.array([0.002, 0.024]),
+            adj_p=np.array([0.002, 0.024]),
             q=0.05,
             expand_over=(),
             n_total={(): 2},


### PR DESCRIPTION
## Summary

- `Survivors.adj_q` 與 R `p.adjust` / statsmodels `multipletests` 命名慣例不一致——文獻 / 業界一律 `adj_p` / `p_adj`，不論 method 是 FWER (Bonferroni / Holm) 或 FDR (BH / BHY)。
- 原 `adj_q` 命名為對齊 `bhy(q=0.05)` kwarg，但 FWER 場景下 threshold 是 α 不是 q，命名讀來奇怪；first-time user 首問「`adj_q` 是什麼？」是高頻問題。
- 同檔 sibling `bhy_adjusted_p()` 函式名已用 `_p`——field 跟著改一致。
- **`q=` kwarg 保留**——它是 procedure family 統一的 threshold kwarg 名（per #161）。只改輸出 column。

## Test plan

- [x] `uv run pytest -q` — 1122 / 1122 passed
- [x] `uv run mkdocs build --strict` — clean
- [x] `grep -rn "adj_q"` 在非 historical CHANGELOG 與非 `plans/archive/` 路徑為零
- [x] `/simplify` 快速 review — clean，無 outstanding
- [ ] Reviewer 確認 CHANGELOG migration recipe 涵蓋 user 升級的全部 callsite

Closes #245