### PR TITLE
docs: point primary_p surfaces at Reading results

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -647,6 +647,11 @@ Hard constraints — violating these breaks the API contract:
 9. NW HAC lag selection in panel-aggregation cells uses `max(auto_bartlett(T), forward_periods - 1)` — the Hansen-Hodrick floor must not be skipped under overlapping forward returns.
 10. `T < MIN_PERIODS_HARD` raises `InsufficientSampleError`; procedures never silently produce a result on under-sample data.
 
+For the user-facing field walk of `FactorProfile` (and the `Survivors` /
+`MetricsBundle` it composes with), see
+[Reading results](../guides/reading-results.md). Items 5 and 6 above are
+the contract the page links back to.
+
 ---
 
 ## Testing

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -98,6 +98,9 @@ the dispatch cells single-asset paths route to — see
 `N = panel["asset_id"].n_unique()`. Both modes return a real `primary_p`;
 neither is degraded.
 
+For the field-order walk of `FactorProfile.primary_p` and its companion
+fields, see [Reading results](../guides/reading-results.md).
+
 For the full sample-guard contract (PANEL/TIMESERIES tiers, behaviour
 per factory at each `n_assets` regime, special N = 1 paths) see
 [Guides § Panel vs timeseries](../guides/panel-timeseries.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -109,6 +109,10 @@ catch pattern, and recovery via `suggested_fix`, see
 it is a risk flag. The user decides whether to filter on warnings before
 BHY. For single-factor pre-registered analysis compare `primary_p` against your nominal threshold directly.
 
+For the full field-order walk of `FactorProfile` — and of
+`Survivors` (after `bhy`) and `MetricsBundle` (after `run_metrics`) —
+see [Reading results](../guides/reading-results.md).
+
 ---
 
 ## Next steps
@@ -120,10 +124,12 @@ You have one `FactorProfile` for one factor. The common follow-ups:
 | Screen N candidate factors with FDR control | [`multi_factor.bhy(profiles)`](../api/multi-factor.md) — or `partial_conjunction` / `bhy_hierarchical` for nested structure | [Batch screening with BHY](../guides/batch-screening.md) |
 | Compare the descriptive surface across factors | [`run_metrics`](../api/run-metrics.md) × N → [`compare(bundles)`](../api/compare.md) | [Standalone metrics](../guides/standalone-metrics.md) |
 | Rank factors after screening | [`compare(survivors)`](../api/compare.md) — leaderboard with `adj_q` | — |
-| Explore one metric across slices (sector / regime / decile) | [`by_slice`](../api/by-slice.md) → `SliceResult.to_frame()` | [Slice analysis](../guides/slice-analysis.md) |
+| Explore one metric across slices (sector / regime / universe / ADV bucket) | [`by_slice`](../api/by-slice.md) → `SliceResult.to_frame()` | [Slice analysis](../guides/slice-analysis.md) |
 | Test whether slices differ statistically | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | [Slice analysis](../guides/slice-analysis.md) |
 
 For function semantics, the input contract, and cross-function topics
 (`expand_over` semantics, regime-analysis dispatch), see the
 [API reference landing](../api/index.md) and
-[Cross-function reference](../api/decision-tree.md).
+[Cross-function reference](../api/decision-tree.md). For the field-order
+walk of `FactorProfile` / `Survivors` / `MetricsBundle`, see
+[Reading results](../guides/reading-results.md).

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -86,7 +86,10 @@ flowchart LR
 
 The dispatch arrow is the single line that distinguishes factrix
 from peers that apply one uniform formula across factor types
-(see [§4](#4-same-purpose-peers)).
+(see [§4](#4-same-purpose-peers)). For the field-order walk of the
+`FactorProfile` shown in the graph — `primary_p`, `primary_stat`,
+`warnings`, and the rest — see
+[Reading results](guides/reading-results.md).
 
 ## 3. Scope boundaries
 


### PR DESCRIPTION
## Summary

WS2 step 2 of #336. Closes the H4 loop opened by #343: every upstream page that mentions `primary_p` now points at the canonical field-walk in `guides/reading-results.md`.

## Changes

- **`getting-started/quickstart.md`** — Reading results pointer after the warnings/primary_p paragraph; Next steps trailing pointer extended to include Reading results.
- **`getting-started/concepts.md`** — Reading results pointer at the end of the Mode: PANEL vs TIMESERIES section.
- **`where-factrix-fits.md` §2.2** — Reading results pointer after the dispatch-arrow paragraph, on the `FactorProfile` shown in the call-graph diagram.
- **`development/architecture.md`** — bidirectional cross-link after the invariants list, naming items 5 and 6 as the contract Reading results links back to.

Sweeps two stale `decile` mentions in quickstart Next steps and the slice-analysis row (`by_slice` is axis-agnostic but ships no built-in decile binning; aligns with the same fix landed in `guides/index.md` via #343).

## Why

The canonical paragraph for `primary_p` field semantics now lives in `guides/reading-results.md`, but readers who first encounter `primary_p` in quickstart / concepts / where-factrix-fits had no forward breadcrumb. Architecture invariants 5 and 6 stay as the contract source — the bidirectional link in this PR makes that role explicit.

## What this PR does **not** cover

`batch-screening.md` no longer mentions `primary_p` directly (the issue body's M9 reference was stale on this surface). The other H4 surfaces are addressed; no further demotes are pending for WS2.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: four new pointers resolve; architecture invariants section reads cleanly after the bidirectional note

Refs #336