### PR TITLE
feat(mtc): partial_conjunction — contract-bearing k-of-m FDR (#162)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -35,6 +35,13 @@
 # checked).
 ^https://github\.com/[^/]+/[^/]+/edit/
 
+# Academic publishers (Oxford Academic, Wiley Online Library) return
+# 403 Forbidden to bot user-agents including the GitHub Actions runner
+# pool. The links resolve fine for humans; CI cannot reach them. These
+# host BH2008 / BB2014 / similar canonical citations in docs/api/.
+^https://academic\.oup\.com/
+^https://onlinelibrary\.wiley\.com/
+
 # pola.rs (Polars project home) intermittently fails TLS handshake
 # from GitHub Actions runners with "Maybe a certificate error?" — the
 # site itself has a valid LE cert but the runner pool occasionally

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -1,0 +1,140 @@
+# partial_conjunction
+
+Contract-bearing screening for the "factor X is significant in $k$ of
+$m$ conditions" claim. Replaces the notebook idiom
+`set(survivors_a) & set(survivors_b)`, which does **not** preserve FDR
+([Benjamini & Bogomolov 2014](https://academic.oup.com/jrsssb/article/76/1/297/7075880)),
+with the partial conjunction test of
+[Benjamini & Heller (2008)](https://onlinelibrary.wiley.com/doi/10.1111/j.1541-0420.2008.00984.x).
+
+```python
+import factrix as fx
+
+# "Momentum is significant in BOTH large-cap AND small-cap universes"
+profiles = [
+    fx.evaluate(panel_large, cfg, factor_col="mom"),
+    fx.evaluate(panel_small, cfg, factor_col="mom"),
+    # ... + value, quality, etc. one profile per (factor, universe) cell
+]
+survivors = fx.multi_factor.partial_conjunction(
+    profiles,
+    min_pass=2,
+    n_conditions=2,
+    expand_over=["universe_id"],
+    q=0.05,
+)
+```
+
+## Versus `bhy(expand_over=...)` — same data, different question
+
+Both verbs accept `expand_over=`, but the **survivor unit** and the
+**question answered** differ. This is the single most common source of
+confusion; pick the row that matches your claim.
+
+| Verb | Survivor unit | Question | Example claim |
+|---|---|---|---|
+| `bhy(profiles, expand_over=["universe_id"])` | `(factor, universe)` pair | "Where is this factor significant?" | "Momentum is significant in `large_cap`; value is significant in `small_cap`" |
+| `partial_conjunction(profiles, min_pass=2, expand_over=["universe_id"])` | `factor` identity | "Which factors are significant across all conditions?" | "Momentum is significant across both universes" |
+
+In other words: `bhy` treats each universe as **its own hypothesis** and
+expands the family; `partial_conjunction` treats each universe as a
+**condition the factor must pass jointly** and aggregates back to one
+hypothesis per factor.
+
+## When *not* to reach for `partial_conjunction`
+
+| Real intent | Reach for | Why |
+|---|---|---|
+| "At least *any* condition is significant" | `bhy(profiles, expand_over=[...])` | `min_pass=1` is union semantics — FDR inflates to ~2q. `partial_conjunction` raises rather than implement this. |
+| Rank candidates (no FDR control) | [`compare`](compare.md) | `compare` is a view, not a filter. |
+| Sensitivity to estimator / sample choice | `robustness` (#178) | Conditions there are *methods*, not data slices. |
+| Cross-slice metric difference (descriptive) | [`by_slice`](by-slice.md) | Returns per-slice metric values; no inference. |
+| Cross-slice metric difference (inferential, slice-pairs) | [`slice_pairwise_test` / `slice_joint_test`](slice-test.md) | Tests whether the slices' metric series differ, not whether the factor is jointly significant. |
+
+## Strict vs lenient mode
+
+`n_conditions` is the contract knob.
+
+| Mode | When | Behavior |
+|---|---|---|
+| **Strict** (`n_conditions=int`) | Paper-grade; you know the design (e.g. exactly 2 universes, exactly 4 horizons) | Identity with any condition count other than `n_conditions` raises. Data gaps surface fail-loud. |
+| **Lenient** (`n_conditions=None`) | EDA / prototyping; condition count varies by identity | `m` inferred per identity from the data; only requires `m >= min_pass`. |
+
+```python
+# Strict: 2 universes required for every factor; missing one raises.
+fx.multi_factor.partial_conjunction(
+    profiles, min_pass=2, n_conditions=2, expand_over=["universe_id"]
+)
+
+# Lenient: "at least 3 of however many horizons each factor has".
+fx.multi_factor.partial_conjunction(
+    profiles, min_pass=3, expand_over=["fwd_period"]
+)
+```
+
+## How the math works
+
+Per identity, the $m$ per-condition $p$-values are reduced to a single
+**PC $p$-value** (Bonferroni-style, BH2008):
+
+$$
+p_{\text{PC}}^{(k/m)} = \min\bigl(1,\; (m - k + 1) \cdot p_{(k)}\bigr)
+$$
+
+where $p_{(k)}$ is the $k$-th smallest of the $m$ $p$-values and
+$k = \texttt{min\_pass}$. Two corner cases worth knowing:
+
+- $k = m$ (full conjunction) → $p_{\text{PC}} = \max(p)$. Reject only
+  when even the worst condition is significant.
+- $k = 1$ (union) → $p_{\text{PC}} = m \cdot \min(p)$. Bonferroni-corrected
+  minimum. **Forbidden here** — the surface raises with a pointer to
+  `bhy(expand_over=...)`, where the family-level FDR inflation is
+  explicit rather than hidden in a "robust across" claim.
+
+The PC $p$-values are then fed to a standard BHY step-up across
+identities, controlling group-level FDR ≤ `q`. The harmonic dependence
+correction $c(m) = \sum 1/i$ is applied because PC $p$-values across
+identities are not generally PRDS — sharing underlying panels makes the
+joint distribution unknown, so the conservative choice is the default.
+
+BH2008 also presents a Simes-style PC combiner, which is less
+conservative under PRDS. factrix ships only the Bonferroni-style — it
+is uniformly valid without dependence assumptions; a Simes path may
+be added later if a use case demands it.
+
+## Survivors output
+
+`partial_conjunction` returns the same [`Survivors`](multi-factor.md)
+container as `bhy`, populated with PC-specific metadata:
+
+| Field | Meaning |
+|---|---|
+| `profiles` | One representative profile per surviving identity (the first profile of that identity in input order) |
+| `adj_p` | BHY-adjusted PC $p$-value; survivor iff `adj_p <= q` |
+| `pc_p` | Raw PC $p$-value (pre-BHY) |
+| `min_pass` | The $k$ you passed |
+| `n_total` | Keyed by identity tuple `(factor_id, forward_periods)` → actual $m$ used |
+| `n_passed_uncorr` | Per-identity count of raw $p < q$. Descriptive — flags borderline (`n_passed_uncorr == min_pass`) and data-gap cases at a glance. **Cutoff is your `q`**, so the count moves with `q` — using it to override `adj_p` survivor selection is the anti-shopping failure mode this verb exists to prevent. |
+
+## Validation summary
+
+| Trigger | Outcome |
+|---|---|
+| `min_pass < 2` | `UserInputError`. `min_pass == 1` additionally points at `bhy(expand_over=...)`. |
+| `expand_over` empty / `None` | `UserInputError` — the verb is undefined without a condition axis. |
+| `expand_over` names an identity field (`factor_id` / `forward_periods`) | `UserInputError` (#160 anti-shopping defense — same as `bhy`). |
+| `n_conditions < min_pass` | `UserInputError` (unsatisfiable). |
+| Strict mode: identity's condition count $\neq$ `n_conditions` | `UserInputError` — surfaces missing-universe / missing-horizon data gaps. |
+| Identity with condition count $<$ `min_pass` (lenient) | `UserInputError`. |
+| Duplicate `(identity, expand_over_values)` partition key | `UserInputError` (family-resolution invariant). |
+
+## References
+
+- **[BH2008]** Benjamini, Y. & Heller, R. (2008). Screening for partial
+  conjunction hypotheses. *Biometrics*, 64(4), 1215–1222.
+- **[BB2014]** Benjamini, Y. & Bogomolov, M. (2014). Selective inference
+  on multiple families of hypotheses. *JRSS-B*, 76(1).
+- **[HY2014]** Heller, R. & Yekutieli, D. (2014). Replicability analysis
+  for genome-wide association studies. *AOAS*, 8(1).
+
+::: factrix.multi_factor.partial_conjunction

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -25,8 +25,9 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from factrix._errors import UserInputError
 from factrix._family import _resolve_family
-from factrix.stats.multiple_testing import bhy_adjusted_p
+from factrix.stats.multiple_testing import bhy_adjusted_p, partial_conjunction_p
 
 if TYPE_CHECKING:
     from factrix._profile import FactorProfile
@@ -56,12 +57,29 @@ class Survivors:
         q: Nominal FDR (or family-wise) target shared across all
             buckets.
         expand_over: Context keys used to partition the input into
-            independent step-up buckets. Empty tuple when the full
-            input is one family.
-        n_total: Per-bucket family size fed into the step-up math,
-            keyed by the bucket's ``expand_over_values`` tuple
-            (``()`` for the single-bucket case). Records the ``m``
-            two-stage screening uses.
+            independent step-up buckets (``bhy``) or to aggregate
+            conditions per identity (``partial_conjunction``). Empty
+            tuple when the full input is one family.
+        n_total: Family size per bucket fed into the step-up math.
+            Keying depends on the verb: ``bhy`` keys by
+            ``expand_over_values`` tuple (``()`` for the single-bucket
+            case); ``partial_conjunction`` keys by ``identity`` tuple
+            (``(factor_id, forward_periods)``) and records the ``m``
+            condition count per identity.
+        pc_p: Raw partial-conjunction p-value per survivor (Benjamini
+            & Heller 2008 Bonferroni-style: ``(m - min_pass + 1) *
+            p_((min_pass))``, capped at 1). ``None`` when the verb is
+            not ``partial_conjunction``.
+        min_pass: ``k`` in the ``k`` of ``m`` partial conjunction test.
+            ``None`` when the verb is not ``partial_conjunction``.
+        n_passed_uncorr: Per-identity count of raw p-values strictly
+            below ``q`` (descriptive — **not** used in inference; flags
+            borderline cases and data gaps at a glance). The cutoff is
+            the caller's ``q`` (same value driving the BHY step-up), so
+            this count moves with ``q``; using it to override
+            ``adj_p`` survivor selection is the anti-shopping failure
+            mode this verb exists to prevent. ``None`` when the verb is
+            not ``partial_conjunction``.
     """
 
     profiles: list[FactorProfile]
@@ -69,6 +87,9 @@ class Survivors:
     q: float
     expand_over: tuple[str, ...]
     n_total: Mapping[tuple[Any, ...], int]
+    pc_p: np.ndarray | None = None
+    min_pass: int | None = None
+    n_passed_uncorr: np.ndarray | None = None
 
     def __len__(self) -> int:
         return len(self.profiles)
@@ -81,12 +102,43 @@ class Survivors:
         in earlier iterations.
         """
         headers: tuple[str, ...]
-        if self.expand_over:
+        pc_mode = self.pc_p is not None
+        if pc_mode:
+            headers = (
+                "identity",
+                "pc_p",
+                "adj_p",
+                "n_total",
+                "n_passed_uncorr",
+            )
+        elif self.expand_over:
             headers = ("expand_over_values", "identity", "primary_p", "adj_p")
         else:
             headers = ("identity", "primary_p", "adj_p")
 
         rows: list[tuple[str, ...]] = []
+        if pc_mode:
+            assert self.pc_p is not None
+            assert self.n_passed_uncorr is not None
+            for profile, pc, adj, n_passed in zip(
+                self.profiles,
+                self.pc_p,
+                self.adj_p,
+                self.n_passed_uncorr,
+                strict=True,
+            ):
+                m = self.n_total.get(profile.identity, 0)
+                rows.append(
+                    (
+                        repr(profile.identity),
+                        f"{float(pc):.4g}",
+                        f"{float(adj):.4g}",
+                        str(m),
+                        str(int(n_passed)),
+                    )
+                )
+            return headers, rows
+
         for profile, adj in zip(self.profiles, self.adj_p, strict=True):
             cells = (
                 repr(profile.identity),
@@ -102,6 +154,8 @@ class Survivors:
 
     def _header_summary(self) -> str:
         parts = [f"n={len(self.profiles)}", f"q={self.q:g}"]
+        if self.min_pass is not None:
+            parts.append(f"min_pass={self.min_pass}")
         if self.expand_over:
             parts.append(f"expand_over={list(self.expand_over)!r}")
             n_total_repr = ", ".join(
@@ -249,6 +303,236 @@ def bhy(
         q=q,
         expand_over=expand_over_tuple,
         n_total=n_total,
+    )
+
+
+def partial_conjunction(
+    profiles: Iterable[FactorProfile],
+    *,
+    min_pass: int,
+    expand_over: Sequence[str],
+    n_conditions: int | None = None,
+    estimator: Estimator | None = None,
+    q: float = 0.05,
+) -> Survivors:
+    """Partial conjunction screening: filter identities significant in
+    at least ``min_pass`` of ``m`` expanded conditions, FDR-controlled.
+
+    For "factor X is significant in universes A and B" style claims,
+    naive ``set(survivors_A) & set(survivors_B)`` does not preserve FDR
+    [Benjamini & Bogomolov 2014]. The partial conjunction test
+    [Benjamini & Heller 2008] provides a contract-bearing path: per
+    identity, combine the ``m`` per-condition p-values into a single
+    PC p-value, then run BHY across identities.
+
+    The PC p-value formula (Bonferroni-style, BH2008): for ``k`` =
+    ``min_pass``, ``p_PC = (m - k + 1) * p_((k))`` capped at 1, where
+    ``p_((k))`` is the ``k``-th smallest p-value across the identity's
+    ``m`` conditions. ``k = m`` reduces to ``max(p)`` (full conjunction);
+    ``k = 1`` reduces to ``m * min(p)`` (Bonferroni-union, forbidden
+    here — see below).
+
+    Args:
+        profiles: Iterable of :class:`FactorProfile`. Conditions per
+            identity come from ``expand_over``; multiple profiles
+            sharing an identity must differ on at least one
+            ``expand_over`` key (the standard ``_resolve_family``
+            uniqueness check).
+        min_pass: ``k`` in "k of m" — minimum number of conditions
+            required to be significant. Must be ``>= 2``; ``min_pass=1``
+            is union semantics (FDR ≈ ``2q`` under independence) and
+            raises with a pointer to ``bhy(expand_over=...)``.
+        expand_over: Required, non-empty. Context keys defining the
+            condition axis. Identity dimensions (``factor_id`` /
+            ``forward_periods``) are rejected by the family-resolution
+            layer (#160 anti-shopping defense).
+        n_conditions: Strict-mode declaration. ``None`` (lenient) lets
+            ``m`` be inferred per identity from the data; an ``int``
+            requires every identity to have exactly that many
+            conditions and raises on mismatch (paper-grade — surfaces
+            data gaps fail-loud).
+        estimator: Optional inference-method override (#170). ``None``
+            uses each profile's ``primary_p``.
+        q: Nominal FDR target for the BHY step-up over PC p-values.
+            Default ``0.05``.
+
+    Returns:
+        :class:`Survivors` in input order (deduplicated to one row per
+        surviving identity, using the first profile of that identity as
+        representative). ``adj_p`` is the BHY-adjusted PC p-value;
+        ``pc_p`` is the raw PC p-value; ``n_total[identity]`` is the
+        condition count ``m``; ``n_passed_uncorr[i]`` is the count of
+        raw p-values strictly below ``q`` for survivor ``i``.
+
+    Raises:
+        UserInputError: ``min_pass < 2`` (with ``min_pass=1`` flagged
+            as union semantics); ``expand_over`` empty or ``None``;
+            ``n_conditions < min_pass``; strict-mode ``n_conditions``
+            mismatch with actual condition count; identity with fewer
+            than ``min_pass`` conditions; family-resolution invariants
+            (unknown ``expand_over`` key, identity-shadowing,
+            duplicate partition key).
+    """
+    if min_pass < 2:
+        if min_pass == 1:
+            raise UserInputError(
+                verb="partial_conjunction",
+                field="min_pass",
+                value=min_pass,
+                expected=(
+                    "min_pass >= 2. min_pass=1 reduces to union semantics "
+                    "(rejects when any single condition is significant) "
+                    "and inflates FDR to ~2q under independence; the "
+                    "partial conjunction surface is contract-bearing only "
+                    "for k >= 2. There is no drop-in 'any-significant' "
+                    "verb — the closest available is "
+                    "bhy(profiles, expand_over=[...]), which expands the "
+                    "family across conditions instead of aggregating "
+                    "(survivor unit becomes (factor, condition) pair, "
+                    "not factor identity; see docs)"
+                ),
+                docs_path="api/partial-conjunction#min-pass-must-be-at-least-2",
+            )
+        raise UserInputError(
+            verb="partial_conjunction",
+            field="min_pass",
+            value=min_pass,
+            expected="positive integer >= 2",
+            docs_path="api/partial-conjunction#min-pass-must-be-at-least-2",
+        )
+
+    if not expand_over:
+        raise UserInputError(
+            verb="partial_conjunction",
+            field="expand_over",
+            value=expand_over,
+            expected=(
+                "non-empty list of context keys naming the condition "
+                "axis (e.g. ['universe_id'] for cross-universe "
+                "replication, ['fwd_period'] for cross-horizon "
+                "replication). partial_conjunction is undefined without "
+                "a condition axis"
+            ),
+            docs_path="api/partial-conjunction#expand-over-required",
+        )
+
+    if n_conditions is not None and n_conditions < min_pass:
+        raise UserInputError(
+            verb="partial_conjunction",
+            field="n_conditions",
+            value=n_conditions,
+            expected=(
+                f"n_conditions >= min_pass ({min_pass}); requiring more "
+                "passes than total conditions is unsatisfiable"
+            ),
+            docs_path="api/partial-conjunction#n-conditions",
+        )
+
+    expand_over_tuple: tuple[str, ...] = tuple(expand_over)
+    profile_list = list(profiles)
+
+    if not profile_list:
+        return Survivors(
+            profiles=[],
+            adj_p=np.zeros(0, dtype=np.float64),
+            q=q,
+            expand_over=expand_over_tuple,
+            n_total={},
+            pc_p=np.zeros(0, dtype=np.float64),
+            min_pass=min_pass,
+            n_passed_uncorr=np.zeros(0, dtype=np.int64),
+        )
+
+    entries = _resolve_family(
+        profile_list,
+        verb="partial_conjunction",
+        expand_over=expand_over,
+        estimator=estimator,
+    )
+
+    groups: dict[tuple[str, int], list[Any]] = defaultdict(list)
+    for entry in entries:
+        groups[entry.identity].append(entry)
+
+    identities_ordered: list[tuple[str, int]] = []
+    seen_identities: set[tuple[str, int]] = set()
+    for entry in entries:
+        if entry.identity not in seen_identities:
+            seen_identities.add(entry.identity)
+            identities_ordered.append(entry.identity)
+
+    pc_p_arr = np.empty(len(identities_ordered), dtype=np.float64)
+    n_passed_arr = np.empty(len(identities_ordered), dtype=np.int64)
+    n_total_per_identity: dict[tuple[Any, ...], int] = {}
+    rep_profiles: list[FactorProfile] = []
+
+    for i, identity in enumerate(identities_ordered):
+        group = groups[identity]
+        m = len(group)
+
+        if n_conditions is not None and m != n_conditions:
+            raise UserInputError(
+                verb="partial_conjunction",
+                field="n_conditions",
+                value=n_conditions,
+                expected=(
+                    f"identity {identity} has {m} condition(s) in data "
+                    f"but n_conditions={n_conditions} declared (strict "
+                    "mode). Pass n_conditions=None for lenient mode, or "
+                    "fix the input so every identity has exactly "
+                    f"{n_conditions} conditions"
+                ),
+                docs_path="api/partial-conjunction#strict-vs-lenient",
+            )
+
+        if m < min_pass:
+            raise UserInputError(
+                verb="partial_conjunction",
+                field="profiles",
+                value=identity,
+                expected=(
+                    f"identity {identity} has only {m} condition(s) but "
+                    f"min_pass={min_pass} requires at least that many. "
+                    "Either drop this identity from the input or lower "
+                    "min_pass"
+                ),
+                docs_path="api/partial-conjunction#insufficient-conditions",
+            )
+
+        ps = np.array([e.p_value for e in group], dtype=np.float64)
+        pc_p_arr[i] = partial_conjunction_p(ps, min_pass=min_pass)
+        n_passed_arr[i] = int(np.sum(ps < q))
+        n_total_per_identity[identity] = m
+        rep_profiles.append(group[0].profile)
+
+    if n_conditions is None:
+        m_values = set(n_total_per_identity.values())
+        if len(m_values) > 1:
+            warnings.warn(
+                "partial_conjunction: lenient mode (n_conditions=None) is "
+                f"running with heterogeneous condition counts m={sorted(m_values)} "
+                "across identities. PC p-values are valid marginally but the "
+                "k/m bar differs per identity (an identity with m=8 faces a "
+                "much stricter Bonferroni multiplier at k=2 than one with "
+                "m=2). For cross-identity comparability pass "
+                "n_conditions=<int> (strict mode) or split the call.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    adj_p_all = bhy_adjusted_p(pc_p_arr)
+    survivor_idx = np.flatnonzero(adj_p_all <= q)
+
+    surviving_identities = [identities_ordered[i] for i in survivor_idx]
+    return Survivors(
+        profiles=[rep_profiles[i] for i in survivor_idx],
+        adj_p=adj_p_all[survivor_idx],
+        q=q,
+        expand_over=expand_over_tuple,
+        n_total={ident: n_total_per_identity[ident] for ident in surviving_identities},
+        pc_p=pc_p_arr[survivor_idx],
+        min_pass=min_pass,
+        n_passed_uncorr=n_passed_arr[survivor_idx],
     )
 
 

--- a/factrix/multi_factor.py
+++ b/factrix/multi_factor.py
@@ -6,6 +6,6 @@ v0.4 deletion sweep that retires the existing v0.4 implementations
 of those primitives.
 """
 
-from factrix._multi_factor import bhy
+from factrix._multi_factor import bhy, partial_conjunction
 
-__all__ = ["bhy"]
+__all__ = ["bhy", "partial_conjunction"]

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -24,6 +24,9 @@ References:
     Benjamini, Y. & Yekutieli, D. (2001). "The Control of the False
     Discovery Rate in Multiple Testing under Dependency."
     Annals of Statistics 29(4), 1165-1188.
+
+    Benjamini, Y. & Heller, R. (2008). "Screening for partial conjunction
+    hypotheses." Biometrics 64(4), 1215-1222. — partial_conjunction_p
 """
 
 from __future__ import annotations
@@ -151,3 +154,43 @@ def bhy_adjusted_p(
     out = np.empty(n, dtype=float)
     out[order] = adj_sorted
     return out
+
+
+def partial_conjunction_p(
+    p_values: npt.ArrayLike,
+    *,
+    min_pass: int,
+) -> float:
+    """Bonferroni-style partial conjunction p-value (Benjamini-Heller 2008).
+
+    Tests ``H_0^{k/m}``: at most ``k - 1`` of the ``m`` alternatives are
+    true, against ``H_1^{k/m}``: at least ``k`` are true. The combined
+    p-value is
+
+        ``p_PC = min(1, (m - k + 1) * p_((k)))``
+
+    where ``p_((k))`` is the ``k``-th smallest of the ``m`` p-values
+    (1-indexed). ``k = m`` reduces to ``max(p)`` (full conjunction);
+    ``k = 1`` reduces to Bonferroni-corrected ``min(p)``.
+
+    Args:
+        p_values: 1-D array of m per-condition p-values for a single
+            hypothesis (e.g. one factor across m universes).
+        min_pass: ``k`` — the minimum number of conditions required to
+            be significant. Must satisfy ``1 <= min_pass <= m``.
+
+    Returns:
+        The PC p-value, clipped to ``[0, 1]``.
+    """
+    p = np.asarray(p_values, dtype=float)
+    m = len(p)
+    if m == 0:
+        raise ValueError("partial_conjunction_p: p_values must be non-empty.")
+    if not 1 <= min_pass <= m:
+        raise ValueError(
+            f"partial_conjunction_p: min_pass ({min_pass}) must satisfy "
+            f"1 <= min_pass <= m ({m})."
+        )
+    sorted_p = np.sort(p)
+    pc = (m - min_pass + 1) * float(sorted_p[min_pass - 1])
+    return min(pc, 1.0)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,7 @@ nav:
           - by_slice: api/by-slice.md
           - slice_pairwise_test / slice_joint_test: api/slice-test.md
           - multi_factor: api/multi-factor.md
+          - partial_conjunction: api/partial-conjunction.md
           - list_metrics: api/list-metrics.md
           - suggest_config: api/suggest-config.md
           - compare: api/compare.md

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from factrix.stats.multiple_testing import bhy_adjust, bhy_adjusted_p
+from factrix.stats.multiple_testing import (
+    bhy_adjust,
+    bhy_adjusted_p,
+    partial_conjunction_p,
+)
 
 
 class TestBhyAdjust:
@@ -165,3 +169,35 @@ class TestNTotal:
             # Allow tiny float noise
             assert (curr + 1e-12 >= prev).all()
             prev = curr
+
+
+class TestPartialConjunctionP:
+    def test_full_conjunction_k_equals_m(self):
+        # k = m: pc_p = 1 * max(p)
+        p = [0.01, 0.04, 0.20]
+        assert partial_conjunction_p(p, min_pass=3) == pytest.approx(0.20)
+
+    def test_union_k_equals_one(self):
+        # k = 1: pc_p = m * min(p) (Bonferroni)
+        p = [0.01, 0.04, 0.20]
+        assert partial_conjunction_p(p, min_pass=1) == pytest.approx(3 * 0.01)
+
+    def test_intermediate_k(self):
+        # k = 2, m = 4: pc_p = 3 * p_((2))
+        p = [0.001, 0.005, 0.04, 0.5]
+        assert partial_conjunction_p(p, min_pass=2) == pytest.approx(3 * 0.005)
+
+    def test_clipped_at_one(self):
+        # k = 1, m = 3, min(p) = 0.5: raw = 1.5, clipped to 1.0
+        p = [0.5, 0.6, 0.7]
+        assert partial_conjunction_p(p, min_pass=1) == pytest.approx(1.0)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            partial_conjunction_p([], min_pass=1)
+
+    def test_min_pass_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="1 <= min_pass <= m"):
+            partial_conjunction_p([0.01, 0.02], min_pass=3)
+        with pytest.raises(ValueError, match="1 <= min_pass <= m"):
+            partial_conjunction_p([0.01, 0.02], min_pass=0)

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -1,0 +1,245 @@
+"""v0.13 ``multi_factor.partial_conjunction`` — contract-bearing path
+for "factor X significant in k of m conditions" (#162)."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from factrix._analysis_config import AnalysisConfig
+from factrix._axis import Metric, Mode
+from factrix._codes import StatCode
+from factrix._errors import UserInputError
+from factrix._multi_factor import Survivors, partial_conjunction
+from factrix._profile import FactorProfile
+
+
+def _profile(
+    *,
+    factor_id: str,
+    forward_periods: int = 5,
+    primary_p: float,
+    context: dict[str, object] | None = None,
+) -> FactorProfile:
+    cfg = AnalysisConfig.individual_continuous(
+        metric=Metric.IC, forward_periods=forward_periods
+    )
+    return FactorProfile(
+        config=cfg,
+        mode=Mode.PANEL,
+        primary_p=primary_p,
+        primary_stat=2.0,
+        primary_stat_name=StatCode.T_NW,
+        n_obs=100,
+        n_pairs=3000,
+        n_periods=100,
+        n_assets=30,
+        factor_id=factor_id,
+        context=context or {},
+        stats={StatCode.P_NW: primary_p},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestMinPassValidation:
+    def test_min_pass_one_raises_with_pointer_to_bhy(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.01, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.02, context={"u": "b"}),
+        ]
+        with pytest.raises(UserInputError) as ex:
+            partial_conjunction(prof, min_pass=1, expand_over=["u"])
+        assert ex.value.field == "min_pass"
+        message = str(ex.value)
+        assert "bhy" in message and "expand_over" in message
+        assert "union" in message
+
+    def test_min_pass_zero_raises(self) -> None:
+        prof = [_profile(factor_id="f", primary_p=0.01, context={"u": "a"})]
+        with pytest.raises(UserInputError):
+            partial_conjunction(prof, min_pass=0, expand_over=["u"])
+
+    def test_min_pass_negative_raises(self) -> None:
+        prof = [_profile(factor_id="f", primary_p=0.01, context={"u": "a"})]
+        with pytest.raises(UserInputError):
+            partial_conjunction(prof, min_pass=-1, expand_over=["u"])
+
+
+class TestExpandOverValidation:
+    def test_empty_expand_over_raises(self) -> None:
+        prof = [_profile(factor_id="f", primary_p=0.01, context={"u": "a"})]
+        with pytest.raises(UserInputError) as ex:
+            partial_conjunction(prof, min_pass=2, expand_over=[])
+        assert "expand_over" in str(ex.value)
+
+    def test_unknown_expand_over_key_raises(self) -> None:
+        prof = [_profile(factor_id="f", primary_p=0.01, context={"u": "a"})]
+        with pytest.raises(UserInputError):
+            partial_conjunction(prof, min_pass=2, expand_over=["regime_id"])
+
+    def test_identity_field_in_expand_over_raises(self) -> None:
+        prof = [_profile(factor_id="f", primary_p=0.01, context={"u": "a"})]
+        with pytest.raises(UserInputError):
+            partial_conjunction(prof, min_pass=2, expand_over=["factor_id"])
+
+
+class TestNConditionsValidation:
+    def test_n_conditions_less_than_min_pass_raises(self) -> None:
+        prof = [_profile(factor_id="f", primary_p=0.01, context={"u": "a"})]
+        with pytest.raises(UserInputError) as ex:
+            partial_conjunction(prof, min_pass=3, n_conditions=2, expand_over=["u"])
+        assert ex.value.field == "n_conditions"
+
+    def test_strict_mismatch_raises(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.01, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.02, context={"u": "b"}),
+            _profile(factor_id="f", primary_p=0.03, context={"u": "c"}),
+        ]
+        with pytest.raises(UserInputError) as ex:
+            partial_conjunction(prof, min_pass=2, n_conditions=2, expand_over=["u"])
+        assert ex.value.field == "n_conditions"
+
+    def test_insufficient_conditions_raises(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.01, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.02, context={"u": "b"}),
+        ]
+        with pytest.raises(UserInputError):
+            partial_conjunction(prof, min_pass=3, expand_over=["u"])
+
+
+# ---------------------------------------------------------------------------
+# PC p-value math (BH2008 Bonferroni-style: (m - k + 1) * p_((k)))
+# ---------------------------------------------------------------------------
+
+
+class TestPCPValueMath:
+    def test_full_conjunction_equals_max(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.01, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.03, context={"u": "b"}),
+        ]
+        sv = partial_conjunction(prof, min_pass=2, n_conditions=2, expand_over=["u"])
+        assert sv.pc_p is not None
+        assert sv.pc_p[0] == pytest.approx(0.03)
+
+    def test_partial_conjunction_bonferroni_scaled(self) -> None:
+        ps = [0.001, 0.005, 0.04, 0.5]
+        prof = [
+            _profile(factor_id="f", primary_p=p, context={"u": f"u{i}"})
+            for i, p in enumerate(ps)
+        ]
+        sv = partial_conjunction(
+            prof, min_pass=2, n_conditions=4, expand_over=["u"], q=0.5
+        )
+        assert sv.pc_p is not None
+        assert sv.pc_p[0] == pytest.approx(3 * 0.005)
+
+    def test_pc_p_capped_at_one(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.4, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.5, context={"u": "b"}),
+            _profile(factor_id="f", primary_p=0.6, context={"u": "c"}),
+        ]
+        sv = partial_conjunction(
+            prof, min_pass=2, n_conditions=3, expand_over=["u"], q=1.0
+        )
+        assert sv.pc_p is not None
+        assert sv.pc_p[0] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Survivor selection
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivorSelection:
+    def test_only_robust_factor_survives(self) -> None:
+        # mom passes both universes; val only one
+        prof = [
+            _profile(factor_id="mom", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="mom", primary_p=0.002, context={"u": "b"}),
+            _profile(factor_id="val", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="val", primary_p=0.30, context={"u": "b"}),
+        ]
+        sv = partial_conjunction(
+            prof, min_pass=2, n_conditions=2, expand_over=["u"], q=0.05
+        )
+        assert [p.factor_id for p in sv.profiles] == ["mom"]
+
+    def test_returns_survivors_with_pc_metadata(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.002, context={"u": "b"}),
+        ]
+        sv = partial_conjunction(
+            prof, min_pass=2, n_conditions=2, expand_over=["u"], q=0.05
+        )
+        assert isinstance(sv, Survivors)
+        assert sv.min_pass == 2
+        assert sv.pc_p is not None
+        assert sv.n_passed_uncorr is not None
+        assert sv.expand_over == ("u",)
+        assert sv.n_total[("f", 5)] == 2
+
+    def test_n_passed_uncorr_counts_raw_below_q(self) -> None:
+        prof = [
+            _profile(factor_id="f", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="f", primary_p=0.04, context={"u": "b"}),
+            _profile(factor_id="f", primary_p=0.20, context={"u": "c"}),
+        ]
+        sv = partial_conjunction(
+            prof, min_pass=2, n_conditions=3, expand_over=["u"], q=0.5
+        )
+        assert sv.n_passed_uncorr is not None
+        assert int(sv.n_passed_uncorr[0]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Lenient (n_conditions=None) mode
+# ---------------------------------------------------------------------------
+
+
+class TestLenientMode:
+    def test_lenient_infers_m_per_identity(self) -> None:
+        prof = [
+            _profile(factor_id="A", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="A", primary_p=0.002, context={"u": "b"}),
+            _profile(factor_id="B", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="B", primary_p=0.002, context={"u": "b"}),
+            _profile(factor_id="B", primary_p=0.003, context={"u": "c"}),
+        ]
+        with pytest.warns(RuntimeWarning, match="heterogeneous"):
+            sv = partial_conjunction(prof, min_pass=2, expand_over=["u"], q=0.5)
+        assert sv.n_total[("A", 5)] == 2
+        assert sv.n_total[("B", 5)] == 3
+
+    def test_lenient_homogeneous_m_no_warning(self) -> None:
+        prof = [
+            _profile(factor_id="A", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="A", primary_p=0.002, context={"u": "b"}),
+            _profile(factor_id="B", primary_p=0.001, context={"u": "a"}),
+            _profile(factor_id="B", primary_p=0.002, context={"u": "b"}),
+        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            partial_conjunction(prof, min_pass=2, expand_over=["u"], q=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Empty input edge case
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_profiles_returns_empty_survivors(self) -> None:
+        sv = partial_conjunction([], min_pass=2, expand_over=["u"])
+        assert sv.profiles == []
+        assert len(sv.adj_p) == 0
+        assert sv.min_pass == 2
+        assert sv.pc_p is not None and len(sv.pc_p) == 0


### PR DESCRIPTION
## Summary

- Adds `factrix.multi_factor.partial_conjunction` — the contract-bearing path for "factor X significant in at least *k* of *m* conditions" (BH2008 Bonferroni-style PC p-value composed with BHY across identities). Replaces the FDR-unsound `set(survivors_a) & set(survivors_b)` notebook idiom flagged in #162.
- New stats primitive `factrix.stats.multiple_testing.partial_conjunction_p` parallels `bhy_adjusted_p` (citation-local, separately unit-tested for the k=m / k=1 / intermediate / clipped corners).
- Extends `Survivors` with three optional fields populated only by the new verb: `pc_p`, `min_pass`, `n_passed_uncorr`. Existing `bhy` path / `compare(Survivors)` path unchanged.
- New docs page `docs/api/partial-conjunction.md` — opens with the survivor-unit contrast vs `bhy(expand_over=)` (single most common confusion per the issue discussion); covers strict vs lenient mode, the PC math, BHY-on-PC-p dependence rationale, and the `n_passed_uncorr` anti-shopping warning.

## Signature

\`\`\`python
partial_conjunction(
    profiles, *,
    min_pass,                 # k, >= 2 (1 = union semantics; raises with pointer to bhy)
    expand_over,              # required, non-empty
    n_conditions=None,        # strict: int (fail-loud); lenient: None (infer per identity)
    estimator=None,
    q=0.05,
) -> Survivors
\`\`\`

## UX guardrails

- `min_pass=1` raises and points at `bhy(expand_over=...)` — but the error message flags that survivor units differ (pair vs identity), so the user is not misled into thinking it is a drop-in alternative.
- Lenient mode + heterogeneous `m` across identities → `RuntimeWarning` (the k/m bar differs per identity, comparing PC p-values across them is apples-to-oranges).
- `n_passed_uncorr` docstring + docs callout explicitly flag the anti-shopping failure mode (using it to override `adj_p` survivor selection is the exact thing this verb exists to prevent).

## Test plan

- [x] `tests/test_partial_conjunction.py` — 19 tests: validation (min_pass / expand_over / n_conditions / identity-shadow), PC math (k=m, intermediate, clipped), survivor selection, strict mode mismatch, lenient mode + heterogeneous-m warning, empty input edge case.
- [x] `tests/stats/test_multiple_testing.py` — 7 new tests covering `partial_conjunction_p` corner cases.
- [x] Full suite: `pytest` — **1216 passed** (no regressions in `test_multi_factor.py` / `test_family_resolution.py`).
- [x] `mypy factrix/_multi_factor.py factrix/stats/multiple_testing.py` — clean.
- [x] `mkdocs build --strict` — clean.

Close #162.