### PR TITLE
docs(where-factrix-fits): exit pointer

### DIFF
--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -454,6 +454,16 @@ self-defeating once they read the source.
   replication is on the roadmap and is a credibility gap until it
   ships.
 
+## Next steps
+
+If this page resolved the fit question and you want to run factrix:
+
+- [Quickstart](getting-started/quickstart.md) — 30-second example from a raw panel to a `primary_p` readout.
+- [Concepts](getting-started/concepts.md) — the three-axis taxonomy and the metric dispatch underneath the routing examples above.
+- [Choosing a metric](guides/choosing-metric.md) — research-question to metric mapping for the five scenarios in §2.
+
+If you want to compare factrix to a specific peer before installing, the [§4 same-purpose peers](#4-same-purpose-peers) table is the densest summary on this page.
+
 ## 8. Citations
 
 The methodological choices on this page anchor in the following


### PR DESCRIPTION
## Summary

Adds a "Next steps" block before §8 Citations on `where-factrix-fits.md`. Points at quickstart / concepts / choosing-metric, plus a back-reference to §4 peers for readers still in comparison mode.

## Why

H2 finding from #336: a reader arriving from the homepage to decide whether to use factrix walks through ~500 lines of positioning, peers, and weaknesses, then hits citations with no breadcrumb to the first run. Closes the dead funnel.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: rendered "Next steps" lands above §8 with working links

Closes #336 H2 only — issue stays open for remaining findings.

Refs #336