### PR TITLE
fix(docs): use white text on active sidebar item (#345)

### DIFF
--- a/docs/stylesheets/nav.css
+++ b/docs/stylesheets/nav.css
@@ -24,7 +24,7 @@
 .md-nav__link--active {
   font-weight: 700;
   background-color: var(--md-primary-fg-color--light);
-  color: var(--md-primary-bg-color);
+  color: #fff;
   border-radius: 0.15rem;
   box-shadow: inset 0.2rem 0 0 var(--md-primary-fg-color);
 }


### PR DESCRIPTION
## Summary

- Replace `color: var(--md-primary-bg-color)` (near-black under indigo palette) with `color: #fff` on `.md-nav__link--active` so the light-scheme active sidebar item reads as white text on the indigo background.
- Slate-scheme override at `docs/stylesheets/nav.css:32` is untouched; it already used a light foreground.
- Only the `color` property changes — background, border-radius, box-shadow accent, font-weight all preserved.

## Test plan

- [x] `mkdocs build --strict` passes in the worktree.
- [ ] Visual spot-check User guide / Concepts / Reference active items on the live site (deferred to reviewer; not runnable in CI agent).
- [ ] Confirm hover state and inset box-shadow accent unchanged.

Closes #345