### PR TITLE
refactor!: MetricOutput.n_obs first-class field (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ### Changed
 
+- **`MetricOutput.n_obs` first-class field** (breaking, #248). Promoted from a metadata dict key to a first-class dataclass field — `n_obs: int | None = None` — so user / AI-agent consumers reach the metric primitive's sample size with `output.n_obs` instead of `output.metadata.get("n_obs")`. Builds on the `n_observed → n_obs` metadata rename from #246. `_short_circuit_output(name, reason, n_obs=n, ...)` callers (~38 sites) auto-route via kwarg-only signature change; direct `MetricOutput(...)` constructions in `factrix/metrics/spanning.py` and `factrix/metrics/fama_macbeth.py` are updated to pass `n_obs=` at the top level instead of nesting under `metadata={"n_obs": ...}`. `__repr__` now surfaces `n_obs=` between `value=` and `stat=` when populated. Same family name as `FactorProfile.n_obs` but scoped per metric primitive (single-stage estimator count) rather than per dispatched cell (final-stage test denominator).
+
+  ```python
+  # before (v0.12.0 + #246)
+  out = factrix.metrics.spanning.spanning_alpha(candidate, base_factors)
+  n = out.metadata["n_obs"]
+
+  # after (v0.13.0)
+  n = out.n_obs
+  ```
+
 - **`FactorProfile.diagnose()` schema overhaul** (breaking, #246). Six UX gaps in the structured triage interface land in one schema change. (1) **Four sample axes** replace the previous polymorphic `n_obs` + `n_assets` pair: `n_obs` (cell-canonical final-stage test denominator — semantics unchanged), `n_pairs` (non-null `(period, asset)` pair count, first-stage), `n_periods` (unique periods in raw panel), `n_assets` (unique assets, semantics unchanged). Each axis answers one question and never overlaps with another; a small `n_obs` is now disambiguated by the three companion axes without reverse-engineering the cell. (2) **`primary_stat` / `primary_stat_name` family** added top-level — `primary_stat: float | None` carries the test statistic value paired with `primary_p` (e.g. `t_nw` value for an NW HAC t-test), `primary_stat_name: str` slugs the `stats` key (e.g. `"t_nw"`) so the user can connect `primary_p` to its `stats` entry without consulting the procedure registry. Generic across statistic families: the `None` arm handles future empirical-p primaries (block bootstrap) where there is no test stat. Invariant `stats[primary_stat_name] == primary_stat` (when not `None`) is pinned in docstring. (3) **`cell` group** wraps the dispatch coordinate — `{"scope", "signal", "metric", "mode"}` — so consumers identify which procedure ran without grepping `config`. (4) **Reader-flow key order**: `identity` → `context` → `cell` → sample axes → `primary_p` / `primary_stat` / `primary_stat_name` → `warnings` / `info_notes` → `stats` / `metadata`. (5) **`n_observed` → `n_obs` metadata key rename** across ~38 `factrix/metrics/*.py` short-circuit sites — the two first-class surfaces (`FactorProfile` and `MetricOutput`-metadata) now share the same family name; the `MetricOutput.n_obs` first-class field promotion is tracked separately at #248. (6) **`SuggestConfigResult.diagnose()` "symmetric" docstring** is downgraded to scope-limited — the two surfaces share `warnings` serialisation but answer structurally different questions; no schema change there. Docs (`api/factor-profile.md`, `development/architecture.md`, `llms-full.txt`) are rewritten in lockstep; bare `N` / `T` letter codes in `factor-profile.md` are replaced with full axis names to reduce reader cognitive load.
 
   ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,13 @@ While the version is below `1.0.0`, the public API should be considered unstable
 - **`MetricOutput.n_obs` first-class field** (breaking, #248). Promoted from a metadata dict key to a first-class dataclass field — `n_obs: int | None = None` — so user / AI-agent consumers reach the metric primitive's sample size with `output.n_obs` instead of `output.metadata.get("n_obs")`. Builds on the `n_observed → n_obs` metadata rename from #246. `_short_circuit_output(name, reason, n_obs=n, ...)` callers (~38 sites) auto-route via kwarg-only signature change; direct `MetricOutput(...)` constructions in `factrix/metrics/spanning.py` and `factrix/metrics/fama_macbeth.py` are updated to pass `n_obs=` at the top level instead of nesting under `metadata={"n_obs": ...}`. `__repr__` now surfaces `n_obs=` between `value=` and `stat=` when populated. Same family name as `FactorProfile.n_obs` but scoped per metric primitive (single-stage estimator count) rather than per dispatched cell (final-stage test denominator).
 
   ```python
-  # before (v0.12.0 + #246)
-  out = factrix.metrics.spanning.spanning_alpha(candidate, base_factors)
+  # before (v0.12.0 — pre-rename)
+  n = out.metadata["n_observed"]
+
+  # intermediate (post-#246 metadata key rename, same v0.13.0 release)
   n = out.metadata["n_obs"]
 
-  # after (v0.13.0)
+  # after (#248, v0.13.0 final shape)
   n = out.n_obs
   ```
 

--- a/docs/api/metric-output.md
+++ b/docs/api/metric-output.md
@@ -2,11 +2,14 @@
 
 The unified return type produced by every metric in
 [`factrix.metrics`](metrics/index.md). A single dataclass carrying
-the canonical scalar (`value`), the test statistic (`stat`), the
-significance marker, and a `metadata` dict for everything else
-(p-value, method label, sample-size diagnostics, short-circuit
-reason). All metrics — cell-canonical or auxiliary — return this
-shape so downstream code can treat every metric uniformly.
+the canonical scalar (`value`), the sample size the estimator saw
+(`n_obs`), the test statistic (`stat`), the significance marker, and
+a `metadata` dict for everything else (p-value, method label,
+short-circuit reason, secondary diagnostics). All metrics — primary
+or auxiliary — return this shape so downstream code can treat every
+metric uniformly. `n_obs` shares its name with `FactorProfile.n_obs`
+but a different scope: per-metric single-stage count vs. the
+final-stage test denominator at the dispatched-cell level.
 
 ::: factrix.MetricOutput
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -122,11 +122,12 @@ is emitted.
 - *primary*: `p_value` — single- or two-way clustered OLS `t`. When
   the cluster count G < 3 the test is short-circuited with `stat =
   None` and `p_value = 1.0`.
-- *descriptive*: `n_obs`, `n_clusters` (one-way) or `n_clusters_a`,
+- Sample size: `MetricOutput.n_obs` (row count entering the test).
+- *descriptive*: `n_clusters` (one-way) or `n_clusters_a`,
   `n_clusters_b`, `n_clusters_intersection` (two-way).
 - *descriptive* (conditional, short-circuit): `reason =
-  "insufficient_clusters"`, `n_obs` (smallest G), `min_required`
-  (always 3).
+  "insufficient_clusters"`, `n_clusters` (smallest G — first-class
+  `n_obs` carries the row count), `min_required` (always 3).
 - *descriptive* (conditional): `variance_non_psd_fallback` — names
   the fallback path when the meat matrix is non-PSD.
 
@@ -313,9 +314,10 @@ hypothesis test.
 - *primary*: `p_value` — OLS `t` on α from the multivariate spanning
   regression. Plain (non-HAC) SE — assumes the input spread series
   are non-overlapping.
-- *descriptive*: `n_obs`, `n_base_factors`, `base_factors` (list of
-  base-factor names), `betas` (per-base OLS slope dict),
-  `r_squared`.
+- Sample size: `MetricOutput.n_obs` (length of the aligned
+  candidate-series).
+- *descriptive*: `n_base_factors`, `base_factors` (list of base-factor
+  names), `betas` (per-base OLS slope dict), `r_squared`.
 - *descriptive* (conditional, short-circuit): `reason`.
 
 #### `greedy_forward_selection`
@@ -430,17 +432,20 @@ when input data fails the metric's preconditions (insufficient
 sample, no events, degenerate signal, …). The fallback shape is:
 
 - `value = float("nan")`, `stat = None`, `significance = ""`.
+- `MetricOutput.n_obs: int | None` — first-class sample size the
+  estimator saw before bailing (e.g. how many periods / events were
+  actually available). Populated when the short-circuit knows the
+  number; `None` otherwise.
 - `metadata["reason"]: str` names the short-circuit branch (e.g.
   `"insufficient_periods"`, `"no_events"`,
   `"not_applicable_discrete_signal"`, `"insufficient_clusters"`).
 - `metadata["p_value"] = 1.0` — conservative default so BHY treats
   short-circuited metrics as rejected rather than crashing.
 - Optional diagnostic keys naming what was missing or under-spec:
-  `n_obs`, `min_required`, `min_required_per_asset`,
-  `min_required_per_regime`, `missing_column`, `std_u`, `hint`,
-  `n_distinct`. Each is descriptive — emitted only on the
-  short-circuit branch that needed it; consumers should branch on
-  `reason` before reading.
+  `min_required`, `min_required_per_asset`, `min_required_per_regime`,
+  `missing_column`, `std_u`, `hint`, `n_distinct`. Each is
+  descriptive — emitted only on the short-circuit branch that
+  needed it; consumers should branch on `reason` before reading.
 
 The auxiliary `metadata` keys listed in the per-metric subsections
 above are *not* present on the short-circuit path.

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -75,6 +75,12 @@ class MetricOutput:
     Args:
         name: Metric identifier (e.g. "ic_ir", "oos_decay").
         value: Raw metric value.
+        n_obs: Sample size the metric primitive's estimator actually
+            saw. Same family name as ``FactorProfile.n_obs`` but a
+            different scope: per-metric single-stage count, vs. the
+            final-stage test denominator at the dispatched-cell level.
+            ``None`` for metrics where a single integer count is not
+            meaningful (e.g. multi-window CAAR series).
         stat: Test statistic (t, z, W, chi2, ...), when applicable.
         significance: ``***`` / ``**`` / ``*`` / ``""`` derived from
             ``metadata["p_value"]`` when available.
@@ -84,12 +90,15 @@ class MetricOutput:
 
     name: str
     value: float
+    n_obs: int | None = None
     stat: float | None = None
     significance: str | None = None
     metadata: dict[str, object] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         parts = [f"{self.name}={self.value:.4f}"]
+        if self.n_obs is not None:
+            parts.append(f"n_obs={self.n_obs}")
         if self.stat is not None:
             parts.append(f"stat={self.stat:.2f}")
         if self.significance:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -522,7 +522,10 @@ calling `factrix.suggest_config(raw)`).
 
 Return type for the standalone `factrix.metrics.*` primitives invoked
 directly (outside of `evaluate`). Frozen dataclass: `name` (metric id),
-`value` (raw scalar), `stat` (test statistic when applicable),
+`value` (raw scalar), `n_obs` (`int | None` — per-metric single-stage
+estimator sample size; same family name as `FactorProfile.n_obs` but
+different scope, the latter being the final-stage test denominator at
+the dispatched-cell level), `stat` (test statistic when applicable),
 `significance` (`***` / `**` / `*` / `""` derived from
 `metadata["p_value"]`). The structured-procedure path returns
 `FactorProfile`; only callers reaching into `factrix.metrics.<module>`

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -52,6 +52,8 @@ def _aggregate_to_per_date(
 def _short_circuit_output(
     name: str,
     reason: str,
+    *,
+    n_obs: int | None = None,
     **extra_metadata: object,
 ) -> MetricOutput:
     """Canonical short-circuit ``MetricOutput`` for "cannot compute".
@@ -74,6 +76,7 @@ def _short_circuit_output(
     return MetricOutput(
         name=name,
         value=float("nan"),
+        n_obs=n_obs,
         stat=None,
         significance="",
         metadata={"reason": reason, "p_value": 1.0, **extra_metadata},

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -442,13 +442,13 @@ def pooled_ols(
             return MetricOutput(
                 name="pooled_beta",
                 value=slope,
+                n_obs=n_obs,
                 stat=None,
                 significance="",
                 metadata={
                     "reason": "insufficient_clusters",
                     "n_clusters": g_a,
                     "min_required": 3,
-                    "n_obs": n_obs,
                     "p_value": 1.0,
                 },
             )
@@ -470,13 +470,13 @@ def pooled_ols(
             return MetricOutput(
                 name="pooled_beta",
                 value=slope,
+                n_obs=n_obs,
                 stat=None,
                 significance="",
                 metadata={
                     "reason": "insufficient_clusters",
                     "n_clusters": min(g_a, g_b),
                     "min_required": 3,
-                    "n_obs": n_obs,
                     "n_clusters_a": g_a,
                     "n_clusters_b": g_b,
                     "p_value": 1.0,
@@ -531,7 +531,6 @@ def pooled_ols(
         "stat_type": "t",
         "h0": "β=0",
         "method": method_desc,
-        "n_obs": n_obs,
         **cluster_metadata,
     }
     if non_psd_fallback:
@@ -540,6 +539,7 @@ def pooled_ols(
     return MetricOutput(
         name="pooled_beta",
         value=slope,
+        n_obs=n_obs,
         stat=t_stat,
         significance=_significance_marker(p),
         metadata=metadata,

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -179,10 +179,10 @@ def spanning_alpha(
     return MetricOutput(
         name="spanning_alpha",
         value=ols.alpha,
+        n_obs=n_obs,
         stat=ols.alpha_t,
         significance=_significance_marker(p),
         metadata={
-            "n_obs": n_obs,
             "p_value": p,
             "stat_type": "t",
             "h0": "alpha=0",


### PR DESCRIPTION
## Summary

Promote `n_obs` from a metadata dict key to a first-class `MetricOutput` dataclass field. Builds on the `n_observed → n_obs` metadata rename from #246; closes the loop on the two-surface alignment (FactorProfile and MetricOutput now share the same `n_obs` family name with first-class access on both).

**Stacked on #249 (#246)** — review / merge order: #249 first, then this.

- `_types.py`: add `n_obs: int | None = None` between `value` and `stat`. Docstring scopes it as the per-metric estimator's count (single-stage), paired with but distinct from `FactorProfile.n_obs` (final-stage test denominator at the dispatched cell).
- `_helpers.py`: `_short_circuit_output(name, reason, *, n_obs=None, **extra_metadata)` — kwarg-only `n_obs` so the ~38 existing callers of the form `_short_circuit_output(name, reason, n_obs=n, ...)` auto-route to the new field without per-site edits.
- `spanning.py` / `fama_macbeth.py`: direct `MetricOutput(...)` constructions promoted to pass `n_obs=` at the top level instead of nesting under `metadata={"n_obs": ...}`.
- `__repr__`: surfaces `n_obs=` between `value=` and `stat=` when populated.
- `docs/api/metric-output.md`: preamble rewritten to put `n_obs` in the field overview alongside `value` / `stat`.

## Migration

```python
# before (after #246)
out = factrix.metrics.spanning.spanning_alpha(candidate, base_factors)
n = out.metadata["n_obs"]

# after (#248)
n = out.n_obs
```

## Test plan

- [x] `pytest tests/` — 1122 passed
- [x] Manual smoke: `_short_circuit_output(..., n_obs=5, ...)` produces `MetricOutput(test=nan, n_obs=5)` with `n_obs` on top-level field and clean `metadata` (no `"n_obs"` key residue)
- [x] Docs terminology ratchet still passes

Closes #248