### PR TITLE
docs(api): drop reverse-lookup tree

### DIFF
--- a/docs/api/decision-tree.md
+++ b/docs/api/decision-tree.md
@@ -1,60 +1,30 @@
 ---
-title: Decision tree
+title: Cross-function reference
 ---
 
-Reverse lookup from research question to function. The
-[API reference landing](index.md) is function-centric ("here is each
-public symbol"); this page is question-centric ("here is what to reach
-for, given what you want to know").
+Function semantics that do not belong on any single function's page —
+the comparison-axes matrix (which `compare` / `by_slice` /
+`slice_*_test` to pick), and cross-function topics where the same
+keyword shifts meaning across functions (`expand_over`, regime
+analysis).
 
-Three sections:
+For *"which function do I reach for given my research question"*, the
+[API reference landing](index.md) is the SSOT: the **Function flow**
+graph shows pipeline-level relationships, **Typical patterns** maps
+goals to pipelines, and the **Entry points** table carries a *When to
+read* line per function. Per-function docstrings carry the same
+*When to use* summary at the head of each page.
 
-- **§A. Question → function** — pick a starting function from intent.
-- **§B. Comparison axes** — `row × column` matrix for every "compare N
+Two sections:
+
+- **Comparison axes** — `row × column` matrix for every "compare N
   things across M dimensions" question.
-- **§C. Cross-function topics** — concepts whose meaning shifts across
+- **Cross-function topics** — concepts whose meaning shifts across
   functions (`expand_over`, regime analysis).
 
 ---
 
-## §A. Question → function
-
-```
-What do you want to know?
-│
-├── "Is factor X significant for one cell?"
-│     → evaluate(panel, cfg) → FactorProfile.primary_p
-│
-├── "What is the descriptive surface of factor X for one cell?"
-│     → run_metrics(panel, cfg, factor_col=...) → MetricsBundle
-│
-├── "Which of N candidate factors is strongest?"
-│     ├── with FDR control          → evaluate × N → bhy(profiles) → compare(survivors)
-│     ├── pure ranking, no FDR      → evaluate × N → compare(profiles, sort_by=...)
-│     └── exploratory descriptive   → run_metrics × N → compare(bundles)
-│
-├── "Does factor X hold up across multiple contexts?"
-│     ├── all contexts pass (k = m)         → partial_conjunction(profiles, k_of_m=m)
-│     ├── at least k of m pass             → partial_conjunction(profiles, k_of_m=k)
-│     ├── nested family / group structure  → bhy_hierarchical(profiles, group=...)
-│     └── flat sweep over a context axis   → bhy(profiles, expand_over=[...])
-│
-├── "Is factor X's conclusion robust to estimator choice?"
-│     → by_estimator(profiles, estimators=[...])   # planned, lands v0.14 (#178)
-│
-├── "How does factor X behave across slices (sector / regime / decile)?"
-│     ├── descriptive (per-slice value + n_obs)   → by_slice(metric, df, label=...) → SliceResult
-│     └── statistical test across slices          → slice_pairwise_test / slice_joint_test
-│
-└── "How does factor X behave across regimes?"
-      └── see §C — regime analysis is dispatched to four different functions
-          depending on whether the question is descriptive, FDR-controlled,
-          consistency-across-regimes, or between-regime difference.
-```
-
----
-
-## §B. Comparison axes
+## Comparison axes
 
 Every "compare N things across M dimensions" question reduces to a
 choice of *row variable* × *column variable*. The seven shipped
@@ -79,7 +49,7 @@ only, not the metric pipeline.
 
 ---
 
-## §C. Cross-function topics
+## Cross-function topics
 
 ### `expand_over` is not one concept
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -81,9 +81,9 @@ triggers and fix paths:
 |---|---|---|
 | `unknown metric='...'` | Typo or metric not applicable to the cell | `list_metrics(scope, signal)` enumerates the applicable set; `exc.suggestions` carries the top-3 fuzzy candidates. See [`list_metrics`](list-metrics.md). |
 | `unknown estimator='...'` | Typo or estimator not applicable to the cell | `list_estimators(scope, signal)` enumerates the applicable set. See [`list_estimators`](list-estimators.md). |
-| `unknown expand_over='...'` | Context key not present on every profile in the family | All profiles in the family must carry the key in `.context`; check that the caller is populating it consistently at `evaluate` time. See [Decision tree § §C `expand_over`](decision-tree.md#expand_over-is-not-one-concept) for the three different `expand_over` semantics across functions. |
+| `unknown expand_over='...'` | Context key not present on every profile in the family | All profiles in the family must carry the key in `.context`; check that the caller is populating it consistently at `evaluate` time. See [Cross-function reference § `expand_over`](decision-tree.md#expand_over-is-not-one-concept) for the three different `expand_over` semantics across functions. |
 | `expand_over=[...] requires every profile to carry key 'X'` | One or more profiles missing the key | Confirm the upstream `evaluate` call records the key in `context=...`. |
-| `Expected: list[FactorProfile], got list[MetricsBundle]` | Passing the wrong artefact family to a screening function | Screening (`bhy`, `partial_conjunction`, `bhy_hierarchical`) consumes `list[FactorProfile]` (primary-p carriers). For descriptive cross-factor views use `compare(bundles)`. See [Decision tree § §A](decision-tree.md#a-question--function). |
+| `Expected: list[FactorProfile], got list[MetricsBundle]` | Passing the wrong artefact family to a screening function | Screening (`bhy`, `partial_conjunction`, `bhy_hierarchical`) consumes `list[FactorProfile]` (primary-p carriers). For descriptive cross-factor views use `compare(bundles)`. See [API reference § Typical patterns](index.md#typical-patterns). |
 
 ---
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -404,7 +404,7 @@ which folder they happen to live in. Four shapes carry the whole site:
 - **question-centric** — answers a "how do I do X?" task with a short
   walk-through. Lives under `User guide` > `How-to`. Title is the
   question, body is the recipe. (`Information coefficient vs
-  Fama-MacBeth`, `Panel vs timeseries`, `Decision tree`.)
+  Fama-MacBeth`, `Panel vs timeseries`, `Cross-function reference`.)
 - **lookup** — pure table or reverse-index, scanned not read. Lives
   under `User guide` > `Reference tables`. Ordered by quant scan
   frequency, not alphabetically. (`Metrics applicability`, `Stat keys`,

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -222,7 +222,7 @@ controlling procedure. Once a hypothesis joins a family, the
 procedure's FDR claim only holds *within* that family. Family choice
 is a contract decision: re-running BHY on a filtered subset of
 survivors does not preserve FDR ≤ q. See
-[Decision tree § §C `expand_over`](../api/decision-tree.md#expand_over-is-not-one-concept)
+[Cross-function reference § `expand_over`](../api/decision-tree.md#expand_over-is-not-one-concept)
 for the sample-restriction vs hypothesis-dimension split.
 
 ### `Survivors`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,7 +148,7 @@ nav:
           - Timeseries-mode conventions: reference/ts-mode-conventions.md
       - How-to:
           - Overview: guides/index.md
-          - Decision tree: api/decision-tree.md
+          - Cross-function reference: api/decision-tree.md
           - Information coefficient vs Fama-MacBeth: guides/choosing-metric.md
           - Panel vs timeseries: guides/panel-timeseries.md
           - Batch screening with Benjamini-Hochberg-Yekutieli: guides/batch-screening.md


### PR DESCRIPTION
## Summary

Removes §A (research-question → entry-function ASCII tree) from `api/decision-tree.md`, retitles the page to **Cross-function reference**, and sweeps inbound link text to match. SSOT for "which function to reach for" consolidates on the `api/index.md` **Typical patterns** table plus per-function docstring *When to use* lines.

## Why

WS1 of #336. §A was a manual aggregation of per-function *When to use* summaries that already live in docstrings — with drift evidence in-page (the `by_estimator` row advertising a v0.14 plan inside what should be a stable reference). One SSOT is enough; the second pre-discussion comment on #336 walks through the option-A rationale (remove §A entirely) accepted before this PR.

After removal, the page is the **Comparison axes** matrix plus **Cross-function topics** (`expand_over` semantics, regime analysis dispatch). The §A/§B/§C prefixes are dropped (no inbound links to those anchors).

## What this PR does **not** cover

The four routing surfaces that still display the old framing — homepage Quick links, `concepts.md` §Decision tree, `quickstart.md` §Research question + §Next steps — are content rewrites against the new SSOT, not link-text renames. Tracked as WS1 step 2 follow-up.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [x] Cross-ref sweep: `Decision tree` link text in user-facing pages (errors.md, glossary.md, contributing.md sidebar example) updated to `Cross-function reference`
- [x] Anchor audit: `#a-question--function` (dead) redirected; `#expand_over-is-not-one-concept` (live) preserved
- [ ] Reviewer spot-check: page renders, sidebar shows new title, inbound links resolve

Refs #336