### PR TITLE
docs(guides): add Reading results page

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -2,10 +2,15 @@
 title: Guides
 ---
 
-Step-by-step guides for common factrix workflows.
+Step-by-step guides for common factrix workflows. Left column is the
+research-task framing; right column is the page title as it appears in
+the sidebar.
 
-- [Choosing a metric](choosing-metric.md) — IC vs FM, scenario selection
-- [Panel vs timeseries](panel-timeseries.md) — sample guards, aggregation order, N=1 paths
-- [Batch screening with BHY](batch-screening.md) — FDR control across factor families
-- [Slice analysis](slice-analysis.md) — sector / regime / decile splits of a single metric
-- [Standalone metrics](standalone-metrics.md) — input shapes, post-`evaluate()` integration, per-cell examples
+- **Picking IC vs FM (the `individual_continuous` cell only)** — [Information coefficient vs Fama-MacBeth](choosing-metric.md)  
+  *Other cells dispatch to a single procedure; see [Concepts § Five analysis scenarios](../getting-started/concepts.md#five-analysis-scenarios) for the per-cell map.*
+- **Comparison-axes matrix and shared-keyword semantics (`expand_over`, regime dispatch)** — [Cross-function reference](../api/decision-tree.md)
+- **Sample-mode dispatch (PANEL ↔ TIMESERIES) and the N=1 special path** — [Panel vs timeseries](panel-timeseries.md)
+- **Reading `FactorProfile.primary_p`, `Survivors.adj_p`, and `MetricsBundle.metrics`** — [Reading results](reading-results.md)
+- **False Discovery Rate (FDR) control across a factor batch (BHY / partial conjunction / hierarchical)** — [Batch screening with Benjamini-Hochberg-Yekutieli](batch-screening.md)
+- **Slicing one metric by an attached label column (sector / regime / universe / ADV bucket)** — [Slice analysis](slice-analysis.md)
+- **Running every descriptive metric applicable to a cell (`run_metrics`)** — [Standalone metrics](standalone-metrics.md)

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -1,0 +1,178 @@
+---
+title: Reading results
+---
+
+Each entry point in factrix returns a frozen result dataclass. This page
+walks the field order for the three a quant researcher will encounter:
+
+- [`FactorProfile`](../api/factor-profile.md) — what `evaluate()` returns
+  for one factor (the primary inferential artifact).
+- [`Survivors`](../api/multi-factor.md) — what `bhy()` /
+  `partial_conjunction()` / `bhy_hierarchical()` return after False
+  Discovery Rate (FDR) screening.
+- [`MetricsBundle`](../api/metrics-bundle.md) — what `run_metrics()`
+  returns (descriptive twin of `FactorProfile`).
+
+The cheat sheet below is the scanning version; the sections after walk
+each field with its reading rationale.
+
+## Cheat sheet
+
+| Result | First read | Then | Reference fields |
+|---|---|---|---|
+| `FactorProfile` | `primary_p` | `primary_stat` / `primary_stat_name` | `warnings` · `info_notes` · `stats` · `metadata` |
+| `Survivors` | `survivor[i] iff adj_p[i] <= q` | `profiles[i].primary_p` alongside `adj_p[i]` | `expand_over` · `n_tests` |
+| `MetricsBundle` | per-metric `.value` | `.significance` (`***` / `**` / `*` / `""`) | `.stat` · `.metadata` · `.n_obs` |
+
+---
+
+## `FactorProfile` — single-factor `evaluate()` result
+
+```python
+profile = fx.evaluate(panel, cfg)
+```
+
+Read fields in the order below — this matches `profile.diagnose()` key
+order, which itself reflects the reader-flow from "what was tested" to
+"what was the answer" to "what diagnostics support it".
+
+### 1. Identity — what was tested
+
+| Field | Type | Notes |
+|---|---|---|
+| `factor_id` | `str` | Stable id stamped from the factor column name; the hypothesis dimension that screening / `compare` group by. |
+| `forward_periods` | `int` | Forward-return horizon. |
+| `identity` | `tuple[str, int]` | `(factor_id, forward_periods)`; aligns with `MetricsBundle.identity` so downstream `compare()` can stack the two artifacts. |
+| `context` | `Mapping[str, Any]` | Extra hypothesis-dimension keys (`regime_id`, `universe`, ...); empty by default, populated by upstream slicing. |
+| `config.scope` / `config.signal` / `config.metric` / `mode` | enums | The four-axis dispatch coordinate that selected the procedure. |
+
+### 2. Sample axes — was the test underpowered?
+
+| Field | Type | Reads as |
+|---|---|---|
+| `n_obs` | `int` | Total observations the estimator consumed. |
+| `n_pairs` | `int` | Cross-sectional pairs (per-date asset count summed). |
+| `n_periods` | `int` | Number of dates. |
+| `n_assets` | `int` | Unique asset count. |
+
+Compare to the per-cell `MIN_*` floors in
+[Reference § Sample-size constants](../reference/metric-applicability.md#sample-size-constants).
+
+### 3. Primary significance — the canonical readout
+
+| Field | Type | Notes |
+|---|---|---|
+| `primary_p` | `float` | The procedure-canonical p-value. The one number to read against the significance threshold. Read directly; do not rebuild it from `stats`. |
+| `primary_stat` | `float \| None` | The paired test statistic. The type allows `None` for future procedures that report only a p-value; every shipped procedure today populates it. |
+| `primary_stat_name` | `StatCode` | Which inference machinery produced the `(stat, p)` pair — `t_nw`, `t_clu`, `w_nw`, ... |
+
+This trio is the single source of truth for "is this factor real?"
+against the procedure's null hypothesis. See
+[Architecture § Invariants](../development/architecture.md#invariants)
+items 5 and 6 for the underlying contract: `primary_p` is a real
+probability for every legal cell × mode and never auto-rebinds in
+response to warnings.
+
+### 4. Flag sets — interpretation risks
+
+| Field | Type | Reads as |
+|---|---|---|
+| `warnings` | `frozenset[WarningCode]` | Recoverable risks that do **not** invalidate `primary_p` but flag it for caller-side judgment (`UNRELIABLE_SE_SHORT_PERIODS`, `PERSISTENT_REGRESSOR`, ...). The user decides whether to filter before screening. |
+| `info_notes` | `frozenset[InfoCode]` | Informational; not actionable for pass/fail. |
+
+Full enum and trigger conditions:
+[Reference § Warning / info / stat codes](../reference/warning-codes.md).
+
+### 5. Full stats / metadata
+
+| Field | Type | Reads as |
+|---|---|---|
+| `stats` | `Mapping[StatCode, float]` | Every statistic the procedure produced (`mean`, `t_nw`, `p_nw`, `ic_ir`, ...). Use when a diagnostic beyond `primary_p` is needed. |
+| `metadata` | `Mapping[StatCode, dict]` | Per-stat context (`nw_lags`, `ic_definition`, ...). |
+
+The `profile.diagnose()` method returns a flat dict shaped in this same
+reader order — see
+[Quickstart § profile.diagnose() and warnings](../getting-started/quickstart.md#profilediagnose-and-warnings)
+for a runnable example.
+
+---
+
+## `Survivors` — after BHY / partial conjunction / hierarchical FDR
+
+```python
+survivors = fx.multi_factor.bhy(profiles, q=0.05)
+```
+
+BHY (Benjamini-Hochberg-Yekutieli step-up procedure) controls the FDR
+across a declared family of profiles.
+
+### Contract
+
+`survivor[i] iff adj_p[i] <= q`. This duality holds across every
+screening function (`bhy` / `partial_conjunction` / `bhy_hierarchical`).
+`profiles` and `adj_p` are aligned by input order: `profiles[i]` pairs
+with `adj_p[i]`.
+
+### Reading order
+
+| Field | Type | Reads as |
+|---|---|---|
+| `adj_p[i]` | `np.ndarray[float]` | Bucket-local adjusted p-value for profile `i`; the survival readout. |
+| `profiles[i].primary_p` | `float` | Underlying raw p-value, for comparing raw vs adjusted significance. |
+| `q` | `float` | Family-wise FDR target the survivors were selected against. |
+| `expand_over` | `tuple[str, ...]` | Context keys added as hypothesis dimensions for the screening; empty tuple if none. |
+| `n_tests` | `Mapping[tuple, int]` | Per-bucket family size, keyed by `expand_over` values. |
+
+### Anti-pattern
+
+Do **not** re-run `bhy` on a filtered subset of survivors. FDR control
+is a family-level property; it is not preserved across hand-picked
+sub-families. See
+[`multi_factor`](../api/multi-factor.md) for the pinned discussion of
+sample-restriction vs hypothesis-dimension splits.
+
+---
+
+## `MetricsBundle` — descriptive twin of `FactorProfile`
+
+```python
+bundle = fx.run_metrics(panel, cfg)
+```
+
+`run_metrics` fans out the cell's standalone descriptive metrics; the
+bundle wraps the per-metric `MetricOutput` map.
+
+### Reading order
+
+| Field | Type | Reads as |
+|---|---|---|
+| `bundle.identity` | `tuple[str, int]` | `(factor_id, forward_periods)`; aligns with `FactorProfile.identity` for `compare(profiles, bundles)`. |
+| `bundle.metrics["<name>"]` | `MetricOutput` | Per-metric record — see fields below. |
+| `bundle.skipped` | `Mapping[str, str]` | Metrics that did not auto-run, with one-line reasons. |
+| `bundle.context` | `Mapping[str, Any]` | Sample-restriction / conditioning dimensions; empty unless populated by `factrix.by_slice`. |
+
+Each `MetricOutput` carries:
+
+| Field | Type | Reads as |
+|---|---|---|
+| `name` | `str` | Metric identifier (`ic`, `ic_ir`, `oos_decay`, ...). |
+| `value` | `float` | Headline number for the metric. |
+| `significance` | `str \| None` | Procedure-dependent ladder: `***` / `**` / `*` / `""`. |
+| `stat` | `float \| None` | Test statistic, where applicable. |
+| `n_obs` | `int \| None` | Sample size the metric's estimator consumed. |
+| `metadata` | `dict` | Per-metric context (`p_value`, `stat_type`, ...). |
+
+A `MetricsBundle` does not carry a single `primary_p` because
+"descriptive" rules out a single canonical inference target by design;
+reach for `evaluate()` when a single p-value is what is needed.
+
+---
+
+## See also
+
+- [`FactorProfile`](../api/factor-profile.md) / [`Survivors`](../api/multi-factor.md) / [`MetricsBundle`](../api/metrics-bundle.md) — full symbol references.
+- [Quickstart § profile.diagnose() and warnings](../getting-started/quickstart.md#profilediagnose-and-warnings) — runnable end-to-end example.
+- [Errors](../api/errors.md) — exception classes for the failure modes the result trio does not cover (`InsufficientSampleError`, `ModeAxisError`, ...).
+- [Architecture § Invariants](../development/architecture.md#invariants) — `primary_p` semantic contract (items 5 and 6).
+- [Batch screening with BHY](batch-screening.md) — `Survivors` lifecycle end-to-end.
+- [Standalone metrics](standalone-metrics.md) — `MetricsBundle` composition patterns.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
           - Cross-function reference: api/decision-tree.md
           - Information coefficient vs Fama-MacBeth: guides/choosing-metric.md
           - Panel vs timeseries: guides/panel-timeseries.md
+          - Reading results: guides/reading-results.md
           - Batch screening with Benjamini-Hochberg-Yekutieli: guides/batch-screening.md
           - Slice analysis: guides/slice-analysis.md
           - Standalone metrics: guides/standalone-metrics.md


### PR DESCRIPTION
## Summary

WS2 step 1 of #336. Adds `docs/guides/reading-results.md` as the canonical reader-flow page for the three frozen result classes — `FactorProfile`, `Survivors`, `MetricsBundle` — and restructures `docs/guides/index.md` into a two-column listing (research-task framing on the left, page title on the right).

## Why

H4 (`primary_p` scattered across five pages) and H5 (no results-reading SSOT) of #336 share one root cause: no single page walks the result classes and where `primary_p` sits in their field order. The new page collapses both findings into one SSOT.

The index restructure (closes M6) adds unique value beyond what the sidebar already shows: clearer research-task framing on the left, plus the page-title alignment fix for the two previously-drifted entries (`Choosing a metric` vs `Information coefficient vs Fama-MacBeth`, `Batch screening with BHY` vs `Batch screening with Benjamini-Hochberg-Yekutieli`). Adds the `Cross-function reference` entry that was in `mkdocs.yml` nav but missing from the index.

## What this PR does **not** cover

The five existing `primary_p` surfaces (quickstart, concepts, `architecture.md` §Invariants 5/6, `where-factrix-fits.md` §2.2, batch-screening) demote to one-line pointers in WS2 step 2.

## Decisions logged during drafting

- Page title `Reading results` (short generic), kept consistent with no-unexplained-abbreviations rule and discoverability for non-quant readers.
- `primary_p` invariants 5/6 cross-linked to `architecture.md`, not restated, so the contract has a single source.
- `decile` example dropped from the slice-analysis row — `by_slice` is axis-agnostic but does not provide built-in decile binning; replaced with the supported examples from the guide itself (sector / regime / universe / ADV bucket).
- `bootstrap-quantile` example dropped from the `primary_stat` row — no shipped procedure actually returns `None`; rewrote as type-allows-None for future procedures.
- § as section-citation symbol kept (project-wide convention; switching is a separate convention sweep).

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: cheat sheet renders, all inbound links resolve, `architecture.md#invariants` anchor lands on items 5 and 6

Refs #336