### PR TITLE
docs(api): drop Verb header from comparison tables

### DIFF
--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -15,7 +15,7 @@ fx.compare(profiles, sort_by="primary_p")
 
 ## When to reach for `compare`
 
-| Use case | Verb | Notes |
+| Use case | Function | Notes |
 |---|---|---|
 | Rank N `evaluate` results | `compare(list[FactorProfile])` | Identity + context + `primary_stat` / `primary_stat_name` / `primary_p` |
 | Rank N `run_metrics` results | `compare(list[MetricsBundle])` | Identity + context + one column per standalone metric (`MetricOutput.value`) |

--- a/docs/api/metrics/monotonicity.md
+++ b/docs/api/metrics/monotonicity.md
@@ -42,7 +42,7 @@ title: factrix.metrics.monotonicity
 
 !!! info "Per-bucket cardinality floor"
     `min_assets_per_group = 50` (Patton-Timmermann 2010) — the slice-
-    test verb downscales `n_groups` automatically so each bucket meets
+    test function downscales `n_groups` automatically so each bucket meets
     the floor; below it, per-date bucket means are noise-dominated and
     the rank statistic is unreliable. Defaults: `n_groups=10` for
     universes around 2000 stocks; drop to 5 for $n_{assets} < 1000$

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -31,7 +31,7 @@ Both functions accept `expand_over=`, but the **survivor unit** and the
 **question answered** differ. This is the single most common source of
 confusion; pick the row that matches your claim.
 
-| Verb | Survivor unit | Question | Example claim |
+| Function | Survivor unit | Question | Example claim |
 |---|---|---|---|
 | `bhy(profiles, expand_over=["universe_id"])` | `(factor, universe)` pair | "Where is this factor significant?" | "Momentum is significant in `large_cap`; value is significant in `small_cap`" |
 | `partial_conjunction(profiles, min_pass=2, expand_over=["universe_id"])` | `factor` identity | "Which factors are significant across all conditions?" | "Momentum is significant across both universes" |

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -8,7 +8,7 @@ means differ.
 
 The two functions answer **different statistical questions**:
 
-| Verb | Question | Output shape |
+| Function | Question | Output shape |
 |---|---|---|
 | `slice_pairwise_test` | "Which pairs differ?" — K(K−1)/2 contrasts with family-internal multiple-testing correction | One row per pair: `(slice_a, slice_b, n_obs, stat, p_raw, p_adj)` |
 | `slice_joint_test` | "Do any slices differ at all?" — single omnibus Wald χ² | One row: `(n_obs, k_slices, df, stat, p)` |


### PR DESCRIPTION
## Summary

- Sweep axis 8 of #280: drop issue-discussion "Verb" terminology from user-facing comparison tables.
- `partial-conjunction.md` / `compare.md` / `slice-test.md`: table header `Verb` → `Function`.
- `metrics/monotonicity.md`: "slice-test verb" prose → "slice-test function".
- `bhy.md` already clean (audit was stale); `contributing.md` terminology block and `errors.md` `verb` attribute name intentionally retained.

## Test plan

- [x] `mkdocs build --strict` (pre-push hook)
- [x] `grep -rwn Verb docs/` returns no hits

Closes #286