### PR TITLE
docs(metrics): common + series pages onto #269 template (#271)

### DIFF
--- a/docs/api/metrics/hit_rate.md
+++ b/docs/api/metrics/hit_rate.md
@@ -1,13 +1,141 @@
-# hit_rate
-
-Binomial hit-rate test on any time-indexed numeric series
-(`date, value`). Used as a follow-on diagnostic on IC, CAAR, or
-spread series.
+---
+title: factrix.metrics.hit_rate
+---
 
 ::: factrix.metrics.hit_rate
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - hit_rate
+        - per_date_series
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Sign-significance on a factor-return series__
+
+    ---
+
+    `hit_rate` is a `(*, CONTINUOUS, *, TIMESERIES)` diagnostic — input
+    is a 1-D series with `(date, value)`, not the raw panel. Typical
+    pipes: per-date IC from `compute_ic`, quantile spread from
+    `compute_spread_series`, or any other factor-mimicking-portfolio
+    return series. Reports the fraction of periods with `value > 0`
+    against $H_0: p = 0.5$.
+
+-   __Two-branch test under one $p$-value__
+
+    ---
+
+    Below `_BINOMIAL_EXACT_CUTOFF` the test is the exact two-sided
+    binomial; above the cutoff it switches to the normal-approximation
+    $z$. `stat` / `stat_type` track the branch actually taken, so a
+    reader can never see `stat=z` paired with an exact-binomial $p$.
+
+-   __Non-overlap stride matches the IC pipeline__
+
+    ---
+
+    The series is sub-sampled at stride `forward_periods` before the
+    test so the MA dependence induced by overlapping forward returns
+    does not leak in; same convention as `quantile_spread` and the
+    other non-overlap inference paths.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                       | Function           |
+|----------------------------------------------------------------------------|--------------------|
+| Hit-rate significance vs $p = 0.5$ on a `(date, value)` series             | `hit_rate`         |
+| Per-date hit indicator (`value > 0` cast to float) for slice-test plumbing | `per_date_series`  |
+
+## Worked example — IC series fed into hit_rate
+
+!!! example "compute_ic → hit_rate"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.ic import compute_ic
+    from factrix.metrics.hit_rate import hit_rate
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=100, n_dates=500, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    # The series diagnostic consumes (date, value); the value column on
+    # the compute_ic output is named ``ic``.
+    ic_df = compute_ic(panel)
+    out   = hit_rate(ic_df, value_col="ic", forward_periods=5)
+    print(out.value, out.stat, out.metadata["p_value"], out.metadata["method"])
+    # 0.62  19  0.011   exact-binomial   (approximate)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Series diagnostics landing page](series-tools.md) — other axis-agnostic series diagnostics.
+<div class="grid cards" markdown>
+
+-   __`compute_ic` / `compute_spread_series`__
+
+    ---
+
+    Canonical producers of the `(date, value)` series this diagnostic
+    consumes. `compute_ic` emits `(date, ic, tie_ratio)`;
+    `compute_spread_series` emits `(date, spread, ...)`.
+
+    [api/metrics/ic →](ic.md)
+
+-   __`trend` / `oos`__
+
+    ---
+
+    Sibling series diagnostics on the same input shape — slope
+    detection and IS/OOS persistence.
+
+    [api/metrics/trend →](trend.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Per-slice hit-rate summaries; uses `per_date_series` as the
+    slice-test capability hook.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Two-sided binomial branching, non-overlap stride discipline, and
+    the Hansen-Hodrick autocorrelation floor that motivates it.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    (`MIN_ASSETS_PER_DATE_IC` floor on the sampled series).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Series diagnostics landing__
+
+    ---
+
+    Adjacent axis-agnostic series diagnostics.
+
+    [api/metrics/series-tools →](series-tools.md)
+
+</div>

--- a/docs/api/metrics/oos.md
+++ b/docs/api/metrics/oos.md
@@ -1,13 +1,147 @@
-# oos
-
-In-sample / out-of-sample persistence diagnostic on any time-indexed
-series. Reports median survival ratio and sign-flip detail —
-descriptive (no formal H₀).
+---
+title: factrix.metrics.oos
+---
 
 ::: factrix.metrics.oos
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - multi_split_oos_decay
+        - SplitDetail
+
+<hr>
+
+!!! info "Descriptive only — no formal $H_0$"
+    `multi_split_oos_decay` emits a survival ratio + sign-flip detail;
+    no `p_value` is attached and `stat` is `None`. A $t$-test at the
+    `MIN_OOS_PERIODS` floor would have power $\approx 0$ and would
+    invite mis-reading the diagnostic as a significance test. Callers
+    routing this output into BHY / gate logic must read `status`
+    (`"PASS"` / `"VETOED"`) and `sign_flipped`, not a probability.
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Persistence read on a factor-return series__
+
+    ---
+
+    `multi_split_oos_decay` is a `(*, CONTINUOUS, *, TIMESERIES)`
+    diagnostic — input is a 1-D `(date, value)` series, typically IC
+    from `compute_ic`, spread from `compute_spread_series`, or any
+    other factor-mimicking-portfolio return series. Reports
+    $|\mathrm{mean}_{\text{OOS}}| / |\mathrm{mean}_{\text{IS}}|$ across
+    multiple `(IS_fraction, OOS_fraction)` splits.
+
+-   __Sign-flip veto__
+
+    ---
+
+    Any split with opposite-signed IS and OOS means flips
+    `sign_flipped = True` and forces `status = "VETOED"` — IC
+    sign-flip OOS means the factor predicts the wrong direction, not
+    just a weaker one. McLean & Pontiff (2016) report average OOS
+    decay around 32 %; factrix's default `survival_threshold = 0.5`
+    sits inside that window.
+
+-   __Median across splits, not mean__
+
+    ---
+
+    Headline is `median_f s_f` over the default splits
+    `[(0.6, 0.4), (0.7, 0.3), (0.8, 0.2)]`. A single regime change
+    landing inside one split distorts the mean disproportionately;
+    the median absorbs it.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                          | Function                |
+|-------------------------------------------------------------------------------|-------------------------|
+| Multi-split OOS survival + sign-flip gate on a `(date, value)` series         | `multi_split_oos_decay` |
+| Typed accessor for an individual split's `(is_ratio, mean_is, mean_oos, ...)` | `SplitDetail`           |
+
+## Worked example — IC series fed into multi_split_oos_decay
+
+!!! example "compute_ic → multi_split_oos_decay"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.ic import compute_ic
+    from factrix.metrics.oos import multi_split_oos_decay
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=100, n_dates=1000, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    # The series diagnostic consumes (date, value); the value column on
+    # the compute_ic output is named ``ic``.
+    ic_df = compute_ic(panel)
+    out   = multi_split_oos_decay(ic_df, value_col="ic")
+    print(out.value, out.metadata["status"], out.metadata["sign_flipped"])
+    # 0.94   PASS   False   (approximate)
+    for split in out.metadata["per_split"]:
+        print(split)
+    # {"is_ratio": 0.6, "mean_is": 0.080, "mean_oos": 0.077,
+    #  "survival_ratio": 0.96, "sign_flipped": False}
+    # ...
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Series diagnostics landing page](series-tools.md) — other axis-agnostic series diagnostics.
+<div class="grid cards" markdown>
+
+-   __`compute_ic` / `compute_spread_series`__
+
+    ---
+
+    Canonical producers of the `(date, value)` series this diagnostic
+    consumes.
+
+    [api/metrics/ic →](ic.md)
+
+-   __`hit_rate` / `trend`__
+
+    ---
+
+    Sibling series diagnostics on the same input shape — sign
+    significance and slope detection. Pair with `oos` when both
+    in-sample magnitude and out-of-sample persistence matter.
+
+    [api/metrics/hit_rate →](hit_rate.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Per-slice survival summaries (regime / universe / sector).
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    (`MIN_OOS_PERIODS * 2` floor; per-split `MIN_OOS_PERIODS` on each
+    side).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Series diagnostics landing__
+
+    ---
+
+    Adjacent axis-agnostic series diagnostics.
+
+    [api/metrics/series-tools →](series-tools.md)
+
+</div>

--- a/docs/api/metrics/trend.md
+++ b/docs/api/metrics/trend.md
@@ -1,12 +1,150 @@
-# trend
-
-Theil-Sen median pairwise slope on a time-indexed series; robust trend
-detection (29.3% breakdown point) on IC or other diagnostic series.
+---
+title: factrix.metrics.trend
+---
 
 ::: factrix.metrics.trend
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - ic_trend
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Detect alpha decay / crowding on an IC series__
+
+    ---
+
+    `ic_trend` is a `(*, CONTINUOUS, *, TIMESERIES)` diagnostic — input
+    is a 1-D `(date, value)` series, typically the per-date IC from
+    `compute_ic`. Slope $\approx 0$ = stable; slope significantly $< 0$
+    = decaying (crowding / alpha erosion in the Lou-Polk 2022 sense);
+    slope significantly $> 0$ = improving.
+
+-   __Outlier-robust slope via Theil-Sen__
+
+    ---
+
+    Median pairwise slope $\mathrm{median}\{(y_j - y_i)/(j - i): i <
+    j\}$ has a 29.3 % breakdown point — absorbs IC outliers (e.g. COVID-
+    era spikes) that would dominate an OLS slope. The trade-off is the
+    SE recovered from the rank-CI is approximate, not asymptotically
+    exact.
+
+-   __Unit-root pre-check on the input__
+
+    ---
+
+    `adf_threshold` (default 0.10, the Stock-Watson cutoff) drives an
+    ADF persistence diagnostic on the input series. Above the cutoff
+    the slope null is rejected at inflated rates regardless of the
+    true trend; the slope value is still returned but
+    `metadata["unit_root_suspected"] = True` flags it for sceptical
+    reading. Pass `adf_threshold=None` to skip the check entirely.
+
+-   __Reusable on any post-PANEL series__
+
+    ---
+
+    The `name=` argument lets `EventFactor.caar_trend` /
+    `MacroPanelFactor.beta_trend` pass their own primitive names so
+    method / cache key / primitive name stay three-point unified —
+    the same Theil-Sen primitive serves caar series, rolling-$\beta$
+    series, and spread series, not just IC.
+
+</div>
+
+## Worked example — IC series fed into ic_trend
+
+!!! example "compute_ic → ic_trend with ADF persistence check"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.ic import compute_ic
+    from factrix.metrics.trend import ic_trend
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=100, n_dates=1000, ic_target=0.08, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    # The series diagnostic consumes (date, value); the value column on
+    # the compute_ic output is named ``ic``.
+    ic_df = compute_ic(panel)
+    out   = ic_trend(ic_df, value_col="ic")
+    print(out.value, out.stat, out.metadata["p_value"])
+    # -3.2e-05  -0.91  0.36   (approximate; flat slope)
+    print(out.metadata["ci_low"], out.metadata["ci_high"],
+          out.metadata["ci_excludes_zero"])
+    # -1.0e-04  3.5e-05  False
+    print(out.metadata["adf_p"], out.metadata["unit_root_suspected"])
+    # 0.003  False   (stationary; slope read is trustworthy)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Series diagnostics landing page](series-tools.md) — other axis-agnostic series diagnostics.
+<div class="grid cards" markdown>
+
+-   __`compute_ic` / `compute_spread_series`__
+
+    ---
+
+    Canonical producers of the `(date, value)` series this diagnostic
+    consumes — IC series, spread series, or any other factor-mimicking-
+    portfolio return series.
+
+    [api/metrics/ic →](ic.md)
+
+-   __`hit_rate` / `oos`__
+
+    ---
+
+    Sibling series diagnostics on the same input shape — sign
+    significance and IS/OOS persistence.
+
+    [api/metrics/hit_rate →](hit_rate.md)
+
+-   __`compute_rolling_mean_beta`__
+
+    ---
+
+    Common-factor source of a rolling-$\beta$ series for stability
+    trend analysis via the same primitive.
+
+    [api/metrics/ts_beta →](ts_beta.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Theil-Sen breakdown point, ADF persistence diagnostic (MacKinnon
+    response surface), and the rank-CI to approximate-$t$ recovery.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    ($n \geq 10$).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Series diagnostics landing__
+
+    ---
+
+    Adjacent axis-agnostic series diagnostics.
+
+    [api/metrics/series-tools →](series-tools.md)
+
+</div>

--- a/docs/api/metrics/ts_asymmetry.md
+++ b/docs/api/metrics/ts_asymmetry.md
@@ -1,9 +1,18 @@
-# ts_asymmetry
+---
+title: factrix.metrics.ts_asymmetry
+---
 
-Long-side / short-side asymmetry test for COMMON / single-asset cells.
-Two methods — conditional means and piecewise slopes — both fit by OLS
-with NW HAC and tested by Wald χ², so cross-method *p*-values stay
-comparable under overlapping forward returns.
+::: factrix.metrics.ts_asymmetry
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - ts_asymmetry
+
+<hr>
 
 !!! info "TIMESERIES-mode conventions"
     `FACTOR_ADF_P` persistence diagnostic, plain stage-1 SE rationale,
@@ -11,10 +20,142 @@ comparable under overlapping forward returns.
     here as for the rest of the TS-mode family. See
     [TIMESERIES-mode conventions](../../reference/ts-mode-conventions.md).
 
-::: factrix.metrics.ts_asymmetry
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Decompose $\beta$ into long-side vs short-side response__
+
+    ---
+
+    OLS $\beta$ reports one slope and assumes a symmetric response —
+    $\beta > 0$ could be "rises more on positive factor" *or* "falls
+    less on negative factor". `ts_asymmetry` runs Method A (conditional
+    means on $\mathrm{sign}(f)$ dummies) so the long and short legs
+    are recoverable separately.
+
+-   __Symmetric-magnitude Wald test__
+
+    ---
+
+    Headline is $\beta_{\text{long}} + \beta_{\text{short}}$ — 0 under
+    perfect symmetry, positive when the long side dominates. NW HAC
+    Wald on $H_0: \beta_{\text{long}} + \beta_{\text{short}} = 0$
+    handles the autocorrelation induced by overlapping forward
+    returns; Welch $t$ is intentionally avoided because its iid
+    assumption breaks under `forward_periods > 1`.
+
+-   __Piecewise-slope check (Method B)__
+
+    ---
+
+    When each side has $\geq 2$ distinct factor values, Method B fits
+    $r = \alpha + \beta_{\text{pos}} \max(f, 0) + \beta_{\text{neg}}
+    \min(f, 0)$ and tests $H_0: \beta_{\text{pos}} = \beta_{\text{neg}}$.
+    Distinguishes a magnitude asymmetry (Method A) from a slope
+    asymmetry. Gate C below the cardinality floor records
+    `method_b_skipped` and the reason; Method A already carries the
+    full information for categorical / binary signals.
+
+</div>
+
+## Worked example — sign-asymmetric slopes on a common-factor panel
+
+!!! example "broadcast common factor → ts_asymmetry (Methods A + B)"
+
+    ```python
+    import factrix as fx
+    import polars as pl
+    from factrix.metrics.ts_asymmetry import ts_asymmetry
+    from factrix.preprocess import compute_forward_return
+
+    # Build a panel whose ``factor`` is broadcast (one value per date,
+    # shared across all assets) — VIX / NFP-surprise style.
+    raw = fx.datasets.make_cs_panel(
+        n_assets=50, n_dates=1000, ic_target=0.08, seed=2024,
+    )
+    common = raw.group_by("date").agg(pl.col("factor").mean().alias("factor"))
+    panel  = raw.drop("factor").join(common, on="date")
+    panel  = compute_forward_return(panel, forward_periods=5)
+
+    out = ts_asymmetry(panel, forward_periods=5)
+    print(out.value, out.stat, out.metadata["p_value"])
+    # 0.00021  1.83  0.067   (approximate; method A magnitude)
+    print(out.metadata["beta_long"], out.metadata["beta_short"],
+          out.metadata["abs_short_over_long"])
+    # 0.00088  -0.00067  0.76
+    print(out.metadata.get("beta_pos"), out.metadata.get("beta_neg"),
+          out.metadata.get("p_wald_slopes"))
+    # 0.00121  -0.00102  0.18   (Method B; ~null if Gate C passed)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Common continuous landing page](common-continuous.md) — adjacent macro-factor metrics.
+<div class="grid cards" markdown>
+
+-   __`ts_beta`__
+
+    ---
+
+    Symmetric linear $\beta$ on the same panel; pair when both
+    direction and magnitude asymmetry matter.
+
+    [api/metrics/ts_beta →](ts_beta.md)
+
+-   __`ts_quantile_spread`__
+
+    ---
+
+    Bucketed conditional means — strictly more flexible than the
+    two-flavour split, at the cost of $K$ free parameters and
+    the `n_distinct(factor) >= n_groups * 2` gate.
+
+    [api/metrics/ts_quantile →](ts_quantile.md)
+
+-   __`event_quality` family__
+
+    ---
+
+    Where the input gate redirects when the factor is single-sided
+    (no positive or no negative observations): `event_hit_rate` /
+    `event_ic` / `profit_factor`.
+
+    [api/metrics/event_quality →](event_quality.md)
+
+-   __Statistical methods__
+
+    ---
+
+    NW HAC SE, Andrews bandwidth, Hansen-Hodrick overlap floor, and
+    the Wald-on-linear-restriction framing for both Method A and
+    Method B.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __TIMESERIES-mode conventions__
+
+    ---
+
+    `FACTOR_ADF_P`, plain stage-1 SE rationale, `forward_periods` vs
+    `signal_horizon` bias framing.
+
+    [reference/ts-mode-conventions →](../../reference/ts-mode-conventions.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the gates (Gate B: two-sided factor;
+    Gate C: $\geq 2$ distinct values per side for Method B).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Common × Continuous landing__
+
+    ---
+
+    Adjacent macro-common metrics in the same cell.
+
+    [api/metrics/common-continuous →](common-continuous.md)
+
+</div>

--- a/docs/api/metrics/ts_beta.md
+++ b/docs/api/metrics/ts_beta.md
@@ -1,8 +1,23 @@
-# ts_beta
+---
+title: factrix.metrics.ts_beta
+---
 
-Per-asset time-series β to a macro common factor (VIX, USD index,
-etc.), then cross-asset *t* on the β distribution. Includes mean R²,
-rolling-window β stability, and sign consistency.
+::: factrix.metrics.ts_beta
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - compute_ts_betas
+        - ts_beta
+        - mean_r_squared
+        - ts_beta_sign_consistency
+        - compute_rolling_mean_beta
+        - ts_beta_single_asset_fallback
+
+<hr>
 
 !!! info "TIMESERIES-mode conventions"
     Stage-1 per-asset OLS uses **plain SE**, not HAC — the dominant
@@ -12,17 +27,156 @@ rolling-window β stability, and sign consistency.
     [TIMESERIES-mode conventions](../../reference/ts-mode-conventions.md)
     for the full rationale.
 
-::: factrix.metrics.ts_beta
-    options:
-      members:
-        - ts_beta
-        - mean_r_squared
-        - ts_beta_sign_consistency
-        - compute_rolling_mean_beta
-        - compute_ts_betas
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Compute per-asset TS betas__
+
+    ---
+
+    Stage 1 of the Black-Jensen-Scholes aggregation: per-asset OLS
+    $R_{i,t} = \alpha_i + \beta_i \cdot F_t + \varepsilon$ over each
+    asset's full sample. Pre-step for `ts_beta` / `mean_r_squared` /
+    `ts_beta_sign_consistency`. Assets with fewer than `MIN_TS_OBS`
+    rows or a singular design are dropped.
+
+-   __Cross-asset mean-$\beta$ significance__
+
+    ---
+
+    Stage 2 of BJS: $t = \overline{\beta} / (\mathrm{std}(\beta) /
+    \sqrt{N})$ with $H_0: \mathbb{E}[\beta] = 0$ across assets.
+    Cross-asset iid $t$ is used because the per-asset betas come from
+    non-overlapping time-series fits and are approximately independent
+    unless a strong latent common factor links them.
+
+-   __Explanatory power across the cross-section__
+
+    ---
+
+    `mean_r_squared` reports $\overline{R^2}$ and `median_r_squared`
+    on the per-asset fits. Low values ($< 0.05$) say the factor is
+    too weak or noisy to drive individual-asset returns even when
+    its cross-asset mean $\beta$ looks nonzero; large mean-vs-median
+    gaps say the factor explains a small subset of assets rather than
+    the cross-section as a whole.
+
+-   __Rolling-window stability__
+
+    ---
+
+    `compute_rolling_mean_beta` emits a `(date, value)` series of
+    rolling cross-asset mean $\beta$ at stride `window`. Output schema
+    matches the time-series tools so callers can pipe rolling betas
+    into `trend` / `oos`.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                    | Function                          |
+|-------------------------------------------------------------------------|-----------------------------------|
+| Per-asset TS beta table for downstream inspection / slicing             | `compute_ts_betas`                |
+| Mean-$\beta$ significance across assets (Stage 2 of BJS)                | `ts_beta`                         |
+| Average explanatory power $\overline{R^2}$ across assets                | `mean_r_squared`                  |
+| Direction-agnostic sign agreement on per-asset $\beta$                  | `ts_beta_sign_consistency`        |
+| Rolling cross-asset mean $\beta$ series for trend / OOS pipes           | `compute_rolling_mean_beta`       |
+| $N=1$ degenerate-case fallback used by Profile / Factor entry points    | `ts_beta_single_asset_fallback`   |
+
+## Worked example — per-asset TS betas then cross-asset $t$
+
+!!! example "compute_ts_betas → ts_beta on a broadcast common-factor panel"
+
+    ```python
+    import factrix as fx
+    import polars as pl
+    from factrix.metrics.ts_beta import compute_ts_betas, ts_beta, mean_r_squared
+    from factrix.preprocess import compute_forward_return
+
+    # Build a panel where ``factor`` is broadcast (one value per date,
+    # shared across all assets) — VIX / USD-index / NFP surprise style.
+    raw = fx.datasets.make_cs_panel(
+        n_assets=50, n_dates=500, ic_target=0.08, seed=2024,
+    )
+    common = (
+        raw.group_by("date").agg(pl.col("factor").mean().alias("factor"))
+    )
+    panel = (
+        raw.drop("factor").join(common, on="date")
+    )
+    panel = compute_forward_return(panel, forward_periods=5)
+
+    betas_df = compute_ts_betas(panel)
+    print(betas_df.head())
+    # ┌──────────┬─────────┬─────────┬────────┬───────────┬───────┐
+    # │ asset_id ┆ beta    ┆ alpha   ┆ t_stat ┆ r_squared ┆ n_obs │
+    # ├──────────┼─────────┼─────────┼────────┼───────────┼───────┤
+    # │ A00      ┆  0.082  ┆ 0.0001  ┆  1.91  ┆  0.018    ┆  494  │
+    # │ ...      ┆  ...    ┆ ...     ┆  ...   ┆  ...      ┆  ...  │
+    # └──────────┴─────────┴─────────┴────────┴───────────┴───────┘
+
+    out = ts_beta(betas_df)
+    r2  = mean_r_squared(betas_df)
+    print(out.value, out.stat, out.metadata["p_value"], r2.value)
+    # 0.078  6.84  4.1e-09  0.021   (approximate)
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Common continuous landing page](common-continuous.md) — adjacent macro-factor metrics.
+<div class="grid cards" markdown>
+
+-   __`trend` / `oos`__
+
+    ---
+
+    Pipe `compute_rolling_mean_beta` into the series diagnostics for
+    $\beta$-stability and OOS-survival reads.
+
+    [api/metrics/trend →](trend.md)
+
+-   __`by_slice`__
+
+    ---
+
+    Axis-agnostic slice dispatcher for per-slice $\beta$ summaries.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __TIMESERIES-mode conventions__
+
+    ---
+
+    Stambaugh bias, plain stage-1 SE rationale, ADF persistence
+    discipline.
+
+    [reference/ts-mode-conventions →](../../reference/ts-mode-conventions.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Cross-asset $t$, the BJS aggregation pattern, and unit-root
+    discipline on the common factor.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    (`MIN_TS_OBS`, $N \geq 3$ for cross-asset $t$, $N \geq 2$ for sign
+    consistency).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Common × Continuous landing__
+
+    ---
+
+    Adjacent macro-common metrics in the same cell.
+
+    [api/metrics/common-continuous →](common-continuous.md)
+
+</div>

--- a/docs/api/metrics/ts_quantile.md
+++ b/docs/api/metrics/ts_quantile.md
@@ -1,8 +1,18 @@
-# ts_quantile
+---
+title: factrix.metrics.ts_quantile
+---
 
-Quantile-bucketed NW HAC OLS on the per-date `(_f, _r)` series for
-COMMON / single-asset cells; Wald χ² on the top-bottom bucket spread.
-Catches U-shape / extreme-only signals that linear β assumes away.
+::: factrix.metrics.ts_quantile
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: true
+      show_root_members_full_path: true
+      heading_level: 1
+      members:
+        - ts_quantile_spread
+
+<hr>
 
 !!! info "TIMESERIES-mode conventions"
     `FACTOR_ADF_P` persistence diagnostic, plain stage-1 SE rationale,
@@ -10,10 +20,141 @@ Catches U-shape / extreme-only signals that linear β assumes away.
     here as for the rest of the TS-mode family. See
     [TIMESERIES-mode conventions](../../reference/ts-mode-conventions.md).
 
-::: factrix.metrics.ts_quantile
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Detect non-linear factor → return shape__
+
+    ---
+
+    Linear OLS $\beta$ reports a single slope and fails on
+    U-shape / inverted-U / extreme-only signals. `ts_quantile_spread`
+    aggregates the panel to a per-date $(\_f, \_r)$ series, buckets
+    `_f` into $K$ historical quantiles, and reads the conditional
+    mean return per bucket — preserves whatever shape the relationship
+    has.
+
+-   __Top-bottom spread significance with NW HAC__
+
+    ---
+
+    Headline is $\beta_{K-1} - \beta_0$ — the conditional mean
+    difference between the top and bottom quantile of factor history.
+    Inference is a Wald $\chi^2$ on $H_0: \beta_{K-1} = \beta_0$ with
+    Newey-West HAC covariance; kernel choice is consistent with
+    `ts_asymmetry` so cross-method $p$-values stay comparable under
+    overlapping forward returns.
+
+-   __Rank-monotonicity diagnostic across buckets__
+
+    ---
+
+    `metadata["spearman_rho"]` / `spearman_p` give a non-parametric
+    Spearman rank check on the bucket-mean sequence
+    $(\beta_0, \ldots, \beta_{K-1})$. Catches a monotone shape that
+    the top-bottom Wald would conflate with a wider U.
+
+</div>
+
+## Worked example — quantile-bucketed conditional means on a common-factor panel
+
+!!! example "broadcast common factor → ts_quantile_spread"
+
+    ```python
+    import factrix as fx
+    import polars as pl
+    from factrix.metrics.ts_quantile import ts_quantile_spread
+    from factrix.preprocess import compute_forward_return
+
+    # Build a panel whose ``factor`` is broadcast (one value per date,
+    # shared across all assets) — VIX / USD-index style.
+    raw = fx.datasets.make_cs_panel(
+        n_assets=50, n_dates=1000, ic_target=0.08, seed=2024,
+    )
+    common = raw.group_by("date").agg(pl.col("factor").mean().alias("factor"))
+    panel  = raw.drop("factor").join(common, on="date")
+    panel  = compute_forward_return(panel, forward_periods=5)
+
+    out = ts_quantile_spread(panel, n_groups=5, forward_periods=5)
+    print(out.value, out.stat, out.metadata["p_value"])
+    # 0.0018  3.20  0.0014   (approximate)
+    print(out.metadata["spearman_rho"], out.metadata["spearman_p"])
+    # 0.90  0.037   (approximate; positive ⇒ monotone shape)
+    for b in out.metadata["buckets"]:
+        print(b)
+    # {"idx": 0, "mean_return": -0.00091, "n": 199}
+    # ...
+    # {"idx": 4, "mean_return":  0.00091, "n": 199}
+    ```
 
 ## See also
 
-- [Reference § Metric applicability](../../reference/metric-applicability.md) — when this metric applies and sample-size guards.
-- [Reference § Statistical methods](../../reference/statistical-methods.md) — HAC SE, FDR, robust-scale, unit-root disciplines that govern the inference.
-- [Common continuous landing page](common-continuous.md) — adjacent macro-factor metrics.
+<div class="grid cards" markdown>
+
+-   __`ts_beta` / `ts_asymmetry`__
+
+    ---
+
+    Linear $\beta$ and signed-slope asymmetry diagnostics on the same
+    broadcast-factor panel. Use `ts_quantile_spread` when a Spearman
+    rank check or U-shape detection matters; the others assume a
+    monotone or piecewise-linear response.
+
+    [api/metrics/ts_beta →](ts_beta.md)
+
+-   __`event_quality` family__
+
+    ---
+
+    Where the input gate redirects when the factor cannot sustain
+    quantile cuts (binary / sparse signals): `event_hit_rate` /
+    `event_ic` / `profit_factor` / `event_skewness`.
+
+    [api/metrics/event_quality →](event_quality.md)
+
+-   __`by_slice` / `slice_pairwise_test`__
+
+    ---
+
+    Axis-agnostic slice dispatcher and pairwise Wald (Holm /
+    Romano-Wolf adjusted $p$) for per-slice spread comparisons.
+
+    [api/by-slice →](../by-slice.md)
+
+-   __Statistical methods__
+
+    ---
+
+    NW HAC SE, Andrews bandwidth, Hansen-Hodrick overlap floor, and
+    the Wald-on-linear-restriction framing.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+-   __TIMESERIES-mode conventions__
+
+    ---
+
+    `FACTOR_ADF_P`, plain stage-1 SE rationale, `forward_periods` vs
+    `signal_horizon` bias framing.
+
+    [reference/ts-mode-conventions →](../../reference/ts-mode-conventions.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it
+    (`MIN_PORTFOLIO_PERIODS_HARD`, `n_distinct(factor) >= n_groups * 2`).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Common × Continuous landing__
+
+    ---
+
+    Adjacent macro-common metrics in the same cell.
+
+    [api/metrics/common-continuous →](common-continuous.md)
+
+</div>


### PR DESCRIPTION
## Summary

Batch 3 of 3 for #271 — six leaf metric pages spanning two
sub-sections restructured per the API page template established in
#269 (worked example: `docs/api/metrics/ic.md`; sibling batches: #272,
#274). Completes the sweep across all 18 leaf metric pages.

**Sub-section A — Common × Continuous (3 files)**:
panel-input metrics on broadcast factors (one factor value per date,
shared across assets). See-also cell-landing sibling:
`api/metrics/common-continuous.md`.

- `ts_beta.md` — 4 cards, 6-row decision table covering all six
  callables (incl. the `N=1` `ts_beta_single_asset_fallback`), worked
  example chains `compute_ts_betas → ts_beta + mean_r_squared` on a
  broadcast common factor built inline from `make_cs_panel`. Preserved
  the existing TIMESERIES-mode-conventions `!!! info` admonition.
- `ts_quantile.md` — 3 cards, no decision table (single callable);
  worked example builds the broadcast common factor inline then calls
  `ts_quantile_spread`. Preserved TS-mode-conventions admonition.
- `ts_asymmetry.md` — 3 cards (long/short decomposition, symmetric-
  magnitude Wald, Method B piecewise slope incl. Gate C skip); no
  decision table (single callable); worked example exercises both
  Method A and Method B output keys. Preserved TS-mode-conventions
  admonition.

**Sub-section B — Series diagnostics (3 files)**:
TIMESERIES-cell metrics consuming a `(date, value)` DataFrame produced
by an upstream panel-input metric (typically `compute_ic`,
`compute_spread_series`, or `compute_rolling_mean_beta`). See-also
cell-landing sibling: `api/metrics/series-tools.md`.

- `hit_rate.md` — 3 cards, 2-row decision table, worked example
  `compute_ic → hit_rate(value_col="ic")`.
- `trend.md` — 4 cards, no decision table (single callable
  `ic_trend`); worked example `compute_ic → ic_trend` printing CI +
  ADF metadata.
- `oos.md` — 3 cards, 2-row decision table (`multi_split_oos_decay`,
  `SplitDetail`). Added a new `!!! info` admonition distilling the
  source's descriptive-only contract (`stat=None`, no `p_value`,
  callers must read `status` / `sign_flipped` rather than a
  probability). Skipped the Statistical-methods See-also card
  (precedent: descriptive metrics in earlier batches).

## Subagent briefing items adjusted during work

- Series diagnostics consume a `pl.DataFrame` with `date` + `value_col`,
  not a 1-D array (the briefing's mental model was slightly off). Worked
  examples reflect the actual signatures.
- `trend.py` exposes `ic_trend` (not `trend`); `oos.py` exposes
  `multi_split_oos_decay` + the `SplitDetail` dataclass.
- No synthetic `make_macro_panel` / `make_common_panel` helper exists;
  Common × Continuous worked examples construct the broadcast common
  factor inline from `make_cs_panel` (per-date mean re-joined). Same
  construction across all three pages for consistency.

New admonition on `oos` fact-checked against `factrix/metrics/oos.py`
lines 7, 85, 88-89, 102 — wording verbatim-grounded.

## Test plan

- [ ] `mkdocs build --strict` passes (verified by pre-push hook).
- [ ] Visual check on each of the six pages: grid cards / decision
  tables / `!!! example` worked-example admonition / preserved
  TIMESERIES-mode-conventions admonitions (ts_beta / ts_quantile /
  ts_asymmetry) / new descriptive-only `!!! info` admonition (oos)
  all render.
- [ ] Cross-reference targets in See-also cards resolve, including
  the cross-batch links from series diagnostics back to their
  upstream producers (`compute_ic`, `compute_spread_series`).
- [ ] Cell-landing pages (`api/metrics/common-continuous.md` and
  `api/metrics/series-tools.md`) still route correctly to the relevant
  pages.

Refs #271. Once merged, all 18 leaf metric pages are on the
established template; the umbrella issue can be closed.