### PR TITLE
docs(reference): dedup ts-mode vs statistical-methods

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -178,7 +178,7 @@ is realised. Aligning `AnalysisConfig.forward_periods` with
 `signal_horizon` is the regime where the synthetic IC / drift is
 calibrated; mismatched horizons induce IC decay (synthetic) and bias
 (in TIMESERIES mode — see
-[Timeseries-mode conventions § Non-overlap](ts-mode-conventions.md#non-overlap-convention--forward_periods-vs-signal_horizon)).
+[Timeseries-mode conventions § Non-overlap](ts-mode-conventions.md#non-overlap-convention)).
 
 ### `non-overlapping` returns
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -96,7 +96,9 @@ inflation — i.e. an upper bound on the reported `t`.
 
 Default versus paired t-test is a separate choice: the cell-canonical
 metrics (`ic`, `caar`) use **non-overlapping resampling** as the
-default rather than NW HAC. NW is exposed as an explicit sibling
+default rather than NW HAC.
+[](){ #non-overlap-default }
+NW is exposed as an explicit sibling
 (`ic_newey_west`) for callers who prefer the HAC route. Resampling has
 the advantage of exact rather than asymptotic-Gaussian inference at
 the cost of a factor of `h` in effective sample size; users with long
@@ -246,10 +248,12 @@ section is on the *input* series itself, not the residual structure
 captured by HAC.
 
 For per-asset β regressions in `compute_ts_betas`, factrix
-deliberately retains plain OLS SE rather than HAC: the Stambaugh bias
-arises from the predictor's persistence, not from SE estimation, and
-HAC fixes only the SE while leaving the coefficient bias untouched.
-Adding HAC there would advertise robustness factrix does not deliver.
+deliberately retains plain OLS SE rather than HAC.
+[](){ #stage1-plain-se }
+The Stambaugh bias arises from the predictor's persistence, not from
+SE estimation, and HAC fixes only the SE while leaving the coefficient
+bias untouched. Adding HAC there would advertise robustness factrix
+does not deliver.
 
 ---
 

--- a/docs/reference/ts-mode-conventions.md
+++ b/docs/reference/ts-mode-conventions.md
@@ -3,7 +3,7 @@ title: Timeseries-mode conventions
 ---
 
 !!! tip "Canonical reference"
-    For the `Mode.PANEL` vs `Mode.TIMESERIES` dispatch concept and sample-guard contract, see [Panel vs timeseries](../guides/panel-timeseries.md). This page is the `Mode.TIMESERIES`-specific conventions table.
+    For the `Mode.PANEL` vs `Mode.TIMESERIES` dispatch concept and sample-guard contract, see [Panel vs timeseries](../guides/panel-timeseries.md). For the statistical disciplines (HAC SE, ADF / Stambaugh, non-overlap default) that the rules below build on, see [Statistical methods](statistical-methods.md). This page is the `Mode.TIMESERIES`-specific operational conventions table.
 
 `Common × Continuous` evaluations on a single time series (`ts_beta`,
 `ts_quantile`, `ts_asymmetry` and their variants) inherit four shared
@@ -19,18 +19,17 @@ the resulting β. **Stage 1 deliberately retains plain OLS SE rather
 than NW / HAC** in TIMESERIES mode even when `forward_periods > 1`
 introduces overlap.
 
-Reasoning summarised in
-[Statistical methods § HAC SE](statistical-methods.md#1-hac-se-under-overlapping-returns)
-(last paragraph): the dominant bias under a persistent predictor is
-[Stambaugh 1999][stambaugh-1999] coefficient bias, which HAC does not
-address. Stage 2 cross-asset inference handles whatever residual
-time-axis structure leaks through the β distribution.
+The rationale lives in
+[Statistical methods § stage-1 plain SE](statistical-methods.md#stage1-plain-se):
+the dominant bias under a persistent predictor is Stambaugh
+coefficient bias, which HAC does not address. Stage 2 cross-asset
+inference handles whatever residual time-axis structure leaks through
+the β distribution.
 
-If overlap-induced SE inflation is the binding concern, prefer
-`ic_newey_west` on the same series (Individual × Continuous cell)
-where the HAC adjustment is the canonical inferential primitive.
-
-[stambaugh-1999]: bibliography.md#stambaugh-1999
+Operational tip: if overlap-induced SE inflation is the binding
+concern, prefer `ic_newey_west` on the same series (Individual ×
+Continuous cell) where the HAC adjustment is the canonical
+inferential primitive.
 
 ## `FACTOR_ADF_P` persistence diagnostic
 
@@ -52,11 +51,12 @@ leave the threshold call to the caller.
 
 The diagnostic is on the *input* factor, not the regression residual.
 
-## Non-overlap convention — `forward_periods` vs `signal_horizon`
+## `forward_periods` vs `signal_horizon`: bias under mismatch
+[](){ #non-overlap-convention }
 
 The cell-canonical `Individual × Continuous` metrics (`ic`, `caar`)
-use **non-overlapping resampling** as the inferential default
-([Statistical methods § HAC SE](statistical-methods.md#1-hac-se-under-overlapping-returns)).
+use non-overlapping resampling as the inferential default
+([Statistical methods § non-overlap default](statistical-methods.md#non-overlap-default)).
 TIMESERIES mode inverts this: the per-asset stage-1 regression runs
 on the **full** overlapping series — TIMESERIES lacks the
 cross-section axis to "burn" `h` periods of samples, so


### PR DESCRIPTION
## Summary

M4 of #336. `statistical-methods.md` and `ts-mode-conventions.md` overlapped on the Hansen-Hodrick overlap floor framing, the stage-1 plain-SE rationale, and the non-overlap default for `ic` / `caar` — each implicitly claiming SSOT. This PR collapses the SSOT on `statistical-methods.md` (the canonical source for the underlying disciplines) and trims `ts-mode-conventions.md` to a TIMESERIES-specific operational table that points back for the rationale.

## Changes

### `statistical-methods.md` — content unchanged, two anchors added

- `#stage1-plain-se` on the paragraph stating that `compute_ts_betas` retains plain OLS SE.
- `#non-overlap-default` on the paragraph stating that `ic` / `caar` default to non-overlapping resampling.

### `ts-mode-conventions.md` — overlap trimmed, unique content kept

- Top `!!! tip` block names `statistical-methods.md` as the canonical source for the disciplines, so the relationship is explicit.
- **§Plain SE in stage-1** — rule + operational tip kept; rationale demoted to one-sentence echo + pointer at `#stage1-plain-se`. Fixes a stale link previously pointing at `#1-hac-se-...` (the actual rationale lives in §4).
- **§Non-overlap convention** → renamed `forward_periods` vs `signal_horizon`: bias under mismatch. Opening sentence demotes the non-overlap default to a pointer at `#non-overlap-default`; the TIMESERIES-inversion rationale and the two-source bias discussion (overlap structure + Stambaugh-style coefficient shift) stay as unique operational content.
- Adds short named anchor `#non-overlap-convention` so the inbound link from `glossary.md` survives the heading rename.
- **§`FACTOR_ADF_P` persistence diagnostic** and **§Single-series null** untouched (unique operational content).

### `glossary.md` — inbound deep-link updated to the new short anchor.

## Why

The two pages historically grew their own framings of overlap / Stambaugh / non-overlap, leading to drift. A first-day reader hits the same statistical argument three times with mismatched wording. Picking one SSOT (`statistical-methods.md`) and demoting the other to operational pointers removes the drift surface without losing TIMESERIES-specific operational details that genuinely live in `ts-mode-conventions.md`.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [x] All three new / renamed anchors resolve (verified via strict build)
- [x] glossary.md inbound deep-link still resolves
- [x] Stale link `ts-mode-conventions.md` → `statistical-methods.md#1-hac-se-...` redirected to the correct `#stage1-plain-se` anchor
- [ ] Reviewer spot-check: the two pages read as canonical + operational rather than parallel rivals

Refs #336