### PR TITLE
docs(quickstart): link errors page

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -100,6 +100,10 @@ The most common warnings:
 For the full enum and the trigger conditions for each `WarningCode`,
 `InfoCode`, and `StatCode`, see
 [Reference § Warning / info / stat codes](../reference/warning-codes.md).
+For exception classes (`InsufficientSampleError`, `ModeAxisError`,
+`UserInputError`, `ConfigError`, `MissingConfigError`, ...), their TL;DR
+catch pattern, and recovery via `suggested_fix`, see
+[Errors](../api/errors.md).
 
 `warnings` does **not** affect `primary_p` —
 it is a risk flag. The user decides whether to filter on warnings before


### PR DESCRIPTION
## Summary

Adds a one-paragraph pointer from Quickstart's `diagnose()` / warnings section to `api/errors.md`, placed next to the existing warning-codes pointer.

## Why

M11 finding from #336: `api/errors.md` is a 221-line real taxonomy with TL;DR catch pattern + per-exception sections + `suggested_fix` recovery, but reachable only from the API Reference symbol list. A reader who hits `InsufficientSampleError` or `ModeAxisError` from Quickstart had no breadcrumb to it. Single insertion at the natural reading moment closes the discoverability gap; no new page, no restructure.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: rendered pointer renders next to warning-codes pointer with working link

Refs #336