### PR TITLE
docs: v0.13.0 UX audit micro-fixes (#306)

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -2,10 +2,10 @@
 title: Contributing to factrix
 ---
 
-This document describes the factrix development workflow. The intended
-readers are **the author + future AI agents**—a private repo, so OSS
-conventions like licensing / DCO / CLA are skipped, focusing instead on
-**actual development modes and pitfalls**.
+This document describes the factrix development workflow. factrix is
+currently a private single-author repo, so this guide covers
+**development modes and pitfalls** rather than OSS contributor
+conventions (licensing / DCO / CLA).
 
 ---
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -305,7 +305,7 @@ version follows actual, not pin.
 ### 5.4 When confused, do two things first
 
 1. `git submodule status` — see the pin
-2. `cd external/factrix && git rev-parse HEAD` — see the actual
+2. `cd external/factrix && git rev-parse --short HEAD` — see the actual
 
 If both SHAs match, you're clean; if not, decide whether to bump the
 pin (row 5) or reset actual (row 6).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -53,9 +53,11 @@ See [Concepts](concepts.md) for what each axis means.
 
 ## Research question → factory
 
-The five supported research questions and their factory calls live in
-[Concepts § Five analysis scenarios](concepts.md#five-analysis-scenarios)
-— that page is also the SSOT for the procedure and literature behind each
+The five supported research questions and their factory calls — the
+`AnalysisConfig.*()` classmethod constructors such as
+`individual_continuous()` used above — live in
+[Concepts § Five analysis scenarios](concepts.md#five-analysis-scenarios).
+That page is also the SSOT for the procedure and literature behind each
 factory. For task-oriented help on **picking** the right factory (IC vs FM,
 when to add standalone metrics), see [Choosing a metric](../guides/choosing-metric.md).
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,8 +4,8 @@ title: Guides
 
 Step-by-step guides for common factrix workflows.
 
+- [Choosing a metric](choosing-metric.md) — IC vs FM, scenario selection
 - [PANEL vs TIMESERIES](panel-timeseries.md) — sample guards, aggregation order, N=1 paths
 - [Batch screening with BHY](batch-screening.md) — FDR control across factor families
 - [Slice analysis](slice-analysis.md) — sector / regime / decile splits of a single metric
-- [Choosing a metric](choosing-metric.md) — IC vs FM, scenario selection
 - [Standalone metrics](standalone-metrics.md) — input shapes, post-`evaluate()` integration, per-cell examples

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,5 +6,6 @@ Step-by-step guides for common factrix workflows.
 
 - [PANEL vs TIMESERIES](panel-timeseries.md) — sample guards, aggregation order, N=1 paths
 - [Batch screening with BHY](batch-screening.md) — FDR control across factor families
+- [Slice analysis](slice-analysis.md) — sector / regime / decile splits of a single metric
 - [Choosing a metric](choosing-metric.md) — IC vs FM, scenario selection
 - [Standalone metrics](standalone-metrics.md) — input shapes, post-`evaluate()` integration, per-cell examples

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,10 +144,10 @@ nav:
           - TIMESERIES-mode conventions: reference/ts-mode-conventions.md
       - How-to:
           - guides/index.md
+          - Choosing a metric: guides/choosing-metric.md
           - PANEL vs TIMESERIES: guides/panel-timeseries.md
           - Batch screening (BHY): guides/batch-screening.md
           - Slice analysis: guides/slice-analysis.md
-          - Choosing a metric: guides/choosing-metric.md
           - Standalone metrics: guides/standalone-metrics.md
       - Examples:
           - examples/index.md


### PR DESCRIPTION
## Summary

- Align `git rev-parse` example in `contributing.md` §5.4 to the `--short` form used in §5.1 cheat sheet so the same workflow produces the same SHA shape.
- Soften the `contributing.md` opening from "private-repo, skip OSS conventions" to "private single-author repo, covers development modes rather than OSS conventions" — records the posture without reading as anti-contributor.
- Gloss "factory" inline on first use in `quickstart.md` (points at the `AnalysisConfig.*()` classmethod constructors the reader already saw in the smoke test).
- Add the missing Slice analysis bullet to `guides/index.md` so the index page matches the mkdocs nav.
- Reorder the How-to guides in both `guides/index.md` and `mkdocs.yml` so the reader flow is: pick metric → understand mode dispatch → batch screen → slice → standalone.

## Test plan

- [ ] `mkdocs build --strict` passes (pre-push hook already ran on this branch).
- [ ] Local `mkdocs serve` — Guides nav order reads Choosing → PANEL/TS → BHY → Slice → Standalone; index page lists all five.
- [ ] Quickstart "factory" gloss renders inline; concepts.md link still resolves.
- [ ] contributing.md opening reads neutrally; §5.4 SHA example matches §5.1 cheat sheet.

Closes #306.