### PR TITLE
refactor(metrics): module docstring Notes + __matrix_rows__ dunder (#270)

### DIFF
--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -1,4 +1,4 @@
-"""Shared parser for ``Matrix-row:`` tags in ``factrix/metrics/*.py``.
+"""Shared parser for ``__matrix_rows__`` tuples in ``factrix/metrics/*.py``.
 
 Single source of truth for "which standalone metrics live in which
 cell." Consumed by:
@@ -7,10 +7,10 @@ cell." Consumed by:
   matrix in ``docs/reference/_generated_metric_matrix.md``.
 - ``factrix.list_metrics`` — runtime API exposing the same data.
 
-Each metric module's docstring carries one or more ``Matrix-row:``
-lines with the format::
+Each metric module declares a module-level ``__matrix_rows__`` tuple
+of strings, one entry per row, each with the format::
 
-    Matrix-row: {public_functions} | {cell_scope} | {agg_order} | {inference_se} | {primitives}
+    {public_functions} | {cell_scope} | {agg_order} | {inference_se} | {primitives}
 
 ``public_functions`` is a comma-separated list. ``cell_scope`` is
 either a 4-tuple ``(scope, signal, metric, mode)`` (``*`` denotes
@@ -22,7 +22,7 @@ Continuous pipeline.
 
 Stage-1 aggregation helpers that produce intermediate panels / series
 (rather than a ``MetricOutput``) are filtered out by ``user_facing``
-rows — they are listed in ``Matrix-row:`` for primitive-graph
+rows — they are listed in ``__matrix_rows__`` for primitive-graph
 completeness but are not metrics a user would call directly. The
 exclusion set is explicit (not a ``compute_*`` prefix rule) because
 ``compute_rolling_mean_beta`` is a genuine user-facing metric.
@@ -42,7 +42,6 @@ from factrix._axis import FactorScope, Metric, Mode, Signal
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 _METRICS_DIR = _REPO_ROOT / "factrix" / "metrics"
 
-_MATRIX_ROW_RE = re.compile(r"^\s*Matrix-row:\s*(.+)$", re.MULTILINE)
 _TUPLE_RE = re.compile(r"^\((.*)\)$")
 
 _SPANNING_CELL_LABEL = "factor-return-series consumer (post-PANEL pipeline)"
@@ -276,12 +275,41 @@ def _public_metric_modules() -> list[pathlib.Path]:
 
 
 def _extract_matrix_rows(path: pathlib.Path) -> list[str]:
+    """Return the module-level ``__matrix_rows__`` literal as a list of strings.
+
+    Parses the source via AST and looks for an ``Assign`` node binding the
+    name ``__matrix_rows__`` to a tuple or list of string constants. Returns
+    an empty list when the dunder is absent — the registered metric modules
+    are enumerated by directory scan, so a missing dunder simply means that
+    module contributes no rows (a coverage test in ``tests/test_docs_matrix.py``
+    enforces presence on every public ``factrix/metrics/*.py``).
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except SyntaxError:
         return []
-    doc = ast.get_docstring(tree) or ""
-    return [m.group(1).strip() for m in _MATRIX_ROW_RE.finditer(doc)]
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (
+            len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "__matrix_rows__"
+        ):
+            continue
+        if not isinstance(node.value, (ast.Tuple, ast.List)):
+            raise ValueError(
+                f"{path.name}: __matrix_rows__ must be a tuple or list literal"
+            )
+        rows: list[str] = []
+        for elt in node.value.elts:
+            if not (isinstance(elt, ast.Constant) and isinstance(elt.value, str)):
+                raise ValueError(
+                    f"{path.name}: __matrix_rows__ entries must be string literals"
+                )
+            rows.append(elt.value.strip())
+        return rows
+    return []
 
 
 def _parse_module_entries(path: pathlib.Path) -> list[_MatrixEntry]:

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -1,8 +1,10 @@
 r"""CAAR (Cumulative Average Abnormal Return) significance tests.
 
-Aggregation: per-event-date weighted abnormal return (per-event-date
-step) then non-overlapping cross-event sample; $t$-test on CAAR, or BMP
-standardized AR $z$-test for event-induced variance.
+Notes:
+    **Pipeline.** Per-event-date weighted abnormal return
+    (per-event-date step) then non-overlapping cross-event sample;
+    $t$-test on CAAR, or BMP standardized AR $z$-test for event-induced
+    variance.
 
 Tests $H_0$: event abnormal return = 0, using two complementary methods:
     compute_caar — per-event-date weighted abnormal return series
@@ -13,8 +15,6 @@ References:
     MacKinlay (1997), "Event Studies in Economics and Finance"
     Boehmer, Musumeci & Poulsen (1991), "Event-study methodology
         under conditions of event-induced variance"
-
-Matrix-row: compute_caar, caar, bmp_test | (*, SPARSE, *, PANEL) | per-event | non-overlapping t / z | _calc_t_stat, _p_value_from_t, _p_value_from_z, _significance_marker, _sample_non_overlapping, _short_circuit_output
 """
 
 from __future__ import annotations
@@ -23,6 +23,10 @@ import warnings
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_caar, caar, bmp_test | (*, SPARSE, *, PANEL) | per-event | non-overlapping t / z | _calc_t_stat, _p_value_from_t, _p_value_from_z, _significance_marker, _sample_non_overlapping, _short_circuit_output",
+)
 
 from factrix._codes import WarningCode
 from factrix._stats import (

--- a/factrix/metrics/clustering.py
+++ b/factrix/metrics/clustering.py
@@ -1,8 +1,9 @@
 """Event clustering diagnostic for event signals.
 
-Aggregation: static cross-section — single HHI computed once over the
-event-date histogram; no time-axis aggregation, no formal H₀
-(descriptive concentration index).
+Notes:
+    **Pipeline.** Static cross-section — single HHI computed once over
+    the event-date histogram; no time-axis aggregation, no formal H₀
+    (descriptive concentration index).
 
 When events cluster on the same dates, the independence assumption
 underlying the CAAR t-test is violated, potentially inflating the
@@ -11,14 +12,16 @@ quantifies this concentration.
 
 Only meaningful for multi-asset panels (N > 1). For single-asset
 event studies, clustering across assets is not applicable.
-
-Matrix-row: clustering_diagnostic | (*, SPARSE, *, PANEL) | static-cs | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "clustering_diagnostic | (*, SPARSE, *, PANEL) | static-cs | no formal H₀ | _short_circuit_output",
+)
 
 from factrix._types import MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -1,16 +1,15 @@
 """Top-bucket concentration analysis for cross-sectional panels.
 
-Aggregation: per-date HHI inverse on top-bucket weights (cross-section
-step) → per-date ratio series, then non-overlapping sample;
-across-time t against ``H₀: ratio ≥ 0.5``.
+Notes:
+    **Pipeline.** Per-date HHI inverse on top-bucket weights
+    (cross-section step) → per-date ratio series, then non-overlapping
+    sample; across-time t against ``H₀: ratio ≥ 0.5``.
+
+    **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
 
 Measures whether top-bucket (long-leg) alpha is concentrated in a few
 stocks or broadly distributed, using HHI (Herfindahl-Hirschman Index)
 inverse.
-
-Input: DataFrame with ``date, asset_id, factor, forward_return``.
-
-Matrix-row: top_concentration | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _compute_tie_ratio
 """
 
 from __future__ import annotations
@@ -19,6 +18,10 @@ import warnings
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "top_concentration | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _compute_tie_ratio",
+)
 
 from factrix._codes import WarningCode
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -1,8 +1,9 @@
 """Corrado (1989) nonparametric rank test for event signals.
 
-Aggregation: per-asset full-sample ranks of abnormal returns
-(time-series step), then aggregate event-period ranks across events;
-nonparametric rank test on standardized rank deviation.
+Notes:
+    **Pipeline.** Per-asset full-sample ranks of abnormal returns
+    (time-series step), then aggregate event-period ranks across
+    events; nonparametric rank test on standardized rank deviation.
 
 A non-parametric alternative to the CAAR t-test. Ranks abnormal returns
 across the full sample (event + non-event periods) for each asset, then
@@ -18,14 +19,16 @@ Standalone metric — not in the default profile. Available via:
 References:
     Corrado (1989), "A nonparametric test for abnormal security-price
         performance in event studies"
-
-Matrix-row: corrado_rank_test | (*, SPARSE, *, PANEL) | per-event | nonparametric rank | _calc_t_stat, _p_value_from_z, _significance_marker, _short_circuit_output
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "corrado_rank_test | (*, SPARSE, *, PANEL) | per-event | nonparametric rank | _calc_t_stat, _p_value_from_z, _significance_marker, _short_circuit_output",
+)
 
 from factrix._stats import _calc_t_stat, _p_value_from_z, _significance_marker
 from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -1,7 +1,9 @@
 """Multi-horizon event analysis — how does the signal behave across time?
 
-Aggregation: per-event return profile across `k` offsets (per-event
-step); descriptive curve plus binomial test on per-horizon hit rate.
+Notes:
+    **Pipeline.** Per-event return profile across `k` offsets
+    (per-event step); descriptive curve plus binomial test on
+    per-horizon hit rate.
 
 Answers:
     - Is there pre-event leakage? (T-6..T-1 should be ~0)
@@ -11,14 +13,16 @@ Answers:
 Metrics:
     compute_event_returns — per-event, per-offset raw return data
     event_around_return   — return profile summary at each offset
-
-Matrix-row: compute_event_returns, event_around_return | (*, SPARSE, *, PANEL) | per-event | binomial | _short_circuit_output
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_event_returns, event_around_return | (*, SPARSE, *, PANEL) | per-event | binomial | _short_circuit_output",
+)
 
 from factrix._types import EPSILON, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -1,8 +1,10 @@
 """Per-event quality descriptive statistics for event signals.
 
-Aggregation: per-event scalar (hit / IC / skew / density) computed
-on `signed_car`, then cross-event aggregation; binomial inference for
-hit rate, nonparametric for IC / skewness, descriptive elsewhere.
+Notes:
+    **Pipeline.** Per-event scalar (hit / IC / skew / density) computed
+    on `signed_car`, then cross-event aggregation; binomial inference
+    for hit rate, nonparametric for IC / skewness, descriptive
+    elsewhere.
 
 All metrics operate on the ``signed_car`` (return x sign(factor)) of
 individual events. They describe the quality and shape of per-event
@@ -15,14 +17,16 @@ Metrics:
     signal_density — average time gap between events
     profit_factor  — sum(gains) / sum(losses)
     event_skewness — skewness of signed_car distribution
-
-Matrix-row: event_hit_rate, event_ic, profit_factor, event_skewness, signal_density | (*, SPARSE, *, PANEL) | per-event | binomial / nonparametric rank | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _signed_car
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "event_hit_rate, event_ic, profit_factor, event_skewness, signal_density | (*, SPARSE, *, PANEL) | per-event | binomial / nonparametric rank | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _signed_car",
+)
 
 from factrix._stats import (
     _BINOMIAL_EXACT_CUTOFF,

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -1,9 +1,10 @@
 r"""Fama-MacBeth regression — FM-canonical metric for the
 ``Individual × Continuous`` cell.
 
-Aggregation: per-date cross-sectional OLS slope $\lambda$
-(cross-section step) → time series of $\lambda$, then NW HAC $t$ on
-its mean; pooled OLS variant clusters SE by date.
+Notes:
+    **Pipeline.** Per-date cross-sectional OLS slope $\lambda$
+    (cross-section step) → time series of $\lambda$, then NW HAC $t$
+    on its mean; pooled OLS variant clusters SE by date.
 
 ``compute_fm_betas``: per-date cross-sectional OLS → (date, beta) DataFrame.
 ``fama_macbeth``: Newey-West t-test on the beta series.
@@ -14,8 +15,6 @@ References:
     Fama & MacBeth (1973), "Risk, Return, and Equilibrium."
     Newey & West (1987), "HAC Covariance Matrix."
     Petersen (2009), "Estimating Standard Errors in Finance Panel Data Sets."
-
-Matrix-row: compute_fm_betas, fama_macbeth, pooled_ols, beta_sign_consistency | (INDIVIDUAL, CONTINUOUS, FM, PANEL) | cs-first | NW HAC / clustered t | _newey_west_t_test, _p_value_from_t, _significance_marker, _short_circuit_output
 """
 
 from __future__ import annotations
@@ -25,6 +24,10 @@ import warnings
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_fm_betas, fama_macbeth, pooled_ols, beta_sign_consistency | (INDIVIDUAL, CONTINUOUS, FM, PANEL) | cs-first | NW HAC / clustered t | _newey_west_t_test, _p_value_from_t, _significance_marker, _short_circuit_output",
+)
 
 from factrix._codes import WarningCode
 from factrix._stats import (

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -1,19 +1,23 @@
 """Hit rate computation for any time-indexed series.
 
-Aggregation: time-series only, sampled non-overlapping on a 1-D
-series; binomial test against `p = 0.5`.
+Notes:
+    **Pipeline.** Time-series only, sampled non-overlapping on a 1-D
+    series; binomial test against `p = 0.5`.
 
-Input: DataFrame with ``date, value`` or a 1-D array.
-Output: proportion of periods where the value satisfies a condition
-(default: value > 0).
+    **Input.** DataFrame with ``date, value`` or a 1-D array.
 
-Matrix-row: hit_rate | (*, CONTINUOUS, *, TIMESERIES) | ts-only | binomial | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _sample_non_overlapping
+    **Output.** Proportion of periods where the value satisfies a
+    condition (default: value > 0).
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "hit_rate | (*, CONTINUOUS, *, TIMESERIES) | ts-only | binomial | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _sample_non_overlapping",
+)
 
 from factrix._stats import (
     _BINOMIAL_EXACT_CUTOFF,

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -1,14 +1,14 @@
 """IC (Information Coefficient) computation for cross-sectional panels.
 
-Aggregation: per-date Spearman rank IC (cross-section step) → IC time
-series, then non-overlapping cross-asset t or NW HAC t on its mean;
-the regime variant slices the same pipeline.
+Notes:
+    **Pipeline.** Per-date Spearman rank IC (cross-section step) → IC
+    time series, then non-overlapping cross-asset t or NW HAC t on its
+    mean; the regime variant slices the same pipeline.
 
-Input: DataFrame with ``date, asset_id, factor, forward_return``.
-Output: time-indexed IC series (``date, ic``) that can be fed into
-any ``series/`` tool (oos, trend, significance, hit_rate).
+    **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
 
-Matrix-row: compute_ic, ic, ic_newey_west, ic_ir | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output
+    **Output.** Time-indexed IC series (``date, ic``) that can be fed
+    into any ``series/`` tool (oos, trend, significance, hit_rate).
 """
 
 from __future__ import annotations
@@ -17,6 +17,10 @@ import math
 import warnings as _warnings
 
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_ic, ic, ic_newey_west, ic_ir | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output",
+)
 
 from factrix._stats import (
     _calc_t_stat,

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -1,8 +1,9 @@
 """MFE/MAE — per-event price path excursion analysis.
 
-Aggregation: per-event MFE / MAE excursion over a fixed window
-(per-event step), then cross-event quantile / ratio summary;
-descriptive (no formal H₀).
+Notes:
+    **Pipeline.** Per-event MFE / MAE excursion over a fixed window
+    (per-event step), then cross-event quantile / ratio summary;
+    descriptive (no formal H₀).
 
 Answers: "what does the price path look like after events?"
 
@@ -14,14 +15,16 @@ DataFrame and ``mfe_mae_summary`` returns a short-circuit ``MetricOutput``
 Metrics:
     compute_mfe_mae   — per-event MFE/MAE/Bars_to_MFE/Bars_to_MAE
     mfe_mae_summary   — aggregate summary (p50, p75, ratio)
-
-Matrix-row: compute_mfe_mae, mfe_mae_summary | (*, SPARSE, *, PANEL) | per-event | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_mfe_mae, mfe_mae_summary | (*, SPARSE, *, PANEL) | per-event | no formal H₀ | _short_circuit_output",
+)
 
 from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -1,22 +1,25 @@
 """Monotonicity test for cross-sectional panels.
 
-Aggregation: per-date Spearman corr between quantile index and group
-mean return (cross-section step), then non-overlapping cross-asset t
-on the per-date series.
+Notes:
+    **Pipeline.** Per-date Spearman corr between quantile index and
+    group mean return (cross-section step), then non-overlapping
+    cross-asset t on the per-date series.
+
+    **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
 
 Measures whether factor quantile groups exhibit monotonic return ordering.
 Per-date: split into n_groups by factor rank, compute mean return per group,
 Spearman corr between group index and return.
-
-Input: DataFrame with ``date, asset_id, factor, forward_return``.
-
-Matrix-row: monotonicity | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "monotonicity | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio",
+)
 
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -1,16 +1,17 @@
 """Out-of-sample (OOS) persistence analysis for any time-indexed series.
 
-Aggregation: time-series only, IS/OOS window split on a 1-D series;
-descriptive decay diagnostic (no formal H₀).
+Notes:
+    **Pipeline.** Time-series only, IS/OOS window split on a 1-D
+    series; descriptive decay diagnostic (no formal H₀).
 
-Input: DataFrame with ``date, value`` (IC series, CAAR series, spread series).
-Output: MetricOutput with ``value`` = median survival ratio + sign-flip / status
-detail in ``metadata``.
+    **Input.** DataFrame with ``date, value`` (IC series, CAAR series,
+    spread series).
+
+    **Output.** MetricOutput with ``value`` = median survival ratio +
+    sign-flip / status detail in ``metadata``.
 
 This tool is agnostic to what the series represents — it only knows
 about IS/OOS splits on a time-indexed numeric sequence.
-
-Matrix-row: multi_split_oos_decay | (*, CONTINUOUS, *, TIMESERIES) | ts-only | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations
@@ -20,6 +21,10 @@ from typing import Literal
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "multi_split_oos_decay | (*, CONTINUOUS, *, TIMESERIES) | ts-only | no formal H₀ | _short_circuit_output",
+)
 
 from factrix._types import EPSILON, MIN_OOS_PERIODS, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -1,15 +1,15 @@
 """Quantile analysis for cross-sectional panels.
 
-Aggregation: per-date long-short spread on quantile groups
-(cross-section step), then non-overlapping t on the spread series.
+Notes:
+    **Pipeline.** Per-date long-short spread on quantile groups
+    (cross-section step), then non-overlapping t on the spread series.
 
-Input: DataFrame with ``date, asset_id, factor, forward_return``.
-Output: spread series, long/short alpha decomposition.
+    **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
+
+    **Output.** Spread series, long/short alpha decomposition.
 
 All spread series are time-indexed (``date, value``) and can be fed
 into any ``series/`` tool.
-
-Matrix-row: compute_spread_series, quantile_spread, quantile_spread_vw, compute_group_returns | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio, _lag_within_asset
 """
 
 from __future__ import annotations
@@ -18,6 +18,10 @@ import warnings
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_spread_series, quantile_spread, quantile_spread_vw, compute_group_returns | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio, _lag_within_asset",
+)
 
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -1,8 +1,10 @@
 """Spanning regression — single-factor test and multi-factor selection.
 
-Aggregation: regression of factor return time-series on base-factor
-returns (time-series step); NW HAC t on alpha. The greedy stepwise
-selection variant inflates t-stats and is not for inference.
+Notes:
+    **Pipeline.** Regression of factor return time-series on
+    base-factor returns (time-series step); NW HAC t on alpha. The
+    greedy stepwise selection variant inflates t-stats and is not for
+    inference.
 
 ``spanning_alpha``: does a single factor have alpha after controlling for
 base factors? Standard factor research tool (Barillas & Shanken 2017).
@@ -15,14 +17,16 @@ Both use factor return time series (quantile spread series), not IC.
 References:
     Barillas & Shanken (2017), "Which Alpha?"
     Feng, Giglio & Xiu (2020), "Taming the Factor Zoo."
-
-Matrix-row: spanning_alpha, greedy_forward_selection | factor-return-series consumer (post-PANEL pipeline) | ts-only | NW HAC / OLS t | _p_value_from_t, _significance_marker, _short_circuit_output, _ols_alpha
 """
 
 from __future__ import annotations
 
 import logging
 import warnings
+
+__matrix_rows__ = (
+    "spanning_alpha, greedy_forward_selection | factor-return-series consumer (post-PANEL pipeline) | ts-only | NW HAC / OLS t | _p_value_from_t, _significance_marker, _short_circuit_output, _ols_alpha",
+)
 from dataclasses import dataclass, field
 
 import numpy as np

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -21,12 +21,12 @@ References:
 
 from __future__ import annotations
 
-import logging
-import warnings
-
 __matrix_rows__ = (
     "spanning_alpha, greedy_forward_selection | factor-return-series consumer (post-PANEL pipeline) | ts-only | NW HAC / OLS t | _p_value_from_t, _significance_marker, _short_circuit_output, _ols_alpha",
 )
+
+import logging
+import warnings
 from dataclasses import dataclass, field
 
 import numpy as np

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -1,8 +1,9 @@
 """Tradability metrics: Turnover, Breakeven Cost, Net Spread.
 
-Aggregation: per-date turnover / cost diagnostics on quantile-group
-membership (cross-section step), then time-series mean; descriptive
-(no formal H₀).
+Notes:
+    **Pipeline.** Per-date turnover / cost diagnostics on
+    quantile-group membership (cross-section step), then time-series
+    mean; descriptive (no formal H₀).
 
 Two flavours of turnover co-exist here, measuring different things:
 
@@ -20,15 +21,17 @@ measures — they belong in Profile, not in Gates.
 
 Input for Turnover: DataFrame with ``date, asset_id, factor``.
 Input for Breakeven/Net Spread: pre-computed spread and turnover values.
-
-Matrix-row: notional_turnover, breakeven_cost, net_spread | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | no formal H₀ | _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups
-Matrix-row: turnover | (INDIVIDUAL, CONTINUOUS, *, PANEL) | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ | _short_circuit_output
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "notional_turnover, breakeven_cost, net_spread | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | no formal H₀ | _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups",
+    "turnover | (INDIVIDUAL, CONTINUOUS, *, PANEL) | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ | _short_circuit_output",
+)
 
 from factrix._types import DDOF, EPSILON, MetricOutput
 from factrix.metrics._helpers import (

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -1,15 +1,15 @@
 """IC trend analysis using Theil-Sen estimator.
 
-Aggregation: time-series only, Theil-Sen median pairwise slope on a
-1-D series; CI from the rank-based pairwise slope distribution.
+Notes:
+    **Pipeline.** Time-series only, Theil-Sen median pairwise slope on
+    a 1-D series; CI from the rank-based pairwise slope distribution.
 
-Input: DataFrame with ``date, value`` (typically an IC series).
-Output: slope + confidence interval for trend detection.
+    **Input.** DataFrame with ``date, value`` (typically an IC series).
+
+    **Output.** Slope + confidence interval for trend detection.
 
 Theil-Sen is preferred over OLS because it has a breakdown point of 29.3%,
 making it robust to outliers (e.g. COVID-era IC spikes).
-
-Matrix-row: ic_trend | (*, CONTINUOUS, *, TIMESERIES) | ts-only | Theil-Sen rank-based CI | _significance_marker, _short_circuit_output, _adf, _p_value_from_t
 """
 
 from __future__ import annotations
@@ -17,6 +17,10 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
+
+__matrix_rows__ = (
+    "ic_trend | (*, CONTINUOUS, *, TIMESERIES) | ts-only | Theil-Sen rank-based CI | _significance_marker, _short_circuit_output, _adf, _p_value_from_t",
+)
 
 from factrix._stats import _adf, _p_value_from_t, _significance_marker
 from factrix._types import MetricOutput

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -1,9 +1,10 @@
 """Long-side / short-side asymmetry test (issue #5).
 
-Aggregation: per-date aggregation of factor and forward return to a
-common ``(_f, _r)`` series (cross-section step), then NW HAC OLS with
-sign-asymmetric slopes on the resulting time series; Wald χ² on the
-slope difference.
+Notes:
+    **Pipeline.** Per-date aggregation of factor and forward return to
+    a common ``(_f, _r)`` series (cross-section step), then NW HAC OLS
+    with sign-asymmetric slopes on the resulting time series; Wald χ²
+    on the slope difference.
 
 Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
 cells. OLS β reports a single slope and assumes the response is
@@ -31,14 +32,16 @@ Gates (issue #5):
   and `metadata["method_b_skipped"]` records the reason.
 
 Standalone metric — does not enter the registry.
-
-Matrix-row: ts_asymmetry | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "ts_asymmetry | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear",
+)
 
 from factrix._stats import (
     _ols_nw_multivariate,

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -1,8 +1,9 @@
 """Time-series beta metrics for macro common factors.
 
-Aggregation: per-asset full-sample OLS β (time-series step), then
-cross-asset t on the β distribution; rolling-window variant slices
-the time axis before the per-asset step.
+Notes:
+    **Pipeline.** Per-asset full-sample OLS β (time-series step), then
+    cross-asset t on the β distribution; rolling-window variant slices
+    the time axis before the per-asset step.
 
 macro_common factors (VIX, gold, USD index) are a single time series
 shared across all assets. Per-asset time-series regression measures
@@ -12,14 +13,16 @@ each asset's sensitivity (β) to the common factor.
 ``ts_beta``: cross-sectional test on the β distribution.
 ``mean_r_squared``: average explanatory power across assets.
 ``compute_rolling_mean_beta``: rolling window mean β for stability analysis.
-
-Matrix-row: compute_ts_betas, ts_beta, mean_r_squared, compute_rolling_mean_beta, ts_beta_sign_consistency, ts_beta_single_asset_fallback | (COMMON, CONTINUOUS, *, PANEL) | ts-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _short_circuit_output
 """
 
 from __future__ import annotations
 
 import numpy as np
 import polars as pl
+
+__matrix_rows__ = (
+    "compute_ts_betas, ts_beta, mean_r_squared, compute_rolling_mean_beta, ts_beta_sign_consistency, ts_beta_single_asset_fallback | (COMMON, CONTINUOUS, *, PANEL) | ts-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _short_circuit_output",
+)
 
 from factrix._stats import (
     _calc_t_stat,

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -1,8 +1,9 @@
 """Time-series quantile bucketing + monotonicity test (issue #5).
 
-Aggregation: per-date aggregation to a common ``(_f, _r)`` series
-(cross-section step), then quantile-bucketed NW HAC OLS on that time
-series; Wald χ² on the top-bottom bucket spread.
+Notes:
+    **Pipeline.** Per-date aggregation to a common ``(_f, _r)`` series
+    (cross-section step), then quantile-bucketed NW HAC OLS on that
+    time series; Wald χ² on the top-bottom bucket spread.
 
 Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
 cells: bucket factor history into quantiles and check the conditional
@@ -14,8 +15,6 @@ Standalone metric — does not enter the registry. See
 `ARCHITECTURE.md` §"Registry procedure vs standalone metric" for the
 distinction. SPARSE / binary signals are out of scope; the input gate
 redirects to `event_quality` helpers.
-
-Matrix-row: ts_quantile_spread | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear
 """
 
 from __future__ import annotations
@@ -25,6 +24,10 @@ import warnings
 import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
+
+__matrix_rows__ = (
+    "ts_quantile_spread | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear",
+)
 
 from factrix._stats import (
     _ols_nw_multivariate,

--- a/tests/test_docs_matrix.py
+++ b/tests/test_docs_matrix.py
@@ -1,9 +1,9 @@
-"""Coverage test: Matrix-row: tags in factrix/metrics/ docstrings.
+"""Coverage test: ``__matrix_rows__`` tuples in ``factrix/metrics/`` modules.
 
 Validates that:
-1. Every public metric module (non-underscore *.py) has at least one
-   ``Matrix-row:`` tag in its module-level docstring.
-2. Every ``Matrix-row:`` tag has exactly 5 pipe-separated fields
+1. Every public metric module (non-underscore *.py) declares a non-empty
+   module-level ``__matrix_rows__`` tuple of strings.
+2. Every ``__matrix_rows__`` entry has exactly 5 pipe-separated fields
    (public_functions | cell_scope | aggregation_order | inference_se | primitives).
 3. ``docs/reference/_generated_metric_matrix.md`` exists and is non-empty
    (only meaningful after a build; skipped if the file is absent).
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import ast
 import pathlib
-import re
 
 import pytest
 
@@ -26,8 +25,6 @@ GENERATED_EVALUATE_METRIC = pathlib.Path(
     "docs/reference/_generated_evaluate_metric_table.md"
 )
 
-_MATRIX_ROW_RE = re.compile(r"^\s*Matrix-row:\s*(.+)$", re.MULTILINE)
-
 
 def _public_metric_modules() -> set[str]:
     """Return stem names of all public metric modules."""
@@ -35,14 +32,10 @@ def _public_metric_modules() -> set[str]:
 
 
 def _matrix_rows_for(stem: str) -> list[str]:
-    """Return list of raw Matrix-row values found in the module's docstring."""
-    path = METRICS_DIR / f"{stem}.py"
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return []
-    doc = ast.get_docstring(tree) or ""
-    return [m.group(1).strip() for m in _MATRIX_ROW_RE.finditer(doc)]
+    """Return entries of the module-level ``__matrix_rows__`` tuple."""
+    from factrix._metric_index import _extract_matrix_rows
+
+    return _extract_matrix_rows(METRICS_DIR / f"{stem}.py")
 
 
 # ---------------------------------------------------------------------------
@@ -52,22 +45,22 @@ def _matrix_rows_for(stem: str) -> list[str]:
 
 @pytest.mark.parametrize("stem", sorted(_public_metric_modules()))
 def test_module_has_matrix_row_tag(stem: str) -> None:
-    """Every public metric module must have at least one Matrix-row: tag."""
+    """Every public metric module must declare ``__matrix_rows__``."""
     rows = _matrix_rows_for(stem)
     assert rows, (
-        f"metrics/{stem}.py has no 'Matrix-row:' tag in its module docstring. "
-        "Add a Matrix-row: line so the build-time generator can include it."
+        f"metrics/{stem}.py has no '__matrix_rows__' tuple at module scope. "
+        "Add one so the build-time generator can include it."
     )
 
 
 @pytest.mark.parametrize("stem", sorted(_public_metric_modules()))
 def test_matrix_row_has_five_fields(stem: str) -> None:
-    """Every Matrix-row: tag must have exactly 5 pipe-separated fields."""
+    """Every ``__matrix_rows__`` entry must have exactly 5 pipe-separated fields."""
     for row in _matrix_rows_for(stem):
         fields = [f.strip() for f in row.split("|")]
         assert len(fields) == 5, (
-            f"metrics/{stem}.py: Matrix-row has {len(fields)} pipe-separated"
-            f" fields (expected 5): {row!r}"
+            f"metrics/{stem}.py: __matrix_rows__ entry has {len(fields)}"
+            f" pipe-separated fields (expected 5): {row!r}"
         )
 
 


### PR DESCRIPTION
## Summary

- Convert the 19 metric module docstrings under `factrix/metrics/*.py` from the project-local `Aggregation:` / `Input:` / `Output:` pseudo-fields to a Google-style `Notes:` block with bold sub-headings (`**Pipeline.**` / `**Input.**` / `**Output.**`) so mkdocstrings renders a proper section with visual hierarchy instead of flat prose.
- Move the internal architecture metadata `Matrix-row:` out of the docstring into a module-level `__matrix_rows__: tuple[str, ...]` dunder so it no longer renders into user-facing autodoc; update `factrix/_metric_index.py::_extract_matrix_rows` to read the dunder via `ast` body scan (replacing the prior `ast.get_docstring + regex` path).
- Update `tests/test_docs_matrix.py` to delegate row extraction to `_extract_matrix_rows` (single source of truth).

Resolves item (3) of three follow-ups bundled in #270. With (1) (#276) and (2) (`b4ad95b`) already on `main`, this closes the issue.

## Test plan

- [x] `pytest tests/test_docs_matrix.py` passes (42 tests including the 24 parametric drift / field-count guards).
- [x] `mkdocs build --strict` passes with no warnings.
- [x] `_generated_metric_matrix.md` and `_generated_metric_name_index.md` byte-identical to pre-restructure output (verified locally with `diff -q` against baseline).
- [x] Render check on the deployed preview: any metric module page (e.g. `docs/api/metrics/ic.md`) shows a `Notes` section with bold Pipeline / Input / Output paragraphs; `__matrix_rows__` is not visible (mkdocstrings filters dunders).

Closes #270