### PR TITLE
docs: Examples SSOT + pycon copy strip (#307)

### DIFF
--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -42,7 +42,7 @@ jobs:
           enable-cache: true
 
       - name: Install docs dependencies
-        run: uv sync --python 3.12 --extra docs
+        run: uv sync --frozen --python 3.12 --extra docs
 
       - name: Strict build
         run: uv run mkdocs build --strict
@@ -67,7 +67,7 @@ jobs:
           enable-cache: true
 
       - name: Install docs dependencies
-        run: uv sync --python 3.12 --extra docs
+        run: uv sync --frozen --python 3.12 --extra docs
 
       - name: Strict build
         run: uv run mkdocs build --strict

--- a/.github/workflows/docs-deploy-release.yml
+++ b/.github/workflows/docs-deploy-release.yml
@@ -30,7 +30,7 @@ jobs:
           enable-cache: true
 
       - name: Install docs dependencies
-        run: uv sync --python 3.12 --extra docs
+        run: uv sync --frozen --python 3.12 --extra docs
 
       - name: Configure git for mike
         run: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -36,7 +36,7 @@ jobs:
           enable-cache: true
 
       - name: Install docs dependencies
-        run: uv sync --python 3.12 --extra docs
+        run: uv sync --frozen --python 3.12 --extra docs
 
       - name: Build site
         run: uv run mkdocs build
@@ -78,7 +78,7 @@ jobs:
           enable-cache: true
 
       - name: Install docs dependencies
-        run: uv sync --python 3.12 --extra docs
+        run: uv sync --frozen --python 3.12 --extra docs
 
       - name: Build site
         run: uv run mkdocs build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           enable-cache: true
 
       - name: Install dev tooling
-        run: uv sync --python 3.12 --all-extras
+        run: uv sync --frozen --python 3.12 --all-extras
 
       - name: ruff check
         run: uv run ruff check .
@@ -61,7 +61,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --python ${{ matrix.python }} --all-extras
+        run: uv sync --frozen --python ${{ matrix.python }} --all-extras
 
       - name: Run pytest
         run: uv run --python ${{ matrix.python }} pytest
@@ -80,7 +80,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --python 3.12 --all-extras
+        run: uv sync --frozen --python 3.12 --all-extras
 
       - name: Execute examples/*.ipynb
         run: |

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -49,21 +49,22 @@ title: factrix.multi_factor.bhy
 
 </div>
 
-## Call shape
+## Survivors attributes
 
-```python
-profiles = [
-    fx.evaluate(panel_per_lookback[lookback], cfg, factor_col=f"momentum_{lookback}")
-    for lookback, cfg in candidates
-]
-survivors = fx.multi_factor.bhy(profiles, q=0.05)
+See the docstring Examples block above for the canonical
+multi-factor call. The returned `Survivors` container exposes:
 
-survivors.profiles   # list[FactorProfile] in input order
-survivors.adj_p      # numpy array — bucket-local BHY-adjusted p-value, aligned
-survivors.q          # 0.05 — the nominal target you passed
-survivors.expand_over     # () for a single family; ("regime_id",) etc. otherwise
-survivors.n_tests    # {(): N} or {bucket_key: m_per_bucket}
-```
+| Attribute | Type | Meaning |
+|---|---|---|
+| `survivors.profiles` | `list[FactorProfile]` | input order, surviving subset |
+| `survivors.adj_p` | `np.ndarray` | bucket-local BHY-adjusted p-value, index-aligned with `profiles` |
+| `survivors.q` | `float` | the nominal target you passed |
+| `survivors.expand_over` | `tuple[str, ...]` | `()` for a single family; `("regime_id",)` etc. otherwise |
+| `survivors.n_tests` | `dict[tuple, int]` | `{(): N}` or `{bucket_key: m_per_bucket}` |
+
+Jupyter rendering surfaces a three-column text / HTML table of
+`identity | primary_p | adj_p`, plus an `expand_over_values` column
+when buckets are declared.
 
 The input list **is** the family. `bhy` runs one Benjamini–Yekutieli
 step-up over all profiles by default, returning the surviving subset

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -14,28 +14,18 @@ per slice. Returns a [`SliceResult`](#sliceresult) — a
 The axis name does not bake into the API — market, sector, regime,
 market-cap tier, ADV bucket all share the same dispatcher.
 
-## Call shape
-
-```python
-import polars as pl
-from factrix import by_slice
-from factrix.metrics import compute_ic, ic
-
-ic_df = compute_ic(panel)
-ic_df = ic_df.join(regime_labels, on="date")  # adds 'regime' column
-
-per_regime = by_slice(ic, ic_df, label="regime")
-# SliceResult({"bull": MetricOutput(name="ic", ...), "bear": MetricOutput(name="ic", ...)})
-
-per_regime["bull"].value          # Mapping access — unchanged
-per_regime.to_frame()             # long-form pl.DataFrame for plotting
-```
+## Argument contract
 
 The first argument is the **metric callable** (e.g. `ic`, `caar`,
 `fama_macbeth`); the second is the metric's primary date-keyed
 DataFrame **with the slicing column already present**; `label` names
 that column; remaining keyword args (`forward_periods=...`, etc.)
-forward unchanged on every per-slice call.
+forward unchanged on every per-slice call. See the docstring
+Examples block above for the canonical call shape.
+
+`SliceResult` is a `Mapping[str, MetricOutput]`:
+`result["<slice-key>"].value` for dict-style access,
+`result.to_frame()` for the long-form `pl.DataFrame`.
 
 ## Why "label is a column name"
 

--- a/docs/api/list-estimators.md
+++ b/docs/api/list-estimators.md
@@ -17,7 +17,7 @@ Two contracts to keep in mind:
 
 `Mode` is intentionally not a parameter — estimator applicability is
 cell-axis-dependent (scope × signal), not panel-shape-dependent.
-See the docstring Examples block above for canonical text-list and
+See the docstring Examples block above for the canonical text-list and
 JSON-form calls.
 
 ---

--- a/docs/api/list-estimators.md
+++ b/docs/api/list-estimators.md
@@ -13,23 +13,12 @@ Two contracts to keep in mind:
 - **Cell → procedure is 1:1** (per #148). A cell's primary p-value is produced by exactly one estimator at `evaluate` time.
 - **Family functions accept an `estimator=` override.** `bhy` / `bhy_hierarchical` / `partial_conjunction` swap which already-computed p-value drives the multiplicity step. `list_estimators` returns the candidates for that override, filtered to those applicable to the cell.
 
-## Call shape
+## Mode axis is not an input
 
-```python
-import factrix as fx
-
-# Text list (default) — pretty names for CLI / REPL inspection
-fx.list_estimators(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS)
-# → ['NeweyWest', 'HansenHodrick', 'BlockBootstrap', ...]
-
-# Structured records — programmatic filtering / import paths
-fx.list_estimators(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS,
-                   format='json', with_import=True)
-# → [{'name': 'NeweyWest', 'import': 'from factrix.stats import NeweyWest', ...}, ...]
-```
-
-`Mode` is intentionally not an input — estimator applicability is
+`Mode` is intentionally not a parameter — estimator applicability is
 cell-axis-dependent (scope × signal), not panel-shape-dependent.
+See the docstring Examples block above for canonical text-list and
+JSON-form calls.
 
 ---
 

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -17,7 +17,7 @@ invoke once `evaluate()` has produced a `FactorProfile`.
 `Mode` is intentionally not a parameter — applicability does not
 change across PANEL / TIMESERIES (see
 [Metric applicability](../reference/metric-applicability.md) for the
-underlying matrix). See the docstring Examples block above for
+underlying matrix). See the docstring Examples block above for the
 canonical text-list and JSON-form calls.
 
 ## Discover-then-import workflow

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -12,24 +12,13 @@ returns the full set of standalone callables under
 [`factrix.metrics`](metrics/index.md) that the user can additionally
 invoke once `evaluate()` has produced a `FactorProfile`.
 
-## Call shape
+## Mode axis is not an input
 
-```python
-import factrix as fx
-
-fx.list_metrics(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS)
-# -> ['top_concentration', 'beta_sign_consistency', 'fama_macbeth',
-#     'pooled_ols', 'hit_rate', 'ic', 'ic_ir', 'ic_newey_west',
-#     'monotonicity', 'multi_split_oos_decay', 'quantile_spread',
-#     'quantile_spread_vw', 'greedy_forward_selection', 'spanning_alpha',
-#     'breakeven_cost', 'net_spread', 'notional_turnover', 'turnover',
-#     'ic_trend']
-```
-
-`Mode` is intentionally not an input — applicability does not change
-across PANEL / TIMESERIES (see
+`Mode` is intentionally not a parameter — applicability does not
+change across PANEL / TIMESERIES (see
 [Metric applicability](../reference/metric-applicability.md) for the
-underlying matrix).
+underlying matrix). See the docstring Examples block above for
+canonical text-list and JSON-form calls.
 
 ## Discover-then-import workflow
 

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -58,7 +58,7 @@ extend stage-1 wiring per cell.
 ## Explicit subset error semantics
 
 When `metrics=` is passed an explicit list (see the docstring
-Examples block above for the call shape), unknown names raise
+Examples block above for the canonical call shape), unknown names raise
 [`UserInputError`][factrix.UserInputError] with a fuzzy suggestion
 plus the full candidate list. Names registered for the cell but in
 the auto-discover exclusion set raise the same error type with the

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -24,19 +24,7 @@ types are disjoint by design.
 Both can be called on the same `(panel, cfg)`; neither is a
 prerequisite for the other.
 
-## Call shape
-
-```python
-import factrix as fx
-
-cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
-bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
-
-bundle["ic"].value             # dict-style access
-bundle.identity                # ("momentum_12_1", 5) — (factor_id, fwd)
-bundle.to_frame()              # long-form pl.DataFrame
-dict(bundle.skipped)           # metrics that could not auto-run
-```
+## Identity uniqueness in sweeps
 
 `panel` follows the same canonical schema as `evaluate`
 (`date, asset_id, factor, forward_return`); `factor_col` renames an
@@ -67,17 +55,15 @@ spread consumers) live in the auto-discover exclusion set; the bundle's
 `skipped` map carries the explicit-import recipe for each. v1.x will
 extend stage-1 wiring per cell.
 
-## Explicit subset
+## Explicit subset error semantics
 
-```python
-fx.run_metrics(panel, cfg, metrics=["ic", "monotonicity"])
-```
-
-Unknown names raise [`UserInputError`][factrix.UserInputError] with a fuzzy
-suggestion plus the full candidate list. Names registered for the
-cell but in the auto-discover exclusion set raise the same error type with
-the documented reason and the explicit-call recipe — `run_metrics`
-never silently drops a name the caller asked for.
+When `metrics=` is passed an explicit list (see the docstring
+Examples block above for the call shape), unknown names raise
+[`UserInputError`][factrix.UserInputError] with a fuzzy suggestion
+plus the full candidate list. Names registered for the cell but in
+the auto-discover exclusion set raise the same error type with the
+documented reason and the explicit-call recipe — `run_metrics` never
+silently drops a name the caller asked for.
 
 ## Cross-horizon and cross-universe analysis
 

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -25,24 +25,16 @@ result. They do **not** participate in BHY family expansion — adjusted
 p is a within-slice-family closure, not a cell-level discovery
 commitment.
 
-## Call shape
-
-```python
-import polars as pl
-from factrix import slice_joint_test, slice_pairwise_test
-from factrix.metrics import compute_ic, ic
-
-ic_df = compute_ic(panel)
-ic_df = ic_df.join(regime_labels, on="date")  # adds 'regime' column
-
-pairwise = slice_pairwise_test(ic, ic_df, label="regime")
-omnibus = slice_joint_test(ic, ic_df, label="regime")
-```
+## Metric capability requirement
 
 The metric callable's module must declare `per_date_series` (a
 top-level capability function returning a `(date, value)` long-form
 frame); IC, Fama-MacBeth, and hit_rate ship with this declaration.
 A metric without it raises `TypeError` at the function call site.
+
+See the docstring Examples blocks above for the canonical
+per-sub-universe construction (`compute_ic` per sector, concatenated
+with a `sector` label column).
 
 ## Date alignment is required
 

--- a/docs/api/suggest-config.md
+++ b/docs/api/suggest-config.md
@@ -10,14 +10,10 @@ reasoning behind the suggestion. The proposal is never auto-applied —
 the caller (or an AI agent) reads `reasoning` / `warnings` before
 deciding to use, override, or reject it.
 
-Canonical [`MissingConfigError`][factrix.MissingConfigError] recovery:
-
-```python
-import factrix as fx
-
-result  = fx.suggest_config(panel)
-profile = fx.evaluate(panel, result.suggested)
-```
+The canonical [`MissingConfigError`][factrix.MissingConfigError]
+recovery path — call `suggest_config(panel)`, then pass
+`result.suggested` to `evaluate` — is shown in the docstring
+Examples block above.
 
 ## `SuggestConfigResult`
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -325,6 +325,49 @@ files auto-update and which need manual maintenance.
 | `Matrix-row:` in `factrix/metrics/*.py` | `docs/reference/_generated_metric_matrix.md` | hook: `scripts/mkdocs_hooks/gen_metric_matrix.py` |
 | `factrix/llms*.txt` | site root `llms*.txt` | hook: `scripts/mkdocs_hooks/sync_llms_txt.py` |
 
+#### Docstring `Examples:` — runnable, copy-paste ready
+
+Every user-facing function reachable from the API Reference nav
+(`evaluate`, `run_metrics`, `by_slice`, `slice_pairwise_test`,
+`slice_joint_test`, `multi_factor.{bhy, partial_conjunction,
+bhy_hierarchical}`, `compare`, `suggest_config`, `list_metrics`,
+`list_estimators`) carries an `Examples:` block in its docstring.
+The docstring is the single source of truth — `.md` pages do not
+duplicate runnable examples, only document things the example
+cannot show (output schemas, attribute tables, semantic intent).
+
+Convention:
+
+- Section header is `Examples:` (plural, Google style).
+- Source uses `>>>` doctest prompt syntax. The Material copy button
+  is configured (via `docs/javascripts/copy-strip-pycon.js`) to
+  strip `>>>` prompts and expected-output lines from the clipboard
+  payload, so readers can copy a `pycon` block straight into a
+  REPL or script.
+- Show **call shape**, not fragile output. Lines starting with
+  `>>>` carry the educational value; expected-output lines (lines
+  without `>>>`) are reserved for values stable across BLAS / numpy
+  / polars / Python versions.
+- Avoid concrete floating-point values, DataFrame / array reprs, or
+  multi-line text reprs as expected output. If a value must be
+  shown, prefer structural facts (enum value, integer length,
+  boolean from `isinstance`).
+- Setup is self-contained — construct any required panel inline via
+  `fx.datasets.make_cs_panel(...)` + `compute_forward_return(...)`
+  so the snippet runs verbatim with no surrounding fixtures.
+
+This keeps the Examples blocks doctest-ready. Enabling
+`pytest --doctest-modules` in CI is tracked as a separate
+follow-up; once turned on, no per-example rewrite is needed
+provided new Examples follow the convention above.
+
+Page-level demo admonitions (`## Worked example`, `!!! example`
+blocks) are reserved for end-to-end demos that intentionally show
+something the docstring cannot — typically a longer
+synthetic-panel walk-through with `profile.diagnose()` output or a
+cross-cell config recipe table. They do not echo the docstring
+example.
+
 #### Examples — markdown SSOT + optional runnable mirror
 
 `docs/examples/*.md` are hand-authored; markdown is the SSOT. The `examples/*.ipynb` files at repo root are *optional* runnable mirrors for users who want to step through a recipe interactively — they are not the source for the rendered site and not required.

--- a/docs/javascripts/copy-strip-pycon.js
+++ b/docs/javascripts/copy-strip-pycon.js
@@ -1,12 +1,13 @@
 document.addEventListener(
   "click",
   function (event) {
-    var button = event.target.closest(".md-clipboard");
+    var button = event.target.closest('[data-md-type="copy"]');
     if (!button) return;
-    var block = button.closest(".language-pycon");
-    if (!block) return;
-    var code = block.querySelector("pre code") || block.querySelector("code");
+    var targetSel = button.getAttribute("data-clipboard-target");
+    if (!targetSel) return;
+    var code = document.querySelector(targetSel);
     if (!code) return;
+    if (!code.closest(".language-pycon")) return;
     var clone = code.cloneNode(true);
     clone.querySelectorAll(".gp, .go").forEach(function (node) {
       node.remove();

--- a/docs/javascripts/copy-strip-pycon.js
+++ b/docs/javascripts/copy-strip-pycon.js
@@ -1,0 +1,36 @@
+(function () {
+  function bind(block) {
+    var button = block.querySelector(".md-clipboard");
+    if (!button || button.dataset.pyconStripBound) return;
+    button.dataset.pyconStripBound = "1";
+    button.addEventListener(
+      "click",
+      function (event) {
+        var code = block.querySelector("pre code");
+        if (!code) return;
+        var clone = code.cloneNode(true);
+        clone.querySelectorAll(".gp, .go").forEach(function (node) {
+          node.remove();
+        });
+        var text = clone.textContent
+          .replace(/^[ \t]*\n/gm, "")
+          .replace(/\n{3,}/g, "\n\n")
+          .replace(/\s+$/, "\n");
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        navigator.clipboard.writeText(text);
+      },
+      true,
+    );
+  }
+
+  function setup() {
+    document.querySelectorAll(".language-pycon").forEach(bind);
+  }
+
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(setup);
+  } else {
+    document.addEventListener("DOMContentLoaded", setup);
+  }
+})();

--- a/docs/javascripts/copy-strip-pycon.js
+++ b/docs/javascripts/copy-strip-pycon.js
@@ -1,36 +1,23 @@
-(function () {
-  function bind(block) {
-    var button = block.querySelector(".md-clipboard");
-    if (!button || button.dataset.pyconStripBound) return;
-    button.dataset.pyconStripBound = "1";
-    button.addEventListener(
-      "click",
-      function (event) {
-        var code = block.querySelector("pre code");
-        if (!code) return;
-        var clone = code.cloneNode(true);
-        clone.querySelectorAll(".gp, .go").forEach(function (node) {
-          node.remove();
-        });
-        var text = clone.textContent
-          .replace(/^[ \t]*\n/gm, "")
-          .replace(/\n{3,}/g, "\n\n")
-          .replace(/\s+$/, "\n");
-        event.stopImmediatePropagation();
-        event.preventDefault();
-        navigator.clipboard.writeText(text);
-      },
-      true,
-    );
-  }
-
-  function setup() {
-    document.querySelectorAll(".language-pycon").forEach(bind);
-  }
-
-  if (window.document$ && typeof window.document$.subscribe === "function") {
-    window.document$.subscribe(setup);
-  } else {
-    document.addEventListener("DOMContentLoaded", setup);
-  }
-})();
+document.addEventListener(
+  "click",
+  function (event) {
+    var button = event.target.closest(".md-clipboard");
+    if (!button) return;
+    var block = button.closest(".language-pycon");
+    if (!block) return;
+    var code = block.querySelector("pre code") || block.querySelector("code");
+    if (!code) return;
+    var clone = code.cloneNode(true);
+    clone.querySelectorAll(".gp, .go").forEach(function (node) {
+      node.remove();
+    });
+    var text = clone.textContent
+      .replace(/^[ \t]*\n/gm, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .replace(/\s+$/, "\n");
+    event.stopImmediatePropagation();
+    event.preventDefault();
+    navigator.clipboard.writeText(text);
+  },
+  true,
+);

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -175,22 +175,22 @@ def evaluate(
         FDR but does **not** reduce the per-signal evaluation cost.
 
     Examples:
-        Single-factor inference:
+        Single-factor inference on a cross-sectional panel:
 
-        >>> config = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=250)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> config = fx.AnalysisConfig.individual_continuous(forward_periods=5)
         >>> profile = fx.evaluate(panel, config)
-        >>> profile.primary_p
-        0.0001
 
         Non-default signal column name:
 
-        >>> profile = fx.evaluate(panel, config, factor_col="alpha")
+        >>> panel_renamed = panel.rename({"factor": "alpha"})
+        >>> profile = fx.evaluate(panel_renamed, config, factor_col="alpha")
 
-        Multi-factor screening with FDR (see batch screening guide):
-
-        >>> profiles = [fx.evaluate(panel, config, factor_col=name)
-        ...             for name in candidate_signals]
-        >>> survivors = fx.multi_factor.bhy(profiles)
+        Multi-factor screening with FDR — see
+        :func:`factrix.multi_factor.bhy`.
     """
     if config is None:
         raise MissingConfigError(

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -181,13 +181,13 @@ def evaluate(
         >>> from factrix.preprocess import compute_forward_return
         >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=250)
         >>> panel = compute_forward_return(raw, forward_periods=5)
-        >>> config = fx.AnalysisConfig.individual_continuous(forward_periods=5)
-        >>> profile = fx.evaluate(panel, config)
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profile = fx.evaluate(panel, cfg)
 
         Non-default signal column name:
 
         >>> panel_renamed = panel.rename({"factor": "alpha"})
-        >>> profile = fx.evaluate(panel_renamed, config, factor_col="alpha")
+        >>> profile = fx.evaluate(panel_renamed, cfg, factor_col="alpha")
 
         Multi-factor screening with FDR — see
         :func:`factrix.multi_factor.bhy`.

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -59,6 +59,36 @@ def compare(
     Raises:
         UserInputError: Empty input; mixed artifact types; ``sort_by``
             not present in the output schema (with fuzzy suggestion).
+
+    Examples:
+        Leaderboard from a list of :class:`FactorProfile`:
+
+        >>> import dataclasses
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profiles = [
+        ...     dataclasses.replace(
+        ...         fx.evaluate(
+        ...             compute_forward_return(
+        ...                 fx.datasets.make_cs_panel(
+        ...                     n_assets=100, n_dates=250, seed=i,
+        ...                 ),
+        ...                 forward_periods=5,
+        ...             ),
+        ...             cfg,
+        ...         ),
+        ...         factor_id=f"alpha_{i}",
+        ...     )
+        ...     for i in range(3)
+        ... ]
+        >>> leaderboard = fx.compare(profiles, sort_by="primary_p")
+
+        Leaderboard from a :class:`~factrix.multi_factor.Survivors`
+        (adds an ``adj_p`` column):
+
+        >>> survivors = fx.multi_factor.bhy(profiles, q=0.5)
+        >>> board = fx.compare(survivors, sort_by="adj_p")
     """
     if isinstance(artifacts, Survivors):
         if len(artifacts) == 0:

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -398,6 +398,17 @@ def suggest_config(
     Plan §7.2: this is a *suggestion* — never auto-applied. The
     caller (or an AI agent) reads ``reasoning`` and ``warnings`` to
     decide whether to override.
+
+    Examples:
+        Detect cell axes from a synthetic cross-sectional panel and
+        accept the suggestion:
+
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=250)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> result = fx.suggest_config(panel, forward_periods=5)
+        >>> profile = fx.evaluate(panel, result.suggested)
     """
     signal, signal_reason, sparsity = _detect_signal(raw)
     scope, scope_reason = _detect_scope(raw)
@@ -528,6 +539,20 @@ def list_metrics(
     for the date-slicing dispatcher :func:`factrix.by_slice`; ``"scalar"``
     rows (``breakeven_cost``, ``net_spread``) consume pre-aggregated
     scalars and are not eligible.
+
+    Examples:
+        Discover standalone metrics for an INDIVIDUAL × CONTINUOUS cell:
+
+        >>> import factrix as fx
+        >>> names = fx.list_metrics(
+        ...     fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS,
+        ... )
+
+        JSON form (for tooling — adds module / cell / import_path keys):
+
+        >>> rows = fx.list_metrics(
+        ...     fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS, format="json",
+        ... )
     """
     rows = [r for r in user_facing_rows() if r.cell.matches(scope, signal)]
     if not rows:
@@ -596,6 +621,20 @@ def list_estimators(
         ``(scope, signal)`` matches no registered Estimator. ``NeweyWest``
         applies to every user-facing cell, so as long as it stays in the
         registry this branch is defensive.
+
+    Examples:
+        Discover applicable estimators for an INDIVIDUAL × CONTINUOUS cell:
+
+        >>> import factrix as fx
+        >>> names = fx.list_estimators(
+        ...     fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS,
+        ... )
+
+        JSON form for tooling:
+
+        >>> rows = fx.list_estimators(
+        ...     fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS, format="json",
+        ... )
     """
     from factrix.stats import _ESTIMATOR_REGISTRY
 

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -261,6 +261,32 @@ def bhy(
             inflates FDR. Or when most ``expand_over`` buckets contain
             a single profile (BHY on n=1 is a raw cutoff and provides
             no FDR correction).
+
+    Examples:
+        Screen five candidate factors with BHY at q=0.05 — each panel
+        is a seeded synthetic cross-section, ``factor_id`` is stamped
+        post-hoc so the family resolver sees distinct identities:
+
+        >>> import dataclasses
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profiles = [
+        ...     dataclasses.replace(
+        ...         fx.evaluate(
+        ...             compute_forward_return(
+        ...                 fx.datasets.make_cs_panel(
+        ...                     n_assets=100, n_dates=250, seed=i,
+        ...                 ),
+        ...                 forward_periods=5,
+        ...             ),
+        ...             cfg,
+        ...         ),
+        ...         factor_id=f"alpha_{i}",
+        ...     )
+        ...     for i in range(5)
+        ... ]
+        >>> survivors = fx.multi_factor.bhy(profiles, q=0.05)
     """
     expand_over_tuple: tuple[str, ...] = tuple(expand_over) if expand_over else ()
 
@@ -377,6 +403,36 @@ def partial_conjunction(
             than ``min_pass`` conditions; family-resolution invariants
             (unknown ``expand_over`` key, identity-shadowing,
             duplicate partition key).
+
+    Examples:
+        Three candidate factors evaluated in two regions; survive if
+        significant in at least 2 of 2 regions:
+
+        >>> import dataclasses
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profiles = [
+        ...     dataclasses.replace(
+        ...         fx.evaluate(
+        ...             compute_forward_return(
+        ...                 fx.datasets.make_cs_panel(
+        ...                     n_assets=100, n_dates=250,
+        ...                     seed=hash((fid, region)) % 1000,
+        ...                 ),
+        ...                 forward_periods=5,
+        ...             ),
+        ...             cfg,
+        ...         ),
+        ...         factor_id=fid,
+        ...         context={"region": region},
+        ...     )
+        ...     for fid in ("alpha_1", "alpha_2", "alpha_3")
+        ...     for region in ("US", "EU")
+        ... ]
+        >>> survivors = fx.multi_factor.partial_conjunction(
+        ...     profiles, min_pass=2, expand_over=["region"]
+        ... )
     """
     if min_pass < 2:
         if min_pass == 1:
@@ -637,6 +693,35 @@ def bhy_hierarchical(
     References:
         Yekutieli, D. (2008). "Hierarchical false discovery rate-
         controlling methodology." JASA 103(481), 309-316.
+
+    Examples:
+        Six candidate factors split into two family groups; FDR is
+        controlled across groups (outer) and within each group (inner):
+
+        >>> import dataclasses
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profiles = [
+        ...     dataclasses.replace(
+        ...         fx.evaluate(
+        ...             compute_forward_return(
+        ...                 fx.datasets.make_cs_panel(
+        ...                     n_assets=100, n_dates=250, seed=i,
+        ...                 ),
+        ...                 forward_periods=5,
+        ...             ),
+        ...             cfg,
+        ...         ),
+        ...         factor_id=f"f_{family}_{i}",
+        ...         context={"family": family},
+        ...     )
+        ...     for family in ("momentum", "value")
+        ...     for i in range(3)
+        ... ]
+        >>> survivors = fx.multi_factor.bhy_hierarchical(
+        ...     profiles, group="family"
+        ... )
     """
     profile_list = list(profiles)
     expand_over_tuple: tuple[str, ...] = (group,)

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -313,16 +313,22 @@ def run_metrics(
             short-circuits are converted to short-circuit
             ``MetricOutput`` entries inside the bundle, **not** raised.
 
-    Example:
-        ```python
-        import factrix as fx
+    Examples:
+        Auto-discover every applicable metric for the cell:
 
-        cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
-        bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
-        bundle["ic"].value           # dict-style access
-        bundle.to_frame()            # long-form pl.DataFrame
-        dict(bundle.skipped)         # what we could not auto-run
-        ```
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=250)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> bundle = fx.run_metrics(panel, cfg)
+        >>> ic_output = bundle["ic"]
+        >>> long_frame = bundle.to_frame()
+        >>> skipped = dict(bundle.skipped)
+
+        Restrict to a subset by name:
+
+        >>> bundle = fx.run_metrics(panel, cfg, metrics=["ic"])
     """
     missing = {"date", "asset_id", factor_col, "forward_return"} - set(panel.columns)
     if missing:

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -159,7 +159,7 @@ def romano_wolf(
     # Enforce monotonicity in descending-significance order: an earlier
     # (more significant) rejection cannot have a larger adjusted p than
     # a later one. Cummax over the sequence.
-    p_adj_desc = np.maximum.accumulate(p_adj_desc)  # type: ignore[assignment]
+    p_adj_desc = np.maximum.accumulate(p_adj_desc)  # type: ignore[assignment, unused-ignore]
     p_adj_desc = np.minimum(p_adj_desc, 1.0)
 
     out = np.empty(m, dtype=float)

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -159,7 +159,7 @@ def romano_wolf(
     # Enforce monotonicity in descending-significance order: an earlier
     # (more significant) rejection cannot have a larger adjusted p than
     # a later one. Cummax over the sequence.
-    p_adj_desc = np.maximum.accumulate(p_adj_desc)  # type: ignore[assignment, unused-ignore]
+    p_adj_desc = np.maximum.accumulate(p_adj_desc)
     p_adj_desc = np.minimum(p_adj_desc, 1.0)
 
     out = np.empty(m, dtype=float)

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -159,7 +159,7 @@ def romano_wolf(
     # Enforce monotonicity in descending-significance order: an earlier
     # (more significant) rejection cannot have a larger adjusted p than
     # a later one. Cummax over the sequence.
-    p_adj_desc = np.maximum.accumulate(p_adj_desc)
+    p_adj_desc = np.maximum.accumulate(p_adj_desc)  # type: ignore[assignment]
     p_adj_desc = np.minimum(p_adj_desc, 1.0)
 
     out = np.empty(m, dtype=float)

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -499,7 +499,7 @@ def _estimate_sar_icc(
 
     w_num = (multi["v"] * (multi["n"] - 1)).sum()
     w_den = (multi["n"] - 1).sum()
-    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0  # type: ignore[operator, unused-ignore]
+    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0  # type: ignore[operator]
 
     date_means = multi["m"].to_numpy()
     sigma2_between = float(np.var(date_means, ddof=DDOF))

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -499,7 +499,7 @@ def _estimate_sar_icc(
 
     w_num = (multi["v"] * (multi["n"] - 1)).sum()
     w_den = (multi["n"] - 1).sum()
-    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0  # type: ignore[operator]
+    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0
 
     date_means = multi["m"].to_numpy()
     sigma2_between = float(np.var(date_means, ddof=DDOF))

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -499,7 +499,7 @@ def _estimate_sar_icc(
 
     w_num = (multi["v"] * (multi["n"] - 1)).sum()
     w_den = (multi["n"] - 1).sum()
-    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0
+    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0  # type: ignore[operator, unused-ignore]
 
     date_means = multi["m"].to_numpy()
     sigma2_between = float(np.var(date_means, ddof=DDOF))

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -57,15 +57,21 @@ def by_slice(
         TypeError: ``df`` is not a polars DataFrame.
         ValueError: ``label`` not in ``df.columns``, or ``df`` is empty.
 
-    Example:
-        ```python
-        import polars as pl
-        from factrix import by_slice
-        from factrix.metrics import ic, compute_ic
+    Examples:
+        Per-year IC on a synthetic cross-sectional panel — attach the
+        slice label to the metric's primary DataFrame upstream, then
+        dispatch one metric call per slice value:
 
-        ic_df = compute_ic(panel)              # already has 'sector'
-        per_sector = by_slice(ic, ic_df, label="sector")
-        ```
+        >>> import polars as pl
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> from factrix.metrics import ic, compute_ic
+        >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=500)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> ic_df = compute_ic(panel).with_columns(
+        ...     pl.col("date").dt.year().alias("year")
+        ... )
+        >>> per_year = fx.by_slice(ic, ic_df, label="year")
 
     Universe overlap (superset / multi-membership / hierarchical /
     sliding window / cross-product) is composed by the caller — see

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -147,6 +147,42 @@ def slice_pairwise_test(
             ``per_date_series`` capability).
         NotImplementedError: Estimator outside ``WaldNWCluster`` /
             ``BlockBootstrap``.
+
+    Examples:
+        Pairwise IC contrasts across two sub-universes. The canonical
+        pattern is to compute the per-date metric series per slice
+        upstream and concatenate with a label column — slices must
+        share dates, so date-disjoint labels (e.g. calendar year)
+        do not apply:
+
+        >>> import polars as pl
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> from factrix.metrics import ic, compute_ic
+        >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=500)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> assets = panel["asset_id"].unique().sort().to_list()
+        >>> half = len(assets) // 2
+        >>> sector_map = {a: ("tech" if i < half else "fin")
+        ...               for i, a in enumerate(assets)}
+        >>> panel_sec = panel.with_columns(
+        ...     pl.col("asset_id").replace_strict(sector_map).alias("sector")
+        ... )
+        >>> per_sector_ic = pl.concat([
+        ...     compute_ic(panel_sec.filter(pl.col("sector") == s))
+        ...        .with_columns(pl.lit(s).alias("sector"))
+        ...     for s in ("tech", "fin")
+        ... ])
+        >>> pairs = fx.slice_pairwise_test(ic, per_sector_ic, label="sector")
+
+        Block-bootstrap path (auto-switches to Romano-Wolf
+        multiple-testing):
+
+        >>> from factrix.stats import BlockBootstrap
+        >>> pairs_bb = fx.slice_pairwise_test(
+        ...     ic, per_sector_ic, label="sector",
+        ...     estimator=BlockBootstrap(rng_seed=0),
+        ... )
     """
     est = _resolve_estimator(estimator, "slice_pairwise_test")
 
@@ -258,6 +294,31 @@ def slice_joint_test(
             ``per_date_series`` capability).
         NotImplementedError: Non-``WaldNWCluster`` estimator passed
             before the block-bootstrap batch lands.
+
+    Examples:
+        Joint omnibus test that mean IC is identical across two
+        sub-universes (see :func:`slice_pairwise_test` for the
+        per-sector ic panel construction):
+
+        >>> import polars as pl
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> from factrix.metrics import ic, compute_ic
+        >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=500)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> assets = panel["asset_id"].unique().sort().to_list()
+        >>> half = len(assets) // 2
+        >>> sector_map = {a: ("tech" if i < half else "fin")
+        ...               for i, a in enumerate(assets)}
+        >>> panel_sec = panel.with_columns(
+        ...     pl.col("asset_id").replace_strict(sector_map).alias("sector")
+        ... )
+        >>> per_sector_ic = pl.concat([
+        ...     compute_ic(panel_sec.filter(pl.col("sector") == s))
+        ...        .with_columns(pl.lit(s).alias("sector"))
+        ...     for s in ("tech", "fin")
+        ... ])
+        >>> joint = fx.slice_joint_test(ic, per_sector_ic, label="sector")
     """
     est = _resolve_estimator(estimator, "slice_joint_test")
     if isinstance(est, BlockBootstrap):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/copy-strip-pycon.js
 
 extra:
   version:


### PR DESCRIPTION
## Summary

- Adopt docstring `Examples:` blocks as the single source of truth for runnable examples on every entry-point + utility verb reachable from the API Reference nav (12 functions).
- Keep `>>>` doctest prompt syntax in source; intercept the mkdocs-material copy button so the clipboard payload strips `.gp` / `.go` (prompts + expected output). Source stays doctest-ready for a future CI adoption without a second format migration.
- Apply a call-shape-over-fragile-output convention: no concrete floats, DataFrame reprs, or multi-line text reprs as expected-output lines. Setup is self-contained via `fx.datasets.make_cs_panel(...)` + `compute_forward_return(...)`.
- Sweep `docs/api/*.md` to remove `## Call shape` blocks that now duplicate the docstring Examples; preserve narrative material (attribute tables, error semantics, schema illustrations) that the docstring cannot show.
- Record the convention in `docs/development/contributing.md` §6.

## Test plan

- [ ] `uv run --frozen mkdocs build -q` exits 0, no warnings (run during development; CI will re-verify).
- [ ] `uv run --frozen mypy factrix` passes (two pre-existing errors cleared in this PR — see `f20b1b9`).
- [ ] Each of the 12 in-scope Examples blocks executes end-to-end from a fresh interpreter — verified by the correctness review agent.
- [ ] On `mkdocs serve`, clicking the copy button on a `pycon` code block (e.g. `/api/evaluate/`) writes paste-ready Python to the clipboard — no `>>>`, no expected-output lines. **Verified manually by the author.**

## Out of scope

- Enabling `pytest --doctest-modules` in CI. The Examples-writing convention adopted here is doctest-ready in format; turning the CI on becomes a config + workflow change, tracked separately if pursued.
- Google-style docstring section audit (`Args:` / `Returns:` / `Raises:` ordering, naming, blank-line conventions). `list_metrics` / `list_estimators` still carry NumPy-style headers; converting them is a distinct axis under #280.
- Examples blocks on result dataclasses (`FactorProfile`, `MetricsBundle`, `SliceResult`, `Survivors`, `SuggestConfigResult`), `AnalysisConfig` factory methods, and `factrix.datasets` / `factrix.preprocess` entry points. None carry an Examples block today; a follow-up sub-issue under #280 will sweep them.

Closes #307