### PR TITLE
docs: add reverse links for five asymmetric page pairs

### DIFF
--- a/docs/development/design-notes.md
+++ b/docs/development/design-notes.md
@@ -122,7 +122,7 @@ market and comparing the returned `FactorProfile`s.
 
 ## 5. BHY rather than Bayesian multiple-testing
 
-factrix's `multi_factor.bhy` runs Benjamini-Yekutieli
+factrix's [`multi_factor.bhy`](../api/bhy.md) runs Benjamini-Yekutieli
 ([Benjamini-Yekutieli 2001][benjamini-yekutieli-2001]) FDR control
 with the `c(m) = Σ 1/i` dependence correction. It does not implement
 Bayesian alternatives such as

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -9,6 +9,9 @@ performance — see
 [Guides § Standalone metrics — Scope](../guides/standalone-metrics.md#scope)
 for the full boundary (what is in, what is downstream).
 
+Once the axes below are familiar, [Decision tree](../api/decision-tree.md)
+maps a research question to the function that answers it.
+
 ## Three orthogonal axes
 
 [`AnalysisConfig`][factrix.AnalysisConfig] is defined by three user-facing

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -118,3 +118,4 @@ You have one `FactorProfile` for one factor. The common follow-ups:
 | Test whether slices differ statistically | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | [Slice analysis](../guides/slice-analysis.md) |
 | Look up the panel input contract | [Panel schema](../api/panel-schema.md) | — |
 | Pick a metric for a given research question | [Choosing a metric](../guides/choosing-metric.md) | — |
+| Pick a function (rather than a metric) | [Decision tree](../api/decision-tree.md) | — |

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -6,6 +6,7 @@ title: PANEL vs TIMESERIES
     What `Mode.PANEL` vs `Mode.TIMESERIES` mean, when each is dispatched, and the sample-guard contract for each.
     For the conventions table (column names, alignment), see [TIMESERIES-mode conventions](../reference/ts-mode-conventions.md).
     For the `mode=` parameter on `evaluate()`, see [`evaluate`](../api/evaluate.md).
+    For sample-guard error surfacing (`InsufficientSampleError`, `ModeAxisError`), see [Errors](../api/errors.md).
 
 ## Sample guards
 

--- a/docs/reference/metric-pipelines.md
+++ b/docs/reference/metric-pipelines.md
@@ -6,6 +6,7 @@ title: Metric pipelines
     How is each metric computed — aggregation order, inference SE machinery.
     For applicability gates and sample thresholds, see [Metric applicability](metric-applicability.md).
     For output schema and metadata keys, see [Stat keys by metric](stat-keys-by-metric.md).
+    For the research-question → metric mapping, see [Choosing a metric](../guides/choosing-metric.md).
 
 Cross-module index of every module under `factrix/metrics/`. Use this
 page to pick the existing aggregation pattern a new metric should


### PR DESCRIPTION
## Summary

Sweep axis 10 of #280: audit `docs/` for one-way navigational links, fix five high-value asymmetries with single-line reverse links.

| Source (links to target) | Target (gains reverse) | Where |
|---|---|---|
| `api/decision-tree.md` → Concepts | `getting-started/concepts.md` | Pointer line under §"What factrix is for" |
| `api/decision-tree.md` → Quickstart § Next steps | `getting-started/quickstart.md` | New row in Next steps table |
| `api/errors.md` → PANEL vs TIMESERIES | `guides/panel-timeseries.md` | Abstract callout |
| `guides/choosing-metric.md` → Metric pipelines | `reference/metric-pipelines.md` | Abstract callout |
| `api/bhy.md` → Design notes §5 | `development/design-notes.md` | §5 inline link on `multi_factor.bhy` |

The issue's example pair (`ts-mode-conventions.md` ↔ `panel-timeseries.md`) was already reciprocal — no change there.

Low-priority asymmetries (incidental references, hub → leaf, glossary-style indexes) left as-is per the audit's acceptable-asymmetry rules.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] Each fix is one line on the target page

Closes #288