### PR TITLE
feat(stats): HACEstimator — cell-internal HAC inference swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,44 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ## [Unreleased]
 
+### Added
+
+- **`HACEstimator(Estimator)` sub-protocol + cell-internal estimator swap** (#163). `Estimator` (the #170 selection protocol) gains a runtime-checkable sub-protocol `HACEstimator` adding `min_periods: int` and `compute(series: np.ndarray, *, forward_periods: int) -> InferenceResult`. `NeweyWest` and `HansenHodrick` implement it; the slice-test instances (`WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`) stay on the selection-only base (their compute paths are multivariate). `AnalysisConfig` gains a fifth field `estimator: HACEstimator = NeweyWest()`, surfaced through the four factory methods as the new `estimator=` kwarg; `__post_init__` validates `estimator.applicable_to(scope, signal)` at construction time so `AnalysisConfig.common_continuous(estimator=HansenHodrick())` raises immediately rather than deep inside `evaluate`. `to_dict` / `from_dict` round-trip the estimator by name string via the new `factrix.stats.get_estimator(name)` registry helper; missing-`estimator` keys in legacy v0.11/v0.12 dicts fall back to `NeweyWest()`. `UnknownEstimatorError(ConfigError, ValueError)` lists every registered estimator on a name miss. IC PANEL / FM PANEL / CAAR PANEL procedures now route through `cfg.estimator.compute(...)` instead of hardcoded `_newey_west_t_test`; `profile.context["estimator"]` records the cfg-driven choice on every procedure for audit-time provenance (HLZ2016 spec-search defence — see "Why" below). Retires the v0.12.0 `ComputableEstimator` placeholder name from the #170 entry below: the design landed as the `HACEstimator` split (selection vs HAC-on-mean), not as a single computable extension; moment-condition estimators (GMM J-test, #191) and slope-axis HAC (TS β / TS Dummy) live on parallel sub-protocols when they land rather than overloading `HACEstimator.compute`.
+
+  ```python
+  # default — bit-equal v0.12 NW path
+  cfg = AnalysisConfig.individual_continuous(metric=Metric.IC)
+  profile = fx.evaluate(panel, cfg)
+  profile.primary_stat_name  # StatCode.T_NW
+  profile.context["estimator"]  # "NeweyWest"
+
+  # swap to Hansen-Hodrick at study scope
+  cfg = AnalysisConfig.individual_continuous(
+      metric=Metric.IC, estimator=HansenHodrick(),
+  )
+  profile = fx.evaluate(panel, cfg)
+  profile.primary_stat_name  # StatCode.T_HH
+  profile.primary_p == profile.stats[StatCode.P_HH]  # True
+  profile.context["estimator"]  # "HansenHodrick"
+  ```
+
+  **Why**: HLZ2016's spec-search defence is "don't pick an estimator after seeing results," not "always use a single estimator forever." v0.12 hardcoded NW + auto-side-emitted HH, which let downstream code cherry-pick whichever p was smaller. v0.13's design forces estimator choice to be cfg-scoped (study-level, not per-call) and stamps the choice in `profile.context` so audit-time review can see whether multiple estimators ran on the same study. Per-call `evaluate(panel, cfg, estimator=...)` is deliberately not opened — the cfg object is the spec-search lock. (Related follow-ups: `list_estimators(scope, signal)` cell-filter #255, third-party `register_estimator` #256, provenance asymmetry on slope-axis cells #257.)
+
 ### Changed
+
+- **`primary_p` / `primary_stat_name` semantic — cfg-driven, not hardcoded NW** (breaking, #163). On IC PANEL / FM PANEL / CAAR PANEL the canonical pair now reflects whichever `HACEstimator` was wired on `cfg.estimator`, not the hardcoded `(T_NW, P_NW)` v0.12 wrote unconditionally. With default `NeweyWest()` cfg the values are bit-equal to v0.12; with `HansenHodrick()` they shift to `(T_HH, P_HH)`. Downstream callers reading `profile.stats[StatCode.T_NW]` or `profile.stats[StatCode.P_NW]` directly will `KeyError` when a non-NW estimator was used — read `profile.primary_stat` / `profile.primary_stat_name` / `profile.primary_p` instead (these stay populated regardless of estimator) and consult `profile.context["estimator"]` for provenance. TS β / TS Dummy / common-panel procedures are unchanged because they run NW HAC on an OLS slope or an iid cross-asset t (neither fits the HAC-on-mean `compute(series, *, forward_periods)` contract); a slope-axis sub-protocol is tracked separately. `UNRELIABLE_SE_SHORT_PERIODS` is now emitted uniformly on `0 < n_periods < 30` across IC / FM / CAAR — previously only the FM procedure's procedure-side guard fired (4 ≤ n < 30), so a 25-period IC analysis silently lacked the short-sample tag; the estimator-side emission consolidates this and the FM-side guard is removed as redundant.
+
+  ```python
+  # before (v0.12.0) — stats[T_NW] always populated
+  profile = fx.evaluate(panel, cfg)
+  t = profile.stats[StatCode.T_NW]  # safe under any cfg
+
+  # after (v0.13.0) — read primary_stat to stay estimator-agnostic
+  profile = fx.evaluate(panel, cfg_with_hh)
+  t = profile.primary_stat                  # ← canonical pair, regardless of estimator
+  code = profile.primary_stat_name          # StatCode.T_HH under cfg_with_hh
+  who = profile.context["estimator"]        # "HansenHodrick" — provenance
+  ```
 
 - **`MetricOutput.n_obs` first-class field** (breaking, #248). Promoted from a metadata dict key to a first-class dataclass field — `n_obs: int | None = None` — so user / AI-agent consumers reach the metric primitive's sample size with `output.n_obs` instead of `output.metadata.get("n_obs")`. Builds on the `n_observed → n_obs` metadata rename from #246. `_short_circuit_output(name, reason, n_obs=n, ...)` callers (~38 sites) auto-route via kwarg-only signature change; direct `MetricOutput(...)` constructions in `factrix/metrics/spanning.py` and `factrix/metrics/fama_macbeth.py` are updated to pass `n_obs=` at the top level instead of nesting under `metadata={"n_obs": ...}`. `__repr__` now surfaces `n_obs=` between `value=` and `stat=` when populated. Same family name as `FactorProfile.n_obs` but scoped per metric primitive (single-stage estimator count) rather than per dispatched cell (final-stage test denominator).
 
@@ -74,6 +111,8 @@ While the version is below `1.0.0`, the public API should be considered unstable
   ```
 
 ### Removed
+
+- **Auto side-emission of `(T_HH, P_HH)` on default cfg** (breaking, #163). v0.12 IC PANEL / FM PANEL procedures populated `StatCode.P_HH` / `StatCode.T_HH` alongside `P_NW` / `T_NW` whenever `forward_periods > 1`, on every cfg, so callers could read either pair without re-running. Under the new dispatch (#163 Added entry above) only the `HACEstimator` wired on `cfg.estimator` populates its `(stat_name, p_name)` pair — default `NeweyWest()` cfg writes `(T_NW, P_NW)` only; `HansenHodrick()` cfg writes `(T_HH, P_HH)` only. Switch downstream code that hardcoded `profile.stats[StatCode.P_HH]` lookups to either (a) construct a separate `cfg_hh = AnalysisConfig.individual_continuous(metric=..., estimator=HansenHodrick())` and call `evaluate(panel, cfg_hh)` explicitly, or (b) read `profile.primary_p` + `profile.context["estimator"]` for the cfg-driven canonical pair. Family-verb selection — `bhy(profiles, estimator=HansenHodrick())` reading an already-populated `StatCode.P_HH` — still works against profiles produced under an HH cfg.
 
 - **`FactorProfile.verdict()` and `Verdict` enum** (breaking, #243). `verdict(*, threshold=0.05, gate=None)` was a `primary_p < threshold` wrapper. Removed because (a) for N candidate factors, iterating `profile.verdict()` and counting passes is the spec-search anti-pattern factrix explicitly avoids — multi-factor decisions belong to `multi_factor.bhy` survivors, not per-factor threshold gates; (b) the `Verdict` `PASS / FAIL` outcome ignored emitted `WarningCode` (e.g. `UNRELIABLE_SE_SHORT_PERIODS`), letting unreliable inference report `PASS`. The `Verdict` enum is removed alongside the method.
 

--- a/docs/api/estimator-alternatives.md
+++ b/docs/api/estimator-alternatives.md
@@ -1,0 +1,135 @@
+# Estimator alternatives
+
+How to swap the HAC inference path that drives `primary_p`, and why
+factrix's design keeps that swap study-scoped rather than per-call.
+
+## The choice
+
+For HAC-on-mean cells (IC PANEL, FM PANEL, CAAR PANEL) you can choose
+which HAC standard-error path computes `primary_p`:
+
+| Estimator | When to pick |
+|---|---|
+| `NeweyWest()` *(default)* | Bartlett kernel + NW1994 auto-bandwidth + Hansen-Hodrick overlap floor. Universally applicable; produces a positive-semidefinite variance estimate by construction. |
+| `HansenHodrick()` | Rectangular kernel matched to the MA(h-1) overlap structure forward returns induce. Closed-form variance under the textbook overlap assumption; no PSD guarantee on short / mildly anti-correlated samples (factrix clamps to 0 and emits `WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`). Applicable to `(INDIVIDUAL, CONTINUOUS)` cells only. |
+
+```python
+import factrix as fx
+from factrix.stats import HansenHodrick
+
+cfg = fx.AnalysisConfig.individual_continuous(
+    metric=fx.Metric.IC,
+    forward_periods=5,
+    estimator=HansenHodrick(),       # default NeweyWest()
+)
+profile = fx.evaluate(panel, cfg)
+
+profile.primary_stat_name             # StatCode.T_HH
+profile.primary_p                     # HH p-value, drives bhy / bonferroni / etc.
+profile.context["estimator"]          # "HansenHodrick" — audit trail
+```
+
+The estimator is part of the cfg, so it serializes with `to_dict()`
+and rehydrates via `AnalysisConfig.from_dict(...)`:
+
+```python
+cfg.to_dict()
+# {"scope": "individual", "signal": "continuous", "metric": "ic",
+#  "forward_periods": 5, "estimator": "HansenHodrick"}
+
+# Round-trip is exact; missing-key legacy dicts fall back to NeweyWest()
+restored = fx.AnalysisConfig.from_dict(cfg.to_dict())
+restored == cfg                       # True
+```
+
+## Why study-scoped, not per-call
+
+Harvey, Liu, Zhu (2016, "... and the Cross-Section of Expected
+Returns," RFS) is the canonical citation for cross-sectional
+specification-search bias: when researchers can swap inference methods
+freely after seeing results, p-values lose their guarantee. The
+straightforward defence is "always use one estimator forever," but
+that's stronger than what HLZ actually argue — they argue against
+**post-hoc** estimator picking, not against estimator plurality
+itself.
+
+factrix's design splits the difference:
+
+1. **`AnalysisConfig.estimator` is set once per study.** The factory
+   call sites are the only place to wire it; there is no
+   `evaluate(panel, cfg, estimator=...)` per-call kwarg by design.
+2. **Provenance lands in `profile.context["estimator"]`.** Audit-time
+   review can see which estimator drove each profile; running the
+   same factor under both NW and HH produces two profiles whose
+   `context` makes the difference visible (and downstream tools that
+   detect "same identity, different context" can flag the A/B path).
+3. **BHY family-verb FDR doesn't fan out on estimator.** Same
+   hypothesis under a different estimator is not a new hypothesis —
+   `bhy([nw_profile, hh_profile])` with the same `factor_id` raises
+   on duplicate identity rather than silently widening the family.
+
+The defence is "the choice is recorded and visible" rather than "the
+choice is locked." Pre-registered single-factor studies can ship one
+estimator; methodology papers comparing estimators ship multiple cfgs
+under different `factor_id`s.
+
+## What changes when you swap
+
+The shape of `profile.stats` changes — only the chosen estimator's
+`(stat_name, p_name)` pair populates the inference layer:
+
+```python
+# default cfg — NW path
+profile = fx.evaluate(panel, fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC))
+sorted(profile.stats)         # [MEAN, P_NW, T_NW]
+
+# HH cfg
+profile = fx.evaluate(
+    panel,
+    fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, estimator=HansenHodrick()),
+)
+sorted(profile.stats)         # [MEAN, P_HH, T_HH]
+```
+
+This is a v0.13 BREAKING change from v0.12, which auto-side-emitted
+both pairs on every IC / FM PANEL evaluate. Downstream code should
+read `profile.primary_p` / `profile.primary_stat_name` (canonical,
+estimator-agnostic) rather than hardcoded `stats[StatCode.T_NW]` /
+`stats[StatCode.P_HH]` lookups; see the CHANGELOG entry for the full
+migration note.
+
+## Inapplicable estimators raise early
+
+The applicability gate runs at `AnalysisConfig` construction, not at
+`evaluate`. Mis-matched cells fail loud:
+
+```python
+fx.AnalysisConfig.common_continuous(estimator=HansenHodrick())
+# IncompatibleAxisError: estimator='HansenHodrick' not applicable to
+# (scope=common, signal=continuous). Applicable HAC estimators: NeweyWest
+```
+
+To inspect what's available for a given cell:
+
+```python
+fx.list_estimators(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS)
+# ['BlockBootstrap', 'HansenHodrick', 'NeweyWest', 'WaldNWCluster', 'WaldTwoWayCluster']
+```
+
+`list_estimators` returns every registered `Estimator` (selection-axis
+and HAC-axis); the construction gate further narrows to `HACEstimator`
+instances applicable to the cell.
+
+## When not in scope
+
+- **Per-factor estimator swap.** Permanently not opened — single-cfg
+  decision frequency is the spec-search lock.
+- **Slope-axis HAC (TS β, TS Dummy).** Single-asset OLS regressions
+  with NW HAC SE on the slope run a different math shape (`(y, x)
+  → β, SE(β)`) than the series-mean `compute(series, *,
+  forward_periods)` contract. A slope-axis sub-protocol is tracked
+  for a future release.
+- **Moment-condition estimators (GMM J-test).** GMM consumes
+  multi-dimensional moment conditions; the parallel
+  `MomentEstimator(Estimator)` sub-protocol lands with
+  [#191](https://github.com/awwesomeman/factrix/issues/191).

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -12,17 +12,20 @@ package; nothing under `_stats` is part of the public API.
 
 ## Estimator catalogue
 
-`Estimator` is a [selection-only `Protocol`](#estimator-protocol) —
-each instance names *which inference path* downstream code should
-read from `FactorProfile.stats`, not how to compute it. Default-
-constructed instances live in `factrix.stats._ESTIMATOR_REGISTRY`
-and surface through `list_estimators(scope, signal)` (top-level
-factrix export).
+`Estimator` is the base [`Protocol`](#estimator-protocol) — each
+instance names *which inference path* downstream code reads from
+`FactorProfile.stats`. `HACEstimator(Estimator)` is the sub-protocol
+adding cell-internal `compute(series, *, forward_periods) ->
+InferenceResult` for HAC-on-mean estimators; pass instances to
+`AnalysisConfig.estimator=` for evaluate-time inference dispatch.
+Default-constructed instances live in
+`factrix.stats._ESTIMATOR_REGISTRY` and surface through
+`list_estimators(scope, signal)` (top-level factrix export).
 
-| Class | Algorithm family | Emits | Applicable to | Use when |
-|---|---|---|---|---|
-| `NeweyWest` | NW Bartlett HAC | `(T_NW, P_NW)` | every cell | Default — drives `primary_p` on every PANEL / TIMESERIES procedure. |
-| `HansenHodrick` | HH rectangular HAC | `(T_HH, P_HH)` | `(INDIVIDUAL, CONTINUOUS)` only | Overlapping forward returns on IC PANEL / FM PANEL — the MA(h-1) overlap structure has a closed-form rectangular-kernel SE. |
+| Class | Protocol | Algorithm family | Emits | Applicable to | Use when |
+|---|---|---|---|---|---|
+| `NeweyWest` | `HACEstimator` | NW Bartlett HAC | `(T_NW, P_NW)` | every cell | Default — drives `primary_p` on every PANEL / TIMESERIES procedure. |
+| `HansenHodrick` | `HACEstimator` | HH rectangular HAC | `(T_HH, P_HH)` | `(INDIVIDUAL, CONTINUOUS)` only | Overlapping forward returns on IC PANEL / FM PANEL — the MA(h-1) overlap structure has a closed-form rectangular-kernel SE. Pass via `AnalysisConfig.individual_continuous(estimator=HansenHodrick())` to drive `primary_p` from the HH path instead of NW. |
 | `WaldNWCluster` | Cluster-Wald χ² (NW HAC + 1-way cluster on slice) | `(WALD_NWCL, P_WALD_NWCL)` | `(INDIVIDUAL, CONTINUOUS)` | Slice test on a stacked per-date metric panel (#176 verbs). |
 | `WaldTwoWayCluster` | Cluster-Wald χ² (Cameron-Gelbach-Miller two-way cluster on (date, asset)) | `(WALD_TWOWAY, P_WALD_TWOWAY)` | `(INDIVIDUAL, CONTINUOUS)` | Reserved interface — raw asset-date panel path. No verb consumes it until `factor_decomposition` lands later. |
 | `BlockBootstrap` | Politis-Romano stationary or Künsch fixed block bootstrap; Politis-White auto block length | `(P_BOOT,)` | `(INDIVIDUAL, CONTINUOUS)` | Paired-diff slice test when distributional assumptions of the cluster-Wald path are uncomfortable (heavy tails, persistent shocks). |
@@ -124,6 +127,11 @@ Romano-Wolf for date-shared slices.
 
 ## Estimator protocol
 
+Two-layer protocol: base `Estimator` for family-verb selection
+(`bhy(profiles, estimator=...)`); `HACEstimator(Estimator)` for
+evaluate-time cell-internal dispatch
+(`AnalysisConfig.estimator=`).
+
 ```python
 @runtime_checkable
 class Estimator(Protocol):
@@ -138,8 +146,49 @@ class Estimator(Protocol):
         signal: Signal,
         metric: Metric | None,
     ) -> StatCode: ...
+
+
+@runtime_checkable
+class HACEstimator(Estimator, Protocol):
+    @property
+    def min_periods(self) -> int: ...
+    def compute(
+        self,
+        series: np.ndarray,
+        *,
+        forward_periods: int,
+    ) -> InferenceResult: ...
 ```
 
-Selection-only by design: cell-internal `compute()` lives on a
-future `ComputableEstimator(Estimator)` sub-protocol so the
-common-case Estimator instance stays trivial to write.
+`NeweyWest` and `HansenHodrick` implement `HACEstimator`; the slice-
+test instances (`WaldNWCluster` / `WaldTwoWayCluster` /
+`BlockBootstrap`) implement only the selection base since their
+compute paths are multivariate (cross-asset / cross-slice) rather
+than HAC-on-mean. Moment-condition estimators (GMM J-test,
+[#191](https://github.com/awwesomeman/factrix/issues/191)) and a
+slope-axis HAC sub-protocol are tracked separately rather than
+overloading `HACEstimator.compute`.
+
+### `InferenceResult`
+
+`HACEstimator.compute` returns a frozen dataclass carrying the
+inference layer of a `FactorProfile` (procedure stitches descriptive
+stats like `MEAN` on top):
+
+```python
+@dataclass(frozen=True, slots=True)
+class InferenceResult:
+    stat: float                          # t-statistic
+    p: float                             # two-sided p-value
+    stat_name: StatCode                  # T_NW / T_HH / ...
+    p_name: StatCode                     # P_NW / P_HH / ...
+    metadata: Mapping[str, Any]          # {"nw_lags": k} / {"kernel": ..., "variance_clamped": bool}
+    warnings: frozenset[WarningCode]
+```
+
+### `get_estimator(name) -> Estimator`
+
+Registry lookup helper used by `AnalysisConfig.from_dict` to
+rehydrate `cfg.estimator` from its serialized name string. Raises
+`UnknownEstimatorError` if `name` is not registered; the error
+message lists every available estimator.

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -64,6 +64,7 @@ from factrix._errors import (
     MissingConfigError,
     ModeAxisError,
     RunMetricsError,
+    UnknownEstimatorError,
     UserInputError,
 )
 from factrix._evaluate import _evaluate as _evaluate
@@ -158,6 +159,7 @@ __all__ = [
     "MissingConfigError",
     "ModeAxisError",
     "RunMetricsError",
+    "UnknownEstimatorError",
     "UserInputError",
     # Profile + dispatch
     "FactorProfile",

--- a/factrix/_analysis_config.py
+++ b/factrix/_analysis_config.py
@@ -53,23 +53,26 @@ def _validate_estimator_compat(
     """
     if not isinstance(estimator, HACEstimator):
         raise IncompatibleAxisError(
-            f"estimator={type(estimator).__name__!r} does not implement "
-            "HACEstimator (missing compute / min_periods). "
-            "AnalysisConfig.estimator must be a HACEstimator; use "
-            "list_estimators(scope, signal) to inspect applicable instances."
+            f"estimator={type(estimator).__name__!r} is not an HAC estimator "
+            "(it does not provide a HAC-SE compute path on a 1-D series). "
+            "AnalysisConfig.estimator drives cell-internal inference; use "
+            "list_estimators(scope, signal) to see HAC estimators applicable "
+            "to this cell."
         )
     if not estimator.applicable_to(scope, signal):
         from factrix.stats import _ESTIMATOR_REGISTRY
 
-        applicable = sorted(
-            e.name
-            for e in _ESTIMATOR_REGISTRY
-            if isinstance(e, HACEstimator) and e.applicable_to(scope, signal)
+        applicable = ", ".join(
+            sorted(
+                e.name
+                for e in _ESTIMATOR_REGISTRY
+                if isinstance(e, HACEstimator) and e.applicable_to(scope, signal)
+            )
         )
         raise IncompatibleAxisError(
             f"estimator={estimator.name!r} not applicable to "
             f"(scope={scope.value}, signal={signal.value}). "
-            f"Applicable HACEstimators: {applicable}"
+            f"Applicable HAC estimators: {applicable}"
         )
 
 

--- a/factrix/_analysis_config.py
+++ b/factrix/_analysis_config.py
@@ -8,12 +8,13 @@ validation, reachable from every path that produces an ``AnalysisConfig``.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Self
 
 from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._errors import IncompatibleAxisError
 from factrix._registry import matches_user_axis
+from factrix.stats import HACEstimator, NeweyWest
 
 # Nearest-legal cell suggested when an evaluate-time mode/sample check
 # fails (§4.5 A4). Keyed by ``(scope, signal, mode)``; values are
@@ -37,6 +38,39 @@ _FALLBACK_MAP: dict[
         Mode.TIMESERIES,
     ): lambda: AnalysisConfig.common_continuous(),
 }
+
+
+def _validate_estimator_compat(
+    estimator: HACEstimator,
+    scope: FactorScope,
+    signal: Signal,
+) -> None:
+    """Raise ``IncompatibleAxisError`` if ``estimator`` is not a
+    ``HACEstimator`` applicable to the ``(scope, signal)`` cell (#163).
+
+    Runs after axis compatibility — the axis tuple is already legal
+    when this is called.
+    """
+    if not isinstance(estimator, HACEstimator):
+        raise IncompatibleAxisError(
+            f"estimator={type(estimator).__name__!r} does not implement "
+            "HACEstimator (missing compute / min_periods). "
+            "AnalysisConfig.estimator must be a HACEstimator; use "
+            "list_estimators(scope, signal) to inspect applicable instances."
+        )
+    if not estimator.applicable_to(scope, signal):
+        from factrix.stats import _ESTIMATOR_REGISTRY
+
+        applicable = sorted(
+            e.name
+            for e in _ESTIMATOR_REGISTRY
+            if isinstance(e, HACEstimator) and e.applicable_to(scope, signal)
+        )
+        raise IncompatibleAxisError(
+            f"estimator={estimator.name!r} not applicable to "
+            f"(scope={scope.value}, signal={signal.value}). "
+            f"Applicable HACEstimators: {applicable}"
+        )
 
 
 def _validate_axis_compat(
@@ -98,9 +132,11 @@ class AnalysisConfig:
     signal: Signal
     metric: Metric | None
     forward_periods: int = 5
+    estimator: HACEstimator = field(default_factory=NeweyWest)
 
     def __post_init__(self) -> None:
         _validate_axis_compat(self.scope, self.signal, self.metric)
+        _validate_estimator_compat(self.estimator, self.scope, self.signal)
 
     @classmethod
     def individual_continuous(
@@ -108,6 +144,7 @@ class AnalysisConfig:
         *,
         metric: Metric = Metric.IC,
         forward_periods: int = 5,
+        estimator: HACEstimator | None = None,
     ) -> Self:
         """Per-(date, asset) continuous factor.
 
@@ -116,6 +153,9 @@ class AnalysisConfig:
                 unit-of-exposure premium (Fama-MacBeth λ).
             forward_periods: Forward-return horizon (rows of the time
                 axis).
+            estimator: ``HACEstimator`` driving evaluate-time inference;
+                ``None`` defaults to ``NeweyWest()``. Pass
+                ``HansenHodrick()`` to swap the rectangular-kernel path.
 
         Returns:
             A validated ``AnalysisConfig`` for the
@@ -126,10 +166,16 @@ class AnalysisConfig:
             Signal.CONTINUOUS,
             metric,
             forward_periods=forward_periods,
+            estimator=estimator if estimator is not None else NeweyWest(),
         )
 
     @classmethod
-    def individual_sparse(cls, *, forward_periods: int = 5) -> Self:
+    def individual_sparse(
+        cls,
+        *,
+        forward_periods: int = 5,
+        estimator: HACEstimator | None = None,
+    ) -> Self:
         """Per-(date, asset) sparse trigger (``{-1, 0, +1}``).
 
         PANEL canonical procedure is the CAAR cross-event t-test;
@@ -139,6 +185,8 @@ class AnalysisConfig:
         Args:
             forward_periods: Forward-return horizon (rows of the time
                 axis).
+            estimator: ``HACEstimator`` driving evaluate-time inference;
+                ``None`` defaults to ``NeweyWest()``.
 
         Returns:
             A validated ``AnalysisConfig`` for the
@@ -149,10 +197,16 @@ class AnalysisConfig:
             Signal.SPARSE,
             None,
             forward_periods=forward_periods,
+            estimator=estimator if estimator is not None else NeweyWest(),
         )
 
     @classmethod
-    def common_continuous(cls, *, forward_periods: int = 5) -> Self:
+    def common_continuous(
+        cls,
+        *,
+        forward_periods: int = 5,
+        estimator: HACEstimator | None = None,
+    ) -> Self:
         """Broadcast continuous factor (e.g. VIX).
 
         Canonical procedure is the per-asset β estimate followed by a
@@ -161,6 +215,8 @@ class AnalysisConfig:
         Args:
             forward_periods: Forward-return horizon (rows of the time
                 axis).
+            estimator: ``HACEstimator`` driving evaluate-time inference;
+                ``None`` defaults to ``NeweyWest()``.
 
         Returns:
             A validated ``AnalysisConfig`` for the
@@ -171,10 +227,16 @@ class AnalysisConfig:
             Signal.CONTINUOUS,
             None,
             forward_periods=forward_periods,
+            estimator=estimator if estimator is not None else NeweyWest(),
         )
 
     @classmethod
-    def common_sparse(cls, *, forward_periods: int = 5) -> Self:
+    def common_sparse(
+        cls,
+        *,
+        forward_periods: int = 5,
+        estimator: HACEstimator | None = None,
+    ) -> Self:
         """Broadcast sparse trigger (FOMC, policy, index rebalance).
 
         PANEL canonical: per-asset β on dummy + cross-asset t-test.
@@ -183,6 +245,8 @@ class AnalysisConfig:
         Args:
             forward_periods: Forward-return horizon (rows of the time
                 axis).
+            estimator: ``HACEstimator`` driving evaluate-time inference;
+                ``None`` defaults to ``NeweyWest()``.
 
         Returns:
             A validated ``AnalysisConfig`` for the
@@ -193,6 +257,7 @@ class AnalysisConfig:
             Signal.SPARSE,
             None,
             forward_periods=forward_periods,
+            estimator=estimator if estimator is not None else NeweyWest(),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -207,6 +272,7 @@ class AnalysisConfig:
             "signal": self.signal.value,
             "metric": self.metric.value if self.metric is not None else None,
             "forward_periods": self.forward_periods,
+            "estimator": self.estimator.name,
         }
 
     @classmethod
@@ -216,6 +282,10 @@ class AnalysisConfig:
         Goes through ``__post_init__``, so an invalid triple raises
         ``IncompatibleAxisError`` instead of silently constructing.
 
+        ``estimator`` is rehydrated via ``factrix.stats.get_estimator``
+        registry lookup; missing key falls back to the ``NeweyWest()``
+        default for forward compatibility with v0.11 serialized configs.
+
         Args:
             d: Mapping in the shape produced by ``to_dict``.
 
@@ -224,12 +294,22 @@ class AnalysisConfig:
 
         Raises:
             IncompatibleAxisError: If the ``(scope, signal, metric)``
-                triple is not a legal cell.
+                triple is not a legal cell, or if the estimator is not
+                applicable to the cell.
+            UnknownEstimatorError: If ``d["estimator"]`` is not a name
+                in ``factrix.stats._ESTIMATOR_REGISTRY``.
         """
+        from factrix.stats import get_estimator
+
         m = d.get("metric")
+        est_name = d.get("estimator")
+        # ``get_estimator`` returns base ``Estimator``; ``__post_init__``
+        # narrows to ``HACEstimator`` with the canonical error path.
+        estimator = NeweyWest() if est_name is None else get_estimator(est_name)
         return cls(
             scope=FactorScope(d["scope"]),
             signal=Signal(d["signal"]),
             metric=Metric(m) if m is not None else None,
             forward_periods=d.get("forward_periods", 5),
+            estimator=estimator,  # type: ignore[arg-type]
         )

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -134,6 +134,16 @@ class MissingConfigError(ConfigError):
     """
 
 
+class UnknownEstimatorError(ConfigError, ValueError):
+    """``get_estimator(name)`` lookup miss (#163).
+
+    Inherits ``ValueError`` so ``pytest.raises(ValueError)`` and the
+    ecosystem ``UserInputError`` convention both catch it. Raised by
+    ``factrix.stats.get_estimator`` and by ``AnalysisConfig.from_dict``
+    when ``estimator`` name is not in the registry.
+    """
+
+
 class IncompatibleAxisError(ConfigError):
     """``(scope, signal, metric)`` tuple is not a legal analysis cell.
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -166,7 +166,9 @@ class _ICContPanelProcedure:
             StatCode.MEAN,
             StatCode.T_NW,
             StatCode.P_NW,
-            # (T_HH, P_HH) pair, conditionally emitted when forward_periods > 1.
+            # (T_HH, P_HH) pair, emitted when cfg.estimator=HansenHodrick().
+            # NW vs HH are mutually exclusive — only the chosen estimator's
+            # (T, P) pair populates stats for a given evaluate() call.
             StatCode.T_HH,
             StatCode.P_HH,
         }
@@ -228,7 +230,9 @@ class _FMContPanelProcedure:
             StatCode.MEAN,
             StatCode.T_NW,
             StatCode.P_NW,
-            # (T_HH, P_HH) pair, conditionally emitted when forward_periods > 1.
+            # (T_HH, P_HH) pair, emitted when cfg.estimator=HansenHodrick().
+            # NW vs HH are mutually exclusive — only the chosen estimator's
+            # (T, P) pair populates stats for a given evaluate() call.
             StatCode.T_HH,
             StatCode.P_HH,
         }

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import StatCode
 from factrix._registry import _SCOPE_COLLAPSED, _DispatchKey, register
+from factrix.stats import InferenceResult
 
 # ---------------------------------------------------------------------------
 # Metadata helpers (#188)
@@ -59,10 +60,14 @@ def _panel_envelope(
 
 
 def _nw_metadata(nw_lags: int) -> dict[StatCode, Mapping[str, Any]]:
-    """NW HAC bandwidth → ``T_NW`` + ``P`` (shared single bandwidth choice).
+    """NW HAC bandwidth → ``T_NW`` + ``P_NW`` for procedures that bypass
+    ``HACEstimator.compute`` (regression-slope NW: TS β / TS dummy).
 
-    Returns a fresh inner dict per StatCode so downstream code that
-    mutates one entry does not silently bleed into the other.
+    These cells run NW HAC on an OLS slope rather than a series mean,
+    which doesn't fit the ``HACEstimator.compute(series, *,
+    forward_periods)`` contract. Inference dispatch awaits a future
+    slope-shaped sub-protocol; until then, the procedure keeps its
+    own metadata stitch.
     """
     return {
         StatCode.T_NW: {"nw_lags": nw_lags},
@@ -88,57 +93,26 @@ def _hhi_metadata(n_bins: int) -> dict[StatCode, Mapping[str, Any]]:
     return {StatCode.EVENT_HHI_VALUE: {"n_bins": n_bins}}
 
 
-def _hh_metadata(clamped: bool) -> dict[StatCode, Mapping[str, Any]]:
-    """HH-pure rectangular-kernel HAC → ``T_HH`` / ``P_HH`` reproducibility record.
+def _hac_inference(
+    cfg: AnalysisConfig,
+    series: Any,
+) -> tuple[InferenceResult, dict[StatCode, float], dict[StatCode, Mapping[str, Any]]]:
+    """Dispatch ``cfg.estimator.compute`` and stitch the inference layer.
 
-    ``variance_clamped=True`` mirrors the ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``
-    flag (γ₀ + 2 Σγⱼ < 0 → SE clamped to 0 → t_HH = 0, p_HH = 1.0). The
-    lag count ``h - 1`` is derivable from ``profile.config.forward_periods``
-    so it is not duplicated here. An equivalent (but independent) record
-    is stored under both ``T_HH`` and ``P_HH`` so downstream mutation of
-    one entry does not silently bleed into the other — same contract
-    ``_nw_metadata`` carries for the ``(T_NW, P)`` pair.
+    Returns ``(result, stats, metadata)`` keyed by the StatCode the
+    estimator emits. Descriptive stats (e.g. ``MEAN``) and procedure-
+    side warnings live on the caller side — the helper only stitches
+    the t / p / metadata pair. Inner metadata dicts are fresh per
+    StatCode so downstream mutation of one entry does not bleed into
+    the other (mirrors the v0.5 ``_nw_metadata`` contract).
     """
-    return {
-        StatCode.T_HH: {"kernel": "rectangular", "variance_clamped": clamped},
-        StatCode.P_HH: {"kernel": "rectangular", "variance_clamped": clamped},
+    result = cfg.estimator.compute(series, forward_periods=cfg.forward_periods)
+    stats = {result.stat_name: result.stat, result.p_name: result.p}
+    metadata = {
+        result.stat_name: dict(result.metadata),
+        result.p_name: dict(result.metadata),
     }
-
-
-def _emit_hh_p(
-    values: Any,
-    *,
-    forward_periods: int,
-    stats: dict[StatCode, float],
-    metadata: dict[StatCode, Mapping[str, Any]],
-    warnings: frozenset[WarningCode],
-) -> frozenset[WarningCode]:
-    """Compute and stitch the HH t-test result into a procedure's outputs.
-
-    No-op when ``forward_periods <= 1`` (no overlap → HH collapses to
-    iid SE; ``HansenHodrick`` lands on the missing-stat error). Otherwise
-    populates ``stats[P_HH]``, merges ``_hh_metadata``, and folds in
-    ``RECT_KERNEL_NEGATIVE_VARIANCE`` when the rectangular-kernel sum
-    came out negative. The series is consumed as-is (post-null-drop):
-    same compromise NW makes — strictly the MA(h-1) structure assumes
-    1-calendar-unit spacing, but null IC / FM dates are rare zero-variance
-    cases and re-densifying would distort the mean.
-    """
-    from factrix._codes import WarningCode
-    from factrix._stats import _hansen_hodrick_t_test
-
-    if forward_periods <= 1:
-        return warnings
-
-    t_hh, p_hh, _, hh_clamped = _hansen_hodrick_t_test(
-        values, forward_periods=forward_periods
-    )
-    stats[StatCode.T_HH] = t_hh
-    stats[StatCode.P_HH] = p_hh
-    metadata.update(_hh_metadata(hh_clamped))
-    if hh_clamped:
-        warnings |= frozenset({WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE})
-    return warnings
+    return result, stats, metadata
 
 
 if TYPE_CHECKING:
@@ -205,10 +179,8 @@ class _ICContPanelProcedure:
     ) -> FactorProfile:
         import numpy as np
 
-        from factrix._codes import StatCode, WarningCode
+        from factrix._codes import StatCode
         from factrix._profile import FactorProfile
-        from factrix._stats import _newey_west_t_test, _resolve_nw_lags
-        from factrix._stats.constants import auto_bartlett
         from factrix.metrics.ic import compute_ic
 
         # ``compute_ic`` filters by MIN_ASSETS_PER_DATE_IC but does not drop nulls;
@@ -217,48 +189,25 @@ class _ICContPanelProcedure:
         ic_values = compute_ic(raw)["ic"].drop_nulls().to_numpy()
         n_periods = len(ic_values)
         n_pairs, n_periods_raw, n_assets = _panel_envelope(raw)
-        # Plan §5.2 picks NW1994 auto_bartlett as the default lag, but
-        # h-period forward returns force MA(h-1) structure on the IC
-        # series so we floor at ``forward_periods - 1`` (Hansen-Hodrick
-        # 1980) to keep the HAC SE consistent. ``_resolve_nw_lags``
-        # applies that floor and the ``min(., n_periods-1)`` clip in one place.
-        nw_lags = (
-            _resolve_nw_lags(
-                n_periods, auto_bartlett(n_periods), config.forward_periods
-            )
-            if n_periods >= 2
-            else 0
-        )
         ic_mean = float(np.mean(ic_values)) if n_periods > 0 else 0.0
-        t_stat, p_value, _ = _newey_west_t_test(ic_values, lags=nw_lags)
 
-        stats: dict[StatCode, float] = {
-            StatCode.MEAN: ic_mean,
-            StatCode.T_NW: t_stat,
-            StatCode.P_NW: p_value,
-        }
-        metadata = _nw_metadata(nw_lags)
-        warnings = _emit_hh_p(
-            ic_values,
-            forward_periods=config.forward_periods,
-            stats=stats,
-            metadata=metadata,
-            warnings=frozenset[WarningCode](),
-        )
+        result, stats, metadata = _hac_inference(config, ic_values)
+        stats[StatCode.MEAN] = ic_mean
 
         return FactorProfile(
             config=config,
             mode=Mode.PANEL,
-            primary_p=p_value,
-            primary_stat=t_stat,
-            primary_stat_name=StatCode.T_NW,
+            primary_p=result.p,
+            primary_stat=result.stat,
+            primary_stat_name=result.stat_name,
             n_obs=n_periods,
             n_pairs=n_pairs,
             n_periods=n_periods_raw,
             n_assets=n_assets,
-            warnings=warnings,
+            warnings=result.warnings,
             stats=stats,
             metadata=metadata,
+            context={"estimator": config.estimator.name},
         )
 
 
@@ -292,62 +241,32 @@ class _FMContPanelProcedure:
     ) -> FactorProfile:
         import numpy as np
 
-        from factrix._codes import StatCode, WarningCode
+        from factrix._codes import StatCode
         from factrix._profile import FactorProfile
-        from factrix._stats import _newey_west_t_test, _resolve_nw_lags
-        from factrix._stats.constants import auto_bartlett
-        from factrix.metrics.fama_macbeth import (
-            MIN_FM_PERIODS_HARD,
-            MIN_FM_PERIODS_WARN,
-            compute_fm_betas,
-        )
+        from factrix.metrics.fama_macbeth import compute_fm_betas
 
         beta_values = compute_fm_betas(raw)["beta"].drop_nulls().to_numpy()
         n_periods = len(beta_values)
         n_pairs, n_periods_raw, n_assets = _panel_envelope(raw)
-        nw_lags = (
-            _resolve_nw_lags(
-                n_periods, auto_bartlett(n_periods), config.forward_periods
-            )
-            if n_periods >= 2
-            else 0
-        )
         lambda_mean = float(np.mean(beta_values)) if n_periods > 0 else 0.0
-        t_stat, p_value, _ = _newey_west_t_test(beta_values, lags=nw_lags)
 
-        warning_codes: frozenset[WarningCode] = (
-            frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS})
-            if MIN_FM_PERIODS_HARD <= n_periods < MIN_FM_PERIODS_WARN
-            else frozenset()
-        )
-
-        stats: dict[StatCode, float] = {
-            StatCode.MEAN: lambda_mean,
-            StatCode.T_NW: t_stat,
-            StatCode.P_NW: p_value,
-        }
-        metadata = _nw_metadata(nw_lags)
-        warning_codes = _emit_hh_p(
-            beta_values,
-            forward_periods=config.forward_periods,
-            stats=stats,
-            metadata=metadata,
-            warnings=warning_codes,
-        )
+        result, stats, metadata = _hac_inference(config, beta_values)
+        stats[StatCode.MEAN] = lambda_mean
 
         return FactorProfile(
             config=config,
             mode=Mode.PANEL,
-            primary_p=p_value,
-            primary_stat=t_stat,
-            primary_stat_name=StatCode.T_NW,
+            primary_p=result.p,
+            primary_stat=result.stat,
+            primary_stat_name=result.stat_name,
             n_obs=n_periods,
             n_pairs=n_pairs,
             n_periods=n_periods_raw,
             n_assets=n_assets,
-            warnings=warning_codes,
+            warnings=result.warnings,
             stats=stats,
             metadata=metadata,
+            context={"estimator": config.estimator.name},
         )
 
 
@@ -397,8 +316,6 @@ class _CAARSparsePanelProcedure:
 
         from factrix._codes import StatCode, WarningCode
         from factrix._profile import FactorProfile
-        from factrix._stats import _newey_west_t_test, _resolve_nw_lags
-        from factrix._stats.constants import auto_bartlett
         from factrix._types import MIN_EVENTS_HARD, MIN_EVENTS_WARN
         from factrix.metrics._helpers import _is_sparse_magnitude_weighted
         from factrix.metrics.caar import compute_caar
@@ -427,34 +344,24 @@ class _CAARSparsePanelProcedure:
             if event_caar.height > 0
             else 0.0
         )
-        nw_lags = (
-            _resolve_nw_lags(
-                n_periods,
-                auto_bartlett(n_periods),
-                config.forward_periods,
-            )
-            if n_periods >= 2
-            else 0
-        )
-        t_stat, p_value, _ = _newey_west_t_test(caar_dense, lags=nw_lags)
+
+        result, stats, metadata = _hac_inference(config, caar_dense)
+        stats[StatCode.MEAN] = event_mean
 
         return FactorProfile(
             config=config,
             mode=Mode.PANEL,
-            primary_p=p_value,
-            primary_stat=t_stat,
-            primary_stat_name=StatCode.T_NW,
+            primary_p=result.p,
+            primary_stat=result.stat,
+            primary_stat_name=result.stat_name,
             n_obs=n_periods,
             n_pairs=n_pairs,
             n_periods=n_periods_raw,
             n_assets=n_assets,
-            warnings=frozenset(warning_codes),
-            stats={
-                StatCode.MEAN: event_mean,
-                StatCode.T_NW: t_stat,
-                StatCode.P_NW: p_value,
-            },
-            metadata=_nw_metadata(nw_lags),
+            warnings=frozenset(warning_codes) | result.warnings,
+            stats=stats,
+            metadata=metadata,
+            context={"estimator": config.estimator.name},
         )
 
 
@@ -657,6 +564,7 @@ def _compute_common_panel(
         warnings=frozenset(warnings),
         stats=stats,
         metadata=metadata,
+        context={"estimator": config.estimator.name},
     )
 
 
@@ -756,6 +664,7 @@ class _TSBetaContTimeseriesProcedure:
                 StatCode.FACTOR_ADF_P: adf_p,
             },
             metadata=_nw_metadata(nw_lags) | _adf_metadata(),
+            context={"estimator": config.estimator.name},
         )
 
 
@@ -871,6 +780,7 @@ class _TSDummySparseTimeseriesProcedure:
                 | _ljung_box_metadata(ljung_box_h)
                 | _hhi_metadata(_HHI_N_BINS)
             ),
+            context={"estimator": config.estimator.name},
         )
 
 

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -108,7 +108,7 @@ def _hac_inference(
     """
     result = cfg.estimator.compute(series, forward_periods=cfg.forward_periods)
     stats = {result.stat_name: result.stat, result.p_name: result.p}
-    metadata = {
+    metadata: dict[StatCode, Mapping[str, Any]] = {
         result.stat_name: dict(result.metadata),
         result.p_name: dict(result.metadata),
     }

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -158,20 +158,37 @@ gate. **All factory parameters are keyword-only.**
 
 ```
 AnalysisConfig.individual_continuous(*, metric: Metric = Metric.IC,
-                                     forward_periods: int = 5) -> AnalysisConfig
-AnalysisConfig.individual_sparse(*, forward_periods: int = 5) -> AnalysisConfig
+                                     forward_periods: int = 5,
+                                     estimator: HACEstimator | None = None) -> AnalysisConfig
+AnalysisConfig.individual_sparse(*, forward_periods: int = 5,
+                                     estimator: HACEstimator | None = None) -> AnalysisConfig
                                      # CAAR event study
-AnalysisConfig.common_continuous(*, forward_periods: int = 5) -> AnalysisConfig
+AnalysisConfig.common_continuous(*, forward_periods: int = 5,
+                                     estimator: HACEstimator | None = None) -> AnalysisConfig
                                      # timeseries beta on broadcast factor
-AnalysisConfig.common_sparse(*, forward_periods: int = 5) -> AnalysisConfig
+AnalysisConfig.common_sparse(*, forward_periods: int = 5,
+                                     estimator: HACEstimator | None = None) -> AnalysisConfig
                                      # CAAR on broadcast event flag
 ```
 
-Serialisation: `cfg.to_dict()` → `dict`; `AnalysisConfig.from_dict(d)` →
-`AnalysisConfig` (re-runs validation).
+Serialisation: `cfg.to_dict()` → `dict` (carries `estimator` as name
+string); `AnalysisConfig.from_dict(d)` → `AnalysisConfig` (re-runs
+validation; missing `estimator` key falls back to `NeweyWest()` for
+forward-compat with v0.11 dicts).
 
 `forward_periods` counts **rows** of the time axis, not calendar days. Daily
 panel + `forward_periods=5` = 5 trading days; weekly = 5 weeks.
+
+`estimator` selects the HAC-on-mean inference path for IC PANEL / FM
+PANEL / CAAR PANEL cells; default `NeweyWest()`. Pass
+`HansenHodrick()` to drive `primary_p` from the rectangular-kernel
+HH path on overlapping forward returns. **BREAKING (#163)**: v0.11
+auto-side-emitted `P_HH` / `T_HH` on every IC / FM PANEL run
+regardless of cfg; v0.13 only emits them when the estimator is
+explicitly `HansenHodrick`. Downstream readers should use
+`profile.primary_p` / `profile.primary_stat_name` plus
+`profile.context["estimator"]` rather than hardcoded
+`stats[StatCode.T_NW]` / `stats[StatCode.P_HH]` lookups.
 
 ---
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -193,7 +193,10 @@ that requires re-implementing the family split by hand.
 Raises (subclasses of `FactrixError`; see `## Errors`
 below for the full hierarchy + recovery payloads):
 - `MissingConfigError` — `evaluate(raw)` called without an `AnalysisConfig`
-- `IncompatibleAxisError` — config axes form an illegal cell
+- `IncompatibleAxisError` — config axes form an illegal cell (also raised when
+  `cfg.estimator` is not applicable to the cell)
+- `UnknownEstimatorError` — `AnalysisConfig.from_dict` /
+  `factrix.stats.get_estimator` saw a name not in the registry
 - `ModeAxisError` — legal cell has no procedure under the derived mode;
   carries `.suggested_fix: AnalysisConfig | None`
 - `InsufficientSampleError` — `T` below the procedure's `MIN_PERIODS_HARD`

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -1,20 +1,24 @@
 """Statistical tooling shared across the library.
 
-``Estimator`` — inference-method protocol selected via family-verb
-``estimator=`` kwarg (#170).
-``NeweyWest`` — reference ``Estimator`` for the procedure-canonical
-NW HAC inference path.
+``Estimator`` — base inference-method protocol selected via family-verb
+``estimator=`` kwarg (#170); pure selection semantics (no ``compute``).
+``HACEstimator(Estimator)`` — sub-protocol adding cell-internal
+``compute(series, *, forward_periods) -> InferenceResult`` for HAC-on-
+mean inference (#163). ``NeweyWest`` / ``HansenHodrick`` implement it.
+``InferenceResult`` — harmonized return shape for ``HACEstimator.compute``.
+``NeweyWest`` — Newey-West HAC ``HACEstimator``; default for
+``AnalysisConfig.estimator``.
 ``HansenHodrick`` — rectangular-kernel HAC variant for IC / FM PANEL
 on overlapping forward returns.
 ``WaldNWCluster`` / ``WaldTwoWayCluster`` — cluster-robust Wald χ²
-Estimators for slice contrasts (#153).
+Estimators for slice contrasts (#153); remain on base ``Estimator``.
 ``BlockBootstrap`` — block-bootstrap empirical-p Estimator for
-paired-diff slice tests (#153).
+paired-diff slice tests (#153); remains on base ``Estimator``.
 ``multiple_testing`` — BHY procedure for FDR control across many factors.
 ``bootstrap`` — stationary-bootstrap resampling + CI for dependent series.
 """
 
-from factrix.stats._estimator import Estimator
+from factrix.stats._estimator import Estimator, HACEstimator, InferenceResult
 from factrix.stats.block_bootstrap import BlockBootstrap
 from factrix.stats.bootstrap import (
     bootstrap_mean_ci,
@@ -43,7 +47,9 @@ _ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (
 __all__ = [
     "BlockBootstrap",
     "Estimator",
+    "HACEstimator",
     "HansenHodrick",
+    "InferenceResult",
     "NeweyWest",
     "WaldNWCluster",
     "WaldTwoWayCluster",

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -44,6 +44,30 @@ _ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (
     BlockBootstrap(),
 )
 
+
+def get_estimator(name: str) -> Estimator:
+    """Look up a registered ``Estimator`` instance by ``name`` (#163).
+
+    Used by ``AnalysisConfig.from_dict`` to rehydrate the ``estimator``
+    field from the serialized name string. Returns the registry's
+    canonical zero-arg instance; mutate-at-your-own-risk callers should
+    construct a fresh instance via the class directly. Returns the
+    base ``Estimator`` type — callers needing ``HACEstimator`` semantics
+    (e.g. ``AnalysisConfig``) ``isinstance``-narrow at the boundary.
+
+    Raises:
+        UnknownEstimatorError: ``name`` is not in the registry; the
+            message lists every available estimator name.
+    """
+    from factrix._errors import UnknownEstimatorError
+
+    for est in _ESTIMATOR_REGISTRY:
+        if est.name == name:
+            return est
+    available = ", ".join(sorted(e.name for e in _ESTIMATOR_REGISTRY))
+    raise UnknownEstimatorError(f"unknown estimator {name!r}. Available: {available}")
+
+
 __all__ = [
     "BlockBootstrap",
     "Estimator",
@@ -56,5 +80,6 @@ __all__ = [
     "bhy_adjust",
     "bhy_adjusted_p",
     "bootstrap_mean_ci",
+    "get_estimator",
     "stationary_bootstrap_resamples",
 ]

--- a/factrix/stats/_estimator.py
+++ b/factrix/stats/_estimator.py
@@ -1,24 +1,29 @@
-"""Estimator protocol — `inference_method` interface for family-verb override (#170).
+"""Estimator protocols — selection (base) and HAC-compute (sub).
 
-Family verbs (`bhy` / `bhy_hierarchical` / `partial_conjunction` / `bonferroni`
-/ `holm` / `romano_wolf`) accept `estimator: Estimator | None` to select which
-inference method's p-value to feed into the step-up math. The protocol carries
-*selection* semantics only — the procedure has already populated
-``FactorProfile.stats`` with the relevant ``StatCode.*_P`` values; an
-``Estimator`` instance names which one to look up for a given cell.
+``Estimator`` (base, #170): family-verb override selects which already-
+computed p-value to feed step-up math. Carries no compute logic — the
+procedure that populated ``FactorProfile.stats`` did the math.
 
-Cell-internal computation (`evaluate()` / standalone metrics) is out of scope:
-that future axis goes through a `ComputableEstimator(Estimator)` sub-protocol
-that adds a `compute(...)` method.
+``HACEstimator(Estimator)`` (#163): adds ``compute(series, *,
+forward_periods) -> InferenceResult`` for cell-internal estimator swap.
+Cell procedures dispatch to ``cfg.estimator.compute(...)`` instead of
+hardcoding the NW HAC path. Base ``Estimator`` is retained for slice-
+test instances (``WaldNWCluster`` / ``BlockBootstrap``, #153 / #176)
+whose compute path is multivariate and lives outside the family-verb
+axis.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from factrix._axis import FactorScope, Metric, Signal
-    from factrix._codes import StatCode
+    from factrix._codes import StatCode, WarningCode
 
 
 @runtime_checkable
@@ -31,7 +36,8 @@ class Estimator(Protocol):
     look up the relevant entry in ``FactorProfile.stats``.
 
     The protocol is deliberately silent on how the value was originally
-    computed — that lives in the procedure that produced the profile.
+    computed — that lives in the procedure that produced the profile, or
+    in the ``HACEstimator.compute`` extension below.
     """
 
     @property
@@ -62,5 +68,81 @@ class Estimator(Protocol):
 
         Called only after ``applicable_to`` has returned ``True``;
         implementations may assume the cell is in their applicability set.
+        """
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class InferenceResult:
+    """Harmonized return shape for ``HACEstimator.compute``.
+
+    Carries everything a cell procedure needs to stitch the inference
+    output into ``FactorProfile`` without an ``isinstance`` ladder.
+    ``stat_name`` / ``p_name`` let the procedure key ``stats`` /
+    ``metadata`` with the estimator-emitted ``StatCode`` (matching
+    ``Estimator.emits_for``); ``metadata`` is a flat ``str -> Any``
+    mapping that the procedure mirrors under both keys (NW emits
+    ``{"nw_lags": k}``; HH emits ``{"kernel": "rectangular",
+    "variance_clamped": bool}``).
+    """
+
+    stat: float
+    p: float
+    stat_name: StatCode
+    p_name: StatCode
+    metadata: Mapping[str, Any]
+    warnings: frozenset[WarningCode]
+
+
+@runtime_checkable
+class HACEstimator(Estimator, Protocol):
+    """``Estimator`` that runs HAC-on-mean inference on a 1-D series.
+
+    Adds ``min_periods`` (sample-size floor below which SE is deemed
+    unreliable; estimator surfaces it via ``warnings`` rather than
+    silently degrading) and ``compute(series, *, forward_periods)``
+    returning an ``InferenceResult``. Cell procedures dispatch to this
+    instead of hardcoding the NW HAC path.
+
+    Moment-condition estimators (GMM J-test, #191) and slice-test
+    estimators (cluster Wald, block bootstrap; #153 / #176) take
+    different input shapes and live on parallel ``Estimator`` sub-
+    protocols rather than overloading this one.
+    """
+
+    @property
+    def min_periods(self) -> int:
+        """Lower bound on ``len(series)`` for SE-validity.
+
+        ``len(series) < min_periods`` should emit
+        ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS`` in
+        ``InferenceResult.warnings``. The HARD-floor case (series so
+        short the test cannot run at all) is the estimator's call to
+        raise ``InsufficientSampleError``; ``min_periods`` is the soft
+        contract.
+        """
+        ...
+
+    def compute(
+        self,
+        series: np.ndarray,
+        *,
+        forward_periods: int,
+    ) -> InferenceResult:
+        """Run the inference test on ``series``.
+
+        Args:
+            series: 1-D HAC-target series (per-period IC, per-date
+                Fama-MacBeth λ, dense CAAR, etc.). The cell procedure
+                owns extraction from raw panel; the estimator only
+                sees the test target.
+            forward_periods: Overlap horizon of the series (MA(h-1)
+                structure). NW uses it to floor the Bartlett bandwidth;
+                HH requires it for the rectangular-kernel lag count.
+
+        Returns:
+            ``InferenceResult`` with ``stat`` / ``p`` and the
+            ``StatCode`` keys the procedure should stitch into
+            ``FactorProfile.stats`` / ``metadata``.
         """
         ...

--- a/factrix/stats/_estimator.py
+++ b/factrix/stats/_estimator.py
@@ -74,7 +74,7 @@ class Estimator(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class InferenceResult:
-    """Harmonized return shape for ``HACEstimator.compute``.
+    """HAC-on-mean return shape for ``HACEstimator.compute``.
 
     Carries everything a cell procedure needs to stitch the inference
     output into ``FactorProfile`` without an ``isinstance`` ladder.
@@ -84,6 +84,12 @@ class InferenceResult:
     mapping that the procedure mirrors under both keys (NW emits
     ``{"nw_lags": k}``; HH emits ``{"kernel": "rectangular",
     "variance_clamped": bool}``).
+
+    Moment-condition estimators (GMM J-test, #191) have a parallel
+    return shape (``GMMResult`` carrying ``j_stat`` / ``df`` /
+    ``overid_p`` / weight-matrix iter); they live on a separate
+    ``MomentEstimator(Estimator)`` sub-protocol rather than reusing
+    this dataclass.
     """
 
     stat: float

--- a/factrix/stats/hansen_hodrick.py
+++ b/factrix/stats/hansen_hodrick.py
@@ -1,23 +1,28 @@
-"""``HansenHodrick`` Estimator instance for the rectangular-kernel HAC path.
+"""``HansenHodrick`` HAC estimator — rectangular-kernel HAC SE on a series mean.
 
 Names the Hansen-Hodrick (1980) overlapping-sample inference path
-emitted by IC PANEL and FM PANEL procedures into ``profile.stats`` as
-``StatCode.P_HH``. Carries no compute logic — the underlying rectangular-
-kernel HAC math lives in :mod:`factrix._stats` and is invoked by each
-applicable cell procedure during :func:`factrix.evaluate`.
+emitted to ``profile.stats`` as ``StatCode.P_HH`` / ``StatCode.T_HH``.
+``compute(series, *, forward_periods)`` delegates to
+:func:`factrix._stats._hansen_hodrick_t_test`.
 
-Procedures only populate ``StatCode.P_HH`` when ``forward_periods > 1``;
-the ``h = 1`` (non-overlapping) case has no autocovariance terms and HH
-collapses to the iid SE — the user is expected to use ``NeweyWest``
-there. Calling ``bhy(estimator=HansenHodrick())`` on a non-overlapping
-profile lands on a missing-stat error whose message points at the
-precondition.
+``forward_periods = 1`` (non-overlapping) has no autocovariance terms
+and HH collapses to the iid SE — ``compute`` still delegates to the
+primitive, which returns the iid result.
+``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` surfaces when the
+rectangular-kernel sum comes out negative (Andrews 1991 §3).
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from factrix._axis import FactorScope, Metric, Signal
-from factrix._codes import StatCode
+from factrix._codes import StatCode, WarningCode
+from factrix._stats.constants import MIN_PERIODS_WARN
+from factrix.stats._estimator import InferenceResult
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class HansenHodrick:
@@ -27,8 +32,8 @@ class HansenHodrick:
     γⱼ) / n`` matched to the MA(h-1) overlap structure induced by
     h-period forward returns. No PSD guarantee (Andrews 1991 §3): on
     short / mildly anti-correlated samples the estimate can come out
-    negative; the procedure clamps variance to 0 and emits
-    ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``.
+    negative; ``compute`` clamps variance to 0 and surfaces
+    ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` in the result.
 
     Applicability is restricted to ``(INDIVIDUAL, CONTINUOUS)`` cells —
     IC PANEL and FM PANEL procedures populate ``StatCode.P_HH``. The
@@ -36,10 +41,12 @@ class HansenHodrick:
     overlapping forward returns is structurally an OLS slope rather than
     a mean t-test, so its HH-OLS variant is deferred to a separate pass.
 
-    Pass an instance to family verbs to make the inference choice
-    explicit::
+    Pass an instance to ``AnalysisConfig`` to drive evaluate-time
+    inference::
 
-        fx.bhy(profiles, estimator=HansenHodrick())
+        cfg = AnalysisConfig.individual_continuous(
+            metric=Metric.IC, estimator=HansenHodrick(),
+        )
 
     Constructor takes no arguments; the kernel and lag-rule are fixed by
     the HH-pure convention.
@@ -56,6 +63,10 @@ class HansenHodrick:
             "(MA(h-1) overlap structure) → t → two-sided p-value."
         )
 
+    @property
+    def min_periods(self) -> int:
+        return MIN_PERIODS_WARN
+
     def applicable_to(self, scope: FactorScope, signal: Signal) -> bool:
         return scope is FactorScope.INDIVIDUAL and signal is Signal.CONTINUOUS
 
@@ -66,3 +77,30 @@ class HansenHodrick:
         _metric: Metric | None,
     ) -> StatCode:
         return StatCode.P_HH
+
+    def compute(
+        self,
+        series: np.ndarray,
+        *,
+        forward_periods: int,
+    ) -> InferenceResult:
+        from factrix._stats import _hansen_hodrick_t_test
+
+        t_hh, p_hh, _, clamped = _hansen_hodrick_t_test(
+            series, forward_periods=forward_periods
+        )
+
+        warnings: frozenset[WarningCode] = frozenset()
+        if clamped:
+            warnings |= frozenset({WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE})
+        if 0 < len(series) < self.min_periods:
+            warnings |= frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS})
+
+        return InferenceResult(
+            stat=t_hh,
+            p=p_hh,
+            stat_name=StatCode.T_HH,
+            p_name=StatCode.P_HH,
+            metadata={"kernel": "rectangular", "variance_clamped": clamped},
+            warnings=warnings,
+        )

--- a/factrix/stats/hansen_hodrick.py
+++ b/factrix/stats/hansen_hodrick.py
@@ -38,10 +38,15 @@ class HansenHodrick:
     ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` in the result.
 
     Applicability is restricted to ``(INDIVIDUAL, CONTINUOUS)`` cells —
-    IC PANEL and FM PANEL procedures populate ``StatCode.P_HH``. The
-    PANEL-vs-TIMESERIES axis is not part of the protocol; TS β on
-    overlapping forward returns is structurally an OLS slope rather than
-    a mean t-test, so its HH-OLS variant is deferred to a separate pass.
+    IC PANEL and FM PANEL. CAAR (SPARSE PANEL) is a mean t-test on the
+    dense per-event-date series and is structurally HH-compatible, but
+    is deferred: the v0.5 procedure had no HH side-emit there so the
+    methodology has not been validated, and SPARSE-axis CAAR introduces
+    a per-event-independence vs MA(h-1) interaction (event clustering
+    inside a horizon window) that warrants its own pass. The
+    PANEL-vs-TIMESERIES axis is not part of the protocol; TS β / TS
+    Dummy run NW HAC on an OLS slope (different math shape) and await
+    a slope-axis sub-protocol.
 
     Pass an instance to ``AnalysisConfig`` to drive evaluate-time
     inference::

--- a/factrix/stats/hansen_hodrick.py
+++ b/factrix/stats/hansen_hodrick.py
@@ -14,6 +14,7 @@ rectangular-kernel sum comes out negative (Andrews 1991 §3).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from factrix._axis import FactorScope, Metric, Signal
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     import numpy as np
 
 
+@dataclass(frozen=True, slots=True)
 class HansenHodrick:
     """Hansen-Hodrick (1980) HAC SE estimator → t-statistic → two-sided p-value.
 

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -19,6 +19,7 @@ identity is carried by ``profile.config`` rather than by the StatCode.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from factrix._axis import FactorScope, Metric, Signal
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
     import numpy as np
 
 
+@dataclass(frozen=True, slots=True)
 class NeweyWest:
     """Newey-West (1987) HAC SE estimator → t-statistic → two-sided p-value.
 

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -1,14 +1,15 @@
-"""``NeweyWest`` reference Estimator instance (#170).
+"""``NeweyWest`` HAC estimator — Bartlett-kernel HAC SE on a series mean.
 
-Names the Newey-West HAC inference path that v0.5 cells already emit
-into ``FactorProfile.stats``. Carries no compute logic — the underlying
-NW HAC math lives in :mod:`factrix._stats` and is invoked by each cell
-procedure during :func:`factrix.evaluate`.
+Names the Newey-West HAC inference path emitted to ``FactorProfile.stats``
+as ``StatCode.P_NW`` / ``StatCode.T_NW``. ``compute(series, *,
+forward_periods)`` delegates to :func:`factrix._stats._newey_west_t_test`
+so cell procedures share one path with the standalone primitive.
 
 The Bartlett kernel + NW1994 auto-bandwidth + Hansen-Hodrick overlap
 floor convention applies uniformly across the four primary_p-emitting
-cells; cell-specific sample-size guards (e.g. ``UNRELIABLE_SE_SHORT_PERIODS``)
-are tracked by the procedures and surface via ``FactorProfile.warnings``.
+cells; ``compute`` pre-resolves the bandwidth via ``_resolve_nw_lags``
+to keep the (lags-honest) metadata observable and to match the v0.5
+procedure call site bit-for-bit.
 
 ``emits_for`` is cell-agnostic — every applicable cell looks up the
 same ``StatCode.P_NW`` key (#187 flattened the prefix; #192 added the
@@ -18,8 +19,15 @@ identity is carried by ``profile.config`` rather than by the StatCode.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from factrix._axis import FactorScope, Metric, Signal
-from factrix._codes import StatCode
+from factrix._codes import StatCode, WarningCode
+from factrix._stats.constants import MIN_PERIODS_WARN
+from factrix.stats._estimator import InferenceResult
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class NeweyWest:
@@ -38,9 +46,10 @@ class NeweyWest:
     deliberately cell-agnostic to keep ``Estimator.emits_for`` from
     re-encoding cell identity.
 
-    Pass an instance to family verbs to make the inference choice
-    explicit::
+    Pass an instance to ``AnalysisConfig`` to run NW at evaluate time
+    (default), or to family verbs to select the NW p-value::
 
+        cfg = AnalysisConfig.individual_continuous(estimator=NeweyWest())
         fx.bhy(profiles, estimator=NeweyWest())
 
     Constructor takes no arguments in this release; lag / kernel /
@@ -60,6 +69,10 @@ class NeweyWest:
             "Hansen-Hodrick overlap floor) → t → two-sided p-value."
         )
 
+    @property
+    def min_periods(self) -> int:
+        return MIN_PERIODS_WARN
+
     def applicable_to(self, _scope: FactorScope, _signal: Signal) -> bool:
         # NW HAC drives `primary_p` on every user-facing cell, so the
         # estimator applies universally until a cell opts out.
@@ -72,3 +85,31 @@ class NeweyWest:
         _metric: Metric | None,
     ) -> StatCode:
         return StatCode.P_NW
+
+    def compute(
+        self,
+        series: np.ndarray,
+        *,
+        forward_periods: int,
+    ) -> InferenceResult:
+        from factrix._stats import _newey_west_t_test, _resolve_nw_lags
+        from factrix._stats.constants import auto_bartlett
+
+        n = len(series)
+        nw_lags = (
+            _resolve_nw_lags(n, auto_bartlett(n), forward_periods) if n >= 2 else 0
+        )
+        t_stat, p_value, _ = _newey_west_t_test(series, lags=nw_lags)
+
+        warnings: frozenset[WarningCode] = frozenset()
+        if 0 < n < self.min_periods:
+            warnings = frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS})
+
+        return InferenceResult(
+            stat=t_stat,
+            p=p_value,
+            stat_name=StatCode.T_NW,
+            p_name=StatCode.P_NW,
+            metadata={"nw_lags": nw_lags},
+            warnings=warnings,
+        )

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -6,10 +6,10 @@ forward_periods)`` delegates to :func:`factrix._stats._newey_west_t_test`
 so cell procedures share one path with the standalone primitive.
 
 The Bartlett kernel + NW1994 auto-bandwidth + Hansen-Hodrick overlap
-floor convention applies uniformly across the four primary_p-emitting
-cells; ``compute`` pre-resolves the bandwidth via ``_resolve_nw_lags``
-to keep the (lags-honest) metadata observable and to match the v0.5
-procedure call site bit-for-bit.
+floor convention is the default HAC path across every PANEL /
+TIMESERIES cell; users swap to a different ``HACEstimator`` via
+``AnalysisConfig.estimator=``. ``compute`` pre-resolves the bandwidth
+via ``_resolve_nw_lags`` to keep the (lags-honest) metadata observable.
 
 ``emits_for`` is cell-agnostic — every applicable cell looks up the
 same ``StatCode.P_NW`` key (#187 flattened the prefix; #192 added the
@@ -37,8 +37,9 @@ class NeweyWest:
 
     The Bartlett-kernel HAC variance estimate uses the NW1994 automatic
     bandwidth rule with a Hansen-Hodrick overlap floor for forward-return
-    regressions, matching the convention v0.5 procedures already use to
-    populate ``primary_p`` and ``StatCode.P_NW`` / ``StatCode.T_NW`` entries.
+    regressions, populating ``StatCode.P_NW`` / ``StatCode.T_NW`` via the
+    estimator-dispatch path (or the procedure-internal NW HAC path for
+    slope-axis cells until a slope-shaped sub-protocol lands).
 
     Cell interpretation comes from ``profile.config`` (``scope`` /
     ``signal`` / ``metric``) — ``StatCode.P_NW`` is the same key for

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,7 @@ nav:
               - oos: api/metrics/oos.md
       - Other modules:
           - stats: api/stats.md
+          - Estimator alternatives: api/estimator-alternatives.md
           - datasets: api/datasets.md
           - preprocess: api/preprocess.md
           - Multi-horizon (migration): api/multi-horizon.md

--- a/tests/test_estimator_config.py
+++ b/tests/test_estimator_config.py
@@ -1,0 +1,128 @@
+"""Tests for ``AnalysisConfig.estimator`` field + serialization (#163).
+
+Covers the study-level estimator switch:
+- default ``NeweyWest()`` matches v0.11 behavior
+- explicit ``HansenHodrick()`` on (INDIVIDUAL, CONTINUOUS) cells
+- applicability gate raises early at ``__post_init__``
+- ``to_dict`` / ``from_dict`` round-trip via name-string serialization
+- legacy dicts without ``estimator`` key default to ``NeweyWest()``
+- ``get_estimator(name)`` registry lookup + ``UnknownEstimatorError``
+"""
+
+from __future__ import annotations
+
+import pytest
+from factrix import AnalysisConfig, IncompatibleAxisError, UnknownEstimatorError
+from factrix.stats import (
+    BlockBootstrap,
+    HansenHodrick,
+    NeweyWest,
+    WaldNWCluster,
+    get_estimator,
+)
+
+
+class TestDefaultEstimator:
+    """Every factory method defaults to ``NeweyWest()`` for v0.11 parity."""
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            AnalysisConfig.individual_continuous,
+            AnalysisConfig.individual_sparse,
+            AnalysisConfig.common_continuous,
+            AnalysisConfig.common_sparse,
+        ],
+    )
+    def test_default_is_newey_west(self, factory) -> None:
+        cfg = factory()
+        assert cfg.estimator == NeweyWest()
+
+
+class TestExplicitEstimator:
+    """Factory ``estimator=`` kwarg forwards to the validated field."""
+
+    def test_individual_continuous_with_hh(self) -> None:
+        cfg = AnalysisConfig.individual_continuous(estimator=HansenHodrick())
+        assert cfg.estimator == HansenHodrick()
+
+
+class TestApplicabilityGate:
+    """``__post_init__`` rejects non-applicable / non-HAC estimators."""
+
+    def test_hh_on_common_continuous_raises(self) -> None:
+        with pytest.raises(IncompatibleAxisError, match="not applicable"):
+            AnalysisConfig.common_continuous(estimator=HansenHodrick())
+
+    def test_hh_on_individual_sparse_raises(self) -> None:
+        with pytest.raises(IncompatibleAxisError, match="not applicable"):
+            AnalysisConfig.individual_sparse(estimator=HansenHodrick())
+
+    def test_slice_estimator_rejected_as_non_hac(self) -> None:
+        with pytest.raises(IncompatibleAxisError, match="HACEstimator"):
+            AnalysisConfig.individual_continuous(estimator=WaldNWCluster())  # type: ignore[arg-type]
+
+    def test_block_bootstrap_rejected_as_non_hac(self) -> None:
+        with pytest.raises(IncompatibleAxisError, match="HACEstimator"):
+            AnalysisConfig.individual_continuous(estimator=BlockBootstrap())  # type: ignore[arg-type]
+
+    def test_error_message_lists_applicable(self) -> None:
+        with pytest.raises(IncompatibleAxisError) as exc_info:
+            AnalysisConfig.common_continuous(estimator=HansenHodrick())
+        assert "NeweyWest" in str(exc_info.value)
+
+
+class TestSerialization:
+    """``to_dict`` / ``from_dict`` round-trip the estimator by name."""
+
+    def test_to_dict_carries_estimator_name(self) -> None:
+        cfg = AnalysisConfig.individual_continuous(estimator=HansenHodrick())
+        assert cfg.to_dict()["estimator"] == "HansenHodrick"
+
+    def test_roundtrip_preserves_equality(self) -> None:
+        cfg = AnalysisConfig.individual_continuous(estimator=HansenHodrick())
+        assert AnalysisConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_roundtrip_default_estimator(self) -> None:
+        cfg = AnalysisConfig.individual_continuous()
+        assert AnalysisConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_legacy_dict_without_estimator_defaults_nw(self) -> None:
+        legacy = {
+            "scope": "individual",
+            "signal": "continuous",
+            "metric": "ic",
+            "forward_periods": 5,
+        }
+        cfg = AnalysisConfig.from_dict(legacy)
+        assert cfg.estimator == NeweyWest()
+
+    def test_from_dict_unknown_estimator_raises(self) -> None:
+        d = {
+            "scope": "individual",
+            "signal": "continuous",
+            "metric": "ic",
+            "forward_periods": 5,
+            "estimator": "Bogus",
+        }
+        with pytest.raises(UnknownEstimatorError, match="unknown estimator 'Bogus'"):
+            AnalysisConfig.from_dict(d)
+
+
+class TestGetEstimator:
+    """``factrix.stats.get_estimator`` registry lookup."""
+
+    def test_lookup_newey_west(self) -> None:
+        assert get_estimator("NeweyWest") == NeweyWest()
+
+    def test_lookup_hansen_hodrick(self) -> None:
+        assert get_estimator("HansenHodrick") == HansenHodrick()
+
+    def test_unknown_name_raises(self) -> None:
+        with pytest.raises(UnknownEstimatorError) as exc_info:
+            get_estimator("DoesNotExist")
+        # Message lists every registered name for discoverability.
+        msg = str(exc_info.value)
+        assert "NeweyWest" in msg
+        assert "HansenHodrick" in msg
+        assert "WaldNWCluster" in msg

--- a/tests/test_estimator_config.py
+++ b/tests/test_estimator_config.py
@@ -59,11 +59,11 @@ class TestApplicabilityGate:
             AnalysisConfig.individual_sparse(estimator=HansenHodrick())
 
     def test_slice_estimator_rejected_as_non_hac(self) -> None:
-        with pytest.raises(IncompatibleAxisError, match="HACEstimator"):
+        with pytest.raises(IncompatibleAxisError, match="not an HAC estimator"):
             AnalysisConfig.individual_continuous(estimator=WaldNWCluster())  # type: ignore[arg-type]
 
     def test_block_bootstrap_rejected_as_non_hac(self) -> None:
-        with pytest.raises(IncompatibleAxisError, match="HACEstimator"):
+        with pytest.raises(IncompatibleAxisError, match="not an HAC estimator"):
             AnalysisConfig.individual_continuous(estimator=BlockBootstrap())  # type: ignore[arg-type]
 
     def test_error_message_lists_applicable(self) -> None:

--- a/tests/test_estimator_dispatch.py
+++ b/tests/test_estimator_dispatch.py
@@ -1,0 +1,120 @@
+"""Cell-procedure dispatch through ``cfg.estimator.compute`` (#163 batch 3).
+
+Verifies the BREAKING behavior changes:
+- D9: default cfg no longer emits ``P_HH`` / ``T_HH`` as a side-stat
+- D10: ``primary_p`` / ``primary_stat_name`` reflect the chosen estimator
+- ``profile.context["estimator"]`` records provenance on every cell
+
+Bit-equal check: default ``NeweyWest()`` cfg produces the same
+``primary_p`` as the v0.11 hardcoded NW path (via ``compute`` delegating
+to the same primitive); explicit ``HansenHodrick()`` produces the HH
+result that the v0.11 side-emit used to expose.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix import AnalysisConfig, Metric, evaluate
+from factrix._codes import StatCode
+from factrix._stats import _hansen_hodrick_t_test, _newey_west_t_test, _resolve_nw_lags
+from factrix._stats.constants import auto_bartlett
+from factrix.metrics.ic import compute_ic
+from factrix.stats import HansenHodrick, NeweyWest
+
+
+def _panel(*, n_dates: int = 80, n_assets: int = 15, seed: int = 0) -> pl.DataFrame:
+    rng = np.random.default_rng(seed)
+    start = dt.date(2024, 1, 1)
+    rows: list[dict[str, object]] = []
+    for i in range(n_dates):
+        d = start + dt.timedelta(days=i)
+        fwd = rng.standard_normal(n_assets)
+        noise = rng.standard_normal(n_assets)
+        for j in range(n_assets):
+            rows.append(
+                {
+                    "date": d,
+                    "asset_id": f"A{j:03d}",
+                    "factor": float(noise[j]),
+                    "forward_return": float(fwd[j]),
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+class TestDefaultNWBitEqual:
+    """Default cfg (``NeweyWest()``) is bit-equal to the v0.11 hardcoded path."""
+
+    def test_ic_panel_primary_p_matches_primitive(self) -> None:
+        panel = _panel(seed=1)
+        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC, forward_periods=5)
+        profile = evaluate(panel, cfg)
+
+        ic_values = compute_ic(panel)["ic"].drop_nulls().to_numpy()
+        n = len(ic_values)
+        nw_lags = _resolve_nw_lags(n, auto_bartlett(n), 5)
+        t_expected, p_expected, _ = _newey_west_t_test(ic_values, lags=nw_lags)
+
+        assert profile.primary_p == p_expected
+        assert profile.primary_stat == t_expected
+        assert profile.primary_stat_name is StatCode.T_NW
+
+
+class TestDefaultDoesNotEmitHH:
+    """D9: default ``NeweyWest()`` cfg no longer side-emits ``P_HH`` / ``T_HH``."""
+
+    @pytest.mark.parametrize("metric", [Metric.IC, Metric.FM])
+    def test_p_hh_absent(self, metric: Metric) -> None:
+        panel = _panel(seed=2)
+        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=5)
+        profile = evaluate(panel, cfg)
+        assert StatCode.P_HH not in profile.stats
+        assert StatCode.T_HH not in profile.stats
+
+
+class TestHHDispatch:
+    """Explicit ``HansenHodrick()`` cfg routes the HH path through dispatch."""
+
+    def test_primary_p_matches_hh_primitive(self) -> None:
+        panel = _panel(seed=3)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=Metric.IC, forward_periods=5, estimator=HansenHodrick()
+        )
+        profile = evaluate(panel, cfg)
+
+        ic_values = compute_ic(panel)["ic"].drop_nulls().to_numpy()
+        t_expected, p_expected, _, _ = _hansen_hodrick_t_test(
+            ic_values, forward_periods=5
+        )
+
+        assert profile.primary_p == p_expected
+        assert profile.primary_stat == t_expected
+        assert profile.primary_stat_name is StatCode.T_HH
+
+
+class TestContextProvenance:
+    """``profile.context["estimator"]`` records the cfg-driven estimator."""
+
+    @pytest.mark.parametrize(
+        ("estimator", "expected_name"),
+        [(NeweyWest(), "NeweyWest"), (HansenHodrick(), "HansenHodrick")],
+    )
+    def test_ic_panel_context(self, estimator, expected_name: str) -> None:
+        panel = _panel(seed=4)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=Metric.IC, forward_periods=5, estimator=estimator
+        )
+        profile = evaluate(panel, cfg)
+        assert profile.context["estimator"] == expected_name
+
+    def test_common_continuous_default_records_nw(self) -> None:
+        # COMMON cells don't dispatch through estimator (no HAC-on-mean),
+        # but provenance is still written so all profiles carry the key.
+        panel = _panel(seed=5)
+        cfg = AnalysisConfig.common_continuous(forward_periods=5)
+        profile = evaluate(panel, cfg)
+        assert profile.context["estimator"] == "NeweyWest"

--- a/tests/test_hac_estimator.py
+++ b/tests/test_hac_estimator.py
@@ -1,0 +1,143 @@
+"""Tests for ``HACEstimator`` sub-protocol + ``InferenceResult`` (#163).
+
+Verifies:
+- ``HACEstimator`` runtime_checkable identity (NW / HH satisfy;
+  slice-test estimators on base ``Estimator`` only).
+- ``NeweyWest.compute`` / ``HansenHodrick.compute`` are bit-equal to
+  the underlying ``factrix._stats`` primitives the v0.11 cell
+  procedures call (no behavior drift from the dispatch refactor's
+  Protocol layer).
+- ``InferenceResult`` carries the ``StatCode`` keys + flat metadata +
+  warning frozenset the cell procedure will stitch into ``FactorProfile``.
+- ``min_periods`` soft floor surfaces ``UNRELIABLE_SE_SHORT_PERIODS``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._codes import StatCode, WarningCode
+from factrix._stats import (
+    _hansen_hodrick_t_test,
+    _newey_west_t_test,
+    _resolve_nw_lags,
+)
+from factrix._stats.constants import MIN_PERIODS_WARN, auto_bartlett
+from factrix.stats import (
+    BlockBootstrap,
+    Estimator,
+    HACEstimator,
+    HansenHodrick,
+    InferenceResult,
+    NeweyWest,
+    WaldNWCluster,
+    WaldTwoWayCluster,
+)
+
+
+class TestProtocolIdentity:
+    """Layered ``isinstance`` semantics for base vs HAC sub-protocol."""
+
+    def test_nw_satisfies_both(self) -> None:
+        nw = NeweyWest()
+        assert isinstance(nw, Estimator)
+        assert isinstance(nw, HACEstimator)
+
+    def test_hh_satisfies_both(self) -> None:
+        hh = HansenHodrick()
+        assert isinstance(hh, Estimator)
+        assert isinstance(hh, HACEstimator)
+
+    @pytest.mark.parametrize(
+        "estimator", [WaldNWCluster(), WaldTwoWayCluster(), BlockBootstrap()]
+    )
+    def test_slice_estimators_base_only(self, estimator: object) -> None:
+        assert isinstance(estimator, Estimator)
+        assert not isinstance(estimator, HACEstimator)
+
+
+class TestNeweyWestCompute:
+    """``NeweyWest.compute`` matches ``_newey_west_t_test`` bit-for-bit."""
+
+    @pytest.mark.parametrize("forward_periods", [1, 5, 10])
+    def test_bit_equal_to_primitive(self, forward_periods: int) -> None:
+        rng = np.random.default_rng(42)
+        series = rng.standard_normal(60)
+        result = NeweyWest().compute(series, forward_periods=forward_periods)
+
+        n = len(series)
+        nw_lags = _resolve_nw_lags(n, auto_bartlett(n), forward_periods)
+        t_direct, p_direct, _ = _newey_west_t_test(series, lags=nw_lags)
+
+        assert result.stat == t_direct
+        assert result.p == p_direct
+        assert result.metadata == {"nw_lags": nw_lags}
+
+    def test_inference_result_keys(self) -> None:
+        result = NeweyWest().compute(
+            np.random.default_rng(0).standard_normal(40), forward_periods=5
+        )
+        assert isinstance(result, InferenceResult)
+        assert result.stat_name is StatCode.T_NW
+        assert result.p_name is StatCode.P_NW
+
+    def test_short_series_emits_warning(self) -> None:
+        series = np.random.default_rng(0).standard_normal(MIN_PERIODS_WARN - 5)
+        result = NeweyWest().compute(series, forward_periods=5)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in result.warnings
+
+    def test_long_series_no_warning(self) -> None:
+        series = np.random.default_rng(0).standard_normal(MIN_PERIODS_WARN + 10)
+        result = NeweyWest().compute(series, forward_periods=5)
+        assert result.warnings == frozenset()
+
+    def test_degenerate_series_does_not_crash(self) -> None:
+        # ``n < 2`` is the existing call-site guard; compute must not
+        # raise, and the primitive returns the conservative (0, 1).
+        result = NeweyWest().compute(np.array([0.0]), forward_periods=5)
+        assert result.stat == 0.0
+        assert result.p == 1.0
+        assert result.metadata["nw_lags"] == 0
+
+
+class TestHansenHodrickCompute:
+    """``HansenHodrick.compute`` matches ``_hansen_hodrick_t_test`` bit-for-bit."""
+
+    @pytest.mark.parametrize("forward_periods", [2, 5, 10])
+    def test_bit_equal_to_primitive(self, forward_periods: int) -> None:
+        rng = np.random.default_rng(42)
+        series = rng.standard_normal(60)
+        result = HansenHodrick().compute(series, forward_periods=forward_periods)
+
+        t_direct, p_direct, _, clamped = _hansen_hodrick_t_test(
+            series, forward_periods=forward_periods
+        )
+
+        assert result.stat == t_direct
+        assert result.p == p_direct
+        assert result.metadata == {
+            "kernel": "rectangular",
+            "variance_clamped": clamped,
+        }
+
+    def test_inference_result_keys(self) -> None:
+        result = HansenHodrick().compute(
+            np.random.default_rng(0).standard_normal(40), forward_periods=5
+        )
+        assert isinstance(result, InferenceResult)
+        assert result.stat_name is StatCode.T_HH
+        assert result.p_name is StatCode.P_HH
+
+    def test_clamp_surfaces_warning(self) -> None:
+        series = np.random.default_rng(0).standard_normal(10)
+        result = HansenHodrick().compute(series, forward_periods=4)
+        assert result.metadata["variance_clamped"] is True
+        assert WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE in result.warnings
+
+
+class TestMinPeriodsContract:
+    """``min_periods`` advertises the SE-validity soft floor."""
+
+    @pytest.mark.parametrize("estimator", [NeweyWest(), HansenHodrick()])
+    def test_min_periods_is_warn_floor(self, estimator: HACEstimator) -> None:
+        assert estimator.min_periods == MIN_PERIODS_WARN

--- a/tests/test_hansen_hodrick_procedure.py
+++ b/tests/test_hansen_hodrick_procedure.py
@@ -1,10 +1,11 @@
-"""IC PANEL + FM PANEL procedures emit ``StatCode.P_HH`` (#184).
+"""IC PANEL + FM PANEL procedures dispatch HH via ``cfg.estimator`` (#163, #184).
 
-Procedure-side wiring: when ``forward_periods > 1`` the IC / FM
-procedures populate ``P_HH`` alongside ``P``, set the kernel + clamp
-metadata, and ``HansenHodrick`` dispatched via ``bhy(estimator=...)``
-reads it. ``forward_periods=1`` (no overlap) skips the emission so the
-estimator lands on a missing-stat error rather than aliasing NW.
+Procedure-side wiring: when ``AnalysisConfig.estimator=HansenHodrick()``
+and ``forward_periods > 1`` the IC / FM procedures populate
+``primary_p`` / ``primary_stat`` from the HH path, keying ``P_HH`` /
+``T_HH`` in ``profile.stats`` with kernel + clamp metadata; default
+``NeweyWest()`` does NOT emit ``P_HH`` (#163 D9 BREAKING — v0.11's
+"auto-emit both" side-emission is removed).
 """
 
 from __future__ import annotations
@@ -49,10 +50,12 @@ def _build_panel(
 
 
 @pytest.mark.parametrize("metric", [Metric.IC, Metric.FM])
-class TestProcedureEmitsPHh:
-    def test_emits_p_hh_when_overlap(self, metric: Metric) -> None:
+class TestHHDispatch:
+    def test_emits_p_hh_under_hh_estimator(self, metric: Metric) -> None:
         panel = _build_panel(n_dates=80, n_assets=15, seed=1)
-        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=5)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=metric, forward_periods=5, estimator=HansenHodrick()
+        )
         profile = evaluate(panel, cfg)
         assert StatCode.P_HH in profile.stats
         assert StatCode.T_HH in profile.stats
@@ -63,29 +66,47 @@ class TestProcedureEmitsPHh:
         meta = profile.metadata[StatCode.P_HH]
         assert meta["kernel"] == "rectangular"
         assert meta["variance_clamped"] is False
-        # Same metadata mirrored under T_HH so single-key lookup stays honest.
         assert profile.metadata[StatCode.T_HH] == meta
 
-    def test_no_emission_when_forward_periods_one(self, metric: Metric) -> None:
+    def test_primary_p_is_hh_under_hh_estimator(self, metric: Metric) -> None:
+        panel = _build_panel(n_dates=80, n_assets=15, seed=1)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=metric, forward_periods=5, estimator=HansenHodrick()
+        )
+        profile = evaluate(panel, cfg)
+        assert profile.primary_stat_name == StatCode.T_HH
+        assert profile.primary_p == profile.stats[StatCode.P_HH]
+
+    def test_default_nw_does_not_emit_p_hh(self, metric: Metric) -> None:
         panel = _build_panel(n_dates=80, n_assets=15, seed=2)
-        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=1)
+        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=5)
         profile = evaluate(panel, cfg)
         assert StatCode.P_HH not in profile.stats
         assert StatCode.T_HH not in profile.stats
         assert StatCode.P_NW in profile.stats
 
-    def test_bhy_dispatches_hh_p_value(self, metric: Metric) -> None:
+    def test_context_records_hh(self, metric: Metric) -> None:
         panel = _build_panel(n_dates=80, n_assets=15, seed=3)
-        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=5)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=metric, forward_periods=5, estimator=HansenHodrick()
+        )
+        profile = evaluate(panel, cfg)
+        assert profile.context["estimator"] == "HansenHodrick"
+
+    def test_bhy_dispatches_hh_p_value(self, metric: Metric) -> None:
+        # Strong factor signal so the single profile survives bhy at q=0.05.
+        panel = _build_panel(n_dates=80, n_assets=15, seed=3, factor_strength=0.4)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=metric, forward_periods=5, estimator=HansenHodrick()
+        )
         profile = evaluate(panel, cfg)
         family = bhy([profile], estimator=HansenHodrick())
-        # The single-profile family must read p from StatCode.P_HH, not the
-        # NW-canonical primary_p — confirm by comparing to the source value.
         assert family.profiles[0].stats[StatCode.P_HH] == profile.stats[StatCode.P_HH]
 
     def test_bhy_missing_p_hh_raises_user_input_error(self, metric: Metric) -> None:
-        panel = _build_panel(n_dates=80, n_assets=15, seed=4)
-        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=1)
+        panel = _build_panel(n_dates=80, n_assets=15, seed=5)
+        # Default NW cfg — no P_HH emitted regardless of forward_periods now.
+        cfg = AnalysisConfig.individual_continuous(metric=metric, forward_periods=5)
         profile = evaluate(panel, cfg)
         with pytest.raises(UserInputError) as exc:
             bhy([profile], estimator=HansenHodrick())
@@ -116,7 +137,9 @@ class TestNegativeVarianceWarning:
                     }
                 )
         panel = pl.DataFrame(rows)
-        cfg = AnalysisConfig.individual_continuous(metric=Metric.IC, forward_periods=2)
+        cfg = AnalysisConfig.individual_continuous(
+            metric=Metric.IC, forward_periods=2, estimator=HansenHodrick()
+        )
         profile = evaluate(panel, cfg)
         assert WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE in profile.warnings
         assert profile.metadata[StatCode.P_HH]["variance_clamped"] is True

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -98,9 +98,9 @@ def test_evaluate_default_factor_col_stamps_canonical_name() -> None:
     assert profile.factor_id == "factor"
 
 
-def test_context_empty_by_default() -> None:
+def test_context_carries_estimator_provenance() -> None:
     profile = evaluate(_panel(), _cfg(), factor_col="momentum_12_1")
-    assert dict(profile.context) == {}
+    assert dict(profile.context) == {"estimator": "NeweyWest"}
 
 
 def test_diagnose_includes_identity_and_context() -> None:
@@ -110,7 +110,7 @@ def test_diagnose_includes_identity_and_context() -> None:
         "factor_id": "momentum_12_1",
         "forward_periods": 7,
     }
-    assert d["context"] == {}
+    assert d["context"] == {"estimator": "NeweyWest"}
 
 
 def test_replace_preserves_identity_when_only_other_fields_change() -> None:


### PR DESCRIPTION
## Summary

- `HACEstimator(Estimator)` sub-protocol adds `compute(series, *, forward_periods) -> InferenceResult` + `min_periods` for cell-internal HAC dispatch; selection-only base `Estimator` retained for slice-test instances (`WaldCluster` / `BlockBootstrap`)
- `AnalysisConfig.estimator: HACEstimator = NeweyWest()` plus name-string `to_dict`/`from_dict` serialization; applicability gated at `__post_init__`
- IC PANEL / FM PANEL / CAAR PANEL procedures dispatch through `cfg.estimator.compute(...)`; default `NeweyWest()` is bit-equal to v0.12; `HansenHodrick()` swaps to rectangular-kernel HAC; `profile.context["estimator"]` records cfg-driven choice (HLZ2016 spec-search defence)

**BREAKING**: default cfg no longer side-emits `(T_HH, P_HH)`; `primary_p` / `primary_stat_name` reflect the dispatched estimator. Migration: read `profile.primary_stat` + `profile.context["estimator"]` instead of hardcoded `stats[StatCode.T_NW]` / `stats[StatCode.P_HH]`. Full migration note in CHANGELOG.

Final design + 6 Open Decisions + 15 decision table + DoD all consolidated at #163's [canonical SSOT comment](https://github.com/awwesomeman/factrix/issues/163#issuecomment-4427574370).

## Test plan

- [x] 1190 tests pass (`pytest tests/`)
- [x] mypy clean (`uv run mypy factrix`)
- [x] ruff clean (pre-commit gate)
- [x] Bit-equal verification: NW dispatch numerical match to v0.12 hardcoded path (`tests/test_estimator_dispatch.py::TestDefaultNWBitEqual`)
- [x] HH dispatch path numerical match to `_hansen_hodrick_t_test` primitive (`tests/test_hac_estimator.py::TestHansenHodrickCompute`)
- [x] Applicability gate fires at cfg construction, not deep in evaluate
- [x] `from_dict` legacy schema (no estimator key) round-trips to `NeweyWest()`
- [x] Provenance: `profile.context["estimator"]` populated across all 6 procedures
- [x] Per-batch /simplify review (3) + final dual-agent senior-backend + quant UX review

## Out of scope (tracked separately)

- `list_estimators(scope, signal)` cell-filter — #255
- Third-party `register_estimator(...)` API — #256
- Provenance asymmetry on non-dispatch cells (TS β / TS Dummy / common-panel) — #257
- GMM J-test / MomentEstimator sub-protocol — #191
- Slope-axis HAC sub-protocol (TS β / TS Dummy dispatch) — future issue

## Commits

- \`191ed07\` feat(stats): HACEstimator subprotocol
- \`0a58e13\` feat(stats): AnalysisConfig.estimator field
- \`3ffed0f\` feat(stats): dispatch HAC inference via cfg.estimator
- \`03f7553\` docs(stats): purge ComputableEstimator residue + clarify HH scope
- \`8fa4135\` docs(stats): CHANGELOG + estimator-alternatives guide

Closes #163