### PR TITLE
refactor(docs): sweep verb prose residue across factrix/ (#332)

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -240,7 +240,7 @@ __all__ = [
     "list_estimators",
     "list_metrics",
     "suggest_config",
-    # Slicing dispatcher + cross-slice inference verbs
+    # Slicing dispatcher + cross-slice inference functions
     "SliceResult",
     "by_slice",
     "slice_joint_test",

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -189,7 +189,7 @@ class StatCode(StrEnum):
     GMM emits J rather than T), ``(WALD_NWCL, P_WALD_NWCL)`` for NW
     HAC + one-way cluster on the slice grouping, and ``(WALD_TWOWAY,
     P_WALD_TWOWAY)`` for two-way cluster on (date, asset) (slice-test
-    verbs, #153 / #176). The Wald pairs follow the same
+    functions, #153 / #176). The Wald pairs follow the same
     ``<KIND>_<ALGO>`` shape — KIND = ``WALD`` (χ² statistic name,
     parallel to ``T``), ALGO names the cluster-SE family
     (parallel to ``NW`` / ``HH`` naming the kernel family). ``P_BOOT``
@@ -230,8 +230,9 @@ class StatCode(StrEnum):
     Python variable convention is unambiguous from context.
 
     ``is_p_value`` returns ``True`` for any code whose
-    underscore-separated tokens contain ``"p"``; family-verb
-    ``estimator=`` (#170) dispatches via :class:`Estimator.emits_for`
+    underscore-separated tokens contain ``"p"``; the
+    family-function ``estimator=`` kwarg (#170) dispatches via
+    :class:`Estimator.emits_for`
     and is implicitly a p-value source by construction.
     """
 
@@ -255,7 +256,7 @@ class StatCode(StrEnum):
     J_GMM = "j_gmm"
     P_GMM = "p_gmm"
     # Cluster-robust Wald χ² for linear restrictions on a slice contrast
-    # / joint coefficient (slice-test verbs, #153 / #176). KIND = WALD (χ²
+    # / joint coefficient (slice-test functions, #153 / #176). KIND = WALD (χ²
     # test statistic, parallel to T); ALGO names the cluster-SE family
     # (parallel to NW / HH naming the kernel family).
     # NWCL = NW Bartlett HAC + one-way cluster on the slice grouping

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -1,6 +1,6 @@
-"""Shared family resolution layer for multiple-testing verbs (#161, #170).
+"""Shared family resolution layer for multiple-testing functions (#161, #170).
 
-Every closed-form family verb (``bhy`` / ``bhy_hierarchical`` /
+Every closed-form family function (``bhy`` / ``bhy_hierarchical`` /
 ``partial_conjunction`` / ``bonferroni`` / ``holm``) and the
 resampling-based ``romano_wolf`` runs through ``_resolve_family`` to
 turn a list of :class:`~factrix._profile.FactorProfile` into flat
@@ -43,7 +43,7 @@ _ESTIMATOR_DOCS_ANCHOR = "estimator"
 
 @dataclass(frozen=True, slots=True)
 class _FamilyEntry:
-    """Flat record fed to family-verb procedures after invariant checks.
+    """Flat record fed to family-function procedures after invariant checks.
 
     Attributes:
         identity: ``(factor_id, forward_periods)`` from

--- a/factrix/_profile.py
+++ b/factrix/_profile.py
@@ -79,7 +79,7 @@ class FactorProfile:
             profile is constructed directly.
         context: Sample-restriction / conditioning dimensions
             (``universe_id``, ``regime_id``, future axes). Populated
-            by higher-level verbs via ``dataclasses.replace``.
+            by higher-level functions via ``dataclasses.replace``.
         warnings, info_notes, stats: per-procedure flags / scalars.
         metadata: Hyperparameter-selection records the procedure made
             internally, keyed by the ``StatCode`` they produced.

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -65,8 +65,8 @@ class MetricsBundle:
     Attributes:
         identity: ``(factor_id, forward_periods)`` — the hypothesis
             dimensions per #160. Aligns with ``FactorProfile.identity``
-            so downstream verbs (``compare`` / cross-slice analysis)
-            can stack profiles and bundles by the same key.
+            so downstream functions (``compare`` / cross-slice
+            analysis) can stack profiles and bundles by the same key.
         metrics: Metric name → ``MetricOutput`` mapping for every
             metric that produced a value (including short-circuit
             ``MetricOutput`` entries — ``value=NaN`` with a reason in
@@ -77,7 +77,7 @@ class MetricsBundle:
             ``__repr__`` / ``_repr_html_`` and a single ``logging.info``.
         context: Sample-restriction / conditioning dimensions per #160.
             v1 always empty; downstream slicers (``factrix.by_slice``
-            and the slice-test verb pair) populate via
+            and the slice-test function pair) populate via
             ``dataclasses.replace`` once available, or callers stamp
             manually after panel-side filtering.
 

--- a/factrix/_stats/slice_policy.py
+++ b/factrix/_stats/slice_policy.py
@@ -1,21 +1,22 @@
 """Slice-test policy helpers — pre-flight subset detection + ``n_groups`` downscale.
 
-Two private helpers consumed by the slice-test verbs (#176)
+Two private helpers consumed by the slice-test functions (#176)
 (``slice_pairwise_test`` / ``slice_joint_test``):
 
 - ``_detect_strict_subsets`` — pre-flight check for paired tests.
   When slice A's (date, asset) key-set is strictly contained in slice
   B's, the pairwise diff inherits A's universe entirely; the SE
   estimate has degeneracies the standard cluster-NW formula does not
-  warn about. The verb emits a ``UserWarning`` on non-empty output
-  and steers the caller toward ``slice_joint_test`` (omnibus over all
-  slices) which handles the geometry properly.
+  warn about. The slice-test function emits a ``UserWarning`` on
+  non-empty output and steers the caller toward
+  ``slice_joint_test`` (omnibus over all slices) which handles the
+  geometry properly.
 - ``_downscale_n_groups`` — for slice tests on metrics that bucket
   cross-section assets (quantile spread, monotonicity), shrinks
   ``n_groups`` so each bucket retains at least ``min_per_group``
   assets. The per-metric ``min_per_group`` floor lives on the metric
-  module itself (#153 §5); the verb resolves it per slice and feeds
-  it here.
+  module itself (#153 §5); the slice-test function resolves it per
+  slice and feeds it here.
 
 Issue spec deviation: ``_downscale_n_groups`` takes ``int`` rather than
 ``AnalysisConfig`` because ``AnalysisConfig`` carries no ``n_groups``

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -46,7 +46,7 @@ __all__ = [
 # bucket means converge to their cross-sectional expectation; below
 # this floor individual-asset noise dominates the rank statistic.
 # `_downscale_n_groups(base, n_assets, min_per_group=50)` caps
-# `n_groups` accordingly inside the slice-test verb.
+# `n_groups` accordingly inside the slice-test function.
 min_assets_per_group: int | None = 50
 
 

--- a/factrix/slicing/__init__.py
+++ b/factrix/slicing/__init__.py
@@ -1,4 +1,4 @@
-"""factrix.slicing — cross-slice dispatcher and inference verbs.
+"""factrix.slicing — cross-slice dispatcher and inference functions.
 
 Public surface:
 
@@ -9,10 +9,11 @@ Public surface:
 - :func:`slice_joint_test` — single-row omnibus Wald χ² that all
   slice means are equal.
 
-These verbs are intentionally *not* hosted under ``factrix.metrics``:
-that package is a structural registry where every public ``*.py`` is
-a per-(scope, signal) cell metric. Slicing verbs are infrastructure
-that consumes a metric callable, so they live in their own package.
+These functions are intentionally *not* hosted under
+``factrix.metrics``: that package is a structural registry where
+every public ``*.py`` is a per-(scope, signal) cell metric. Slicing
+functions are infrastructure that consumes a metric callable, so
+they live in their own package.
 """
 
 from __future__ import annotations

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -1,11 +1,11 @@
-"""Cross-slice statistical-test verbs.
+"""Cross-slice statistical-test functions.
 
 ``slice_pairwise_test`` reports K(K-1)/2 cross-slice contrasts as a
 long-form DataFrame of pairwise ``(stat, p_raw, p_adj)``;
 ``slice_joint_test`` reports the single omnibus Wald χ² that all K
 slice means are equal.
 
-The ``_test`` suffix marks "verb whose headline output is a
+The ``_test`` suffix marks "function whose headline output is a
 comparison test result (stat + p)" — distinct from metrics like
 ``ic`` / ``fama_macbeth`` whose significance is sidecar to a value,
 and from ``compare`` which renders existing stats without
@@ -22,7 +22,7 @@ the joint per-date K-vector panel — cross-slice covariance enters
 through the joint HAC, so paired-diff degeneracies do not arise on
 this path.
 
-Matrix-row: slice_pairwise_test, slice_joint_test | (*, *, *, *) | inference verb | per-pair Wald χ² + Holm/RW/Bonferroni / joint Wald χ² | _build_per_date_panel, _resolve_estimator, _joint_block_bootstrap_pairwise_distribution
+Matrix-row: slice_pairwise_test, slice_joint_test | (*, *, *, *) | inference function | per-pair Wald χ² + Holm/RW/Bonferroni / joint Wald χ² | _build_per_date_panel, _resolve_estimator, _joint_block_bootstrap_pairwise_distribution
 """
 
 from __future__ import annotations

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -1,7 +1,8 @@
 """Statistical tooling shared across the library.
 
-``Estimator`` — base inference-method protocol selected via family-verb
-``estimator=`` kwarg (#170); pure selection semantics (no ``compute``).
+``Estimator`` — base inference-method protocol selected via the
+family-function ``estimator=`` kwarg (#170); pure selection
+semantics (no ``compute``).
 ``HACEstimator(Estimator)`` — sub-protocol adding cell-internal
 ``compute(series, *, forward_periods) -> InferenceResult`` for HAC-on-
 mean inference (#163). ``NeweyWest`` / ``HansenHodrick`` implement it.
@@ -48,7 +49,7 @@ from factrix.stats.wald_cluster import WaldNWCluster, WaldTwoWayCluster
 # of truth for "which estimators exist". Slice-test Estimators (#153)
 # enter the registry with default-constructed instances; callers
 # override the defaults by passing an explicitly-constructed instance
-# to the slice-test verb (#176).
+# to the slice-test function (#176).
 _ESTIMATOR_REGISTRY: tuple[Estimator, ...] = (
     NeweyWest(),
     HansenHodrick(),

--- a/factrix/stats/_estimator.py
+++ b/factrix/stats/_estimator.py
@@ -1,8 +1,9 @@
 """Estimator protocols — selection (base), HAC-compute, moment-compute.
 
-``Estimator`` (base, #170): family-verb override selects which already-
-computed p-value to feed step-up math. Carries no compute logic — the
-procedure that populated ``FactorProfile.stats`` did the math.
+``Estimator`` (base, #170): family-function override selects which
+already-computed p-value to feed step-up math. Carries no compute
+logic — the procedure that populated ``FactorProfile.stats`` did the
+math.
 
 ``HACEstimator(Estimator)`` (#163): adds ``compute(series, *,
 forward_periods) -> InferenceResult`` for cell-internal estimator swap.
@@ -19,7 +20,7 @@ data-shape essentials only.
 
 Base ``Estimator`` is retained for slice-test instances
 (``WaldNWCluster`` / ``BlockBootstrap``, #153 / #176) whose compute
-path is multivariate and lives outside the family-verb axis.
+path is multivariate and lives outside the family-function axis.
 """
 
 from __future__ import annotations
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class Estimator(Protocol):
-    """Inference-method instance: names the p-value source family verbs select.
+    """Inference-method instance: names the p-value source family functions select.
 
     Implementations supply identity (``name``), human-readable summary
     (``description``), cell-applicability check (``applicable_to``), and a

--- a/factrix/stats/block_bootstrap.py
+++ b/factrix/stats/block_bootstrap.py
@@ -4,7 +4,7 @@ Names the block-bootstrap inference path for the paired-diff slice
 test. Numerics — Politis-Romano stationary scheme, Künsch fixed
 scheme, Politis-White automatic block length — live in
 ``factrix._stats.bootstrap``; this module is the dispatch handle
-exposed to family verbs / slice-test verbs (#176).
+exposed to family functions / slice-test functions (#176).
 
 Public ``factrix.stats.bootstrap`` standalone helpers
 (``stationary_bootstrap_resamples`` / ``bootstrap_mean_ci``) remain
@@ -39,14 +39,14 @@ class BlockBootstrap:
     to fix it.
 
     Applicability is restricted to ``(INDIVIDUAL, CONTINUOUS)`` —
-    consistent with the slice-test verbs that produce paired per-date
+    consistent with the slice-test functions that produce paired per-date
     diffs (slice IC, slice FM-λ, …).
 
     Constructor parameters are stored on the instance and read by the
-    slice-test verb procedure when it calls
+    slice-test function procedure when it calls
     ``factrix._stats.bootstrap._block_bootstrap_diff_p``. Two
     ``BlockBootstrap`` instances with different ``scheme`` / block
-    length are distinct Estimators from the verb's perspective; the
+    length are distinct Estimators from the function's perspective; the
     StatCode emitted (``P_BOOT``) does not split on scheme — scheme is
     metadata, not a separate code (parallel to how ``NeweyWest``'s lag
     rule lives in ``metadata`` rather than splitting ``P_NW``).

--- a/factrix/stats/newey_west.py
+++ b/factrix/stats/newey_west.py
@@ -50,7 +50,7 @@ class NeweyWest:
     re-encoding cell identity.
 
     Pass an instance to ``AnalysisConfig`` to run NW at evaluate time
-    (default), or to family verbs to select the NW p-value::
+    (default), or to family functions to select the NW p-value::
 
         cfg = AnalysisConfig.individual_continuous(estimator=NeweyWest())
         fx.bhy(profiles, estimator=NeweyWest())

--- a/factrix/stats/wald_cluster.py
+++ b/factrix/stats/wald_cluster.py
@@ -1,7 +1,7 @@
 """Cluster-robust Wald χ² Estimator instances (#153).
 
 Two ``Estimator`` implementations targeting the slice-test setting
-(#176 verbs ``slice_pairwise_test`` / ``slice_joint_test``):
+(#176 functions ``slice_pairwise_test`` / ``slice_joint_test``):
 
 - ``WaldNWCluster`` — NW HAC + 1-way cluster on the slice grouping;
   consumes the stacked per-date metric panel. Emits
@@ -9,15 +9,16 @@ Two ``Estimator`` implementations targeting the slice-test setting
   statistic side).
 - ``WaldTwoWayCluster`` — Cameron-Gelbach-Miller (2011) two-way
   cluster on (date, asset); consumes the raw asset-date panel.
-  Emits ``StatCode.P_WALD_TWOWAY``. Interface ships this issue but no
-  verb consumes it until ``factor_decomposition`` lands later;
-  calling ``bhy(estimator=WaldTwoWayCluster())`` against a profile
-  produced by ``evaluate()`` lands on a missing-stat error until
-  the verb populates ``profile.stats[StatCode.P_WALD_TWOWAY]``.
+  Emits ``StatCode.P_WALD_TWOWAY``. Interface ships this issue but
+  no function consumes it until ``factor_decomposition`` lands
+  later; calling ``bhy(estimator=WaldTwoWayCluster())`` against a
+  profile produced by ``evaluate()`` lands on a missing-stat error
+  until the function populates
+  ``profile.stats[StatCode.P_WALD_TWOWAY]``.
 
 Numerical implementations live in ``factrix._stats.wald``; this
-module names the inference path the family verbs / slice-test verbs
-dispatch to.
+module names the inference path the family functions / slice-test
+functions dispatch to.
 """
 
 from __future__ import annotations
@@ -40,8 +41,8 @@ class WaldNWCluster:
     panel. ``COMMON`` cells produce one number per date by definition
     of the scope and have no within-cell cross-section to slice over.
 
-    Pass an instance to a slice-test verb to make the inference choice
-    explicit::
+    Pass an instance to a slice-test function to make the inference
+    choice explicit::
 
         fx.slice_pairwise_test(metric=ic, df=panel, label="sector",
                                 estimator=WaldNWCluster())
@@ -83,7 +84,7 @@ class WaldTwoWayCluster:
     interaction with full panel SE). Numerics live in
     ``factrix._stats.wald._wald_two_way_cluster``.
 
-    Interface ships this PR; no verb consumes it until
+    Interface ships this PR; no function consumes it until
     ``factor_decomposition`` lands later. ``list_estimators`` surfaces
     it for ``(INDIVIDUAL, CONTINUOUS)`` cells — calling
     ``bhy(estimator=WaldTwoWayCluster())`` against a profile produced


### PR DESCRIPTION
## Summary

Completes the `verb` terminology retirement started in #316 / #317 (which renamed `UserInputError.verb` → `func_name` and swept internal `verb=` kwarg call sites). Those two issues touched the API surface; this sweep handles the broader prose vocabulary — `family verb`, `slice-test verb`, `inference verbs`, `family-verb override`, etc. — that remained in 36 occurrences across 14 module docstrings, class docstrings, and code comments under `factrix/`.

Counterpart to #286 (axis 8), which removed the same vocabulary from `bhy.md` / `partial_conjunction.md` table headers; #286 covered the `.md` surface, this covers the `.py` surface. Tracked as axis 23 on #280.

Replacements are context-sensitive, not mechanical:

- `family verb` / `family-verb` → `family function` (references to `bhy` / `bhy_hierarchical` / `partial_conjunction` / `bonferroni` / `holm` / `romano_wolf`).
- `slice-test verb` → `slice-test function` (references to `slice_pairwise_test` / `slice_joint_test`).
- `inference verbs` → `inference functions`; `downstream verbs` → `downstream functions`.
- Standalone `the verb` → `the function`, or reworded to name the specific function set when the surrounding sentence picks one out.

No symbol names changed; no signatures touched. Pure prose rewrite.

Closes #332.

## Test plan

- [x] `uv run ruff check factrix/` — All checks passed
- [x] `uv run pytest -q` — 1319 passed
- [x] `uv run mkdocs build --strict` — 0 error / 0 warning
- [x] `grep -rnE '\bverb(s)?\b' factrix/ --include='*.py'` — 0 hits (DoD satisfied)
- [ ] Reviewer spot-check on `slicing/inference.py` / `stats/wald_cluster.py` / `_family.py` module docstrings where the term carried the most semantic weight