### PR TITLE
docs: module docstring layering + References migration (#319)

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -555,6 +555,42 @@ The project's style policy is split between two complementary but distinct conve
 
 NumPy-style underline sections (`Parameters\n----------`) and Sphinx field lists (`:param x:` / `:returns:`) are not parsed by the Google handler and render as plain prose under generic headings. Convert on sight.
 
+### Module docstring layering — navigation vs implementation
+
+Module-level and function-level docstrings carry different roles. The split is structural, not stylistic.
+
+- **Module docstring** holds navigation + cross-module context only:
+    - A one-to-three-sentence TL;DR of what the module is for and which entry point / public surface consumes it.
+    - When the module hosts several callables sharing one theoretical frame (e.g. `_stats/bootstrap.py` covering stationary + fixed schemes): a brief inventory naming each public callable with a one-line distinguishing characteristic.
+    - Non-obvious sibling-module relationships when the boundary matters (e.g. `_stats/multiple_testing.py` is sister to public `factrix.stats.multiple_testing`).
+- **Function / class / method docstring** holds the implementation contract: `Args:` / `Returns:` / `Raises:` / `Notes:` / `Examples:` / `References:`.
+- The module docstring does **not** hold parameter contracts, return shape, pipeline `Notes:`, runnable `Examples:`, or implementation rationale.
+
+#### `References:` placement — function-level by default
+
+Aligns with NumPy / SciPy / scikit-learn convention. Every user-facing `References:` block lives on the function / class / method that owns the behaviour.
+
+- Same paper cited by multiple functions: **duplicate inline** in each docstring. Reader self-sufficiency on the function page beats dedup; the cost is bounded because each paper is cited by 1–3 callables in practice.
+- Module-level `References:` is reserved for private modules (`factrix/_stats/*`) as source-only context for maintainers reading code. The public sister module (`factrix.stats.*`) still carries inline citations on each public function — module-level `References:` is not a substitute.
+- Format is Google `References:` (colon-terminated heading, indented body), not NumPy underline (`References\n----------`).
+
+#### `bibliography.md` as catalog, not single SSOT
+
+Full citation metadata (author / year / title / journal / volume / pages) appears **inline** in each docstring's `References:` block. Readers on a function API page see the full citation without leaving.
+
+`docs/reference/bibliography.md` is a **catalog page**, not the SSOT: every cited paper appears there once with its full citation and a slug anchor (e.g. `corrado-1989`). It serves two purposes:
+
+- Aggregated browse view ("which papers does factrix cite").
+- Anchor provider for cross-page links from guides / how-tos using the autorefs form `[Corrado 1989][corrado-1989]`.
+
+Removing the catalog page does not break any function's `References:` block. When updating a citation (typo, DOI), update each inline copy and the catalog entry.
+
+#### `Notes:` rule — function self-contained
+
+Function docstrings are self-sufficient. If a function's behaviour is only intelligible with one sentence of module-level frame, **copy that sentence into the function `Notes:`** rather than forcing the reader to scroll up. Duplication cost is less than reading-context-break cost.
+
+Module-level `Notes:` exists only when no single function carries the canonical pipeline — rare in factrix, since most modules host one canonical function per metric.
+
 ### Markdown code-block intent layers — runnable vs illustrative
 
 Code blocks under `docs/api/**/*.md` carry two distinct intents; verify which layer a block belongs to before editing.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -568,7 +568,7 @@ Module-level and function-level docstrings carry different roles. The split is s
 
 #### Section order — body prose before structured sections
 
-Within any docstring (module-level or function-level), free-form body prose comes before all structured Google sections. The canonical order is: summary line → body prose → `Args:` / `Returns:` / `Raises:` / `Yields:` → `Examples:` → `Notes:` → `References:` → `See Also:`. The same rule applies to attribute-bearing classes (`Attributes:` sits with `Args:` / `Returns:` and accepts no trailing prose).
+Within any docstring (module-level or function-level), free-form body prose comes before all structured Google sections. The canonical order follows NumPy / numpydoc convention (factrix imports NumPy-only sections such as `Notes:` / `References:` / `See Also:`, so the trailing-section order aligns with the broader convention rather than Google's narrower spec): summary line → body prose → `Args:` / `Returns:` / `Yields:` / `Receives:` / `Other Parameters:` → `Raises:` / `Warns:` / `Warnings:` → `See Also:` → `Notes:` → `References:` → `Examples:`. `Examples:` sits last. The same rule applies to attribute-bearing classes (`Attributes:` sits with `Args:` / `Returns:` and accepts no trailing prose).
 
 Putting `Notes:` or `References:` mid-text — between the summary and the rest of the prose, with prose still appearing below the heading — breaks the rendered metric page: the admonition box jumps above the function inventory, severing the reader's eye-path from summary to body.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -566,6 +566,12 @@ Module-level and function-level docstrings carry different roles. The split is s
 - **Function / class / method docstring** holds the implementation contract: `Args:` / `Returns:` / `Raises:` / `Notes:` / `Examples:` / `References:`.
 - The module docstring does **not** hold parameter contracts, return shape, pipeline `Notes:`, runnable `Examples:`, or implementation rationale.
 
+#### Section order — body prose before structured sections
+
+Within any docstring (module-level or function-level), free-form body prose comes before all structured Google sections. The canonical order is: summary line → body prose → `Args:` / `Returns:` / `Raises:` / `Yields:` → `Examples:` → `Notes:` → `References:` → `See Also:`. The same rule applies to attribute-bearing classes (`Attributes:` sits with `Args:` / `Returns:` and accepts no trailing prose).
+
+Putting `Notes:` or `References:` mid-text — between the summary and the rest of the prose, with prose still appearing below the heading — breaks the rendered metric page: the admonition box jumps above the function inventory, severing the reader's eye-path from summary to body.
+
 #### `References:` placement — by callable count
 
 Placement is driven by how many public callables the module hosts, not by paper-vs-module scope. The rule matches the rendered metric / API page: `::: factrix.metrics.<x>` with several `members:` produces one page with multiple function sections, and reader UX differs by layout.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -566,24 +566,53 @@ Module-level and function-level docstrings carry different roles. The split is s
 - **Function / class / method docstring** holds the implementation contract: `Args:` / `Returns:` / `Raises:` / `Notes:` / `Examples:` / `References:`.
 - The module docstring does **not** hold parameter contracts, return shape, pipeline `Notes:`, runnable `Examples:`, or implementation rationale.
 
-#### `References:` placement — function-level by default
+#### `References:` placement — by callable count
 
-Aligns with NumPy / SciPy / scikit-learn convention. Every user-facing `References:` block lives on the function / class / method that owns the behaviour.
+Placement is driven by how many public callables the module hosts, not by paper-vs-module scope. The rule matches the rendered metric / API page: `::: factrix.metrics.<x>` with several `members:` produces one page with multiple function sections, and reader UX differs by layout.
 
-- Same paper cited by multiple functions: **duplicate inline** in each docstring. Reader self-sufficiency on the function page beats dedup; the cost is bounded because each paper is cited by 1–3 callables in practice.
-- Module-level `References:` is reserved for private modules (`factrix/_stats/*`) as source-only context for maintainers reading code. The public sister module (`factrix.stats.*`) still carries inline citations on each public function — module-level `References:` is not a substitute.
-- Format is Google `References:` (colon-terminated heading, indented body), not NumPy underline (`References\n----------`).
+- **Single-callable module** (e.g. `corrado.py`, most `metrics/*.py` files that host one public function): `References:` lives only on the function. No module-level References — would just duplicate the function block above it on the rendered page.
+- **Multi-callable module** (e.g. `caar.py` with `compute_caar` / `caar` / `bmp_test`; `factrix.stats.multiple_testing` with the BHY family): module docstring carries a short-form `References:` overview listing the key papers covering the module's topic; each function then carries its own `References:` block with inline full citations for the specific paper driving that function's algorithm. Same paper appearing at both module-overview and function-detail levels is accepted here — they serve different reader animations on the same page.
+- **Private `_stats/*` modules**: source-only. Inline full citation at module level is fine since these are not rendered to user-facing pages.
+
+Format in every case: Google `References:` (colon-terminated heading, indented body), not NumPy underline (`References\n----------`).
+
+#### Inline citation form — autorefs hyperlink + full text
+
+`References:` entries are hyperlinked to the catalog using mkdocs-autorefs reference-style links. The author-year prefix is the link; the rest of the citation is plain text following it.
+
+```
+References:
+    [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
+    and Finance." Journal of Economic Literature, 35(1), 13–39.
+```
+
+This serves two animations without compromising either:
+
+- Reader who does not click — sees the full citation inline (author, year, title, journal, volume, pages) and never needs to leave the page.
+- Reader who clicks the author-year link — jumps to `bibliography.md#mackinlay-1997` to read the paper's role in factrix and cross-metric usage.
+
+Short-form module-level overviews on multi-callable modules can drop the trailing full-citation text (the link + title is enough at the overview layer):
+
+```
+References:
+    [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
+        and Finance."
+    [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
+        "Event-study methodology under conditions of event-induced
+        variance."
+```
+
+The slug must match an anchor declared in `docs/reference/bibliography.md`; missing anchors produce an mkdocs `--strict` warning.
 
 #### `bibliography.md` as catalog, not single SSOT
 
-Full citation metadata (author / year / title / journal / volume / pages) appears **inline** in each docstring's `References:` block. Readers on a function API page see the full citation without leaving.
-
-`docs/reference/bibliography.md` is a **catalog page**, not the SSOT: every cited paper appears there once with its full citation and a slug anchor (e.g. `corrado-1989`). It serves two purposes:
+`docs/reference/bibliography.md` is a **catalog page**, not the SSOT for citation metadata: every cited paper appears there once with its full citation, an anchor, and a paragraph on the paper's role in factrix. It serves three roles:
 
 - Aggregated browse view ("which papers does factrix cite").
+- Anchor target for inline `References:` hyperlinks inside docstrings.
 - Anchor provider for cross-page links from guides / how-tos using the autorefs form `[Corrado 1989][corrado-1989]`.
 
-Removing the catalog page does not break any function's `References:` block. When updating a citation (typo, DOI), update each inline copy and the catalog entry.
+The hyperlinks are an enhancement, not a dependency: if `bibliography.md` is removed, inline citations still carry the full metadata inline — only the link targets would 404. When updating a citation (typo, DOI), update the catalog entry and each inline copy that carries the full text.
 
 #### `Notes:` rule — function self-contained
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -576,14 +576,14 @@ Placement is driven by how many public callables the module hosts, not by paper-
 
 Format in every case: Google `References:` (colon-terminated heading, indented body), not NumPy underline (`References\n----------`).
 
-#### Inline citation form — autorefs hyperlink + full text
+#### Inline citation form — bullet list + autorefs hyperlink + full text
 
-`References:` entries are hyperlinked to the catalog using mkdocs-autorefs reference-style links. The author-year prefix is the link; the rest of the citation is plain text following it.
+`References:` entries are markdown bullet list items, uniformly — one paper or many, every entry starts with `- `. Each entry's author-year prefix is an autorefs reference-style link to the catalog; the rest of the citation follows as plain text on continuation lines indented to align under the link.
 
 ```
 References:
-    [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
-    and Finance." Journal of Economic Literature, 35(1), 13–39.
+    - [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
+      and Finance." Journal of Economic Literature, 35(1), 13–39.
 ```
 
 This serves two animations without compromising either:
@@ -595,14 +595,14 @@ Short-form module-level overviews on multi-callable modules can drop the trailin
 
 ```
 References:
-    [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
-        and Finance."
-    [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
-        "Event-study methodology under conditions of event-induced
-        variance."
+    - [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
+      and Finance."
+    - [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
+      "Event-study methodology under conditions of event-induced
+      variance."
 ```
 
-The slug must match an anchor declared in `docs/reference/bibliography.md`; missing anchors produce an mkdocs `--strict` warning.
+The uniform bullet form keeps every `References:` block visually identical regardless of paper count and removes the failure mode of forgetting blank-line separators when a second paper is added. The slug must match an anchor declared in `docs/reference/bibliography.md`; missing anchors produce an mkdocs `--strict` warning.
 
 #### `bibliography.md` as catalog, not single SSOT
 

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -410,14 +410,26 @@ Financial Economics." *Journal of Finance* 75(5), 2503–2553.
 FDR-adjusted t-thresholds for asset-pricing tests; complements
 Harvey-Liu-Zhu (2016).
 
+### Holm (1979)
+[](){ #holm-1979 }
+
+Holm, S. (1979). "A Simple Sequentially Rejective Multiple Test
+Procedure." *Scandinavian Journal of Statistics* 6(2), 65–70.
+
+FWER step-down procedure that uniformly dominates Bonferroni under
+the same dependence assumptions; the default slice-test adjustment
+in `_stats.multiple_testing` when callers do not supply a bootstrap
+distribution.
+
 ### Romano & Wolf (2005)
 [](){ #romano-wolf-2005 }
 
 Romano, J. P. & Wolf, M. (2005). "Stepwise Multiple Testing as
 Formalized Data Snooping." *Econometrica* 73(4), 1237–1282.
 
-Stepwise FDP control; cited as background for stricter
-data-snooping discipline beyond what BHY provides.
+Bootstrap-based FWER step-down exploiting the joint dependence of
+test statistics; implemented in `_stats.multiple_testing` for the
+date-shared slice-test setting (e.g. universe pairwise IC).
 
 ### White (2000)
 [](){ #white-2000 }
@@ -507,6 +519,15 @@ Association* 88(424), 1273–1283.
 Sn / Qn estimators as MAD alternatives; cited as the "considered
 but not implemented" alternative robust scale.
 
+### Künsch (1989)
+[](){ #kunsch-1989 }
+
+Künsch, H. R. (1989). "The Jackknife and the Bootstrap for General
+Stationary Observations." *Annals of Statistics* 17(3), 1217–1241.
+
+Fixed-block (moving-block) bootstrap for stationary time series;
+underlies the deterministic block scheme in `_stats.bootstrap`.
+
 ### Politis & Romano (1994)
 [](){ #politis-romano-1994 }
 
@@ -514,8 +535,18 @@ Politis, D. N. & Romano, J. P. (1994). "The Stationary Bootstrap."
 *Journal of the American Statistical Association* 89(428),
 1303–1313.
 
-Stationary block bootstrap. Cited as background; not implemented
-inside factrix.
+Stationary block bootstrap with geometric block lengths; underlies
+the stationary scheme in `_stats.bootstrap`.
+
+### Politis & White (2004)
+[](){ #politis-white-2004 }
+
+Politis, D. N. & White, H. (2004). "Automatic Block-Length Selection
+for the Dependent Bootstrap." *Econometric Reviews* 23(1), 53–70.
+
+Data-driven block-length selector for stationary / circular
+bootstraps; supplies the automatic `L` choice in `_stats.bootstrap`
+when callers do not pass one.
 
 ### Sen (1968)
 [](){ #sen-1968 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -382,6 +382,34 @@ Statistics* 29(4), 1165–1188.
 BH under arbitrary dependence with the `c(m) = Σ 1/i` correction;
 implemented as `bhy_adjust` and consumed by `multi_factor.bhy`.
 
+### Simes (1986)
+[](){ #simes-1986 }
+
+Simes, R. J. (1986). "An Improved Bonferroni Procedure for Multiple
+Tests of Significance." *Biometrika* 73(3), 751–754.
+
+Simes' global test combining ordered p-values; used by `simes_p` as
+the group representative in hierarchical FDR procedures.
+
+### Benjamini & Heller (2008)
+[](){ #benjamini-heller-2008 }
+
+Benjamini, Y. & Heller, R. (2008). "Screening for Partial Conjunction
+Hypotheses." *Biometrics* 64(4), 1215–1222.
+
+Partial-conjunction test for "at least r of K hypotheses are true";
+backs `partial_conjunction_p`.
+
+### Yekutieli (2008)
+[](){ #yekutieli-2008 }
+
+Yekutieli, D. (2008). "Hierarchical False Discovery Rate-Controlling
+Methodology." *Journal of the American Statistical Association*
+103(481), 309–316.
+
+Hierarchical FDR with Simes as group representative; cited as the
+theoretical context for the BHY + Simes composition.
+
 ### Harvey, Liu & Zhu (2016)
 [](){ #harvey-liu-zhu-2016 }
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -95,40 +95,6 @@ def evaluate(
     [`partial_conjunction`][factrix.multi_factor.partial_conjunction] /
     [`bhy_hierarchical`][factrix.multi_factor.bhy_hierarchical]).
 
-    Args:
-        panel: Long-format panel satisfying the four-column floor
-            ``(date, asset_id, factor, forward_return)``. See
-            [Panel schema](panel-schema.md) for the canonical contract
-            and dtype semantics.
-        config: Validated ``AnalysisConfig`` selecting the dispatch cell
-            (``Scope × Signal × Metric``). Construct via one of the four
-            factories on the class.
-        factor_col: Name of the signal column on ``panel`` (default
-            ``"factor"``). Renamed to ``"factor"`` internally before
-            dispatch. Looping over candidates with different
-            ``factor_col=`` values is the canonical multi-factor pattern.
-
-    Returns:
-        [`FactorProfile`][factrix.FactorProfile] with ``primary_p``,
-        ``stats``, ``warnings``, ``info_notes``, ``mode``, ``n_obs``,
-        ``n_assets``, plus ``identity = (factor_id, forward_periods)``
-        and ``context = {universe_id, regime_id, ...}``.
-
-    Raises:
-        MissingConfigError: ``evaluate(panel)`` called without an
-            ``AnalysisConfig``. Recovery: call
-            [`suggest_config`][factrix.suggest_config].
-        IncompatibleAxisError: ``config`` axes form an illegal cell.
-        ModeAxisError: Legal cell has no procedure under the derived
-            ``Mode``. Carries ``.suggested_fix: AnalysisConfig | None``
-            with the nearest-legal config.
-        InsufficientSampleError: ``T`` below the procedure's
-            ``MIN_PERIODS_HARD`` floor. Carries ``.actual_periods`` /
-            ``.required_periods``.
-        ValueError: ``factor_col`` not present on ``panel``, or both
-            ``"factor"`` and ``factor_col`` present with differing values
-            (ambiguous which is the signal — drop the unused column).
-
     All factrix-raised errors inherit from
     [`FactrixError`](errors.md).
 
@@ -173,6 +139,40 @@ def evaluate(
         cost scales as `O(n_factors × per_date_cost)`. There is no
         shared-pass primitive; [`bhy`][factrix.multi_factor.bhy] controls
         FDR but does **not** reduce the per-signal evaluation cost.
+
+    Args:
+        panel: Long-format panel satisfying the four-column floor
+            ``(date, asset_id, factor, forward_return)``. See
+            [Panel schema](panel-schema.md) for the canonical contract
+            and dtype semantics.
+        config: Validated ``AnalysisConfig`` selecting the dispatch cell
+            (``Scope × Signal × Metric``). Construct via one of the four
+            factories on the class.
+        factor_col: Name of the signal column on ``panel`` (default
+            ``"factor"``). Renamed to ``"factor"`` internally before
+            dispatch. Looping over candidates with different
+            ``factor_col=`` values is the canonical multi-factor pattern.
+
+    Returns:
+        [`FactorProfile`][factrix.FactorProfile] with ``primary_p``,
+        ``stats``, ``warnings``, ``info_notes``, ``mode``, ``n_obs``,
+        ``n_assets``, plus ``identity = (factor_id, forward_periods)``
+        and ``context = {universe_id, regime_id, ...}``.
+
+    Raises:
+        MissingConfigError: ``evaluate(panel)`` called without an
+            ``AnalysisConfig``. Recovery: call
+            [`suggest_config`][factrix.suggest_config].
+        IncompatibleAxisError: ``config`` axes form an illegal cell.
+        ModeAxisError: Legal cell has no procedure under the derived
+            ``Mode``. Carries ``.suggested_fix: AnalysisConfig | None``
+            with the nearest-legal config.
+        InsufficientSampleError: ``T`` below the procedure's
+            ``MIN_PERIODS_HARD`` floor. Carries ``.actual_periods`` /
+            ``.required_periods``.
+        ValueError: ``factor_col`` not present on ``panel``, or both
+            ``"factor"`` and ``factor_col`` present with differing values
+            (ambiguous which is the signal — drop the unused column).
 
     Examples:
         Single-factor inference on a cross-sectional panel:

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -671,29 +671,6 @@ def bhy_hierarchical(
             the outer Simes representative equals that single p, so
             those groups get no FDR correction at either layer.
 
-    Caveats:
-        - **Simes as the outer representative**: dominates Bonferroni
-          ``m * min(p)`` and is the Yekutieli 2008 recommended choice.
-          The kwarg is not exposed at v1 (Edgington-style mean p has
-          no valid null; Bonferroni-min is strictly worse than Simes
-          under the procedure's PRDS assumption).
-        - **PRDS within group**: Simes is valid under positive
-          regression dependence (typical for factors within one
-          family — they share style exposure). If a group mixes
-          structurally opposite factors (e.g. momentum and reversal
-          in one bucket), the within-group PRDS assumption can fail;
-          split the bucket or pre-orthogonalize.
-        - **Pre-filtered input**: ``bhy_hierarchical`` assumes the
-          input *is* the candidate family. If profiles came from
-          upstream pre-filtering (e.g. top-50 of 500 candidates),
-          the FDR claim does not cover the full screening pipeline —
-          count K accordingly per the Haircut Sharpe / experiment-log
-          discipline.
-
-    References:
-        Yekutieli, D. (2008). "Hierarchical false discovery rate-
-        controlling methodology." JASA 103(481), 309-316.
-
     Examples:
         Six candidate factors split into two family groups; FDR is
         controlled across groups (outer) and within each group (inner):
@@ -722,6 +699,29 @@ def bhy_hierarchical(
         >>> survivors = fx.multi_factor.bhy_hierarchical(
         ...     profiles, group="family"
         ... )
+
+    Notes:
+        - **Simes as the outer representative**: dominates Bonferroni
+          ``m * min(p)`` and is the Yekutieli 2008 recommended choice.
+          The kwarg is not exposed at v1 (Edgington-style mean p has
+          no valid null; Bonferroni-min is strictly worse than Simes
+          under the procedure's PRDS assumption).
+        - **PRDS within group**: Simes is valid under positive
+          regression dependence (typical for factors within one
+          family — they share style exposure). If a group mixes
+          structurally opposite factors (e.g. momentum and reversal
+          in one bucket), the within-group PRDS assumption can fail;
+          split the bucket or pre-orthogonalize.
+        - **Pre-filtered input**: ``bhy_hierarchical`` assumes the
+          input *is* the candidate family. If profiles came from
+          upstream pre-filtering (e.g. top-50 of 500 candidates),
+          the FDR claim does not cover the full screening pipeline —
+          count K accordingly per the Haircut Sharpe / experiment-log
+          discipline.
+
+    References:
+        Yekutieli, D. (2008). "Hierarchical false discovery rate-
+        controlling methodology." JASA 103(481), 309-316.
     """
     profile_list = list(profiles)
     expand_over_tuple: tuple[str, ...] = (group,)

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -616,19 +616,11 @@ def bhy_hierarchical(
 
     Pick this over the alternatives by survivor unit and claim shape:
 
-    +-----------------------------+-------------------+-----------------------+
-    | Claim                       | Survivor unit     | Function              |
-    +=============================+===================+=======================+
-    | "factor X significant in    | (factor, context) | ``bhy(expand_over=)`` |
-    | each universe / horizon"    | pair              |                       |
-    +-----------------------------+-------------------+-----------------------+
-    | "factor X significant in    | factor identity   | ``partial_conjunction``|
-    | >= k of m conditions"       |                   |                       |
-    +-----------------------------+-------------------+-----------------------+
-    | "which families have signal,| factor identity   | ``bhy_hierarchical``  |
-    | and within those, which     | (group-then-      |                       |
-    | factors"                    | within FDR)       |                       |
-    +-----------------------------+-------------------+-----------------------+
+    | Claim | Survivor unit | Function |
+    |---|---|---|
+    | "factor X significant in each universe / horizon" | (factor, context) pair | ``bhy(expand_over=)`` |
+    | "factor X significant in ≥ k of m conditions" | factor identity | ``partial_conjunction`` |
+    | "which families have signal, and within those, which factors" | factor identity (group-then-within FDR) | ``bhy_hierarchical`` |
 
     Args:
         profiles: Iterable of :class:`FactorProfile`. Each profile is

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -671,6 +671,29 @@ def bhy_hierarchical(
             the outer Simes representative equals that single p, so
             those groups get no FDR correction at either layer.
 
+    Notes:
+        - **Simes as the outer representative**: dominates Bonferroni
+          ``m * min(p)`` and is the Yekutieli 2008 recommended choice.
+          The kwarg is not exposed at v1 (Edgington-style mean p has
+          no valid null; Bonferroni-min is strictly worse than Simes
+          under the procedure's PRDS assumption).
+        - **PRDS within group**: Simes is valid under positive
+          regression dependence (typical for factors within one
+          family — they share style exposure). If a group mixes
+          structurally opposite factors (e.g. momentum and reversal
+          in one bucket), the within-group PRDS assumption can fail;
+          split the bucket or pre-orthogonalize.
+        - **Pre-filtered input**: ``bhy_hierarchical`` assumes the
+          input *is* the candidate family. If profiles came from
+          upstream pre-filtering (e.g. top-50 of 500 candidates),
+          the FDR claim does not cover the full screening pipeline —
+          count K accordingly per the Haircut Sharpe / experiment-log
+          discipline.
+
+    References:
+        Yekutieli, D. (2008). "Hierarchical false discovery rate-
+        controlling methodology." JASA 103(481), 309-316.
+
     Examples:
         Six candidate factors split into two family groups; FDR is
         controlled across groups (outer) and within each group (inner):
@@ -699,29 +722,6 @@ def bhy_hierarchical(
         >>> survivors = fx.multi_factor.bhy_hierarchical(
         ...     profiles, group="family"
         ... )
-
-    Notes:
-        - **Simes as the outer representative**: dominates Bonferroni
-          ``m * min(p)`` and is the Yekutieli 2008 recommended choice.
-          The kwarg is not exposed at v1 (Edgington-style mean p has
-          no valid null; Bonferroni-min is strictly worse than Simes
-          under the procedure's PRDS assumption).
-        - **PRDS within group**: Simes is valid under positive
-          regression dependence (typical for factors within one
-          family — they share style exposure). If a group mixes
-          structurally opposite factors (e.g. momentum and reversal
-          in one bucket), the within-group PRDS assumption can fail;
-          split the bucket or pre-orthogonalize.
-        - **Pre-filtered input**: ``bhy_hierarchical`` assumes the
-          input *is* the candidate family. If profiles came from
-          upstream pre-filtering (e.g. top-50 of 500 candidates),
-          the FDR claim does not cover the full screening pipeline —
-          count K accordingly per the Haircut Sharpe / experiment-log
-          discipline.
-
-    References:
-        Yekutieli, D. (2008). "Hierarchical false discovery rate-
-        controlling methodology." JASA 103(481), 309-316.
     """
     profile_list = list(profiles)
     expand_over_tuple: tuple[str, ...] = (group,)

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -31,6 +31,16 @@ class FactorProfile:
     a sparse panel. Each axis answers one question and never overlaps
     with another.
 
+    The four sample axes are paired with ``primary_*``, not with
+    secondary diagnostic entries in ``stats`` — e.g. an ADF run on the
+    factor reports its own n inside its ``stats`` / ``metadata`` entry,
+    not via ``n_obs``.
+
+    Hashing is disabled (``__hash__ = None``) because ``context``
+    defaults to ``dict`` (unhashable). Equality is field-by-field via
+    the auto-generated ``__eq__``; bhy family partitioning uses
+    ``identity`` directly without needing the profile to be hashable.
+
     Attributes:
         config: The ``AnalysisConfig`` that produced this profile.
         mode: Evaluation mode (``PANEL`` / ``TIMESERIES``).
@@ -83,16 +93,6 @@ class FactorProfile:
             populates both ``T_NW`` and ``P`` from one bandwidth
             choice) duplicate the inner dict under both keys to keep
             single-key lookup honest (#188).
-
-    The four sample axes are paired with ``primary_*``, not with
-    secondary diagnostic entries in ``stats`` — e.g. an ADF run on the
-    factor reports its own n inside its ``stats`` / ``metadata`` entry,
-    not via ``n_obs``.
-
-    Hashing is disabled (``__hash__ = None``) because ``context``
-    defaults to ``dict`` (unhashable). Equality is field-by-field via
-    the auto-generated ``__eq__``; bhy family partitioning uses
-    ``identity`` directly without needing the profile to be hashable.
     """
 
     config: AnalysisConfig

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -57,6 +57,11 @@ class MetricsBundle:
     successfully evaluated for the cell, plus a ``skipped`` map of
     metrics that could not auto-run (with reason).
 
+    Hashing is disabled (``__hash__ = None``) because the bundle holds
+    ``MetricOutput`` instances whose ``metadata`` is a mutable dict.
+    Group bundles by ``identity`` (a hashable tuple), not by the bundle
+    itself.
+
     Attributes:
         identity: ``(factor_id, forward_periods)`` — the hypothesis
             dimensions per #160. Aligns with ``FactorProfile.identity``
@@ -75,11 +80,6 @@ class MetricsBundle:
             and the slice-test verb pair) populate via
             ``dataclasses.replace`` once available, or callers stamp
             manually after panel-side filtering.
-
-    Hashing is disabled (``__hash__ = None``) because the bundle holds
-    ``MetricOutput`` instances whose ``metadata`` is a mutable dict.
-    Group bundles by ``identity`` (a hashable tuple), not by the bundle
-    itself.
     """
 
     identity: tuple[str, int]

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -5,8 +5,8 @@ Public surface lives in ``factrix.stats`` (``Estimator`` / ``NeweyWest``
 multiple-testing / ``WarningCode``); this package holds the private
 primitives those façades and the procedure layer call into.
 
-Submodules
-----------
+**Submodules:**
+
 - ``constants``   — TIMESERIES / PANEL sample-size thresholds and
   ``auto_bartlett`` Newey-West bandwidth.
 - ``core``        — t-statistic, p-value (t / z), significance marker,

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -18,17 +18,15 @@ private module is consumed by the procedure that backs the
 ``BlockBootstrap`` Estimator under #176.
 
 References:
-    Künsch, H. R. (1989). "The jackknife and the bootstrap for
-    general stationary observations." Annals of Statistics, 17(3),
-    1217–1241.
-
-    Politis, D. N. & Romano, J. P. (1994). "The Stationary
-    Bootstrap." Journal of the American Statistical Association,
-    89(428), 1303–1313.
-
-    Politis, D. N. & White, H. (2004). "Automatic Block-Length
-    Selection for the Dependent Bootstrap." Econometric Reviews,
-    23(1), 53–70.
+    - Künsch, H. R. (1989). "The jackknife and the bootstrap for
+      general stationary observations." Annals of Statistics, 17(3),
+      1217–1241.
+    - Politis, D. N. & Romano, J. P. (1994). "The Stationary
+      Bootstrap." Journal of the American Statistical Association,
+      89(428), 1303–1313.
+    - Politis, D. N. & White, H. (2004). "Automatic Block-Length
+      Selection for the Dependent Bootstrap." Econometric Reviews,
+      23(1), 53–70.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -17,14 +17,18 @@ that want a CI utility outside the Estimator dispatch chain. This
 private module is consumed by the procedure that backs the
 ``BlockBootstrap`` Estimator under #176.
 
-References
-----------
-Künsch, H. R. (1989). "The jackknife and the bootstrap for general
-    stationary observations." Annals of Statistics, 17(3), 1217-1241.
-Politis, D. N. & Romano, J. P. (1994). "The Stationary Bootstrap."
-    JASA, 89(428), 1303-1313.
-Politis, D. N. & White, H. (2004). "Automatic Block-Length Selection
-    for the Dependent Bootstrap." Econometric Reviews, 23(1), 53-70.
+References:
+    Künsch, H. R. (1989). "The jackknife and the bootstrap for
+    general stationary observations." Annals of Statistics, 17(3),
+    1217–1241.
+
+    Politis, D. N. & Romano, J. P. (1994). "The Stationary
+    Bootstrap." Journal of the American Statistical Association,
+    89(428), 1303–1313.
+
+    Politis, D. N. & White, H. (2004). "Automatic Block-Length
+    Selection for the Dependent Bootstrap." Econometric Reviews,
+    23(1), 53–70.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/gmm.py
+++ b/factrix/_stats/gmm.py
@@ -10,10 +10,9 @@ kernel sharing ``_resolve_nw_lags`` with ``hac._newey_west_se`` so the
 HAC-bandwidth convention (with the ``forward_periods - 1`` overlap
 floor) is uniform across single- and multi-moment inference.
 
-Reference
----------
-Hansen, L. P. (1982). *Large sample properties of generalized method
-of moments estimators.* Econometrica 50(4), 1029-1054.
+References:
+    Hansen, L. P. (1982). "Large sample properties of generalized
+    method of moments estimators." Econometrica, 50(4), 1029–1054.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/gmm.py
+++ b/factrix/_stats/gmm.py
@@ -11,8 +11,8 @@ HAC-bandwidth convention (with the ``forward_periods - 1`` overlap
 floor) is uniform across single- and multi-moment inference.
 
 References:
-    Hansen, L. P. (1982). "Large sample properties of generalized
-    method of moments estimators." Econometrica, 50(4), 1029–1054.
+    - Hansen, L. P. (1982). "Large sample properties of generalized
+      method of moments estimators." Econometrica, 50(4), 1029–1054.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -25,11 +25,10 @@ Romano-Wolf. The function-side fallback that picks between the two
 lives in #176 — this module does not encode a default.
 
 References:
-    Holm, S. (1979). "A simple sequentially rejective multiple test
-    procedure." Scandinavian Journal of Statistics, 6(2), 65–70.
-
-    Romano, J. P. & Wolf, M. (2005). "Stepwise multiple testing as
-    formalized data snooping." Econometrica, 73(4), 1237–1282.
+    - Holm, S. (1979). "A simple sequentially rejective multiple test
+      procedure." Scandinavian Journal of Statistics, 6(2), 65–70.
+    - Romano, J. P. & Wolf, M. (2005). "Stepwise multiple testing as
+      formalized data snooping." Econometrica, 73(4), 1237–1282.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -96,6 +96,13 @@ def romano_wolf(
 ) -> list[float]:
     """Romano-Wolf (2005) step-down adjusted p-values.
 
+    The step-down critical sequence is built from the *max* of the
+    bootstrap distribution restricted to the not-yet-rejected
+    hypotheses, so the dependence structure (universe co-movement,
+    common-factor exposure) shrinks the multiplicity penalty
+    automatically — Bonferroni / Holm assume worst-case dependence
+    and over-correct in this regime.
+
     Args:
         statistics: Observed test statistics ``t_1, …, t_m`` (e.g.
             studentized contrasts). Sign convention: large positive
@@ -112,13 +119,6 @@ def romano_wolf(
 
     Returns:
         Adjusted p-values in input order, each in ``[0, 1]``.
-
-    The step-down critical sequence is built from the *max* of the
-    bootstrap distribution restricted to the not-yet-rejected
-    hypotheses, so the dependence structure (universe co-movement,
-    common-factor exposure) shrinks the multiplicity penalty
-    automatically — Bonferroni / Holm assume worst-case dependence
-    and over-correct in this regime.
     """
     t = np.asarray(statistics, dtype=float)
     boot = np.asarray(bootstrap_distribution, dtype=float)

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -21,15 +21,15 @@ the slice-test setting where a small number of hypotheses
 The choice between Holm and Romano-Wolf is the caller's: time-disjoint
 slices (e.g. regimes) work fine under Holm; date-shared slices
 (universe pairwise) leave significant power on the table without
-Romano-Wolf. The verb-side fallback that picks between the two lives
-in #176 — this module does not encode a default.
+Romano-Wolf. The function-side fallback that picks between the two
+lives in #176 — this module does not encode a default.
 
-References
-----------
-Holm, S. (1979). "A simple sequentially rejective multiple test
-    procedure." Scandinavian Journal of Statistics, 6(2), 65-70.
-Romano, J. P. & Wolf, M. (2005). "Stepwise multiple testing as
-    formalized data snooping." Econometrica, 73(4), 1237-1282.
+References:
+    Holm, S. (1979). "A simple sequentially rejective multiple test
+    procedure." Scandinavian Journal of Statistics, 6(2), 65–70.
+
+    Romano, J. P. & Wolf, M. (2005). "Stepwise multiple testing as
+    formalized data snooping." Econometrica, 73(4), 1237–1282.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -16,15 +16,17 @@ Three layers of HAC / cluster covariance feed the same closing
   the raw asset-date panel. Cameron-Gelbach-Miller (2011)
   ``V_DC = V_date + V_asset - V_intersection`` shape. Backs the
   ``WaldTwoWayCluster`` Estimator — interface preserved this issue;
-  no verb consumes it until ``factor_decomposition`` lands later.
+  no public function consumes it until ``factor_decomposition`` lands
+  later.
 
-References
-----------
-Cameron, A. C., Gelbach, J. B. & Miller, D. L. (2011). "Robust
-    Inference With Multiway Clustering." JBES, 29(2), 238-249.
-Newey, W. K. & West, K. D. (1987). "A Simple, Positive Semi-Definite,
-    Heteroskedasticity and Autocorrelation Consistent Covariance
-    Matrix." Econometrica, 55(3), 703-708.
+References:
+    Cameron, A. C., Gelbach, J. B. & Miller, D. L. (2011). "Robust
+    Inference With Multiway Clustering." Journal of Business &
+    Economic Statistics, 29(2), 238–249.
+
+    Newey, W. K. & West, K. D. (1987). "A Simple, Positive
+    Semi-Definite, Heteroskedasticity and Autocorrelation Consistent
+    Covariance Matrix." Econometrica, 55(3), 703–708.
 """
 
 from __future__ import annotations

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -20,13 +20,12 @@ Three layers of HAC / cluster covariance feed the same closing
   later.
 
 References:
-    Cameron, A. C., Gelbach, J. B. & Miller, D. L. (2011). "Robust
-    Inference With Multiway Clustering." Journal of Business &
-    Economic Statistics, 29(2), 238–249.
-
-    Newey, W. K. & West, K. D. (1987). "A Simple, Positive
-    Semi-Definite, Heteroskedasticity and Autocorrelation Consistent
-    Covariance Matrix." Econometrica, 55(3), 703–708.
+    - Cameron, A. C., Gelbach, J. B. & Miller, D. L. (2011). "Robust
+      Inference With Multiway Clustering." Journal of Business &
+      Economic Statistics, 29(2), 238–249.
+    - Newey, W. K. & West, K. D. (1987). "A Simple, Positive
+      Semi-Definite, Heteroskedasticity and Autocorrelation Consistent
+      Covariance Matrix." Econometrica, 55(3), 703–708.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -1,15 +1,15 @@
 r"""CAAR (Cumulative Average Abnormal Return) significance tests.
 
+Tests $H_0$: event abnormal return = 0, using two complementary methods:
+    compute_caar — per-event-date weighted abnormal return series
+    caar         — CAAR t-test (parametric, non-overlapping sampling)
+    bmp_test     — BMP standardized AR test (robust to event-induced variance)
+
 Notes:
     **Pipeline.** Per-event-date weighted abnormal return
     (per-event-date step) then non-overlapping cross-event sample;
     $t$-test on CAAR, or BMP standardized AR $z$-test for event-induced
     variance.
-
-Tests $H_0$: event abnormal return = 0, using two complementary methods:
-    compute_caar — per-event-date weighted abnormal return series
-    caar         — CAAR t-test (parametric, non-overlapping sampling)
-    bmp_test     — BMP standardized AR test (robust to event-induced variance)
 
 References:
     - [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
@@ -69,12 +69,6 @@ def compute_caar(
 ) -> pl.DataFrame:
     r"""Per-event-date weighted abnormal return series.
 
-    Aggregation:
-        cs-first. For each event date, take the cross-sectional mean of
-        ``signed_car`` $= r \times f$ across event rows where $f \neq 0$;
-        the resulting ``n_event_dates``-length CAAR series feeds a
-        downstream NW HAC $t$-test on the mean.
-
     Magnitude is preserved — no ``.sign()`` coercion. factrix accepts
     two input contracts; everything else (including signed
     $\{-1, 0, +1\}$) is just a special case of the second:
@@ -92,6 +86,12 @@ def compute_caar(
     leg vol). If literature-standard signed CAAR is what you want,
     pre-compute it externally; factrix's primitive treats $\pm 1$ as
     weights, not as direction labels.
+
+    Aggregation:
+        cs-first. For each event date, take the cross-sectional mean of
+        ``signed_car`` $= r \times f$ across event rows where $f \neq 0$;
+        the resulting ``n_event_dates``-length CAAR series feeds a
+        downstream NW HAC $t$-test on the mean.
 
     Scale:
         CAAR magnitude tracks the units of ``factor`` (bps, z-score,
@@ -275,6 +275,9 @@ def bmp_test(
     residual volatility, making the test robust to event-induced variance
     inflation that biases the ordinary CAAR $t$-test.
 
+    Uses ``price`` column for estimation-window volatility if available;
+    falls back to per-asset historical ``forward_return`` std otherwise.
+
     Steps:
         1. For each event ($\text{factor} \neq 0$), look back
            ``estimation_window`` periods of the same asset's returns to
@@ -282,9 +285,6 @@ def bmp_test(
         2. Scale $\sigma_i$ to match the forward_return horizon.
         3. $\mathrm{SAR}_i = \mathrm{AR}^{\mathrm{signed}}_i / \sigma^{\text{scaled}}_i$.
         4. $z = \mathrm{mean}(\mathrm{SAR}) / (\mathrm{std}(\mathrm{SAR}) / \sqrt{N})$.
-
-    Uses ``price`` column for estimation-window volatility if available;
-    falls back to per-asset historical ``forward_return`` std otherwise.
 
     Args:
         df: Full panel (including non-event rows) with ``date, asset_id,
@@ -478,21 +478,23 @@ def _estimate_sar_icc(
 ) -> tuple[float | None, float, KPSource]:
     r"""ICC-style within-date correlation $\hat r$ of SAR and average cluster size.
 
-    Args:
-        sar_by_date: Event-level DataFrame with ``date`` and ``_sar``
-            columns (one row per event, SAR already standardized).
-
-    Returns ``(r_hat, n_eff, source)`` where ``source`` is one of:
-        - ``"icc"``: standard between/within decomposition across event
-          dates with $n_k \geq 2$ events each.
-        - ``"no_multi_event_dates"``: not enough date-clusters to
-          estimate within-variance; $\hat r$ is ``None``.
-
     Uses $\sigma^2_{\mathrm{between}} = \mathrm{var}(\overline{\mathrm{SAR}}_d)$ (date-mean SAR)
     and $\sigma^2_{\mathrm{within}}$ = the pooled within-date variance
     (weighted by $n_k - 1$).
     $\hat r = \sigma^2_{\mathrm{between}} / (\sigma^2_{\mathrm{between}} + \sigma^2_{\mathrm{within}})$
     clipped to $[0, 1]$.
+
+    Args:
+        sar_by_date: Event-level DataFrame with ``date`` and ``_sar``
+            columns (one row per event, SAR already standardized).
+
+    Returns:
+        ``(r_hat, n_eff, source)`` where ``source`` is one of:
+
+        - ``"icc"``: standard between/within decomposition across event
+          dates with $n_k \geq 2$ events each.
+        - ``"no_multi_event_dates"``: not enough date-clusters to
+          estimate within-variance; $\hat r$ is ``None``.
     """
     per_date = sar_by_date.group_by("date").agg(
         pl.col("_sar").mean().alias("m"),

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -123,6 +123,14 @@ def compute_caar(
         Sefcik-Thompson (1986) lineage rather than the equal-weighted
         MacKinlay CAAR.
 
+        When ``factor_col`` triggers ``_is_sparse_magnitude_weighted``
+        the primitive emits a Python ``UserWarning`` directly. The
+        sparse PANEL procedures additionally attach
+        ``WarningCode.SPARSE_MAGNITUDE_WEIGHTED`` to
+        ``FactorProfile.warnings`` independently — the dual emission is
+        deliberate so batch runs that silence Python warnings still
+        surface the regime-switch through the structured channel.
+
     References:
         [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
         and Finance." Journal of Economic Literature, 35(1), 13–39.
@@ -140,15 +148,6 @@ def compute_caar(
         Returns: The Case of Event Studies." Journal of Financial
         Economics, 14(1), 3–31. Daily event-study methodology backing
         the parametric-test path.
-
-    Note:
-        When ``factor_col`` triggers ``_is_sparse_magnitude_weighted``
-        the primitive emits a Python ``UserWarning`` directly. The
-        sparse PANEL procedures additionally attach
-        ``WarningCode.SPARSE_MAGNITUDE_WEIGHTED`` to
-        ``FactorProfile.warnings`` independently — the dual emission is
-        deliberate so batch runs that silence Python warnings still
-        surface the regime-switch through the structured channel.
     """
     if _is_sparse_magnitude_weighted(df, factor_col):
         warnings.warn(

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -12,9 +12,11 @@ Tests $H_0$: event abnormal return = 0, using two complementary methods:
     bmp_test     — BMP standardized AR test (robust to event-induced variance)
 
 References:
-    MacKinlay (1997), "Event Studies in Economics and Finance"
-    Boehmer, Musumeci & Poulsen (1991), "Event-study methodology
-        under conditions of event-induced variance"
+    [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
+        and Finance."
+    [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
+        "Event-study Methodology Under Conditions of Event-induced
+        Variance."
 """
 
 from __future__ import annotations
@@ -122,13 +124,22 @@ def compute_caar(
         MacKinlay CAAR.
 
     References:
-        [MacKinlay 1997][mackinlay-1997]: standardised event-window /
-        estimation-window vocabulary inherited by ``EventConfig``.
-        [Sefcik-Thompson 1986][sefcik-thompson-1986]: per-event
-        regression-slope ancestor of the magnitude-weighted CAAR
-        produced when ``factor`` is continuous.
-        [Brown-Warner 1985][brown-warner-1985]: daily event-study
-        methodology backing the parametric-test path.
+        [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
+        and Finance." Journal of Economic Literature, 35(1), 13–39.
+        Standardised event-window / estimation-window vocabulary
+        inherited by ``EventConfig``.
+
+        [Sefcik & Thompson (1986)][sefcik-thompson-1986]. "An Approach
+        to Statistical Inference in Cross-Sectional Models with
+        Security Abnormal Returns as Dependent Variable." Journal of
+        Accounting Research, 24(2), 316–334. Per-event regression-
+        slope ancestor of the magnitude-weighted CAAR produced when
+        ``factor`` is continuous.
+
+        [Brown & Warner (1985)][brown-warner-1985]. "Using Daily Stock
+        Returns: The Case of Event Studies." Journal of Financial
+        Economics, 14(1), 3–31. Daily event-study methodology backing
+        the parametric-test path.
 
     Note:
         When ``factor_col`` triggers ``_is_sparse_magnitude_weighted``
@@ -187,9 +198,14 @@ def caar(
         variance regimes.
 
     References:
-        [Brown-Warner 1985][brown-warner-1985]: daily event-study
-        t-test specification at standard sample sizes.
-        [MacKinlay 1997][mackinlay-1997]: event-window vocabulary.
+        [Brown & Warner (1985)][brown-warner-1985]. "Using Daily Stock
+        Returns: The Case of Event Studies." Journal of Financial
+        Economics, 14(1), 3–31. Daily event-study t-test specification
+        at standard sample sizes.
+
+        [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
+        and Finance." Journal of Economic Literature, 35(1), 13–39.
+        Event-window vocabulary.
     """
     vals = caar_df["caar"].drop_nulls()
     n = len(vals)
@@ -338,11 +354,17 @@ def bmp_test(
         BMP denominator $\sigma_i \cdot \sqrt{1 + 1/T_{\mathrm{est}}}$.
 
     References:
-        [Boehmer-Musumeci-Poulsen 1991][boehmer-musumeci-poulsen-1991]:
-        the BMP standardised AR test.
-        [Kolari-Pynnönen 2010][kolari-pynnonen-2010]: clustering-
-        adjusted BMP variant referenced by
-        ``EventConfig.adjust_clustering`` (not yet implemented).
+        [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991].
+        "Event-study Methodology Under Conditions of Event-induced
+        Variance." Journal of Financial Economics, 30(2), 253–272.
+        The BMP standardised AR test factrix simplifies (mean-adjusted
+        residuals, no prediction-error correction by default).
+
+        [Kolari & Pynnönen (2010)][kolari-pynnonen-2010]. "Event Study
+        Testing with Cross-sectional Correlation of Abnormal Returns."
+        Review of Financial Studies, 23(11), 3996–4025. Clustering-
+        adjusted BMP variant referenced by ``EventConfig.adjust_clustering``
+        (not yet implemented).
     """
     sorted_df = df.sort(["asset_id", "date"])
 

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -12,11 +12,11 @@ Tests $H_0$: event abnormal return = 0, using two complementary methods:
     bmp_test     — BMP standardized AR test (robust to event-induced variance)
 
 References:
-    [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
-        and Finance."
-    [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
-        "Event-study Methodology Under Conditions of Event-induced
-        Variance."
+    - [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
+      and Finance."
+    - [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
+      "Event-study Methodology Under Conditions of Event-induced
+      Variance."
 """
 
 from __future__ import annotations
@@ -132,22 +132,20 @@ def compute_caar(
         surface the regime-switch through the structured channel.
 
     References:
-        [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
-        and Finance." Journal of Economic Literature, 35(1), 13–39.
-        Standardised event-window / estimation-window vocabulary
-        inherited by ``EventConfig``.
-
-        [Sefcik & Thompson (1986)][sefcik-thompson-1986]. "An Approach
-        to Statistical Inference in Cross-Sectional Models with
-        Security Abnormal Returns as Dependent Variable." Journal of
-        Accounting Research, 24(2), 316–334. Per-event regression-
-        slope ancestor of the magnitude-weighted CAAR produced when
-        ``factor`` is continuous.
-
-        [Brown & Warner (1985)][brown-warner-1985]. "Using Daily Stock
-        Returns: The Case of Event Studies." Journal of Financial
-        Economics, 14(1), 3–31. Daily event-study methodology backing
-        the parametric-test path.
+        - [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
+          and Finance." Journal of Economic Literature, 35(1), 13–39.
+          Standardised event-window / estimation-window vocabulary
+          inherited by ``EventConfig``.
+        - [Sefcik & Thompson (1986)][sefcik-thompson-1986]. "An Approach
+          to Statistical Inference in Cross-Sectional Models with
+          Security Abnormal Returns as Dependent Variable." Journal of
+          Accounting Research, 24(2), 316–334. Per-event regression-
+          slope ancestor of the magnitude-weighted CAAR produced when
+          ``factor`` is continuous.
+        - [Brown & Warner (1985)][brown-warner-1985]. "Using Daily Stock
+          Returns: The Case of Event Studies." Journal of Financial
+          Economics, 14(1), 3–31. Daily event-study methodology backing
+          the parametric-test path.
     """
     if _is_sparse_magnitude_weighted(df, factor_col):
         warnings.warn(
@@ -197,14 +195,13 @@ def caar(
         variance regimes.
 
     References:
-        [Brown & Warner (1985)][brown-warner-1985]. "Using Daily Stock
-        Returns: The Case of Event Studies." Journal of Financial
-        Economics, 14(1), 3–31. Daily event-study t-test specification
-        at standard sample sizes.
-
-        [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
-        and Finance." Journal of Economic Literature, 35(1), 13–39.
-        Event-window vocabulary.
+        - [Brown & Warner (1985)][brown-warner-1985]. "Using Daily Stock
+          Returns: The Case of Event Studies." Journal of Financial
+          Economics, 14(1), 3–31. Daily event-study t-test specification
+          at standard sample sizes.
+        - [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
+          and Finance." Journal of Economic Literature, 35(1), 13–39.
+          Event-window vocabulary.
     """
     vals = caar_df["caar"].drop_nulls()
     n = len(vals)
@@ -353,17 +350,16 @@ def bmp_test(
         BMP denominator $\sigma_i \cdot \sqrt{1 + 1/T_{\mathrm{est}}}$.
 
     References:
-        [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991].
-        "Event-study Methodology Under Conditions of Event-induced
-        Variance." Journal of Financial Economics, 30(2), 253–272.
-        The BMP standardised AR test factrix simplifies (mean-adjusted
-        residuals, no prediction-error correction by default).
-
-        [Kolari & Pynnönen (2010)][kolari-pynnonen-2010]. "Event Study
-        Testing with Cross-sectional Correlation of Abnormal Returns."
-        Review of Financial Studies, 23(11), 3996–4025. Clustering-
-        adjusted BMP variant referenced by ``EventConfig.adjust_clustering``
-        (not yet implemented).
+        - [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991].
+          "Event-study Methodology Under Conditions of Event-induced
+          Variance." Journal of Financial Economics, 30(2), 253–272.
+          The BMP standardised AR test factrix simplifies (mean-adjusted
+          residuals, no prediction-error correction by default).
+        - [Kolari & Pynnönen (2010)][kolari-pynnonen-2010]. "Event Study
+          Testing with Cross-sectional Correlation of Abnormal Returns."
+          Review of Financial Studies, 23(11), 3996–4025. Clustering-
+          adjusted BMP variant referenced by ``EventConfig.adjust_clustering``
+          (not yet implemented).
     """
     sorted_df = df.sort(["asset_id", "date"])
 

--- a/factrix/metrics/clustering.py
+++ b/factrix/metrics/clustering.py
@@ -1,10 +1,5 @@
 """Event clustering diagnostic for event signals.
 
-Notes:
-    **Pipeline.** Static cross-section — single HHI computed once over
-    the event-date histogram; no time-axis aggregation, no formal H₀
-    (descriptive concentration index).
-
 When events cluster on the same dates, the independence assumption
 underlying the CAAR t-test is violated, potentially inflating the
 test statistic. The Herfindahl-Hirschman Index (HHI) on event dates
@@ -12,6 +7,11 @@ quantifies this concentration.
 
 Only meaningful for multi-asset panels (N > 1). For single-asset
 event studies, clustering across assets is not applicable.
+
+Notes:
+    **Pipeline.** Static cross-section — single HHI computed once over
+    the event-date histogram; no time-axis aggregation, no formal H₀
+    (descriptive concentration index).
 """
 
 from __future__ import annotations

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -1,15 +1,15 @@
 """Top-bucket concentration analysis for cross-sectional panels.
 
+Measures whether top-bucket (long-leg) alpha is concentrated in a few
+stocks or broadly distributed, using HHI (Herfindahl-Hirschman Index)
+inverse.
+
 Notes:
     **Pipeline.** Per-date HHI inverse on top-bucket weights
     (cross-section step) → per-date ratio series, then non-overlapping
     sample; across-time t against ``H₀: ratio ≥ 0.5``.
 
     **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
-
-Measures whether top-bucket (long-leg) alpha is concentrated in a few
-stocks or broadly distributed, using HHI (Herfindahl-Hirschman Index)
-inverse.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -1,24 +1,8 @@
-"""Corrado (1989) nonparametric rank test for event signals.
+"""Corrado nonparametric rank test on event abnormal returns.
 
-Notes:
-    **Pipeline.** Per-asset full-sample ranks of abnormal returns
-    (time-series step), then aggregate event-period ranks across
-    events; nonparametric rank test on standardized rank deviation.
-
-A non-parametric alternative to the CAAR t-test. Ranks abnormal returns
-across the full sample (event + non-event periods) for each asset, then
-tests whether event-period ranks deviate from their expected value.
-
-Robust to extreme returns, non-normal distributions, and cross-asset
-heteroscedasticity. Direction-adjusted for two-sided signals (extension
-of the original one-directional test).
-
-Standalone metric — not in the default profile. Available via:
-    ``from factrix.metrics import corrado_rank_test``
-
-References:
-    Corrado (1989), "A nonparametric test for abnormal security-price
-        performance in event studies"
+Standalone metric in cell ``(*, SPARSE, *, PANEL)`` — not part of the
+default profile. Available via
+``from factrix.metrics import corrado_rank_test``.
 """
 
 from __future__ import annotations
@@ -43,23 +27,18 @@ def corrado_rank_test(
 ) -> MetricOutput:
     r"""Corrado nonparametric rank test for event abnormal returns.
 
-    For each asset:
-        1. Rank ``return_col`` across the full time series (event + non-event).
-        2. Transform ranks to $U_{it} = \mathrm{rank} / (T+1) - 0.5$ (centered at 0).
-        3. Extract $U$ values at event dates.
-    Across all event observations:
-        4. $z = \mathrm{mean}(U_{\text{event}} \times \mathrm{sign}(\text{factor})) / (\mathrm{std}(U_{\text{all}}) / \sqrt{N_{\text{events}}})$.
+    A non-parametric alternative to the CAAR t-test. Robust to extreme
+    returns, non-normal distributions, and cross-asset
+    heteroscedasticity. Direction-adjusted for two-sided signals
+    (extension of the original one-directional test).
 
-    Deviation from Corrado (1989) eq.(5):
-        The paper computes the denominator as the time-series std of the
-        **cross-sectional mean** of rank deviations across the combined
-        estimation + event window. We use the **pooled std of U_all**
-        across all (asset, date) cells instead — a simpler estimator
-        that conflates asset-level and time-level dispersion. The two
-        coincide under iid ranks but diverge when event-date clustering
-        is present. Adequate for a robustness screen against parametric
-        BMP / CAAR; not a substitute for a reference event-study package
-        if strict size control matters.
+    Formula:
+        For each asset $i$, rank ``return`` across the full sample
+        (event + non-event), transform to
+        $U_{i,t} = \mathrm{rank} / (T+1) - 0.5$, and on event rows
+        form $U_{\text{event,signed}} = U_{\text{event}} \cdot \mathrm{sign}(\text{factor})$.
+        Test statistic
+        $z = \mathrm{mean}(U_{\text{event,signed}}) / (\mathrm{std}(U_{\text{all}}) / \sqrt{N_{\text{events}}})$.
 
     Args:
         df: Full panel with ``date, asset_id, factor, forward_return``.
@@ -69,27 +48,29 @@ def corrado_rank_test(
         MetricOutput with value=mean rank deviation, stat=z.
 
     Notes:
-        For each asset $i$, rank ``return`` across the full sample,
-        transform to $U_{i,t} = \mathrm{rank} / (T+1) - 0.5$ (centered at 0),
-        and on event rows form $U_{\text{event}} \cdot \mathrm{sign}(\text{factor})$.
-        Test statistic
-        $z = \mathrm{mean}(U_{\text{event,signed}}) / (\mathrm{std}(U_{\text{all}}) / \sqrt{N_{\text{events}}})$.
-
         factrix uses the **pooled** std of ``U_all`` across all
-        ``(asset, date)`` cells in the denominator instead of the
+        ``(asset, date)`` cells in the denominator, instead of the
         time-series std of the cross-sectional mean used by Corrado
         (1989) eq. (5). The two coincide under iid ranks but diverge
         when event-date clustering is present; treat this as a
         robustness screen against parametric BMP / CAAR rather than a
-        substitute for a reference event-study package when strict size
-        control matters.
+        substitute for a reference event-study package when strict
+        size control matters.
+
+        Short-circuits to ``MetricOutput`` with
+        ``metadata["reason"]="insufficient_events"`` when
+        ``N_events < MIN_EVENTS_HARD``, and
+        ``"degenerate_rank_variance"`` when ``std(U_all) < EPSILON``.
 
     References:
-        [Corrado 1989][corrado-1989]: nonparametric rank test for
-        event-window abnormal returns.
-        [Corrado-Zivney 1992][corrado-zivney-1992]: source of the
-        direction-adjustment idea factrix adopts for two-sided
-        signals.
+        Corrado, C. J. (1989). "A Nonparametric Test for Abnormal
+        Security-price Performance in Event Studies." *Journal of
+        Financial Economics* 23(2), 385–395.
+
+        Corrado, C. J. & Zivney, T. L. (1992). "The Specification
+        and Power of the Sign Test in Event Study Hypothesis Tests
+        Using Daily Stock Returns." *Journal of Financial and
+        Quantitative Analysis* 27(3), 465–478.
     """
     ranked = df.with_columns(
         (

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -63,17 +63,16 @@ def corrado_rank_test(
         ``"degenerate_rank_variance"`` when ``std(U_all) < EPSILON``.
 
     References:
-        [Corrado (1989)][corrado-1989]. "A Nonparametric Test for
-        Abnormal Security-price Performance in Event Studies."
-        *Journal of Financial Economics* 23(2), 385–395. The
-        nonparametric rank test factrix implements with a pooled-std
-        denominator simplification.
-
-        [Corrado & Zivney (1992)][corrado-zivney-1992]. "The
-        Specification and Power of the Sign Test in Event Study
-        Hypothesis Tests Using Daily Stock Returns." *Journal of
-        Financial and Quantitative Analysis* 27(3), 465–478. Source
-        of the direction-adjustment idea applied to two-sided signals.
+        - [Corrado (1989)][corrado-1989]. "A Nonparametric Test for
+          Abnormal Security-price Performance in Event Studies."
+          *Journal of Financial Economics* 23(2), 385–395. The
+          nonparametric rank test factrix implements with a pooled-std
+          denominator simplification.
+        - [Corrado & Zivney (1992)][corrado-zivney-1992]. "The
+          Specification and Power of the Sign Test in Event Study
+          Hypothesis Tests Using Daily Stock Returns." *Journal of
+          Financial and Quantitative Analysis* 27(3), 465–478. Source
+          of the direction-adjustment idea applied to two-sided signals.
     """
     ranked = df.with_columns(
         (

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -63,14 +63,14 @@ def corrado_rank_test(
         ``"degenerate_rank_variance"`` when ``std(U_all) < EPSILON``.
 
     References:
-        Corrado, C. J. (1989). "A Nonparametric Test for Abnormal
-        Security-price Performance in Event Studies." *Journal of
-        Financial Economics* 23(2), 385–395.
+        [Corrado (1989)][corrado-1989]. "A Nonparametric Test for
+        Abnormal Security-price Performance in Event Studies."
+        *Journal of Financial Economics* 23(2), 385–395.
 
-        Corrado, C. J. & Zivney, T. L. (1992). "The Specification
-        and Power of the Sign Test in Event Study Hypothesis Tests
-        Using Daily Stock Returns." *Journal of Financial and
-        Quantitative Analysis* 27(3), 465–478.
+        [Corrado & Zivney (1992)][corrado-zivney-1992]. "The
+        Specification and Power of the Sign Test in Event Study
+        Hypothesis Tests Using Daily Stock Returns." *Journal of
+        Financial and Quantitative Analysis* 27(3), 465–478.
     """
     ranked = df.with_columns(
         (

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -65,12 +65,15 @@ def corrado_rank_test(
     References:
         [Corrado (1989)][corrado-1989]. "A Nonparametric Test for
         Abnormal Security-price Performance in Event Studies."
-        *Journal of Financial Economics* 23(2), 385–395.
+        *Journal of Financial Economics* 23(2), 385–395. The
+        nonparametric rank test factrix implements with a pooled-std
+        denominator simplification.
 
         [Corrado & Zivney (1992)][corrado-zivney-1992]. "The
         Specification and Power of the Sign Test in Event Study
         Hypothesis Tests Using Daily Stock Returns." *Journal of
-        Financial and Quantitative Analysis* 27(3), 465–478.
+        Financial and Quantitative Analysis* 27(3), 465–478. Source
+        of the direction-adjustment idea applied to two-sided signals.
     """
     ranked = df.with_columns(
         (

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -1,10 +1,5 @@
 """Multi-horizon event analysis — how does the signal behave across time?
 
-Notes:
-    **Pipeline.** Per-event return profile across `k` offsets
-    (per-event step); descriptive curve plus binomial test on
-    per-horizon hit rate.
-
 Answers:
     - Is there pre-event leakage? (T-6..T-1 should be ~0)
     - At which horizon is the signal strongest?
@@ -13,6 +8,11 @@ Answers:
 Metrics:
     compute_event_returns — per-event, per-offset raw return data
     event_around_return   — return profile summary at each offset
+
+Notes:
+    **Pipeline.** Per-event return profile across `k` offsets
+    (per-event step); descriptive curve plus binomial test on
+    per-horizon hit rate.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -1,11 +1,5 @@
 """Per-event quality descriptive statistics for event signals.
 
-Notes:
-    **Pipeline.** Per-event scalar (hit / IC / skew / density) computed
-    on `signed_car`, then cross-event aggregation; binomial inference
-    for hit rate, nonparametric for IC / skewness, descriptive
-    elsewhere.
-
 All metrics operate on the ``signed_car`` (return x sign(factor)) of
 individual events. They describe the quality and shape of per-event
 outcomes — distinct from significance testing (caar.py) and path
@@ -17,6 +11,12 @@ Metrics:
     signal_density — average time gap between events
     profit_factor  — sum(gains) / sum(losses)
     event_skewness — skewness of signed_car distribution
+
+Notes:
+    **Pipeline.** Per-event scalar (hit / IC / skew / density) computed
+    on `signed_car`, then cross-event aggregation; binomial inference
+    for hit rate, nonparametric for IC / skewness, descriptive
+    elsewhere.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -12,13 +12,13 @@ Notes:
 ``beta_sign_consistency``: fraction of periods with correct beta sign.
 
 References:
-    [Fama & MacBeth (1973)][fama-macbeth-1973], "Risk, Return, and
-        Equilibrium: Empirical Tests."
-    [Newey & West (1987)][newey-west-1987], "A Simple, Positive
-        Semi-Definite, Heteroskedasticity and Autocorrelation
-        Consistent Covariance Matrix."
-    [Petersen (2009)][petersen-2009], "Estimating Standard Errors in
-        Finance Panel Data Sets: Comparing Approaches."
+    - [Fama & MacBeth (1973)][fama-macbeth-1973], "Risk, Return, and
+      Equilibrium: Empirical Tests."
+    - [Newey & West (1987)][newey-west-1987], "A Simple, Positive
+      Semi-Definite, Heteroskedasticity and Autocorrelation Consistent
+      Covariance Matrix."
+    - [Petersen (2009)][petersen-2009], "Estimating Standard Errors in
+      Finance Panel Data Sets: Comparing Approaches."
 """
 
 from __future__ import annotations
@@ -98,10 +98,10 @@ def compute_fm_betas(
         series with no NaN propagation in the NW kernel.
 
     References:
-        [Fama & MacBeth (1973)][fama-macbeth-1973]. "Risk, Return, and
-        Equilibrium: Empirical Tests." Journal of Political Economy,
-        81(3), 607–636. The per-date cross-sectional regression at
-        stage 1 of the FM procedure.
+        - [Fama & MacBeth (1973)][fama-macbeth-1973]. "Risk, Return, and
+          Equilibrium: Empirical Tests." Journal of Political Economy,
+          81(3), 607–636. The per-date cross-sectional regression at
+          stage 1 of the FM procedure.
     """
     dates = df["date"].unique().sort()
     rows: list[dict] = []
@@ -204,33 +204,28 @@ def fama_macbeth(
         so the correction is honest only for large $T$.
 
     References:
-        [Fama & MacBeth (1973)][fama-macbeth-1973]. "Risk, Return, and
-        Equilibrium: Empirical Tests." Journal of Political Economy,
-        81(3), 607–636. Two-stage λ procedure underlying this test.
-
-        [Newey & West (1987)][newey-west-1987]. "A Simple, Positive
-        Semi-Definite, Heteroskedasticity and Autocorrelation
-        Consistent Covariance Matrix." Econometrica, 55(3), 703–708.
-        HAC variance estimator.
-
-        [Andrews (1991)][andrews-1991]. "Heteroskedasticity and
-        Autocorrelation Consistent Covariance Matrix Estimation."
-        Econometrica, 59(3), 817–858. Optimal Bartlett growth rate.
-
-        [Hansen & Hodrick (1980)][hansen-hodrick-1980]. "Forward
-        Exchange Rates as Optimal Predictors of Future Spot Rates."
-        Journal of Political Economy, 88(5), 829–853. Overlap horizon
-        flooring the kernel.
-
-        [Shanken (1992)][shanken-1992]. "On the Estimation of
-        Beta-Pricing Models." Review of Financial Studies, 5(1), 1–33.
-        Errors-in-variables correction for FM stage-2 t when the
-        regressor is itself estimated.
-
-        [Kan & Zhang (1999)][kan-zhang-1999]. "Two-Pass Tests of Asset
-        Pricing Models with Useless Factors." Journal of Finance,
-        54(1), 203–235. Single-factor simplification of the Shanken
-        EIV correction that factrix actually applies.
+        - [Fama & MacBeth (1973)][fama-macbeth-1973]. "Risk, Return, and
+          Equilibrium: Empirical Tests." Journal of Political Economy,
+          81(3), 607–636. Two-stage λ procedure underlying this test.
+        - [Newey & West (1987)][newey-west-1987]. "A Simple, Positive
+          Semi-Definite, Heteroskedasticity and Autocorrelation
+          Consistent Covariance Matrix." Econometrica, 55(3), 703–708.
+          HAC variance estimator.
+        - [Andrews (1991)][andrews-1991]. "Heteroskedasticity and
+          Autocorrelation Consistent Covariance Matrix Estimation."
+          Econometrica, 59(3), 817–858. Optimal Bartlett growth rate.
+        - [Hansen & Hodrick (1980)][hansen-hodrick-1980]. "Forward
+          Exchange Rates as Optimal Predictors of Future Spot Rates."
+          Journal of Political Economy, 88(5), 829–853. Overlap horizon
+          flooring the kernel.
+        - [Shanken (1992)][shanken-1992]. "On the Estimation of
+          Beta-Pricing Models." Review of Financial Studies, 5(1), 1–33.
+          Errors-in-variables correction for FM stage-2 t when the
+          regressor is itself estimated.
+        - [Kan & Zhang (1999)][kan-zhang-1999]. "Two-Pass Tests of Asset
+          Pricing Models with Useless Factors." Journal of Finance,
+          54(1), 203–235. Single-factor simplification of the Shanken
+          EIV correction that factrix actually applies.
     """
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
@@ -420,20 +415,18 @@ def pooled_ols(
         motivated using clustered SE in the first place.
 
     References:
-        [Petersen (2009)][petersen-2009]. "Estimating Standard Errors
-        in Finance Panel Data Sets: Comparing Approaches." Review of
-        Financial Studies, 22(1), 435–480. Comparison of FM, clustered,
-        and two-way SE under firm/time correlation.
-
-        [Cameron, Gelbach & Miller (2011)][cameron-gelbach-miller-2011].
-        "Robust Inference With Multiway Clustering." Journal of
-        Business & Economic Statistics, 29(2), 238–249. Two-way
-        clustering formula `V_AB = V_A + V_B − V_{A∩B}`.
-
-        [Thompson (2011)][thompson-2011]. "Simple Formulas for Standard
-        Errors that Cluster by Both Firm and Time." Journal of
-        Financial Economics, 99(1), 1–10. Finite-sample df correction
-        `min(G_A, G_B) − 1`.
+        - [Petersen (2009)][petersen-2009]. "Estimating Standard Errors
+          in Finance Panel Data Sets: Comparing Approaches." Review of
+          Financial Studies, 22(1), 435–480. Comparison of FM, clustered,
+          and two-way SE under firm/time correlation.
+        - [Cameron, Gelbach & Miller (2011)][cameron-gelbach-miller-2011].
+          "Robust Inference With Multiway Clustering." Journal of
+          Business & Economic Statistics, 29(2), 238–249. Two-way
+          clustering formula `V_AB = V_A + V_B − V_{A∩B}`.
+        - [Thompson (2011)][thompson-2011]. "Simple Formulas for Standard
+          Errors that Cluster by Both Firm and Time." Journal of
+          Financial Economics, 99(1), 1–10. Finite-sample df correction
+          `min(G_A, G_B) − 1`.
     """
     y = df[return_col].to_numpy().astype(np.float64)
     x = df[factor_col].to_numpy().astype(np.float64)

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -1,15 +1,15 @@
 r"""Fama-MacBeth regression — FM-canonical metric for the
 ``Individual × Continuous`` cell.
 
-Notes:
-    **Pipeline.** Per-date cross-sectional OLS slope $\lambda$
-    (cross-section step) → time series of $\lambda$, then NW HAC $t$
-    on its mean; pooled OLS variant clusters SE by date.
-
 ``compute_fm_betas``: per-date cross-sectional OLS → (date, beta) DataFrame.
 ``fama_macbeth``: Newey-West t-test on the beta series.
 ``pooled_ols``: pooled OLS with clustered SE by date.
 ``beta_sign_consistency``: fraction of periods with correct beta sign.
+
+Notes:
+    **Pipeline.** Per-date cross-sectional OLS slope $\lambda$
+    (cross-section step) → time series of $\lambda$, then NW HAC $t$
+    on its mean; pooled OLS variant clusters SE by date.
 
 References:
     - [Fama & MacBeth (1973)][fama-macbeth-1973], "Risk, Return, and
@@ -352,6 +352,20 @@ def pooled_ols(
 ) -> MetricOutput:
     r"""Pooled OLS with clustered SE — robustness check against FM.
 
+    Clustering on date alone catches contemporaneous cross-sectional
+    dependence but misses asset-level persistence; on asset alone the
+    reverse. Petersen (2009) shows panel data usually has both —
+    single-way clusters understate SE by 20-50% in that regime.
+
+    FM and single-way share the same point estimate under a balanced
+    panel but typically disagree on SE; when $\hat\beta$ and FM
+    $\hat\lambda$ have **opposite signs**, ``profile.diagnose()``
+    flags an FM/pooled sign-mismatch — a red flag for misspecification.
+
+    Short-circuits when $N < 10$ (no regression), returns ``stat=None``
+    with $p=1.0$ when the effective $G < 3$ (SE undefined with < 3
+    clusters).
+
     Formula:
         Point estimate:
 
@@ -386,20 +400,6 @@ def pooled_ols(
         clustered on $A$, on $B$, and on the intersection cells
         $(A, B)$. Each component uses its own finite-sample correction.
         $\mathrm{df} = \min(G_A, G_B) - 1$ (Thompson 2011).
-
-    Clustering on date alone catches contemporaneous cross-sectional
-    dependence but misses asset-level persistence; on asset alone the
-    reverse. Petersen (2009) shows panel data usually has both —
-    single-way clusters understate SE by 20-50% in that regime.
-
-    FM and single-way share the same point estimate under a balanced
-    panel but typically disagree on SE; when $\hat\beta$ and FM
-    $\hat\lambda$ have **opposite signs**, ``profile.diagnose()``
-    flags an FM/pooled sign-mismatch — a red flag for misspecification.
-
-    Short-circuits when $N < 10$ (no regression), returns ``stat=None``
-    with $p=1.0$ when the effective $G < 3$ (SE undefined with < 3
-    clusters).
 
     Notes:
         Pool ``(date, asset)`` rows and run a single OLS ``R = alpha +

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -12,9 +12,13 @@ Notes:
 ``beta_sign_consistency``: fraction of periods with correct beta sign.
 
 References:
-    Fama & MacBeth (1973), "Risk, Return, and Equilibrium."
-    Newey & West (1987), "HAC Covariance Matrix."
-    Petersen (2009), "Estimating Standard Errors in Finance Panel Data Sets."
+    [Fama & MacBeth (1973)][fama-macbeth-1973], "Risk, Return, and
+        Equilibrium: Empirical Tests."
+    [Newey & West (1987)][newey-west-1987], "A Simple, Positive
+        Semi-Definite, Heteroskedasticity and Autocorrelation
+        Consistent Covariance Matrix."
+    [Petersen (2009)][petersen-2009], "Estimating Standard Errors in
+        Finance Panel Data Sets: Comparing Approaches."
 """
 
 from __future__ import annotations
@@ -94,8 +98,10 @@ def compute_fm_betas(
         series with no NaN propagation in the NW kernel.
 
     References:
-        [Fama-MacBeth 1973][fama-macbeth-1973]: the per-date cross-
-        sectional regression at stage 1 of the FM procedure.
+        [Fama & MacBeth (1973)][fama-macbeth-1973]. "Risk, Return, and
+        Equilibrium: Empirical Tests." Journal of Political Economy,
+        81(3), 607–636. The per-date cross-sectional regression at
+        stage 1 of the FM procedure.
     """
     dates = df["date"].unique().sort()
     rows: list[dict] = []
@@ -198,16 +204,33 @@ def fama_macbeth(
         so the correction is honest only for large $T$.
 
     References:
-        [Fama-MacBeth 1973][fama-macbeth-1973]: two-stage lambda
-        procedure underlying this test.
-        [Newey-West 1987][newey-west-1987]: HAC variance estimator.
-        [Andrews 1991][andrews-1991]: optimal Bartlett growth rate.
-        [Hansen-Hodrick 1980][hansen-hodrick-1980]: overlap horizon
+        [Fama & MacBeth (1973)][fama-macbeth-1973]. "Risk, Return, and
+        Equilibrium: Empirical Tests." Journal of Political Economy,
+        81(3), 607–636. Two-stage λ procedure underlying this test.
+
+        [Newey & West (1987)][newey-west-1987]. "A Simple, Positive
+        Semi-Definite, Heteroskedasticity and Autocorrelation
+        Consistent Covariance Matrix." Econometrica, 55(3), 703–708.
+        HAC variance estimator.
+
+        [Andrews (1991)][andrews-1991]. "Heteroskedasticity and
+        Autocorrelation Consistent Covariance Matrix Estimation."
+        Econometrica, 59(3), 817–858. Optimal Bartlett growth rate.
+
+        [Hansen & Hodrick (1980)][hansen-hodrick-1980]. "Forward
+        Exchange Rates as Optimal Predictors of Future Spot Rates."
+        Journal of Political Economy, 88(5), 829–853. Overlap horizon
         flooring the kernel.
-        [Shanken 1992][shanken-1992]: errors-in-variables correction
-        for FM stage-2 t when the regressor is itself estimated.
-        [Kan-Zhang 1999][kan-zhang-1999]: single-factor simplification
-        of the Shanken EIV correction that factrix actually applies.
+
+        [Shanken (1992)][shanken-1992]. "On the Estimation of
+        Beta-Pricing Models." Review of Financial Studies, 5(1), 1–33.
+        Errors-in-variables correction for FM stage-2 t when the
+        regressor is itself estimated.
+
+        [Kan & Zhang (1999)][kan-zhang-1999]. "Two-Pass Tests of Asset
+        Pricing Models with Useless Factors." Journal of Finance,
+        54(1), 203–235. Single-factor simplification of the Shanken
+        EIV correction that factrix actually applies.
     """
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
@@ -397,14 +420,25 @@ def pooled_ols(
         motivated using clustered SE in the first place.
 
     References:
-        [Petersen 2009][petersen-2009]: comparison of FM, clustered, and
-        two-way SE under firm/time correlation.
-        [Newey-West 1987][newey-west-1987]: HAC variance ancestor of the
-        sandwich form used here.
-        Cameron, Gelbach & Miller (2011), "Robust Inference With
-        Multiway Clustering."
-        Thompson (2011), "Simple Formulas for Standard Errors that
-        Cluster by Both Firm and Time."
+        [Petersen (2009)][petersen-2009]. "Estimating Standard Errors
+        in Finance Panel Data Sets: Comparing Approaches." Review of
+        Financial Studies, 22(1), 435–480. Comparison of FM, clustered,
+        and two-way SE under firm/time correlation.
+
+        [Newey & West (1987)][newey-west-1987]. "A Simple, Positive
+        Semi-Definite, Heteroskedasticity and Autocorrelation
+        Consistent Covariance Matrix." Econometrica, 55(3), 703–708.
+        HAC variance ancestor of the sandwich form used here.
+
+        [Cameron, Gelbach & Miller (2011)][cameron-gelbach-miller-2011].
+        "Robust Inference With Multiway Clustering." Journal of
+        Business & Economic Statistics, 29(2), 238–249. Two-way
+        clustering formula `V_AB = V_A + V_B − V_{A∩B}`.
+
+        [Thompson (2011)][thompson-2011]. "Simple Formulas for Standard
+        Errors that Cluster by Both Firm and Time." Journal of
+        Financial Economics, 99(1), 1–10. Finite-sample df correction
+        `min(G_A, G_B) − 1`.
     """
     y = df[return_col].to_numpy().astype(np.float64)
     x = df[factor_col].to_numpy().astype(np.float64)

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -425,11 +425,6 @@ def pooled_ols(
         Financial Studies, 22(1), 435–480. Comparison of FM, clustered,
         and two-way SE under firm/time correlation.
 
-        [Newey & West (1987)][newey-west-1987]. "A Simple, Positive
-        Semi-Definite, Heteroskedasticity and Autocorrelation
-        Consistent Covariance Matrix." Econometrica, 55(3), 703–708.
-        HAC variance ancestor of the sandwich form used here.
-
         [Cameron, Gelbach & Miller (2011)][cameron-gelbach-miller-2011].
         "Robust Inference With Multiway Clustering." Journal of
         Business & Economic Statistics, 29(2), 238–249. Two-way

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -1,10 +1,5 @@
 """MFE/MAE — per-event price path excursion analysis.
 
-Notes:
-    **Pipeline.** Per-event MFE / MAE excursion over a fixed window
-    (per-event step), then cross-event quantile / ratio summary;
-    descriptive (no formal H₀).
-
 Answers: "what does the price path look like after events?"
 
 Requires bar-by-bar ``price`` data within the event window.
@@ -15,6 +10,11 @@ DataFrame and ``mfe_mae_summary`` returns a short-circuit ``MetricOutput``
 Metrics:
     compute_mfe_mae   — per-event MFE/MAE/Bars_to_MFE/Bars_to_MAE
     mfe_mae_summary   — aggregate summary (p50, p75, ratio)
+
+Notes:
+    **Pipeline.** Per-event MFE / MAE excursion over a fixed window
+    (per-event step), then cross-event quantile / ratio summary;
+    descriptive (no formal H₀).
 """
 
 from __future__ import annotations

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -1,15 +1,15 @@
 """Monotonicity test for cross-sectional panels.
 
+Measures whether factor quantile groups exhibit monotonic return ordering.
+Per-date: split into n_groups by factor rank, compute mean return per group,
+Spearman corr between group index and return.
+
 Notes:
     **Pipeline.** Per-date Spearman corr between quantile index and
     group mean return (cross-section step), then non-overlapping
     cross-asset t on the per-date series.
 
     **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
-
-Measures whether factor quantile groups exhibit monotonic return ordering.
-Per-date: split into n_groups by factor rank, compute mean return per group,
-Spearman corr between group index and return.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -1,5 +1,8 @@
 """Out-of-sample (OOS) persistence analysis for any time-indexed series.
 
+This tool is agnostic to what the series represents — it only knows
+about IS/OOS splits on a time-indexed numeric sequence.
+
 Notes:
     **Pipeline.** Time-series only, IS/OOS window split on a 1-D
     series; descriptive decay diagnostic (no formal H₀).
@@ -9,9 +12,6 @@ Notes:
 
     **Output.** MetricOutput with ``value`` = median survival ratio +
     sign-flip / status detail in ``metadata``.
-
-This tool is agnostic to what the series represents — it only knows
-about IS/OOS splits on a time-indexed numeric sequence.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -1,5 +1,8 @@
 """Quantile analysis for cross-sectional panels.
 
+All spread series are time-indexed (``date, value``) and can be fed
+into any ``series/`` tool.
+
 Notes:
     **Pipeline.** Per-date long-short spread on quantile groups
     (cross-section step), then non-overlapping t on the spread series.
@@ -7,9 +10,6 @@ Notes:
     **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
 
     **Output.** Spread series, long/short alpha decomposition.
-
-All spread series are time-indexed (``date, value``) and can be fed
-into any ``series/`` tool.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -145,12 +145,6 @@ def spanning_alpha(
         [Barillas & Shanken (2017)][barillas-shanken-2017]. "Which
         Alpha?" Review of Financial Studies, 30(4), 1316–1338.
         Spanning-test framework for nested factor models.
-
-        [White (1980)][white-1980]. "A Heteroskedasticity-Consistent
-        Covariance Matrix Estimator and a Direct Test for
-        Heteroskedasticity." Econometrica, 48(4), 817–838.
-        Heteroskedasticity-consistent SE ancestor of the HAC variants
-        applicable when overlap is added.
     """
     if base_spreads is None:
         base_spreads = {}

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -15,8 +15,9 @@ select those with incremental alpha (Stage 2).
 Both use factor return time series (quantile spread series), not IC.
 
 References:
-    Barillas & Shanken (2017), "Which Alpha?"
-    Feng, Giglio & Xiu (2020), "Taming the Factor Zoo."
+    [Barillas & Shanken (2017)][barillas-shanken-2017], "Which Alpha?"
+    [Feng, Giglio & Xiu (2020)][feng-giglio-xiu-2020], "Taming the
+        Factor Zoo: A Test of New Factors."
 """
 
 from __future__ import annotations
@@ -141,9 +142,15 @@ def spanning_alpha(
         with their own HAC SE.
 
     References:
-        Barillas & Shanken (2017), "Which Alpha?"
-        [White 1980][white-1980]: heteroskedasticity-consistent SE
-        ancestor of the HAC variants applicable when overlap is added.
+        [Barillas & Shanken (2017)][barillas-shanken-2017]. "Which
+        Alpha?" Review of Financial Studies, 30(4), 1316–1338.
+        Spanning-test framework for nested factor models.
+
+        [White (1980)][white-1980]. "A Heteroskedasticity-Consistent
+        Covariance Matrix Estimator and a Direct Test for
+        Heteroskedasticity." Econometrica, 48(4), 817–838.
+        Heteroskedasticity-consistent SE ancestor of the HAC variants
+        applicable when overlap is added.
     """
     if base_spreads is None:
         base_spreads = {}
@@ -263,9 +270,15 @@ def greedy_forward_selection(
         survivors on a held-out window.
 
     References:
-        White (2000), "A Reality Check for Data Snooping."
-        Harvey, Liu & Zhu (2016), "…and the Cross-Section of Expected
-        Returns," Section on stepwise-selection bias.
+        [White (2000)][white-2000]. "A Reality Check for Data Snooping."
+        Econometrica, 68(5), 1097–1126. Bootstrap reality-check for
+        data-snooping bias — the canonical correction this function
+        does *not* apply (inflates t-stats by design).
+
+        [Harvey, Liu & Zhu (2016)][harvey-liu-zhu-2016]. "…and the
+        Cross-Section of Expected Returns." Review of Financial
+        Studies, 29(1), 5–68. Empirical case for raising t-thresholds;
+        section on stepwise-selection bias.
     """
     if not suppress_snooping_warning:
         warnings.warn(

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -1,11 +1,5 @@
 """Spanning regression — single-factor test and multi-factor selection.
 
-Notes:
-    **Pipeline.** Regression of factor return time-series on
-    base-factor returns (time-series step); NW HAC t on alpha. The
-    greedy stepwise selection variant inflates t-stats and is not for
-    inference.
-
 ``spanning_alpha``: does a single factor have alpha after controlling for
 base factors? Standard factor research tool (Barillas & Shanken 2017).
 
@@ -13,6 +7,12 @@ base factors? Standard factor research tool (Barillas & Shanken 2017).
 select those with incremental alpha (Stage 2).
 
 Both use factor return time series (quantile spread series), not IC.
+
+Notes:
+    **Pipeline.** Regression of factor return time-series on
+    base-factor returns (time-series step); NW HAC t on alpha. The
+    greedy stepwise selection variant inflates t-stats and is not for
+    inference.
 
 References:
     - [Barillas & Shanken (2017)][barillas-shanken-2017], "Which Alpha?"

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -15,9 +15,9 @@ select those with incremental alpha (Stage 2).
 Both use factor return time series (quantile spread series), not IC.
 
 References:
-    [Barillas & Shanken (2017)][barillas-shanken-2017], "Which Alpha?"
-    [Feng, Giglio & Xiu (2020)][feng-giglio-xiu-2020], "Taming the
-        Factor Zoo: A Test of New Factors."
+    - [Barillas & Shanken (2017)][barillas-shanken-2017], "Which Alpha?"
+    - [Feng, Giglio & Xiu (2020)][feng-giglio-xiu-2020], "Taming the
+      Factor Zoo: A Test of New Factors."
 """
 
 from __future__ import annotations
@@ -142,9 +142,9 @@ def spanning_alpha(
         with their own HAC SE.
 
     References:
-        [Barillas & Shanken (2017)][barillas-shanken-2017]. "Which
-        Alpha?" Review of Financial Studies, 30(4), 1316–1338.
-        Spanning-test framework for nested factor models.
+        - [Barillas & Shanken (2017)][barillas-shanken-2017]. "Which
+          Alpha?" Review of Financial Studies, 30(4), 1316–1338.
+          Spanning-test framework for nested factor models.
     """
     if base_spreads is None:
         base_spreads = {}
@@ -264,15 +264,14 @@ def greedy_forward_selection(
         survivors on a held-out window.
 
     References:
-        [White (2000)][white-2000]. "A Reality Check for Data Snooping."
-        Econometrica, 68(5), 1097–1126. Bootstrap reality-check for
-        data-snooping bias — the canonical correction this function
-        does *not* apply (inflates t-stats by design).
-
-        [Harvey, Liu & Zhu (2016)][harvey-liu-zhu-2016]. "…and the
-        Cross-Section of Expected Returns." Review of Financial
-        Studies, 29(1), 5–68. Empirical case for raising t-thresholds;
-        section on stepwise-selection bias.
+        - [White (2000)][white-2000]. "A Reality Check for Data Snooping."
+          Econometrica, 68(5), 1097–1126. Bootstrap reality-check for
+          data-snooping bias — the canonical correction this function
+          does *not* apply (inflates t-stats by design).
+        - [Harvey, Liu & Zhu (2016)][harvey-liu-zhu-2016]. "…and the
+          Cross-Section of Expected Returns." Review of Financial
+          Studies, 29(1), 5–68. Empirical case for raising t-thresholds;
+          section on stepwise-selection bias.
     """
     if not suppress_snooping_warning:
         warnings.warn(

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -1,10 +1,5 @@
 """Tradability metrics: Turnover, Breakeven Cost, Net Spread.
 
-Notes:
-    **Pipeline.** Per-date turnover / cost diagnostics on
-    quantile-group membership (cross-section step), then time-series
-    mean; descriptive (no formal H₀).
-
 Two flavours of turnover co-exist here, measuring different things:
 
 - ``turnover()`` — ``1 − mean(rank autocorrelation)``. Rank-stability
@@ -21,6 +16,11 @@ measures — they belong in Profile, not in Gates.
 
 Input for Turnover: DataFrame with ``date, asset_id, factor``.
 Input for Breakeven/Net Spread: pre-computed spread and turnover values.
+
+Notes:
+    **Pipeline.** Per-date turnover / cost diagnostics on
+    quantile-group membership (cross-section step), then time-series
+    mean; descriptive (no formal H₀).
 """
 
 from __future__ import annotations

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -1,5 +1,8 @@
 """IC trend analysis using Theil-Sen estimator.
 
+Theil-Sen is preferred over OLS because it has a breakdown point of 29.3%,
+making it robust to outliers (e.g. COVID-era IC spikes).
+
 Notes:
     **Pipeline.** Time-series only, Theil-Sen median pairwise slope on
     a 1-D series; CI from the rank-based pairwise slope distribution.
@@ -7,9 +10,6 @@ Notes:
     **Input.** DataFrame with ``date, value`` (typically an IC series).
 
     **Output.** Slope + confidence interval for trend detection.
-
-Theil-Sen is preferred over OLS because it has a breakdown point of 29.3%,
-making it robust to outliers (e.g. COVID-era IC spikes).
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -1,11 +1,5 @@
 """Long-side / short-side asymmetry test (issue #5).
 
-Notes:
-    **Pipeline.** Per-date aggregation of factor and forward return to
-    a common ``(_f, _r)`` series (cross-section step), then NW HAC OLS
-    with sign-asymmetric slopes on the resulting time series; Wald χ²
-    on the slope difference.
-
 Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
 cells. OLS β reports a single slope and assumes the response is
 symmetric around zero — `β > 0` could be "rises more on positive
@@ -32,6 +26,12 @@ Gates (issue #5):
   and `metadata["method_b_skipped"]` records the reason.
 
 Standalone metric — does not enter the registry.
+
+Notes:
+    **Pipeline.** Per-date aggregation of factor and forward return to
+    a common ``(_f, _r)`` series (cross-section step), then NW HAC OLS
+    with sign-asymmetric slopes on the resulting time series; Wald χ²
+    on the slope difference.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -1,10 +1,5 @@
 """Time-series beta metrics for macro common factors.
 
-Notes:
-    **Pipeline.** Per-asset full-sample OLS β (time-series step), then
-    cross-asset t on the β distribution; rolling-window variant slices
-    the time axis before the per-asset step.
-
 macro_common factors (VIX, gold, USD index) are a single time series
 shared across all assets. Per-asset time-series regression measures
 each asset's sensitivity (β) to the common factor.
@@ -13,6 +8,11 @@ each asset's sensitivity (β) to the common factor.
 ``ts_beta``: cross-sectional test on the β distribution.
 ``mean_r_squared``: average explanatory power across assets.
 ``compute_rolling_mean_beta``: rolling window mean β for stability analysis.
+
+Notes:
+    **Pipeline.** Per-asset full-sample OLS β (time-series step), then
+    cross-asset t on the β distribution; rolling-window variant slices
+    the time axis before the per-asset step.
 """
 
 from __future__ import annotations

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -1,10 +1,5 @@
 """Time-series quantile bucketing + monotonicity test (issue #5).
 
-Notes:
-    **Pipeline.** Per-date aggregation to a common ``(_f, _r)`` series
-    (cross-section step), then quantile-bucketed NW HAC OLS on that
-    time series; Wald χ² on the top-bottom bucket spread.
-
 Diagnostic for `(COMMON, CONTINUOUS, *)` and single-asset TIMESERIES
 cells: bucket factor history into quantiles and check the conditional
 mean forward return per bucket. Catches U-shape / inverted-U /
@@ -15,6 +10,11 @@ Standalone metric — does not enter the registry. See
 `ARCHITECTURE.md` §"Registry procedure vs standalone metric" for the
 distinction. SPARSE / binary signals are out of scope; the input gate
 redirects to `event_quality` helpers.
+
+Notes:
+    **Pipeline.** Per-date aggregation to a common ``(_f, _r)`` series
+    (cross-section step), then quantile-bucketed NW HAC OLS on that
+    time series; Wald χ² on the top-bottom bucket spread.
 """
 
 from __future__ import annotations

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -29,6 +29,12 @@ def by_slice(
 ) -> SliceResult:
     """Apply ``metric`` to each value-partition of ``df`` keyed by ``label``.
 
+    Universe overlap (superset / multi-membership / hierarchical /
+    sliding window / cross-product) is composed by the caller — see
+    the API page for reference patterns. ``by_slice`` does no
+    cross-slice statistical inference; for paired comparison see
+    :func:`factrix.slice_pairwise_test` / :func:`factrix.slice_joint_test`.
+
     Args:
         metric: Callable returning a ``MetricOutput`` (e.g.
             :func:`factrix.metrics.ic`, :func:`factrix.metrics.caar`).
@@ -72,12 +78,6 @@ def by_slice(
         ...     pl.col("date").dt.year().alias("year")
         ... )
         >>> per_year = fx.by_slice(ic, ic_df, label="year")
-
-    Universe overlap (superset / multi-membership / hierarchical /
-    sliding window / cross-product) is composed by the caller — see
-    the API page for reference patterns. ``by_slice`` does no
-    cross-slice statistical inference; for paired comparison see
-    :func:`factrix.slice_pairwise_test` / :func:`factrix.slice_joint_test`.
     """
     sliced = _slice_by_label(df, label)
     return SliceResult(

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -121,15 +121,6 @@ def slice_pairwise_test(
             with an analytic estimator raises ``ValueError`` (RW
             requires a bootstrap distribution).
 
-    Note:
-        BlockBootstrap reproducibility — pass an explicit ``rng_seed``
-        on the :class:`BlockBootstrap` instance to fix the bootstrap
-        draw. Bootstrap metadata (resolved block length, scheme, seed)
-        is not attached to the returned DataFrame in this release;
-        callers wanting it can either reconstruct from the estimator
-        config or use :func:`factrix._stats.bootstrap._block_bootstrap_diff_p`
-        directly per pair.
-
     Returns:
         Long-form ``pl.DataFrame`` with columns
         ``(slice_a, slice_b, n_obs, stat, p_raw, p_adj)``; one row per
@@ -183,6 +174,15 @@ def slice_pairwise_test(
         ...     ic, per_sector_ic, label="sector",
         ...     estimator=BlockBootstrap(rng_seed=0),
         ... )
+
+    Notes:
+        BlockBootstrap reproducibility — pass an explicit ``rng_seed``
+        on the :class:`BlockBootstrap` instance to fix the bootstrap
+        draw. Bootstrap metadata (resolved block length, scheme, seed)
+        is not attached to the returned DataFrame in this release;
+        callers wanting it can either reconstruct from the estimator
+        config or use :func:`factrix._stats.bootstrap._block_bootstrap_diff_p`
+        directly per pair.
     """
     est = _resolve_estimator(estimator, "slice_pairwise_test")
 

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -139,6 +139,15 @@ def slice_pairwise_test(
         NotImplementedError: Estimator outside ``WaldNWCluster`` /
             ``BlockBootstrap``.
 
+    Notes:
+        BlockBootstrap reproducibility — pass an explicit ``rng_seed``
+        on the :class:`BlockBootstrap` instance to fix the bootstrap
+        draw. Bootstrap metadata (resolved block length, scheme, seed)
+        is not attached to the returned DataFrame in this release;
+        callers wanting it can either reconstruct from the estimator
+        config or use :func:`factrix._stats.bootstrap._block_bootstrap_diff_p`
+        directly per pair.
+
     Examples:
         Pairwise IC contrasts across two sub-universes. The canonical
         pattern is to compute the per-date metric series per slice
@@ -174,15 +183,6 @@ def slice_pairwise_test(
         ...     ic, per_sector_ic, label="sector",
         ...     estimator=BlockBootstrap(rng_seed=0),
         ... )
-
-    Notes:
-        BlockBootstrap reproducibility — pass an explicit ``rng_seed``
-        on the :class:`BlockBootstrap` instance to fix the bootstrap
-        draw. Bootstrap metadata (resolved block length, scheme, seed)
-        is not attached to the returned DataFrame in this release;
-        callers wanting it can either reconstruct from the estimator
-        config or use :func:`factrix._stats.bootstrap._block_bootstrap_diff_p`
-        directly per pair.
     """
     est = _resolve_estimator(estimator, "slice_pairwise_test")
 

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -9,13 +9,13 @@ suitable for event-clustering situations, persistent macro factors, and
 non-normal IC distributions.
 
 References:
-    [Politis & Romano (1994)][politis-romano-1994], "The Stationary
-        Bootstrap."
-    [Politis & White (2004)][politis-white-2004], "Automatic Block-
-        Length Selection for the Dependent Bootstrap." Full procedure
-        requires spectral-density estimation; this module falls back
-        to the practical ``L = round(1.75 * T^(1/3))`` rule when
-        ``block_length=None``.
+    - [Politis & Romano (1994)][politis-romano-1994], "The Stationary
+      Bootstrap."
+    - [Politis & White (2004)][politis-white-2004], "Automatic Block-
+      Length Selection for the Dependent Bootstrap." Full procedure
+      requires spectral-density estimation; this module falls back to
+      the practical ``L = round(1.75 * T^(1/3))`` rule when
+      ``block_length=None``.
 """
 
 from __future__ import annotations
@@ -67,15 +67,14 @@ def stationary_bootstrap_resamples(
         ``(n_bootstrap, T)`` numpy array of resampled series.
 
     References:
-        [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
-        Bootstrap." Journal of the American Statistical Association,
-        89(428), 1303–1313. Stationary block bootstrap with geometric
-        block lengths — the resampling scheme this function implements.
-
-        [Politis & White (2004)][politis-white-2004]. "Automatic Block-
-        Length Selection for the Dependent Bootstrap." Econometric
-        Reviews, 23(1), 53–70. Source of the practical ``1.75 * T^(1/3)``
-        block-length default.
+        - [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
+          Bootstrap." Journal of the American Statistical Association,
+          89(428), 1303–1313. Stationary block bootstrap with geometric
+          block lengths — the resampling scheme this function implements.
+        - [Politis & White (2004)][politis-white-2004]. "Automatic Block-
+          Length Selection for the Dependent Bootstrap." Econometric
+          Reviews, 23(1), 53–70. Source of the practical ``1.75 * T^(1/3)``
+          block-length default.
     """
     from factrix._stats.bootstrap import _stationary_block_indices
 
@@ -124,10 +123,10 @@ def bootstrap_mean_ci(
         on the original sample.
 
     References:
-        [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
-        Bootstrap." Journal of the American Statistical Association,
-        89(428), 1303–1313. Underlying resampling scheme; percentile CI
-        on the bootstrap distribution of the statistic.
+        - [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
+          Bootstrap." Journal of the American Statistical Association,
+          89(428), 1303–1313. Underlying resampling scheme; percentile CI
+          on the bootstrap distribution of the statistic.
     """
     if not 0.0 < ci < 1.0:
         raise ValueError(f"ci must be in (0, 1), got {ci!r}")

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -9,11 +9,13 @@ suitable for event-clustering situations, persistent macro factors, and
 non-normal IC distributions.
 
 References:
-    Politis & Romano (1994), "The Stationary Bootstrap."
-    Politis & White (2004), "Automatic Block-Length Selection for
-        the Dependent Bootstrap." (Full procedure requires spectral-
-        density estimation; this module falls back to the practical
-        ``L = round(1.75 * T^(1/3))`` rule when ``block_length=None``.)
+    [Politis & Romano (1994)][politis-romano-1994], "The Stationary
+        Bootstrap."
+    [Politis & White (2004)][politis-white-2004], "Automatic Block-
+        Length Selection for the Dependent Bootstrap." Full procedure
+        requires spectral-density estimation; this module falls back
+        to the practical ``L = round(1.75 * T^(1/3))`` rule when
+        ``block_length=None``.
 """
 
 from __future__ import annotations
@@ -63,6 +65,17 @@ def stationary_bootstrap_resamples(
 
     Returns:
         ``(n_bootstrap, T)`` numpy array of resampled series.
+
+    References:
+        [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
+        Bootstrap." Journal of the American Statistical Association,
+        89(428), 1303–1313. Stationary block bootstrap with geometric
+        block lengths — the resampling scheme this function implements.
+
+        [Politis & White (2004)][politis-white-2004]. "Automatic Block-
+        Length Selection for the Dependent Bootstrap." Econometric
+        Reviews, 23(1), 53–70. Source of the practical ``1.75 * T^(1/3)``
+        block-length default.
     """
     from factrix._stats.bootstrap import _stationary_block_indices
 
@@ -109,6 +122,12 @@ def bootstrap_mean_ci(
     Returns:
         ``(ci_low, ci_high, point)`` where ``point`` is the statistic
         on the original sample.
+
+    References:
+        [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
+        Bootstrap." Journal of the American Statistical Association,
+        89(428), 1303–1313. Underlying resampling scheme; percentile CI
+        on the bootstrap distribution of the statistic.
     """
     if not 0.0 < ci < 1.0:
         raise ValueError(f"ci must be in (0, 1), got {ci!r}")

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -21,19 +21,15 @@ are implicitly not rejected. Default (``None``) reproduces single-stage
 BHY where ``m = len(p_values)``.
 
 References:
-    Benjamini, Y. & Yekutieli, D. (2001). "The Control of the False
-    Discovery Rate in Multiple Testing under Dependency."
-    Annals of Statistics 29(4), 1165-1188.
-
-    Benjamini, Y. & Heller, R. (2008). "Screening for partial conjunction
-    hypotheses." Biometrics 64(4), 1215-1222. — partial_conjunction_p
-
-    Simes, R. J. (1986). "An improved Bonferroni procedure for multiple
-    tests of significance." Biometrika 73(3), 751-754. — simes_p
-
-    Yekutieli, D. (2008). "Hierarchical false discovery rate-controlling
-    methodology." JASA 103(481), 309-316. — Simes as group representative
-    in hierarchical FDR procedures.
+    [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001], "The
+        Control of the False Discovery Rate in Multiple Testing under
+        Dependency."
+    [Benjamini & Heller (2008)][benjamini-heller-2008], "Screening
+        for Partial Conjunction Hypotheses."
+    [Simes (1986)][simes-1986], "An Improved Bonferroni Procedure
+        for Multiple Tests of Significance."
+    [Yekutieli (2008)][yekutieli-2008], "Hierarchical False Discovery
+        Rate-controlling Methodology."
 """
 
 from __future__ import annotations
@@ -96,6 +92,12 @@ def bhy_adjust(
     Returns:
         Boolean mask of length ``len(p_values)`` — True where the null
         is rejected. Order matches the input.
+
+    References:
+        [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. "The
+        Control of the False Discovery Rate in Multiple Testing under
+        Dependency." Annals of Statistics, 29(4), 1165–1188. The
+        ``c(m) = Σ 1/i`` correction underlying this step-up rule.
     """
     p = np.asarray(p_values, dtype=float)
     n = len(p)
@@ -142,6 +144,13 @@ def bhy_adjusted_p(
     ``n_tests`` follows the same contract as ``bhy_adjust`` — pass the
     pre-filter size when the submitted p's are survivors of a larger
     candidate family.
+
+    References:
+        [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. "The
+        Control of the False Discovery Rate in Multiple Testing under
+        Dependency." Annals of Statistics, 29(4), 1165–1188. The
+        per-hypothesis adjusted-p mapping derived from the same
+        step-up rule used by ``bhy_adjust``.
     """
     p = np.asarray(p_values, dtype=float)
     n = len(p)
@@ -186,6 +195,17 @@ def simes_p(p_values: npt.ArrayLike) -> float:
     Raises:
         ValueError: ``len(p_values) == 0`` (Simes is undefined on an
             empty group).
+
+    References:
+        [Simes (1986)][simes-1986]. "An Improved Bonferroni Procedure
+        for Multiple Tests of Significance." Biometrika, 73(3),
+        751–754. The combined-test formula implemented here.
+
+        [Yekutieli (2008)][yekutieli-2008]. "Hierarchical False
+        Discovery Rate-controlling Methodology." Journal of the
+        American Statistical Association, 103(481), 309–316. Uses
+        Simes as the group representative in hierarchical FDR
+        procedures fed to an outer BHY step-up.
     """
     p = np.asarray(p_values, dtype=float)
     m = len(p)
@@ -221,6 +241,11 @@ def partial_conjunction_p(
 
     Returns:
         The PC p-value, clipped to ``[0, 1]``.
+
+    References:
+        [Benjamini & Heller (2008)][benjamini-heller-2008]. "Screening
+        for Partial Conjunction Hypotheses." Biometrics, 64(4),
+        1215–1222. The partial-conjunction test implemented here.
     """
     p = np.asarray(p_values, dtype=float)
     m = len(p)

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -21,15 +21,15 @@ are implicitly not rejected. Default (``None``) reproduces single-stage
 BHY where ``m = len(p_values)``.
 
 References:
-    [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001], "The
-        Control of the False Discovery Rate in Multiple Testing under
-        Dependency."
-    [Benjamini & Heller (2008)][benjamini-heller-2008], "Screening
-        for Partial Conjunction Hypotheses."
-    [Simes (1986)][simes-1986], "An Improved Bonferroni Procedure
-        for Multiple Tests of Significance."
-    [Yekutieli (2008)][yekutieli-2008], "Hierarchical False Discovery
-        Rate-controlling Methodology."
+    - [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001], "The
+      Control of the False Discovery Rate in Multiple Testing under
+      Dependency."
+    - [Benjamini & Heller (2008)][benjamini-heller-2008], "Screening
+      for Partial Conjunction Hypotheses."
+    - [Simes (1986)][simes-1986], "An Improved Bonferroni Procedure
+      for Multiple Tests of Significance."
+    - [Yekutieli (2008)][yekutieli-2008], "Hierarchical False Discovery
+      Rate-controlling Methodology."
 """
 
 from __future__ import annotations
@@ -94,10 +94,10 @@ def bhy_adjust(
         is rejected. Order matches the input.
 
     References:
-        [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. "The
-        Control of the False Discovery Rate in Multiple Testing under
-        Dependency." Annals of Statistics, 29(4), 1165–1188. The
-        ``c(m) = Σ 1/i`` correction underlying this step-up rule.
+        - [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. "The
+          Control of the False Discovery Rate in Multiple Testing under
+          Dependency." Annals of Statistics, 29(4), 1165–1188. The
+          ``c(m) = Σ 1/i`` correction underlying this step-up rule.
     """
     p = np.asarray(p_values, dtype=float)
     n = len(p)
@@ -146,11 +146,11 @@ def bhy_adjusted_p(
     candidate family.
 
     References:
-        [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. "The
-        Control of the False Discovery Rate in Multiple Testing under
-        Dependency." Annals of Statistics, 29(4), 1165–1188. The
-        per-hypothesis adjusted-p mapping derived from the same
-        step-up rule used by ``bhy_adjust``.
+        - [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. "The
+          Control of the False Discovery Rate in Multiple Testing under
+          Dependency." Annals of Statistics, 29(4), 1165–1188. The
+          per-hypothesis adjusted-p mapping derived from the same
+          step-up rule used by ``bhy_adjust``.
     """
     p = np.asarray(p_values, dtype=float)
     n = len(p)
@@ -197,15 +197,14 @@ def simes_p(p_values: npt.ArrayLike) -> float:
             empty group).
 
     References:
-        [Simes (1986)][simes-1986]. "An Improved Bonferroni Procedure
-        for Multiple Tests of Significance." Biometrika, 73(3),
-        751–754. The combined-test formula implemented here.
-
-        [Yekutieli (2008)][yekutieli-2008]. "Hierarchical False
-        Discovery Rate-controlling Methodology." Journal of the
-        American Statistical Association, 103(481), 309–316. Uses
-        Simes as the group representative in hierarchical FDR
-        procedures fed to an outer BHY step-up.
+        - [Simes (1986)][simes-1986]. "An Improved Bonferroni Procedure
+          for Multiple Tests of Significance." Biometrika, 73(3),
+          751–754. The combined-test formula implemented here.
+        - [Yekutieli (2008)][yekutieli-2008]. "Hierarchical False
+          Discovery Rate-controlling Methodology." Journal of the
+          American Statistical Association, 103(481), 309–316. Uses
+          Simes as the group representative in hierarchical FDR
+          procedures fed to an outer BHY step-up.
     """
     p = np.asarray(p_values, dtype=float)
     m = len(p)
@@ -243,9 +242,9 @@ def partial_conjunction_p(
         The PC p-value, clipped to ``[0, 1]``.
 
     References:
-        [Benjamini & Heller (2008)][benjamini-heller-2008]. "Screening
-        for Partial Conjunction Hypotheses." Biometrics, 64(4),
-        1215–1222. The partial-conjunction test implemented here.
+        - [Benjamini & Heller (2008)][benjamini-heller-2008]. "Screening
+          for Partial Conjunction Hypotheses." Biometrics, 64(4),
+          1215–1222. The partial-conjunction test implemented here.
     """
     p = np.asarray(p_values, dtype=float)
     m = len(p)


### PR DESCRIPTION
## Summary

- Introduces a module docstring layering policy in `contributing.md` §6: module docstrings hold navigation + cross-module context; function / class / method docstrings hold the implementation contract (Args / Returns / Raises / Notes / Examples / References).
- `References:` placement is decided by callable count. Single-callable modules carry References only on the function. Multi-callable modules carry a short-form References overview at module level + per-function inline-full-citation blocks. Private `_stats/*` modules carry source-only References (format-only conversion from NumPy underline to Google form).
- Inline citations use mkdocs-autorefs hyperlinks: `[Author (Year)][slug]` resolves to a `docs/reference/bibliography.md` anchor, followed by the full inline citation text and an optional role-note. `bibliography.md` is repositioned as a catalog page (browse view + cross-page anchor target), not the single SSOT for citation metadata.
- Migrates `factrix/_stats/{bootstrap,multiple_testing,wald,gmm,__init__}.py`, `factrix/metrics/{corrado,caar,fama_macbeth,spanning}.py`, and `factrix/stats/{bootstrap,multiple_testing}.py` to the new convention.
- Adds three previously missing bibliography anchors (`simes-1986`, `benjamini-heller-2008`, `yekutieli-2008`) consumed by the new function-level citations on `stats/multiple_testing.py`.

Closes #319.

## Test plan

- [x] `uv run mkdocs build --strict` clean (all autorefs slugs resolve)
- [x] Pre-commit `ruff check` + `ruff format --check` green on every commit
- [x] Pre-push `mkdocs build --strict` + `mypy factrix` green
- [ ] Reviewer spot-check on rendered `api/metrics/caar.md`, `api/metrics/fama-macbeth.md`, `api/metrics/spanning.md`, `api/stats.md`: module-overview References at top of page + per-function References inside each function section; author-year hyperlinks navigate to `bibliography.md`.
- [ ] Reviewer spot-check on rendered `api/metrics/corrado.md`: no module-level References (single-callable module); function-level References with hyperlinks.

## Known follow-ups (not in this PR)

Surfaces flagged by the final review but out of #319's scope:

- `factrix/_describe.py` carries 5 NumPy underline blocks (`Parameters\n----------`) — separate `Google-style audit` axis, tracked in #313.
- 6 metric modules without any References (`event_horizon`, `mfe_mae`, `event_quality`, `quantile`, `ts_beta`, `hit_rate`) — most look operational; needs a sweep to confirm vs file as a small follow-up.
- Pre-existing factrix-wide claim that Andrews (1991) gives the $T^{1/3}$ Bartlett rate (consistent in `bibliography.md` + `fama_macbeth.py`); $T^{1/3}$ is conventionally Newey-West, Andrews (1991) is $T^{1/5}$ plug-in. Worth a separate attribution-correction issue if a methodology-savvy reviewer confirms.
- Kan-Zhang (1999) attribution for the single-factor Shanken EIV simplification in `fama_macbeth` — Shanken (1992) §4 is the more direct source. Same axis as the Andrews note above.