### PR TITLE
docs: demote routing surfaces to api landing

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -9,8 +9,9 @@ performance — see
 [Guides § Standalone metrics — Scope](../guides/standalone-metrics.md#scope)
 for the full boundary (what is in, what is downstream).
 
-Once the axes below are familiar, [Decision tree](../api/decision-tree.md)
-maps a research question to the function that answers it.
+Once the axes below are familiar, the
+[API reference landing](../api/index.md) maps a research question to the
+function that answers it.
 
 ## Three orthogonal axes
 
@@ -56,7 +57,9 @@ Choose by research question, not data shape:
 | Question | Does the factor predict rank ordering of returns? | What premium does each unit of factor exposure earn? |
 | Method | Rank-based, outlier-robust | Slope-based, economic interpretation |
 
-## Decision tree
+## Axis dispatch
+
+How the three axes above pick a factory:
 
 ```
                           your panel
@@ -71,6 +74,9 @@ Choose by research question, not data shape:
     │              │                       │              │
   IC / FM   individual_sparse     common_continuous   common_sparse
 ```
+
+The table below pairs each factory with the procedure it runs and the
+literature behind it.
 
 ## Five analysis scenarios
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -122,6 +122,8 @@ You have one `FactorProfile` for one factor. The common follow-ups:
 | Rank factors after screening | [`compare(survivors)`](../api/compare.md) — leaderboard with `adj_q` | — |
 | Explore one metric across slices (sector / regime / decile) | [`by_slice`](../api/by-slice.md) → `SliceResult.to_frame()` | [Slice analysis](../guides/slice-analysis.md) |
 | Test whether slices differ statistically | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | [Slice analysis](../guides/slice-analysis.md) |
-| Look up the panel input contract | [Panel schema](../api/panel-schema.md) | — |
-| Pick a metric for a given research question | [Choosing a metric](../guides/choosing-metric.md) | — |
-| Pick a function (rather than a metric) | [Decision tree](../api/decision-tree.md) | — |
+
+For function semantics, the input contract, and cross-function topics
+(`expand_over` semantics, regime-analysis dispatch), see the
+[API reference landing](../api/index.md) and
+[Cross-function reference](../api/decision-tree.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,6 @@ See the [API reference landing](api/index.md) for the function-flow graph, edge 
 | If you want | Go to |
 |---|---|
 | **Install and run a smoke test** | [Installation](getting-started/install.md) · [Quickstart](getting-started/quickstart.md) |
-| **Find the right function from a research question** | [Decision tree](api/decision-tree.md) |
 | **Understand the three-axis design** (scope / signal / metric) | [Concepts](getting-started/concepts.md) |
 | **Compare factrix against alphalens / qlib / peers** | [Where factrix fits](where-factrix-fits.md) |
 | **Screen a batch of factors with BHY** | [Batch screening](guides/batch-screening.md) |


### PR DESCRIPTION
## Summary

Completes WS1 of #336. After #341 dropped the `decision-tree.md` §A reverse-lookup tree and consolidated the SSOT on `api/index.md`, the homepage / concepts / quickstart references either restate the same map or carry now-stale "Decision tree" link text. This PR demotes them to summary + pointer.

## Changes

- **`docs/index.md` Quick links** — drop the "Find the right function from a research question" row. The preceding paragraph already points at the `api/index.md` function-flow graph and entry-points table.
- **`docs/getting-started/concepts.md`** — rewrite the L12 forward pointer to target the API reference landing. Rename `§Decision tree` to `§Axis dispatch` and add a one-line lead-in to the Five analysis scenarios table; the ASCII figure visualises the three-axis taxonomy, not a routing tree.
- **`docs/getting-started/quickstart.md` §Next steps** — trim to the five genuine post-evaluate follow-ups (BHY / compare / by_slice / slice tests). Replace the three meta-discovery rows (Panel schema / Choosing a metric / Decision tree) with one trailing pointer to the API reference landing and Cross-function reference.

## What this PR does **not** cover

`§Research question → factory` in quickstart is already in summary + pointer form against Concepts and Choosing a metric — verified clean, no edit needed. H3 / H4 / H5 and other findings on #336 remain open as separate workstreams.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: homepage Quick links table reads cleanly, concepts §Axis dispatch flows into §Five analysis scenarios, quickstart §Next steps trailing pointer resolves

Refs #336