### PR TITLE
feat(multi_factor): promote Survivors to public namespace (#270)

### DIFF
--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -24,7 +24,7 @@ title: factrix.multi_factor.bhy
     Run `evaluate` over `m` candidate signals on the same return panel,
     feed the resulting list of [`FactorProfile`][factrix.FactorProfile]
     to `bhy`, and read the surviving subset off the
-    `Survivors` container. Controls
+    [`Survivors`][factrix.multi_factor.Survivors] container. Controls
     FDR ≤ `q` under arbitrary dependence — the regime that matches a
     correlated factor pool (e.g. 200 momentum variants on one panel).
 
@@ -198,6 +198,13 @@ for s in survivors.profiles:
     print(s.factor_id)
 # or just `repr(survivors)` in Jupyter for the table view
 ```
+
+::: factrix.multi_factor.Survivors
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 3
 
 ## Behaviour change (#161)
 

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -40,13 +40,13 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True, repr=False)
 class Survivors:
-    """Family-verb survivor container with rich Jupyter rendering.
+    """Survivor container for multi-factor screening functions with rich Jupyter rendering.
 
-    Procedure-agnostic: ``adj_p`` carries the verb's procedure-canonical
-    adjusted p-value (BHY ``bhy_adjusted_p``, Holm step-down, Bonferroni
-    ``min(p*m, 1)``, Romano-Wolf resampling, ...). The contract is
-    ``survivor[i] iff adj_p[i] <= q`` — a duality every step-up /
-    step-down family procedure satisfies.
+    Procedure-agnostic: ``adj_p`` carries the function's
+    procedure-canonical adjusted p-value (BHY ``bhy_adjusted_p``, Holm
+    step-down, Bonferroni ``min(p*m, 1)``, Romano-Wolf resampling, ...).
+    The contract is ``survivor[i] iff adj_p[i] <= q`` — a duality every
+    step-up / step-down family procedure satisfies.
 
     Invariants:
         ``len(profiles) == len(adj_p)`` and entries align in input
@@ -65,25 +65,26 @@ class Survivors:
             conditions per identity (``partial_conjunction``). Empty
             tuple when the full input is one family.
         n_tests: Family size per bucket fed into the step-up math.
-            Keying depends on the verb: ``bhy`` keys by
+            Keying depends on the producing function: ``bhy`` keys by
             ``expand_over_values`` tuple (``()`` for the single-bucket
             case); ``partial_conjunction`` keys by ``identity`` tuple
             (``(factor_id, forward_periods)``) and records the ``m``
             condition count per identity.
         pc_p: Raw partial-conjunction p-value per survivor (Benjamini
             & Heller 2008 Bonferroni-style: ``(m - min_pass + 1) *
-            p_((min_pass))``, capped at 1). ``None`` when the verb is
-            not ``partial_conjunction``.
+            p_((min_pass))``, capped at 1). ``None`` when the producing
+            function is not ``partial_conjunction``.
         min_pass: ``k`` in the ``k`` of ``m`` partial conjunction test.
-            ``None`` when the verb is not ``partial_conjunction``.
+            ``None`` when the producing function is not
+            ``partial_conjunction``.
         n_passed_uncorr: Per-identity count of raw p-values strictly
             below ``q`` (descriptive — **not** used in inference; flags
             borderline cases and data gaps at a glance). The cutoff is
             the caller's ``q`` (same value driving the BHY step-up), so
             this count moves with ``q``; using it to override
             ``adj_p`` survivor selection is the anti-shopping failure
-            mode this verb exists to prevent. ``None`` when the verb is
-            not ``partial_conjunction``.
+            mode ``partial_conjunction`` exists to prevent. ``None``
+            when the producing function is not ``partial_conjunction``.
     """
 
     profiles: list[FactorProfile]

--- a/factrix/multi_factor.py
+++ b/factrix/multi_factor.py
@@ -6,6 +6,11 @@ v0.4 deletion sweep that retires the existing v0.4 implementations
 of those primitives.
 """
 
-from factrix._multi_factor import bhy, bhy_hierarchical, partial_conjunction
+from factrix._multi_factor import (
+    Survivors,
+    bhy,
+    bhy_hierarchical,
+    partial_conjunction,
+)
 
-__all__ = ["bhy", "bhy_hierarchical", "partial_conjunction"]
+__all__ = ["Survivors", "bhy", "bhy_hierarchical", "partial_conjunction"]


### PR DESCRIPTION
## Summary

Resolves the first of three follow-ups bundled into #270.

- `factrix/multi_factor.py` — re-export `Survivors` from
  `factrix._multi_factor` and add it to `__all__`.
- `factrix/_multi_factor.py` — sweep "verb" → "function" in the
  `Survivors` class docstring (six occurrences) so the now-user-facing
  class matches the two-register terminology convention shipped in
  #267. Internal `verb=` kwargs on `_resolve_family` /
  `family_aggregator` call sites stay as code-level identifiers (same
  exception as `UserInputError.verb`).
- `docs/api/bhy.md` — restore the cross-ref
  `[`Survivors`][factrix.multi_factor.Survivors]` (was demoted to
  plain code in `6c6c26b` for the #269 strict-build unblock) and
  append an autodoc block at the end of the `Return type` section so
  the field list renders directly from the dataclass.

No behaviour change. `Survivors` was already constructed and returned
by `bhy` / `bhy_hierarchical` / `partial_conjunction`; this only
changes its import path from `factrix._multi_factor.Survivors` to
`factrix.multi_factor.Survivors`. Callers using the private path keep
working (the underscored module is not removed).

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally; pre-push hook
  enforces).
- [ ] `python -c "from factrix.multi_factor import Survivors; print(Survivors)"`
  resolves to `<class 'factrix._multi_factor.Survivors'>`.
- [ ] Visual check on `api/bhy.md`: the Return type section ends with
  an autodoc-rendered `factrix.multi_factor.Survivors` heading + the
  Attributes table; the cross-reference inside the Use-cases card
  resolves on hover.
- [ ] `mypy factrix/multi_factor.py factrix/_multi_factor.py` clean
  (verified locally).

Refs #270 (this resolves sub-item 2 of three; sub-items 1 and 3 —
error classes autodoc home, metric module docstring restructure —
remain open).