### PR TITLE
feat(api): compare leaderboard (#177)

### DIFF
--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -1,0 +1,123 @@
+# compare
+
+Leaderboard renderer that stacks N artifacts side by side as a
+[polars `DataFrame`](https://docs.pola.rs/api/python/stable/reference/dataframe/index.html).
+Pure projection — no metric is recomputed; `Survivors.adj_p` is read
+straight through so BHY survivor tables keep their adjusted p-values
+without manual re-attach.
+
+```python
+import factrix as fx
+
+profiles = [fx.evaluate(panel, cfg, factor_col=c) for c in candidates]
+fx.compare(profiles, sort_by="primary_p")
+```
+
+## When to reach for `compare`
+
+| Use case | Verb | Notes |
+|---|---|---|
+| Rank N `evaluate` results | `compare(list[FactorProfile])` | Identity + context + `primary_stat` / `primary_stat_name` / `primary_p` |
+| Rank N `run_metrics` results | `compare(list[MetricsBundle])` | Identity + context + one column per standalone metric (`MetricOutput.value`) |
+| Rank BHY survivors | `compare(Survivors)` | Profile schema plus `adj_p` (read from `Survivors.adj_p`) |
+| Re-run inference under perturbations | [`robustness`](../api/index.md) (#178) | `compare` is a pure view; `robustness` recomputes |
+| Test factor across slices | [`slice_pairwise_test` / `slice_joint_test`](slice-test.md) | Re-runs inference per slice; `compare` does not |
+
+If you need fresh statistics, you want a *re-compute* verb. `compare`
+is strictly read-through.
+
+## Input dispatch
+
+Single entrypoint, input-type dispatch — no `compare_profiles` /
+`compare_bundles` split, so the call site does not branch on artifact
+shape.
+
+```python
+compare(
+    artifacts: list[FactorProfile] | list[MetricsBundle] | Survivors,
+    *,
+    sort_by: str | None = None,
+) -> pl.DataFrame
+```
+
+### `list[FactorProfile]`
+
+```
+┌───────────────┬─────────────────┬─────────────┬──────────────┬───────────────────┬──────────┐
+│ factor_id     │ forward_periods │ universe_id │ primary_stat │ primary_stat_name │ primary_p│
+│ str           │ i64             │ str         │ f64          │ str               │ f64      │
+╞═══════════════╪═════════════════╪═════════════╪══════════════╪═══════════════════╪══════════╡
+│ quality_roe   │ 1               │ large_cap   │ 3.21         │ t_nw              │ 0.0013   │
+│ momentum_12_1 │ 1               │ large_cap   │ 2.84         │ t_nw              │ 0.0046   │
+│ value_btm     │ 1               │ large_cap   │ 1.92         │ t_nw              │ 0.0550   │
+└───────────────┴─────────────────┴─────────────┴──────────────┴───────────────────┴──────────┘
+```
+
+`primary_stat_name` looks redundant when every entry shares one
+procedure, but it is the only disambiguation for mixed lists — for
+example a Newey-West t-stat alongside a block-bootstrap p-only entry.
+The column carries the `StatCode.value` slug (`"t_nw"` / `"wald_nwcl"`
+/ `"p_boot"` / …).
+
+### `list[MetricsBundle]`
+
+```
+┌───────────────┬─────────────────┬─────────────┬───────┬───────┬───────────┬──────────┐
+│ factor_id     │ forward_periods │ universe_id │ ic    │ ic_ir │ fm_lambda │ hit_rate │
+│ str           │ i64             │ str         │ f64   │ f64   │ f64       │ f64      │
+╞═══════════════╪═════════════════╪═════════════╪═══════╪═══════╪═══════════╪══════════╡
+│ quality_roe   │ 1               │ large_cap   │ 0.051 │ 1.83  │ 0.0042    │ 0.561    │
+│ momentum_12_1 │ 1               │ large_cap   │ 0.042 │ 1.52  │ 0.0031    │ 0.547    │
+│ value_btm     │ 1               │ large_cap   │ 0.028 │ 0.89  │ 0.0019    │ 0.521    │
+└───────────────┴─────────────────┴─────────────┴───────┴───────┴───────────┴──────────┘
+```
+
+One column per metric, projected from `MetricOutput.value`. Per-cell
+`n_obs` (first-class on [`MetricOutput`](metric-output.md)) is *not*
+flattened — for 4 metrics that would double the table to 8 columns
+and drown the leaderboard. When you need sample-size honesty for a
+specific cell, look up `bundle[metric].n_obs` directly.
+
+### `Survivors`
+
+```python
+survivors = fx.multi_factor.bhy(profiles, q=0.05)
+fx.compare(survivors, sort_by="adj_p")
+```
+
+```
+┌───────────────┬─────────────────┬─────────────┬──────────────┬───────────────────┬──────────┬────────┐
+│ factor_id     │ forward_periods │ universe_id │ primary_stat │ primary_stat_name │ primary_p│ adj_p  │
+│ str           │ i64             │ str         │ f64          │ str               │ f64      │ f64    │
+╞═══════════════╪═════════════════╪═════════════╪══════════════╪═══════════════════╪══════════╪════════╡
+│ quality_roe   │ 1               │ large_cap   │ 3.21         │ t_nw              │ 0.0013   │ 0.0078 │
+│ momentum_12_1 │ 1               │ large_cap   │ 2.84         │ t_nw              │ 0.0046   │ 0.0120 │
+└───────────────┴─────────────────┴─────────────┴──────────────┴───────────────────┴──────────┴────────┘
+```
+
+When `bhy(..., expand_over=[k, ...])` was used, the partitioning keys
+are already inside `profile.context[k]`. `compare` reads them through
+the same context-key path as every other context column — there is no
+sidecar `expand_over_values` field on `Survivors`, and the renderer
+does no reverse lookup.
+
+## Column policy
+
+| Concern | Behaviour |
+|---|---|
+| Identity | Always flattens to `factor_id` + `forward_periods` (two columns), matching `FactorProfile.identity` and `MetricsBundle.identity`. |
+| Context | Union of keys across entries, ordered by first appearance; missing keys fill with `null`. Matches `pl.concat(how="diagonal")`. |
+| `sort_by` | `None` keeps input order; otherwise polars sort with `nulls_last=True`. Unknown column raises with a fuzzy suggestion. |
+| Mixed-type list | `FactorProfile` and `MetricsBundle` cannot be mixed — raises with the offending indices. |
+| Empty input | `[]` and empty `Survivors` raise (rather than returning a schema-undefined empty frame). |
+
+## Errors
+
+`compare` raises [`UserInputError`](errors.md) for every input shape
+issue (empty input, mixed types, unknown `sort_by`). Unknown
+`sort_by` carries `suggestions` populated by `difflib` against the
+output schema.
+
+## Source
+
+::: factrix.compare

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,12 +13,16 @@ flowchart LR
     ST["slice_pairwise_test<br/>slice_joint_test"]
     BHY{{multi_factor.bhy}}
     LM[/list_metrics/]
+    CMP[compare]
 
     P ==> EV
     P ==> RM
     P -.-> BS
     P -.-> ST
     EV ==>|profiles| BHY
+    EV ==>|profiles| CMP
+    RM ==>|bundles| CMP
+    BHY ==>|survivors| CMP
     LM -.->|metric names| RM
 
     classDef compute fill:#e3f2fd,stroke:#1976d2,color:#000
@@ -27,7 +31,7 @@ flowchart LR
     classDef introspect fill:#fff9c4,stroke:#f9a825,color:#000
     class EV,RM compute
     class BHY decision
-    class BS,ST view
+    class BS,ST,CMP view
     class LM introspect
 
     click EV "evaluate/" "evaluate API"
@@ -36,6 +40,7 @@ flowchart LR
     click ST "slice-test/" "slice_pairwise_test / slice_joint_test API"
     click BHY "multi-factor/" "multi_factor.bhy API"
     click LM "list-metrics/" "list_metrics API"
+    click CMP "compare/" "compare API"
 ```
 
 Click any node to jump to its API page.
@@ -46,10 +51,10 @@ Click any node to jump to its API page.
 
 - **Compute** (blue) — `evaluate` / `run_metrics`. Produce primary artefacts (`FactorProfile` / `MetricsBundle`) from `(panel, cfg)`.
 - **Decision** (pink) — `multi_factor.bhy`. Multiplicity-correction primitive; consumes `Profile[]`.
-- **View** (purple) — `by_slice` / `slice_pairwise_test` / `slice_joint_test`. Render or test a derived view of a metric. (`by_slice` is the dispatcher; the `_test` pair are statistical tests over the slices — both share the slice-surface shape per #148, hence one bucket.)
+- **View** (purple) — `by_slice` / `slice_pairwise_test` / `slice_joint_test` / `compare`. Render or test a derived view of artefacts the compute verbs already produced — no fresh statistics. (`by_slice` is the slice dispatcher; the `_test` pair are statistical tests over the slices; `compare` is the cross-factor leaderboard.)
 - **Introspection** (yellow) — `list_metrics`. Discovers what's applicable to a cell.
 
-**Deliberately omitted from the graph (not yet implemented).** The full v1 design (#148) also covers `compare` (cross-factor leaderboard), `robustness` (per-stat-choice sensitivity), and the family verbs `bhy_hierarchical` / `partial_conjunction` for hierarchical FDR and partial-conjunction multiplicity control. All four are view-class or decision-class verbs that depend on the same artefact shapes shown above. They are not drawn because drawing them would either mislead a reader into clicking a URL that 404s, or force a legend explaining which nodes are real — both worse than the small omission.
+**Deliberately omitted from the graph (not yet implemented).** The full v1 design (#148) also covers `robustness` (per-stat-choice sensitivity) and the family verbs `bhy_hierarchical` / `partial_conjunction` for hierarchical FDR and partial-conjunction multiplicity control. All three are view-class or decision-class verbs that depend on the same artefact shapes shown above. They are not drawn because drawing them would either mislead a reader into clicking a URL that 404s, or force a legend explaining which nodes are real — both worse than the small omission.
 
 ## Typical patterns
 
@@ -61,6 +66,7 @@ Click any node to jump to its API page.
 | Slice statistical test | `slice_pairwise_test(metric, df, label="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
 | Cell metric discovery | `list_metrics(scope, signal)` → names → `run_metrics(metrics=[...])` |
 | Multi-factor screening with FDR | `[evaluate(panel, cfg_i) for cfg_i in cfgs]` → `multi_factor.bhy(profiles)` |
+| Cross-factor leaderboard | `compare(profiles)` / `compare(bundles)` / `compare(survivors)` → `pl.DataFrame` |
 
 See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surface end-to-end, and the [Batch screening with BHY](../guides/batch-screening.md) guide for the multi-factor screening workflow.
 
@@ -75,6 +81,7 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 | [`stats`](stats.md) | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking inference method for `bhy(estimator=…)` or cross-slice tests. |
 | [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
 | [`suggest_config`](suggest-config.md) | Heuristic introspection — inspect a raw panel, propose an `AnalysisConfig` with per-axis reasoning and pre-evaluate warnings. | Recovering from `MissingConfigError`, or letting an agent pick a starting cell. |
+| [`compare`](compare.md) | Cross-factor leaderboard — stacks `FactorProfile` / `MetricsBundle` / `Survivors` artifacts into a `pl.DataFrame` (pure projection, no recompute). | Ranking N candidate factors after `evaluate` / `run_metrics` / `bhy`. |
 | [`Metrics`](metrics/index.md) | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly on a `FactorProfile` / panel. |
 
 ## Supporting surface

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -48,6 +48,7 @@ from factrix._axis import (  # noqa: F401  Mode re-exported for namespace access
     Signal,
 )
 from factrix._codes import InfoCode, StatCode, WarningCode
+from factrix._compare import compare
 from factrix._describe import (
     SuggestConfigResult,
     describe_analysis_modes,
@@ -162,6 +163,7 @@ __all__ = [
     "FactorProfile",
     "MetricOutput",
     "MetricsBundle",
+    "compare",
     "evaluate",
     "run_metrics",
     # Introspection

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -1,0 +1,181 @@
+"""``compare`` — leaderboard renderer for factrix artifacts (#177).
+
+Pure projection: stacks ``FactorProfile`` / ``MetricsBundle`` /
+``Survivors`` artifacts into a wide ``pl.DataFrame`` for sorting and
+visual diff. No metric is recomputed; ``Survivors.adj_p`` is read
+through, so BHY survivor leaderboards keep their adjusted p-values
+without manual re-attach.
+
+Heterogeneous context keys follow ``pl.concat(how="diagonal")`` —
+union + null-fill — so an entry missing ``regime_id`` surfaces as a
+``null`` cell rather than a silent drop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, cast
+
+import polars as pl
+
+from factrix._errors import UserInputError
+from factrix._multi_factor import Survivors
+from factrix._profile import FactorProfile
+from factrix._run_metrics import MetricsBundle
+
+CompareInput = list[FactorProfile] | list[MetricsBundle] | Survivors
+
+
+def compare(
+    artifacts: CompareInput,
+    *,
+    sort_by: str | None = None,
+) -> pl.DataFrame:
+    """Render a leaderboard ``pl.DataFrame`` for a list of artifacts.
+
+    Args:
+        artifacts: One of three input shapes (input-type dispatch — no
+            ``compare_profiles`` / ``compare_bundles`` split):
+
+            - ``list[FactorProfile]`` → identity + context +
+              ``primary_stat`` / ``primary_stat_name`` / ``primary_p``
+            - ``list[MetricsBundle]`` → identity + context + one column
+              per standalone metric (``MetricOutput.value``)
+            - :class:`~factrix.multi_factor.Survivors` → as the
+              profile branch plus a final ``adj_p`` column (read from
+              ``Survivors.adj_p``). ``expand_over`` dimensions surface
+              as ordinary context columns (via ``profile.context[k]``).
+
+            Mixed-type lists raise.
+        sort_by: Column name to sort by. ``None`` keeps input order.
+            ``nulls_last=True`` matches polars default so heterogeneous
+            context / metric coverage stays robust.
+
+    Returns:
+        ``pl.DataFrame`` with columns laid out as ``factor_id``,
+        ``forward_periods``, then context keys (union across entries,
+        first-seen order), then branch-specific columns.
+
+    Raises:
+        UserInputError: Empty input; mixed artifact types; ``sort_by``
+            not present in the output schema (with fuzzy suggestion).
+    """
+    if isinstance(artifacts, Survivors):
+        if len(artifacts) == 0:
+            raise UserInputError(
+                verb="compare",
+                field="artifacts",
+                value=artifacts,
+                expected="non-empty Survivors",
+                docs_path="api/compare/",
+            )
+        df = _profile_frame(artifacts.profiles).with_columns(
+            pl.Series("adj_p", artifacts.adj_p)
+        )
+    else:
+        entries = list(artifacts)
+        if not entries:
+            raise UserInputError(
+                verb="compare",
+                field="artifacts",
+                value=entries,
+                expected="non-empty list of FactorProfile or MetricsBundle",
+                docs_path="api/compare/",
+            )
+        kind = _classify(entries)
+        if kind is FactorProfile:
+            df = _profile_frame(cast("list[FactorProfile]", entries))
+        else:
+            df = _bundle_frame(cast("list[MetricsBundle]", entries))
+
+    if sort_by is not None:
+        if sort_by not in df.columns:
+            raise UserInputError(
+                verb="compare",
+                field="sort_by",
+                value=sort_by,
+                candidates=df.columns,
+                docs_path="api/compare/",
+            )
+        df = df.sort(sort_by, nulls_last=True)
+
+    return df
+
+
+def _classify(entries: list[Any]) -> type:
+    head = entries[0]
+    if isinstance(head, FactorProfile):
+        kind: type = FactorProfile
+    elif isinstance(head, MetricsBundle):
+        kind = MetricsBundle
+    else:
+        raise UserInputError(
+            verb="compare",
+            field="artifacts[0]",
+            value=head,
+            expected="FactorProfile or MetricsBundle",
+            docs_path="api/compare/",
+        )
+    mismatches = [
+        (i, type(e).__name__)
+        for i, e in enumerate(entries[1:], start=1)
+        if not isinstance(e, kind)
+    ]
+    if mismatches:
+        rendered = ", ".join(f"[{i}]={name}" for i, name in mismatches)
+        raise UserInputError(
+            verb="compare",
+            field="artifacts",
+            value=f"mixed types ({kind.__name__} + {rendered})",
+            expected=f"all entries to be {kind.__name__}",
+            docs_path="api/compare/",
+        )
+    return kind
+
+
+def _profile_frame(profiles: Sequence[FactorProfile]) -> pl.DataFrame:
+    context_keys = _ordered_keys(p.context for p in profiles)
+    rows: list[dict[str, Any]] = []
+    for p in profiles:
+        row: dict[str, Any] = {
+            "factor_id": p.factor_id,
+            "forward_periods": p.forward_periods,
+        }
+        for k in context_keys:
+            row[k] = p.context.get(k)
+        row["primary_stat"] = p.primary_stat
+        row["primary_stat_name"] = p.primary_stat_name.value
+        row["primary_p"] = p.primary_p
+        rows.append(row)
+    return pl.DataFrame(rows)
+
+
+def _bundle_frame(bundles: Sequence[MetricsBundle]) -> pl.DataFrame:
+    context_keys = _ordered_keys(b.context for b in bundles)
+    metric_keys = _ordered_keys(b.metrics for b in bundles)
+    rows: list[dict[str, Any]] = []
+    for b in bundles:
+        row: dict[str, Any] = {
+            "factor_id": b.factor_id,
+            "forward_periods": b.forward_periods,
+        }
+        for k in context_keys:
+            row[k] = b.context.get(k)
+        for m in metric_keys:
+            output = b.metrics.get(m)
+            row[m] = output.value if output is not None else None
+        rows.append(row)
+    return pl.DataFrame(rows)
+
+
+def _ordered_keys(maps: Iterable[Mapping[str, Any]]) -> list[str]:
+    """Union of mapping keys, ordered by first appearance.
+
+    Matches ``pl.concat(how="diagonal")`` semantics without imposing
+    alphabetic re-shuffling.
+    """
+    seen: dict[str, None] = {}
+    for m in maps:
+        for k in m:
+            seen.setdefault(k, None)
+    return list(seen)

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -397,6 +397,43 @@ via the auto-generated `__eq__`.
 
 ---
 
+### `compare`
+
+```
+factrix.compare(
+    artifacts: list[FactorProfile] | list[MetricsBundle] | Survivors,
+    *,
+    sort_by: str | None = None,
+) -> pl.DataFrame
+```
+
+Leaderboard renderer — stacks N artifacts side by side as a polars
+DataFrame. Pure projection (no metric is recomputed; `Survivors.adj_p`
+is read straight through). Single entrypoint with input-type dispatch:
+
+- `list[FactorProfile]` → `factor_id`, `forward_periods` + context
+  + `primary_stat`, `primary_stat_name`, `primary_p`.
+  `primary_stat_name` carries the `StatCode.value` slug (`"t_nw"` /
+  `"wald_nwcl"` / `"p_boot"` …) so mixed-procedure lists disambiguate.
+- `list[MetricsBundle]` → `factor_id`, `forward_periods` + context +
+  one column per metric (`MetricOutput.value`). Per-cell `n_obs` is
+  not flattened; look up `bundle[metric].n_obs` directly.
+- `Survivors` → as the profile branch plus a final `adj_p` column.
+  `expand_over` dimensions surface as ordinary context columns via
+  `profile.context[k]` — there is no sidecar field on `Survivors`.
+
+Context keys union across entries (matches `pl.concat(how="diagonal")`)
+and fill `null` where missing; ordering follows first appearance.
+`sort_by=None` keeps input order; a non-None value sorts with
+polars `nulls_last=True`.
+
+`UserInputError` raises on empty input (list or `Survivors`), mixed
+artifact types (e.g. `FactorProfile` + `MetricsBundle` in one list),
+unknown `sort_by` (with `difflib` fuzzy suggestion against the output
+schema).
+
+---
+
 ### `describe_analysis_modes` / `suggest_config` / `list_metrics` / `list_estimators`
 
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
           - multi_factor: api/multi-factor.md
           - list_metrics: api/list-metrics.md
           - suggest_config: api/suggest-config.md
+          - compare: api/compare.md
       - Results:
           - FactorProfile: api/factor-profile.md
           - MetricOutput: api/metric-output.md

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,246 @@
+"""``compare`` leaderboard renderer (#177)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._analysis_config import AnalysisConfig
+from factrix._axis import Metric, Mode
+from factrix._codes import StatCode
+from factrix._compare import compare
+from factrix._errors import UserInputError
+from factrix._multi_factor import Survivors
+from factrix._profile import FactorProfile
+from factrix._run_metrics import MetricsBundle
+from factrix._types import MetricOutput
+
+
+def _profile(
+    *,
+    factor_id: str,
+    forward_periods: int = 1,
+    primary_p: float = 0.05,
+    primary_stat: float | None = 2.0,
+    primary_stat_name: StatCode = StatCode.T_NW,
+    context: dict[str, object] | None = None,
+) -> FactorProfile:
+    cfg = AnalysisConfig.individual_continuous(
+        metric=Metric.IC, forward_periods=forward_periods
+    )
+    return FactorProfile(
+        config=cfg,
+        mode=Mode.PANEL,
+        primary_p=primary_p,
+        primary_stat=primary_stat,
+        primary_stat_name=primary_stat_name,
+        n_obs=100,
+        n_pairs=3000,
+        n_periods=100,
+        n_assets=30,
+        factor_id=factor_id,
+        context=context or {},
+    )
+
+
+def _bundle(
+    *,
+    factor_id: str,
+    forward_periods: int = 1,
+    metrics: dict[str, MetricOutput] | None = None,
+    context: dict[str, object] | None = None,
+) -> MetricsBundle:
+    return MetricsBundle(
+        identity=(factor_id, forward_periods),
+        metrics=metrics or {},
+        context=context or {},
+    )
+
+
+def _metric(value: float, *, name: str = "ic", n_obs: int = 100) -> MetricOutput:
+    return MetricOutput(name=name, value=value, n_obs=n_obs)
+
+
+# ---------------------------------------------------------------------------
+# Profile branch
+# ---------------------------------------------------------------------------
+
+
+class TestProfileBranch:
+    def test_columns_and_order(self) -> None:
+        profiles = [
+            _profile(
+                factor_id="momentum", primary_p=0.01, context={"universe_id": "lc"}
+            ),
+            _profile(factor_id="value", primary_p=0.04, context={"universe_id": "lc"}),
+        ]
+        df = compare(profiles)
+        assert df.columns == [
+            "factor_id",
+            "forward_periods",
+            "universe_id",
+            "primary_stat",
+            "primary_stat_name",
+            "primary_p",
+        ]
+        assert df["factor_id"].to_list() == ["momentum", "value"]
+        assert df["primary_stat_name"].to_list() == ["t_nw", "t_nw"]
+
+    def test_sort_by_primary_p(self) -> None:
+        profiles = [
+            _profile(factor_id="a", primary_p=0.10),
+            _profile(factor_id="b", primary_p=0.01),
+            _profile(factor_id="c", primary_p=0.05),
+        ]
+        df = compare(profiles, sort_by="primary_p")
+        assert df["factor_id"].to_list() == ["b", "c", "a"]
+
+    def test_heterogeneous_context_union_null_fill(self) -> None:
+        profiles = [
+            _profile(factor_id="a", context={"universe_id": "lc"}),
+            _profile(factor_id="b", context={"regime_id": "calm"}),
+        ]
+        df = compare(profiles)
+        assert df.columns[:4] == [
+            "factor_id",
+            "forward_periods",
+            "universe_id",
+            "regime_id",
+        ]
+        assert df["universe_id"].to_list() == ["lc", None]
+        assert df["regime_id"].to_list() == [None, "calm"]
+
+    def test_mixed_procedure_primary_stat_name(self) -> None:
+        profiles = [
+            _profile(
+                factor_id="nw",
+                primary_stat=2.5,
+                primary_stat_name=StatCode.T_NW,
+            ),
+            _profile(
+                factor_id="boot",
+                primary_stat=None,
+                primary_stat_name=StatCode.P_BOOT,
+            ),
+        ]
+        df = compare(profiles)
+        assert df["primary_stat_name"].to_list() == ["t_nw", "p_boot"]
+        assert df["primary_stat"].to_list() == [2.5, None]
+
+
+# ---------------------------------------------------------------------------
+# Bundle branch
+# ---------------------------------------------------------------------------
+
+
+class TestBundleBranch:
+    def test_metric_value_columns(self) -> None:
+        bundles = [
+            _bundle(
+                factor_id="a",
+                metrics={"ic": _metric(0.05), "ic_ir": _metric(1.5, name="ic_ir")},
+            ),
+            _bundle(
+                factor_id="b",
+                metrics={"ic": _metric(0.03), "ic_ir": _metric(0.8, name="ic_ir")},
+            ),
+        ]
+        df = compare(bundles, sort_by="ic_ir")
+        assert df.columns == ["factor_id", "forward_periods", "ic", "ic_ir"]
+        assert df["factor_id"].to_list() == ["b", "a"]
+        assert df["ic_ir"].to_list() == [0.8, 1.5]
+
+    def test_metric_union_null_fill(self) -> None:
+        bundles = [
+            _bundle(factor_id="a", metrics={"ic": _metric(0.05)}),
+            _bundle(
+                factor_id="b", metrics={"hit_rate": _metric(0.55, name="hit_rate")}
+            ),
+        ]
+        df = compare(bundles)
+        assert df.columns == ["factor_id", "forward_periods", "ic", "hit_rate"]
+        assert df["ic"].to_list() == [0.05, None]
+        assert df["hit_rate"].to_list() == [None, 0.55]
+
+
+# ---------------------------------------------------------------------------
+# Survivors branch
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivorsBranch:
+    def test_adj_p_column_present(self) -> None:
+        profiles = [
+            _profile(factor_id="a", primary_p=0.01, context={"universe_id": "lc"}),
+            _profile(factor_id="b", primary_p=0.02, context={"universe_id": "lc"}),
+        ]
+        survivors = Survivors(
+            profiles=profiles,
+            adj_p=np.array([0.008, 0.018], dtype=np.float64),
+            q=0.05,
+            expand_over=(),
+            n_total={(): 2},
+        )
+        df = compare(survivors, sort_by="adj_p")
+        assert df.columns[-1] == "adj_p"
+        assert df["adj_p"].to_list() == [0.008, 0.018]
+
+    def test_expand_over_dimension_via_context(self) -> None:
+        profiles = [
+            _profile(factor_id="a", primary_p=0.01, context={"universe_id": "lc"}),
+            _profile(factor_id="a", primary_p=0.02, context={"universe_id": "sc"}),
+        ]
+        survivors = Survivors(
+            profiles=profiles,
+            adj_p=np.array([0.011, 0.022], dtype=np.float64),
+            q=0.05,
+            expand_over=("universe_id",),
+            n_total={("lc",): 1, ("sc",): 1},
+        )
+        df = compare(survivors)
+        assert "universe_id" in df.columns
+        assert df["universe_id"].to_list() == ["lc", "sc"]
+
+    def test_empty_survivors_raises(self) -> None:
+        empty = Survivors(
+            profiles=[],
+            adj_p=np.zeros(0, dtype=np.float64),
+            q=0.05,
+            expand_over=(),
+            n_total={},
+        )
+        with pytest.raises(UserInputError) as exc:
+            compare(empty)
+        assert exc.value.field == "artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_empty_list_raises(self) -> None:
+        with pytest.raises(UserInputError):
+            compare([])
+
+    def test_mixed_types_raise(self) -> None:
+        with pytest.raises(UserInputError) as exc:
+            compare([_profile(factor_id="a"), _bundle(factor_id="b")])  # type: ignore[list-item]
+        assert "FactorProfile" in str(exc.value)
+        assert "MetricsBundle" in str(exc.value)
+
+    def test_unknown_artifact_type_raises(self) -> None:
+        with pytest.raises(UserInputError):
+            compare(["not an artifact"])  # type: ignore[list-item]
+
+    def test_sort_by_unknown_column_raises_with_suggestion(self) -> None:
+        profiles = [_profile(factor_id="a")]
+        with pytest.raises(UserInputError) as exc:
+            compare(profiles, sort_by="primary_pp")
+        assert exc.value.field == "sort_by"
+        assert "primary_p" in exc.value.suggestions
+
+    def test_returns_polars_dataframe(self) -> None:
+        df = compare([_profile(factor_id="a")])
+        assert isinstance(df, pl.DataFrame)


### PR DESCRIPTION
## Summary

- `compare(artifacts, *, sort_by=None) -> pl.DataFrame` — leaderboard renderer over `list[FactorProfile]` / `list[MetricsBundle]` / `Survivors`. Pure projection, no recompute.
- `Survivors.adj_p` is read straight through, so BHY survivor tables no longer require manual re-attach.
- Profile branch surfaces `primary_stat` / `primary_stat_name` / `primary_p` (three columns) — `primary_stat_name` disambiguates mixed-procedure lists (T_NW + WALD_NWCL + P_BOOT). Bundle branch flattens `MetricOutput.value` only; `n_obs` stays per-cell. `expand_over` dimensions surface through `profile.context[k]` like any other context column (no sidecar).
- Heterogeneous context follows `pl.concat(how="diagonal")` semantics (union of keys, first-seen order, null-fill).

## Test plan

- [x] `pytest tests/test_compare.py` — 14 tests covering all three branches, mixed-procedure schema, heterogeneous context union, mixed-type / empty / unknown-`sort_by` raises (with fuzzy suggestion)
- [x] Full suite: 1140 passed
- [x] `mypy factrix` clean
- [x] `mkdocs build --strict` clean

Closes #177