### PR TITLE
docs(metrics): individual-continuous pages onto #269 template (#271)

### DIFF
--- a/docs/api/metrics/concentration.md
+++ b/docs/api/metrics/concentration.md
@@ -1,13 +1,127 @@
-# concentration
-
-HHI-inverse on top-bucket weights — measures whether long-leg alpha
-is broadly distributed or concentrated in a handful of names.
-One-sided *t* against `H₀: ratio ≥ 0.5`.
+---
+title: factrix.metrics.concentration
+---
 
 ::: factrix.metrics.concentration
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - top_concentration
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Signal concentration in the long leg__
+
+    ---
+
+    `weight_by="abs_factor"` (default) — HHI on $|\text{factor}|$
+    inside the top-$q$ bucket. Answers "how concentrated is the
+    *signal* itself in the long leg". Conservative; depends only on
+    factor values, not on realised returns.
+
+-   __Realised risk concentration__
+
+    ---
+
+    `weight_by="alpha_contribution"` — HHI on
+    $|\text{sign}(\text{factor}) \cdot \text{forward\_return}|$.
+    Captures whether the long-leg's realised return is dominated by a
+    few outliers. Absolute value: a single big winner and a single
+    big loser both register as concentration (the right framing for
+    *risk*, not for signed-alpha attribution).
+
+-   __Diversification test, one-sided__
+
+    ---
+
+    `value = mean(1/HHI)` (effective number of independent bets);
+    `stat` is a one-sided $t$ against $H_0: \mathbb{E}[r] \geq 0.5$
+    where $r_t = n^{\text{eff}}_t / n^{\text{top}}$. Rejecting flags
+    the long leg as concentrated relative to the bucket cardinality.
+
+</div>
+
+## Worked example — top-bucket HHI on a synthetic panel
+
+!!! example "top_concentration with both weighting modes"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.concentration import top_concentration
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=500, n_dates=500, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    # Signal-level concentration (no return dependence)
+    sig = top_concentration(panel, forward_periods=5, q_top=0.2,
+                            weight_by="abs_factor")
+    print(sig.value, sig.metadata["ratio_eff_to_total"], sig.stat)
+    # 78.4  0.78  -2.40   (approximate; ratio > 0.5 -> diversified)
+
+    # Realised-return concentration (risk framing)
+    risk = top_concentration(panel, forward_periods=5, q_top=0.2,
+                             weight_by="alpha_contribution")
+    print(risk.value, risk.metadata["ratio_eff_to_total"], risk.stat)
+    # 41.2  0.41  3.10   (approximate; ratio < 0.5 -> outlier-driven)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.
+<div class="grid cards" markdown>
+
+-   __`quantile_spread` / `quantile_spread_vw`__
+
+    ---
+
+    The long-short spread on the same top / bottom buckets — pair the
+    EW-vs-VW spread gap with concentration to disentangle small-cap
+    vs few-name alpha.
+
+    [api/metrics/quantile →](quantile.md)
+
+-   __`notional_turnover` / `breakeven_cost`__
+
+    ---
+
+    Implementation feasibility on the same long-short construction.
+
+    [api/metrics/tradability →](tradability.md)
+
+-   __Statistical methods__
+
+    ---
+
+    One-sided $t$ on the per-date diversification ratio, DDOF
+    convention, sample-size guards.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    (`MIN_PORTFOLIO_PERIODS_HARD` / `MIN_PORTFOLIO_PERIODS_WARN`).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Continuous landing__
+
+    ---
+
+    Adjacent metrics in the same cell.
+
+    [api/metrics/individual-continuous →](individual-continuous.md)
+
+</div>

--- a/docs/api/metrics/fama_macbeth.md
+++ b/docs/api/metrics/fama_macbeth.md
@@ -1,24 +1,148 @@
-# fama_macbeth
-
-Per-date cross-sectional OLS slope λ then NW HAC *t* on the λ series
-(Fama-MacBeth 1973). Pooled OLS variant with date-clustered SE; β-sign
-consistency check.
-
-→ Formula and references: stage-2 HAC SE on E[λ] —
-[NW HAC](../../reference/statistical-methods.md#nw-hac)
-(includes the Kan-Zhang / Shanken EIV correction invoked by
-`is_estimated_factor=True`).
+---
+title: factrix.metrics.fama_macbeth
+---
 
 ::: factrix.metrics.fama_macbeth
     options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
       members:
+        - compute_fm_betas
         - fama_macbeth
         - pooled_ols
         - beta_sign_consistency
-        - compute_fm_betas
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Compute per-date FM beta series__
+
+    ---
+
+    Stage 1 of Fama-MacBeth: per-date cross-sectional OLS slope
+    $\beta_t$ in $R_{i,t} = \alpha_t + \beta_t \cdot \text{Signal}_{i,t} + \varepsilon_{i,t}$.
+    Pre-step for `fama_macbeth` and the descriptive
+    `beta_sign_consistency` check.
+
+-   __Mean-$\beta$ significance, NW HAC__
+
+    ---
+
+    Stage 2 of Fama-MacBeth: $t$-test on $\mathbb{E}[\beta_t] = 0$
+    with Newey-West HAC SE, bandwidth $\max(\lfloor T^{1/3} \rfloor,
+    h-1)$. Default inferential test for the Individual x Continuous
+    cell.
+
+-   __Errors-in-variables correction for estimated signals__
+
+    ---
+
+    Set `is_estimated_factor=True` (with `factor_return_var=` where the
+    factor-mimicking-portfolio return series is available) to apply the
+    Kan-Zhang (1999) single-factor simplification of Shanken (1992) EIV.
+    Required when the Signal column is itself estimated — rolling beta,
+    PCA score, ML prediction.
+
+-   __Pooled OLS robustness check__
+
+    ---
+
+    `pooled_ols` runs a single regression across the stacked panel with
+    cluster-robust SE (one-way on `date`, or two-way with
+    `two_way_cluster_col`). When pooled $\hat\beta$ and FM
+    $\hat\lambda$ disagree in sign, `profile.diagnose()` flags a
+    misspecification red flag.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                         | Function                |
+|------------------------------------------------------------------------------|-------------------------|
+| Per-date FM beta table for downstream inspection / slicing                   | `compute_fm_betas`      |
+| Mean-$\beta$ significance with NW HAC SE (default Stage 2)                   | `fama_macbeth`          |
+| Pooled OLS with cluster-robust SE (one-way on date, or two-way)              | `pooled_ols`            |
+| Directional stability — fraction of periods with the expected $\beta$ sign   | `beta_sign_consistency` |
+
+## Worked example — per-date FM beta then NW HAC significance
+
+!!! example "compute_fm_betas → fama_macbeth on a synthetic cross-sectional panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.fama_macbeth import compute_fm_betas, fama_macbeth
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=100, n_dates=500, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    beta_df = compute_fm_betas(panel)
+    print(beta_df.head())
+    # ┌────────────┬───────────┐
+    # │ date       ┆ beta      │
+    # ├────────────┼───────────┤
+    # │ 2024-01-01 ┆  0.0091   │
+    # │ 2024-01-02 ┆  0.0077   │
+    # │ ...        ┆  ...      │
+    # └────────────┴───────────┘
+
+    out = fama_macbeth(beta_df, forward_periods=5)
+    print(out.value, out.stat, out.metadata["p_value"])
+    # 0.0084  6.10  1.3e-09   (approximate)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.
+<div class="grid cards" markdown>
+
+-   __`by_slice`__
+
+    ---
+
+    Axis-agnostic slice dispatcher for per-slice FM beta summaries.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __`slice_pairwise_test` / `slice_joint_test`__
+
+    ---
+
+    Cross-slice inference (Wald $\chi^2$ + Holm / Romano-Wolf adjusted $p$).
+
+    [api/slice-test →](../slice-test.md)
+
+-   __Statistical methods__
+
+    ---
+
+    NW HAC SE, Andrews bandwidth, Hansen-Hodrick overlap floor, and the
+    Kan-Zhang simplification of the Shanken EIV correction.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    (`MIN_FM_PERIODS_HARD` / `MIN_FM_PERIODS_WARN`).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Continuous landing__
+
+    ---
+
+    Adjacent metrics in the same cell.
+
+    [api/metrics/individual-continuous →](individual-continuous.md)
+
+</div>

--- a/docs/api/metrics/monotonicity.md
+++ b/docs/api/metrics/monotonicity.md
@@ -1,13 +1,127 @@
-# monotonicity
-
-Per-date Spearman correlation between quantile-group index and group
-mean return; cross-asset *t* on the per-date series tests whether the
-factor sorts returns monotonically.
+---
+title: factrix.metrics.monotonicity
+---
 
 ::: factrix.metrics.monotonicity
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - monotonicity
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Decile-curve direction test__
+
+    ---
+
+    Per-date Spearman correlation between quantile-group index and
+    group mean return; cross-asset $t$ on the signed series asks
+    whether the bucket ordering is *consistently* increasing (or
+    decreasing) across dates — a stronger requirement than a positive
+    long-short spread.
+
+-   __Magnitude vs direction separation__
+
+    ---
+
+    `value` is mean $|\text{Spearman}|$ (magnitude, $\geq 0$); `stat`
+    is a $t$ on the signed series. High `value` with insignificant
+    `stat` flags a factor that monotonically sorts returns but whose
+    direction flips across dates — Patton-Timmermann (2010) territory
+    that a single signed average would hide.
+
+</div>
+
+!!! info "Per-bucket cardinality floor"
+    `min_assets_per_group = 50` (Patton-Timmermann 2010) — the slice-
+    test verb downscales `n_groups` automatically so each bucket meets
+    the floor; below it, per-date bucket means are noise-dominated and
+    the rank statistic is unreliable. Defaults: `n_groups=10` for
+    universes around 2000 stocks; drop to 5 for $n_{assets} < 1000$
+    and 3 for $n_{assets} < 200$.
+
+## Worked example — Spearman direction test on quantile-bucket returns
+
+!!! example "monotonicity on a synthetic cross-sectional panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.monotonicity import monotonicity
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=2000, n_dates=500, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    out = monotonicity(panel, forward_periods=5, n_groups=10)
+    print(out.value, out.stat,
+          out.metadata["mean_signed"], out.metadata["p_value"])
+    # 0.41  5.62  0.39  2.1e-08   (approximate)
+    # value ≈ mean|Spearman|; mean_signed ≈ direction; stat t on signed series
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.
+<div class="grid cards" markdown>
+
+-   __`quantile_spread` / `compute_group_returns`__
+
+    ---
+
+    The decile-curve chart input and the long-short headline spread
+    over the same buckets.
+
+    [api/metrics/quantile →](quantile.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Axis-agnostic slice dispatcher for per-slice monotonicity summaries.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __`slice_pairwise_test` / `slice_joint_test`__
+
+    ---
+
+    Cross-slice inference (Wald $\chi^2$ + Holm / Romano-Wolf adjusted $p$).
+
+    [api/slice-test →](../slice-test.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Cross-asset $t$ on the per-date signed Spearman series, DDOF
+    convention.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    Per-bucket sample-size floor (Patton-Timmermann 2010) and the
+    `n_groups` downscaling contract.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Continuous landing__
+
+    ---
+
+    Adjacent metrics in the same cell.
+
+    [api/metrics/individual-continuous →](individual-continuous.md)
+
+</div>

--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -1,19 +1,161 @@
-# quantile
-
-Quantile-bucket long-short spread on a panel: per-date
-top-minus-bottom return → spread series, then non-overlapping *t* on
-its mean. Equal-weight and value-weight variants.
+---
+title: factrix.metrics.quantile
+---
 
 ::: factrix.metrics.quantile
     options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
       members:
-        - quantile_spread
-        - quantile_spread_vw
         - compute_spread_series
         - compute_group_returns
+        - quantile_spread
+        - quantile_spread_vw
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Compute per-date long-short spread series__
+
+    ---
+
+    Build the per-date `spread = top_return - bottom_return` series
+    (with `top_return`, `bottom_return`, `universe_return`) on a
+    non-overlap-sampled panel. Pre-step for `quantile_spread`; also
+    feeds `spanning_alpha` and any `series/` tool.
+
+-   __Mean-spread significance, equal-weighted__
+
+    ---
+
+    Test $H_0: \mathbb{E}[\text{spread}] = 0$ on the non-overlap
+    spread series, with the long-vs-short alpha decomposition
+    (`top - universe`, `universe - bottom`) attached so callers can
+    attribute the spread to long-side vs short-side excess.
+
+-   __Value-weighted spread for capacity diagnostics__
+
+    ---
+
+    `quantile_spread_vw` weights each bucket by lagged `market_cap`
+    (or any caller-supplied `weight_col=`). When the VW spread is much
+    smaller than the EW spread, the alpha is concentrated in small
+    names and may not survive capacity / liquidity constraints —
+    Hou-Xue-Zhang (2020) found ~65% of factors disappear under VW.
+
+-   __Per-bucket mean returns for monotonicity charts__
+
+    ---
+
+    `compute_group_returns` returns the pooled mean forward return per
+    quantile bucket — the chart input that shows whether returns rise
+    monotonically across deciles, before any formal monotonicity test.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                            | Function                |
+|---------------------------------------------------------------------------------|-------------------------|
+| Per-date long-short spread table for downstream inspection / slicing            | `compute_spread_series` |
+| Per-bucket pooled mean return (decile-curve chart input)                        | `compute_group_returns` |
+| Mean-spread significance, equal-weighted, non-overlap $t$ (default)             | `quantile_spread`       |
+| Mean-spread significance, value-weighted (capacity / size-concentration check)  | `quantile_spread_vw`    |
+
+## Worked example — per-date spread then EW vs VW significance
+
+!!! example "compute_spread_series → quantile_spread → quantile_spread_vw on a synthetic cross-sectional panel"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.quantile import (
+        compute_spread_series, quantile_spread, quantile_spread_vw,
+    )
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=200, n_dates=500, ic_target=0.08,
+        with_market_cap=True, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    spread_df = compute_spread_series(panel, forward_periods=5, n_groups=5)
+    print(spread_df.head())
+    # ┌────────────┬──────────┬───────────────┬─────────────────┬──────────────────┐
+    # │ date       ┆ spread   ┆ top_return    ┆ bottom_return   ┆ universe_return  │
+    # ├────────────┼──────────┼───────────────┼─────────────────┼──────────────────┤
+    # │ 2024-01-01 ┆  0.0042  ┆  0.0061       ┆  0.0019         ┆  0.0040          │
+    # │  ...       ┆  ...     ┆  ...          ┆  ...            ┆  ...             │
+    # └────────────┴──────────┴───────────────┴─────────────────┴──────────────────┘
+
+    ew = quantile_spread(panel, forward_periods=5, n_groups=5,
+                         _precomputed_series=spread_df)
+    print(ew.value, ew.stat, ew.metadata["long_alpha"], ew.metadata["short_alpha"])
+    # 0.0041  4.92  0.0019  0.0022   (approximate)
+
+    vw = quantile_spread_vw(panel, forward_periods=5, n_groups=5,
+                            weight_col="market_cap")
+    print(vw.value, vw.stat)
+    # 0.0017  2.10   (approximate — VW < EW signals small-cap concentration)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.
+<div class="grid cards" markdown>
+
+-   __`monotonicity`__
+
+    ---
+
+    Decile-curve direction-of-monotonicity test on the same buckets.
+
+    [api/metrics/monotonicity →](monotonicity.md)
+
+-   __`spanning_alpha`__
+
+    ---
+
+    Does this spread series carry alpha after controlling for base
+    factor spreads? Consumes `compute_spread_series` output directly.
+
+    [api/metrics/spanning →](spanning.md)
+
+-   __`notional_turnover` / `breakeven_cost` / `net_spread`__
+
+    ---
+
+    Implementation feasibility on the same Q1/Qn long-short portfolio.
+
+    [api/metrics/tradability →](tradability.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Axis-agnostic slice dispatcher for per-slice spread summaries.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Non-overlap $t$ vs NW HAC on overlapping spreads, DDOF convention.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Individual × Continuous landing__
+
+    ---
+
+    Adjacent metrics in the same cell.
+
+    [api/metrics/individual-continuous →](individual-continuous.md)
+
+</div>

--- a/docs/api/metrics/spanning.md
+++ b/docs/api/metrics/spanning.md
@@ -1,19 +1,189 @@
-# spanning
-
-Spanning regression — single-factor alpha against base factors, and
-greedy forward selection over a pool. Operates on factor return time
-series (quantile spread series), not IC.
+---
+title: factrix.metrics.spanning
+---
 
 ::: factrix.metrics.spanning
     options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
       members:
         - spanning_alpha
         - greedy_forward_selection
         - SpanningResult
         - ForwardSelectionResult
 
+<hr>
+
+!!! warning "Inputs are factor-return series, not raw panels"
+    `spanning` is a post-PANEL consumer: both callables operate on
+    spread-series DataFrames (`date, spread`) produced by
+    `compute_spread_series` (or any equivalent factor-mimicking-portfolio
+    return series), not the raw `(date, asset_id, factor, forward_return)`
+    panel consumed by the other metrics in this cell.
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Single-factor incremental alpha__
+
+    ---
+
+    `spanning_alpha` regresses the candidate spread series on a set of
+    base-factor spread series; tests $H_0: \alpha = 0$ via OLS
+    $t$-stat. Standard tool for "does this factor add anything beyond
+    the existing model?" (Barillas-Shanken 2017).
+
+-   __Mean-return test when no base factors__
+
+    ---
+
+    With `base_spreads=None` (or empty), `spanning_alpha` collapses to
+    a plain mean-return $t$-test on the candidate's spread series —
+    convenient when the question is "is there *any* alpha here" before
+    pulling in controls.
+
+-   __Greedy model construction over a pool__
+
+    ---
+
+    `greedy_forward_selection` iteratively adds the candidate with
+    largest $|\alpha|$ above a $|t|$ threshold, then backward-eliminates
+    any selected factor that loses significance. **Use as a
+    model-construction helper only** — the returned $t$-stats are
+    selection-conditioned and not valid for inference.
+
+</div>
+
+!!! warning "Stepwise selection inflates t-stats"
+    `greedy_forward_selection` searches the candidate pool and picks
+    by $|\alpha|$; the per-selected-factor $t$-stat is order-statistic
+    inflated (typically 2-4x on pools of 10-100 candidates) and is
+    *not* a draw from the $t$-null (White 2000; Harvey-Liu-Zhu 2016).
+    The returned `t_stats_inference_invalid=True` flag encodes this
+    contract. For post-selection significance, re-evaluate survivors
+    on a held-out window, or use a Hansen (2005) SPA / White (2000)
+    Reality Check on the pre-selection stage.
+
+## Choosing a function
+
+| Goal                                                                          | Function                    |
+|-------------------------------------------------------------------------------|-----------------------------|
+| Single-factor spanning regression — incremental alpha vs base factors         | `spanning_alpha`            |
+| Greedy multi-factor selection over a candidate pool (model-construction only) | `greedy_forward_selection`  |
+
+## Worked example — single-factor spanning then greedy selection
+
+!!! example "compute_spread_series → spanning_alpha → greedy_forward_selection"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.quantile import compute_spread_series
+    from factrix.metrics.spanning import (
+        spanning_alpha, greedy_forward_selection,
+    )
+    from factrix.preprocess import compute_forward_return
+
+    # Build a spread series for each factor on the same panel dates.
+    panels = {
+        name: compute_forward_return(
+            fx.datasets.make_cs_panel(
+                n_assets=200, n_dates=500, ic_target=ic, seed=seed,
+            ),
+            forward_periods=5,
+        )
+        for name, ic, seed in [
+            ("size",     0.05, 1),
+            ("value",    0.06, 2),
+            ("momentum", 0.08, 3),
+            ("candidate",0.04, 4),
+        ]
+    }
+    spreads = {
+        name: compute_spread_series(p, forward_periods=5, n_groups=5)
+        for name, p in panels.items()
+    }
+
+    # Single-factor: candidate vs the base set
+    out = spanning_alpha(
+        factor_spread = spreads["candidate"],
+        base_spreads  = {k: spreads[k] for k in ("size", "value", "momentum")},
+    )
+    print(out.value, out.stat, out.metadata["p_value"], out.metadata["r_squared"])
+    # 0.0011  1.83  0.068  0.21   (approximate)
+
+    # Multi-factor: greedy build a parsimonious set
+    pool = {k: spreads[k] for k in ("size", "value", "momentum", "candidate")}
+    sel = greedy_forward_selection(
+        factor_spreads          = pool,
+        significance_threshold  = 2.0,
+        max_factors             = 4,
+        suppress_snooping_warning = True,  # acknowledged: construction-only
+    )
+    for s in sel.selected_factors:
+        print(s.factor_name, s.alpha, s.t_stat)
+    # momentum  0.0028  4.10
+    # value     0.0019  2.51   (approximate; t_stats inflated, do not infer)
+    ```
+
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.
+<div class="grid cards" markdown>
+
+-   __`compute_spread_series` / `quantile_spread`__
+
+    ---
+
+    Produces the per-date spread series consumed here.
+
+    [api/metrics/quantile →](quantile.md)
+
+-   __`compute_factor_returns` (preprocess)__
+
+    ---
+
+    Any factor-return / spread time series with `(date, spread)` shape
+    is a valid input; this is the upstream pipeline for the
+    post-PANEL cell.
+
+    [api/preprocess →](../preprocess.md)
+
+-   __`slice_pairwise_test` / `slice_joint_test`__
+
+    ---
+
+    Cross-slice inference on spanning alphas (Wald $\chi^2$ + Holm /
+    Romano-Wolf adjusted $p$).
+
+    [api/slice-test →](../slice-test.md)
+
+-   __Statistical methods__
+
+    ---
+
+    OLS $t$ on the alpha; when overlap is added, swap to NW HAC SE
+    via the same kernel discipline used elsewhere in factrix.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the post-selection-inference contracts
+    that govern `greedy_forward_selection`.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Continuous landing__
+
+    ---
+
+    Adjacent metrics in the same cell.
+
+    [api/metrics/individual-continuous →](individual-continuous.md)
+
+</div>

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -1,19 +1,157 @@
-# tradability
-
-Implementation-feasibility diagnostics: turnover (rank stability),
-notional turnover (Novy-Marx & Velikov τ), breakeven cost, and net
-spread. Profile-level — not gating.
+---
+title: factrix.metrics.tradability
+---
 
 ::: factrix.metrics.tradability
     options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
       members:
         - notional_turnover
         - turnover
         - breakeven_cost
         - net_spread
 
+<hr>
+
+!!! warning "Two flavours of turnover — do not mix them"
+    `notional_turnover` is the Novy-Marx & Velikov (2016) $\tau$:
+    fraction of top-and-bottom quantile members replaced per rebalance.
+    This is the quantity whose units are compatible with `breakeven_cost`
+    and `net_spread`. `turnover` is `1 - mean(rank autocorrelation)`,
+    a *rank-stability diagnostic* over the full cross-section — mid-rank
+    churn that triggers no Q1/Qn rebalance still counts. Feeding
+    `turnover()` into the cost formulas will mis-state the result by a
+    factor that grows with mid-rank churn.
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Portfolio rebalance cost driver__
+
+    ---
+
+    `notional_turnover` — per-rebalance fraction of the equal-weight
+    Q1/Qn long-short portfolio that must be traded. Drop-in input for
+    `breakeven_cost` / `net_spread`. Matches the Novy-Marx & Velikov
+    (2016) $\tau$ used in their anomaly-cost taxonomy.
+
+-   __Cross-factor rank-stability comparison__
+
+    ---
+
+    `turnover` — $1 - \overline{\rho}$ on per-date rank
+    autocorrelation, optionally restricted to the top/bottom-$q$
+    tail union. Use for stability rankings across factors;
+    **not** for cost arithmetic.
+
+-   __Breakeven cost in bps__
+
+    ---
+
+    `breakeven_cost = gross_spread \cdot h / (2 \cdot \tau) \cdot 10^4`.
+    If the venue's actual round-trip cost is below this, the factor's
+    alpha survives. The `\cdot h` lift puts per-period spread onto the
+    per-rebalance scale of $\tau$.
+
+-   __Net spread after estimated costs__
+
+    ---
+
+    `net_spread = gross_spread - 2 \cdot (cost_{bps} / 10^4) \cdot \tau / h`.
+    The cost is paid once per $h$-period rebalance, so dividing by $h$
+    amortises it back to the per-period scale of `gross_spread` — without
+    that, any factor with $h \geq 2$ would be artificially killed.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                            | Function             |
+|---------------------------------------------------------------------------------|----------------------|
+| Per-rebalance Q1/Qn membership churn — feeds the cost formulas (default $\tau$) | `notional_turnover`  |
+| Rank-stability diagnostic across the full cross-section (or tail-union)         | `turnover`           |
+| Breakeven trading cost in bps, given a gross spread and $\tau$                  | `breakeven_cost`     |
+| Net per-period spread after a venue-specific cost estimate                      | `net_spread`         |
+
+## Worked example — turnover then breakeven and net spread
+
+!!! example "quantile_spread → notional_turnover → breakeven_cost / net_spread"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.quantile import quantile_spread
+    from factrix.metrics.tradability import (
+        notional_turnover, breakeven_cost, net_spread,
+    )
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=500, n_dates=500, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    spread = quantile_spread(panel, forward_periods=5, n_groups=10)
+    tau    = notional_turnover(panel, n_groups=10, forward_periods=5)
+    print(spread.value, tau.value)
+    # 0.0021  0.18   (approximate)
+
+    be  = breakeven_cost(spread.value, tau.value, forward_periods=5)
+    net = net_spread(spread.value, tau.value,
+                     estimated_cost_bps=30.0, forward_periods=5)
+    print(be.value, net.value)
+    # 291.7   0.00189   (approximate; bps and per-period spread)
+    ```
+
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Individual continuous landing page](individual-continuous.md) — adjacent metrics in the same cell.
+<div class="grid cards" markdown>
+
+-   __`quantile_spread` / `quantile_spread_vw`__
+
+    ---
+
+    Source of `gross_spread` for the cost formulas; pairs naturally
+    with `notional_turnover` on the same Q1/Qn buckets.
+
+    [api/metrics/quantile →](quantile.md)
+
+-   __`top_concentration`__
+
+    ---
+
+    Long-leg concentration on the same top bucket — combine with
+    turnover for a feasibility picture.
+
+    [api/metrics/concentration →](concentration.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Axis-agnostic slice dispatcher for per-slice turnover / breakeven
+    summaries.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    Profile-level (not Gates) framing of implementation feasibility.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Individual × Continuous landing__
+
+    ---
+
+    Adjacent metrics in the same cell.
+
+    [api/metrics/individual-continuous →](individual-continuous.md)
+
+</div>


### PR DESCRIPTION
## Summary

Batch 2 of 3 for #271 — six Individual × Continuous leaf metric pages
restructured per the API page template established in #269 (worked
example: `docs/api/metrics/ic.md`; batch 1 sibling reference: #272).

The template ingredients (verbatim from #271 / #272):

- Front-matter `title:` so the page H1 is the full qualified module path.
- `::: factrix.metrics.<module>` with `show_root_full_path: true`,
  `show_root_members_full_path: true`, explicit `members:` list,
  `heading_level: 1`.
- `<hr>` between the autodoc block and the hand-written narrative.
- `## Use cases` rendered as a 2- to 4-card Material grid; each card
  grounded in what the metric specifically does.
- `## Choosing a function` decision table when the module exposes more
  than one callable.
- `## Worked example` wrapped in a `!!! example` admonition.
- `## See also` rendered as a grid of cards.
- No Material icons, no per-page mermaid diagrams.

Files swept (one commit each):

- `fama_macbeth.md` — 4 cards, 4-row decision table, worked example
  `compute_fm_betas` → `fama_macbeth`.
- `quantile.md` — 4 cards, 4-row decision table, worked example chains
  `compute_spread_series` → `quantile_spread` →
  `quantile_spread_vw(weight_col="market_cap")`.
- `monotonicity.md` — 2 cards (single-callable; no decision table).
  Added a new `!!! info` admonition surfacing the Patton-Timmermann
  50-asset bucket floor + `n_groups` downscale defaults previously
  only visible in the module docstring.
- `concentration.md` — 3 cards centred on the `weight_by` axis
  (`abs_factor` / `alpha_contribution` / one-sided diversification
  $t$). Single callable (`top_concentration`); no decision table.
- `tradability.md` — 4 cards, 4-row decision table, worked example
  `quantile_spread` → `notional_turnover` → `breakeven_cost` /
  `net_spread`. Added a top-of-page `!!! warning` distilling the
  module-docstring caveat about the two distinct turnover flavours
  (Novy-Marx & Velikov 2016 τ vs rank-stability diagnostic) — they
  are not interchangeable as inputs to cost / break-even formulas.
- `spanning.md` — 3 cards, 2-row decision table. Two new
  `!!! warning` admonitions distilling source-level caveats: (a)
  inputs are factor-return spread series, not raw panels — this is a
  post-PANEL consumer; (b) `greedy_forward_selection` returns t-stats
  flagged `t_stats_inference_invalid=True` per White (2000) /
  Harvey-Liu-Zhu (2016) on order-statistic inflation.

New admonitions fact-checked against the corresponding `factrix/metrics/`
source files; citations and constants match.

## Test plan

- [ ] `mkdocs build --strict` passes (verified by pre-push hook).
- [ ] Visual check on each of the six pages: grid cards / decision
  tables / `!!! example` worked-example admonition / `!!! warning` and
  `!!! info` admonitions on the three flagged pages all render.
- [ ] Cross-reference targets in See-also cards resolve
  (`by-slice.md`, `slice-test.md`, `metric-applicability.md`,
  `statistical-methods.md`, `individual-continuous.md`, the intra-cell
  `quantile` ↔ `tradability` ↔ `spanning` links, and the `preprocess`
  / `compute_spread_series` references on the spanning page).
- [ ] Cell-landing page (`api/metrics/individual-continuous.md`)
  still routes correctly to all six pages.

Refs #271. Last batch (3/3) covers Common × Continuous and Series
diagnostics (six remaining pages).