### PR TITLE
docs(api): error class autodoc + cross-ref promote (#270)

### DIFF
--- a/docs/api/analysis-config.md
+++ b/docs/api/analysis-config.md
@@ -51,7 +51,7 @@ title: factrix.AnalysisConfig
 
     Every construction path runs `__post_init__`. An illegal
     `(scope, signal, metric)` triple raises
-    [`IncompatibleAxisError`](errors.md) at
+    [`IncompatibleAxisError`][factrix.IncompatibleAxisError] at
     *construction* time, not at `evaluate` time.
 
 </div>
@@ -136,8 +136,8 @@ keeping a backtest replayable across code revisions.
 
 `from_dict` runs the same `__post_init__` validation as the factories, so
 a tampered or stale payload raises
-[`IncompatibleAxisError`](errors.md) or
-[`UnknownEstimatorError`](errors.md) up front rather
+[`IncompatibleAxisError`][factrix.IncompatibleAxisError] or
+[`UnknownEstimatorError`][factrix.UnknownEstimatorError] up front rather
 than failing silently later.
 
 ## See also

--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -113,7 +113,7 @@ does no reverse lookup.
 
 ## Errors
 
-`compare` raises [`UserInputError`](errors.md) for every input shape
+`compare` raises [`UserInputError`][factrix.UserInputError] for every input shape
 issue (empty input, mixed types, unknown `sort_by`). Unknown
 `sort_by` carries `suggestions` populated by `difflib` against the
 output schema.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -169,69 +169,60 @@ Autodoc anchors for cross-references of the form
 
 ::: factrix.FactrixError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
-### `UserInputError`
+### User-input failures
 
 ::: factrix.UserInputError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
-### `ConfigError` family
+### Config failures
 
 ::: factrix.ConfigError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.MissingConfigError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.IncompatibleAxisError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.ModeAxisError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.InsufficientSampleError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.UnknownEstimatorError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
-### Other
+### Run-metrics failures
 
 ::: factrix.RunMetricsError
     options:
-      show_root_heading: true
       show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -157,3 +157,81 @@ if metric_name not in fx.list_metrics(cfg):
 Pass exactly one of `candidates` / `expected`. The rendered message is
 human-readable output; downstream code should rely on the attributes
 above, not on substring matches against `str(exc)`.
+
+---
+
+## Class reference
+
+Autodoc anchors for cross-references of the form
+`` [`<Error>`][factrix.<Error>] `` from any docs page.
+
+### Base
+
+::: factrix.FactrixError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+### `UserInputError`
+
+::: factrix.UserInputError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+### `ConfigError` family
+
+::: factrix.ConfigError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+::: factrix.MissingConfigError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+::: factrix.IncompatibleAxisError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+::: factrix.ModeAxisError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+::: factrix.InsufficientSampleError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+::: factrix.UnknownEstimatorError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4
+
+### Other
+
+::: factrix.RunMetricsError
+    options:
+      show_root_heading: true
+      show_root_full_path: true
+      show_root_toc_entry: false
+      heading_level: 4

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -62,7 +62,7 @@ Behaviour:
 - Each call repeats the per-date cross-section work, so cost scales as
   `O(n_factors × per_date_cost)` — there is no shared-pass primitive.
 
-Error cases (both raise [`UserInputError`](errors.md)):
+Error cases (both raise [`UserInputError`][factrix.UserInputError]):
 
 | Trigger | Message hint |
 |---|---|

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -69,7 +69,7 @@ extend stage-1 wiring per cell.
 fx.run_metrics(panel, cfg, metrics=["ic", "monotonicity"])
 ```
 
-Unknown names raise [`UserInputError`](errors.md) with a fuzzy
+Unknown names raise [`UserInputError`][factrix.UserInputError] with a fuzzy
 suggestion plus the full candidate list. Names registered for the
 cell but in the auto-discover exclusion set raise the same error type with
 the documented reason and the explicit-call recipe — `run_metrics`
@@ -158,8 +158,8 @@ Three classes, three responses:
 | Class | Source | What `run_metrics` does |
 |---|---|---|
 | **A** Sample-floor / data-quality | `InsufficientSampleError`, metric-internal `_short_circuit_output` | Convert to a short-circuit `MetricOutput` (`value=NaN`, `metadata["reason"]=...`) inside the bundle. Other metrics keep running. |
-| **B** User input | unknown / excluded `metrics=[...]`, missing / colliding `factor_col` | Raise [`UserInputError`](errors.md) with fuzzy suggestion + fix path. |
-| **C** Unexpected | bug in a metric callable or stage-1 helper | Raise [`RunMetricsError`](errors.md) wrapping the original exception (chained via `__cause__`); attributes `.cell`, `.metric_name`, `.stage` identify which metric broke. |
+| **B** User input | unknown / excluded `metrics=[...]`, missing / colliding `factor_col` | Raise [`UserInputError`][factrix.UserInputError] with fuzzy suggestion + fix path. |
+| **C** Unexpected | bug in a metric callable or stage-1 helper | Raise [`RunMetricsError`][factrix.RunMetricsError] wrapping the original exception (chained via `__cause__`); attributes `.cell`, `.metric_name`, `.stage` identify which metric broke. |
 
 A single `logging.info` line at logger name `factrix.run_metrics`
 summarises ran / skipped counts per call (observability hook for

--- a/docs/api/suggest-config.md
+++ b/docs/api/suggest-config.md
@@ -6,7 +6,7 @@ reasoning behind the suggestion. The proposal is never auto-applied —
 the caller (or an AI agent) reads `reasoning` / `warnings` before
 deciding to use, override, or reject it.
 
-Canonical [`MissingConfigError`](errors.md) recovery:
+Canonical [`MissingConfigError`][factrix.MissingConfigError] recovery:
 
 ```python
 import factrix as fx


### PR DESCRIPTION
## Summary

- Add per-class `:::` autodoc blocks for the 9 exported error classes on `docs/api/errors.md` under a new "Class reference" section so `[Error][factrix.Error]` cross-refs resolve under `mkdocs --strict`.
- Promote the 9 existing flat `[Error](errors.md)` links across `analysis-config.md` / `compare.md` / `panel-schema.md` / `run-metrics.md` / `suggest-config.md` to mkdocstrings refs so clicks land on the exact class section.
- Simplify-pass: drop the per-block `show_root_heading: true` (already global default), rename group H3 labels to parallel categorical form (`User-input failures` / `Config failures` / `Run-metrics failures`) to match the existing fix-mapping taxonomy on the same page.

Resolves item (1) of three follow-ups bundled in #270. Items (2) Survivors visibility and (3) metric module docstring restructure remain open.

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally; pre-push hook re-ran on push).
- [ ] Render check on the deployed preview: `docs/api/errors.md` shows 9 class signatures under "Class reference"; cross-ref clicks on `analysis-config.md` / `compare.md` / `panel-schema.md` / `run-metrics.md` / `suggest-config.md` jump to the per-class anchor (not the page top).

Refs #270