### PR TITLE
docs(reference): polish sweep — glossary, scope headings, code triggers (#336)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -325,7 +325,9 @@ listed below — `n_periods < MIN_PERIODS_HARD` raises `InsufficientSampleError`
 `MIN_PERIODS_HARD ≤ n_periods < MIN_PERIODS_WARN` emits
 `UNRELIABLE_SE_SHORT_PERIODS`. The per-procedure "Failure modes" lists below
 record only the **procedure-specific** failures; for the user-facing tier
-matrix see [Guides § Panel vs timeseries](../guides/panel-timeseries.md).
+matrix see [Guides § Panel vs timeseries](../guides/panel-timeseries.md). For
+the trigger / meaning of every code emitted below see the
+[`WarningCode` table](../reference/warning-codes.md#warningcode).
 
 ### Terminology — aggregation regime
 

--- a/docs/examples/multi_factor_screening.md
+++ b/docs/examples/multi_factor_screening.md
@@ -4,7 +4,7 @@ title: Multi-factor screening
 
 Apply Benjamini-Hochberg-Yekutieli (BHY) FDR control to a batch of
 candidate factors. Demonstrates the explicit-family contract and the
-duplicate-identity defense (#161) — the behaviour that is impossible
+duplicate-identity defense — the behaviour that is impossible
 to learn from docstrings alone.
 
 Runnable notebook: [`examples/multi_factor_screening.ipynb`](https://github.com/awwesomeman/factrix/blob/main/examples/multi_factor_screening.ipynb).
@@ -17,7 +17,7 @@ factor_col=<name>)` for any registered cell — screening is
 factor-type-agnostic.
 
 The input list **is** the family. Each profile must carry a unique
-`identity = (factor_id, forward_periods)` (#160 anti-shopping defense).
+`identity = (factor_id, forward_periods)` — the anti-shopping defense.
 The recommended path: name the factor column distinctly per candidate
 panel and pass it via `factor_col=`; `evaluate` auto-stamps `factor_id`
 from that name. `dataclasses.replace(profile, factor_id=...)` is an

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -6,7 +6,7 @@ title: Concepts
 
 factrix evaluates factor **signal validity**, not portfolio
 performance — see
-[Guides § Standalone metrics — Scope](../guides/standalone-metrics.md#scope)
+[Guides § Standalone metrics — What factrix evaluates](../guides/standalone-metrics.md#what-factrix-evaluates)
 for the full boundary (what is in, what is downstream).
 
 Once the axes below are familiar, the

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -12,7 +12,7 @@ This guide covers the three things a user needs to wire them in:
 which metrics apply to a given cell, what input shape each one
 expects, and where they sit in a screening pipeline.
 
-## Scope
+## What factrix evaluates
 
 factrix evaluates **factor signal validity** — predictive power
 (IC, FM λ), robustness (NW HAC, BHY, regime stability), and event
@@ -21,6 +21,8 @@ performance: no Sharpe / drawdown / Sortino / Calmar / return
 attribution. Those metrics belong downstream of factor selection
 and live in dedicated backtest libraries (e.g.
 [`vectorbt`](https://vectorbt.dev/) or an internal framework).
+For the canonical out-of-scope list with peer-library pointers, see
+[Where factrix fits § 3](../where-factrix-fits.md#3-out-of-scope-use-these-libraries-instead).
 
 The closest crossover inside factrix is `ic_ir` — the information
 ratio of the per-date IC series. It is explicitly a *signal-quality*

--- a/docs/reference/_generated_info_codes.md
+++ b/docs/reference/_generated_info_codes.md
@@ -1,0 +1,3 @@
+| InfoCode | Trigger / meaning |
+|---|---|
+| `scope_axis_collapsed` | N=1 collapsed scope axis; routed via _SCOPE_COLLAPSED sentinel. |

--- a/docs/reference/_generated_stat_codes.md
+++ b/docs/reference/_generated_stat_codes.md
@@ -1,0 +1,19 @@
+| StatCode | Trigger / meaning |
+|---|---|
+| `mean` | Cell primary point estimate (interpretation per `profile.config.metric`: IC mean, FM λ mean, CAAR event-only mean, or TS β / E[β]). |
+| `t_nw` | Newey-West HAC t-stat on the cell primary estimate. Implementation convention lives in `factrix.stats.NeweyWest`. |
+| `p_nw` | Two-sided p-value from the Newey-West HAC t-test on the cell primary estimate. Sibling of `T_NW`. |
+| `t_hh` | Hansen-Hodrick (1980) rectangular-kernel HAC t-stat on the cell primary estimate. Sibling of `T_NW`; uses `Var(mean) = (γ₀ + 2 Σ_{j=1..h-1} γⱼ) / n` instead of NW's Bartlett kernel. |
+| `p_hh` | Two-sided p-value from the Hansen-Hodrick (1980) rectangular-kernel HAC t-test on the cell primary estimate. Implementation convention lives in `factrix.stats.HansenHodrick`. |
+| `j_gmm` | Hansen (1982) GMM J-statistic for over-identifying moment restrictions; chi-square distributed under H₀ with `df = n_moments - n_params`. Implementation convention lives in `factrix.stats.GMM`. |
+| `p_gmm` | Right-tail p-value from the Hansen (1982) GMM J-test (`1 - χ²_df.cdf(J_GMM)`). Sibling under the (J_GMM, P_GMM) algorithm-pair convention; computed by `factrix.stats.GMM`. |
+| `wald_nwcl` | Wald χ² statistic for a linear restriction on slice contrasts / joint coefficients, computed under NW Bartlett HAC plus one-way cluster on the slice grouping. Implementation convention lives in `factrix.stats.WaldNWCluster`. |
+| `p_wald_nwcl` | P-value from `WALD_NWCL`. Sibling under the (WALD_NWCL, P_WALD_NWCL) algorithm-pair convention. |
+| `wald_twoway` | Wald χ² statistic for a linear restriction on a panel coefficient vector, computed under two-way cluster on (date, asset) (Cameron-Gelbach-Miller 2011). Implementation convention lives in `factrix.stats.WaldTwoWayCluster`. |
+| `p_wald_twoway` | P-value from `WALD_TWOWAY`. Sibling under the (WALD_TWOWAY, P_WALD_TWOWAY) algorithm-pair convention. |
+| `p_boot` | Empirical two-sided p-value from a block-bootstrap resample of a paired-diff statistic. Implementation convention lives in `factrix.stats.BlockBootstrap` (Politis-Romano stationary or Künsch fixed scheme; Politis-White auto block length). Single key for both schemes — scheme choice is metadata, not StatCode. |
+| `factor_adf_tau` | ADF τ statistic on the factor input series (constant-only specification); fed to the MacKinnon 1996 response-surface for `FACTOR_ADF_P`. |
+| `factor_adf_p` | ADF unit-root test p-value on the factor input series (MacKinnon 1996 response-surface; constant-only specification). p > 0.05 flags persistent regressor regime. |
+| `resid_ljung_box_q` | Ljung-Box Q statistic on regression residuals (TS-dummy single-asset path); compared against χ²(h) for `RESID_LJUNG_BOX_P`. |
+| `resid_ljung_box_p` | Ljung-Box p-value on residual autocorrelation (TS-dummy single-asset path); p < 0.05 flags under-set NW lag. |
+| `event_hhi_value` | Herfindahl concentration of event counts across calendar bins (cross-sectional / time-axis); high values flag calendar-time clumping. Does not measure within-asset event clustering. |

--- a/docs/reference/_generated_warning_codes.md
+++ b/docs/reference/_generated_warning_codes.md
@@ -1,0 +1,14 @@
+| WarningCode | Trigger / meaning |
+|---|---|
+| `unreliable_se_short_periods` | n_periods is below the WARN floor (~30); NW HAC SE may be biased. Reused across panel time-series guards (MIN_PERIODS_WARN) and primitive inference (MIN_FM_PERIODS_WARN); both default to 30. |
+| `event_window_overlap` | Adjacent events sit within forward_periods; AR windows overlap. |
+| `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
+| `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
+| `small_cross_section_n` | PANEL cross-asset t-test with n_assets < MIN_ASSETS (10); df=n_assets-1 too low — t_crit at n_assets=3 ≈ 4.30 (+119% vs asymptotic 1.96). |
+| `borderline_cross_section_n` | PANEL cross-asset t-test with MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN (10..29); residual t_crit inflation 5–15% — read borderline p-values cautiously. |
+| `sparse_common_few_events` | (COMMON, SPARSE, PANEL) broadcast dummy has MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_WARN (5..19); per-asset β estimable but cross-event averaging too thin for asymptotic t. |
+| `sparse_magnitude_weighted` | Sparse factor column is mixed-sign and not a clean ±1 ternary; statistic is magnitude-weighted (Sefcik-Thompson) rather than textbook MacKinlay signed CAAR — apply .sign() before calling for sign-flip semantics. |
+| `few_events_brown_warner` | CAAR significance test with MIN_EVENTS_HARD ≤ n_event_dates < MIN_EVENTS_WARN (4..29); t-stat returned but Brown-Warner (1985) convention treats sub-30 events as power-thin for the asymptotic t-distribution — read borderline p-values cautiously. |
+| `borderline_portfolio_periods` | top_concentration with MIN_PORTFOLIO_PERIODS_HARD ≤ n_periods < MIN_PORTFOLIO_PERIODS_WARN (3..19); one-sided t-test on the per-date diversification ratio is returned but df=n-1 inflates t_crit relative to the asymptotic cutoff. |
+| `rect_kernel_negative_variance` | Rectangular-kernel HAC variance-of-mean came out negative (no PSD guarantee, Andrews 1991); clamped to 0 → SE=0, t=0, p=1.0. Fires only on short / mildly anti-correlated samples. |
+| `singular_weight_matrix` | GMM long-run covariance Ŝ was numerically singular; J-statistic was computed via Moore-Penrose pseudo-inverse rather than a true inverse. Fires on rank-deficient or strongly collinear moment matrices. |

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -8,6 +8,14 @@ describes the four discipline lines that recur across cells, explains
 the variant of each that factrix implements, and points at the
 [bibliography](bibliography.md) anchor for the source treatment.
 
+!!! note "Audience"
+    This page assumes working familiarity with applied econometrics
+    (HAC SE, FDR control, near-unit-root inference). If you are
+    looking for a first-pass orientation to factrix output, start at
+    [Quickstart](../getting-started/quickstart.md) and
+    [Concepts](../getting-started/concepts.md); return here when you
+    need the discipline-level rationale behind a specific metric.
+
 For per-metric formulae and signatures see the
 [Metrics API pages](../api/metrics/index.md). For the design choices
 behind which disciplines factrix does *not* implement, see

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -2,12 +2,6 @@
 title: Statistical methods
 ---
 
-Cross-cutting statistical disciplines that govern multiple metrics in
-factrix. This page sits **above** the per-metric API pages: it
-describes the four discipline lines that recur across cells, explains
-the variant of each that factrix implements, and points at the
-[bibliography](bibliography.md) anchor for the source treatment.
-
 !!! note "Audience"
     This page assumes working familiarity with applied econometrics
     (HAC SE, FDR control, near-unit-root inference). If you are
@@ -15,6 +9,12 @@ the variant of each that factrix implements, and points at the
     [Quickstart](../getting-started/quickstart.md) and
     [Concepts](../getting-started/concepts.md); return here when you
     need the discipline-level rationale behind a specific metric.
+
+Cross-cutting statistical disciplines that govern multiple metrics in
+factrix. This page sits **above** the per-metric API pages: it
+describes the four discipline lines that recur across cells, explains
+the variant of each that factrix implements, and points at the
+[bibliography](bibliography.md) anchor for the source treatment.
 
 For per-metric formulae and signatures see the
 [Metrics API pages](../api/metrics/index.md). For the design choices

--- a/docs/reference/warning-codes.md
+++ b/docs/reference/warning-codes.md
@@ -18,18 +18,38 @@ The three enums:
 - **`StatCode`** — canonical names for the scalar statistics that
   populate `FactorProfile.metrics`.
 
-For the per-metric mapping of `WarningCode` to the procedure that
-emits it, see
+Each member's trigger / meaning is sourced from
+`factrix._codes.<Code>.description` (single source of truth, also
+returned at runtime by `profile.diagnose()`). For the per-procedure
+breakdown of which codes a given pipeline can emit, see
 [Architecture § Procedure pipelines](../development/architecture.md#procedure-pipelines).
 
 ## WarningCode
 
+--8<-- "docs/reference/_generated_warning_codes.md"
+
 ::: factrix.WarningCode
+    options:
+      show_root_heading: false
+      show_source: false
+      members: false
 
 ## InfoCode
 
+--8<-- "docs/reference/_generated_info_codes.md"
+
 ::: factrix.InfoCode
+    options:
+      show_root_heading: false
+      show_source: false
+      members: false
 
 ## StatCode
 
+--8<-- "docs/reference/_generated_stat_codes.md"
+
 ::: factrix.StatCode
+    options:
+      show_root_heading: false
+      show_source: false
+      members: false

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -93,7 +93,7 @@ from peers that apply one uniform formula across factor types
 `warnings`, and the rest — see
 [Reading results](guides/reading-results.md).
 
-## 3. Scope boundaries
+## 3. Out of scope (use these libraries instead)
 
 What factrix deliberately does **not** do, and the canonical tool for
 each. This is a commitment, not a TODO. To expand factrix scope,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,11 +161,11 @@ nav:
           - Multi-factor screening: examples/multi_factor_screening.md
           - Stock factor evaluation: examples/stock_factor_evaluation.md
       - Reference tables:
+          - Glossary: reference/glossary.md
           - Metrics applicability: reference/metric-applicability.md
           - Stat keys: reference/stat-keys-by-metric.md
           - Warning / info / stat codes: reference/warning-codes.md
           - Metrics pipelines: reference/metric-pipelines.md
-          - Glossary: reference/glossary.md
           - Bibliography: reference/bibliography.md
   - API reference:
       - Overview: api/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,9 @@ hooks:
   - scripts/mkdocs_hooks/gen_registry_cells.py
   # factrix/_registry._DISPATCH_REGISTRY -> docs/reference/_generated_evaluate_metric_table.md
   - scripts/mkdocs_hooks/gen_evaluate_metric_table.py
+  # factrix/_codes.{WarningCode,InfoCode,StatCode}.description ->
+  # docs/reference/_generated_{warning,info,stat}_codes.md
+  - scripts/mkdocs_hooks/gen_code_descriptions.py
   # factrix/llms*.txt -> site root llms*.txt
   - scripts/mkdocs_hooks/sync_llms_txt.py
 

--- a/scripts/mkdocs_hooks/gen_code_descriptions.py
+++ b/scripts/mkdocs_hooks/gen_code_descriptions.py
@@ -1,0 +1,57 @@
+"""Build-time generator for `WarningCode` / `InfoCode` / `StatCode` tables.
+
+Renders three Markdown tables to `docs/reference/_generated_*_codes.md`
+from the description dictionaries in `factrix._codes`. The descriptions
+are the SSOT for trigger / meaning text; this hook surfaces them on the
+user-facing `reference/warning-codes.md` page without manual sync.
+
+MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
+
+    The ``on_pre_build(config)`` function is called by MkDocs before
+    each build.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from factrix._codes import InfoCode, StatCode, WarningCode
+
+_REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+_OUT_DIR = _REPO_ROOT / "docs" / "reference"
+
+
+def _render_table(header: str, rows: list[tuple[str, str]]) -> str:
+    lines = [f"| {header} | Trigger / meaning |\n|---|---|\n"]
+    for code, desc in rows:
+        desc_inline = desc.replace("\n", " ").replace("|", "\\|")
+        lines.append(f"| `{code}` | {desc_inline} |\n")
+    return "".join(lines)
+
+
+def generate() -> None:
+    warning_rows = [(m.value, m.description) for m in WarningCode]
+    info_rows = [(m.value, m.description) for m in InfoCode]
+    stat_rows = [(m.value, m.description) for m in StatCode]
+
+    (_OUT_DIR / "_generated_warning_codes.md").write_text(
+        _render_table("WarningCode", warning_rows), encoding="utf-8"
+    )
+    (_OUT_DIR / "_generated_info_codes.md").write_text(
+        _render_table("InfoCode", info_rows), encoding="utf-8"
+    )
+    (_OUT_DIR / "_generated_stat_codes.md").write_text(
+        _render_table("StatCode", stat_rows), encoding="utf-8"
+    )
+    print(
+        f"gen_code_descriptions: wrote {len(warning_rows)} WarningCode / "
+        f"{len(info_rows)} InfoCode / {len(stat_rows)} StatCode row(s)"
+    )
+
+
+def on_pre_build(config: object) -> None:
+    generate()
+
+
+if __name__ == "__main__":
+    generate()


### PR DESCRIPTION
## Summary

Five low-severity polish findings from #336's docs content audit:

- **Glossary nav placement** — `mkdocs.yml`: Glossary up to first position under Reference tables (Alphalens / Barra migrators land top-down).
- **Inline issue refs in user-facing example** — `examples/multi_factor_screening.md`: strip `(#161)` / `(#160)`; `architecture.md` keeps issue refs as contributor-doc provenance.
- **§Scope heading disambiguation** — `where-factrix-fits §3` → "Out of scope...", `standalone-metrics §Scope` → "What factrix evaluates"; `concepts §scope` axis-disambiguator unchanged.
- **`statistical-methods.md` audience signal** — top-of-page admonition above the intro paragraph so misrouted readers bounce before reading.
- **Warning / info / stat code triggers** — new build hook `scripts/mkdocs_hooks/gen_code_descriptions.py` reads `factrix._codes.{Warning,Info,Stat}Code.description` SSOT and emits Markdown tables embedded into `reference/warning-codes.md`. `architecture.md §Procedure pipelines` gets a reverse link to the WarningCode table.

## Test plan

- [ ] `uv run mkdocs build --strict` green
- [ ] No stale `#scope` / `#3-scope-boundaries` cross-links under `docs/` / `factrix/` / `README*`
- [ ] `gen_code_descriptions.py` covers every member of `WarningCode` / `InfoCode` / `StatCode`; no missing description-dict entry
- [ ] Rendered `site/reference/warning-codes/index.html` shows each enum value exactly once (table only — no mkdocstrings member-list duplication)

Refs #336, #329, #335