### PR TITLE
fix(docs): raise active nav rule specificity (#345)

### DIFF
--- a/docs/stylesheets/nav.css
+++ b/docs/stylesheets/nav.css
@@ -21,16 +21,19 @@
 /* Stronger active-page highlight than Material's default (text-tint only is
  * easy to miss on a long nav list).
  */
+.md-nav__item--active > .md-nav__link--active,
 .md-nav__link--active {
   font-weight: 700;
-  background-color: var(--md-primary-fg-color--light);
+  background: var(--md-primary-fg-color);
   color: #fff;
   border-radius: 0.15rem;
-  box-shadow: inset 0.2rem 0 0 var(--md-primary-fg-color);
+  box-shadow: inset 0.2rem 0 0 var(--md-primary-fg-color--dark);
+  position: static;
 }
 
+[data-md-color-scheme="slate"] .md-nav__item--active > .md-nav__link--active,
 [data-md-color-scheme="slate"] .md-nav__link--active {
-  background-color: color-mix(in srgb, var(--md-primary-fg-color--light) 18%, transparent);
-  color: var(--md-primary-fg-color--light);
-  box-shadow: inset 0.2rem 0 0 var(--md-primary-fg-color--light);
+  background: var(--md-primary-fg-color--light);
+  color: #fff;
+  box-shadow: inset 0.2rem 0 0 var(--md-primary-fg-color);
 }


### PR DESCRIPTION
## Summary
- Material's `.md-nav__item--active > .md-nav__link` (specificity 0,2,0) was overriding the previous `.md-nav__link--active` rule (0,1,0), resetting both background and color so the active sidebar item rendered with insufficient contrast (blue-ish bg, dark text).
- Pair the bare selector with `.md-nav__item--active > .md-nav__link--active` (0,3,0) to win specificity in both light and slate schemes; use `background` shorthand to match Material's shorthand and `--md-primary-fg-color` for stronger white-text contrast.

## Test plan
- [ ] `mkdocs build --strict` passes
- [ ] Visual spot-check: active sidebar item shows solid indigo background with white text in light scheme
- [ ] Visual spot-check: same in slate (dark) scheme

Closes #345