### PR TITLE
feat(mtc): bhy_hierarchical — Yekutieli 2008 two-stage FDR (#175)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -35,12 +35,14 @@
 # checked).
 ^https://github\.com/[^/]+/[^/]+/edit/
 
-# Academic publishers (Oxford Academic, Wiley Online Library) return
-# 403 Forbidden to bot user-agents including the GitHub Actions runner
-# pool. The links resolve fine for humans; CI cannot reach them. These
-# host BH2008 / BB2014 / similar canonical citations in docs/api/.
+# Academic publishers (Oxford Academic, Wiley Online Library, Taylor &
+# Francis) return 403 Forbidden to bot user-agents including the GitHub
+# Actions runner pool. The links resolve fine for humans; CI cannot
+# reach them. These host BH2008 / BB2014 / Y2008 / similar canonical
+# citations in docs/api/.
 ^https://academic\.oup\.com/
 ^https://onlinelibrary\.wiley\.com/
+^https://www\.tandfonline\.com/
 
 # pola.rs (Polars project home) intermittently fails TLS handshake
 # from GitHub Actions runners with "Maybe a certificate error?" — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ While the version is below `1.0.0`, the public API should be considered unstable
 
 ### Added
 
+- **`bhy_hierarchical` two-stage FDR verb + `simes_p` primitive** (#264). `factrix.multi_factor.bhy_hierarchical(profiles, *, group: str, estimator=None, q=0.05) -> Survivors` implements the Yekutieli (2008) procedure for factor sets with natural group structure (momentum / value / quality families, cross-region universes). Outer Benjamini-Yekutieli step-up on Simes group representatives controls *group-level* FDR ≤ `q`; inner BHY within each passing group controls *within-group* FDR ≤ `q`. The cell-level `adj_p` is the max-of-layers fold `max(outer_adj_p[g], inner_adj_p[i])` so the universal `Survivors` duality `survivor[i] iff adj_p[i] <= q` still holds — both layer signals are folded into one number rather than splitting into `q_outer` / `q_inner` kwargs that would break the contract. `factrix.stats.multiple_testing.simes_p(p_values)` lands as a standalone primitive (Simes 1986 global-null combiner, dominates Bonferroni `m * min(p)`, valid under PRDS). The verb closes the third leg of the v0.13 multi-factor-verb surface (alongside `bhy(expand_over=)` and `partial_conjunction`); the three are distinguished by *survivor unit* — pair / identity-joint / identity-group-then-within — and the new `docs/api/bhy-hierarchical.md` opens with the routing table so a factor-zoo researcher picks the right verb without leaving the docs. Three failure modes that would otherwise produce surface-valid output are now blocked at the call site: single-group input raises and points at `bhy()`; every-profile-is-its-own-group at `n >= 3` raises (group axis is near-unique, probably a continuous variable mistakenly passed); majority-singleton-group inputs emit `RuntimeWarning` (inner BHY on n=1 is a raw cutoff, outer Simes on n=1 equals that p — no FDR correction at either layer for those groups). Reuses `_resolve_family` for group-key validation (identity-shadowing rejected, missing-context-key surfaced fail-loud) and the existing `estimator=` selection path so a Newey-West / Hansen-Hodrick p-value can drive both layers without per-call reconfiguration.
+
+  ```python
+  import factrix as fx
+
+  # "Which factor families show signal, and within those, which factors?"
+  survivors = fx.multi_factor.bhy_hierarchical(
+      profiles, group="family", q=0.05,
+  )
+  survivors.adj_p             # max-of-layers fold per cell
+  survivors.n_tests           # {(family,): m_in_family} for every input group
+  # per-survivor group label is profile.context["family"]
+  ```
+
 - **`MomentEstimator(Estimator)` sub-protocol + `GMM` Hansen J-test** (#191). A symmetric third Estimator layer alongside `HACEstimator`, for over-identifying-restriction tests on a multivariate moment-condition system. `MomentEstimator` adds `min_periods: int` and `compute(moments: np.ndarray, *, forward_periods: int) -> GMMResult`; `GMMResult` is a frozen dataclass parallel to `InferenceResult` carrying `j_stat` / `df` / `overid_p` / `n_moments` / `n_params` / `metadata` / `warnings` (no `stat_name` / `p_name` — the type itself implies the `(StatCode.J_GMM, StatCode.P_GMM)` pair). `factrix.stats.GMM` is the concrete instance: hand-rolled Hansen (1982) two-step efficient GMM in `factrix._stats.gmm` (no statsmodels dependency, matching the lean-dep pattern of `factrix._stats.hac`), pure over-identification (`n_params = 0`) only — parametric GMM is a forward hook. `StatCode.J_GMM` and `WarningCode.SINGULAR_WEIGHT_MATRIX` ship alongside (the latter distinguishes a rank-deficient long-run covariance from a generic short-sample warning, mirroring how `RECT_KERNEL_NEGATIVE_VARIANCE` separates Hansen-Hodrick's kernel-specific failure). `AnalysisConfig.moment_estimator: MomentEstimator | None = None` is wired through the four factory methods + `to_dict` / `from_dict` (backward-compatible with pre-#191 serialized configs that omit the key); `_moment_inference(cfg, moments)` mirrors `_hac_inference(cfg, series)` and stitches `GMMResult` into the procedure-layer `(stats, metadata)` contract keyed by `(J_GMM, P_GMM)`. Applicability gate runs at `__post_init__` time.
 
   ```python
@@ -57,6 +71,20 @@ While the version is below `1.0.0`, the public API should be considered unstable
   **Why**: HLZ2016's spec-search defence is "don't pick an estimator after seeing results," not "always use a single estimator forever." v0.12 hardcoded NW + auto-side-emitted HH, which let downstream code cherry-pick whichever p was smaller. v0.13's design forces estimator choice to be cfg-scoped (study-level, not per-call) and stamps the choice in `profile.context` so audit-time review can see whether multiple estimators ran on the same study. Per-call `evaluate(panel, cfg, estimator=...)` is deliberately not opened — the cfg object is the spec-search lock. (Related follow-ups: `list_estimators(scope, signal)` cell-filter #255, third-party `register_estimator` #256, provenance asymmetry on slope-axis cells #257.)
 
 ### Changed
+
+- **`Survivors.n_total` / `bhy_adjust(..., n_total=)` / `bhy_adjusted_p(..., n_total=)` → `n_tests`** (breaking, #264). The BHY denominator field / kwarg sat alongside `FactorProfile.n_obs` / `n_periods` / `n_pairs` / `n_assets` under the same `n_*` prefix but answered a structurally different question — those four are sample-size axes (observation counts inside one cell), while the BHY denominator is the multiple-testing family size (count of hypotheses in the step-up). A reader scanning `survivors.n_total` would first read "total observations" before noticing the field is a `Mapping[bucket_key, int]`; the name actively misled. `n_tests` names the domain directly. Migration is a single-token find-and-replace at every reading site:
+
+  ```python
+  # before
+  fx.multi_factor.bhy(profiles, q=0.05).n_total
+  fx.stats.bhy_adjusted_p(p, n_total=1000)
+
+  # after
+  fx.multi_factor.bhy(profiles, q=0.05).n_tests
+  fx.stats.bhy_adjusted_p(p, n_tests=1000)
+  ```
+
+  Unrelated `n_total` occurrences in event-study / hit-rate / Corrado / orthogonalize modules are genuine sample counts (events processed, rows retained) and stay untouched.
 
 - **`primary_p` / `primary_stat_name` semantic — cfg-driven, not hardcoded NW** (breaking, #163). On IC PANEL / FM PANEL / CAAR PANEL the canonical pair now reflects whichever `HACEstimator` was wired on `cfg.estimator`, not the hardcoded `(T_NW, P_NW)` v0.12 wrote unconditionally. With default `NeweyWest()` cfg the values are bit-equal to v0.12; with `HansenHodrick()` they shift to `(T_HH, P_HH)`. Downstream callers reading `profile.stats[StatCode.T_NW]` or `profile.stats[StatCode.P_NW]` directly will `KeyError` when a non-NW estimator was used — read `profile.primary_stat` / `profile.primary_stat_name` / `profile.primary_p` instead (these stay populated regardless of estimator) and consult `profile.context["estimator"]` for provenance. TS β / TS Dummy / common-panel procedures are unchanged because they run NW HAC on an OLS slope or an iid cross-asset t (neither fits the HAC-on-mean `compute(series, *, forward_periods)` contract); a slope-axis sub-protocol is tracked separately. `UNRELIABLE_SE_SHORT_PERIODS` is now emitted uniformly on `0 < n_periods < 30` across IC / FM / CAAR — previously only the FM procedure's procedure-side guard fired (4 ≤ n < 30), so a 25-period IC analysis silently lacked the short-sample tag; the estimator-side emission consolidates this and the FM-side guard is removed as redundant.
 

--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -1,0 +1,135 @@
+# bhy_hierarchical
+
+Two-stage FDR for factor sets with natural group structure (factor
+families, regions, sectors). Outer Benjamini-Yekutieli on
+[Simes (1986)](https://academic.oup.com/biomet/article/73/3/751/277681)
+group representatives + inner BHY within each passing group, per
+[Yekutieli (2008)](https://www.tandfonline.com/doi/abs/10.1198/jasa.2007.ap06035).
+
+```python
+import factrix as fx
+
+# "Which factor families have signal, and within those, which factors?"
+profiles = [
+    fx.evaluate(panel_mom_1m, cfg, factor_col="mom_1m",
+                context={"family": "momentum"}),
+    fx.evaluate(panel_mom_12m, cfg, factor_col="mom_12m",
+                context={"family": "momentum"}),
+    fx.evaluate(panel_pb, cfg, factor_col="pb",
+                context={"family": "value"}),
+    fx.evaluate(panel_pe, cfg, factor_col="pe",
+                context={"family": "value"}),
+    # ... + quality, low-vol, etc.
+]
+survivors = fx.multi_factor.bhy_hierarchical(profiles, group="family", q=0.05)
+```
+
+## Which verb does this question want?
+
+Same input shape (one profile per (factor, condition)), three different
+claims:
+
+| Claim | Survivor unit | Function |
+|---|---|---|
+| "Factor X significant in *each* condition / universe" | `(factor, condition)` pair | [`bhy(expand_over=)`](multi-factor.md) |
+| "Factor X significant in $\ge k$ of $m$ conditions" | factor identity | [`partial_conjunction`](partial-conjunction.md) |
+| "Which families have signal, and within those, which factors?" | factor identity (group-then-within) | `bhy_hierarchical` |
+
+`bhy_hierarchical` is the only one of the three that keeps the
+**family-level answer** first-class — readers learn both "5 of 8
+families showed signal" and "within those, factors A / B / C survived"
+from a single Survivors container.
+
+## How the math works
+
+Per group $g$ with $m_g$ member p-values:
+
+1. Compute the group representative
+
+    $$
+    p_{\text{Simes},g} = \min_{k=1,\ldots,m_g} \frac{m_g}{k} \cdot p_{(k),g}
+    $$
+
+   where $p_{(k),g}$ is the $k$-th smallest p-value in group $g$. Simes
+   dominates the Bonferroni representative $m_g \cdot \min(p)$ and is
+   the Yekutieli 2008 recommended choice.
+
+2. Outer BHY across the $G$ group representatives gives
+   $p_{\text{outer},g}^{\text{adj}}$.
+
+3. Inner BHY within each group gives $p_{\text{inner},i}^{\text{adj}}$
+   for member $i$ of group $g(i)$.
+
+4. The cell-level adjusted p is the max-of-layers fold
+
+    $$
+    p_i^{\text{adj}} = \max\bigl(p_{\text{outer},g(i)}^{\text{adj}},\; p_{\text{inner},i}^{\text{adj}}\bigr)
+    $$
+
+   This preserves the universal Survivors duality
+   `survivor[i] iff adj_p[i] <= q` while encoding the two-layer logic:
+   a cell can fail because its group failed outer, because the cell
+   itself failed inner, or both.
+
+## Survivors output
+
+| Field | Meaning |
+|---|---|
+| `profiles` | Surviving profiles in input order |
+| `adj_p` | Max-of-layers $\text{adj}_p$; survivor iff `adj_p <= q` |
+| `q` | The `q` you passed (single target, both layers) |
+| `expand_over` | `(group,)` — single-element tuple |
+| `n_tests` | Mapping `(group_value,) -> m_group` for **every** input group (covers dead families too, so "N of M families survived" claims are computable directly). Counter to `partial_conjunction`, which keeps surviving identities only. |
+
+Per-survivor group label: `profile.context[group]`.
+
+## When *not* to reach for `bhy_hierarchical`
+
+| Real intent | Reach for | Why |
+|---|---|---|
+| No natural group structure | [`bhy`](multi-factor.md) | The grouping is real or it isn't; faking a group axis trivializes the procedure. |
+| "Factor X passes in *every* condition" | [`partial_conjunction`](partial-conjunction.md) with `min_pass == m` | Hierarchical is "group-then-within", not "joint across conditions". |
+| Flat BHY split by family for display only | [`bhy(expand_over=["family"])`](multi-factor.md) | Independent step-ups per bucket, no group-level inference. Use when you do not need a "this family has signal" answer. |
+| Mixed-sign factors in one bucket | Split the bucket / pre-orthogonalize | Within-group Simes assumes PRDS; structurally opposite factors (e.g. momentum + reversal in one group) can violate it. |
+
+## Validation summary
+
+| Trigger | Outcome |
+|---|---|
+| `group` shadows an identity field (`factor_id` / `forward_periods`) | `UserInputError`. |
+| `group` key missing from a profile's `context` | `UserInputError`. |
+| Only one distinct group value across input | `UserInputError` — points at [`bhy`](multi-factor.md). |
+| Every profile is its own group at $n \ge 3$ (group axis near-unique) | `UserInputError` — pick a coarser categorical. |
+| Duplicate `(identity, group_value)` partition key | `UserInputError`. |
+| More than half of input groups contain a single profile | `RuntimeWarning` — inner BHY on $n=1$ is a raw cutoff. |
+
+## Caveats
+
+- **Simes outer representative**: not exposed as a kwarg. Dominates
+  Bonferroni-min under PRDS; Edgington-style mean-p has no valid null
+  distribution and is rejected.
+- **PRDS within group**: Simes is valid under positive regression
+  dependence — typical for factors within one family that share style
+  exposure. If a group mixes structurally opposite factors (e.g.
+  momentum + reversal in one bucket), the within-group PRDS assumption
+  can fail; split the group or pre-orthogonalize.
+- **Pre-filtered input**: the verb assumes the input *is* the
+  candidate family. If profiles came from upstream pre-filtering
+  (e.g. top-50 of 500 candidates), the FDR claim does not cover the
+  full screening pipeline — track $K$ per the experiment-log discipline.
+- **Composed FDR is approximate at exact $q$**: Yekutieli 2008 bounds
+  group-level FDR $\le q$ and within-group FDR $\le q$ conditional on
+  group passing; the *composed* per-hypothesis FDR under PRDS is bounded
+  but not exactly $q$. Researcher claims should be "FDR-controlled at
+  $q$ in each layer", not "joint FDR $= q$".
+
+## References
+
+- **[S1986]** Simes, R. J. (1986). An improved Bonferroni procedure
+  for multiple tests of significance. *Biometrika*, 73(3), 751–754.
+- **[Y2008]** Yekutieli, D. (2008). Hierarchical false discovery
+  rate-controlling methodology. *JASA*, 103(481), 309–316.
+- **[NBER34050]** NBER WP 34050 (2025). Hierarchical Multiple Testing
+  in Empirical Asset Pricing.
+
+::: factrix.multi_factor.bhy_hierarchical

--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -24,7 +24,7 @@ profiles = [
 survivors = fx.multi_factor.bhy_hierarchical(profiles, group="family", q=0.05)
 ```
 
-## Which verb does this question want?
+## Which function fits this question?
 
 Same input shape (one profile per (factor, condition)), three different
 claims:
@@ -113,7 +113,7 @@ Per-survivor group label: `profile.context[group]`.
   exposure. If a group mixes structurally opposite factors (e.g.
   momentum + reversal in one bucket), the within-group PRDS assumption
   can fail; split the group or pre-orthogonalize.
-- **Pre-filtered input**: the verb assumes the input *is* the
+- **Pre-filtered input**: `bhy_hierarchical` assumes the input *is* the
   candidate family. If profiles came from upstream pre-filtering
   (e.g. top-50 of 500 candidates), the FDR claim does not cover the
   full screening pipeline — track $K$ per the experiment-log discipline.

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -23,7 +23,7 @@ survivors.profiles   # list[FactorProfile] in input order
 survivors.adj_p      # numpy array — bucket-local BHY-adjusted p-value, aligned
 survivors.q          # 0.05 — the nominal target you passed
 survivors.expand_over     # () for a single family; ("regime_id",) etc. otherwise
-survivors.n_total    # {(): N} or {bucket_key: m_per_bucket}
+survivors.n_tests    # {(): N} or {bucket_key: m_per_bucket}
 ```
 
 The input list **is** the family. `bhy` runs one Benjamini–Yekutieli
@@ -135,7 +135,7 @@ construction.
 `adj_p[i]` is computed within `profiles[i]`'s **own** `expand_over`
 bucket — bucket-local `n` and `p_array`, never pooled across buckets.
 This is the per-family adjustment that selective-inference theory
-(Benjamini & Bogomolov 2014) requires; `n_total[bucket_key]` records
+(Benjamini & Bogomolov 2014) requires; `n_tests[bucket_key]` records
 the `m` fed into each step-up so the audit trail is self-contained.
 
 Migration from the v0.10 list-of-profiles return:

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -113,7 +113,7 @@ container as `bhy`, populated with PC-specific metadata:
 | `adj_p` | BHY-adjusted PC $p$-value; survivor iff `adj_p <= q` |
 | `pc_p` | Raw PC $p$-value (pre-BHY) |
 | `min_pass` | The $k$ you passed |
-| `n_total` | Keyed by identity tuple `(factor_id, forward_periods)` → actual $m$ used |
+| `n_tests` | Keyed by identity tuple `(factor_id, forward_periods)` → actual $m$ used |
 | `n_passed_uncorr` | Per-identity count of raw $p < q$. Descriptive — flags borderline (`n_passed_uncorr == min_pass`) and data-gap cases at a glance. **Cutoff is your `q`**, so the count moves with `q` — using it to override `adj_p` survivor selection is the anti-shopping failure mode this verb exists to prevent. |
 
 ## Validation summary

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -107,10 +107,10 @@ enum.
 Standalone helpers that don't go through the Estimator dispatch
 chain:
 
-- **`bhy_adjust(p_values, fdr=0.05, *, n_total=None)`** —
+- **`bhy_adjust(p_values, fdr=0.05, *, n_tests=None)`** —
   Benjamini-Yekutieli step-up rejection mask. Returns
   `np.ndarray[bool]` aligned to input order.
-- **`bhy_adjusted_p(p_values, *, n_total=None)`** — per-hypothesis
+- **`bhy_adjusted_p(p_values, *, n_tests=None)`** — per-hypothesis
   BHY-adjusted p-values (clipped at 1).
 - **`stationary_bootstrap_resamples(values, n_bootstrap, …)`** —
   Politis-Romano (1994) resamples; emits the value matrix directly.

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -78,7 +78,7 @@
     "3. `survivors.adj_p[i]` — the BHY-adjusted p-value driving the\n",
     "   survivor decision (`survivor[i] iff adj_p[i] <= q`). Computed\n",
     "   bucket-locally when `expand_over` is set.\n",
-    "4. `survivors.n_total` — per-bucket `m` fed into each step-up;\n",
+    "4. `survivors.n_tests` — per-bucket `m` fed into each step-up;\n",
     "   audit trail for two-stage screening.\n",
     "5. Any emitted `RuntimeWarning` — flags mixed `forward_periods`\n",
     "   without `expand_over` (FDR-inflation foot-gun) or singleton\n",
@@ -168,7 +168,7 @@
     "The input list **is** the family. `bhy` runs one Benjamini-Yekutieli\n",
     "step-up over all profiles and returns a `Survivors` container —\n",
     "`.profiles` in input order, `.adj_p` aligned, `.q` / `.expand_over` /\n",
-    "`.n_total` for audit. Survivor membership is definitionally\n",
+    "`.n_tests` for audit. Survivor membership is definitionally\n",
     "`adj_p <= q`. The `c(N)` correction is applied internally; pass your\n",
     "nominal `q`."
    ]
@@ -201,10 +201,10 @@
     {
      "data": {
       "text/html": [
-       "<table class='factrix-survivors'><caption>Survivors (n=5, q=0.05, n_total=5)</caption><thead><tr><th style='text-align:left'>identity</th><th style='text-align:left'>primary_p</th><th style='text-align:left'>adj_p</th></tr></thead><tbody><tr><td>(&#x27;variant_0&#x27;, 5)</td><td>2.136e-39</td><td>2.439e-38</td></tr><tr><td>(&#x27;variant_1&#x27;, 5)</td><td>4.052e-26</td><td>2.313e-25</td></tr><tr><td>(&#x27;variant_2&#x27;, 5)</td><td>6.682e-22</td><td>2.543e-21</td></tr><tr><td>(&#x27;variant_3&#x27;, 5)</td><td>3.987e-17</td><td>1.138e-16</td></tr><tr><td>(&#x27;variant_4&#x27;, 5)</td><td>7.407e-14</td><td>1.691e-13</td></tr></tbody></table>"
+       "<table class='factrix-survivors'><caption>Survivors (n=5, q=0.05, n_tests=5)</caption><thead><tr><th style='text-align:left'>identity</th><th style='text-align:left'>primary_p</th><th style='text-align:left'>adj_p</th></tr></thead><tbody><tr><td>(&#x27;variant_0&#x27;, 5)</td><td>2.136e-39</td><td>2.439e-38</td></tr><tr><td>(&#x27;variant_1&#x27;, 5)</td><td>4.052e-26</td><td>2.313e-25</td></tr><tr><td>(&#x27;variant_2&#x27;, 5)</td><td>6.682e-22</td><td>2.543e-21</td></tr><tr><td>(&#x27;variant_3&#x27;, 5)</td><td>3.987e-17</td><td>1.138e-16</td></tr><tr><td>(&#x27;variant_4&#x27;, 5)</td><td>7.407e-14</td><td>1.691e-13</td></tr></tbody></table>"
       ],
       "text/plain": [
-       "Survivors(n=5, q=0.05, n_total=5)\n",
+       "Survivors(n=5, q=0.05, n_tests=5)\n",
        "identity          primary_p  adj_p    \n",
        "('variant_0', 5)  2.136e-39  2.439e-38\n",
        "('variant_1', 5)  4.052e-26  2.313e-25\n",

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -625,12 +625,12 @@ def bhy_hierarchical(
           family — they share style exposure). If a group mixes
           structurally opposite factors (e.g. momentum and reversal
           in one bucket), the within-group PRDS assumption can fail;
-          use ``bonferroni`` for that bucket or split the group.
-        - **Pre-filtered input**: this verb assumes the input *is*
-          the candidate family. If profiles came from upstream
-          pre-filtering (e.g. top-50 of 500 candidates), the FDR
-          claim does not cover the full screening pipeline — count K
-          accordingly per the Haircut Sharpe / experiment-log
+          split the bucket or pre-orthogonalize.
+        - **Pre-filtered input**: ``bhy_hierarchical`` assumes the
+          input *is* the candidate family. If profiles came from
+          upstream pre-filtering (e.g. top-50 of 500 candidates),
+          the FDR claim does not cover the full screening pipeline —
+          count K accordingly per the Haircut Sharpe / experiment-log
           discipline.
 
     References:
@@ -675,7 +675,7 @@ def bhy_hierarchical(
                 "A single group reduces the procedure to plain BHY on the "
                 "members. Call bhy(profiles, q=...) directly"
             ),
-            docs_path="api/bhy-hierarchical#single-group",
+            docs_path="api/bhy-hierarchical#validation-summary",
         )
     if n_groups == len(entries) and len(entries) >= 3:
         raise UserInputError(
@@ -690,7 +690,7 @@ def bhy_hierarchical(
                 "categorical (family / region / sector) or call bhy() "
                 "without grouping"
             ),
-            docs_path="api/bhy-hierarchical#group-too-fine",
+            docs_path="api/bhy-hierarchical#validation-summary",
         )
 
     singletons = sum(1 for ix in groups.values() if len(ix) == 1)

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -620,6 +620,46 @@ def bhy_hierarchical(
     )
 
     n_groups = len(group_keys_ordered)
+    if n_groups == 1:
+        raise UserInputError(
+            verb="bhy_hierarchical",
+            field="group",
+            value=group,
+            expected=(
+                f"a context key with at least 2 distinct values across "
+                f"input profiles; got 1 group ({group_keys_ordered[0]!r}). "
+                "A single group reduces the procedure to plain BHY on the "
+                "members. Call bhy(profiles, q=...) directly"
+            ),
+            docs_path="api/bhy-hierarchical#single-group",
+        )
+    if n_groups == len(entries) and len(entries) >= 3:
+        raise UserInputError(
+            verb="bhy_hierarchical",
+            field="group",
+            value=group,
+            expected=(
+                f"a context key that partitions profiles into groups of "
+                f"size >= 2; got {n_groups} groups across {len(entries)} "
+                "profiles (every profile is its own group). The group "
+                "axis is probably a near-unique field — pick a coarser "
+                "categorical (family / region / sector) or call bhy() "
+                "without grouping"
+            ),
+            docs_path="api/bhy-hierarchical#group-too-fine",
+        )
+
+    singletons = sum(1 for ix in groups.values() if len(ix) == 1)
+    if singletons * 2 > n_groups:
+        warnings.warn(
+            f"bhy_hierarchical: {singletons} of {n_groups} groups contain "
+            "a single profile — inner BHY on n=1 is a raw cutoff and "
+            "the outer Simes representative equals that single p-value, "
+            "so those groups get no FDR correction at either layer.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     group_simes = np.empty(n_groups, dtype=np.float64)
     inner_adjs: list[np.ndarray] = []
     n_tests: dict[tuple[Any, ...], int] = {}

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -549,27 +549,42 @@ def bhy_hierarchical(
 ) -> Survivors:
     """Hierarchical BHY: control FDR across groups then within groups.
 
-    For factor sets with a natural group structure (momentum / value /
+    For factor sets with natural group structure (momentum / value /
     quality families; cross-region universes), the Yekutieli 2008
     two-stage procedure controls *group-level* FDR ≤ ``q`` on the outer
     layer (Simes group representative + BHY) and *within-group* FDR
     ≤ ``q`` on the inner layer (BHY restricted to passing groups). Flat
     BHY across the whole input loses group-level interpretability and
-    pays full m-correction even when most groups are dead; this verb
-    keeps the group answer first-class.
+    pays full m-correction even when most groups are dead.
+
+    Pick this over the alternatives by survivor unit and claim shape:
+
+    +-----------------------------+-------------------+-----------------------+
+    | Claim                       | Survivor unit     | Function              |
+    +=============================+===================+=======================+
+    | "factor X significant in    | (factor, context) | ``bhy(expand_over=)`` |
+    | each universe / horizon"    | pair              |                       |
+    +-----------------------------+-------------------+-----------------------+
+    | "factor X significant in    | factor identity   | ``partial_conjunction``|
+    | >= k of m conditions"       |                   |                       |
+    +-----------------------------+-------------------+-----------------------+
+    | "which families have signal,| factor identity   | ``bhy_hierarchical``  |
+    | and within those, which     | (group-then-      |                       |
+    | factors"                    | within FDR)       |                       |
+    +-----------------------------+-------------------+-----------------------+
 
     Args:
         profiles: Iterable of :class:`FactorProfile`. Each profile is
             assigned to one group via ``profile.context[group]``;
             within a group, ``(factor_id, forward_periods)`` must be
-            unique (the standard ``_resolve_family`` partition-key
-            check).
+            unique. Stamp the group label upstream of the call —
+            either ``evaluate(..., context={"family": "momentum"})``
+            or post-hoc via ``dataclasses.replace(profile, context={
+            **profile.context, "family": "momentum"})``.
         group: Single context key naming the group axis (e.g.
             ``"family"`` for momentum / value / quality, ``"region"``
             for cross-region replication). Identity dimensions
-            (``factor_id`` / ``forward_periods``) are rejected — using
-            them as group keys collapses each cell to its own group
-            and trivializes the procedure.
+            (``factor_id`` / ``forward_periods``) are rejected.
         estimator: Optional inference-method override. ``None`` uses
             each profile's ``primary_p``.
         q: Nominal FDR target shared by both layers. Default ``0.05``.
@@ -578,16 +593,45 @@ def bhy_hierarchical(
         :class:`Survivors` in input order. ``adj_p`` is the
         max-of-layers fold ``max(outer_adj_p[g], inner_adj_p[i])`` so
         the universal duality ``survivor[i] iff adj_p[i] <= q`` holds.
-        ``n_tests`` maps group key to its inner family size;
-        ``expand_over`` is ``(group,)`` and per-survivor group labels
-        are recoverable via ``profile.context[group]``.
+        ``n_tests`` maps each group key to its inner family size
+        (covers *all* input groups, not just survivors — counter to
+        ``partial_conjunction`` which keeps surviving identities
+        only). ``expand_over`` is ``(group,)``; per-survivor group
+        labels are recoverable via ``profile.context[group]``.
 
     Raises:
-        UserInputError: ``group`` shadows an identity dimension
-            (``factor_id`` / ``forward_periods``); ``group`` missing
-            from a profile's ``context``; duplicate ``(identity,
-            group_value)`` partition key; estimator applicability
-            failures (per ``_resolve_family``).
+        UserInputError: ``group`` shadows an identity dimension; key
+            missing from a profile's ``context``; only one distinct
+            group value in the input (call ``bhy`` instead); every
+            profile is its own group at ``n >= 3`` (group axis is
+            near-unique — pick a coarser categorical); duplicate
+            ``(identity, group_value)`` partition key; estimator
+            applicability failures.
+
+    Warns:
+        RuntimeWarning: More than half of input groups contain a
+            single profile — inner BHY on n=1 is a raw cutoff and
+            the outer Simes representative equals that single p, so
+            those groups get no FDR correction at either layer.
+
+    Caveats:
+        - **Simes as the outer representative**: dominates Bonferroni
+          ``m * min(p)`` and is the Yekutieli 2008 recommended choice.
+          The kwarg is not exposed at v1 (Edgington-style mean p has
+          no valid null; Bonferroni-min is strictly worse than Simes
+          under the procedure's PRDS assumption).
+        - **PRDS within group**: Simes is valid under positive
+          regression dependence (typical for factors within one
+          family — they share style exposure). If a group mixes
+          structurally opposite factors (e.g. momentum and reversal
+          in one bucket), the within-group PRDS assumption can fail;
+          use ``bonferroni`` for that bucket or split the group.
+        - **Pre-filtered input**: this verb assumes the input *is*
+          the candidate family. If profiles came from upstream
+          pre-filtering (e.g. top-50 of 500 candidates), the FDR
+          claim does not cover the full screening pipeline — count K
+          accordingly per the Haircut Sharpe / experiment-log
+          discipline.
 
     References:
         Yekutieli, D. (2008). "Hierarchical false discovery rate-

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -84,12 +84,6 @@ class Survivors:
             ``adj_p`` survivor selection is the anti-shopping failure
             mode this verb exists to prevent. ``None`` when the verb is
             not ``partial_conjunction``.
-        group_id: Per-survivor group label for ``bhy_hierarchical``
-            (the ``profile.context[group]`` value). ``adj_p[i]`` for
-            this verb is the max-of-layers fold ``max(outer_adj_p[g],
-            inner_adj_p[i])`` so the universal duality
-            ``survivor[i] iff adj_p[i] <= q`` still holds. ``None``
-            when the verb is not ``bhy_hierarchical``.
     """
 
     profiles: list[FactorProfile]
@@ -100,7 +94,6 @@ class Survivors:
     pc_p: np.ndarray | None = None
     min_pass: int | None = None
     n_passed_uncorr: np.ndarray | None = None
-    group_id: np.ndarray | None = None
 
     def __len__(self) -> int:
         return len(self.profiles)
@@ -114,7 +107,6 @@ class Survivors:
         """
         headers: tuple[str, ...]
         pc_mode = self.pc_p is not None
-        hier_mode = self.group_id is not None
         if pc_mode:
             headers = (
                 "identity",
@@ -123,8 +115,6 @@ class Survivors:
                 "n_total",
                 "n_passed_uncorr",
             )
-        elif hier_mode:
-            headers = ("group_id", "identity", "primary_p", "adj_p")
         elif self.expand_over:
             headers = ("expand_over_values", "identity", "primary_p", "adj_p")
         else:
@@ -153,16 +143,13 @@ class Survivors:
                 )
             return headers, rows
 
-        for i, (profile, adj) in enumerate(zip(self.profiles, self.adj_p, strict=True)):
+        for profile, adj in zip(self.profiles, self.adj_p, strict=True):
             cells = (
                 repr(profile.identity),
                 f"{profile.primary_p:.4g}",
                 f"{float(adj):.4g}",
             )
-            if hier_mode:
-                assert self.group_id is not None
-                rows.append((repr(self.group_id[i]), *cells))
-            elif self.expand_over:
+            if self.expand_over:
                 bucket_repr = repr(tuple(profile.context[k] for k in self.expand_over))
                 rows.append((bucket_repr, *cells))
             else:
@@ -173,13 +160,7 @@ class Survivors:
         parts = [f"n={len(self.profiles)}", f"q={self.q:g}"]
         if self.min_pass is not None:
             parts.append(f"min_pass={self.min_pass}")
-        if self.group_id is not None:
-            parts.append(f"n_groups={len(self.n_total)}")
-            n_total_repr = ", ".join(
-                f"{k!r}: {v}" for k, v in sorted(self.n_total.items())
-            )
-            parts.append(f"n_total={{{n_total_repr}}}")
-        elif self.expand_over:
+        if self.expand_over:
             parts.append(f"expand_over={list(self.expand_over)!r}")
             n_total_repr = ", ".join(
                 f"{k!r}: {v}" for k, v in sorted(self.n_total.items())
@@ -588,19 +569,18 @@ def bhy_hierarchical(
             for cross-region replication). Identity dimensions
             (``factor_id`` / ``forward_periods``) are rejected — using
             them as group keys collapses each cell to its own group
-            and trivializes the procedure (see #160 anti-shopping
-            defense).
-        estimator: Optional inference-method override (#170). ``None``
-            uses each profile's ``primary_p``.
+            and trivializes the procedure.
+        estimator: Optional inference-method override. ``None`` uses
+            each profile's ``primary_p``.
         q: Nominal FDR target shared by both layers. Default ``0.05``.
 
     Returns:
         :class:`Survivors` in input order. ``adj_p`` is the
         max-of-layers fold ``max(outer_adj_p[g], inner_adj_p[i])`` so
         the universal duality ``survivor[i] iff adj_p[i] <= q`` holds.
-        ``group_id`` carries each survivor's group label; ``n_total``
-        maps group key to its inner family size; ``expand_over`` is
-        ``(group,)``.
+        ``n_total`` maps group key to its inner family size;
+        ``expand_over`` is ``(group,)`` and per-survivor group labels
+        are recoverable via ``profile.context[group]``.
 
     Raises:
         UserInputError: ``group`` shadows an identity dimension
@@ -623,7 +603,6 @@ def bhy_hierarchical(
             q=q,
             expand_over=expand_over_tuple,
             n_total={},
-            group_id=np.empty(0, dtype=object),
         )
 
     entries = _resolve_family(
@@ -636,46 +615,35 @@ def bhy_hierarchical(
     groups: dict[Any, list[int]] = defaultdict(list)
     for idx, entry in enumerate(entries):
         groups[entry.expand_over_values[0]].append(idx)
-
-    group_keys_ordered: list[Any] = []
-    seen_groups: set[Any] = set()
-    for entry in entries:
-        gkey = entry.expand_over_values[0]
-        if gkey not in seen_groups:
-            seen_groups.add(gkey)
-            group_keys_ordered.append(gkey)
+    group_keys_ordered = list(
+        dict.fromkeys(entry.expand_over_values[0] for entry in entries)
+    )
 
     n_groups = len(group_keys_ordered)
     group_simes = np.empty(n_groups, dtype=np.float64)
-    for g_idx, gkey in enumerate(group_keys_ordered):
-        member_p = np.array(
-            [entries[i].p_value for i in groups[gkey]], dtype=np.float64
-        )
-        group_simes[g_idx] = simes_p(member_p)
-
-    outer_adj = bhy_adjusted_p(group_simes)
-
-    adj_p_all = np.empty(len(entries), dtype=np.float64)
+    inner_adjs: list[np.ndarray] = []
     n_total: dict[tuple[Any, ...], int] = {}
     for g_idx, gkey in enumerate(group_keys_ordered):
         member_idxs = groups[gkey]
         member_p = np.array([entries[i].p_value for i in member_idxs], dtype=np.float64)
-        inner_adj = bhy_adjusted_p(member_p)
-        for j, idx in enumerate(member_idxs):
-            adj_p_all[idx] = max(outer_adj[g_idx], inner_adj[j])
+        group_simes[g_idx] = simes_p(member_p)
+        inner_adjs.append(bhy_adjusted_p(member_p))
         n_total[(gkey,)] = len(member_idxs)
 
+    outer_adj = bhy_adjusted_p(group_simes)
+
+    adj_p_all = np.empty(len(entries), dtype=np.float64)
+    for g_idx, gkey in enumerate(group_keys_ordered):
+        for j, idx in enumerate(groups[gkey]):
+            adj_p_all[idx] = max(outer_adj[g_idx], inner_adjs[g_idx][j])
+
     survivor_idxs = np.flatnonzero(adj_p_all <= q)
-    group_id_arr = np.array(
-        [entries[i].expand_over_values[0] for i in survivor_idxs], dtype=object
-    )
     return Survivors(
         profiles=[entries[i].profile for i in survivor_idxs],
         adj_p=adj_p_all[survivor_idxs],
         q=q,
         expand_over=expand_over_tuple,
         n_total=n_total,
-        group_id=group_id_arr,
     )
 
 

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -64,7 +64,7 @@ class Survivors:
             independent step-up buckets (``bhy``) or to aggregate
             conditions per identity (``partial_conjunction``). Empty
             tuple when the full input is one family.
-        n_total: Family size per bucket fed into the step-up math.
+        n_tests: Family size per bucket fed into the step-up math.
             Keying depends on the verb: ``bhy`` keys by
             ``expand_over_values`` tuple (``()`` for the single-bucket
             case); ``partial_conjunction`` keys by ``identity`` tuple
@@ -90,7 +90,7 @@ class Survivors:
     adj_p: np.ndarray
     q: float
     expand_over: tuple[str, ...]
-    n_total: Mapping[tuple[Any, ...], int]
+    n_tests: Mapping[tuple[Any, ...], int]
     pc_p: np.ndarray | None = None
     min_pass: int | None = None
     n_passed_uncorr: np.ndarray | None = None
@@ -112,7 +112,7 @@ class Survivors:
                 "identity",
                 "pc_p",
                 "adj_p",
-                "n_total",
+                "n_tests",
                 "n_passed_uncorr",
             )
         elif self.expand_over:
@@ -131,7 +131,7 @@ class Survivors:
                 self.n_passed_uncorr,
                 strict=True,
             ):
-                m = self.n_total.get(profile.identity, 0)
+                m = self.n_tests.get(profile.identity, 0)
                 rows.append(
                     (
                         repr(profile.identity),
@@ -162,12 +162,12 @@ class Survivors:
             parts.append(f"min_pass={self.min_pass}")
         if self.expand_over:
             parts.append(f"expand_over={list(self.expand_over)!r}")
-            n_total_repr = ", ".join(
-                f"{k!r}: {v}" for k, v in sorted(self.n_total.items())
+            n_tests_repr = ", ".join(
+                f"{k!r}: {v}" for k, v in sorted(self.n_tests.items())
             )
-            parts.append(f"n_total={{{n_total_repr}}}")
+            parts.append(f"n_tests={{{n_tests_repr}}}")
         else:
-            parts.append(f"n_total={self.n_total.get((), len(self.profiles))}")
+            parts.append(f"n_tests={self.n_tests.get((), len(self.profiles))}")
         return ", ".join(parts)
 
     def __repr__(self) -> str:
@@ -270,7 +270,7 @@ def bhy(
             adj_p=np.zeros(0, dtype=np.float64),
             q=q,
             expand_over=expand_over_tuple,
-            n_total={},
+            n_tests={},
         )
 
     _warn_on_mixed_horizons(profile_list, expand_over=expand_over)
@@ -294,11 +294,11 @@ def bhy(
         )
 
     adj_p_all = np.full(len(entries), np.nan, dtype=np.float64)
-    n_total: dict[tuple[Any, ...], int] = {}
+    n_tests: dict[tuple[Any, ...], int] = {}
     for bucket_key, ix in buckets.items():
         p_array = np.array([entries[i].p_value for i in ix], dtype=np.float64)
         adj_p_all[ix] = bhy_adjusted_p(p_array)
-        n_total[bucket_key] = len(ix)
+        n_tests[bucket_key] = len(ix)
 
     survivor_idxs = np.flatnonzero(adj_p_all <= q)
     return Survivors(
@@ -306,7 +306,7 @@ def bhy(
         adj_p=adj_p_all[survivor_idxs],
         q=q,
         expand_over=expand_over_tuple,
-        n_total=n_total,
+        n_tests=n_tests,
     )
 
 
@@ -364,7 +364,7 @@ def partial_conjunction(
         :class:`Survivors` in input order (deduplicated to one row per
         surviving identity, using the first profile of that identity as
         representative). ``adj_p`` is the BHY-adjusted PC p-value;
-        ``pc_p`` is the raw PC p-value; ``n_total[identity]`` is the
+        ``pc_p`` is the raw PC p-value; ``n_tests[identity]`` is the
         condition count ``m``; ``n_passed_uncorr[i]`` is the count of
         raw p-values strictly below ``q`` for survivor ``i``.
 
@@ -441,7 +441,7 @@ def partial_conjunction(
             adj_p=np.zeros(0, dtype=np.float64),
             q=q,
             expand_over=expand_over_tuple,
-            n_total={},
+            n_tests={},
             pc_p=np.zeros(0, dtype=np.float64),
             min_pass=min_pass,
             n_passed_uncorr=np.zeros(0, dtype=np.int64),
@@ -467,7 +467,7 @@ def partial_conjunction(
 
     pc_p_arr = np.empty(len(identities_ordered), dtype=np.float64)
     n_passed_arr = np.empty(len(identities_ordered), dtype=np.int64)
-    n_total_per_identity: dict[tuple[Any, ...], int] = {}
+    n_tests_per_identity: dict[tuple[Any, ...], int] = {}
     rep_profiles: list[FactorProfile] = []
 
     for i, identity in enumerate(identities_ordered):
@@ -506,11 +506,11 @@ def partial_conjunction(
         ps = np.array([e.p_value for e in group], dtype=np.float64)
         pc_p_arr[i] = partial_conjunction_p(ps, min_pass=min_pass)
         n_passed_arr[i] = int(np.sum(ps < q))
-        n_total_per_identity[identity] = m
+        n_tests_per_identity[identity] = m
         rep_profiles.append(group[0].profile)
 
     if n_conditions is None:
-        m_values = set(n_total_per_identity.values())
+        m_values = set(n_tests_per_identity.values())
         if len(m_values) > 1:
             warnings.warn(
                 "partial_conjunction: lenient mode (n_conditions=None) is "
@@ -533,7 +533,7 @@ def partial_conjunction(
         adj_p=adj_p_all[survivor_idx],
         q=q,
         expand_over=expand_over_tuple,
-        n_total={ident: n_total_per_identity[ident] for ident in surviving_identities},
+        n_tests={ident: n_tests_per_identity[ident] for ident in surviving_identities},
         pc_p=pc_p_arr[survivor_idx],
         min_pass=min_pass,
         n_passed_uncorr=n_passed_arr[survivor_idx],
@@ -578,7 +578,7 @@ def bhy_hierarchical(
         :class:`Survivors` in input order. ``adj_p`` is the
         max-of-layers fold ``max(outer_adj_p[g], inner_adj_p[i])`` so
         the universal duality ``survivor[i] iff adj_p[i] <= q`` holds.
-        ``n_total`` maps group key to its inner family size;
+        ``n_tests`` maps group key to its inner family size;
         ``expand_over`` is ``(group,)`` and per-survivor group labels
         are recoverable via ``profile.context[group]``.
 
@@ -602,7 +602,7 @@ def bhy_hierarchical(
             adj_p=np.zeros(0, dtype=np.float64),
             q=q,
             expand_over=expand_over_tuple,
-            n_total={},
+            n_tests={},
         )
 
     entries = _resolve_family(
@@ -622,13 +622,13 @@ def bhy_hierarchical(
     n_groups = len(group_keys_ordered)
     group_simes = np.empty(n_groups, dtype=np.float64)
     inner_adjs: list[np.ndarray] = []
-    n_total: dict[tuple[Any, ...], int] = {}
+    n_tests: dict[tuple[Any, ...], int] = {}
     for g_idx, gkey in enumerate(group_keys_ordered):
         member_idxs = groups[gkey]
         member_p = np.array([entries[i].p_value for i in member_idxs], dtype=np.float64)
         group_simes[g_idx] = simes_p(member_p)
         inner_adjs.append(bhy_adjusted_p(member_p))
-        n_total[(gkey,)] = len(member_idxs)
+        n_tests[(gkey,)] = len(member_idxs)
 
     outer_adj = bhy_adjusted_p(group_simes)
 
@@ -643,7 +643,7 @@ def bhy_hierarchical(
         adj_p=adj_p_all[survivor_idxs],
         q=q,
         expand_over=expand_over_tuple,
-        n_total=n_total,
+        n_tests=n_tests,
     )
 
 

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -27,7 +27,11 @@ import numpy as np
 
 from factrix._errors import UserInputError
 from factrix._family import _resolve_family
-from factrix.stats.multiple_testing import bhy_adjusted_p, partial_conjunction_p
+from factrix.stats.multiple_testing import (
+    bhy_adjusted_p,
+    partial_conjunction_p,
+    simes_p,
+)
 
 if TYPE_CHECKING:
     from factrix._profile import FactorProfile
@@ -80,6 +84,12 @@ class Survivors:
             ``adj_p`` survivor selection is the anti-shopping failure
             mode this verb exists to prevent. ``None`` when the verb is
             not ``partial_conjunction``.
+        group_id: Per-survivor group label for ``bhy_hierarchical``
+            (the ``profile.context[group]`` value). ``adj_p[i]`` for
+            this verb is the max-of-layers fold ``max(outer_adj_p[g],
+            inner_adj_p[i])`` so the universal duality
+            ``survivor[i] iff adj_p[i] <= q`` still holds. ``None``
+            when the verb is not ``bhy_hierarchical``.
     """
 
     profiles: list[FactorProfile]
@@ -90,6 +100,7 @@ class Survivors:
     pc_p: np.ndarray | None = None
     min_pass: int | None = None
     n_passed_uncorr: np.ndarray | None = None
+    group_id: np.ndarray | None = None
 
     def __len__(self) -> int:
         return len(self.profiles)
@@ -103,6 +114,7 @@ class Survivors:
         """
         headers: tuple[str, ...]
         pc_mode = self.pc_p is not None
+        hier_mode = self.group_id is not None
         if pc_mode:
             headers = (
                 "identity",
@@ -111,6 +123,8 @@ class Survivors:
                 "n_total",
                 "n_passed_uncorr",
             )
+        elif hier_mode:
+            headers = ("group_id", "identity", "primary_p", "adj_p")
         elif self.expand_over:
             headers = ("expand_over_values", "identity", "primary_p", "adj_p")
         else:
@@ -139,13 +153,16 @@ class Survivors:
                 )
             return headers, rows
 
-        for profile, adj in zip(self.profiles, self.adj_p, strict=True):
+        for i, (profile, adj) in enumerate(zip(self.profiles, self.adj_p, strict=True)):
             cells = (
                 repr(profile.identity),
                 f"{profile.primary_p:.4g}",
                 f"{float(adj):.4g}",
             )
-            if self.expand_over:
+            if hier_mode:
+                assert self.group_id is not None
+                rows.append((repr(self.group_id[i]), *cells))
+            elif self.expand_over:
                 bucket_repr = repr(tuple(profile.context[k] for k in self.expand_over))
                 rows.append((bucket_repr, *cells))
             else:
@@ -156,7 +173,13 @@ class Survivors:
         parts = [f"n={len(self.profiles)}", f"q={self.q:g}"]
         if self.min_pass is not None:
             parts.append(f"min_pass={self.min_pass}")
-        if self.expand_over:
+        if self.group_id is not None:
+            parts.append(f"n_groups={len(self.n_total)}")
+            n_total_repr = ", ".join(
+                f"{k!r}: {v}" for k, v in sorted(self.n_total.items())
+            )
+            parts.append(f"n_total={{{n_total_repr}}}")
+        elif self.expand_over:
             parts.append(f"expand_over={list(self.expand_over)!r}")
             n_total_repr = ", ".join(
                 f"{k!r}: {v}" for k, v in sorted(self.n_total.items())
@@ -533,6 +556,126 @@ def partial_conjunction(
         pc_p=pc_p_arr[survivor_idx],
         min_pass=min_pass,
         n_passed_uncorr=n_passed_arr[survivor_idx],
+    )
+
+
+def bhy_hierarchical(
+    profiles: Iterable[FactorProfile],
+    *,
+    group: str,
+    estimator: Estimator | None = None,
+    q: float = 0.05,
+) -> Survivors:
+    """Hierarchical BHY: control FDR across groups then within groups.
+
+    For factor sets with a natural group structure (momentum / value /
+    quality families; cross-region universes), the Yekutieli 2008
+    two-stage procedure controls *group-level* FDR ≤ ``q`` on the outer
+    layer (Simes group representative + BHY) and *within-group* FDR
+    ≤ ``q`` on the inner layer (BHY restricted to passing groups). Flat
+    BHY across the whole input loses group-level interpretability and
+    pays full m-correction even when most groups are dead; this verb
+    keeps the group answer first-class.
+
+    Args:
+        profiles: Iterable of :class:`FactorProfile`. Each profile is
+            assigned to one group via ``profile.context[group]``;
+            within a group, ``(factor_id, forward_periods)`` must be
+            unique (the standard ``_resolve_family`` partition-key
+            check).
+        group: Single context key naming the group axis (e.g.
+            ``"family"`` for momentum / value / quality, ``"region"``
+            for cross-region replication). Identity dimensions
+            (``factor_id`` / ``forward_periods``) are rejected — using
+            them as group keys collapses each cell to its own group
+            and trivializes the procedure (see #160 anti-shopping
+            defense).
+        estimator: Optional inference-method override (#170). ``None``
+            uses each profile's ``primary_p``.
+        q: Nominal FDR target shared by both layers. Default ``0.05``.
+
+    Returns:
+        :class:`Survivors` in input order. ``adj_p`` is the
+        max-of-layers fold ``max(outer_adj_p[g], inner_adj_p[i])`` so
+        the universal duality ``survivor[i] iff adj_p[i] <= q`` holds.
+        ``group_id`` carries each survivor's group label; ``n_total``
+        maps group key to its inner family size; ``expand_over`` is
+        ``(group,)``.
+
+    Raises:
+        UserInputError: ``group`` shadows an identity dimension
+            (``factor_id`` / ``forward_periods``); ``group`` missing
+            from a profile's ``context``; duplicate ``(identity,
+            group_value)`` partition key; estimator applicability
+            failures (per ``_resolve_family``).
+
+    References:
+        Yekutieli, D. (2008). "Hierarchical false discovery rate-
+        controlling methodology." JASA 103(481), 309-316.
+    """
+    profile_list = list(profiles)
+    expand_over_tuple: tuple[str, ...] = (group,)
+
+    if not profile_list:
+        return Survivors(
+            profiles=[],
+            adj_p=np.zeros(0, dtype=np.float64),
+            q=q,
+            expand_over=expand_over_tuple,
+            n_total={},
+            group_id=np.empty(0, dtype=object),
+        )
+
+    entries = _resolve_family(
+        profile_list,
+        verb="bhy_hierarchical",
+        expand_over=[group],
+        estimator=estimator,
+    )
+
+    groups: dict[Any, list[int]] = defaultdict(list)
+    for idx, entry in enumerate(entries):
+        groups[entry.expand_over_values[0]].append(idx)
+
+    group_keys_ordered: list[Any] = []
+    seen_groups: set[Any] = set()
+    for entry in entries:
+        gkey = entry.expand_over_values[0]
+        if gkey not in seen_groups:
+            seen_groups.add(gkey)
+            group_keys_ordered.append(gkey)
+
+    n_groups = len(group_keys_ordered)
+    group_simes = np.empty(n_groups, dtype=np.float64)
+    for g_idx, gkey in enumerate(group_keys_ordered):
+        member_p = np.array(
+            [entries[i].p_value for i in groups[gkey]], dtype=np.float64
+        )
+        group_simes[g_idx] = simes_p(member_p)
+
+    outer_adj = bhy_adjusted_p(group_simes)
+
+    adj_p_all = np.empty(len(entries), dtype=np.float64)
+    n_total: dict[tuple[Any, ...], int] = {}
+    for g_idx, gkey in enumerate(group_keys_ordered):
+        member_idxs = groups[gkey]
+        member_p = np.array([entries[i].p_value for i in member_idxs], dtype=np.float64)
+        inner_adj = bhy_adjusted_p(member_p)
+        for j, idx in enumerate(member_idxs):
+            adj_p_all[idx] = max(outer_adj[g_idx], inner_adj[j])
+        n_total[(gkey,)] = len(member_idxs)
+
+    survivor_idxs = np.flatnonzero(adj_p_all <= q)
+    group_id_arr = np.array(
+        [entries[i].expand_over_values[0] for i in survivor_idxs], dtype=object
+    )
+    return Survivors(
+        profiles=[entries[i].profile for i in survivor_idxs],
+        adj_p=adj_p_all[survivor_idxs],
+        q=q,
+        expand_over=expand_over_tuple,
+        n_total=n_total,
+        group_id=group_id_arr,
     )
 
 

--- a/factrix/multi_factor.py
+++ b/factrix/multi_factor.py
@@ -6,6 +6,6 @@ v0.4 deletion sweep that retires the existing v0.4 implementations
 of those primitives.
 """
 
-from factrix._multi_factor import bhy, partial_conjunction
+from factrix._multi_factor import bhy, bhy_hierarchical, partial_conjunction
 
-__all__ = ["bhy", "partial_conjunction"]
+__all__ = ["bhy", "bhy_hierarchical", "partial_conjunction"]

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -27,6 +27,13 @@ References:
 
     Benjamini, Y. & Heller, R. (2008). "Screening for partial conjunction
     hypotheses." Biometrics 64(4), 1215-1222. — partial_conjunction_p
+
+    Simes, R. J. (1986). "An improved Bonferroni procedure for multiple
+    tests of significance." Biometrika 73(3), 751-754. — simes_p
+
+    Yekutieli, D. (2008). "Hierarchical false discovery rate-controlling
+    methodology." JASA 103(481), 309-316. — Simes as group representative
+    in hierarchical FDR procedures.
 """
 
 from __future__ import annotations
@@ -154,6 +161,39 @@ def bhy_adjusted_p(
     out = np.empty(n, dtype=float)
     out[order] = adj_sorted
     return out
+
+
+def simes_p(p_values: npt.ArrayLike) -> float:
+    """Simes (1986) global-null p-value for a group of tests.
+
+    Formula: ``p_Simes = min_{k=1..m} (m / k) * p_((k))`` where
+    ``p_((k))`` is the ``k``-th smallest of the ``m`` p-values
+    (1-indexed). Tests the global null "all ``m`` nulls hold" against
+    "at least one alternative is true"; valid under independence and
+    PRDS.
+
+    Yekutieli (2008) uses Simes as the default group representative
+    in hierarchical FDR procedures — it dominates Bonferroni
+    (``m * min(p)``) and preserves group-level FDR control when fed
+    to an outer BHY step-up.
+
+    Args:
+        p_values: 1-D array of ``m`` p-values for one group. ``m >= 1``.
+
+    Returns:
+        The Simes combined p-value, clipped to ``[0, 1]``.
+
+    Raises:
+        ValueError: ``len(p_values) == 0`` (Simes is undefined on an
+            empty group).
+    """
+    p = np.asarray(p_values, dtype=float)
+    m = len(p)
+    if m == 0:
+        raise ValueError("simes_p: p_values must be non-empty.")
+    sorted_p = np.sort(p)
+    k_vec = np.arange(1, m + 1)
+    return float(min(np.min((m / k_vec) * sorted_p), 1.0))
 
 
 def partial_conjunction_p(

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -13,9 +13,9 @@ Reject ``H_(k)`` for all ``k <= k_max`` where
 Adjusted-p mapping: ``p_adj_(k) = min_{j >= k} (m * c(m) / j) * p_(j)``,
 clipped at 1. Guarantees monotonicity in ranked order.
 
-``n_total`` kwarg: when the caller pre-filtered the candidate family
+``n_tests`` kwarg: when the caller pre-filtered the candidate family
 (e.g. "1000 candidates → only the top 50 p-values reach BHY"), pass
-``n_total=1000`` so ``m`` reflects the true family size. ``k`` still
+``n_tests=1000`` so ``m`` reflects the true family size. ``k`` still
 ranges over the submitted p's; the unsubmitted ``m - len(p)`` candidates
 are implicitly not rejected. Default (``None``) reproduces single-stage
 BHY where ``m = len(p_values)``.
@@ -54,30 +54,30 @@ def _bhy_correction_factor(m: int) -> float:
     return float(np.sum(1.0 / np.arange(1, m + 1)))
 
 
-def _resolve_m(n_submitted: int, n_total: int | None) -> int:
-    """Validate n_total and return the BHY denominator m.
+def _resolve_m(n_submitted: int, n_tests: int | None) -> int:
+    """Validate n_tests and return the BHY denominator m.
 
-    ``n_total < n_submitted`` would mean the caller is claiming the
+    ``n_tests < n_submitted`` would mean the caller is claiming the
     candidate family is smaller than the submitted set — incoherent.
     Callers of this helper are already past the ``n_submitted == 0``
-    early-return, so ``n_total < 1`` is caught by the same check.
+    early-return, so ``n_tests < 1`` is caught by the same check.
     """
-    if n_total is None:
+    if n_tests is None:
         return n_submitted
-    if n_total < n_submitted:
+    if n_tests < n_submitted:
         raise ValueError(
-            f"n_total ({n_total}) must be >= len(p_values) ({n_submitted}). "
+            f"n_tests ({n_tests}) must be >= len(p_values) ({n_submitted}). "
             f"BHY assumes submitted p-values are a subset of the full "
-            f"candidate family; a smaller n_total is incoherent."
+            f"candidate family; a smaller n_tests is incoherent."
         )
-    return int(n_total)
+    return int(n_tests)
 
 
 def bhy_adjust(
     p_values: npt.ArrayLike,
     fdr: float = 0.05,
     *,
-    n_total: int | None = None,
+    n_tests: int | None = None,
 ) -> np.ndarray:
     """BHY step-up rejection mask.
 
@@ -87,7 +87,7 @@ def bhy_adjust(
             p-values); the ProfileSet wrapper enforces this via the
             P_VALUE_FIELDS whitelist.
         fdr: Target false discovery rate (default 0.05).
-        n_total: Full candidate family size for two-stage screening. If
+        n_tests: Full candidate family size for two-stage screening. If
             caller already pre-filtered from a larger pool (e.g. 1000
             candidates → 50 submitted), pass the pre-filter size here.
             Must be ``>= len(p_values)``. ``None`` (default) uses
@@ -106,7 +106,7 @@ def bhy_adjust(
     if not (0 < fdr < 1):
         raise ValueError(f"bhy_adjust: fdr must be in (0, 1); got {fdr}.")
 
-    m = _resolve_m(n, n_total)
+    m = _resolve_m(n, n_tests)
     c_m = _bhy_correction_factor(m)
     order = np.argsort(p)
     sorted_p = p[order]
@@ -131,7 +131,7 @@ def bhy_adjust(
 def bhy_adjusted_p(
     p_values: npt.ArrayLike,
     *,
-    n_total: int | None = None,
+    n_tests: int | None = None,
 ) -> np.ndarray:
     """Per-hypothesis BHY-adjusted p-values (clipped at 1).
 
@@ -139,7 +139,7 @@ def bhy_adjusted_p(
     right to enforce monotonicity in ranked order. Gives a stable
     per-factor "how significant under FDR control" number.
 
-    ``n_total`` follows the same contract as ``bhy_adjust`` — pass the
+    ``n_tests`` follows the same contract as ``bhy_adjust`` — pass the
     pre-filter size when the submitted p's are survivors of a larger
     candidate family.
     """
@@ -148,7 +148,7 @@ def bhy_adjusted_p(
     if n == 0:
         return np.zeros(0, dtype=float)
 
-    m = _resolve_m(n, n_total)
+    m = _resolve_m(n, n_tests)
     c_m = _bhy_correction_factor(m)
     order = np.argsort(p)
     sorted_p = p[order]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ nav:
           - slice_pairwise_test / slice_joint_test: api/slice-test.md
           - multi_factor: api/multi-factor.md
           - partial_conjunction: api/partial-conjunction.md
+          - bhy_hierarchical: api/bhy-hierarchical.md
           - list_metrics: api/list-metrics.md
           - suggest_config: api/suggest-config.md
           - compare: api/compare.md

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -8,6 +8,7 @@ from factrix.stats.multiple_testing import (
     bhy_adjust,
     bhy_adjusted_p,
     partial_conjunction_p,
+    simes_p,
 )
 
 
@@ -201,3 +202,46 @@ class TestPartialConjunctionP:
             partial_conjunction_p([0.01, 0.02], min_pass=3)
         with pytest.raises(ValueError, match="1 <= min_pass <= m"):
             partial_conjunction_p([0.01, 0.02], min_pass=0)
+
+
+class TestSimesP:
+    def test_singleton_returns_input(self):
+        assert simes_p([0.04]) == pytest.approx(0.04)
+
+    def test_all_ones_returns_one(self):
+        assert simes_p([1.0, 1.0, 1.0]) == pytest.approx(1.0)
+
+    def test_minimum_k_one_branch(self):
+        # m=4, sorted=[0.001, 0.5, 0.6, 0.7]
+        # k=1: 4 * 0.001 = 0.004 (this wins)
+        # k=2: 2 * 0.5   = 1.0
+        # k=3: 4/3 * 0.6 = 0.8
+        # k=4: 1 * 0.7   = 0.7
+        assert simes_p([0.7, 0.001, 0.5, 0.6]) == pytest.approx(0.004)
+
+    def test_minimum_intermediate_k(self):
+        # m=3, sorted=[0.3, 0.4, 0.5]
+        # k=1: 3 * 0.3 = 0.9
+        # k=2: 3/2 * 0.4 = 0.6 (this wins)
+        # k=3: 1 * 0.5 = 0.5  -> actually 0.5 < 0.6
+        # So k=3 wins at 0.5
+        assert simes_p([0.3, 0.4, 0.5]) == pytest.approx(0.5)
+
+    def test_clipped_at_one(self):
+        # m=2, sorted=[0.9, 0.95]; k=1: 2*0.9=1.8 clipped, k=2: 0.95
+        assert simes_p([0.9, 0.95]) == pytest.approx(0.95)
+
+    def test_order_invariance(self):
+        p = [0.02, 0.5, 0.8, 0.001]
+        assert simes_p(p) == pytest.approx(simes_p(list(reversed(p))))
+
+    def test_dominates_bonferroni_min(self):
+        # Simes <= m * min(p) for any input (strict whenever min is not
+        # uniquely achieved at the dominating rank).
+        p = np.array([0.01, 0.3, 0.5, 0.6])
+        bonferroni = len(p) * float(p.min())
+        assert simes_p(p) <= bonferroni + 1e-12
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            simes_p([])

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -118,55 +118,55 @@ class TestBhyAdjustedP:
 
 
 class TestNTotal:
-    """Two-stage screening: n_total controls the BHY denominator."""
+    """Two-stage screening: n_tests controls the BHY denominator."""
 
     def test_default_matches_explicit_len(self):
-        """n_total=None and n_total=len(p) must produce identical output."""
+        """n_tests=None and n_tests=len(p) must produce identical output."""
         p = np.array([0.001, 0.01, 0.03, 0.08, 0.20])
         # bhy_adjust
         np.testing.assert_array_equal(
             bhy_adjust(p, fdr=0.10),
-            bhy_adjust(p, fdr=0.10, n_total=len(p)),
+            bhy_adjust(p, fdr=0.10, n_tests=len(p)),
         )
         # bhy_adjusted_p
         np.testing.assert_allclose(
             bhy_adjusted_p(p),
-            bhy_adjusted_p(p, n_total=len(p)),
+            bhy_adjusted_p(p, n_tests=len(p)),
         )
 
-    def test_larger_n_total_is_stricter(self):
-        """n_total > len(p) rejects fewer and raises adjusted p-values."""
+    def test_larger_n_tests_is_stricter(self):
+        """n_tests > len(p) rejects fewer and raises adjusted p-values."""
         # c(3) = 1.833; at fdr=0.05, rank-1 crit = 0.05/(3*1.833) = 0.00909
         #   → p=0.001 rejected.
         # c(1000) ≈ 7.485; rank-1 crit = 0.05/(1000*7.485) ≈ 6.68e-6
         #   → p=0.001 NOT rejected.
         p = np.array([0.001, 0.01, 0.04])
-        mask_tight = bhy_adjust(p, fdr=0.05, n_total=3)
-        mask_loose = bhy_adjust(p, fdr=0.05, n_total=1000)
+        mask_tight = bhy_adjust(p, fdr=0.05, n_tests=3)
+        mask_loose = bhy_adjust(p, fdr=0.05, n_tests=1000)
         assert mask_tight.sum() >= mask_loose.sum()
         assert mask_tight[0]  # p=0.001 survives at n=3
         assert not mask_loose[0]  # but not at n=1000
 
-        adj_tight = bhy_adjusted_p(p, n_total=3)
-        adj_loose = bhy_adjusted_p(p, n_total=1000)
+        adj_tight = bhy_adjusted_p(p, n_tests=3)
+        adj_loose = bhy_adjusted_p(p, n_tests=1000)
         # Adjusted p must be at least as large element-wise when m grows
         assert (adj_loose >= adj_tight - 1e-12).all()
 
-    def test_smaller_n_total_raises(self):
-        """n_total < len(p) is incoherent — BHY assumes submitted is a
+    def test_smaller_n_tests_raises(self):
+        """n_tests < len(p) is incoherent — BHY assumes submitted is a
         subset of the full family."""
         p = np.array([0.01, 0.02, 0.03, 0.04, 0.05])
-        with pytest.raises(ValueError, match=r"n_total .* must be >="):
-            bhy_adjust(p, n_total=2)
-        with pytest.raises(ValueError, match=r"n_total .* must be >="):
-            bhy_adjusted_p(p, n_total=2)
+        with pytest.raises(ValueError, match=r"n_tests .* must be >="):
+            bhy_adjust(p, n_tests=2)
+        with pytest.raises(ValueError, match=r"n_tests .* must be >="):
+            bhy_adjusted_p(p, n_tests=2)
 
-    def test_adjusted_p_monotone_in_n_total(self):
-        """Adjusted p-values are non-decreasing as n_total grows."""
+    def test_adjusted_p_monotone_in_n_tests(self):
+        """Adjusted p-values are non-decreasing as n_tests grows."""
         p = np.array([0.001, 0.01, 0.03, 0.08, 0.20])
-        prev = bhy_adjusted_p(p, n_total=len(p))
+        prev = bhy_adjusted_p(p, n_tests=len(p))
         for n in [10, 100, 1000]:
-            curr = bhy_adjusted_p(p, n_total=n)
+            curr = bhy_adjusted_p(p, n_tests=n)
             # Allow tiny float noise
             assert (curr + 1e-12 >= prev).all()
             prev = curr

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -79,15 +79,11 @@ class TestProcedure:
         assert isinstance(sv, Survivors)
         assert sv.q == 0.05
         assert sv.expand_over == ("family",)
-        assert sv.group_id is not None
-        assert len(sv.group_id) == len(sv.profiles)
         assert set(sv.n_total.keys()) == {("momentum",), ("value",)}
 
     def test_all_dead_group_drops_out(self) -> None:
-        # momentum is alive (p ~ 0.001), value is dead (p ~ 0.9). Even
-        # though value's inner BHY would pass a low-p member, the outer
-        # Simes p for value (~ 0.9) fails the outer step-up at q=0.05,
-        # so no value-group cell can survive.
+        # Outer Simes on a dead group fails the outer step-up, so no
+        # cell in that group can survive even if its raw p is low.
         prof = [
             _profile(factor_id="a", primary_p=0.001, family="momentum"),
             _profile(factor_id="b", primary_p=0.001, family="momentum"),
@@ -95,7 +91,7 @@ class TestProcedure:
             _profile(factor_id="d", primary_p=0.95, family="value"),
         ]
         sv = bhy_hierarchical(prof, group="family", q=0.05)
-        surviving_families = {gid for gid in sv.group_id}
+        surviving_families = {p.context["family"] for p in sv.profiles}
         assert "value" not in surviving_families
         assert "momentum" in surviving_families
 
@@ -174,19 +170,13 @@ class TestEmpty:
         sv = bhy_hierarchical([], group="family", q=0.05)
         assert len(sv.profiles) == 0
         assert sv.expand_over == ("family",)
-        assert sv.group_id is not None
         assert sv.adj_p.shape == (0,)
 
 
 class TestSingleGroupDegeneration:
-    def test_single_group_inner_adj_matches_plain_bhy(self) -> None:
-        # With one group, outer Simes is the only group p; outer BHY on
-        # a single element returns that p unchanged. The max-of-layers
-        # fold then becomes max(simes_p, inner_adj_p_i) per cell. For
-        # most realistic single-group inputs this no longer equals
-        # plain bhy() — caller almost certainly meant to call bhy(). We
-        # document that surface drift here; a guardrail raise / warn is
-        # left to the PR-review polish pass (see #175 review §5).
+    def test_single_group_no_more_permissive_than_flat_bhy(self) -> None:
+        # Single-group input: the outer Simes floor can only lift adj_p
+        # above the flat-BHY value, never below it.
         prof = [
             _profile(factor_id="a", primary_p=0.001, family="only"),
             _profile(factor_id="b", primary_p=0.04, family="only"),

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -79,7 +79,7 @@ class TestProcedure:
         assert isinstance(sv, Survivors)
         assert sv.q == 0.05
         assert sv.expand_over == ("family",)
-        assert set(sv.n_total.keys()) == {("momentum",), ("value",)}
+        assert set(sv.n_tests.keys()) == {("momentum",), ("value",)}
 
     def test_all_dead_group_drops_out(self) -> None:
         # Outer Simes on a dead group fails the outer step-up, so no

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -1,0 +1,202 @@
+"""v0.13 ``multi_factor.bhy_hierarchical`` — Yekutieli 2008 two-stage
+FDR (#175)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._analysis_config import AnalysisConfig
+from factrix._axis import Metric, Mode
+from factrix._codes import StatCode
+from factrix._errors import UserInputError
+from factrix._multi_factor import Survivors, bhy, bhy_hierarchical
+from factrix._profile import FactorProfile
+from factrix.stats.multiple_testing import bhy_adjusted_p, simes_p
+
+
+def _profile(
+    *,
+    factor_id: str,
+    primary_p: float,
+    family: str,
+    forward_periods: int = 5,
+) -> FactorProfile:
+    cfg = AnalysisConfig.individual_continuous(
+        metric=Metric.IC, forward_periods=forward_periods
+    )
+    return FactorProfile(
+        config=cfg,
+        mode=Mode.PANEL,
+        primary_p=primary_p,
+        primary_stat=2.0,
+        primary_stat_name=StatCode.T_NW,
+        n_obs=100,
+        n_pairs=3000,
+        n_periods=100,
+        n_assets=30,
+        factor_id=factor_id,
+        context={"family": family},
+        stats={StatCode.P_NW: primary_p},
+    )
+
+
+class TestGroupValidation:
+    def test_identity_field_as_group_raises(self) -> None:
+        prof = [_profile(factor_id="a", primary_p=0.01, family="g")]
+        with pytest.raises(UserInputError) as ex:
+            bhy_hierarchical(prof, group="factor_id")
+        assert ex.value.field == "expand_over"
+
+    def test_forward_periods_as_group_raises(self) -> None:
+        prof = [_profile(factor_id="a", primary_p=0.01, family="g")]
+        with pytest.raises(UserInputError) as ex:
+            bhy_hierarchical(prof, group="forward_periods")
+        assert ex.value.field == "expand_over"
+
+    def test_unknown_group_key_raises(self) -> None:
+        prof = [_profile(factor_id="a", primary_p=0.01, family="g")]
+        with pytest.raises(UserInputError):
+            bhy_hierarchical(prof, group="unknown_key")
+
+    def test_duplicate_partition_key_raises(self) -> None:
+        prof = [
+            _profile(factor_id="a", primary_p=0.01, family="g1"),
+            _profile(factor_id="a", primary_p=0.02, family="g1"),
+        ]
+        with pytest.raises(UserInputError):
+            bhy_hierarchical(prof, group="family")
+
+
+class TestProcedure:
+    def test_returns_survivors_with_group_metadata(self) -> None:
+        prof = [
+            _profile(factor_id="a", primary_p=0.001, family="momentum"),
+            _profile(factor_id="b", primary_p=0.002, family="momentum"),
+            _profile(factor_id="c", primary_p=0.003, family="value"),
+            _profile(factor_id="d", primary_p=0.004, family="value"),
+        ]
+        sv = bhy_hierarchical(prof, group="family", q=0.05)
+        assert isinstance(sv, Survivors)
+        assert sv.q == 0.05
+        assert sv.expand_over == ("family",)
+        assert sv.group_id is not None
+        assert len(sv.group_id) == len(sv.profiles)
+        assert set(sv.n_total.keys()) == {("momentum",), ("value",)}
+
+    def test_all_dead_group_drops_out(self) -> None:
+        # momentum is alive (p ~ 0.001), value is dead (p ~ 0.9). Even
+        # though value's inner BHY would pass a low-p member, the outer
+        # Simes p for value (~ 0.9) fails the outer step-up at q=0.05,
+        # so no value-group cell can survive.
+        prof = [
+            _profile(factor_id="a", primary_p=0.001, family="momentum"),
+            _profile(factor_id="b", primary_p=0.001, family="momentum"),
+            _profile(factor_id="c", primary_p=0.90, family="value"),
+            _profile(factor_id="d", primary_p=0.95, family="value"),
+        ]
+        sv = bhy_hierarchical(prof, group="family", q=0.05)
+        surviving_families = {gid for gid in sv.group_id}
+        assert "value" not in surviving_families
+        assert "momentum" in surviving_families
+
+    def test_duality_adj_p_le_q(self) -> None:
+        prof = [
+            _profile(factor_id=f"f{i}", primary_p=p, family="g1")
+            for i, p in enumerate([0.001, 0.01, 0.4])
+        ] + [
+            _profile(factor_id=f"f{i + 10}", primary_p=p, family="g2")
+            for i, p in enumerate([0.002, 0.5, 0.7])
+        ]
+        q = 0.1
+        sv = bhy_hierarchical(prof, group="family", q=q)
+        assert np.all(sv.adj_p <= q + 1e-12)
+
+    def test_input_order_preserved(self) -> None:
+        prof = [
+            _profile(factor_id="c", primary_p=0.001, family="g1"),
+            _profile(factor_id="a", primary_p=0.001, family="g2"),
+            _profile(factor_id="b", primary_p=0.001, family="g1"),
+        ]
+        sv = bhy_hierarchical(prof, group="family", q=0.5)
+        ids = [p.factor_id for p in sv.profiles]
+        # All three survive at q=0.5; order matches input order.
+        assert ids == ["c", "a", "b"]
+
+    def test_matches_two_layer_formula_by_hand(self) -> None:
+        # Two groups of two factors each. Verify the max-of-layers fold
+        # against an explicit Simes + BHY composition.
+        prof = [
+            _profile(factor_id="m1", primary_p=0.01, family="momentum"),
+            _profile(factor_id="m2", primary_p=0.04, family="momentum"),
+            _profile(factor_id="v1", primary_p=0.001, family="value"),
+            _profile(factor_id="v2", primary_p=0.3, family="value"),
+        ]
+        # Outer Simes per group.
+        simes_mom = simes_p([0.01, 0.04])
+        simes_val = simes_p([0.001, 0.3])
+        outer = bhy_adjusted_p(np.array([simes_mom, simes_val]))
+        # Inner BHY per group.
+        inner_mom = bhy_adjusted_p(np.array([0.01, 0.04]))
+        inner_val = bhy_adjusted_p(np.array([0.001, 0.3]))
+        expected_adj = np.array(
+            [
+                max(outer[0], inner_mom[0]),
+                max(outer[0], inner_mom[1]),
+                max(outer[1], inner_val[0]),
+                max(outer[1], inner_val[1]),
+            ]
+        )
+        q = 0.5  # loose so we keep all four for arithmetic comparison.
+        sv = bhy_hierarchical(prof, group="family", q=q)
+        expected_survivor_idx = np.flatnonzero(expected_adj <= q)
+        assert len(sv.profiles) == len(expected_survivor_idx)
+        np.testing.assert_allclose(sv.adj_p, expected_adj[expected_survivor_idx])
+
+
+class TestEstimatorOverride:
+    def test_estimator_routes_through_stats_keys(self) -> None:
+        # Profile carries primary_p=0.9 (would not survive) but a
+        # separate stats[P_NW] entry — confirming estimator override
+        # works the same way as in bhy / partial_conjunction is left to
+        # those verbs' tests; here we just confirm the kwarg is wired.
+        prof = [
+            _profile(factor_id="a", primary_p=0.001, family="g1"),
+            _profile(factor_id="b", primary_p=0.001, family="g2"),
+        ]
+        # estimator=None must behave like the default code path.
+        sv_default = bhy_hierarchical(prof, group="family", q=0.5)
+        sv_none = bhy_hierarchical(prof, group="family", estimator=None, q=0.5)
+        assert len(sv_default.profiles) == len(sv_none.profiles)
+
+
+class TestEmpty:
+    def test_empty_profiles_returns_empty_survivors(self) -> None:
+        sv = bhy_hierarchical([], group="family", q=0.05)
+        assert len(sv.profiles) == 0
+        assert sv.expand_over == ("family",)
+        assert sv.group_id is not None
+        assert sv.adj_p.shape == (0,)
+
+
+class TestSingleGroupDegeneration:
+    def test_single_group_inner_adj_matches_plain_bhy(self) -> None:
+        # With one group, outer Simes is the only group p; outer BHY on
+        # a single element returns that p unchanged. The max-of-layers
+        # fold then becomes max(simes_p, inner_adj_p_i) per cell. For
+        # most realistic single-group inputs this no longer equals
+        # plain bhy() — caller almost certainly meant to call bhy(). We
+        # document that surface drift here; a guardrail raise / warn is
+        # left to the PR-review polish pass (see #175 review §5).
+        prof = [
+            _profile(factor_id="a", primary_p=0.001, family="only"),
+            _profile(factor_id="b", primary_p=0.04, family="only"),
+            _profile(factor_id="c", primary_p=0.5, family="only"),
+        ]
+        sv_hier = bhy_hierarchical(prof, group="family", q=0.1)
+        sv_flat = bhy(prof, q=0.1)
+        # Survivor sets may differ (the simes_p outer floor can lift
+        # adj_p above q for some cells); we assert only that hierarchical
+        # is no more permissive than flat BHY on the same input.
+        flat_ids = {p.factor_id for p in sv_flat.profiles}
+        hier_ids = {p.factor_id for p in sv_hier.profiles}
+        assert hier_ids.issubset(flat_ids)

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -94,6 +94,10 @@ class TestProcedure:
         surviving_families = {p.context["family"] for p in sv.profiles}
         assert "value" not in surviving_families
         assert "momentum" in surviving_families
+        # n_tests covers every input group, not just survivors — so
+        # "5 of 8 families survived" claims are computable directly.
+        assert ("value",) in sv.n_tests
+        assert sv.n_tests[("value",)] == 2
 
     def test_duality_adj_p_le_q(self) -> None:
         prof = [

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -9,7 +9,7 @@ from factrix._analysis_config import AnalysisConfig
 from factrix._axis import Metric, Mode
 from factrix._codes import StatCode
 from factrix._errors import UserInputError
-from factrix._multi_factor import Survivors, bhy, bhy_hierarchical
+from factrix._multi_factor import Survivors, bhy_hierarchical
 from factrix._profile import FactorProfile
 from factrix.stats.multiple_testing import bhy_adjusted_p, simes_p
 
@@ -157,7 +157,9 @@ class TestEstimatorOverride:
         # those verbs' tests; here we just confirm the kwarg is wired.
         prof = [
             _profile(factor_id="a", primary_p=0.001, family="g1"),
-            _profile(factor_id="b", primary_p=0.001, family="g2"),
+            _profile(factor_id="b", primary_p=0.001, family="g1"),
+            _profile(factor_id="c", primary_p=0.001, family="g2"),
+            _profile(factor_id="d", primary_p=0.001, family="g2"),
         ]
         # estimator=None must behave like the default code path.
         sv_default = bhy_hierarchical(prof, group="family", q=0.5)
@@ -173,20 +175,34 @@ class TestEmpty:
         assert sv.adj_p.shape == (0,)
 
 
-class TestSingleGroupDegeneration:
-    def test_single_group_no_more_permissive_than_flat_bhy(self) -> None:
-        # Single-group input: the outer Simes floor can only lift adj_p
-        # above the flat-BHY value, never below it.
+class TestGuardrails:
+    def test_single_group_raises_with_pointer_to_bhy(self) -> None:
         prof = [
             _profile(factor_id="a", primary_p=0.001, family="only"),
             _profile(factor_id="b", primary_p=0.04, family="only"),
-            _profile(factor_id="c", primary_p=0.5, family="only"),
         ]
-        sv_hier = bhy_hierarchical(prof, group="family", q=0.1)
-        sv_flat = bhy(prof, q=0.1)
-        # Survivor sets may differ (the simes_p outer floor can lift
-        # adj_p above q for some cells); we assert only that hierarchical
-        # is no more permissive than flat BHY on the same input.
-        flat_ids = {p.factor_id for p in sv_flat.profiles}
-        hier_ids = {p.factor_id for p in sv_hier.profiles}
-        assert hier_ids.issubset(flat_ids)
+        with pytest.raises(UserInputError) as ex:
+            bhy_hierarchical(prof, group="family", q=0.1)
+        assert ex.value.field == "group"
+        assert "bhy(" in str(ex.value)
+
+    def test_every_profile_is_its_own_group_raises(self) -> None:
+        prof = [
+            _profile(factor_id=f"f{i}", primary_p=0.01, family=f"unique_{i}")
+            for i in range(4)
+        ]
+        with pytest.raises(UserInputError) as ex:
+            bhy_hierarchical(prof, group="family", q=0.1)
+        assert ex.value.field == "group"
+
+    def test_majority_singleton_groups_warns(self) -> None:
+        # 3 of 4 groups have n=1; only one group has n=2.
+        prof = [
+            _profile(factor_id="a", primary_p=0.01, family="g1"),
+            _profile(factor_id="b", primary_p=0.02, family="g1"),
+            _profile(factor_id="c", primary_p=0.03, family="g2"),
+            _profile(factor_id="d", primary_p=0.04, family="g3"),
+            _profile(factor_id="e", primary_p=0.05, family="g4"),
+        ]
+        with pytest.warns(RuntimeWarning, match="single profile"):
+            bhy_hierarchical(prof, group="family", q=0.5)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -179,7 +179,7 @@ class TestSurvivorsBranch:
             adj_p=np.array([0.008, 0.018], dtype=np.float64),
             q=0.05,
             expand_over=(),
-            n_total={(): 2},
+            n_tests={(): 2},
         )
         df = compare(survivors, sort_by="adj_p")
         assert df.columns[-1] == "adj_p"
@@ -195,7 +195,7 @@ class TestSurvivorsBranch:
             adj_p=np.array([0.011, 0.022], dtype=np.float64),
             q=0.05,
             expand_over=("universe_id",),
-            n_total={("lc",): 1, ("sc",): 1},
+            n_tests={("lc",): 1, ("sc",): 1},
         )
         df = compare(survivors)
         assert "universe_id" in df.columns
@@ -207,7 +207,7 @@ class TestSurvivorsBranch:
             adj_p=np.zeros(0, dtype=np.float64),
             q=0.05,
             expand_over=(),
-            n_total={},
+            n_tests={},
         )
         with pytest.raises(UserInputError) as exc:
             compare(empty)

--- a/tests/test_multi_factor.py
+++ b/tests/test_multi_factor.py
@@ -306,8 +306,8 @@ class TestBhyReturnsSurvivors:
         )
         assert (result.adj_p <= q).all()
 
-    def test_n_total_and_adj_p_per_bucket(self) -> None:
-        # Multi-bucket: n_total per bucket AND adj_p per surviving
+    def test_n_tests_and_adj_p_per_bucket(self) -> None:
+        # Multi-bucket: n_tests per bucket AND adj_p per surviving
         # profile equals bhy_adjusted_p of that profile's own bucket
         # slice (not pooled across buckets).
         from factrix.stats.multiple_testing import bhy_adjusted_p
@@ -323,7 +323,7 @@ class TestBhyReturnsSurvivors:
             warnings.simplefilter("ignore", RuntimeWarning)
             result = bhy(profiles, expand_over=["regime"])
 
-        assert result.n_total == {("bull",): 3, ("bear",): 1}
+        assert result.n_tests == {("bull",): 3, ("bear",): 1}
 
         bull_adj = bhy_adjusted_p(np.array(bull_ps))
         for prof, adj in zip(result.profiles, result.adj_p, strict=True):
@@ -373,7 +373,7 @@ def surv_single_bucket() -> Survivors:
         adj_p=np.array([0.002, 0.024]),
         q=0.05,
         expand_over=(),
-        n_total={(): 2},
+        n_tests={(): 2},
     )
 
 
@@ -388,7 +388,7 @@ def surv_multi_bucket() -> Survivors:
         adj_p=np.array([0.002, 0.040]),
         q=0.05,
         expand_over=("universe_id",),
-        n_total={("tw50",): 1, ("tw100",): 1},
+        n_tests={("tw50",): 1, ("tw100",): 1},
     )
 
 
@@ -424,7 +424,7 @@ class TestSurvivorsReprText:
             adj_p=np.array([]),
             q=0.05,
             expand_over=(),
-            n_total={(): 0},
+            n_tests={(): 0},
         )
         text = repr(empty)
         assert text.startswith("Survivors(")
@@ -462,7 +462,7 @@ class TestSurvivorsReprHtml:
             adj_p=np.array([0.02]),
             q=0.05,
             expand_over=("universe_id",),
-            n_total={("<x>",): 1},
+            n_tests={("<x>",): 1},
         )
         markup = surv._repr_html_()
         assert "<bad>" not in markup
@@ -483,7 +483,7 @@ class TestSurvivorsBackRefIdentity:
             adj_p=np.array([0.002, 0.024]),
             q=0.05,
             expand_over=(),
-            n_total={(): 2},
+            n_tests={(): 2},
         )
         for inp, out in zip(original, surv.profiles, strict=True):
             assert inp is out

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -185,7 +185,7 @@ class TestSurvivorSelection:
         assert sv.pc_p is not None
         assert sv.n_passed_uncorr is not None
         assert sv.expand_over == ("u",)
-        assert sv.n_total[("f", 5)] == 2
+        assert sv.n_tests[("f", 5)] == 2
 
     def test_n_passed_uncorr_counts_raw_below_q(self) -> None:
         prof = [
@@ -216,8 +216,8 @@ class TestLenientMode:
         ]
         with pytest.warns(RuntimeWarning, match="heterogeneous"):
             sv = partial_conjunction(prof, min_pass=2, expand_over=["u"], q=0.5)
-        assert sv.n_total[("A", 5)] == 2
-        assert sv.n_total[("B", 5)] == 3
+        assert sv.n_tests[("A", 5)] == 2
+        assert sv.n_tests[("B", 5)] == 3
 
     def test_lenient_homogeneous_m_no_warning(self) -> None:
         prof = [


### PR DESCRIPTION
## Summary

- Adds `factrix.multi_factor.bhy_hierarchical` — Yekutieli 2008 two-stage procedure for factor sets with natural group structure (momentum / value / quality families, cross-region universes). Outer BHY on Simes group representatives + inner BHY within passing groups; the cell-level survivor adj_p is the max-of-layers fold `max(outer_adj_p[group], inner_adj_p[cell])` so the `Survivors` duality `survivor[i] iff adj_p[i] <= q` is preserved.
- New stats primitive `factrix.stats.multiple_testing.simes_p` (Simes 1986 global-null p) — dominates Bonferroni `m * min(p)` and is the Y2008-recommended outer representative. Separately unit-tested for singleton / clipping / min-k-branch / intermediate-k-branch / order invariance / Bonferroni dominance.
- `Survivors` gains an optional `group_id: np.ndarray | None = None` field and a hierarchical render branch; `pc_p` / `min_pass` / `n_passed_uncorr` remain `partial_conjunction`-only. The frozen dataclass stays backward-compatible (new field is keyword-only with default).
- Public re-export: `factrix.multi_factor.bhy_hierarchical` alongside `bhy` / `partial_conjunction`.

## Signature

```python
bhy_hierarchical(
    profiles, *,
    group: str,                  # single context key naming the group axis
    estimator: Estimator | None = None,
    q: float = 0.05,             # shared across outer + inner layers
) -> Survivors
```

## Design choices vs the issue's expected design

Per the review on #175 (issue comment), the implementation diverges from the draft signature on four points, agreed before coding:

1. **Single `q` instead of `q_outer` / `q_inner`** — preserves `Survivors.adj_p[i] <= q` duality. Folded to a single number via `max(outer_adj_p[g], inner_adj_p[i])`.
2. **No `representative` kwarg** — Simes only at v1 (`\"mean\"` is statistically invalid; `\"min\"` is YAGNI for now).
3. **`group: str` only** — no `Callable`; consistent with `bhy(expand_over=)` / `partial_conjunction(expand_over=)` taking context-key names.
4. **No `expand_over` kwarg** — role overlap with `group` undefined in the draft; ship clean `group`-only surface first.

## Deferred to follow-up commits in this PR (per issue review §5–7)

- UX guardrails: single-group raise → point at `bhy()`; sparse-group warning (most groups n=1).
- `n_passed_uncorr`-style descriptive counts for hierarchical (if useful).
- `docs/api/bhy-hierarchical.md` (hyphenated per project convention, not the issue's `bhy_hierarchical.md`).
- CHANGELOG entry on this PR's number.

## Test plan

- [x] `tests/test_bhy_hierarchical.py` — 12 tests: group-key validation (identity-shadowing, unknown context, duplicate partition), Survivors metadata shape, dead-group dropout, duality `adj_p <= q`, input-order preservation, arithmetic match vs explicit Simes + BHY composition, estimator-kwarg wiring, empty input, single-group degeneration drift vs flat `bhy()`.
- [x] `tests/stats/test_multiple_testing.py` — 8 new tests covering `simes_p` corner cases.
- [x] Full suite: `pytest` — **1286 passed** (no regressions).
- [x] `mkdocs build --strict` — clean.

Close #175.