### PR TITLE
docs: relocate Architecture and dedupe axis table (#336)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -73,22 +73,18 @@ Plus introspection / error / enum re-exports:
 
 ---
 
-## Three orthogonal axes + Mode
+## Mode — the derived fourth axis
 
-The user-facing axis triple is `(FactorScope, Signal, Metric)`. A fourth
-axis `Mode` is **derived at evaluate-time** from `panel["asset_id"].n_unique()`:
+The three user-facing axes (`FactorScope`, `Signal`, `Metric`) are the SSOT;
+see [Concepts § Three orthogonal axes](../getting-started/concepts.md#three-orthogonal-axes)
+for their values and orthogonality.
 
-| Axis        | Values                                      | User-facing? |
-|-------------|---------------------------------------------|--------------|
-| `FactorScope` | `INDIVIDUAL` / `COMMON`                   | yes          |
-| `Signal`    | `CONTINUOUS` / `SPARSE`                     | yes          |
-| `Metric`    | `IC` / `FM` / `None`                        | yes (only `(INDIVIDUAL, CONTINUOUS)` accepts a non-None metric) |
-| `Mode`      | `PANEL` (N≥2) / `TIMESERIES` (N=1)          | no — derived  |
-
-Five legal `(scope, signal, metric)` triples × two modes give seven legal
-`(scope, signal, metric, mode)` cells (TIMESERIES narrows to three triples; the
-remaining tuples are routed via the `_SCOPE_COLLAPSED` sentinel defined in
-`factrix/_axis.py`).
+`Mode` is the fourth axis but is **not user-facing** — it is derived at
+evaluate-time from `panel["asset_id"].n_unique()`: `PANEL` for `N ≥ 2`,
+`TIMESERIES` for `N = 1`. Five legal `(scope, signal, metric)` triples ×
+two modes give seven legal `(scope, signal, metric, mode)` cells
+(TIMESERIES narrows to three triples; the remaining tuples are routed via
+the `_SCOPE_COLLAPSED` sentinel defined in `factrix/_axis.py`).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,7 +146,6 @@ nav:
       - Concepts:
           - Overview: getting-started/concepts.md
           - Where factrix fits: where-factrix-fits.md
-          - Architecture: development/architecture.md
           - Statistical methods: reference/statistical-methods.md
           - Timeseries-mode conventions: reference/ts-mode-conventions.md
       - How-to:
@@ -233,6 +232,7 @@ nav:
           - datasets: api/datasets.md
           - preprocess: api/preprocess.md
   - Development:
+      - Architecture: development/architecture.md
       - Design notes: development/design-notes.md
       - Contributing: development/contributing.md
   - Release notes: development/changelog.md


### PR DESCRIPTION
## Summary

Two commits addressing #336 M3 (architecture.md placement) and H3(a) (axis-table duplication):

- **Architecture sidebar placement** — `docs/development/architecture.md` is a contributor doc (~700 lines: `_registry.py` SSOT, bootstrap order, CI invariants) but the sidebar shelved it under `User guide → Concepts`. Moved to the existing top-level `Development` group alongside Design notes and Contributing. File path unchanged; all 11 inbound cross-links keep working.
- **Architecture §axes dedup** — the 3-axis table in architecture.md was a verbatim repeat of concepts.md §Three orthogonal axes with one `Mode` row added. Replaced with a pointer to Concepts (SSOT) plus a dedicated `Mode — derived fourth axis` paragraph holding the contributor-relevant evaluate-time derivation and `_SCOPE_COLLAPSED` routing detail.

## Test plan

- [ ] `uv run mkdocs build --strict` green
- [ ] Sidebar renders Architecture under Development, not under Concepts
- [ ] Inbound anchor links (`#procedure-pipelines`, `#invariants`, `#family-functions-and-the-resolution-layer`, etc.) still resolve from `panel-timeseries.md`, `factor-profile.md`, `reading-results.md`, `bhy.md`
- [ ] No remaining cross-link targets `architecture.md#three-orthogonal-axes-mode` (anchor removed)

Refs #336