### PR TITLE
docs(metrics): sparse cell pages onto the #269 page template (#271)

### DIFF
--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -1,14 +1,20 @@
-# caar
+---
+title: factrix.metrics.caar
+---
 
-Cumulative Average Abnormal Return tests for event signals. CAAR
-*t*-test (parametric) and BMP standardised AR *z*-test (robust to
-event-induced variance).
+::: factrix.metrics.caar
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - compute_caar
+        - caar
+        - bmp_test
 
-→ Formula and references:
-[CAAR cross-event t](../../reference/statistical-methods.md#caar-cross-event-t)
-(`caar`),
-[BMP standardised AR](../../reference/statistical-methods.md#bmp-standardised-ar)
-(`bmp_test`).
+<hr>
 
 !!! info "Event-study contracts"
     `signed_car`, the `estimation_window` consumed by `bmp_test`, and
@@ -17,10 +23,145 @@ event-induced variance).
     factrix computes **CAR** (sum of per-period abnormal returns), not
     BHAR; see the same section for the distinction.
 
-::: factrix.metrics.caar
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Per-event-date CAAR series__
+
+    ---
+
+    Build the per-event-date weighted abnormal return series from a
+    long-format panel before any inferential test. Pre-step for `caar`
+    and (where the magnitude-weighted form is wanted) for downstream
+    slicing.
+
+-   __Mean-CAAR significance, non-overlapping__
+
+    ---
+
+    Test $H_0: \mathbb{E}[\mathrm{CAAR}] = 0$ on the every-`forward_periods`
+    subsample of the per-event-date CAAR series to avoid the
+    autocorrelation induced by overlapping forward returns. Default
+    parametric test for the event-sparse cell.
+
+-   __Event-induced variance, BMP $z$-test__
+
+    ---
+
+    Standardise each event's abnormal return by the asset's pre-event
+    residual volatility before pooling. Robust to event-induced
+    variance inflation that biases the ordinary CAAR $t$-test; pair
+    with `kolari_pynnonen_adjust=True` when the event-date HHI flags
+    same-date shock sharing.
+
+-   __Magnitude-weighted CAAR__
+
+    ---
+
+    With a continuous `factor` column, `compute_caar` returns the
+    per-event regression-slope statistic in the Sefcik-Thompson (1986)
+    lineage rather than the textbook equal-weighted MacKinlay CAAR —
+    see the docstring for the input-contract table.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                         | Function       |
+|--------------------------------------------------------------|----------------|
+| Per-event-date CAAR table for downstream inspection / slicing | `compute_caar` |
+| Mean-CAAR significance, deterministic non-overlap subsample   | `caar`         |
+| Variance-robust event-induced significance (BMP standardised $z$) | `bmp_test`     |
+
+## Worked example — per-event-date CAAR then mean significance
+
+!!! example "compute_caar → caar on a synthetic event panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.caar import compute_caar, caar, bmp_test
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_event_panel(
+        n_assets=200, n_dates=500, event_rate=0.02,
+        post_event_drift=0.004, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    caar_df = compute_caar(panel)
+    print(caar_df.head())
+    # ┌────────────┬───────────┐
+    # │ date       ┆ caar      │
+    # ├────────────┼───────────┤
+    # │ 2024-01-04 ┆  0.0041   │
+    # │ 2024-01-11 ┆  0.0037   │
+    # │ ...        ┆ ...       │
+    # └────────────┴───────────┘
+
+    out = caar(caar_df, forward_periods=5)
+    print(out.value, out.stat, out.metadata["p_value"])
+    # 0.0039  6.42  1.4e-09   (approximate)
+
+    # Variance-robust alternative when same-date clustering is high:
+    z_bmp = bmp_test(panel, estimation_window=60, forward_periods=5,
+                     kolari_pynnonen_adjust=True)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual sparse landing page](individual-sparse.md) — adjacent event-study metrics.
+<div class="grid cards" markdown>
+
+-   __`clustering_diagnostic`__
+
+    ---
+
+    Event-date HHI — when to switch on the Kolari-Pynnönen adjustment
+    or read `caar`'s $t$ with caution.
+
+    [api/metrics/clustering →](clustering.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Axis-agnostic slice dispatcher for per-slice CAAR summaries.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __`slice_pairwise_test` / `slice_joint_test`__
+
+    ---
+
+    Cross-slice CAAR inference (Wald $\chi^2$ + Holm / Romano-Wolf
+    adjusted $p$).
+
+    [api/slice-test →](../slice-test.md)
+
+-   __Statistical methods__
+
+    ---
+
+    CAAR cross-event $t$, BMP standardised AR $z$, Kolari-Pynnönen
+    clustering adjustment.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies, sample-size guards, and the event-study
+    contracts that fix `signed_car`.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Sparse landing__
+
+    ---
+
+    Adjacent event-study metrics in the same cell.
+
+    [api/metrics/individual-sparse →](individual-sparse.md)
+
+</div>

--- a/docs/api/metrics/clustering.md
+++ b/docs/api/metrics/clustering.md
@@ -1,13 +1,104 @@
-# clustering
-
-Static HHI on the event-date histogram — flags violations of the
-event-independence assumption underlying the CAAR *t*-test. Descriptive
-concentration index.
+---
+title: factrix.metrics.clustering
+---
 
 ::: factrix.metrics.clustering
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - clustering_diagnostic
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Gate the CAAR independence assumption__
+
+    ---
+
+    Read `value` (HHI on the event-date histogram) and
+    `metadata["effective_n_dates"]` $= 1 / \mathrm{HHI}$. High HHI →
+    events concentrate in few dates → cross-event independence under
+    `caar`'s $t$-test is violated and the statistic may be inflated.
+
+-   __Trigger the Kolari-Pynnönen adjustment__
+
+    ---
+
+    When `hhi_normalized` is high ($\geq 0.3$ is the threshold the BMP
+    docstring calls out), switch on
+    `bmp_test(kolari_pynnonen_adjust=True)` to absorb same-date shock
+    sharing in the $z$ statistic.
+
+</div>
+
+## Worked example — HHI on event dates
+
+!!! example "clustering_diagnostic on a synthetic event panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.clustering import clustering_diagnostic
+    from factrix.metrics.caar import bmp_test
+
+    panel = fx.datasets.make_event_panel(
+        n_assets=200, n_dates=500, event_rate=0.02,
+        cluster_dates=True, seed=2024,
+    )
+
+    diag = clustering_diagnostic(panel)
+    print(diag.value,
+          diag.metadata["effective_n_dates"],
+          diag.metadata["hhi_normalized"])
+    # 0.041  24.4  0.36   (approximate)
+
+    # hhi_normalized >= 0.3 -> reach for the K-P adjustment:
+    z = bmp_test(panel, kolari_pynnonen_adjust=True)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual sparse landing page](individual-sparse.md) — adjacent event-study metrics.
+<div class="grid cards" markdown>
+
+-   __`caar` / `bmp_test`__
+
+    ---
+
+    The downstream tests whose independence assumption this metric
+    gates. `bmp_test(kolari_pynnonen_adjust=True)` is the formal
+    correction.
+
+    [api/metrics/caar →](caar.md)
+
+-   __`signal_density`__
+
+    ---
+
+    Inverse firing frequency — pair with `clustering_hhi` since
+    bars-per-event ignores temporal concentration.
+
+    [api/metrics/event_quality →](event_quality.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    Confounded-event handling and within-asset event clustering notes.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Sparse landing__
+
+    ---
+
+    Adjacent event-study metrics in the same cell.
+
+    [api/metrics/individual-sparse →](individual-sparse.md)
+
+</div>

--- a/docs/api/metrics/corrado.md
+++ b/docs/api/metrics/corrado.md
@@ -1,26 +1,127 @@
-# corrado
+---
+title: factrix.metrics.corrado
+---
 
-Corrado (1989) nonparametric rank test on event abnormal returns.
-Robust to extreme returns, non-normality, and cross-asset
-heteroscedasticity. Direction-adjusted for two-sided signals.
+::: factrix.metrics.corrado
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - corrado_rank_test
 
-→ Formula and references:
-[Corrado nonparametric rank](../../reference/statistical-methods.md#corrado-rank).
+<hr>
 
 !!! info "Event-study contracts"
-    Corrado's primitive is `signed_rank = uniform_rank(forward_return) ×
-    sign(factor)` — note that the direction adjustment is on the rank,
-    not on the return itself. The
+    Corrado's primitive is
+    $\text{signed\_rank} = \text{uniform\_rank}(\text{forward\_return}) \times \text{sign}(\text{factor})$
+    — note that the direction adjustment is on the rank, **not** on
+    the return itself. The
     [Event-study contracts table](../../reference/metric-applicability.md#abnormal-return-definition-per-metric)
     contrasts this with `caar` (magnitude-weighted) and `event_quality`
     (sign-only on the raw return). The
     [`estimation_window`](../../reference/metric-applicability.md#estimation_window)
     section specifies the per-asset baseline this test ranks against.
 
-::: factrix.metrics.corrado
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Robustness screen against parametric CAAR / BMP__
+
+    ---
+
+    Rank-based two-sided $z$ on event-window abnormal returns. Robust
+    to extreme returns, non-normal distributions, and cross-asset
+    heteroscedasticity — flips the conclusion when parametric CAAR is
+    being driven by a handful of outliers.
+
+-   __Direction-adjusted nonparametric inference__
+
+    ---
+
+    Ranks are sign-flipped via `sign(factor)` before pooling, so the
+    test handles two-sided signals (long / short events) directly —
+    the Corrado-Zivney (1992) extension to the original one-directional
+    test.
+
+</div>
+
+## Worked example — rank test alongside parametric CAAR
+
+!!! example "corrado_rank_test on a synthetic event panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.corrado import corrado_rank_test
+    from factrix.metrics.caar import compute_caar, caar
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_event_panel(
+        n_assets=200, n_dates=500, event_rate=0.02,
+        post_event_drift=0.004, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    rank_out = corrado_rank_test(panel)
+    print(rank_out.value, rank_out.stat, rank_out.metadata["p_value"])
+    # 0.041  5.18  2.2e-07   (approximate)
+
+    # Compare to parametric CAAR — divergence flags outlier-driven CAAR:
+    caar_out = caar(compute_caar(panel), forward_periods=5)
+    print(caar_out.stat, rank_out.stat)
+    # 6.42   5.18
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual sparse landing page](individual-sparse.md) — adjacent event-study metrics.
+<div class="grid cards" markdown>
+
+-   __`caar` / `bmp_test`__
+
+    ---
+
+    Parametric counterparts; read alongside Corrado for an
+    outlier-robustness cross-check.
+
+    [api/metrics/caar →](caar.md)
+
+-   __`clustering_diagnostic`__
+
+    ---
+
+    The pooled-std denominator factrix uses diverges from the Corrado
+    (1989) eq. (5) form when event-date clustering is present —
+    inspect HHI before reading $p$ at the size boundary.
+
+    [api/metrics/clustering →](clustering.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Corrado nonparametric rank test specification and the deviation
+    from eq. (5) factrix takes.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies, sample-size guards, and the per-asset
+    full-sample ranking contract.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Sparse landing__
+
+    ---
+
+    Adjacent event-study metrics in the same cell.
+
+    [api/metrics/individual-sparse →](individual-sparse.md)
+
+</div>

--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -1,40 +1,155 @@
-# event_horizon
-
-Multi-horizon event analysis — per-event return profile across `k`
-offsets, plus binomial test on per-horizon hit rate. Detects pre-event
-leakage and identifies the strongest horizon.
-
-## Offset conventions
-
-Defaults: `offsets = [-6, -3, -1, 1, 6, 12, 24]`. Offset `0` is the
-event date itself and is excluded from the defaults; user-supplied
-`offsets` lists are honoured verbatim.
-
-| `k` | Anchor | Formula | Sign-adjusted |
-|---|---|---|---|
-| `k > 0` (post-event) | Cumulative from `t+1` entry | `price[t+1+k] / price[t+1] − 1` | Yes — multiplied by `sign(factor)`. The reading is signal *quality*. |
-| `k < 0` (pre-event) | Single bar at offset | `price[t+k] / price[t+k−1] − 1` | **No** — the reading is *leakage*, where the bar's directional response is what matters independent of the eventual signal sign. |
-| `k == 0` (corner) | Single bar at event | `price[t] / price[t−1] − 1` | No — falls into the pre-event branch. Pass with care; the event-day bar is usually contaminated by the announcement itself. |
-
-The pre/post asymmetry is intentional. Mixing the two conventions on a
-single chart (post-event cumulative + pre-event single-bar) is the
-default factrix presentation; downstream consumers should not
-re-cumulate the pre-event leg.
-
-The binomial null at each offset assumes per-event independence at
-that offset. **Adjacent post-event offsets are serially correlated
-within the same event** — `k=6` and `k=12` share the `t+1` entry
-price and overlap on bars `[t+2, t+7]`. The reported per-offset
-*p*-values therefore have understated variance under the joint null
-across offsets; treat the curve as descriptive and read the binomial
-*p* one offset at a time. See also the
-[confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
-on within-asset event clustering, which compounds the same issue.
+---
+title: factrix.metrics.event_horizon
+---
 
 ::: factrix.metrics.event_horizon
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - compute_event_returns
+        - event_around_return
+
+<hr>
+
+!!! info "Offset conventions"
+    Defaults: `offsets = [-6, -3, -1, 1, 6, 12, 24]`. Offset `0` is the
+    event date itself and is excluded from the defaults; user-supplied
+    `offsets` lists are honoured verbatim.
+
+    | $k$ | Anchor | Formula | Sign-adjusted |
+    |---|---|---|---|
+    | $k > 0$ (post-event) | Cumulative from $t+1$ entry | `price[t+1+k] / price[t+1] − 1` | Yes — multiplied by `sign(factor)`. The reading is signal *quality*. |
+    | $k < 0$ (pre-event) | Single bar at offset | `price[t+k] / price[t+k−1] − 1` | **No** — the reading is *leakage*, where the bar's directional response matters independent of the eventual signal sign. |
+    | $k = 0$ (corner) | Single bar at event | `price[t] / price[t−1] − 1` | No — falls into the pre-event branch. Pass with care; the event-day bar is usually contaminated by the announcement itself. |
+
+    The pre/post asymmetry is intentional. Mixing the two conventions
+    on a single chart (post-event cumulative + pre-event single-bar) is
+    the default factrix presentation; downstream consumers should not
+    re-cumulate the pre-event leg.
+
+!!! warning "Serial correlation across offsets"
+    The binomial null at each offset assumes per-event independence at
+    that offset. **Adjacent post-event offsets are serially correlated
+    within the same event** — $k = 6$ and $k = 12$ share the $t+1$
+    entry price and overlap on bars $[t+2, t+7]$. The reported
+    per-offset $p$-values therefore have understated variance under
+    the joint null across offsets; treat the curve as descriptive and
+    read the binomial $p$ one offset at a time. See also the
+    [confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
+    on within-asset event clustering, which compounds the same issue.
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Right-size the event window__
+
+    ---
+
+    Read the post-event mean curve over $k = 1 \ldots K$ to locate the
+    horizon where signed drift peaks before reverting. Drives the
+    choice of `EventConfig.event_window_post` for downstream MFE/MAE
+    and CAAR work.
+
+-   __Pre-event leakage check__
+
+    ---
+
+    Inspect $k < 0$ mean returns: a healthy signal has flat pre-event
+    means. The headline `event_around_return.value` is
+    $\mathrm{mean}_{k < 0} |\mathrm{mean}_k|$, summarising the leakage
+    score in a single number.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                          | Function                |
+|---------------------------------------------------------------|-------------------------|
+| Per-event, per-offset raw return table for custom plots / cuts | `compute_event_returns` |
+| Per-offset summary (mean / median / quartiles / hit-rate) with pre-event leakage headline | `event_around_return`   |
+
+## Worked example — leakage score + per-offset curve
+
+!!! example "compute_event_returns → event_around_return on a synthetic event panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.event_horizon import (
+        compute_event_returns, event_around_return,
+    )
+
+    panel = fx.datasets.make_event_panel(
+        n_assets=200, n_dates=500, event_rate=0.02,
+        post_event_drift=0.004, with_price=True, seed=2024,
+    )
+
+    rets = compute_event_returns(panel, offsets=[-6, -3, -1, 1, 6, 12, 24])
+    print(rets.head())
+    # ┌────────┬────────────┬──────────┬────────────────┐
+    # │ offset ┆ date       ┆ asset_id ┆ signed_return  │
+    # ├────────┼────────────┼──────────┼────────────────┤
+    # │   -6   ┆ 2024-01-04 ┆ A0001    ┆  0.0012        │
+    # │    1   ┆ 2024-01-04 ┆ A0001    ┆  0.0041        │
+    # │  ...   ┆ ...        ┆ ...      ┆ ...            │
+    # └────────┴────────────┴──────────┴────────────────┘
+
+    out = event_around_return(panel)
+    print(out.value)                              # mean |pre-event mean|
+    print(out.metadata["per_offset"][6]["mean"])  # post-event signed mean at k=6
+    # 0.0007   0.0094   (approximate)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual sparse landing page](individual-sparse.md) — adjacent event-study metrics.
+<div class="grid cards" markdown>
+
+-   __`mfe_mae`__
+
+    ---
+
+    Per-event excursion analysis on the same post-event window — peak
+    favourable / adverse move and bars-to-peak.
+
+    [api/metrics/mfe_mae →](mfe_mae.md)
+
+-   __`caar` / `bmp_test`__
+
+    ---
+
+    Inferential CAAR / BMP tests on the chosen `forward_periods`
+    horizon.
+
+    [api/metrics/caar →](caar.md)
+
+-   __`clustering_diagnostic`__
+
+    ---
+
+    Event-date HHI — the serial-correlation caveat above compounds
+    with same-date clustering.
+
+    [api/metrics/clustering →](clustering.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    Event-window / estimation-window contracts and confounded-event
+    handling.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Sparse landing__
+
+    ---
+
+    Adjacent event-study metrics in the same cell.
+
+    [api/metrics/individual-sparse →](individual-sparse.md)
+
+</div>

--- a/docs/api/metrics/event_quality.md
+++ b/docs/api/metrics/event_quality.md
@@ -1,21 +1,14 @@
-# event_quality
-
-Per-event quality summaries computed on `signed_car`: hit rate, IC,
-profit factor, skewness, signal density. Inference is binomial or
-nonparametric — descriptive elsewhere.
-
-!!! info "Event-study contracts"
-    These metrics use the **sign-only** form `signed_car =
-    forward_return × sign(factor)` — distinct from `caar`'s
-    magnitude-weighted `forward_return × factor`. See the
-    [abnormal-return table](../../reference/metric-applicability.md#abnormal-return-definition-per-metric)
-    for the full per-metric contract and the
-    [confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
-    for how the binomial / Spearman nulls behave under within-asset
-    event clustering.
+---
+title: factrix.metrics.event_quality
+---
 
 ::: factrix.metrics.event_quality
     options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
       members:
         - event_hit_rate
         - event_ic
@@ -23,8 +16,154 @@ nonparametric — descriptive elsewhere.
         - event_skewness
         - signal_density
 
+<hr>
+
+!!! info "Event-study contracts"
+    These metrics use the **sign-only** form
+    $\text{signed\_car} = \text{forward\_return} \times \text{sign}(\text{factor})$
+    — distinct from `caar`'s magnitude-weighted
+    $\text{forward\_return} \times \text{factor}$. See the
+    [abnormal-return table](../../reference/metric-applicability.md#abnormal-return-definition-per-metric)
+    for the full per-metric contract and the
+    [confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
+    for how the binomial / Spearman nulls behave under within-asset
+    event clustering.
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Directional accuracy__
+
+    ---
+
+    Fraction of events whose `signed_car` is positive, with a two-sided
+    binomial test against $H_0: p = 0.5$. Exact branch below the
+    normal-approximation cutoff; $z$ branch above. Headline statistic
+    for "is the sign right more often than chance".
+
+-   __Magnitude → magnitude__
+
+    ---
+
+    Among triggered events, does the signal's `|factor|` co-move with
+    the realised `signed_car`? Spearman rank correlation with Fisher-$z$
+    inference. Auto-skips on $\{0, \pm 1\}$ inputs where `|factor|` has
+    no variance.
+
+-   __Gain / loss ratio and shape__
+
+    ---
+
+    `profit_factor` reports $\sum\text{gains} / |\sum\text{losses}|$ as
+    a descriptive gross ratio; `event_skewness` reports the Fisher-
+    corrected skewness of the `signed_car` distribution with a
+    D'Agostino test when $N \geq 20$. Useful for screening
+    fat-right-tail vs symmetric event payoffs.
+
+-   __Firing frequency__
+
+    ---
+
+    `signal_density` reports mean bars-per-event per asset (inverse
+    frequency). Pair with `clustering_diagnostic` when independence
+    assumptions matter — bars-per-event ignores temporal clustering.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                       | Function             |
+|------------------------------------------------------------|----------------------|
+| Directional-accuracy binomial test                         | `event_hit_rate`     |
+| Magnitude-of-signal → magnitude-of-return rank correlation | `event_ic`           |
+| Gross gain / loss ratio (descriptive only)                 | `profit_factor`      |
+| Tail asymmetry of `signed_car` with D'Agostino skew test   | `event_skewness`     |
+| Inverse firing frequency (bars per event)                  | `signal_density`     |
+
+## Worked example — directional accuracy + tail shape
+
+!!! example "event_hit_rate + event_skewness on a synthetic event panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.event_quality import (
+        event_hit_rate, event_skewness, profit_factor,
+    )
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_event_panel(
+        n_assets=200, n_dates=500, event_rate=0.02,
+        post_event_drift=0.004, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    hit = event_hit_rate(panel)
+    print(hit.value, hit.stat, hit.metadata["p_value"])
+    # 0.564  3.81  1.4e-04   (approximate)
+
+    sk = event_skewness(panel)
+    print(sk.value, sk.stat)
+    # 0.42  4.10   (approximate; stat is D'Agostino z when N >= 20)
+
+    pf = profit_factor(panel)
+    print(pf.value, pf.metadata["n_wins"], pf.metadata["n_losses"])
+    # 1.34  1131  864
+    ```
+
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual sparse landing page](individual-sparse.md) — adjacent event-study metrics.
+<div class="grid cards" markdown>
+
+-   __`caar` / `bmp_test`__
+
+    ---
+
+    Mean-CAAR significance and BMP variance-robust $z$ on the same
+    event sample.
+
+    [api/metrics/caar →](caar.md)
+
+-   __`clustering_diagnostic`__
+
+    ---
+
+    Event-date concentration index — read alongside `signal_density`
+    when independence matters.
+
+    [api/metrics/clustering →](clustering.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Per-slice event-quality summaries (regime / universe / sector).
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Binomial test branches, Fisher-$z$ Spearman, D'Agostino skew test.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    Sample-size guards and `signed_car` contracts for the sign-only
+    family.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Sparse landing__
+
+    ---
+
+    Adjacent event-study metrics in the same cell.
+
+    [api/metrics/individual-sparse →](individual-sparse.md)
+
+</div>

--- a/docs/api/metrics/mfe_mae.md
+++ b/docs/api/metrics/mfe_mae.md
@@ -1,13 +1,134 @@
-# mfe_mae
-
-Maximum Favourable / Adverse Excursion path analysis on bar-by-bar
-event windows. Descriptive distribution summaries (p50, p75, ratio);
-no formal H₀.
+---
+title: factrix.metrics.mfe_mae
+---
 
 ::: factrix.metrics.mfe_mae
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - compute_mfe_mae
+        - mfe_mae_summary
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Peak favourable vs adverse excursion__
+
+    ---
+
+    For each event, find the peak gain (MFE) and peak loss (MAE) over
+    the post-event window, plus bars-to-peak. Descriptive of the
+    *shape* of the post-event price path, not just its endpoint.
+
+-   __Risk-adjusted favourability__
+
+    ---
+
+    Headline ratio $\mathrm{MFE}_{p50} / |\mathrm{MAE}_{p75}|$ pairs
+    the median favourable excursion against the 75th percentile
+    adverse excursion — captures whether typical upside exceeds worst-
+    quartile downside.
+
+-   __Cross-horizon / cross-regime comparison__
+
+    ---
+
+    Z-scored variants `mfe_z` / `mae_z` (divided by
+    $\hat\sigma \sqrt{W}$) absorb the $\sqrt{W \cdot \sigma^2}$
+    horizon scaling of order statistics — the apples-to-apples
+    quantity for comparing event setups across windows or volatility
+    regimes.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                | Function           |
+|---------------------------------------------------------------------|--------------------|
+| Per-event MFE / MAE / bars-to-peak table for downstream cuts        | `compute_mfe_mae`  |
+| Aggregate distribution summary (quantiles, ratio, z-scored siblings) | `mfe_mae_summary` |
+
+## Worked example — per-event excursion then summary
+
+!!! example "compute_mfe_mae → mfe_mae_summary on a synthetic event panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.mfe_mae import compute_mfe_mae, mfe_mae_summary
+
+    panel = fx.datasets.make_event_panel(
+        n_assets=200, n_dates=500, event_rate=0.02,
+        post_event_drift=0.004, with_price=True, seed=2024,
+    )
+
+    per_event = compute_mfe_mae(panel, window=20, estimation_window=60)
+    print(per_event.head())
+    # ┌────────────┬──────────┬────────┬─────────┬────────┬────────┐
+    # │ date       ┆ asset_id ┆  mfe   ┆  mae    ┆ mfe_z  ┆ mae_z  │
+    # ├────────────┼──────────┼────────┼─────────┼────────┼────────┤
+    # │ 2024-01-04 ┆ A0001    ┆ 0.031  ┆ -0.018  ┆  0.74  ┆ -0.43  │
+    # │  ...       ┆ ...      ┆  ...   ┆  ...    ┆  ...   ┆  ...   │
+    # └────────────┴──────────┴────────┴─────────┴────────┴────────┘
+
+    out = mfe_mae_summary(per_event)
+    print(out.value,
+          out.metadata["mfe_p50"], out.metadata["mae_p75"],
+          out.metadata.get("mfe_mae_ratio_z"))
+    # 1.27  0.024  -0.019  1.31   (approximate)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual sparse landing page](individual-sparse.md) — adjacent event-study metrics.
+<div class="grid cards" markdown>
+
+-   __`event_around_return`__
+
+    ---
+
+    Per-offset mean curve on the same post-event window — read for
+    drift shape; MFE/MAE read for excursion magnitude.
+
+    [api/metrics/event_horizon →](event_horizon.md)
+
+-   __`caar` / `bmp_test`__
+
+    ---
+
+    Inferential CAAR / BMP $z$ on the endpoint of the same event
+    window.
+
+    [api/metrics/caar →](caar.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Per-slice excursion summaries (regime / universe / sector).
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    Event-window / estimation-window contracts and price-data
+    requirements.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Sparse landing__
+
+    ---
+
+    Adjacent event-study metrics in the same cell.
+
+    [api/metrics/individual-sparse →](individual-sparse.md)
+
+</div>


### PR DESCRIPTION
## Summary

Batch 1 of 3 for #271 — six Individual × Sparse leaf metric pages
restructured per the API page template established in #269 (worked
example: `docs/api/metrics/ic.md`).

The template:

- Front-matter `title:` so the page H1 is the full qualified module path.
- `::: factrix.metrics.<module>` with `show_root_full_path: true`,
  `show_root_members_full_path: true`, explicit `members:` list,
  `heading_level: 1`.
- `<hr>` between the autodoc block and the hand-written narrative.
- `## Use cases` rendered as a 2- to 4-card Material grid; each card
  grounded in what the metric specifically does (no boilerplate).
- `## Choosing a function` decision table when the module exposes more
  than one callable; skipped on single-callable modules.
- `## Worked example` wrapped in a `!!! example` admonition with a
  runnable code block.
- `## See also` rendered as a grid of cards with arrow-CTA links.
- No Material icons, no per-page mermaid diagrams.

Files swept (one commit each):

- `docs/api/metrics/caar.md` — 4 cards, 3-row decision table, worked
  example chains `compute_caar` → `caar` with `bmp_test` as variance-
  robust sibling.
- `docs/api/metrics/event_quality.md` — 4 cards, 5-row decision table,
  worked example combines `event_hit_rate` + `event_skewness` +
  `profit_factor`.
- `docs/api/metrics/event_horizon.md` — 2 cards, 2-row decision table;
  preserved offset-conventions `!!! info` and serial-correlation
  `!!! warning` admonitions verbatim.
- `docs/api/metrics/mfe_mae.md` — 3 cards, 2-row decision table; no
  Statistical-methods See-also (descriptive — no formal $H_0$).
- `docs/api/metrics/clustering.md` — 2 cards; skipped "Choosing a
  function" (single public callable); worked example shows the
  gate→adjust pattern (read HHI → enable
  `bmp_test(kolari_pynnonen_adjust=True)`).
- `docs/api/metrics/corrado.md` — 2 cards; skipped "Choosing a
  function" (single public callable); worked example pairs
  `corrado_rank_test` against parametric `caar` for the cross-check.

Existing custom `!!! info` admonitions (`Event-study contracts` on
caar / corrado, `signed_car` vs magnitude-weighted on event_quality,
offset conventions + serial correlation on event_horizon) were
preserved in place above the autodoc block.

## Test plan

- [ ] `mkdocs build --strict` passes (verified by pre-push; will
  re-verify on merge).
- [ ] Visual check on each of the six pages: grid cards / decision
  tables / `!!! example` worked-example admonition / See-also grid all
  render.
- [ ] Cross-reference targets in See-also cards resolve
  (`by-slice.md`, `slice-test.md`, `metric-applicability.md`,
  `statistical-methods.md`, `individual-sparse.md`, and intra-cell
  links like `clustering.md` → `caar.md`).
- [ ] Cell-landing page (`api/metrics/individual-sparse.md`) still
  routes correctly to all six pages.

Refs #271.