### PR TITLE
docs(where-factrix-fits): add common_sparse dispatch arm

### DIFF
--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -77,9 +77,11 @@ flowchart LR
     DISP -->|individual_continuous| CS[IC + FM<br/>+ diagnostics]
     DISP -->|individual_sparse| EV[CAAR<br/>+ diagnostics]
     DISP -->|common_continuous| CO[ts_beta<br/>+ diagnostics]
+    DISP -->|common_sparse| DUM[ts_beta on dummies<br/>+ diagnostics]
     CS --> PROF[FactorProfile<br/>stats · primary_p · diagnose]
     EV --> PROF
     CO --> PROF
+    DUM --> PROF
     PROF --> BHY[multi_factor.bhy<br/>FDR within family]
     BHY --> SURV[Surviving profiles]
 ```


### PR DESCRIPTION
## Summary

M2 of #336. The §2.2 internals mermaid in `where-factrix-fits.md` claimed `(scope, signal, metric, mode)` 4-axis dispatch in the surrounding prose but only drew three arms (`individual_continuous`, `individual_sparse`, `common_continuous`), omitting `common_sparse`. The chart made factrix look like it has three factor types rather than the documented four.

Adds the missing `common_sparse` → `ts_beta on dummies` arm.

## Why this and not align with `architecture.md`

`architecture.md`'s global mermaid collapses all seven concrete procedures into a single `FactorProcedure` node, documented inline (`"the in-graph collapse here keeps the high-level dispatch path legible on mobile widths"`). The two diagrams serve different abstraction levels — the high-level contract overview in `architecture.md` versus the call-graph drill-down in `where-factrix-fits.md` — so collapsing both to one shape would lose the per-factor-type visibility that `where-factrix-fits.md` exists to provide. The minimal fix is to honour the call-graph framing already chosen in §2.2 and add the missing arm.

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] Reviewer spot-check: rendered §2.2 graph shows four DISP arms; the new `DUM` node connects back to `PROF`

Refs #336