### PR TITLE
docs(api): Examples on remaining public API surface (#312)

### DIFF
--- a/factrix/_analysis_config.py
+++ b/factrix/_analysis_config.py
@@ -202,6 +202,22 @@ class AnalysisConfig:
         Returns:
             A validated ``AnalysisConfig`` for the
             ``(INDIVIDUAL, CONTINUOUS, metric)`` cell.
+
+        Examples:
+            >>> import factrix as fx
+            >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=10)
+            >>> cfg.scope is fx.FactorScope.INDIVIDUAL
+            True
+            >>> cfg.signal is fx.Signal.CONTINUOUS
+            True
+            >>> cfg.metric is fx.Metric.IC
+            True
+
+            Switch metric to Fama-MacBeth λ:
+
+            >>> cfg_fm = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.FM)
+            >>> cfg_fm.metric is fx.Metric.FM
+            True
         """
         return cls(
             FactorScope.INDIVIDUAL,
@@ -235,6 +251,16 @@ class AnalysisConfig:
         Returns:
             A validated ``AnalysisConfig`` for the
             ``(INDIVIDUAL, SPARSE, None)`` cell.
+
+        Examples:
+            >>> import factrix as fx
+            >>> cfg = fx.AnalysisConfig.individual_sparse(forward_periods=5)
+            >>> cfg.scope is fx.FactorScope.INDIVIDUAL
+            True
+            >>> cfg.signal is fx.Signal.SPARSE
+            True
+            >>> cfg.metric is None
+            True
         """
         return cls(
             FactorScope.INDIVIDUAL,
@@ -267,6 +293,16 @@ class AnalysisConfig:
         Returns:
             A validated ``AnalysisConfig`` for the
             ``(COMMON, CONTINUOUS, None)`` cell.
+
+        Examples:
+            >>> import factrix as fx
+            >>> cfg = fx.AnalysisConfig.common_continuous(forward_periods=5)
+            >>> cfg.scope is fx.FactorScope.COMMON
+            True
+            >>> cfg.signal is fx.Signal.CONTINUOUS
+            True
+            >>> cfg.metric is None
+            True
         """
         return cls(
             FactorScope.COMMON,
@@ -299,6 +335,16 @@ class AnalysisConfig:
         Returns:
             A validated ``AnalysisConfig`` for the
             ``(COMMON, SPARSE, None)`` cell.
+
+        Examples:
+            >>> import factrix as fx
+            >>> cfg = fx.AnalysisConfig.common_sparse(forward_periods=5)
+            >>> cfg.scope is fx.FactorScope.COMMON
+            True
+            >>> cfg.signal is fx.Signal.SPARSE
+            True
+            >>> cfg.metric is None
+            True
         """
         return cls(
             FactorScope.COMMON,

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -206,6 +206,15 @@ def describe_analysis_modes(
     cells exist") and groups by user-facing ``(scope, signal, metric)``
     so each row carries both ``PANEL`` and ``TIMESERIES`` information
     when registered. Plan §7.1.
+
+    Examples:
+        >>> import factrix as fx
+        >>> text = fx.describe_analysis_modes()
+        >>> isinstance(text, str)
+        True
+        >>> rows = fx.describe_analysis_modes(format="json")
+        >>> isinstance(rows, list) and all(isinstance(r, dict) for r in rows)
+        True
     """
     rows = [_row_for_tuple(*t) for t in _user_facing_axis_tuples()]
     if format == "json":
@@ -241,6 +250,17 @@ class SuggestConfigResult:
     | ``n_assets``         | int       | unique ``asset_id`` count                 |
     | ``n_periods``        | int       | unique ``date`` count                     |
     | ``sparsity``         | float     | zero-ratio in ``factor`` column           |
+
+    Examples:
+        >>> import factrix as fx
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> result = fx.suggest_config(raw)
+        >>> isinstance(result, fx.SuggestConfigResult)
+        True
+        >>> isinstance(result.suggested, fx.AnalysisConfig)
+        True
+        >>> set(result.detected) >= {"scope", "signal", "mode", "n_assets", "n_periods", "sparsity"}
+        True
     """
 
     suggested: AnalysisConfig
@@ -266,24 +286,16 @@ class SuggestConfigResult:
             the per-axis reasoning strings, and warnings as a sorted
             list of ``.value`` strings.
 
-        Example:
-            >>> result.diagnose()  # doctest: +SKIP
-            {
-                "suggested": {
-                    "scope": "individual",
-                    "signal": "continuous",
-                    "metric": "ic",
-                    "forward_periods": 5,
-                },
-                "detected": {
-                    "scope": "individual", "signal": "continuous",
-                    "mode": "panel", "n_assets": 100,
-                    "n_periods": 494, "sparsity": 0.0,
-                },
-                "reasoning": {"scope": "...", "signal": "...",
-                              "metric": "...", "mode": "..."},
-                "warnings": [],
-            }
+        Examples:
+            >>> import factrix as fx
+            >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+            >>> d = fx.suggest_config(raw).diagnose()
+            >>> isinstance(d, dict)
+            True
+            >>> set(d) == {"suggested", "detected", "reasoning", "warnings"}
+            True
+            >>> isinstance(d["suggested"], dict) and "scope" in d["suggested"]
+            True
         """
         return {
             "suggested": self.suggested.to_dict(),

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -85,6 +85,32 @@ class Survivors:
             ``adj_p`` survivor selection is the anti-shopping failure
             mode ``partial_conjunction`` exists to prevent. ``None``
             when the producing function is not ``partial_conjunction``.
+
+    Examples:
+        >>> import dataclasses
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profiles = [
+        ...     dataclasses.replace(
+        ...         fx.evaluate(
+        ...             compute_forward_return(
+        ...                 fx.datasets.make_cs_panel(n_assets=30, n_dates=120, seed=i),
+        ...                 forward_periods=5,
+        ...             ),
+        ...             cfg,
+        ...         ),
+        ...         factor_id=f"alpha_{i}",
+        ...     )
+        ...     for i in range(3)
+        ... ]
+        >>> survivors = fx.multi_factor.bhy(profiles, q=0.05)
+        >>> isinstance(survivors, fx.multi_factor.Survivors)
+        True
+        >>> len(survivors) == len(survivors.profiles)
+        True
+        >>> survivors.q == 0.05
+        True
     """
 
     profiles: list[FactorProfile]

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -93,6 +93,20 @@ class FactorProfile:
             populates both ``T_NW`` and ``P`` from one bandwidth
             choice) duplicate the inner dict under both keys to keep
             single-key lookup honest (#188).
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profile = fx.evaluate(panel, cfg)
+        >>> isinstance(profile, fx.FactorProfile)
+        True
+        >>> 0.0 <= profile.primary_p <= 1.0
+        True
+        >>> profile.n_assets == 20
+        True
     """
 
     config: AnalysisConfig
@@ -171,6 +185,20 @@ class FactorProfile:
             (``primary_p`` / ``primary_stat`` / ``primary_stat_name``),
             sorted warning / info code names, and the full ``stats``
             mapping with enum keys converted to their string values.
+
+        Examples:
+            >>> import factrix as fx
+            >>> from factrix.preprocess import compute_forward_return
+            >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+            >>> panel = compute_forward_return(raw, forward_periods=5)
+            >>> profile = fx.evaluate(panel, fx.AnalysisConfig.individual_continuous())
+            >>> d = profile.diagnose()
+            >>> isinstance(d, dict)
+            True
+            >>> set(["identity", "cell", "primary_p", "stats"]).issubset(d)
+            True
+            >>> d["cell"]["scope"] == "individual"
+            True
         """
         return {
             "identity": {

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -212,8 +212,8 @@ class MetricsBundle:
             >>> panel = compute_forward_return(raw, forward_periods=5)
             >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())
             >>> df = bundle.to_frame()
-            >>> df.columns
-            ['factor_id', 'forward_periods', 'metric', 'value', 'stat', 'significance', 'p_value', 'short_circuit_reason']
+            >>> set(df.columns) >= {"factor_id", "metric", "value", "p_value"}
+            True
             >>> df.height >= 1
             True
         """

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -80,6 +80,20 @@ class MetricsBundle:
             and the slice-test verb pair) populate via
             ``dataclasses.replace`` once available, or callers stamp
             manually after panel-side filtering.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())
+        >>> isinstance(bundle, fx.MetricsBundle)
+        True
+        >>> "ic" in bundle
+        True
+        >>> ic_output = bundle["ic"]
+        >>> bundle.identity == ("factor", 5)
+        True
     """
 
     identity: tuple[str, int]
@@ -190,6 +204,18 @@ class MetricsBundle:
 
         ``skipped`` entries do not appear; only successful and
         short-circuited ``MetricOutput`` rows are emitted.
+
+        Examples:
+            >>> import factrix as fx
+            >>> from factrix.preprocess import compute_forward_return
+            >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+            >>> panel = compute_forward_return(raw, forward_periods=5)
+            >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())
+            >>> df = bundle.to_frame()
+            >>> df.columns
+            ['factor_id', 'forward_periods', 'metric', 'value', 'stat', 'significance', 'p_value', 'short_circuit_reason']
+            >>> df.height >= 1
+            True
         """
         rows = []
         for name, out in sorted(self.metrics.items()):

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -117,6 +117,21 @@ def make_cs_panel(
         ``date`` dtype ``pl.Datetime("ms")``. Attach ``forward_return``
         (e.g. via ``factrix.preprocess.compute_forward_return``)
         before passing to ``fx.evaluate``.
+
+    Examples:
+        >>> import factrix as fx
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> set(raw.columns) == {"date", "asset_id", "price", "factor"}
+        True
+        >>> raw["asset_id"].n_unique() == 20
+        True
+
+        Attach a forward return before evaluating:
+
+        >>> from factrix.preprocess import compute_forward_return
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> "forward_return" in panel.columns
+        True
     """
     if n_assets < 2:
         raise ValueError("n_assets must be >= 2 for a cross-section")
@@ -206,6 +221,20 @@ def make_event_panel(
         ``forward_return`` (e.g. via
         ``factrix.preprocess.compute_forward_return``) before
         passing to ``fx.evaluate``.
+
+    Examples:
+        >>> import factrix as fx
+        >>> raw = fx.datasets.make_event_panel(n_assets=20, n_dates=120, event_rate=0.05)
+        >>> set(raw["factor"].unique().to_list()) <= {-1.0, 0.0, 1.0}
+        True
+
+        Pair with the sparse factory:
+
+        >>> from factrix.preprocess import compute_forward_return
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> cfg = fx.AnalysisConfig.individual_sparse(forward_periods=5)
+        >>> cfg.signal is fx.Signal.SPARSE
+        True
     """
     if n_assets < 1:
         raise ValueError("n_assets must be >= 1")

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -46,6 +46,23 @@ def compute_forward_return(
     Returns:
         Input DataFrame with ``forward_return`` column appended.
         Rows where forward return is null (end of series) are dropped.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> "forward_return" in panel.columns
+        True
+        >>> panel["forward_return"].null_count() == 0
+        True
+
+        The output panel is the canonical input to ``fx.evaluate``:
+
+        >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+        >>> profile = fx.evaluate(panel, cfg)
+        >>> isinstance(profile, fx.FactorProfile)
+        True
     """
     return (
         df.sort(["asset_id", "date"])

--- a/factrix/slicing/result.py
+++ b/factrix/slicing/result.py
@@ -42,6 +42,22 @@ class SliceResult(Mapping[str, MetricOutput]):
         Bonferroni) or :func:`factrix.slice_joint_test` (omnibus χ²)
         instead. The container is for exploration; the inference
         verbs are for claims.
+
+    Examples:
+        >>> import polars as pl
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> from factrix.metrics import ic, compute_ic
+        >>> raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=240)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> ic_df = compute_ic(panel).with_columns(
+        ...     pl.col("date").dt.year().alias("year")
+        ... )
+        >>> per_year = fx.by_slice(ic, ic_df, label="year")
+        >>> isinstance(per_year, fx.SliceResult)
+        True
+        >>> len(per_year) >= 1
+        True
     """
 
     def __init__(self, data: Mapping[str, MetricOutput]) -> None:
@@ -76,6 +92,27 @@ class SliceResult(Mapping[str, MetricOutput]):
         Returns:
             ``pl.DataFrame`` with one row per slice. Row order follows
             iteration order of ``self``.
+
+        Examples:
+            >>> import polars as pl
+            >>> import factrix as fx
+            >>> from factrix.preprocess import compute_forward_return
+            >>> from factrix.metrics import ic, compute_ic
+            >>> raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=240)
+            >>> panel = compute_forward_return(raw, forward_periods=5)
+            >>> ic_df = compute_ic(panel).with_columns(
+            ...     pl.col("date").dt.year().alias("year")
+            ... )
+            >>> per_year = fx.by_slice(ic, ic_df, label="year")
+            >>> df = per_year.to_frame()
+            >>> df.columns
+            ['slice', 'name', 'value', 'stat', 'p_value']
+
+            Override the slice column name to avoid collision:
+
+            >>> df2 = per_year.to_frame(slice_col="year")
+            >>> "year" in df2.columns
+            True
         """
         cols = (slice_col, "name", "value", "stat", "p_value")
         rows: dict[str, list[object]] = {c: [] for c in cols}

--- a/factrix/slicing/result.py
+++ b/factrix/slicing/result.py
@@ -105,8 +105,8 @@ class SliceResult(Mapping[str, MetricOutput]):
             ... )
             >>> per_year = fx.by_slice(ic, ic_df, label="year")
             >>> df = per_year.to_frame()
-            >>> df.columns
-            ['slice', 'name', 'value', 'stat', 'p_value']
+            >>> set(df.columns) >= {"slice", "name", "value"}
+            True
 
             Override the slice column name to avoid collision:
 


### PR DESCRIPTION
## Summary

Extends the `Examples:` convention pinned in #307 to the public API surface beyond the 12 sealed entry / utility functions: the four `AnalysisConfig` factories, every result dataclass + its methods, `describe_analysis_modes`, and the dataset / preprocess setup chain those examples depend on. Every new block follows the section order pinned in #319 (Examples last) and the call-shape-over-fragile-output convention (boolean / `isinstance` / column-list assertions; no concrete floats, DataFrame reprs, or multi-line text reprs).

Three atomic commits, by group:

- Factories: cell semantics surfaced inline via `(scope, signal, metric)` axis checks next to the call shape.
- Result dataclasses: class + method examples chain from the upstream entry function's output (`evaluate` / `run_metrics` / `by_slice` / `multi_factor.bhy` / `suggest_config`) rather than re-running panel setup.
- Datasets + `compute_forward_return`: closes the setup chain so a reader landing on those API pages first sees a runnable starting point hand-off into `fx.evaluate`.

Also replaces a stale singular `Example:` block on `SuggestConfigResult.diagnose` that was `+SKIP`-ed and showed concrete dict output — incompatible with the doctest CI gate.

The five non-public preprocess helpers originally listed in #312 (`winsorize_forward_return`, `compute_abnormal_return`, `mad_winsorize`, `cross_sectional_zscore`, `orthogonalize_factor`) are tracked separately in #323 (publicize decision + page wiring + Examples), since they are not currently reachable from the API Reference nav.

## Test plan

- [ ] `uv run pytest --doctest-modules factrix/` passes (29 doctests collected on touched modules).
- [ ] `uv run mkdocs build --strict` passes.
- [ ] Spot-check render: factory pages show cell-semantics inline; dataclass pages show upstream-chained examples without re-derived setup.

Closes #312