### PR TITLE
chore(ci): enable pytest --doctest-modules (#314)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,25 @@ jobs:
       - name: Run pytest
         run: uv run --python ${{ matrix.python }} pytest
 
+  doctest:
+    name: pytest --doctest-modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --python 3.12 --all-extras
+
+      - name: Run doctests
+        run: uv run pytest --doctest-modules factrix/
+
   examples:
     name: example notebooks execute
     runs-on: ubuntu-latest

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -356,10 +356,14 @@ Convention:
   `fx.datasets.make_cs_panel(...)` + `compute_forward_return(...)`
   so the snippet runs verbatim with no surrounding fixtures.
 
-This keeps the Examples blocks doctest-ready. Enabling
-`pytest --doctest-modules` in CI is tracked as a separate
-follow-up; once turned on, no per-example rewrite is needed
-provided new Examples follow the convention above.
+Examples blocks are CI-verified. The `doctest` job in
+`.github/workflows/test.yml` runs `pytest --doctest-modules
+factrix/` on every PR; option flags (`ELLIPSIS`,
+`NORMALIZE_WHITESPACE`) live in `[tool.pytest.ini_options]
+doctest_optionflags` so individual Examples carry no
+`# doctest:` directives. A renamed symbol, changed signature,
+or dropped import that breaks an Example surfaces on the same
+PR as the change.
 
 Page-level demo admonitions (`## Worked example`, `!!! example`
 blocks) are reserved for end-to-end demos that intentionally show

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ all = ["factrix[jupyter]"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --tb=short"
+doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary

- New `doctest` job in `.github/workflows/test.yml` runs `pytest --doctest-modules factrix/` on every PR (ubuntu, py3.12 — doctest is platform-independent so single-shot, not matrix).
- `doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"` centralized in `[tool.pytest.ini_options]`; no per-Example `# doctest:` directives.
- `docs/development/contributing.md` updated from "tracked as a follow-up" to current-state "CI-verified".

Kept as a separate job (not folded into the `test` matrix) so doctest failures triage cleanly and the local `pytest` invocation stays scoped to `tests/`.

## Test plan

- [x] `uv run pytest --doctest-modules factrix/` → 12 passed, 1 skipped locally
- [x] `uv run pytest` → 1300 passed (existing suite unaffected)
- [ ] CI `doctest` job green on this PR

Closes #314.