### PR TITLE
docs(api): move autodoc block to page top

### DIFF
--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -2,6 +2,8 @@
 title: factrix.multi_factor.bhy_hierarchical
 ---
 
+::: factrix.multi_factor.bhy_hierarchical
+
 Two-stage FDR for factor sets with natural group structure (factor
 families, regions, sectors). Outer Benjamini-Yekutieli on
 [Simes (1986)](https://academic.oup.com/biomet/article/73/3/751/277681)
@@ -133,5 +135,3 @@ Per-survivor group label: `profile.context[group]`.
   rate-controlling methodology. *JASA*, 103(481), 309–316.
 - **[NBER34050]** NBER WP 34050 (2025). Hierarchical Multiple Testing
   in Empirical Asset Pricing.
-
-::: factrix.multi_factor.bhy_hierarchical

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -2,6 +2,16 @@
 title: factrix.by_slice
 ---
 
+::: factrix.slicing.dispatcher
+    options:
+      members:
+        - by_slice
+
+::: factrix.slicing.result
+    options:
+      members:
+        - SliceResult
+
 Axis-agnostic research dispatcher. Slices any metric's date-keyed
 input by a column already present in the DataFrame and runs the metric
 per slice. Returns a [`SliceResult`](#sliceresult) — a
@@ -247,14 +257,3 @@ pl.DataFrame(
 )
 ```
 
-## API reference
-
-::: factrix.slicing.dispatcher
-    options:
-      members:
-        - by_slice
-
-::: factrix.slicing.result
-    options:
-      members:
-        - SliceResult

--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -2,6 +2,8 @@
 title: factrix.compare
 ---
 
+::: factrix.compare
+
 Leaderboard renderer that stacks N artifacts side by side as a
 [polars `DataFrame`](https://docs.pola.rs/api/python/stable/reference/dataframe/index.html).
 Pure projection — no metric is recomputed; `Survivors.adj_p` is read
@@ -120,6 +122,3 @@ issue (empty input, mixed types, unknown `sort_by`). Unknown
 `sort_by` carries `suggestions` populated by `difflib` against the
 output schema.
 
-## Source
-
-::: factrix.compare

--- a/docs/api/list-estimators.md
+++ b/docs/api/list-estimators.md
@@ -2,6 +2,8 @@
 title: factrix.list_estimators
 ---
 
+::: factrix.list_estimators
+
 Programmatic discovery of inference methods (`Estimator` instances)
 applicable to a given `(scope, signal)` cell — the inference-side twin
 of [`list_metrics`](list-metrics.md).
@@ -37,5 +39,3 @@ cell-axis-dependent (scope × signal), not panel-shape-dependent.
   using `estimator=` on screening functions
 - [`stats`](stats.md) — full estimator catalogue and StatCode pairings
 - [`list_metrics`](list-metrics.md) — descriptive metric counterpart
-
-::: factrix.list_estimators

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -2,6 +2,8 @@
 title: factrix.list_metrics
 ---
 
+::: factrix.list_metrics
+
 Programmatic discovery of standalone metrics applicable to a given
 analysis cell. Complements [`describe_analysis_modes`](
 ../reference/metric-applicability.md) — that helper enumerates the
@@ -126,5 +128,3 @@ is defensive — surfaced for symmetry with the rest of the API.
 (`factrix._metric_index`). Adding a new metric only requires adding a
 `Matrix-row:` tag to the new module's docstring; both surfaces pick it
 up automatically.
-
-::: factrix.list_metrics

--- a/docs/api/metrics-bundle.md
+++ b/docs/api/metrics-bundle.md
@@ -11,6 +11,8 @@ identity tuple `(factor_id, forward_periods)` so downstream functions
 ([`compare`](compare.md), survivors workflows) can join the two
 artifact families row-by-row.
 
+::: factrix.MetricsBundle
+
 | Bundle | Profile |
 |---|---|
 | `run_metrics` — descriptive surface (no FDR claim) | `evaluate` — primary inferential decision (drives FDR) |
@@ -34,5 +36,3 @@ bundle.skipped            # {metric_name: reason} — metrics that short-circuit
 For the wide multi-factor pattern (looping `run_metrics` with
 `factor_col=` over candidate signals) see the
 [Batch screening guide](../guides/batch-screening.md).
-
-::: factrix.MetricsBundle

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -2,6 +2,8 @@
 title: factrix.multi_factor.partial_conjunction
 ---
 
+::: factrix.multi_factor.partial_conjunction
+
 Contract-bearing screening for the "factor X is significant in $k$ of
 $m$ conditions" claim. Replaces the notebook idiom
 `set(survivors_a) & set(survivors_b)`, which does **not** preserve FDR
@@ -138,5 +140,3 @@ container as `bhy`, populated with PC-specific metadata:
   on multiple families of hypotheses. *JRSS-B*, 76(1).
 - **[HY2014]** Heller, R. & Yekutieli, D. (2014). Replicability analysis
   for genome-wide association studies. *AOAS*, 8(1).
-
-::: factrix.multi_factor.partial_conjunction

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -2,6 +2,8 @@
 title: factrix.run_metrics
 ---
 
+::: factrix.run_metrics
+
 Cell-level descriptive batch runner — the descriptive twin of
 [`evaluate`](evaluate.md). Where `evaluate` runs a cell's primary
 inferential procedure and returns a [`FactorProfile`](factor-profile.md),

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -2,6 +2,14 @@
 title: factrix.slicing.inference
 ---
 
+::: factrix.slicing.inference
+    options:
+        members:
+          - slice_pairwise_test
+          - slice_joint_test
+        show_root_heading: false
+        show_source: false
+
 Cross-slice statistical-test function pair. Both consume a metric callable
 and a date-keyed DataFrame whose `label` column carries the slice
 identifier; the functions partition by `label`, line up per-date metric
@@ -108,12 +116,3 @@ reserved for the future `factor_decomposition` function.
 | FDR-adjusted survivor selection across factors | `bhy(profiles, ...)` |
 | Multi-factor leaderboard rendering | `compare(...)` |
 
-## Reference
-
-::: factrix.slicing.inference
-    options:
-        members:
-          - slice_pairwise_test
-          - slice_joint_test
-        show_root_heading: false
-        show_source: false

--- a/docs/api/suggest-config.md
+++ b/docs/api/suggest-config.md
@@ -2,6 +2,8 @@
 title: factrix.suggest_config
 ---
 
+::: factrix.suggest_config
+
 Heuristic introspection that inspects a raw panel and proposes an
 [`AnalysisConfig`](analysis-config.md) plus the observations and
 reasoning behind the suggestion. The proposal is never auto-applied —
@@ -153,6 +155,3 @@ defaulted based on the other three. See
 | `mode` | `n_assets ≤ 1` → `TIMESERIES`, else `PANEL` |
 | `metric` | `INDIVIDUAL × CONTINUOUS` defaults to `Metric.IC` (Information Coefficient — rank predictive ordering); collapsed (`None`) on every other cell |
 
-## Source
-
-::: factrix.suggest_config


### PR DESCRIPTION
## Summary

Sweep axis 2 of #280: align ten function- and dataclass-level API pages onto the reference shape (`evaluate.md` / `bhy.md` / `metric-output.md`):

- `bhy-hierarchical.md`, `partial-conjunction.md`, `compare.md`, `suggest-config.md`, `list-metrics.md`, `list-estimators.md`, `slice-test.md`, `by-slice.md`, `metrics-bundle.md` — autodoc block relocated from page bottom to the top (after frontmatter / input-contract callout); narrative preserved verbatim below.
- `run-metrics.md` — gained its missing `::: factrix.run_metrics` block; the signature was previously unreachable from its own page.

Autodoc `options:` blocks preserved verbatim where present. Option uniformity is a separate axis (#282) — not addressed here.

## Test plan

- [x] `uv run mkdocs build --strict` clean
- [x] No prose / tables / worked examples deleted (only relocated)

Closes #279