### PR TITLE
docs(install): unpin example from 0.8.0 to placeholder

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -18,11 +18,15 @@ uv add factrix
 
 ## Version pinning
 
+factrix is pre-1.0 (v0.x.x) and the public API may break on MINOR bumps; pin a specific version in long-running projects.
+
 ```bash
-pip install factrix==0.8.0
+pip install factrix==X.Y.Z
 # or
-uv add factrix==0.8.0
+uv add factrix==X.Y.Z
 ```
+
+Replace `X.Y.Z` with the [latest release tag](https://github.com/awwesomeman/factrix/releases).
 
 ## Local development
 


### PR DESCRIPTION
## Summary

Sweep axis 9 of #280 (install.md half): §"Version pinning" pinned `factrix==0.8.0` literally, which rotted silently on every release (current 0.12.0).

Replaced the literal with `X.Y.Z` placeholder + one-line pointer to the releases page. The section's purpose (show the pin syntax) is preserved; the page no longer carries a version string that drifts on bump.

Notebook execution output drift (axis 11's other half: `examples/*.ipynb`) lands with the notebook → markdown migration on #289 so both artefact families converge to one fix path.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] No remaining literal `factrix==<digit>` patterns in `docs/` (excluding `.ipynb`)

Closes #287