### PR TITLE
docs: record Input-contract callout policy + align format

### DIFF
--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -3,8 +3,7 @@ title: factrix.evaluate
 ---
 
 > **Input contract** — the panel must satisfy the four-column floor
-> documented in [Panel schema](panel-schema.md). The per-cell extension
-> table on the schema page adds optional columns on top of that floor.
+> documented in [Panel schema](panel-schema.md).
 
 ::: factrix.evaluate
     options:

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -2,6 +2,9 @@
 title: factrix.run_metrics
 ---
 
+> **Input contract** — the panel must satisfy the four-column floor
+> documented in [Panel schema](panel-schema.md).
+
 ::: factrix.run_metrics
 
 Cell-level descriptive batch runner — the descriptive twin of
@@ -12,9 +15,6 @@ in `factrix.metrics.*` and returns a [`MetricsBundle`](#metricsbundle).
 
 The two paths share the `(panel, cfg)` entry contract; their result
 types are disjoint by design.
-
-> **Input contract** — the panel must satisfy the four-column floor
-> documented in [Panel schema](panel-schema.md).
 
 | Function | Returns | Use when |
 |---|---|---|

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -527,6 +527,7 @@ plain prose; reach for a callout only when the elevation earns it.
 - `!!! info` — contract / convention block (e.g. event-study contracts, TS-mode conventions).
 - `!!! example` — minimal worked code that surrounding prose references.
 - `??? note "..."` (collapsible) — long content for a subset of readers (derivations, full enum tables).
+- `> **Input contract** — …` (blockquote, two lines) — appears only on raw-panel `(panel, cfg)` entry points (`docs/api/evaluate.md`, `docs/api/run-metrics.md`), placed between the frontmatter and the autodoc block. Format: one short sentence naming the four-column floor + a link to [Panel schema](../api/panel-schema.md). Other API pages consume pre-computed artefacts (`FactorProfile` / `Survivors` / `MetricsBundle`) and do not carry the callout.
 
 Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
 


### PR DESCRIPTION
## Summary

Sweep axis 5 of #280: record the Input-contract callout policy in `contributing.md` and align the two existing callouts (`evaluate.md`, `run-metrics.md`) to one short format.

**Policy** (added to `contributing.md` Docs callout conventions):

- Scope: only raw-panel `(panel, cfg)` entry points carry the callout (`evaluate.md`, `run-metrics.md`).
- Placement: between frontmatter and autodoc block.
- Format: two-line blockquote — four-column floor sentence + link to Panel schema.

**Touched pages**:

- `evaluate.md`: dropped the third sentence (per-cell extension-table note); the linked schema page already exposes that table.
- `run-metrics.md`: callout was buried below narrative + comparison table; raised to the canonical between-frontmatter-and-autodoc slot.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] Both callouts byte-identical

Closes #283