### PR TITLE
docs(api): autodoc-first shape on dataclass pages

### DIFF
--- a/docs/api/analysis-config.md
+++ b/docs/api/analysis-config.md
@@ -4,11 +4,7 @@ title: factrix.AnalysisConfig
 
 ::: factrix.AnalysisConfig
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - individual_continuous
         - individual_sparse

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -3,13 +3,6 @@ title: factrix.multi_factor.bhy
 ---
 
 ::: factrix.multi_factor.bhy
-    options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
-      heading_level: 1
-      separate_signature: true
-      show_signature_annotations: true
 
 <hr>
 
@@ -201,8 +194,6 @@ for s in survivors.profiles:
 
 ::: factrix.multi_factor.Survivors
     options:
-      show_root_heading: true
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 3
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -171,7 +171,6 @@ Autodoc anchors for cross-references of the form
 
 ::: factrix.FactrixError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
@@ -179,7 +178,6 @@ Autodoc anchors for cross-references of the form
 
 ::: factrix.UserInputError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
@@ -187,37 +185,31 @@ Autodoc anchors for cross-references of the form
 
 ::: factrix.ConfigError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.MissingConfigError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.IncompatibleAxisError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.ModeAxisError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.InsufficientSampleError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
 ::: factrix.UnknownEstimatorError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4
 
@@ -225,6 +217,5 @@ Autodoc anchors for cross-references of the form
 
 ::: factrix.RunMetricsError
     options:
-      show_root_full_path: true
       show_root_toc_entry: false
       heading_level: 4

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -6,13 +6,6 @@ title: factrix.evaluate
 > documented in [Panel schema](panel-schema.md).
 
 ::: factrix.evaluate
-    options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
-      heading_level: 1
-      separate_signature: true
-      show_signature_annotations: true
 
 <hr>
 

--- a/docs/api/factor-profile.md
+++ b/docs/api/factor-profile.md
@@ -2,6 +2,11 @@
 title: factrix.FactorProfile
 ---
 
+::: factrix.FactorProfile
+    options:
+      members:
+        - diagnose
+
 Procedure-canonical analysis result for a single factor. Every
 registered procedure produces an instance of this dataclass with
 cell-specific scalars keyed in the `stats` mapping; adding a new
@@ -9,12 +14,6 @@ metric does not grow the schema.
 
 See [Metric applicability](../reference/metric-applicability.md) for
 `n_obs` and `n_assets` thresholds per procedure.
-
-::: factrix.FactorProfile
-    options:
-      show_root_heading: false
-      members:
-        - diagnose
 
 ## `diagnose()` return schema
 

--- a/docs/api/metric-output.md
+++ b/docs/api/metric-output.md
@@ -2,6 +2,8 @@
 title: factrix.MetricOutput
 ---
 
+::: factrix.MetricOutput
+
 The unified return type produced by every metric in
 [`factrix.metrics`](metrics/index.md). A single dataclass carrying
 the canonical scalar (`value`), the sample size the estimator saw
@@ -12,8 +14,6 @@ or auxiliary — return this shape so downstream code can treat every
 metric uniformly. `n_obs` shares its name with `FactorProfile.n_obs`
 but a different scope: per-metric single-stage count vs. the
 final-stage test denominator at the dispatched-cell level.
-
-::: factrix.MetricOutput
 
 ## Resolving `MetricOutput.name` to a docs page
 [](){ #name-index }

--- a/docs/api/metrics-bundle.md
+++ b/docs/api/metrics-bundle.md
@@ -2,6 +2,8 @@
 title: factrix.MetricsBundle
 ---
 
+::: factrix.MetricsBundle
+
 Result type returned by [`run_metrics`](run-metrics.md) — holds every
 standalone metric the cell successfully evaluated for one factor at one
 horizon, plus a `skipped` map for metrics that could not auto-run.
@@ -10,8 +12,6 @@ Parallel to [`FactorProfile`](factor-profile.md): both share the
 identity tuple `(factor_id, forward_periods)` so downstream functions
 ([`compare`](compare.md), survivors workflows) can join the two
 artifact families row-by-row.
-
-::: factrix.MetricsBundle
 
 | Bundle | Profile |
 |---|---|

--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -4,11 +4,7 @@ title: factrix.metrics.caar
 
 ::: factrix.metrics.caar
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_caar
         - caar

--- a/docs/api/metrics/clustering.md
+++ b/docs/api/metrics/clustering.md
@@ -4,11 +4,7 @@ title: factrix.metrics.clustering
 
 ::: factrix.metrics.clustering
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - clustering_diagnostic
 

--- a/docs/api/metrics/concentration.md
+++ b/docs/api/metrics/concentration.md
@@ -4,11 +4,7 @@ title: factrix.metrics.concentration
 
 ::: factrix.metrics.concentration
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - top_concentration
 

--- a/docs/api/metrics/corrado.md
+++ b/docs/api/metrics/corrado.md
@@ -4,11 +4,7 @@ title: factrix.metrics.corrado
 
 ::: factrix.metrics.corrado
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - corrado_rank_test
 

--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -4,11 +4,7 @@ title: factrix.metrics.event_horizon
 
 ::: factrix.metrics.event_horizon
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_event_returns
         - event_around_return

--- a/docs/api/metrics/event_quality.md
+++ b/docs/api/metrics/event_quality.md
@@ -4,11 +4,7 @@ title: factrix.metrics.event_quality
 
 ::: factrix.metrics.event_quality
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - event_hit_rate
         - event_ic

--- a/docs/api/metrics/fama_macbeth.md
+++ b/docs/api/metrics/fama_macbeth.md
@@ -4,11 +4,7 @@ title: factrix.metrics.fama_macbeth
 
 ::: factrix.metrics.fama_macbeth
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_fm_betas
         - fama_macbeth

--- a/docs/api/metrics/hit_rate.md
+++ b/docs/api/metrics/hit_rate.md
@@ -4,11 +4,7 @@ title: factrix.metrics.hit_rate
 
 ::: factrix.metrics.hit_rate
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - hit_rate
         - per_date_series

--- a/docs/api/metrics/ic.md
+++ b/docs/api/metrics/ic.md
@@ -4,11 +4,7 @@ title: factrix.metrics.ic
 
 ::: factrix.metrics.ic
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_ic
         - ic

--- a/docs/api/metrics/mfe_mae.md
+++ b/docs/api/metrics/mfe_mae.md
@@ -4,11 +4,7 @@ title: factrix.metrics.mfe_mae
 
 ::: factrix.metrics.mfe_mae
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_mfe_mae
         - mfe_mae_summary

--- a/docs/api/metrics/monotonicity.md
+++ b/docs/api/metrics/monotonicity.md
@@ -4,11 +4,7 @@ title: factrix.metrics.monotonicity
 
 ::: factrix.metrics.monotonicity
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - monotonicity
 

--- a/docs/api/metrics/oos.md
+++ b/docs/api/metrics/oos.md
@@ -4,11 +4,7 @@ title: factrix.metrics.oos
 
 ::: factrix.metrics.oos
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - multi_split_oos_decay
         - SplitDetail

--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -4,11 +4,7 @@ title: factrix.metrics.quantile
 
 ::: factrix.metrics.quantile
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_spread_series
         - compute_group_returns

--- a/docs/api/metrics/spanning.md
+++ b/docs/api/metrics/spanning.md
@@ -4,11 +4,7 @@ title: factrix.metrics.spanning
 
 ::: factrix.metrics.spanning
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - spanning_alpha
         - greedy_forward_selection

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -4,11 +4,7 @@ title: factrix.metrics.tradability
 
 ::: factrix.metrics.tradability
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - notional_turnover
         - turnover

--- a/docs/api/metrics/trend.md
+++ b/docs/api/metrics/trend.md
@@ -4,11 +4,7 @@ title: factrix.metrics.trend
 
 ::: factrix.metrics.trend
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - ic_trend
 

--- a/docs/api/metrics/ts_asymmetry.md
+++ b/docs/api/metrics/ts_asymmetry.md
@@ -4,11 +4,7 @@ title: factrix.metrics.ts_asymmetry
 
 ::: factrix.metrics.ts_asymmetry
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - ts_asymmetry
 

--- a/docs/api/metrics/ts_beta.md
+++ b/docs/api/metrics/ts_beta.md
@@ -4,11 +4,7 @@ title: factrix.metrics.ts_beta
 
 ::: factrix.metrics.ts_beta
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - compute_ts_betas
         - ts_beta

--- a/docs/api/metrics/ts_quantile.md
+++ b/docs/api/metrics/ts_quantile.md
@@ -4,11 +4,7 @@ title: factrix.metrics.ts_quantile
 
 ::: factrix.metrics.ts_quantile
     options:
-      show_root_heading: true
-      show_root_full_path: true
-      show_root_toc_entry: true
       show_root_members_full_path: true
-      heading_level: 1
       members:
         - ts_quantile_spread
 

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -8,7 +8,6 @@ title: factrix.slicing.inference
           - slice_pairwise_test
           - slice_joint_test
         show_root_heading: false
-        show_source: false
 
 Cross-slice statistical-test function pair. Both consume a metric callable
 and a date-keyed DataFrame whose `label` column carries the slice

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -531,6 +531,18 @@ plain prose; reach for a callout only when the elevation earns it.
 
 Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
 
+### Autodoc options — globals + per-block deviations
+
+`mkdocs.yml` carries the page-primary defaults for mkdocstrings (`show_root_heading: true`, `show_root_full_path: true`, `show_root_toc_entry: true`, `heading_level: 1`, `separate_signature: true`, `show_signature_annotations: true`, `show_source: false`, `merge_init_into_class: true`, `docstring_style: google`). Every `::: factrix.<X>` block in `docs/api/**` inherits these.
+
+Per-block `options:` should carry **only deviations** from the globals. Common deviations:
+
+- Secondary block on a page (e.g. `Survivors` on `bhy.md`, individual error classes on `errors.md`): `show_root_toc_entry: false`, `heading_level: 3` or `4`.
+- Dataclass page where the class name is already in the frontmatter title: `show_root_heading: false`.
+- Module-level block with a curated function list: `members: [...]`, optionally `show_root_members_full_path: true`.
+
+Bare `::: factrix.<X>` is the canonical form for page-primary function / dataclass blocks; do not duplicate globals.
+
 ### Page-shape conventions — when to add `## Use cases` / `## Worked example`
 
 These two sections appear on pages whose primary purpose is to show the reader *how to call the API*. They are content shapes for workflow-oriented pages — not a universal requirement.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,9 +71,12 @@ plugins:
             docstring_style: google
             show_source: false
             show_root_heading: true
+            show_root_full_path: true
+            show_root_toc_entry: true
             show_signature_annotations: true
             separate_signature: true
             merge_init_into_class: true
+            heading_level: 1
   - mkdocs-jupyter:
       execute: false
       include_source: false


### PR DESCRIPTION
## Summary

Fix a rendering bug introduced by #279's dataclass-page shape: the three dataclass pages (`factor-profile.md`, `metric-output.md`, `metrics-bundle.md`) opened with an intro paragraph before the autodoc block. Frontmatter `title:` controls browser tab + nav but does not emit a body h1, so the rendered page had no h1 at the top of content — the autodoc-rendered h1 was buried below the intro.

`factor-profile.md` was worse: it additionally set `show_root_heading: false`, suppressing the only h1 source entirely.

Move autodoc to the slot directly under frontmatter on all three pages; intro paragraph drops below. Drop the `show_root_heading: false` override on factor-profile.

Net effect: dataclass pages now match the function-page shape (frontmatter → autodoc → narrative), and every API page renders a visible h1 at the top of body content.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] Verified intro prose preserved verbatim (only relocated relative to autodoc anchor)
- [x] All three pages now render `factrix.<Name> dataclass` h1 at the top

Refs #279