### PR TITLE
docs: mkdocs UX overhaul — surface taxonomy, schema hub, decision tree (#164)

### DIFF
--- a/docs/api/decision-tree.md
+++ b/docs/api/decision-tree.md
@@ -1,0 +1,137 @@
+# Decision tree
+
+Reverse lookup from research question to function. The
+[API reference landing](index.md) is function-centric ("here is each
+public symbol"); this page is question-centric ("here is what to reach
+for, given what you want to know").
+
+Three sections:
+
+- **§A. Question → function** — pick a starting function from intent.
+- **§B. Comparison axes** — `row × column` matrix for every "compare N
+  things across M dimensions" question.
+- **§C. Cross-function topics** — concepts whose meaning shifts across
+  functions (`expand_over`, regime analysis).
+
+---
+
+## §A. Question → function
+
+```
+What do you want to know?
+│
+├── "Is factor X significant for one cell?"
+│     → evaluate(panel, cfg) → FactorProfile.primary_p
+│
+├── "What is the descriptive surface of factor X for one cell?"
+│     → run_metrics(panel, cfg, factor_col=...) → MetricsBundle
+│
+├── "Which of N candidate factors is strongest?"
+│     ├── with FDR control          → evaluate × N → bhy(profiles) → compare(survivors)
+│     ├── pure ranking, no FDR      → evaluate × N → compare(profiles, sort_by=...)
+│     └── exploratory descriptive   → run_metrics × N → compare(bundles)
+│
+├── "Does factor X hold up across multiple contexts?"
+│     ├── all contexts pass (k = m)         → partial_conjunction(profiles, k_of_m=m)
+│     ├── at least k of m pass             → partial_conjunction(profiles, k_of_m=k)
+│     ├── nested family / group structure  → bhy_hierarchical(profiles, group=...)
+│     └── flat sweep over a context axis   → bhy(profiles, expand_over=[...])
+│
+├── "Is factor X's conclusion robust to estimator choice?"
+│     → by_estimator(profiles, estimators=[...])   # planned, lands v0.14 (#178)
+│
+├── "How does factor X behave across slices (sector / regime / decile)?"
+│     ├── descriptive (per-slice value + n_obs)   → by_slice(metric, df, label=...) → SliceResult
+│     └── statistical test across slices          → slice_pairwise_test / slice_joint_test
+│
+└── "How does factor X behave across regimes?"
+      └── see §C — regime analysis is dispatched to four different functions
+          depending on whether the question is descriptive, FDR-controlled,
+          consistency-across-regimes, or between-regime difference.
+```
+
+---
+
+## §B. Comparison axes
+
+Every "compare N things across M dimensions" question reduces to a
+choice of *row variable* × *column variable*. The seven shipped
+comparisons:
+
+| You want to compare | Function | Row | Column |
+|---|---|---|---|
+| N factors × 1 primary metric | `compare(profiles)` | factor | primary stat |
+| N factors × M descriptive metrics | `compare(bundles)` | factor | each standalone metric |
+| N factors × 1 primary, post-FDR | `compare(survivors)` | survivor | primary stat + `adj_q` |
+| N factors × M estimators *(planned v0.14)* | `by_estimator(profiles, estimators=…)` | factor | each estimator's (t, p) |
+| 1 metric × K slices (descriptive) | `by_slice(metric, df, label=…)` | slice value | metric value + n_obs |
+| 1 metric × K slices (pairwise tests) | `slice_pairwise_test(metric, df, label=…)` | slice pair | test statistic + adjusted p |
+| 1 metric × K slices (omnibus test) | `slice_joint_test(metric, df, label=…)` | — | one χ² + p |
+
+Read the matrix as: row × column = the cells of the returned
+`pl.DataFrame`. None of these functions recompute the underlying
+metric — they are projections over artefacts the compute functions
+(`evaluate` / `run_metrics` / a metric callable) already produced.
+The exception is `by_estimator`, which re-runs the inference layer
+only, not the metric pipeline.
+
+---
+
+## §C. Cross-function topics
+
+### `expand_over` is not one concept
+
+The keyword is reused across screening functions but the **what is
+expanded** differs. Confusing the three semantics is the most common
+multiplicity-correction bug in user code.
+
+| Function | `expand_over` meaning | What ends up in the FDR family |
+|---|---|---|
+| `bhy(profiles, expand_over=["regime_id"])` | Add the listed context keys as hypothesis dimensions | `factor_id × forward_periods × regime_id` — every (factor, horizon, regime) row is an independent hypothesis |
+| `partial_conjunction(profiles, k_of_m, expand_over=["regime_id"])` | Group rows by everything *except* the listed keys; require k-of-m passes within each group | Each non-expanded group yields one partial-conjunction p; BHY then runs over the resulting reduced family |
+| `by_estimator` *(planned)* | Does not accept `expand_over` | — |
+
+Two practical rules:
+
+- **Universe / regime as sample restriction** — `filter(...)` then
+  `bhy(...)`. Standard FDR over `factor_id × forward_periods`.
+- **Universe / regime as a hypothesis dimension** —
+  `bhy(profiles, expand_over=[axis])`. FDR over `factor_id × forward_periods × axis`.
+
+See [`multi_factor`](multi-factor.md) for the pinned discussion that
+walks through the sample-restriction-vs-hypothesis-dimension split.
+
+### Regime analysis — four functions for four questions
+
+"I want to analyse regimes" is a leading question — the right function
+depends on what specifically is being asked.
+
+| Question | Function | Why |
+|---|---|---|
+| "What does factor X look like in each regime?" (descriptive) | `by_slice(metric, df, label="regime_id")` → `SliceResult` | Single-axis slice surface; no inference claim |
+| "Which (factor, regime) cells are FDR-significant?" | `bhy(profiles, expand_over=["regime_id"])` | regime is a hypothesis dimension; FDR scope expands accordingly |
+| "Is factor X consistent across all (or k of) regimes?" | `partial_conjunction(profiles, k_of_m=k, expand_over=["regime_id"])` | The PC null is "fails in ≥ k regimes"; BHY then on the reduced PC p-values |
+| "Do regime means differ statistically?" | `slice_pairwise_test(metric, df, label="regime_id")` or `slice_joint_test(...)` | Between-slice inference; family-internal MTC; no cell-level FDR claim |
+
+Three notes:
+
+- **Lookahead bias on ex-post regime labels.** If the regime label is
+  built using future information (e.g. "high-vol regime" defined by
+  realised vol over the window), every result above inherits that
+  bias. Cleanest fix: pre-publish the regime rule and apply it with no
+  lookahead; otherwise treat the analysis as descriptive only.
+- **Effect-size comparison across regimes** is not a separate function
+  — it is a paper-craft question. Quote the relevant per-regime
+  effect sizes from `by_slice` output and reason in prose; do not add
+  a `compare(across="regime")` knob to `compare`.
+- **`by_estimator` does not interact with regimes.** It re-runs the
+  inference layer for a fixed cell; it has no regime axis.
+
+---
+
+## See also
+
+- [API reference landing](index.md) — function-centric overview and function-flow graph
+- [Concepts](../getting-started/concepts.md) — three-axis taxonomy
+- [Quickstart § Next steps](../getting-started/quickstart.md#next-steps) — exit ramps from a single `FactorProfile`
+- [Errors](errors.md) — error code → fix mapping

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -45,6 +45,46 @@ FactrixError                       # base
 | `InsufficientSampleError` | `T` below the procedure floor | `.actual_periods`, `.required_periods` |
 | `UserInputError` | Unknown metric / `p_stat` / context key, column not in panel, wrong type | structured `.field`, `.value`, `.candidates`, `.suggestions`, `.expected`, `.docs_url` |
 
+---
+
+## Error → fix mapping
+
+Concrete messages, what triggers them, and where to look for the fix.
+Use the table to skim; jump to the linked page for the why.
+
+### Panel-schema failures
+
+| Message hint | Trigger | Fix |
+|---|---|---|
+| `factor_col 'X' not in panel columns` | Typo or wrong column name | Check `panel.columns`; pass the actual name to `factor_col=`. See [Panel schema § `factor_col=`](panel-schema.md#factor_col--non-default-signal-column-name). |
+| `Both 'factor' and 'X' present` | Wide panel still has stale `"factor"` column alongside the renamed one | `panel.drop("factor")` before calling. |
+| `forward_return column missing` | Forgot the preprocess step | `compute_forward_return(raw, forward_periods=h)` before `evaluate`. See [Panel schema § Preprocess pipeline](panel-schema.md#preprocess-pipeline). |
+
+### Config failures (`ConfigError` family)
+
+| Exception / message | Trigger | Fix |
+|---|---|---|
+| `MissingConfigError: evaluate(raw) needs AnalysisConfig` | `evaluate(panel)` called with no `cfg` | `fx.suggest_config(panel)` returns a `SuggestConfigResult` with `.suggested` (an `AnalysisConfig`) and per-axis reasoning. See [`suggest_config`](suggest-config.md). |
+| `IncompatibleAxisError: (scope, signal, metric) is not a legal cell` | Combination like `(INDIVIDUAL, SPARSE, IC)` that the dispatch table never registers | Use one of the four factories (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`) — illegal combos are unreachable via factories. See [Concepts](../getting-started/concepts.md). |
+| `ModeAxisError: no procedure at runtime Mode=TIMESERIES` | Legal cell, but `N = panel["asset_id"].n_unique()` triggers a Mode the cell does not implement (typical case: `individual_continuous` at `N=1`) | Read `.suggested_fix` — it carries the nearest-legal `AnalysisConfig` for the actual `Mode`. See [Quickstart § N = 1](../getting-started/quickstart.md). |
+| `InsufficientSampleError: T below required` | `n_periods` below the procedure's `MIN_PERIODS_HARD` floor | Read `.actual_periods` and `.required_periods`. The fix is either more data, or — if the procedure is not the right one for short series — switching to a TIMESERIES-friendly cell. See [PANEL vs TIMESERIES](../guides/panel-timeseries.md). |
+
+### User-input failures (`UserInputError`)
+
+Every `UserInputError` carries structured attributes (see
+[Reading a `UserInputError`](#reading-a-userinputerror)). Common
+triggers and fix paths:
+
+| Message hint | Trigger | Fix |
+|---|---|---|
+| `unknown metric='...'` | Typo or metric not applicable to the cell | `list_metrics(scope, signal)` enumerates the applicable set; `exc.suggestions` carries the top-3 fuzzy candidates. See [`list_metrics`](list-metrics.md). |
+| `unknown estimator='...'` | Typo or estimator not applicable to the cell | `list_estimators(scope, signal)` enumerates the applicable set. See [`list_estimators`](list-estimators.md). |
+| `unknown expand_over='...'` | Context key not present on every profile in the family | All profiles in the family must carry the key in `.context`; check that the caller is populating it consistently at `evaluate` time. See [Decision tree § §C `expand_over`](decision-tree.md#expand_over-is-not-one-concept) for the three different `expand_over` semantics across functions. |
+| `expand_over=[...] requires every profile to carry key 'X'` | One or more profiles missing the key | Confirm the upstream `evaluate` call records the key in `context=...`. |
+| `Expected: list[FactorProfile], got list[MetricsBundle]` | Passing the wrong artefact family to a screening function | Screening (`bhy`, `partial_conjunction`, `bhy_hierarchical`) consumes `list[FactorProfile]` (primary-p carriers). For descriptive cross-factor views use `compare(bundles)`. See [Decision tree § §A](decision-tree.md#a-question--function). |
+
+---
+
 ## Reading a `UserInputError`
 
 Every user-facing raise that takes a named input renders the same

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -4,6 +4,10 @@ Single-factor evaluation entry point. Routes a
 `(raw, AnalysisConfig)` pair to the procedure registered for the
 dispatch cell and returns a [`FactorProfile`](factor-profile.md).
 
+> **Input contract** — the panel must satisfy the four-column floor
+> documented in [Panel schema](panel-schema.md). The per-cell extension
+> table below adds optional columns on top of that floor.
+
 ## Call shape
 
 ```python

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -9,13 +9,13 @@ flowchart LR
     P[panel + cfg]
     EV[evaluate]
     RM[run_metrics]
-    BS[by_slice]
-    ST["slice_pairwise_test<br/>slice_joint_test"]
+    BS(by_slice)
+    ST{"slice_pairwise_test<br/>slice_joint_test"}
     BHY{{bhy}}
     PC{{partial_conjunction}}
     BHYH{{bhy_hierarchical}}
     LM[/list_metrics/]
-    CMP[compare]
+    CMP(compare)
 
     P ==> EV
     P ==> RM
@@ -30,17 +30,6 @@ flowchart LR
     PC ==>|survivors| CMP
     BHYH ==>|survivors| CMP
     LM -.->|metric names| RM
-
-    classDef compute fill:#e3f2fd,stroke:#1976d2,color:#000
-    classDef screening fill:#fce4ec,stroke:#c2185b,color:#000
-    classDef inference fill:#ffe0b2,stroke:#e65100,color:#000
-    classDef view fill:#f3e5f5,stroke:#7b1fa2,color:#000
-    classDef introspect fill:#fff9c4,stroke:#f9a825,color:#000
-    class EV,RM compute
-    class BHY,PC,BHYH screening
-    class ST inference
-    class BS,CMP view
-    class LM introspect
 
     click EV "evaluate/" "evaluate API"
     click RM "run-metrics/" "run_metrics API"
@@ -57,16 +46,17 @@ Click any node to jump to its API page.
 
 **Edge convention.** Solid `==>` is a hard signature dependency — the target function's call signature takes the source object literally (e.g. `evaluate(panel, cfg)` consumes the input `P`, and `bhy` / `partial_conjunction` / `bhy_hierarchical` consume a list of `FactorProfile`s that only `evaluate` produces). Dashed `-.->` is a suggested workflow — the source is panel-derived but the target function's signature differs in shape (`by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame built from the panel via e.g. `compute_ic(panel)`; `list_metrics` returns candidate names you pass to `run_metrics(metrics=[…])`).
 
-**Six categories** (background colour):
+**Category encoding by node shape:**
 
-- **Compute** (blue) — `evaluate`, `run_metrics`. Produce primary artefacts (`FactorProfile` / `MetricsBundle`) from `(panel, cfg)`.
-- **Screening (FDR)** (pink) — `bhy`, `partial_conjunction`, `bhy_hierarchical`. Multiplicity-correction primitives that consume `Profile[]` and produce `Survivors`.
-- **Inference (no FDR)** (orange) — `slice_pairwise_test`, `slice_joint_test`. Re-compute statistical tests over slice families; carry family-internal MTC but make no cell-level FDR claim.
-- **Descriptive view** (purple) — `by_slice`, `compare`. Render or aggregate artefacts the compute functions already produced — no fresh statistics.
-- **Compare-sensitivity** *(planned, v0.14)* — `by_estimator` (#178). Re-runs inference layer under alternative estimators for the same cell.
-- **Introspection** (yellow) — `list_metrics`, `list_estimators`, `suggest_config`. Discover what is applicable to a cell.
+| Shape | Category | Behaviour |
+|---|---|---|
+| Rectangle `[ ]` | **Compute** | Produces primary artefact from `(panel, cfg)` |
+| Hexagon `{{ }}` | **Screening (FDR)** | Multiplicity-correction primitive; `Profile[] → Survivors` |
+| Diamond `{ }` | **Inference (no FDR)** | Re-computes statistical tests; family-internal MTC only, no cell-level FDR claim |
+| Rounded `( )` | **Descriptive view** | Render or aggregate existing artefacts; no fresh statistics |
+| Parallelogram `[/ /]` | **Introspection** | Discover what is applicable to a cell |
 
-> *`by_estimator` is not yet implemented; it lands in v0.14 once #263 unblocks HACEstimator parameter config + catalog expansion. The graph is otherwise complete for shipped functions.*
+> The sixth category, **Compare-sensitivity** (`by_estimator`, #178), is not drawn — it lands in v0.14 once #263 unblocks HACEstimator parameter config + catalog expansion.
 
 ## Typical patterns
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,7 +44,14 @@ flowchart LR
 
 Click any node to jump to its API page.
 
-**Edge convention.** Solid `==>` is a hard signature dependency — the target function's call signature takes the source object literally (e.g. `evaluate(panel, cfg)` consumes the input `P`, and `bhy` / `partial_conjunction` / `bhy_hierarchical` consume a list of `FactorProfile`s that only `evaluate` produces). Dashed `-.->` is a suggested workflow — the source is panel-derived but the target function's signature differs in shape (`by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame built from the panel via e.g. `compute_ic(panel)`; `list_metrics` returns candidate names you pass to `run_metrics(metrics=[…])`).
+**Edge convention:**
+
+- **Solid `==>` — hard signature dependency.** The target's call signature literally accepts the source object.
+    - `evaluate(panel, cfg)` consumes `P` (the panel).
+    - `bhy` / `partial_conjunction` / `bhy_hierarchical` consume `list[FactorProfile]`, which only `evaluate` produces.
+- **Dashed `-.->` — suggested workflow.** The source is panel-derived, but the target's signature differs in shape.
+    - `by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame the caller builds from the panel (e.g. `compute_ic(panel)`).
+    - `list_metrics` returns candidate names the caller forwards to `run_metrics(metrics=[…])`.
 
 **Category encoding by node shape:**
 
@@ -57,6 +64,8 @@ Click any node to jump to its API page.
 | Parallelogram `[/ /]` | **Introspection** | Discover what is applicable to a cell |
 
 > The sixth category, **Compare-sensitivity** (`by_estimator`, #178), is not drawn — it lands in v0.14 once #263 unblocks HACEstimator parameter config + catalog expansion.
+
+---
 
 ## Typical patterns
 
@@ -71,6 +80,8 @@ Click any node to jump to its API page.
 | Cross-factor leaderboard | `compare(profiles)` / `compare(bundles)` / `compare(survivors)` → `pl.DataFrame` |
 
 See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surface end-to-end, and the [Batch screening with BHY](../guides/batch-screening.md) guide for the multi-factor screening workflow.
+
+---
 
 ## Entry points
 
@@ -91,6 +102,8 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 | [`Metrics`](metrics/index.md) | Catalogue | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly. |
 | [`stats`](stats.md) | Catalogue | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking an inference method to pass through `estimator=`. |
 
+---
+
 ## Supporting surface
 
 | Page | What it is |
@@ -104,6 +117,8 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 `describe_analysis_modes` is an introspection shim documented inline
 on [`AnalysisConfig`](analysis-config.md) and
 [Concepts](../getting-started/concepts.md).
+
+---
 
 ## Naming convention
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,15 +7,30 @@ Reference for every public symbol exported from `factrix`.
 ```mermaid
 flowchart LR
     P[panel + cfg]
-    EV[evaluate]
-    RM[run_metrics]
-    BS(by_slice)
-    ST{"slice_pairwise_test<br/>slice_joint_test"}
-    BHY{{bhy}}
-    PC{{partial_conjunction}}
-    BHYH{{bhy_hierarchical}}
-    LM[/list_metrics/]
-    CMP(compare)
+
+    subgraph Compute
+        EV[evaluate]
+        RM[run_metrics]
+    end
+
+    subgraph Screening["Screening (FDR)"]
+        BHY[bhy]
+        PC[partial_conjunction]
+        BHYH[bhy_hierarchical]
+    end
+
+    subgraph Inference["Inference (no FDR)"]
+        ST["slice_pairwise_test<br/>slice_joint_test"]
+    end
+
+    subgraph View["Descriptive view"]
+        BS[by_slice]
+        CMP[compare]
+    end
+
+    subgraph Introspection
+        LM[list_metrics]
+    end
 
     P ==> EV
     P ==> RM
@@ -42,7 +57,7 @@ flowchart LR
     click CMP "compare/" "compare API"
 ```
 
-Click any node to jump to its API page.
+Click any node to jump to its API page. Nodes are grouped into category subgraphs; the sixth category, **Compare-sensitivity** (`by_estimator`, #178), is not drawn — it lands in v0.14 once #263 unblocks HACEstimator parameter config + catalog expansion.
 
 **Edge convention:**
 
@@ -52,18 +67,6 @@ Click any node to jump to its API page.
 - **Dashed `-.->` — suggested workflow.** The source is panel-derived, but the target's signature differs in shape.
     - `by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame the caller builds from the panel (e.g. `compute_ic(panel)`).
     - `list_metrics` returns candidate names the caller forwards to `run_metrics(metrics=[…])`.
-
-**Category encoding by node shape:**
-
-| Shape | Category | Behaviour |
-|---|---|---|
-| Rectangle `[ ]` | **Compute** | Produces primary artefact from `(panel, cfg)` |
-| Hexagon `{{ }}` | **Screening (FDR)** | Multiplicity-correction primitive; `Profile[] → Survivors` |
-| Diamond `{ }` | **Inference (no FDR)** | Re-computes statistical tests; family-internal MTC only, no cell-level FDR claim |
-| Rounded `( )` | **Descriptive view** | Render or aggregate existing artefacts; no fresh statistics |
-| Parallelogram `[/ /]` | **Introspection** | Discover what is applicable to a cell |
-
-> The sixth category, **Compare-sensitivity** (`by_estimator`, #178), is not drawn — it lands in v0.14 once #263 unblocks HACEstimator parameter config + catalog expansion.
 
 ---
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,7 +2,7 @@
 
 Reference for every public symbol exported from `factrix`.
 
-## Verb map
+## Function flow
 
 ```mermaid
 flowchart LR
@@ -12,6 +12,8 @@ flowchart LR
     BS[by_slice]
     ST["slice_pairwise_test<br/>slice_joint_test"]
     BHY{{multi_factor.bhy}}
+    PC{{partial_conjunction}}
+    BHYH{{bhy_hierarchical}}
     LM[/list_metrics/]
     CMP[compare]
 
@@ -20,18 +22,24 @@ flowchart LR
     P -.-> BS
     P -.-> ST
     EV ==>|profiles| BHY
+    EV ==>|profiles| PC
+    EV ==>|profiles| BHYH
     EV ==>|profiles| CMP
     RM ==>|bundles| CMP
     BHY ==>|survivors| CMP
+    PC ==>|survivors| CMP
+    BHYH ==>|survivors| CMP
     LM -.->|metric names| RM
 
     classDef compute fill:#e3f2fd,stroke:#1976d2,color:#000
-    classDef decision fill:#fce4ec,stroke:#c2185b,color:#000
+    classDef screening fill:#fce4ec,stroke:#c2185b,color:#000
+    classDef inference fill:#ffe0b2,stroke:#e65100,color:#000
     classDef view fill:#f3e5f5,stroke:#7b1fa2,color:#000
     classDef introspect fill:#fff9c4,stroke:#f9a825,color:#000
     class EV,RM compute
-    class BHY decision
-    class BS,ST,CMP view
+    class BHY,PC,BHYH screening
+    class ST inference
+    class BS,CMP view
     class LM introspect
 
     click EV "evaluate/" "evaluate API"
@@ -39,22 +47,26 @@ flowchart LR
     click BS "by-slice/" "by_slice API"
     click ST "slice-test/" "slice_pairwise_test / slice_joint_test API"
     click BHY "multi-factor/" "multi_factor.bhy API"
+    click PC "partial-conjunction/" "partial_conjunction API"
+    click BHYH "bhy-hierarchical/" "bhy_hierarchical API"
     click LM "list-metrics/" "list_metrics API"
     click CMP "compare/" "compare API"
 ```
 
 Click any node to jump to its API page.
 
-**Edge convention.** Solid `==>` is a hard signature dependency — the target verb's call signature takes the source object literally (e.g. `evaluate(panel, cfg)` consumes the input `P`, and `multi_factor.bhy` consumes a list of `FactorProfile`s that only `evaluate` produces). Dashed `-.->` is a suggested workflow — the source is panel-derived but the target verb's signature differs in shape (`by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame built from the panel via e.g. `compute_ic(panel)`; `list_metrics` returns candidate names you pass to `run_metrics(metrics=[…])`).
+**Edge convention.** Solid `==>` is a hard signature dependency — the target function's call signature takes the source object literally (e.g. `evaluate(panel, cfg)` consumes the input `P`, and `multi_factor.bhy` / `partial_conjunction` / `bhy_hierarchical` consume a list of `FactorProfile`s that only `evaluate` produces). Dashed `-.->` is a suggested workflow — the source is panel-derived but the target function's signature differs in shape (`by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame built from the panel via e.g. `compute_ic(panel)`; `list_metrics` returns candidate names you pass to `run_metrics(metrics=[…])`).
 
-**Node category** (background colour):
+**Six categories** (background colour):
 
-- **Compute** (blue) — `evaluate` / `run_metrics`. Produce primary artefacts (`FactorProfile` / `MetricsBundle`) from `(panel, cfg)`.
-- **Decision** (pink) — `multi_factor.bhy`. Multiplicity-correction primitive; consumes `Profile[]`.
-- **View** (purple) — `by_slice` / `slice_pairwise_test` / `slice_joint_test` / `compare`. Render or test a derived view of artefacts the compute verbs already produced — no fresh statistics. (`by_slice` is the slice dispatcher; the `_test` pair are statistical tests over the slices; `compare` is the cross-factor leaderboard.)
-- **Introspection** (yellow) — `list_metrics`. Discovers what's applicable to a cell.
+- **Compute** (blue) — `evaluate`, `run_metrics`. Produce primary artefacts (`FactorProfile` / `MetricsBundle`) from `(panel, cfg)`.
+- **Screening (FDR)** (pink) — `multi_factor.bhy`, `partial_conjunction`, `bhy_hierarchical`. Multiplicity-correction primitives that consume `Profile[]` and produce `Survivors`.
+- **Inference (no FDR)** (orange) — `slice_pairwise_test`, `slice_joint_test`. Re-compute statistical tests over slice families; carry family-internal MTC but make no cell-level FDR claim.
+- **Descriptive view** (purple) — `by_slice`, `compare`. Render or aggregate artefacts the compute functions already produced — no fresh statistics.
+- **Compare-sensitivity** *(planned, v0.14)* — `by_estimator` (#178). Re-runs inference layer under alternative estimators for the same cell.
+- **Introspection** (yellow) — `list_metrics`, `list_estimators`, `suggest_config`. Discover what is applicable to a cell.
 
-**Deliberately omitted from the graph (not yet implemented).** The full v1 design (#148) also covers `robustness` (per-stat-choice sensitivity) and the family verbs `bhy_hierarchical` / `partial_conjunction` for hierarchical FDR and partial-conjunction multiplicity control. All three are view-class or decision-class verbs that depend on the same artefact shapes shown above. They are not drawn because drawing them would either mislead a reader into clicking a URL that 404s, or force a legend explaining which nodes are real — both worse than the small omission.
+> *`by_estimator` is not yet implemented; it lands in v0.14 once #263 unblocks HACEstimator parameter config + catalog expansion. The graph is otherwise complete for shipped functions.*
 
 ## Typical patterns
 
@@ -72,22 +84,30 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 
 ## Entry points
 
-| Page | What it is | When to read |
-|---|---|---|
-| [`AnalysisConfig`](analysis-config.md) | Three-axis frozen dataclass selecting the dispatch cell. Four factory methods (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`). | Picking the analysis cell. |
-| [`evaluate`](evaluate.md) | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
-| [`FactorProfile`](factor-profile.md) | Frozen result object: `primary_p`, `diagnose()`, `stats`, `warnings`, `info_notes`, `mode`, `n_obs`, `n_assets`. | Reading the result. |
-| [`multi_factor`](multi-factor.md) | `bhy(...)` for per-family BHY FDR screening across a list of `FactorProfile`s. | Multi-factor screening. |
-| [`stats`](stats.md) | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking inference method for `bhy(estimator=…)` or cross-slice tests. |
-| [`list_metrics`](list-metrics.md) | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a given `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
-| [`suggest_config`](suggest-config.md) | Heuristic introspection — inspect a raw panel, propose an `AnalysisConfig` with per-axis reasoning and pre-evaluate warnings. | Recovering from `MissingConfigError`, or letting an agent pick a starting cell. |
-| [`compare`](compare.md) | Cross-factor leaderboard — stacks `FactorProfile` / `MetricsBundle` / `Survivors` artifacts into a `pl.DataFrame` (pure projection, no recompute). | Ranking N candidate factors after `evaluate` / `run_metrics` / `bhy`. |
-| [`Metrics`](metrics/index.md) | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly on a `FactorProfile` / panel. |
+| Page | Category | What it is | When to read |
+|---|---|---|---|
+| [`AnalysisConfig`](analysis-config.md) | Configuration | Three-axis frozen dataclass selecting the dispatch cell. Four factory methods (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`). | Picking the analysis cell. |
+| [`evaluate`](evaluate.md) | Compute | Single dispatch entry — runs the registered procedure for a `(config, panel)` pair and returns a `FactorProfile`. | Running an analysis. |
+| [`run_metrics`](run-metrics.md) | Compute | Descriptive twin of `evaluate` — fans out across all standalone metrics in the cell, returns a `MetricsBundle`. | Descriptive scan of a cell. |
+| [`by_slice`](by-slice.md) | Descriptive view | Slice a metric over a label column; returns a `SliceResult` with `.to_frame()` rendering. | Per-slice metric exploration. |
+| [`slice_pairwise_test` / `slice_joint_test`](slice-test.md) | Inference (no FDR) | Statistical tests over slice families (pairwise / omnibus) with family-internal MTC. No cell-level FDR claim. | Testing whether slice means differ. |
+| [`multi_factor`](multi-factor.md) | Screening (FDR) | `bhy(...)` for BHY FDR screening across a `Profile[]`; `expand_over=` opens hypothesis-dimension expansion. | Multi-factor FDR screening. |
+| [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction p-values (Benjamini-Heller 2008) → BHY. | "Factor X passes in ≥ k of m contexts." |
+| [`bhy_hierarchical`](bhy-hierarchical.md) | Screening (FDR) | Hierarchical FDR (Yekutieli 2008) — outer BHY on group representatives, inner BHY within passing groups. | Factor families / nested-context structure. |
+| [`compare`](compare.md) | Descriptive view | Cross-factor leaderboard — stacks `FactorProfile` / `MetricsBundle` / `Survivors` artifacts into a `pl.DataFrame` (no recompute). | Ranking N candidate factors. |
+| [`list_metrics`](list-metrics.md) | Introspection | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
+| [`list_estimators`](list-estimators.md) | Introspection | Estimators applicable to a cell — inference-side twin of `list_metrics`. | Picking `estimator=` for family verbs. |
+| [`suggest_config`](suggest-config.md) | Introspection | Inspect a raw panel; propose an `AnalysisConfig` with per-axis reasoning + pre-evaluate warnings. | Recovering from `MissingConfigError`, agent pickers. |
+| [`Metrics`](metrics/index.md) | Catalogue | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly. |
+| [`stats`](stats.md) | Catalogue | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking an inference method to pass through `estimator=`. |
 
 ## Supporting surface
 
 | Page | What it is |
 |---|---|
+| [Panel schema](panel-schema.md) | The four-column input contract every panel-consuming function depends on. |
+| [`FactorProfile`](factor-profile.md) | Frozen result of `evaluate`: `primary_p`, `diagnose()`, `stats`, `warnings`, `info_notes`. |
+| [`MetricsBundle`](metrics-bundle.md) | Frozen result of `run_metrics`: per-metric `MetricOutput` map + identity. |
 | [`MetricOutput`](metric-output.md) | Common wrapper returned by every standalone metric — `value`, `p_value`, `stats`, `metadata`. |
 | [`datasets`](datasets.md) | Synthetic panels (`make_cs_panel`, `make_event_panel`) for smoke tests and docs examples. |
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,7 +11,7 @@ flowchart LR
     RM[run_metrics]
     BS[by_slice]
     ST["slice_pairwise_test<br/>slice_joint_test"]
-    BHY{{multi_factor.bhy}}
+    BHY{{bhy}}
     PC{{partial_conjunction}}
     BHYH{{bhy_hierarchical}}
     LM[/list_metrics/]
@@ -46,7 +46,7 @@ flowchart LR
     click RM "run-metrics/" "run_metrics API"
     click BS "by-slice/" "by_slice API"
     click ST "slice-test/" "slice_pairwise_test / slice_joint_test API"
-    click BHY "multi-factor/" "multi_factor.bhy API"
+    click BHY "multi-factor/" "bhy API"
     click PC "partial-conjunction/" "partial_conjunction API"
     click BHYH "bhy-hierarchical/" "bhy_hierarchical API"
     click LM "list-metrics/" "list_metrics API"
@@ -55,12 +55,12 @@ flowchart LR
 
 Click any node to jump to its API page.
 
-**Edge convention.** Solid `==>` is a hard signature dependency — the target function's call signature takes the source object literally (e.g. `evaluate(panel, cfg)` consumes the input `P`, and `multi_factor.bhy` / `partial_conjunction` / `bhy_hierarchical` consume a list of `FactorProfile`s that only `evaluate` produces). Dashed `-.->` is a suggested workflow — the source is panel-derived but the target function's signature differs in shape (`by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame built from the panel via e.g. `compute_ic(panel)`; `list_metrics` returns candidate names you pass to `run_metrics(metrics=[…])`).
+**Edge convention.** Solid `==>` is a hard signature dependency — the target function's call signature takes the source object literally (e.g. `evaluate(panel, cfg)` consumes the input `P`, and `bhy` / `partial_conjunction` / `bhy_hierarchical` consume a list of `FactorProfile`s that only `evaluate` produces). Dashed `-.->` is a suggested workflow — the source is panel-derived but the target function's signature differs in shape (`by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame built from the panel via e.g. `compute_ic(panel)`; `list_metrics` returns candidate names you pass to `run_metrics(metrics=[…])`).
 
 **Six categories** (background colour):
 
 - **Compute** (blue) — `evaluate`, `run_metrics`. Produce primary artefacts (`FactorProfile` / `MetricsBundle`) from `(panel, cfg)`.
-- **Screening (FDR)** (pink) — `multi_factor.bhy`, `partial_conjunction`, `bhy_hierarchical`. Multiplicity-correction primitives that consume `Profile[]` and produce `Survivors`.
+- **Screening (FDR)** (pink) — `bhy`, `partial_conjunction`, `bhy_hierarchical`. Multiplicity-correction primitives that consume `Profile[]` and produce `Survivors`.
 - **Inference (no FDR)** (orange) — `slice_pairwise_test`, `slice_joint_test`. Re-compute statistical tests over slice families; carry family-internal MTC but make no cell-level FDR claim.
 - **Descriptive view** (purple) — `by_slice`, `compare`. Render or aggregate artefacts the compute functions already produced — no fresh statistics.
 - **Compare-sensitivity** *(planned, v0.14)* — `by_estimator` (#178). Re-runs inference layer under alternative estimators for the same cell.

--- a/docs/api/list-estimators.md
+++ b/docs/api/list-estimators.md
@@ -1,0 +1,38 @@
+# list_estimators
+
+Programmatic discovery of inference methods (`Estimator` instances)
+applicable to a given `(scope, signal)` cell — the inference-side twin
+of [`list_metrics`](list-metrics.md).
+
+A cell's primary p-value is produced by exactly one estimator
+(per #148 cell→procedure 1:1). Family verbs (`bhy`, `bhy_hierarchical`,
+`partial_conjunction`) accept an `estimator=` override that swaps which
+already-computed p-value drives the multiplicity step; this function
+returns the candidates for that override, filtered by cell applicability.
+
+## Call shape
+
+```python
+import factrix as fx
+
+# Text list (default) — pretty names for CLI / REPL inspection
+fx.list_estimators(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS)
+# → ['NeweyWest', 'HansenHodrick', 'BlockBootstrap', ...]
+
+# Structured records — programmatic filtering / import paths
+fx.list_estimators(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS,
+                   format='json', with_import=True)
+# → [{'name': 'NeweyWest', 'import': 'from factrix.stats import NeweyWest', ...}, ...]
+```
+
+`Mode` is intentionally not an input — estimator applicability is
+cell-axis-dependent (scope × signal), not panel-shape-dependent.
+
+## See also
+
+- [Estimator alternatives](estimator-alternatives.md) — cookbook for
+  using `estimator=` on family verbs
+- [`stats`](stats.md) — full estimator catalogue and StatCode pairings
+- [`list_metrics`](list-metrics.md) — descriptive metric counterpart
+
+::: factrix.list_estimators

--- a/docs/api/list-estimators.md
+++ b/docs/api/list-estimators.md
@@ -4,11 +4,10 @@ Programmatic discovery of inference methods (`Estimator` instances)
 applicable to a given `(scope, signal)` cell — the inference-side twin
 of [`list_metrics`](list-metrics.md).
 
-A cell's primary p-value is produced by exactly one estimator
-(per #148 cell→procedure 1:1). Family verbs (`bhy`, `bhy_hierarchical`,
-`partial_conjunction`) accept an `estimator=` override that swaps which
-already-computed p-value drives the multiplicity step; this function
-returns the candidates for that override, filtered by cell applicability.
+Two contracts to keep in mind:
+
+- **Cell → procedure is 1:1** (per #148). A cell's primary p-value is produced by exactly one estimator at `evaluate` time.
+- **Family verbs accept an `estimator=` override.** `bhy` / `bhy_hierarchical` / `partial_conjunction` swap which already-computed p-value drives the multiplicity step. `list_estimators` returns the candidates for that override, filtered to those applicable to the cell.
 
 ## Call shape
 
@@ -27,6 +26,8 @@ fx.list_estimators(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS,
 
 `Mode` is intentionally not an input — estimator applicability is
 cell-axis-dependent (scope × signal), not panel-shape-dependent.
+
+---
 
 ## See also
 

--- a/docs/api/metrics-bundle.md
+++ b/docs/api/metrics-bundle.md
@@ -1,0 +1,36 @@
+# MetricsBundle
+
+Result type returned by [`run_metrics`](run-metrics.md) — holds every
+standalone metric the cell successfully evaluated for one factor at one
+horizon, plus a `skipped` map for metrics that could not auto-run.
+
+Parallel to [`FactorProfile`](factor-profile.md): both share the
+identity tuple `(factor_id, forward_periods)` so downstream verbs
+([`compare`](compare.md), survivors workflows) can join the two
+artifact families row-by-row.
+
+| Bundle | Profile |
+|---|---|
+| `run_metrics` — descriptive surface (no FDR claim) | `evaluate` — primary inferential decision (drives FDR) |
+| Many metrics per cell, each a [`MetricOutput`](metric-output.md) | One primary stat + sidecar `stats` dict |
+| `compare(bundles)` → cross-factor descriptive view | `compare(profiles)` / `compare(survivors)` |
+
+## Typical use
+
+```python
+import factrix as fx
+
+cfg    = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
+bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+
+bundle.identity           # ('momentum_12_1', 5)
+bundle.metrics            # dict[str, MetricOutput]
+bundle.to_frame()         # pl.DataFrame — flat tabular view for compare / plotting
+bundle.skipped            # {metric_name: reason} — metrics that short-circuited
+```
+
+For the wide multi-factor pattern (looping `run_metrics` with
+`factor_col=` over candidate signals) see the
+[Batch screening guide](../guides/batch-screening.md).
+
+::: factrix.MetricsBundle

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -1,0 +1,116 @@
+# Panel schema
+
+Single-source contract for every `factrix` entry point that consumes a
+panel. Every dispatch cell registered through `evaluate` /
+`run_metrics` floors its `INPUT_SCHEMA` at the same four columns
+described here. Per-cell extensions (optional weight / price columns)
+are listed under [Optional columns](#optional-columns).
+
+## Four-column contract
+
+| Column | dtype | Semantics |
+|---|---|---|
+| `date` | `Date` (preferred) or `Datetime` | Observation timestamp. Sorted ascending per asset. Frequency-agnostic — factrix shifts rows, never calendar time. |
+| `asset_id` | `Utf8` / `Categorical` | Cross-section identifier. Identical for COMMON-scope factors (`df.group_by("date").agg(pl.col("factor").n_unique() == 1).all()` is `True`). |
+| `factor` | `Float64` | The signal value. Continuous: real-valued (z-score, IC-rankable). Sparse: `{0, R}` event trigger — `0` for non-events, arbitrary real magnitude otherwise; expect ≥ 50% zeros. |
+| `forward_return` | `Float64` | Look-ahead return over the horizon used at evaluate time. Attach via [`compute_forward_return`](preprocess.md) so the horizon is explicit and aligned with `AnalysisConfig.forward_periods`. |
+
+The minimal panel is therefore long-format
+`(date, asset_id, factor, forward_return)`. A 3-row preview:
+
+```python
+import polars as pl
+from datetime import date
+
+panel = pl.DataFrame({
+    "date":           [date(2024, 1, 1), date(2024, 1, 1),
+                       date(2024, 1, 2), date(2024, 1, 2),
+                       date(2024, 1, 3), date(2024, 1, 3)],
+    "asset_id":       ["A", "B", "A", "B", "A", "B"],
+    "factor":         [0.12, -0.08, 0.20, 0.04, -0.15, 0.18],
+    "forward_return": [0.01,  0.00, 0.02, 0.00, -0.01, 0.03],
+})
+```
+
+The two synthetic dataset generators emit this layout (plus a `price`
+column) ready for `compute_forward_return`:
+[`fx.datasets.make_cs_panel`](datasets.md) (cross-sectional) and
+`fx.datasets.make_event_panel` (event-study).
+
+## `factor_col=` — non-default signal column name
+
+Panels often arrive with the signal column named something other than
+`"factor"` (e.g. `"alpha"`, `"score"`, `"momentum_12_1"`). Pass
+`factor_col=` to rename in place at dispatch time without mutating the
+caller's frame:
+
+```python
+profile = fx.evaluate(panel, cfg, factor_col="alpha")
+bundle  = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+```
+
+Behaviour:
+
+- The column is renamed to `"factor"` internally so every procedure's
+  `INPUT_SCHEMA` still sees the canonical schema.
+- `bundle.identity = (factor_col, cfg.forward_periods)` — looping
+  `factor_col=name` over a wide multi-factor panel is the canonical
+  pattern for batch screening; see
+  [Batch screening guide](../guides/batch-screening.md).
+- Each call repeats the per-date cross-section work, so cost scales as
+  `O(n_factors × per_date_cost)` — there is no shared-pass primitive.
+
+Error cases (both raise [`UserInputError`](errors.md)):
+
+| Trigger | Message hint |
+|---|---|
+| `factor_col` not present on the panel | Lists the actual columns; suggests a fuzzy match. |
+| Both `"factor"` and `factor_col` present, values differ | Flags the ambiguity. Drop the unused column before calling. |
+
+## Optional columns
+
+Per-cell extensions activate additional standalone metrics when present
+and short-circuit (`NaN` with `reason`) when absent — they never gate the
+core procedure.
+
+| Column | Activates | Cell |
+|---|---|---|
+| `market_cap` (or any name passed as `weight_col=`) | `quantile_spread_vw` value-weighting | Individual × Continuous |
+| `price` | `event_around_return`, `mfe_mae_summary`, event-window diagnostics | Individual × Sparse |
+
+## Common errors
+
+Schema-related failures and their fix paths:
+
+| Message | Trigger | Fix |
+|---|---|---|
+| `factor_col 'X' not in panel columns` | Typo / wrong column name | Check `panel.columns`; pass the actual name to `factor_col=`. |
+| `Both 'factor' and 'X' present` | Wide panel still has stale `"factor"` column | `panel.drop("factor")` before calling. |
+| `MissingConfigError: evaluate(raw) needs AnalysisConfig` | Called `evaluate(panel)` with no `cfg` | `fx.suggest_config(panel)` recovers a starting cell. |
+| `forward_return column missing` | Forgot the preprocess step | `panel = compute_forward_return(raw, forward_periods=h)` before `evaluate`. |
+
+Full error taxonomy and recovery patterns: [Errors](errors.md).
+
+## Preprocess pipeline
+
+The canonical pipeline from raw price/event data to evaluate-ready panel:
+
+```
+raw price panel  ──compute_forward_return(h)──▶  (date, asset_id, factor, forward_return)
+                                                          │
+                                                          ▼
+                                                       evaluate / run_metrics / by_slice / ...
+```
+
+Pre-attachment helpers live in [`factrix.preprocess`](preprocess.md);
+synthetic panels in [`factrix.datasets`](datasets.md). Wide-format
+multi-factor inputs are handled by looping `evaluate` / `run_metrics`
+with `factor_col=` rather than by reshaping the panel — see the
+[Batch screening guide](../guides/batch-screening.md).
+
+## See also
+
+- [`evaluate`](evaluate.md) — single-factor dispatch entry
+- [`run_metrics`](run-metrics.md) — descriptive metric bundle
+- [`AnalysisConfig`](analysis-config.md) — axis selection
+- [Concepts](../getting-started/concepts.md) — three-axis taxonomy and dispatch cells

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -37,6 +37,8 @@ column) ready for `compute_forward_return`:
 [`fx.datasets.make_cs_panel`](datasets.md) (cross-sectional) and
 `fx.datasets.make_event_panel` (event-study).
 
+---
+
 ## `factor_col=` — non-default signal column name
 
 Panels often arrive with the signal column named something other than
@@ -67,6 +69,8 @@ Error cases (both raise [`UserInputError`](errors.md)):
 | `factor_col` not present on the panel | Lists the actual columns; suggests a fuzzy match. |
 | Both `"factor"` and `factor_col` present, values differ | Flags the ambiguity. Drop the unused column before calling. |
 
+---
+
 ## Optional columns
 
 Per-cell extensions activate additional standalone metrics when present
@@ -77,6 +81,8 @@ core procedure.
 |---|---|---|
 | `market_cap` (or any name passed as `weight_col=`) | `quantile_spread_vw` value-weighting | Individual × Continuous |
 | `price` | `event_around_return`, `mfe_mae_summary`, event-window diagnostics | Individual × Sparse |
+
+---
 
 ## Common errors
 
@@ -90,6 +96,8 @@ Schema-related failures and their fix paths:
 | `forward_return column missing` | Forgot the preprocess step | `panel = compute_forward_return(raw, forward_periods=h)` before `evaluate`. |
 
 Full error taxonomy and recovery patterns: [Errors](errors.md).
+
+---
 
 ## Preprocess pipeline
 
@@ -107,6 +115,8 @@ synthetic panels in [`factrix.datasets`](datasets.md). Wide-format
 multi-factor inputs are handled by looping `evaluate` / `run_metrics`
 with `factor_col=` rather than by reshaping the panel — see the
 [Batch screening guide](../guides/batch-screening.md).
+
+---
 
 ## See also
 

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -9,6 +9,9 @@ in `factrix.metrics.*` and returns a [`MetricsBundle`](#metricsbundle).
 The two paths share the `(panel, cfg)` entry contract; their result
 types are disjoint by design.
 
+> **Input contract** — the panel must satisfy the four-column floor
+> documented in [Panel schema](panel-schema.md).
+
 | Verb | Returns | Use when |
 |---|---|---|
 | [`evaluate`](evaluate.md) | `FactorProfile` (primary p, drives FDR) | you want the single inferential decision for the cell |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -47,6 +47,8 @@ profile = fx.evaluate(panel, result.suggested)
 
 See [Concepts](concepts.md) for what each axis means.
 
+---
+
 ## Research question → factory
 
 The five supported research questions and their factory calls live in
@@ -59,6 +61,8 @@ when to add standalone metrics), see [Choosing a metric](../guides/choosing-metr
     `Mode` auto-switches to `TIMESERIES`. The `common_continuous` and
     `*_sparse` factories work as-is. `individual_continuous` at N=1 raises
     `ModeAxisError` with `suggested_fix=common_continuous(...)`.
+
+---
 
 ## `profile.diagnose()` and warnings
 
@@ -96,6 +100,8 @@ For the full enum and the trigger conditions for each `WarningCode`,
 `warnings` does **not** affect `primary_p` —
 it is a risk flag. The user decides whether to filter on warnings before
 BHY. For single-factor pre-registered analysis compare `primary_p` against your nominal threshold directly.
+
+---
 
 ## Next steps
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -96,3 +96,17 @@ For the full enum and the trigger conditions for each `WarningCode`,
 `warnings` does **not** affect `primary_p` —
 it is a risk flag. The user decides whether to filter on warnings before
 BHY. For single-factor pre-registered analysis compare `primary_p` against your nominal threshold directly.
+
+## Next steps
+
+You have one `FactorProfile` for one factor. The common follow-ups:
+
+| You want to… | Reach for | Guide |
+|---|---|---|
+| Screen N candidate factors with FDR control | [`multi_factor.bhy(profiles)`](../api/multi-factor.md) — or `partial_conjunction` / `bhy_hierarchical` for nested structure | [Batch screening with BHY](../guides/batch-screening.md) |
+| Compare the descriptive surface across factors | [`run_metrics`](../api/run-metrics.md) × N → [`compare(bundles)`](../api/compare.md) | [Standalone metrics](../guides/standalone-metrics.md) |
+| Rank factors after screening | [`compare(survivors)`](../api/compare.md) — leaderboard with `adj_q` | — |
+| Explore one metric across slices (sector / regime / decile) | [`by_slice`](../api/by-slice.md) → `SliceResult.to_frame()` | [Slice analysis](../guides/slice-analysis.md) |
+| Test whether slices differ statistically | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | [Slice analysis](../guides/slice-analysis.md) |
+| Look up the panel input contract | [Panel schema](../api/panel-schema.md) | — |
+| Pick a metric for a given research question | [Choosing a metric](../guides/choosing-metric.md) | — |

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ See the [API reference landing](api/index.md) for the function-flow graph, edge 
 | If you want | Go to |
 |---|---|
 | **Install and run a smoke test** | [Installation](getting-started/install.md) · [Quickstart](getting-started/quickstart.md) |
+| **Find the right function from a research question** | [Decision tree](api/decision-tree.md) |
 | **Understand the three-axis design** (scope / signal / metric) | [Concepts](getting-started/concepts.md) |
 | **Compare factrix against alphalens / qlib / peers** | [Where factrix fits](where-factrix-fits.md) |
 | **Screen a batch of factors with BHY** | [Batch screening](guides/batch-screening.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,43 +6,11 @@ factrix is the first Polars-native Python toolkit that picks the right statistic
 
 [![GitHub](https://img.shields.io/badge/GitHub-factrix-blue?logo=github)](https://github.com/awwesomeman/factrix)
 
-## Verb map
+## What ships
 
-```mermaid
-flowchart LR
-    P[panel + cfg]
-    EV[evaluate]
-    RM[run_metrics]
-    BS[by_slice]
-    ST["slice_pairwise_test<br/>slice_joint_test"]
-    BHY{{multi_factor.bhy}}
-    LM[/list_metrics/]
+factrix exposes a small set of functions organised by category — **Compute** (`evaluate`, `run_metrics`), **Screening (FDR)** (`multi_factor.bhy`, `partial_conjunction`, `bhy_hierarchical`), **Inference** (`slice_pairwise_test`, `slice_joint_test`), **Descriptive view** (`by_slice`, `compare`), **Introspection** (`list_metrics`, `list_estimators`, `suggest_config`).
 
-    P ==> EV
-    P ==> RM
-    P -.-> BS
-    P -.-> ST
-    EV ==>|profiles| BHY
-    LM -.->|metric names| RM
-
-    classDef compute fill:#e3f2fd,stroke:#1976d2,color:#000
-    classDef decision fill:#fce4ec,stroke:#c2185b,color:#000
-    classDef view fill:#f3e5f5,stroke:#7b1fa2,color:#000
-    classDef introspect fill:#fff9c4,stroke:#f9a825,color:#000
-    class EV,RM compute
-    class BHY decision
-    class BS,ST view
-    class LM introspect
-
-    click EV "api/evaluate/" "evaluate API"
-    click RM "api/run-metrics/" "run_metrics API"
-    click BS "api/by-slice/" "by_slice API"
-    click ST "api/slice-test/" "slice_pairwise_test / slice_joint_test API"
-    click BHY "api/multi-factor/" "multi_factor.bhy API"
-    click LM "api/list-metrics/" "list_metrics API"
-```
-
-The seven shipped verbs, coloured by category — **compute** (blue, produce primary artefacts), **decision** (pink, FDR), **view** (purple, slice surface), **introspection** (yellow). Solid arrow = hard signature dependency, dashed = suggested workflow. Click any node to jump to its API page. Full edge convention and the four future-design verbs (`compare`, `robustness`, `bhy_hierarchical`, `partial_conjunction` per #148) are described on the [API reference landing](api/index.md).
+See the [API reference landing](api/index.md) for the function-flow graph, edge conventions, and the full entry-point table with category, signature summary, and when-to-reach-for guidance.
 
 ## Quick links
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,17 @@ factrix is the first Polars-native Python toolkit that picks the right statistic
 
 ## What ships
 
-factrix exposes a small set of functions organised by category — **Compute** (`evaluate`, `run_metrics`), **Screening (FDR)** (`multi_factor.bhy`, `partial_conjunction`, `bhy_hierarchical`), **Inference** (`slice_pairwise_test`, `slice_joint_test`), **Descriptive view** (`by_slice`, `compare`), **Introspection** (`list_metrics`, `list_estimators`, `suggest_config`).
+factrix exposes a small set of functions organised by category:
+
+- **Compute** — `evaluate`, `run_metrics`
+- **Screening (FDR)** — `bhy`, `partial_conjunction`, `bhy_hierarchical`
+- **Inference (no FDR)** — `slice_pairwise_test`, `slice_joint_test`
+- **Descriptive view** — `by_slice`, `compare`
+- **Introspection** — `list_metrics`, `list_estimators`, `suggest_config`
 
 See the [API reference landing](api/index.md) for the function-flow graph, edge conventions, and the full entry-point table with category, signature summary, and when-to-reach-for guidance.
+
+---
 
 ## Quick links
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ nav:
   - API Reference:
       - api/index.md
       - Panel schema: api/panel-schema.md
+      - Decision tree: api/decision-tree.md
       - Entry points:
           - AnalysisConfig: api/analysis-config.md
           - evaluate: api/evaluate.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
           - Stock factor evaluation: examples/stock_factor_evaluation.ipynb
   - API Reference:
       - api/index.md
+      - Panel schema: api/panel-schema.md
       - Entry points:
           - AnalysisConfig: api/analysis-config.md
           - evaluate: api/evaluate.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,10 +168,12 @@ nav:
           - partial_conjunction: api/partial-conjunction.md
           - bhy_hierarchical: api/bhy-hierarchical.md
           - list_metrics: api/list-metrics.md
+          - list_estimators: api/list-estimators.md
           - suggest_config: api/suggest-config.md
           - compare: api/compare.md
       - Results:
           - FactorProfile: api/factor-profile.md
+          - MetricsBundle: api/metrics-bundle.md
           - MetricOutput: api/metric-output.md
           - Identity / context: api/identity.md
       - Tables:


### PR DESCRIPTION
## Summary

mkdocs UX systematic refresh per #164. Chunks A (surface + onboarding hygiene) and B (question-routing hubs) consolidated. Stacked PR for #239 follows on top.

**New pages (chunk A):**
- `api/panel-schema.md` — single-source four-column contract for every panel-consuming entry point; replaces scattered mentions across `evaluate.md` / `run-metrics.md` / metric docstrings
- `api/list-estimators.md` — was nav-orphan despite being in `__all__`
- `api/metrics-bundle.md` — was inlined into `run-metrics.md` without a search-indexable landing

**New page (chunk B):**
- `api/decision-tree.md` — reverse-lookup hub (§A question → function tree; §B comparison axes matrix absorbing #148 close-out DoD; §C cross-function topics covering `expand_over` semantics drift and the four-function regime-analysis dispatch)

**Refreshed pages:**
- `api/index.md` — 6-bucket surface taxonomy; Entry points table gains Category column and lists every shipped function (the prior table omitted `run_metrics`, `by_slice`, `slice_*_test`, `partial_conjunction`, `bhy_hierarchical`, `list_estimators` despite some being nav-visible); landed `partial_conjunction` / `bhy_hierarchical` added to the function-flow mermaid; stale "Deliberately omitted" paragraph removed; `slice_*_test` reclassified View → Inference (no FDR) since it does inference with family-internal MTC
- `docs/index.md` — collapsed duplicate verb-map mermaid; replaced with category overview + link to API reference landing; added "find the right function" Quick links row pointing to decision tree
- `api/errors.md` — Error → fix mapping table (panel-schema / config / user-input families) with links to schema hub, suggest_config, decision tree, list_metrics / list_estimators
- `quickstart.md` — Next steps exit-ramp table (BHY screening / `by_slice` / `compare` / `slice_*_test` / panel schema / choosing a metric)

**Readability pass:**
- Wall-of-text paragraphs (edge convention, list_estimators contracts, "What ships") broken into nested bullets
- Horizontal rules between H2 sections on six pages (bold-on-bold was reading as one block)
- Mermaid graph switched to subgraph grouping (idiomatic Mermaid; previous shape-encoded categories abused ANSI/ISO 5807 flowchart conventions where diamond/parallelogram/rounded carry pre-defined operational semantics)
- `multi_factor.bhy` → `bhy` in display labels (matches bare-name treatment of `partial_conjunction` / `bhy_hierarchical`); runnable call-site examples keep the prefix

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] Visual check: function-flow mermaid renders with subgraph frames, all click handlers resolve
- [ ] Visual check: panel-schema and decision-tree pages render with section dividers
- [ ] Visual check: quickstart Next steps table renders, all links resolve
- [ ] Search index picks up `list_estimators`, `MetricsBundle`, `Panel schema`, `Decision tree`

Refs #164 (Phases 1 / 2 / 3 / 4 / 5 / 6; #148 v1 close-out DoD "compare vs by_estimator vs by_slice vs slice_*_test comparison page" absorbed by decision tree §B). #148 itself closes in v0.14 when `by_estimator` lands; this PR delivers the v0.13.0 portion of #164.

The Gap M terminology sweep (#239 was folded into #164 and deleted) stacks on top of this branch — see PR #267 (base = `feat/164-mkdocs-ux`).