### PR TITLE
docs: post-#336 audit follow-up — quickstart labels, glossary COMMON (#336)

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,7 +17,7 @@ from factrix.preprocess import compute_forward_return
 raw   = fx.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=2024)
 panel = compute_forward_return(raw, forward_periods=5)
 
-# Path B — supply the config directly (type-safe; the IDE rejects illegal combos)
+# Typed factory — supply the config directly (type-safe; the IDE rejects illegal combos)
 cfg     = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
 profile = fx.evaluate(panel, cfg)
 
@@ -40,7 +40,7 @@ If you are not sure which factory to use, let factrix infer it from the
 panel shape:
 
 ```python
-# Path A — inferred config + reasoning trace
+# Inferred config — factrix picks the factory from the panel shape
 result  = fx.suggest_config(panel)
 profile = fx.evaluate(panel, result.suggested)
 # result.reasoning explains how each axis was inferred

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -29,10 +29,12 @@ research operates in.
 
 ### `COMMON`
 
-A single broadcast series shared across **all** assets on a given
-date — the same value for every `asset_id` at that `date`. Macro
-factors (VIX, USD index, term spread, monetary-policy shocks) and
-broadcast event dummies (FOMC announcement days) live here.
+A factor that does not vary across assets: on any given date every
+`asset_id` carries the same factor value. The panel layout is
+unchanged (still long-format `(date, asset_id)` rows) — `scope` is a
+factor attribute, not a data shape. Macro factors (VIX, USD index,
+term spread, monetary-policy shocks) and broadcast event dummies
+(FOMC announcement days) live here.
 
 **Industry equivalents and collisions**:
 


### PR DESCRIPTION
## Summary

Two should-fix findings from the post-merge audit of #336's final state (review delegated to a sub-agent walking the rendered site as a first-day quant). Both are content-polish, no API or schema change. Folded into one PR per merge-cadence preference — no follow-up issue spawned.

- **Quickstart `Path A` / `Path B` labels** — chat-shorthand carried over from #336 working notes. A first-day reader has no narrative context for which letter is which, and the typed-then-inferred presentation order made A read as the fallback rather than the primary. Renamed the two code-block comments to `Typed factory — ...` and `Inferred config — factrix picks the factory from the panel shape`. (This was the parked finding from #336 M5; the sub-agent reader-stumble is the evidence trigger that un-parks it.)
- **Glossary `COMMON` framing** — entry led with "single broadcast series shared across **all** assets", implying a data-shape mental model. `concepts.md §scope` already established that scope is a *factor attribute*, not a data shape — the panel layout is identical between INDIVIDUAL and COMMON, only the per-asset variation of the factor column changes. Rewrote the lead sentence to match the factor-attribute framing and added an explicit note that the panel layout is unchanged. INDIVIDUAL entry's framing was already aligned; only COMMON drifted.

Sub-agent audit also confirmed: 0 blocker / 0 should-fix in correctness (anchors all resolve; generated tables match `factrix/_codes.py` member counts; `concepts.md §Five analysis scenarios` literature + procedure mapping matches `_procedures.py` registrations exactly).

## Test plan

- [ ] `uv run mkdocs build --strict` green
- [ ] `Path A` / `Path B` no longer appear in any rendered docs (`docs/plans/archive/*` is nav-excluded and intentionally untouched)
- [ ] Glossary `COMMON` and `INDIVIDUAL` entries use parallel factor-attribute framing

Refs #336