### PR TITLE
refactor(evaluate): rename first param raw -> panel

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -32,7 +32,7 @@ All factrix-raised exceptions inherit from `FactrixError`, so a single
 ```
 FactrixError                       # base
 ├── ConfigError                    # AnalysisConfig validation / dispatch
-│   ├── MissingConfigError         # evaluate(raw) called without a config
+│   ├── MissingConfigError         # evaluate(panel) called without a config
 │   ├── IncompatibleAxisError      # (scope, signal, metric) is not a legal cell
 │   ├── ModeAxisError              # legal cell, no procedure at runtime mode
 │   └── InsufficientSampleError    # T below MIN_PERIODS_HARD on a TIMESERIES procedure
@@ -41,7 +41,7 @@ FactrixError                       # base
 
 | Exception | When you see it | What it carries |
 |---|---|---|
-| `MissingConfigError` | `evaluate(raw)` called without an `AnalysisConfig` | — (call `fx.suggest_config(raw)` to recover) |
+| `MissingConfigError` | `evaluate(panel)` called without an `AnalysisConfig` | — (call `fx.suggest_config(panel)` to recover) |
 | `IncompatibleAxisError` | `(scope, signal, metric)` is not a legal cell | optional `.suggested_fix` |
 | `ModeAxisError` | Legal cell has no procedure at the runtime `Mode` | typically `.suggested_fix: AnalysisConfig` |
 | `InsufficientSampleError` | `T` below the procedure floor | `.actual_periods`, `.required_periods` |
@@ -66,7 +66,7 @@ Use the table to skim; jump to the linked page for the why.
 
 | Exception / message | Trigger | Fix |
 |---|---|---|
-| `MissingConfigError: evaluate(raw) needs AnalysisConfig` | `evaluate(panel)` called with no `cfg` | `fx.suggest_config(panel)` returns a `SuggestConfigResult` with `.suggested` (an `AnalysisConfig`) and per-axis reasoning. See [`suggest_config`](suggest-config.md). |
+| `MissingConfigError: evaluate(panel) needs AnalysisConfig` | `evaluate(panel)` called with no `cfg` | `fx.suggest_config(panel)` returns a `SuggestConfigResult` with `.suggested` (an `AnalysisConfig`) and per-axis reasoning. See [`suggest_config`](suggest-config.md). |
 | `IncompatibleAxisError: (scope, signal, metric) is not a legal cell` | Combination like `(INDIVIDUAL, SPARSE, IC)` that the dispatch table never registers | Use one of the four factories (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`) — illegal combos are unreachable via factories. See [Concepts](../getting-started/concepts.md). |
 | `ModeAxisError: no procedure at runtime Mode=TIMESERIES` | Legal cell, but `N = panel["asset_id"].n_unique()` triggers a Mode the cell does not implement (typical case: `individual_continuous` at `N=1`) | Read `.suggested_fix` — it carries the nearest-legal `AnalysisConfig` for the actual `Mode`. See [Quickstart § N = 1](../getting-started/quickstart.md). |
 | `InsufficientSampleError: T below required` | `n_periods` below the procedure's `MIN_PERIODS_HARD` floor | Read `.actual_periods` and `.required_periods`. The fix is either more data, or — if the procedure is not the right one for short series — switching to a TIMESERIES-friendly cell. See [PANEL vs TIMESERIES](../guides/panel-timeseries.md). |

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -94,7 +94,7 @@ Schema-related failures and their fix paths:
 |---|---|---|
 | `factor_col 'X' not in panel columns` | Typo / wrong column name | Check `panel.columns`; pass the actual name to `factor_col=`. |
 | `Both 'factor' and 'X' present` | Wide panel still has stale `"factor"` column | `panel.drop("factor")` before calling. |
-| `MissingConfigError: evaluate(raw) needs AnalysisConfig` | Called `evaluate(panel)` with no `cfg` | `fx.suggest_config(panel)` recovers a starting cell. |
+| `MissingConfigError: evaluate(panel) needs AnalysisConfig` | Called `evaluate(panel)` with no `cfg` | `fx.suggest_config(panel)` recovers a starting cell. |
 | `forward_return column missing` | Forgot the preprocess step | `panel = compute_forward_return(raw, forward_periods=h)` before `evaluate`. |
 
 Full error taxonomy and recovery patterns: [Errors](errors.md).

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -80,7 +80,7 @@ from factrix.slicing import (
 
 
 def evaluate(
-    raw: Any,
+    panel: Any,
     config: AnalysisConfig | None = None,
     /,
     *,
@@ -96,14 +96,14 @@ def evaluate(
     [`bhy_hierarchical`][factrix.multi_factor.bhy_hierarchical]).
 
     Args:
-        raw: Long-format panel satisfying the four-column floor
+        panel: Long-format panel satisfying the four-column floor
             ``(date, asset_id, factor, forward_return)``. See
             [Panel schema](panel-schema.md) for the canonical contract
             and dtype semantics.
         config: Validated ``AnalysisConfig`` selecting the dispatch cell
             (``Scope × Signal × Metric``). Construct via one of the four
             factories on the class.
-        factor_col: Name of the signal column on ``raw`` (default
+        factor_col: Name of the signal column on ``panel`` (default
             ``"factor"``). Renamed to ``"factor"`` internally before
             dispatch. Looping over candidates with different
             ``factor_col=`` values is the canonical multi-factor pattern.
@@ -115,7 +115,7 @@ def evaluate(
         and ``context = {universe_id, regime_id, ...}``.
 
     Raises:
-        MissingConfigError: ``evaluate(raw)`` called without an
+        MissingConfigError: ``evaluate(panel)`` called without an
             ``AnalysisConfig``. Recovery: call
             [`suggest_config`][factrix.suggest_config].
         IncompatibleAxisError: ``config`` axes form an illegal cell.
@@ -125,7 +125,7 @@ def evaluate(
         InsufficientSampleError: ``T`` below the procedure's
             ``MIN_PERIODS_HARD`` floor. Carries ``.actual_periods`` /
             ``.required_periods``.
-        ValueError: ``factor_col`` not present on ``raw``, or both
+        ValueError: ``factor_col`` not present on ``panel``, or both
             ``"factor"`` and ``factor_col`` present with differing values
             (ambiguous which is the signal — drop the unused column).
 
@@ -195,11 +195,11 @@ def evaluate(
     if config is None:
         raise MissingConfigError(
             "evaluate() requires an AnalysisConfig. "
-            "Call factrix.suggest_config(raw) for a recommendation, "
+            "Call factrix.suggest_config(panel) for a recommendation, "
             "or see the Get Started guide: "
             "https://awwesomeman.github.io/factrix/getting-started/"
         )
-    return _evaluate(raw, config, factor_col=factor_col)
+    return _evaluate(panel, config, factor_col=factor_col)
 
 
 __version__ = "0.12.0"

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -126,11 +126,11 @@ class ConfigError(FactrixError):
 
 
 class MissingConfigError(ConfigError):
-    """``evaluate(raw)`` called without an ``AnalysisConfig``.
+    """``evaluate(panel)`` called without an ``AnalysisConfig``.
 
     Friendly replacement for the bare ``TypeError`` from the private
     ``_evaluate`` signature. ``suggested_fix`` stays ``None`` — call
-    ``factrix.suggest_config(raw)`` to get a concrete recommendation.
+    ``factrix.suggest_config(panel)`` to get a concrete recommendation.
     """
 
 

--- a/factrix/_evaluate.py
+++ b/factrix/_evaluate.py
@@ -1,14 +1,14 @@
-"""v0.5 ``_evaluate`` — config + raw → registry dispatch → ``FactorProfile``.
+"""v0.5 ``_evaluate`` — config + panel → registry dispatch → ``FactorProfile``.
 
 Implements the four-step routing flow of refactor_api.md §4.4.2:
 
-1. derive ``mode`` from raw data (``N == 1`` → ``TIMESERIES``, else ``PANEL``)
+1. derive ``mode`` from the panel (``N == 1`` → ``TIMESERIES``, else ``PANEL``)
 2. if ``signal == SPARSE`` and ``mode == TIMESERIES`` → rewrite scope to
    ``_SCOPE_COLLAPSED`` (§5.4.1) and tag the result with
    ``InfoCode.SCOPE_AXIS_COLLAPSED``
 3. assemble ``_DispatchKey`` and look up the registry; missing → raise
    ``ModeAxisError`` with the nearest legal fallback (§5.5 / §4.5 A4)
-4. ``entry.procedure.compute(raw, config)`` → ``FactorProfile``
+4. ``entry.procedure.compute(panel, config)`` → ``FactorProfile``
 
 Underscore-prefixed: this is the private dispatch entry. The public
 ``factrix.evaluate`` binding owns the user-facing surface and delegates
@@ -35,37 +35,37 @@ if TYPE_CHECKING:
     from factrix._profile import FactorProfile
 
 
-def _derive_mode(raw: Any) -> Mode:
+def _derive_mode(panel: Any) -> Mode:
     """Return ``TIMESERIES`` if the panel has a single asset, else ``PANEL``.
 
-    Reads ``asset_id`` directly off the raw frame; callers are expected
+    Reads ``asset_id`` directly off the panel; callers are expected
     to have validated the schema against ``procedure.INPUT_SCHEMA``
     before reaching this point.
     """
-    return Mode.TIMESERIES if raw["asset_id"].n_unique() <= 1 else Mode.PANEL
+    return Mode.TIMESERIES if panel["asset_id"].n_unique() <= 1 else Mode.PANEL
 
 
 def _evaluate(
-    raw: Any,
+    panel: Any,
     config: AnalysisConfig,
     *,
     factor_col: str = "factor",
 ) -> FactorProfile:
-    """Dispatch ``config + raw`` to the registered procedure.
+    """Dispatch ``config + panel`` to the registered procedure.
 
-    Mode is derived from ``raw`` (``N == 1`` → ``TIMESERIES``, else
+    Mode is derived from ``panel`` (``N == 1`` → ``TIMESERIES``, else
     ``PANEL``). Sparse signals at ``N == 1`` collapse the scope axis
     so ``individual_sparse`` and ``common_sparse`` route to the same
     cell, tagged with ``InfoCode.SCOPE_AXIS_COLLAPSED`` on the
     returned profile.
 
     Args:
-        raw: Canonical-column panel (``date, asset_id, factor,
+        panel: Canonical-column long panel (``date, asset_id, factor,
             forward_return``). Schema is validated downstream by the
             registered procedure.
         config: Validated ``AnalysisConfig`` produced by one of the
             four factory methods.
-        factor_col: Name of the signal column on ``raw``. Default
+        factor_col: Name of the signal column on ``panel``. Default
             ``"factor"``; pass any other column name when the panel's
             signal is named differently, or when looping over multiple
             candidate signals on a wide panel. The column is renamed
@@ -80,8 +80,8 @@ def _evaluate(
         the routed dispatch cell.
 
     Raises:
-        ValueError: If ``factor_col`` is not present on ``raw``, or if
-            ``factor_col != "factor"`` while ``raw`` already carries a
+        ValueError: If ``factor_col`` is not present on ``panel``, or if
+            ``factor_col != "factor"`` while ``panel`` already carries a
             different ``"factor"`` column (ambiguous which is the
             signal).
         ModeAxisError: If the routed cell has no registered procedure
@@ -90,20 +90,20 @@ def _evaluate(
             ``suggested_fix``.
     """
     if factor_col != "factor":
-        if factor_col not in raw.columns:
+        if factor_col not in panel.columns:
             raise ValueError(
-                f"factor_col={factor_col!r} not found in raw columns: "
-                f"{list(raw.columns)}. Pass the actual signal column "
+                f"factor_col={factor_col!r} not found in panel columns: "
+                f"{list(panel.columns)}. Pass the actual signal column "
                 f"name, or rename the column to 'factor' before calling."
             )
-        if "factor" in raw.columns:
+        if "factor" in panel.columns:
             raise ValueError(
-                f"raw carries both 'factor' and {factor_col!r} columns; "
+                f"panel carries both 'factor' and {factor_col!r} columns; "
                 f"ambiguous which is the signal under test. Drop the "
                 f"unused column before calling evaluate."
             )
-        raw = raw.rename({factor_col: "factor"})
-    mode = _derive_mode(raw)
+        panel = panel.rename({factor_col: "factor"})
+    mode = _derive_mode(panel)
     key = _dispatch_key_for(config.scope, config.signal, config.metric, mode)
     extra_info: frozenset[InfoCode] = (
         frozenset({InfoCode.SCOPE_AXIS_COLLAPSED})
@@ -122,7 +122,7 @@ def _evaluate(
             suggested_fix=suggested,
         )
 
-    profile = entry.procedure.compute(raw, config)
+    profile = entry.procedure.compute(panel, config)
     profile = dataclasses.replace(
         profile,
         factor_id=factor_col,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -195,7 +195,7 @@ explicitly `HansenHodrick`. Downstream readers should use
 ### `evaluate`
 
 ```
-factrix.evaluate(raw: polars.DataFrame, config: AnalysisConfig,
+factrix.evaluate(panel: polars.DataFrame, config: AnalysisConfig,
                  *, factor_col: str = "factor") -> FactorProfile
 ```
 
@@ -209,7 +209,7 @@ by `(dispatch cell, forward_periods)`; do **not** reach into
 that requires re-implementing the family split by hand.
 Raises (subclasses of `FactrixError`; see `## Errors`
 below for the full hierarchy + recovery payloads):
-- `MissingConfigError` — `evaluate(raw)` called without an `AnalysisConfig`
+- `MissingConfigError` — `evaluate(panel)` called without an `AnalysisConfig`
 - `IncompatibleAxisError` — config axes form an illegal cell (also raised when
   `cfg.estimator` is not applicable to the cell)
 - `UnknownEstimatorError` — `AnalysisConfig.from_dict` /
@@ -552,7 +552,7 @@ All factrix exceptions inherit from `FactrixError`, so agents can write
 ```
 FactrixError                       # base — all factrix-raised errors
 ├── ConfigError                    # AnalysisConfig validation / dispatch
-│   ├── MissingConfigError         # evaluate(raw) called without a config
+│   ├── MissingConfigError         # evaluate(panel) called without a config
 │   ├── IncompatibleAxisError      # (scope, signal, metric) is not a legal cell
 │   ├── ModeAxisError              # legal cell, no procedure at runtime mode;
 │   │                              # carries .suggested_fix: AnalysisConfig | None


### PR DESCRIPTION
## Summary

Aligns `evaluate`'s first positional-only parameter (`raw` → `panel`) with the entry-point vocabulary used everywhere else (`run_metrics`, page-level callouts, `docs/api/panel-schema.md`). Parameter is positional-only, so no user-facing breaking change.

Touched:

- `factrix/_evaluate.py` — `_evaluate(panel, ...)` + `_derive_mode(panel)` to keep local variable name in sync.
- `factrix/__init__.py` — public `evaluate` signature, docstring, internal error message ("Call factrix.suggest_config(panel)").
- `factrix/_errors.py` — `MissingConfigError` docstring.
- `docs/api/errors.md` + `docs/api/panel-schema.md` — table rows / hierarchy diagrams.
- `factrix/llms-full.txt` — SSOT refreshed.

`suggest_config`'s own param name (`raw`) is intentionally untouched — out of scope per #278's "Variable names in examples that genuinely mean 'panel before preprocess' stay" carve-out and the issue's narrow `evaluate`-only scope.

## Test plan

- [x] `uv run pytest -x -q` — 1300 passed
- [x] `uv run mkdocs build --strict` clean
- [x] No remaining `evaluate(raw)` outside `docs/plans/archive/`

Closes #278