### PR TITLE
docs(api): promote bare error-class mentions to xrefs

### DIFF
--- a/docs/api/analysis-config.md
+++ b/docs/api/analysis-config.md
@@ -183,7 +183,7 @@ than failing silently later.
     ---
 
     Recommend the nearest legal config from panel shape; the recovery
-    path for `MissingConfigError` from `evaluate`.
+    path for [`MissingConfigError`][factrix.MissingConfigError] from `evaluate`.
 
     [api/suggest-config →](suggest-config.md)
 

--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -96,11 +96,11 @@ Per-survivor group label: `profile.context[group]`.
 
 | Trigger | Outcome |
 |---|---|
-| `group` shadows an identity field (`factor_id` / `forward_periods`) | `UserInputError`. |
-| `group` key missing from a profile's `context` | `UserInputError`. |
-| Only one distinct group value across input | `UserInputError` — points at [`bhy`](multi-factor.md). |
-| Every profile is its own group at $n \ge 3$ (group axis near-unique) | `UserInputError` — pick a coarser categorical. |
-| Duplicate `(identity, group_value)` partition key | `UserInputError`. |
+| `group` shadows an identity field (`factor_id` / `forward_periods`) | [`UserInputError`][factrix.UserInputError]. |
+| `group` key missing from a profile's `context` | [`UserInputError`][factrix.UserInputError]. |
+| Only one distinct group value across input | [`UserInputError`][factrix.UserInputError] — points at [`bhy`](multi-factor.md). |
+| Every profile is its own group at $n \ge 3$ (group axis near-unique) | [`UserInputError`][factrix.UserInputError] — pick a coarser categorical. |
+| Duplicate `(identity, group_value)` partition key | [`UserInputError`][factrix.UserInputError]. |
 | More than half of input groups contain a single profile | `RuntimeWarning` — inner BHY on $n=1$ is a raw cutoff. |
 
 ## Caveats

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -213,7 +213,7 @@ for s in survivors.profiles:
 | `bhy(profiles, threshold=0.05)` | `bhy(profiles, q=0.05)` (`threshold=` removed in v0.12.0; raises `TypeError`) |
 | `bhy(profiles, gate=StatCode.X)` | `bhy(profiles, p_stat=StatCode.X)` (`gate=` removed in v0.11.0) |
 | auto-partition by dispatch cell × horizon | caller declares the family; mixed `forward_periods` without `expand_over` emits `RuntimeWarning`. **Fix:** split the call per horizon, or pass `expand_over=[<context key>]` if profiles legitimately co-exist as one family across horizons. |
-| same `factor_id` across cells silently auto-split | raises `UserInputError` (duplicate identity). **Fix (canonical):** name each panel's factor column distinctly and pass `evaluate(..., factor_col=name)`. **Fix (escape hatch):** post-hoc stamp via `dataclasses.replace(profile, factor_id=...)`. **Or:** use `expand_over` if profiles really do share identity but belong in separate test buckets. |
+| same `factor_id` across cells silently auto-split | raises [`UserInputError`][factrix.UserInputError] (duplicate identity). **Fix (canonical):** name each panel's factor column distinctly and pass `evaluate(..., factor_col=name)`. **Fix (escape hatch):** post-hoc stamp via `dataclasses.replace(profile, factor_id=...)`. **Or:** use `expand_over` if profiles really do share identity but belong in separate test buckets. |
 
 ## Design rationale
 

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -114,7 +114,7 @@ panel_metrics = [
 
 ## Errors
 
-`IncompatibleAxisError` is raised when `(scope, signal)` matches no
+[`IncompatibleAxisError`][factrix.IncompatibleAxisError] is raised when `(scope, signal)` matches no
 registered metric. All four real combinations are populated, so this
 is defensive — surfaced for symmetry with the rest of the API.
 

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -120,13 +120,13 @@ container as `bhy`, populated with PC-specific metadata:
 
 | Trigger | Outcome |
 |---|---|
-| `min_pass < 2` | `UserInputError`. `min_pass == 1` additionally points at `bhy(expand_over=...)`. |
-| `expand_over` empty / `None` | `UserInputError` — the function is undefined without a condition axis. |
-| `expand_over` names an identity field (`factor_id` / `forward_periods`) | `UserInputError` (#160 anti-shopping defense — same as `bhy`). |
-| `n_conditions < min_pass` | `UserInputError` (unsatisfiable). |
-| Strict mode: identity's condition count $\neq$ `n_conditions` | `UserInputError` — surfaces missing-universe / missing-horizon data gaps. |
-| Identity with condition count $<$ `min_pass` (lenient) | `UserInputError`. |
-| Duplicate `(identity, expand_over_values)` partition key | `UserInputError` (family-resolution invariant). |
+| `min_pass < 2` | [`UserInputError`][factrix.UserInputError]. `min_pass == 1` additionally points at `bhy(expand_over=...)`. |
+| `expand_over` empty / `None` | [`UserInputError`][factrix.UserInputError] — the function is undefined without a condition axis. |
+| `expand_over` names an identity field (`factor_id` / `forward_periods`) | [`UserInputError`][factrix.UserInputError] (#160 anti-shopping defense — same as `bhy`). |
+| `n_conditions < min_pass` | [`UserInputError`][factrix.UserInputError] (unsatisfiable). |
+| Strict mode: identity's condition count $\neq$ `n_conditions` | [`UserInputError`][factrix.UserInputError] — surfaces missing-universe / missing-horizon data gaps. |
+| Identity with condition count $<$ `min_pass` (lenient) | [`UserInputError`][factrix.UserInputError]. |
+| Duplicate `(identity, expand_over_values)` partition key | [`UserInputError`][factrix.UserInputError] (family-resolution invariant). |
 
 ## References
 

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -223,5 +223,5 @@ procedures key `FactorProfile.stats` accordingly.
 
 Registry lookup helper used by `AnalysisConfig.from_dict` to
 rehydrate `cfg.estimator` / `cfg.moment_estimator` from their
-serialized name strings. Raises `UnknownEstimatorError` if `name`
+serialized name strings. Raises [`UnknownEstimatorError`][factrix.UnknownEstimatorError] if `name`
 is not registered; the error message lists every available estimator.

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -242,7 +242,7 @@ returns a meaningful-looking result. Three deterministic outcomes:
   `diagnose()` records the degradation.
 
 Structural errors (wrong cell, missing column, `N == 1` on a cell that
-requires `PANEL` Mode) raise `ValueError` / `ConfigError` rather than
+requires `PANEL` Mode) raise `ValueError` / [`ConfigError`][factrix.ConfigError] rather than
 falling back.
 
 ## Event-study contracts


### PR DESCRIPTION
## Summary

- Sweep axis 6 of #280 (expanded scope, see updated #284 body).
- Narrow DoD (flat `[X](errors.md)` form) was already satisfied by #276; this PR addresses the broader same-page-inconsistency residue: bare backtick mentions on pages whose other paragraphs already use `[X][factrix.X]`.
- Touched 7 files / 17 occurrences. Out of scope: `architecture.md` (design discussion), notebooks (#289), `errors.md` itself.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] No `[<ErrorName>](errors.md)` flat-link patterns remain
- [x] Two page-level `[Errors](errors.md)` refs (`panel-schema.md:98`, `decision-tree.md:137`) intentionally retained

Closes #284