### PR TITLE
docs(api): retarget autodoc to top-level path for re-exports

### DIFF
--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -2,15 +2,9 @@
 title: factrix.by_slice
 ---
 
-::: factrix.slicing.dispatcher
-    options:
-      members:
-        - by_slice
+::: factrix.by_slice
 
-::: factrix.slicing.result
-    options:
-      members:
-        - SliceResult
+::: factrix.SliceResult
 
 Axis-agnostic research dispatcher. Slices any metric's date-keyed
 input by a column already present in the DataFrame and runs the metric
@@ -68,8 +62,8 @@ not a defensible cross-regime selection rule. A generic cross-slice test
 be applied honestly across the metric matrix — the appropriate test
 depends on the metric family. For metrics that expose a
 `per_date_series` capability (`ic`, `fama_macbeth`, `hit_rate`),
-[`slice_pairwise_test`](slice-test.md#factrix.slicing.inference.slice_pairwise_test)
-/ [`slice_joint_test`](slice-test.md#factrix.slicing.inference.slice_joint_test)
+[`slice_pairwise_test`](slice-test.md#factrix.slice_pairwise_test)
+/ [`slice_joint_test`](slice-test.md#factrix.slice_joint_test)
 provide cross-slice contrasts with joint-HAC or block-bootstrap
 inference.
 
@@ -208,9 +202,9 @@ result.to_frame().sort(pl.col("stat").abs(), descending=True)
     under H0, K=10 sectors yields ≈ 0.4 expected "significant" slices
     by pure chance. The container is for **exploration**; for
     inference claims with FWER / FDR control, use
-    [`slice_pairwise_test`](slice-test.md#factrix.slicing.inference.slice_pairwise_test)
+    [`slice_pairwise_test`](slice-test.md#factrix.slice_pairwise_test)
     (Holm / Romano-Wolf / Bonferroni) or
-    [`slice_joint_test`](slice-test.md#factrix.slicing.inference.slice_joint_test)
+    [`slice_joint_test`](slice-test.md#factrix.slice_joint_test)
     (omnibus χ²).
 
 ### Schema

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -1,13 +1,10 @@
 ---
-title: factrix.slicing.inference
+title: factrix.slice_pairwise_test / factrix.slice_joint_test
 ---
 
-::: factrix.slicing.inference
-    options:
-        members:
-          - slice_pairwise_test
-          - slice_joint_test
-        show_root_heading: false
+::: factrix.slice_pairwise_test
+
+::: factrix.slice_joint_test
 
 Cross-slice statistical-test function pair. Both consume a metric callable
 and a date-keyed DataFrame whose `label` column carries the slice

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -531,6 +531,15 @@ plain prose; reach for a callout only when the elevation earns it.
 
 Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
 
+### Autodoc target — top-level path for `__all__` symbols
+
+For each `::: <target>` directive in `docs/api/`, the target dotted path matches the symbol's canonical user-facing import:
+
+- Symbol in `factrix.__all__` → top-level path (`::: factrix.evaluate`, `::: factrix.by_slice`, `::: factrix.SliceResult`). Do not target the submodule that physically defines it (e.g. `factrix.slicing.dispatcher` with `members: [by_slice]`) — submodule-target with member filter renders the *submodule* as the page h1 and buries the documented symbol below.
+- Symbol reached only via a submodule path → submodule path (`::: factrix.preprocess.compute_forward_return`, `::: factrix.metrics.ic` with `members: [ic, compute_ic, ic_newey_west]`, `::: factrix.datasets.make_cs_panel`). The submodule path is the canonical import.
+
+mkdocstrings cross-references (`[X][factrix.path.X]`) and intra-doc anchor links (`page.md#factrix.path.X`) follow the same rule — the path inside the brackets matches the autodoc target. Changing one without the other breaks the cross-ref.
+
 ### Autodoc options — globals + per-block deviations
 
 `mkdocs.yml` carries the page-primary defaults for mkdocstrings (`show_root_heading: true`, `show_root_full_path: true`, `show_root_toc_entry: true`, `heading_level: 1`, `separate_signature: true`, `show_signature_annotations: true`, `show_source: false`, `merge_init_into_class: true`, `docstring_style: google`). Every `::: factrix.<X>` block in `docs/api/**` inherits these.

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -33,8 +33,8 @@ below:
 Hypothesis-test metrics share a common envelope (`p_value`,
 `stat_type`, `h0`, `method`) — listed once here, not repeated per
 metric below. Cross-slice inference functions
-([`slice_pairwise_test`][factrix.slicing.inference.slice_pairwise_test] /
-[`slice_joint_test`][factrix.slicing.inference.slice_joint_test]) are
+([`slice_pairwise_test`][factrix.slice_pairwise_test] /
+[`slice_joint_test`][factrix.slice_joint_test]) are
 not listed in the table: their headline output is a DataFrame of
 contrasts, not a sidecar to a primary value.
 


### PR DESCRIPTION
## Summary

Sweep axis 13 of #280: retarget `by-slice.md` and `slice-test.md` autodoc blocks from submodule paths (`factrix.slicing.dispatcher` / `.result` / `.inference`) with `members:` filters onto the canonical top-level paths (`factrix.by_slice`, `factrix.SliceResult`, `factrix.slice_pairwise_test`, `factrix.slice_joint_test` — all in `factrix.__all__`).

Pre-PR audit (subagent sweep across `docs/`) confirmed this was the entire scope of the autodoc-target drift; preprocess / datasets / metrics pages intentionally use submodule paths because those *are* the canonical user-facing imports.

**Touched**:

- `docs/api/by-slice.md` — 2 autodoc directives retargeted; 4 anchor links to slice-test.md updated to the new top-level form.
- `docs/api/slice-test.md` — single submodule block split into two top-level blocks (one per function); `show_root_heading: false` override dropped (no longer needed); frontmatter title updated.
- `docs/reference/stat-keys-by-metric.md` — 2 mkdocstrings cross-refs retargeted to the new top-level form.
- `docs/development/contributing.md` — new "Autodoc target — top-level path for `__all__` symbols" subsection records the rule so this drift cannot land again.

## Test plan

- [x] `mkdocs build --strict` clean (no broken-anchor warnings)
- [x] `grep -rEn "factrix\.slicing\.(inference|dispatcher|result)\." docs/` returns no hits

Closes #303