### PR TITLE
docs(api): function-flow graph completeness

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -32,6 +32,8 @@ flowchart LR
 
     subgraph Introspection
         LM[list_metrics]
+        LE[list_estimators]
+        SC[suggest_config]
     end
 
     P ==> EV
@@ -47,6 +49,8 @@ flowchart LR
     PC ==>|survivors| CMP
     BHYH ==>|survivors| CMP
     LM -.->|metric names| RM
+    LE -.->|estimator names| BHY
+    SC -.->|inferred cfg| EV
 
     click EV "evaluate/" "evaluate API"
     click RM "run-metrics/" "run_metrics API"
@@ -56,6 +60,8 @@ flowchart LR
     click PC "partial-conjunction/" "partial_conjunction API"
     click BHYH "bhy-hierarchical/" "bhy_hierarchical API"
     click LM "list-metrics/" "list_metrics API"
+    click LE "list-estimators/" "list_estimators API"
+    click SC "suggest-config/" "suggest_config API"
     click CMP "compare/" "compare API"
 ```
 


### PR DESCRIPTION
## Summary

Adds `suggest_config` and `list_estimators` to the Introspection subgraph of the function-flow Mermaid in `api/index.md`. Dashed edges mirror the existing `LM -.->|metric names| RM` convention.

## Why

M9 finding from #336: the chart is the visual entry-point map a first-day reader scans before the symbol table, yet both functions were absent from it (listed only in the Entry points table below). A reader following the graph alone misses the config-inference path entirely.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: rendered graph shows SC + LE nodes inside Introspection with click-through links

Refs #336