### PR TITLE
docs(api): wire mkdocstrings inventories (#328)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,9 @@ plugins:
       default_handler: python
       handlers:
         python:
+          inventories:
+            - https://docs.pola.rs/api/python/stable/objects.inv
+            - https://numpy.org/doc/stable/objects.inv
           options:
             docstring_style: google
             show_source: false
@@ -74,6 +77,7 @@ plugins:
             show_root_full_path: true
             show_root_toc_entry: true
             show_signature_annotations: true
+            signature_crossrefs: true
             separate_signature: true
             merge_init_into_class: true
             heading_level: 1


### PR DESCRIPTION
## Summary

Wire polars + numpy `objects.inv` under the mkdocstrings python handler and enable `signature_crossrefs`. Third-party type annotations on `docs/api/**` pages now surface the source library instead of falling through to griffe's strip-the-qualifier default.

- `numpy.ndarray` — clickable cross-reference to upstream numpy docs (full affordance).
- `polars.DataFrame` — hover tooltip surfaces canonical `polars.DataFrame`; click cross-ref **not** wired because polars' published `objects.inv` indexes methods/properties only (no top-level `py:class` entry for `DataFrame`). Upstream-docs limitation, not config.

Config-only change: no source-side annotation rewrites.

## Verification

- `uv run mkdocs build --strict` — clean.
- `docs/api/bhy/` — `numpy.ndarray` renders with `href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray"`.
- `docs/api/metrics/spanning/` — `polars.DataFrame` renders as `<span title="polars.DataFrame">DataFrame</span>` (hover surfaces qualifier; native browser tooltip, ~1s delay).

## Out of scope

- Pandas / scipy inventories — no public signature exposes those types yet.
- Polars class-level entry — upstream polars docs gap. If/when fixed, no further change needed here; the existing `inventories:` entry will start resolving automatically.

Closes #328