### PR TITLE
docs(architecture): drop RFC Option labels + expand DoD abbrev

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -308,8 +308,9 @@ catches it.
 
 The contract is opt-in for new user-facing raises. Each v1 function
 sub-issue (#147 / #160 / #161 / #162) declares conformance in its
-own DoD; retrofit of pre-contract raise sites is tracked separately
-so the helper itself can land without forcing a sweep.
+own acceptance criteria; retrofit of pre-contract raise sites is
+tracked separately so the helper itself can land without forcing a
+sweep.
 
 ---
 
@@ -657,7 +658,7 @@ from disk.
 
 Run: `uv run pytest`
 
-### Docs SSOT strategy (Option B — issue #42)
+### Docs SSOT strategy — docstring tags drive the matrix
 
 `docs/reference/metric-pipelines.md` no longer contains a hand-written
 matrix. The matrix is generated at build time from machine-readable
@@ -681,9 +682,10 @@ matrix. The matrix is generated at build time from machine-readable
 - `_generated_metric_matrix.md` exists and is non-empty (skipped if absent,
   so CI that only runs pytest without a prior build does not false-positive).
 
-**Why Option B over Option C (pure CI guard):** Option C only checked
-presence/absence of module references; drift in any of the five data columns
-(scope, aggregation order, inference SE, primitives) was invisible to CI.
-Option B makes the docstring the single source of truth for all six matrix
-columns — adding a module without a `Matrix-row:` tag fails the test, and
-editing the tag automatically updates the rendered docs on the next build.
+**Why docstring tags rather than a pure CI presence guard:** a guard
+that only checks presence/absence of module references leaves drift in
+the five data columns (scope, aggregation order, inference SE,
+primitives) invisible to CI. Making the docstring the single source of
+truth for all six matrix columns closes that gap — adding a module
+without a `Matrix-row:` tag fails the test, and editing the tag
+automatically updates the rendered docs on the next build.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -531,6 +531,18 @@ plain prose; reach for a callout only when the elevation earns it.
 
 Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
 
+### Page-shape conventions — when to add `## Use cases` / `## Worked example`
+
+These two sections appear on pages whose primary purpose is to show the reader *how to call the API*. They are content shapes for workflow-oriented pages — not a universal requirement.
+
+- **Expected on callable entry points.** Function pages under `docs/api/` whose page subject is a callable the user invokes directly. Includes the entry-point callables (`evaluate`, `run_metrics`, `bhy`, `partial_conjunction`, `bhy_hierarchical`, `by_slice`, `slice_pairwise_test` / `slice_joint_test`, `compare`, `list_metrics`, `list_estimators`, `suggest_config`, `preprocess.compute_forward_return`), and every metric page under `docs/api/metrics/` (each documents one or more callables).
+- **Not expected** on:
+    - Dataclass / container pages (`factor-profile.md`, `metric-output.md`, `metrics-bundle.md`) — these describe a return type, not a workflow.
+    - Reference / taxonomy / hub pages (`errors.md`, `decision-tree.md`, `panel-schema.md`, `api/index.md`, `multi-horizon.md`, `identity.md`, `estimator-alternatives.md`, `metrics/index.md`, the cell-grouped metrics index pages) — content shape is a table or a concept, not a call.
+    - Namespace / module pages (`stats.md`, `datasets.md`) — content shape is a catalogue of members.
+
+A page that legitimately does not need these sections carries no marker — silence is the policy default. Pages in the "expected" category that currently lack the sections are accepted as a backfill debt rather than a defect.
+
 ### Terminology — functional names, not stage labels
 
 Code (`factrix/**/*.py` docstrings + module headers) and published docs (`docs/**/*.md` excluding `docs/plans/`) describe behaviour by **what a function does**, not by **which planning tier it lives in**. Stage labels — `Layer-A` / `Layer-B`, `first / second layer`, `Phase 1` / `P1`, `curated wrapper`, `dispatcher vs wrapper` as a tier pair — belong only to GitHub issues / labels / milestones, where they can be renamed as the roadmap shifts.


### PR DESCRIPTION
## Summary

Sweep axis 12 of #280: scrub issue-tracking vocabulary from `docs/development/architecture.md`.

- §"Docs SSOT strategy" heading dropped `(Option B — issue #42)` suffix; title rewritten functionally.
- §"Docs SSOT strategy" body comparison rewritten from `Why Option B over Option C` to behavioural framing; substance preserved.
- §"Adoption" `DoD` abbrev replaced with "acceptance criteria".

Same family as axis 8 / #286.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] No remaining `Option [A-Z]` or `DoD` tokens in architecture.md

Closes #297