### PR TITLE
docs(nav): apply pure-label policy (#309)

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -346,6 +346,27 @@ New example convention:
   `warning-codes.md`, `bibliography.md`: narrative roll-ups (not
   matrices)
 
+### Nav structure conventions
+
+The mkdocs nav follows a **pure-label** policy: every group label in
+`mkdocs.yml` is a non-clickable organising heading; every entry with
+content is an explicit leaf with a sidebar label. `navigation.indexes`
+is intentionally disabled so the visual contract is "label = heading,
+leaf = page, never both".
+
+When adding a new section or hub page:
+
+- Group labels carry no page reference. They look like `- Concepts:`
+  followed by an indented list of leaves.
+- Hub or overview pages (e.g. `api/metrics/index.md`) appear as an
+  explicit leaf with label `Overview` as the first child of their
+  group: `- Overview: api/metrics/index.md`.
+- Leaf labels are unique within their sidebar branch — never reuse the
+  parent group's name as a leaf label.
+
+This keeps `mkdocs build --strict` green and the sidebar legible without
+clicking through to discover affordance.
+
 ---
 
 ## 7. Drift management

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,6 @@ theme:
     - navigation.sections
     - navigation.expand
     - navigation.top
-    - navigation.indexes
     - navigation.path
     - search.suggest
     - search.highlight
@@ -132,29 +131,29 @@ not_in_nav: |
 
 nav:
   - Get Started:
-      - index.md
+      - Home: index.md
       - Where factrix fits: where-factrix-fits.md
       - Installation: getting-started/install.md
       - Quickstart: getting-started/quickstart.md
   - User Guide:
       - Concepts:
-          - getting-started/concepts.md
+          - Overview: getting-started/concepts.md
           - Architecture: development/architecture.md
           - Statistical methods: reference/statistical-methods.md
           - TIMESERIES-mode conventions: reference/ts-mode-conventions.md
       - How-to:
-          - guides/index.md
+          - Overview: guides/index.md
           - Choosing a metric: guides/choosing-metric.md
           - PANEL vs TIMESERIES: guides/panel-timeseries.md
           - Batch screening (BHY): guides/batch-screening.md
           - Slice analysis: guides/slice-analysis.md
           - Standalone metrics: guides/standalone-metrics.md
       - Examples:
-          - examples/index.md
+          - Overview: examples/index.md
           - Multi-factor screening: examples/multi_factor_screening.md
           - Stock factor evaluation: examples/stock_factor_evaluation.md
   - API Reference:
-      - api/index.md
+      - Overview: api/index.md
       - Panel schema: api/panel-schema.md
       - Decision tree: api/decision-tree.md
       - Entry points:
@@ -166,7 +165,7 @@ nav:
               - by_slice: api/by-slice.md
               - slice_pairwise_test / slice_joint_test: api/slice-test.md
           - Multi-factor:
-              - api/multi-factor.md
+              - Overview: api/multi-factor.md
               - bhy: api/bhy.md
               - partial_conjunction: api/partial-conjunction.md
               - bhy_hierarchical: api/bhy-hierarchical.md
@@ -190,9 +189,9 @@ nav:
           - Errors: api/errors.md
           - Bibliography: reference/bibliography.md
       - Metrics:
-          - api/metrics/index.md
+          - Overview: api/metrics/index.md
           - Individual continuous:
-              - api/metrics/individual-continuous.md
+              - Overview: api/metrics/individual-continuous.md
               - ic: api/metrics/ic.md
               - fama_macbeth: api/metrics/fama_macbeth.md
               - quantile: api/metrics/quantile.md
@@ -201,7 +200,7 @@ nav:
               - tradability: api/metrics/tradability.md
               - spanning: api/metrics/spanning.md
           - Individual sparse:
-              - api/metrics/individual-sparse.md
+              - Overview: api/metrics/individual-sparse.md
               - caar: api/metrics/caar.md
               - event_quality: api/metrics/event_quality.md
               - event_horizon: api/metrics/event_horizon.md
@@ -209,12 +208,12 @@ nav:
               - clustering: api/metrics/clustering.md
               - corrado: api/metrics/corrado.md
           - Common continuous:
-              - api/metrics/common-continuous.md
+              - Overview: api/metrics/common-continuous.md
               - ts_beta: api/metrics/ts_beta.md
               - ts_quantile: api/metrics/ts_quantile.md
               - ts_asymmetry: api/metrics/ts_asymmetry.md
           - Series diagnostics:
-              - api/metrics/series-tools.md
+              - Overview: api/metrics/series-tools.md
               - hit_rate: api/metrics/hit_rate.md
               - trend: api/metrics/trend.md
               - oos: api/metrics/oos.md


### PR DESCRIPTION
## Summary

Implements Policy 1 from #309: every group label in the mkdocs nav becomes a non-clickable organising heading; every hub page is surfaced as an explicit `Overview` leaf inside its group.

- Remove `navigation.indexes` from theme features so section-index collapse no longer happens.
- Every previously bare section-index entry now has an explicit label:
  - `Get Started > Home: index.md`
  - `User Guide > Concepts > Overview: getting-started/concepts.md` (also resolves the duplicate-label collision with the parent group)
  - `User Guide > How-to > Overview: guides/index.md`
  - `User Guide > Examples > Overview: examples/index.md`
  - `API Reference > Overview: api/index.md`
  - `API Reference > Entry points > Multi-factor > Overview: api/multi-factor.md`
  - `API Reference > Metrics > Overview: api/metrics/index.md` and each Metrics sub-bucket's hub gets an explicit `Overview:` leaf.
- Record the convention in `development/contributing.md §6` so future nav additions follow it.

Page URLs are unchanged, so internal cross-page links continue to resolve. No page content moves.

## Test plan

- [ ] `mkdocs build --strict` clean (verified locally).
- [ ] Local `mkdocs serve` — every group label is non-clickable; every group with hub content shows an `Overview` leaf as the first child.
- [ ] `Concepts` group no longer shows a duplicate `Concepts` leaf underneath itself.
- [ ] `api/multi-factor.md` and `api/metrics/index.md` content remains reachable via the new Overview leaves.

Closes #309.