### PR TITLE
docs: add Preparing data + sparse notation sweep

### DIFF
--- a/docs/api/analysis-config.md
+++ b/docs/api/analysis-config.md
@@ -58,7 +58,7 @@ title: factrix.AnalysisConfig
 |---------------------------------------------------|-------------------------------------------|-------------------------------------------|
 | Per-asset real-valued signal, want rank IC        | [`individual_continuous(metric=Metric.IC)`](metrics/individual-continuous.md) | `(INDIVIDUAL, CONTINUOUS, IC)`            |
 | Per-asset real-valued signal, want FM λ premium   | [`individual_continuous(metric=Metric.FM)`](metrics/individual-continuous.md) | `(INDIVIDUAL, CONTINUOUS, FM)`            |
-| Per-asset `{-1, 0, +1}` event trigger             | [`individual_sparse()`](metrics/individual-sparse.md)                     | `(INDIVIDUAL, SPARSE, None)`              |
+| Per-asset `{0, R}` event trigger (event flag or signed magnitude) | [`individual_sparse()`](metrics/individual-sparse.md)                     | `(INDIVIDUAL, SPARSE, None)`              |
 | Broadcast real-valued factor (e.g. VIX)           | [`common_continuous()`](metrics/common-continuous.md)                     | `(COMMON, CONTINUOUS, None)`              |
 | Broadcast event dummy (FOMC, index rebalance)     | [`common_sparse()`](metrics/individual-sparse.md) | `(COMMON, SPARSE, None)`                  |
 

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -114,7 +114,9 @@ Minimum-viable `AnalysisConfig` for each of the four cells. The
 
 === "Individual × Sparse"
 
-    Event study with `factor ∈ {-1, 0, +1}` triggers. Attach a `price`
+    Event study with sparse `{0, R}` event triggers (`R` is any real
+    magnitude; `{0, 1}` for a pure event flag is the simplest form).
+    Attach a `price`
     column on the panel to also get `event_around_return` /
     `mfe_mae_summary` in the profile.
 

--- a/docs/api/metrics/common-continuous.md
+++ b/docs/api/metrics/common-continuous.md
@@ -21,6 +21,7 @@ statistical meaning — see
 [`profile.mode`](../factor-profile.md) for which path ran.
 
 The `Common × Sparse` cell shares the time-series-first aggregation
-shape but with a `{0, R}` broadcast event dummy (canonical
-`{-1, 0, +1}`) in place of the continuous regressor; metrics live
-under [Individual sparse](individual-sparse.md).
+shape but with a `{0, R}` broadcast event dummy (`R` unrestricted;
+`{0, 1}` for a pure event flag is the simplest form) in place of the
+continuous regressor; metrics live under
+[Individual sparse](individual-sparse.md).

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -53,7 +53,7 @@ modules plus a fourth axis-agnostic group**:
 | Cell | Group on this nav | Notes |
 |---|---|---|
 | `Individual × Continuous` | **Individual continuous** | Both `IC` and `FM` primary metrics live in this cell; ancillary metrics (`quantile`, `monotonicity`, `concentration`, `tradability`, `spanning`) are shared across both. |
-| `Individual × Sparse` | **Individual sparse** | Per-event tests on `(date, asset_id, factor)` with sparse `{0, R}` schema (zero on non-event entries; canonical `{-1, 0, +1}`). Domain shorthand: *event signal*. |
+| `Individual × Sparse` | **Individual sparse** | Per-event tests on `(date, asset_id, factor)` with sparse `{0, R}` schema (zero on non-event entries; `R` is any real magnitude, `{0, 1}` is the simplest form). Domain shorthand: *event signal*. |
 | `Common × Sparse` | **Individual sparse** (shared metric modules) | Has its own dispatch procedure (`_CommonSparsePanelProcedure`: per-asset OLS β on the broadcast dummy → cross-asset *t*) — not the CAAR per-event flow used by `Individual × Sparse`. The two cells share the SPARSE column contract and the event-quality / clustering / corrado helper metrics, so factrix groups them on this nav. |
 | `Common × Continuous` | **Common continuous** | Single time series broadcast across assets (VIX, USD index, …). |
 

--- a/docs/api/metrics/individual-sparse.md
+++ b/docs/api/metrics/individual-sparse.md
@@ -5,9 +5,9 @@ title: Individual sparse
 Metrics for the `Individual × Sparse` cell — event signals where most
 `(date, asset_id)` cells carry `factor == 0` and the few non-zero cells
 mark events. The schema is `{0, R}` — zero on non-event entries,
-arbitrary real magnitude otherwise. Canonical example: signed
-`{-1, 0, +1}` ternary; magnitude-weighted continuous values
-(`{0, R≥0}`, `{-R, 0, +R}`) also flow through (see
+any real value otherwise (`R` is unrestricted — positive, negative,
+or any magnitude). Common forms: `{0, 1}` for a pure event flag, or
+`{0, R}` for any real-valued magnitude; both flow through (see
 [`caar`](caar.md) for the input-form table).
 
 | Metric | Role | Page |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -435,8 +435,9 @@ per-asset OLS R_i = α_i + β_i·D over all n_periods dates   (time-series step)
 ```
 
 Same shape as `common_continuous`; the broadcast `D` carries the
-sparse `{0, R}` schema (canonical `{-1, 0, +1}`) and replaces the
-continuous regressor. Factor magnitudes are **preserved** in
+sparse `{0, R}` schema (`R` is unrestricted; `{0, 1}` for a pure
+event flag is the simplest form) and replaces the continuous
+regressor. Factor magnitudes are **preserved** in
 the OLS (no `.sign()` coercion at this layer — distinct from the
 `individual_sparse` PANEL pipeline). ADF persistence diagnostic is skipped
 per I6 (sparse regressors are not unit-root candidates).

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -22,7 +22,7 @@ specific statistical test.
 | Axis | Values | What it asks |
 |------|--------|--------------|
 | `scope` | `INDIVIDUAL` / `COMMON` | Does each asset have its own factor value, or do all assets share one? |
-| `signal` | `CONTINUOUS` / `SPARSE` | Real-valued signal, or `{0, R}` event trigger (zero on non-events; canonical `{−1, 0, +1}`)? |
+| `signal` | `CONTINUOUS` / `SPARSE` | Real-valued signal, or `{0, R}` event trigger (zero on non-events; `R` is any real magnitude — positive, negative, or unsigned)? |
 | `metric` | `IC` / `FM` / *(N/A)* | Only for `(INDIVIDUAL, CONTINUOUS)` — refines the research question |
 
 ### scope — a factor attribute, not a data shape
@@ -41,9 +41,10 @@ axis, not the panel layout itself:
 
 - **`CONTINUOUS`** — real-valued (z-score, percentile, momentum, …).
 - **`SPARSE`** — `{0, R}` event trigger: zero on non-event entries,
-  arbitrary real magnitude otherwise; expect ≥ 50% zeros. Canonical
-  examples: `{−1, 0, +1}` (signed dummy), `{0, 1}` (event flag),
-  `{0, R≥0}` (intensity).
+  any real value otherwise (`R` is unrestricted — positive, negative,
+  or any magnitude); expect ≥ 50% zeros. Common forms: `{0, 1}` for a
+  pure event flag and `{0, R}` for an event carrying signed or
+  unsigned magnitude.
 
 ### metric (only for `INDIVIDUAL × CONTINUOUS`)
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,9 +6,10 @@ Step-by-step guides for common factrix workflows. Left column is the
 research-task framing; right column is the page title as it appears in
 the sidebar.
 
+- **Comparison-axes matrix and shared-keyword semantics (`expand_over`, regime dispatch)** — [Cross-function reference](../api/decision-tree.md)
+- **Raw data to a four-column factrix panel (sort order, frequency alignment, missing data)** — [Preparing data](preparing-data.md)
 - **Picking IC vs FM (the `individual_continuous` cell only)** — [Information coefficient vs Fama-MacBeth](choosing-metric.md)  
   *Other cells dispatch to a single procedure; see [Concepts § Five analysis scenarios](../getting-started/concepts.md#five-analysis-scenarios) for the per-cell map.*
-- **Comparison-axes matrix and shared-keyword semantics (`expand_over`, regime dispatch)** — [Cross-function reference](../api/decision-tree.md)
 - **Sample-mode dispatch (PANEL ↔ TIMESERIES) and the N=1 special path** — [Panel vs timeseries](panel-timeseries.md)
 - **Reading `FactorProfile.primary_p`, `Survivors.adj_p`, and `MetricsBundle.metrics`** — [Reading results](reading-results.md)
 - **False Discovery Rate (FDR) control across a factor batch (BHY / partial conjunction / hierarchical)** — [Batch screening with Benjamini-Hochberg-Yekutieli](batch-screening.md)

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -17,17 +17,23 @@ task-oriented walk-through.
 | 3 | Attach forward return | [`compute_forward_return`](../api/preprocess.md) | adds `forward_return` |
 | 4 | (Optional) drop / impute NaN, align frequencies | manual | clean panel |
 
-## 1. Long-format shape with `price` and `factor`
+## 1. Long-format shape with `price` and the factor column
 
 factrix expects **long-format** panel data — one row per
 `(date, asset_id)` pair. Wide-format (one column per asset) is not
 accepted by any entry point.
 
 [`compute_forward_return`](../api/preprocess.md) computes the
-look-ahead return from a `price` column; the `factor` column is a
+look-ahead return from a `price` column; the factor column is a
 parallel signal you construct yourself (factor construction is outside
 factrix's scope — see
 [Where factrix fits § 1](../where-factrix-fits.md#1-what-factrix-is)).
+
+The factor column name is **user-defined** — `evaluate()` / `run_metrics()`
+accept a `factor_col=` kwarg that binds an arbitrary column to the
+canonical role at dispatch time. The examples below use
+`momentum` to make this binding visible; you can equally pick
+`alpha`, `value_score`, or whatever is meaningful for the strategy.
 
 For per-asset factors (`INDIVIDUAL` scope), each `(date, asset_id)`
 carries its own factor value alongside the price:
@@ -37,21 +43,22 @@ import polars as pl
 from datetime import date
 
 raw = pl.DataFrame({
-    "date":     [date(2024, 1, 1), date(2024, 1, 1),
-                 date(2024, 1, 2), date(2024, 1, 2)],
-    "asset_id": ["AAPL", "MSFT", "AAPL", "MSFT"],
-    "price":    [185.0, 372.0, 186.5, 374.5],
-    "factor":   [0.42, -0.15, 0.51, -0.08],
+    "date":          [date(2024, 1, 1), date(2024, 1, 1),
+                      date(2024, 1, 2), date(2024, 1, 2)],
+    "asset_id":      ["AAPL", "MSFT", "AAPL", "MSFT"],
+    "price":         [185.0, 372.0, 186.5, 374.5],
+    "momentum": [0.42, -0.15, 0.51, -0.08],
 })
 ```
 
 For market-wide factors (`COMMON` scope, e.g. VIX, DXY), the factor
 value is identical across `asset_id` on a given `date`. Verify with
 the one-liner from
-[Concepts § scope](../getting-started/concepts.md#scope--a-factor-attribute-not-a-data-shape):
+[Concepts § scope](../getting-started/concepts.md#scope--a-factor-attribute-not-a-data-shape)
+(swap the column name for whichever the panel carries):
 
 ```python
-raw.group_by("date").agg(pl.col("factor").n_unique() == 1).all()
+raw.group_by("date").agg(pl.col("vix").n_unique() == 1).all()
 ```
 
 ## 2. Regular spacing per asset is load-bearing
@@ -109,14 +116,21 @@ five-trading-day lookahead; on a monthly panel it is five months.
 Frequency is the user's responsibility — see step 4.
 
 The `forward_periods` you pass here must match the
-`AnalysisConfig.forward_periods` you later pass to `evaluate`:
+`AnalysisConfig.forward_periods` you later pass to `evaluate`. Bind
+the custom factor column via `factor_col=`:
 
 ```python
 import factrix as fx
 
 cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
-profile = fx.evaluate(panel, cfg)
+profile = fx.evaluate(panel, cfg, factor_col="momentum")
 ```
+
+If the column is already named `factor` (the default), `factor_col=`
+can be omitted. See
+[Panel schema § factor_col=](../api/panel-schema.md#factor_col--non-default-signal-column-name)
+for the in-place rename contract and the conflict rule (a panel
+cannot carry both `factor` and a non-default `factor_col` at once).
 
 ## 4. Frequency alignment is the caller's job
 
@@ -147,12 +161,14 @@ Three responsibilities sit upstream of `compute_forward_return`:
 ## 6. Sparse and event signals
 
 For `(INDIVIDUAL, SPARSE)` or `(COMMON, SPARSE)` factors — buy/sell
-flags, FOMC dummies, signed event triggers — the `factor` column is
-the `{0, R}` event vector:
+flags, FOMC dummies, event magnitudes — the `factor` column is the
+`{0, R}` event vector:
 
 - `0` on non-event rows.
-- arbitrary real magnitude on event rows (canonical examples:
-  `{−1, 0, +1}`, `{0, 1}`, `{0, R≥0}`).
+- any real value on event rows (`R` is unrestricted — positive,
+  negative, or any magnitude). Common forms: `{0, 1}` for a pure
+  event flag and `{0, R}` for an event carrying signed or unsigned
+  magnitude.
 - expect ≥ 50% zeros.
 
 Sort and forward-return attachment are identical to step 2-3; the

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -1,0 +1,181 @@
+---
+title: Preparing data
+---
+
+The reader-flow from a raw price / signal dataset to a
+`(date, asset_id, factor, forward_return)` panel that
+[`evaluate`](../api/evaluate.md) consumes. For the column-level four-column
+contract, see [Panel schema](../api/panel-schema.md); this page is the
+task-oriented walk-through.
+
+## At a glance
+
+| Step | What you do | Function | Output added |
+|---|---|---|---|
+| 1 | Reshape raw inputs to long format with `price` | manual / Polars ops | `(date, asset_id, price, factor)` |
+| 2 | Ensure regular spacing per asset on the time axis | manual / Polars ops | spacing-regular panel |
+| 3 | Attach forward return | [`compute_forward_return`](../api/preprocess.md) | adds `forward_return` |
+| 4 | (Optional) drop / impute NaN, align frequencies | manual | clean panel |
+
+## 1. Long-format shape with `price` and `factor`
+
+factrix expects **long-format** panel data — one row per
+`(date, asset_id)` pair. Wide-format (one column per asset) is not
+accepted by any entry point.
+
+[`compute_forward_return`](../api/preprocess.md) computes the
+look-ahead return from a `price` column; the `factor` column is a
+parallel signal you construct yourself (factor construction is outside
+factrix's scope — see
+[Where factrix fits § 1](../where-factrix-fits.md#1-what-factrix-is)).
+
+For per-asset factors (`INDIVIDUAL` scope), each `(date, asset_id)`
+carries its own factor value alongside the price:
+
+```python
+import polars as pl
+from datetime import date
+
+raw = pl.DataFrame({
+    "date":     [date(2024, 1, 1), date(2024, 1, 1),
+                 date(2024, 1, 2), date(2024, 1, 2)],
+    "asset_id": ["AAPL", "MSFT", "AAPL", "MSFT"],
+    "price":    [185.0, 372.0, 186.5, 374.5],
+    "factor":   [0.42, -0.15, 0.51, -0.08],
+})
+```
+
+For market-wide factors (`COMMON` scope, e.g. VIX, DXY), the factor
+value is identical across `asset_id` on a given `date`. Verify with
+the one-liner from
+[Concepts § scope](../getting-started/concepts.md#scope--a-factor-attribute-not-a-data-shape):
+
+```python
+raw.group_by("date").agg(pl.col("factor").n_unique() == 1).all()
+```
+
+## 2. Regular spacing per asset is load-bearing
+
+[`compute_forward_return`](../api/preprocess.md) sorts the input by
+`(asset_id, date)` itself, so an unsorted panel is fine. What it
+**does not** inspect is the calendar gap between successive rows —
+the function shifts by row count, not by date.
+
+If asset A has daily rows but asset B is missing two trading days in
+the middle, asset B's row-shift skips the gap silently and the forward
+return on the row before the gap measures the wrong horizon. Verify
+per-asset spacing before calling:
+
+```python
+gaps = raw.sort(["asset_id", "date"]).with_columns(
+    (pl.col("date").diff().over("asset_id")).alias("gap")
+)
+# Inspect gaps.group_by("asset_id").agg(pl.col("gap").n_unique())
+# — single unique gap per asset is the goal.
+```
+
+If the panel is sparse by design (event series, irregular trading
+days), see step 5 on sparse signals.
+
+## 3. Attach forward return
+
+```python
+from factrix.preprocess import compute_forward_return
+
+panel = compute_forward_return(raw, forward_periods=5)
+```
+
+The function computes a **per-period normalized** forward return:
+
+```
+forward_return[t] = (price[t + 1 + N] / price[t + 1] - 1) / N
+```
+
+Three things to know about this formula:
+
+- **Entry at `t + 1`, not `t`** — the function assumes you trade on
+  the bar *after* the signal is observed, preserving a strict
+  signal-then-trade causal boundary.
+- **Exit at `t + 1 + N`** — the holding horizon spans `N` rows of the
+  asset's own date series, where `N = forward_periods`.
+- **Divided by `N`** — returns are normalized to a per-period basis,
+  so `forward_periods=5` and `forward_periods=20` are directly
+  comparable. This differs from the cumulative-return convention used
+  by qlib (`Ref($close, -N)/$close - 1`) and alphalens.
+
+The horizon counts **rows of the asset's own date series**, not
+calendar days. `forward_periods=5` on a daily panel is a
+five-trading-day lookahead; on a monthly panel it is five months.
+Frequency is the user's responsibility — see step 4.
+
+The `forward_periods` you pass here must match the
+`AnalysisConfig.forward_periods` you later pass to `evaluate`:
+
+```python
+import factrix as fx
+
+cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+profile = fx.evaluate(panel, cfg)
+```
+
+## 4. Frequency alignment is the caller's job
+
+factrix is calendar-agnostic — it shifts rows, not calendar time.
+Three responsibilities sit upstream of `compute_forward_return`:
+
+- **Same date axis for factor and price source.** If the factor is
+  monthly and the price source is daily, downsample (or upsample) one
+  side before joining. A frequency mismatch will not raise; it will
+  silently mean the wrong thing.
+- **Same `forward_periods` interpretation.** Five rows on a daily panel
+  is one week of trading days; five rows on a monthly panel is five
+  months. Pick the horizon against your panel's actual cadence.
+- **Slice / regime labels aligned by date.** If you attach a
+  `regime_id` or `universe` column for downstream slicing, align it on
+  the same date axis the panel uses; mismatched labels propagate
+  silently into `by_slice` and screening calls.
+
+## 5. Missing data
+
+| Source | factrix behaviour | Caller action |
+|---|---|---|
+| NaN in `factor` | Not auto-imputed; flows through to the procedure, where it depresses `n_obs` and may trip sample-size guards. | Drop or impute before `compute_forward_return`. |
+| NaN in `price` | `compute_forward_return` produces NaN `forward_return` for the row and then drops it from the output. Tail rows where `t + 1 + N` runs off the end of the series are dropped by the same filter. | If a daily NaN reflects a true gap (suspended trading, holiday), the drop is correct. If imputable (forward-fill from previous close), impute before calling. |
+| Single-asset panel (N = 1) | `Mode` auto-switches to `TIMESERIES`. `individual_continuous` at N = 1 raises [`ModeAxisError`](../api/errors.md) with `suggested_fix=common_continuous(...)`. | Either pass N ≥ 1 explicitly or use the `*_sparse` / `common_*` factories. |
+| T < `MIN_PERIODS_HARD` (= 20) periods | Raises [`InsufficientSampleError`](../api/errors.md); procedures never silently produce a result on under-sample data. | Extend the window or accept the procedure's refusal. |
+
+## 6. Sparse and event signals
+
+For `(INDIVIDUAL, SPARSE)` or `(COMMON, SPARSE)` factors — buy/sell
+flags, FOMC dummies, signed event triggers — the `factor` column is
+the `{0, R}` event vector:
+
+- `0` on non-event rows.
+- arbitrary real magnitude on event rows (canonical examples:
+  `{−1, 0, +1}`, `{0, 1}`, `{0, R≥0}`).
+- expect ≥ 50% zeros.
+
+Sort and forward-return attachment are identical to step 2-3; the
+dispatch routes sparse signals to event-study procedures (`caar`,
+`ts_beta` on dummies). See
+[Concepts § signal](../getting-started/concepts.md#signal) for the
+contract.
+
+## Helpers not yet public
+
+`factrix.preprocess` currently re-exports only `compute_forward_return`.
+Submodule code under `factrix/preprocess/` carries normalization
+(`mad_winsorize`, `cross_sectional_zscore`), forward-return cleaning
+(`winsorize_forward_return`, `compute_abnormal_return`), and
+orthogonalization (`orthogonalize_factor`); publicization is tracked
+under [#323](https://github.com/awwesomeman/factrix/issues/323). Until
+then, treat the submodule paths as internal — they may be renamed or
+re-shaped before they land in `__all__`.
+
+## See also
+
+- [Panel schema](../api/panel-schema.md) — column-level four-column contract and dtype rules.
+- [`compute_forward_return`](../api/preprocess.md) — symbol reference.
+- [Quickstart](../getting-started/quickstart.md) — minimal end-to-end, uses `datasets.make_cs_panel` to skip steps 1-3.
+- [Concepts](../getting-started/concepts.md) — three-axis taxonomy (scope / signal / metric / mode).
+- [Reading results](reading-results.md) — what `evaluate` returns once the panel is ready.

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -77,9 +77,10 @@ mono = fx.metrics.monotonicity(panel, forward_periods=5, n_groups=5)
 
 `caar`, `event_quality`, `event_horizon`, `mfe_mae`, `clustering`, and
 `corrado` read a panel where `factor` is zero on non-event entries
-and arbitrary real magnitude on event entries (canonical `{-1, 0, +1}`,
-also valid: `{0, R≥0}` or `{-R, 0, +R}`). Build via
-`fx.datasets.make_event_panel` or filter your own panel.
+and any real value on event entries (`R` is unrestricted). Common
+forms: `{0, 1}` for a pure event flag, or `{0, R}` for any
+real-valued magnitude. Build via `fx.datasets.make_event_panel` or
+filter your own panel.
 
 ```python
 events = fx.datasets.make_event_panel(n_assets=80, n_dates=500, event_rate=0.05, seed=7)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -64,11 +64,11 @@ Most equity characteristics; macro factors; ML predictor scores.
 ### `SPARSE`
 
 Factor is non-zero only on event dates and zero elsewhere; the panel
-encodes a discrete event arrival process. Canonical encoding is
-`{−1, 0, +1}` (signed event direction); factrix also accepts
-magnitude-weighted `{0, R}` for continuous-magnitude events
-(see `compute_caar`'s input-form table for the resulting estimator
-distinction).
+encodes a discrete event arrival process. The general schema is
+`{0, R}` where `R` is any real value (positive, negative, or any
+magnitude); the simplest form is `{0, 1}` for a pure event flag.
+See `compute_caar`'s input-form table for the resulting estimator
+distinction.
 
 **Industry equivalents**:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - How-to:
           - Overview: guides/index.md
           - Cross-function reference: api/decision-tree.md
+          - Preparing data: guides/preparing-data.md
           - Information coefficient vs Fama-MacBeth: guides/choosing-metric.md
           - Panel vs timeseries: guides/panel-timeseries.md
           - Reading results: guides/reading-results.md


### PR DESCRIPTION
## Summary

Two related WS7 / sparse-doc follow-ups for #336, bundled on one branch for single-squash merge.

### Commit 1 — `docs(guides): add Preparing data page`

Task-oriented reader-flow from raw inputs to a `(date, asset_id, factor, forward_return)` panel. Cross-links `api/panel-schema.md` for the column-level contract; does not duplicate it. Slots under How-to between Cross-function reference and Information coefficient vs Fama-MacBeth — workflow order is data prep before metric pick. `guides/index.md` adopts the existing two-column research-task / page-title format.

### Commit 2 — `docs: preparing-data audit + sparse notation sweep`

Two related fixes bundled:

**Preparing data audit corrections** (caught after the first push):
- `compute_forward_return` takes `price`, not `factor`; step-1 example now carries a `price` column plus a user-named factor column (`momentum`) to make the `factor_col=` binding visible.
- The function auto-sorts; the caller's load-bearing constraint is **regular spacing per asset** on the time axis (rewritten step 2 with a Polars verification snippet).
- Forward-return formula spelled out as `(price[t+1+N] / price[t+1] - 1) / N`, entry at `t+1`, per-period normalization — distinguished from cumulative-return convention in qlib / alphalens.
- NaN `price` row in step 5 corrected: the function filters `forward_return.is_not_null()` and drops affected rows rather than propagating NaN.
- `T < MIN_PERIODS_HARD` floor named explicitly as `20`.
- Step 3 evaluate snippet shows `factor_col="momentum"` plus a pointer to `panel-schema § factor_col=` for the in-place rename contract.

**Sparse-signal notation sweep** across user-facing pages:
- `{-1, 0, +1}` dropped from canonical examples (degenerate case of `{0, R}` at `R = 1`, not a distinct schema).
- `R≥0` replaced with the explicit statement that `R` is unrestricted (positive, negative, or any magnitude).
- `{-R, 0, +R}` dropped (identical to `{0, R}` when `R` is unrestricted; no information added).
- The two retained forms are `{0, 1}` for a pure event flag and `{0, R}` for any real-valued magnitude.
- Touched: `concepts.md`, `standalone-metrics.md`, `individual-sparse.md`, `glossary.md`, `architecture.md`, `analysis-config.md`, `evaluate.md`, `common-continuous.md`, `metrics/index.md`.

## Merge plan

Squash; the squash subject should reflect the bundled scope. Suggested squash title:

```
docs: add Preparing data + sparse-signal notation sweep (#336)
```

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [x] No remaining `{-1, 0, +1}` / `R≥0` / `{-R, 0, +R}` in active docs (frozen `plans/archive/` and auto-generated `llms-full.txt` excluded)
- [ ] Reviewer spot-check: Preparing data page reads cleanly, sparse examples are consistent across the touched pages

Refs #336