### PR TITLE
docs(refs): horizon-shopping + /N citations (#330)

### DIFF
--- a/docs/guides/batch-screening.md
+++ b/docs/guides/batch-screening.md
@@ -41,6 +41,12 @@ If any family degenerates to size=1 (typical misuse: one factor evaluated across
 
 `bhy()` controls FDR within a horizon. If you sweep multiple horizons per factor and pick the minimum p, the horizon selection itself is hidden multiple testing (K = number of horizons). You must collapse the horizon dimension first with a FWER procedure, then feed the result into BHY.
 
+### Background
+
+The multiple-testing discipline for factor research established by [Harvey-Liu-Zhu 2016][harvey-liu-zhu-2016] motivates correcting for selection once factor candidates and horizons are swept — a 5% nominal threshold no longer controls type-I error. factrix's specific composition (FWER across horizons, then FDR within) is a project-level application; HLZ themselves prescribe stricter thresholds, not this two-axis stack. The reason factrix picks FWER for the inner step is the dependence structure [Boudoukh-Richardson-Whitelaw 2008][boudoukh-richardson-whitelaw-2008] documents: under the null and a persistent regressor, OLS slope estimators across horizons are highly correlated — approaching unity between adjacent horizons at dividend-yield-like persistence — so the K horizons behave more like one repeatedly-tested null than K independent draws. Independence- and PRDS-friendly FDR procedures (BH / BHY) assume neither identity and lose their level guarantees in this regime.
+
+[Bailey & López de Prado (2014)][bailey-lopez-de-prado-2014] formalises the parallel multiple-trials problem on the Sharpe axis (Deflated Sharpe Ratio) for backtest selection — same correction path, different statistic; not implemented in factrix.
+
 **Recommended FWER procedures:**
 
 | Procedure | When to use |

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -418,7 +418,10 @@ Expected Returns." *Review of Financial Studies* 29(1), 5–68.
 
 Empirical case for raising t-thresholds in factor research; backs
 the single-factor `t ≥ 2.0` threshold and the BHY-first multi-factor
-discipline in `greedy_forward_selection`.
+discipline in `greedy_forward_selection`, and the FWER-across-horizons
+∘ FDR-within-horizon discipline at `factrix.multi_factor.bhy` and the
+"Horizon-shopping correction" section of
+`docs/guides/batch-screening.md`.
 
 ### Harvey (2017)
 [](){ #harvey-2017 }
@@ -506,6 +509,21 @@ for Estimation, Testing, and Prediction*. Cambridge University Press.
 
 Empirical-Bayes alternative to FDR; cited in design notes as the
 "why not Bayesian" comparison anchor.
+
+### Bailey & López de Prado (2014)
+[](){ #bailey-lopez-de-prado-2014 }
+
+Bailey, D. H. & López de Prado, M. (2014). "The Deflated Sharpe
+Ratio: Correcting for Selection Bias, Backtest Overfitting, and
+Non-Normality." *Journal of Portfolio Management* 40(5), 94–107.
+
+Parallel multiple-trials correction operating on the Sharpe rather
+than the p-value: deflates an observed Sharpe by the expected
+maximum under a number-of-trials null. Cited in the
+"Horizon-shopping correction" section of
+`docs/guides/batch-screening.md` as related literature for the
+multiple-trials problem on the Sharpe axis; not an implemented
+procedure in factrix.
 
 ---
 
@@ -681,6 +699,42 @@ ADF flag matters in `ic_trend`. The specific `p > 0.10 ⇒ unit-root
 suspect` threshold is folklore from the unit-root literature
 (closer to Stock 1994 *Handbook of Econometrics* §III) rather than a
 direct prescription from this paper.
+
+### Fama & French (1988)
+[](){ #fama-french-1988 }
+
+Fama, E. F. & French, K. R. (1988). "Dividend Yields and Expected
+Stock Returns." *Journal of Financial Economics* 22(1), 3–25.
+
+Canonical direct long-horizon predictive regression: summed log
+returns `r_{t→t+N} = Σ log(P_{t+k}/P_{t+k−1})` regressed on the
+dividend yield at horizons 1–4 years. Linear-additive across
+horizons by construction, no compounding bias. Cited at
+`compute_forward_return` as the academic-standard alternative to
+factrix's `÷N` arithmetic per-period normalization — factrix uses
+`÷N` for scale comparability across horizons, not because
+Fama-French (1988) recommends it.
+
+### Boudoukh, Richardson & Whitelaw (2008)
+[](){ #boudoukh-richardson-whitelaw-2008 }
+
+Boudoukh, J., Richardson, M. & Whitelaw, R. F. (2008). "The Myth of
+Long-Horizon Predictability." *Review of Financial Studies* 21(4),
+1577–1605.
+
+Under the null and a persistent regressor (most factor signals),
+OLS slope estimators across horizons are highly correlated —
+approaching unity between adjacent horizons at dividend-yield-like
+persistence — and `R²` is roughly proportional to horizon. Cited at
+`factrix.multi_factor.bhy` and the "Horizon-shopping correction"
+section of `docs/guides/batch-screening.md`: across-horizon test
+statistics are not independent and BHY's PRDS assumption fails, so
+factrix uses an FWER (independence-free) inner step before BHY —
+the FWER prescription is factrix's response to BRW's correlation
+result, not BRW's own recommendation. Cited at
+`compute_forward_return` to motivate treating per-period scaling
+as separate from inference: the across-horizon dependence BRW
+documents is not addressed by any normalization choice.
 
 ---
 
@@ -922,3 +976,19 @@ Foreign Trade*. University of California Press.
 
 Independent earlier formulation of HHI; cited alongside Herfindahl
 (1950).
+
+### Jacquier, Kane & Marcus (2003)
+[](){ #jacquier-kane-marcus-2003 }
+
+Jacquier, E., Kane, A. & Marcus, A. J. (2003). "Geometric or
+Arithmetic Mean: A Reconsideration." *Financial Analysts Journal*
+59(6), 46–53.
+
+Compounding at the arithmetic mean is an upward-biased estimator of
+cumulative wealth; the geometric mean is itself biased; the
+unbiased estimator is a horizon-weighted blend of the two with
+weights depending on the forecast horizon / sample-length ratio.
+Cited at `compute_forward_return` for the compounding-bias caveat
+of factrix's `÷N` per-period normalization — the bias affects
+signed-return mean and t-tests at large `N`, but is negligible for
+rank-based IC.

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -288,6 +288,35 @@ def bhy(
             a single profile (BHY on n=1 is a raw cutoff and provides
             no FDR correction).
 
+    Notes:
+        Horizon multiplicity is a two-axis problem — FDR within a
+        horizon (this function's job) ∘ FWER across horizons (the
+        caller's job, before invoking ``bhy()``). The two cannot be
+        collapsed into a single step-up: under the null and a
+        persistent regressor, slope estimators across horizons are
+        nearly perfectly correlated, so pooling them dilutes the
+        per-rank threshold and silently inflates FDR — the rationale
+        for the ``forward_periods``-mixed warning above. See the
+        "Horizon-shopping correction" section of
+        ``docs/guides/batch-screening.md`` for the recommended
+        Bonferroni / Holm inner step.
+
+    References:
+        - [Harvey, Liu & Zhu (2016)][harvey-liu-zhu-2016]. "…and the
+          Cross-Section of Expected Returns." Review of Financial
+          Studies, 29(1), 5–68. Multiple-testing discipline for
+          factor research motivating correction for selection; the
+          specific FWER ∘ FDR composition is factrix's application,
+          not HLZ's prescription.
+        - [Boudoukh, Richardson & Whitelaw (2008)][boudoukh-richardson-whitelaw-2008].
+          "The Myth of Long-Horizon Predictability." Review of
+          Financial Studies, 21(4), 1577–1605. Across-horizon slope
+          estimators are highly correlated under the null for
+          persistent regressors — independence and PRDS fail when
+          horizons share information through the predictor, so an
+          FWER (independence-free) inner step is the factrix-side
+          response to that dependence.
+
     Examples:
         Screen five candidate factors with BHY at q=0.05 — each panel
         is a seeded synthetic cross-section, ``factor_id`` is stamped

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -32,7 +32,8 @@ def compute_forward_return(
     need for ad-hoc shift corrections.
 
     Dividing by N normalizes returns to a per-period basis, making
-    different forward_periods directly comparable.
+    different forward_periods directly comparable on a scale basis
+    (see Notes for the scope boundary).
 
     Args:
         df: Must contain ``date``, ``asset_id``, ``price``. Must already
@@ -46,6 +47,50 @@ def compute_forward_return(
     Returns:
         Input DataFrame with ``forward_return`` column appended.
         Rows where forward return is null (end of series) are dropped.
+
+    Notes:
+        The ``÷N`` per-period normalization is a *scale* choice with
+        three caveats the caller should know:
+
+        1. **Arithmetic, not summed-log-return.** This is the
+           arithmetic per-period mean of a simple return, not the
+           academic-standard direct long-horizon regression of summed
+           log returns on the predictor (the latter is
+           linear-additive across horizons by construction).
+        2. **Compounding bias.** Compounding at the arithmetic mean
+           is an upward-biased estimator of cumulative wealth; the
+           bias grows with ``N`` and per-bar return variance.
+           Negligible for rank-based IC; not negligible for
+           signed-return mean and t-tests at large ``N``.
+        3. **Scale, not inference.** ``÷N`` aligns the *scale* across
+           horizons — it does *not* address the inference problem.
+           Overlap is handled by HAC (see
+           :class:`factrix.stats.NeweyWest`); across-horizon
+           selection is handled by the FWER correction in
+           :func:`factrix.multi_factor.bhy`. The three concerns
+           (scale, overlap, cross-horizon selection) are addressed
+           at separate layers; overlap and across-horizon dependence
+           share a common source in the persistent regressor, but
+           each requires its own tool.
+
+    References:
+        - [Fama & French (1988)][fama-french-1988]. "Dividend Yields
+          and Expected Stock Returns." Journal of Financial
+          Economics, 22(1), 3–25. Direct summed-log-return
+          long-horizon regression — the academic-standard
+          alternative to factrix's ``÷N``.
+        - [Jacquier, Kane & Marcus (2003)][jacquier-kane-marcus-2003].
+          "Geometric or Arithmetic Mean: A Reconsideration."
+          Financial Analysts Journal, 59(6), 46–53. Compounding bias
+          of the arithmetic mean and the unbiased horizon-weighted
+          blend.
+        - [Boudoukh, Richardson & Whitelaw (2008)][boudoukh-richardson-whitelaw-2008].
+          "The Myth of Long-Horizon Predictability." Review of
+          Financial Studies, 21(4), 1577–1605. Documents that
+          across-horizon regression statistics share information
+          through the persistent regressor — separate from any
+          per-period scaling choice, and the reason inference across
+          horizons is not addressed by normalization.
 
     Examples:
         >>> import factrix as fx


### PR DESCRIPTION
## Summary

- Cite horizon-shopping and forward-return-normalization literature at the call sites where each treatment lives: `factrix._multi_factor.bhy` docstring, `factrix.preprocess.returns.compute_forward_return` docstring, and the "Horizon-shopping correction" section of `docs/guides/batch-screening.md`.
- Add 4 new bibliography entries (Boudoukh-Richardson-Whitelaw 2008, Fama-French 1988, Jacquier-Kane-Marcus 2003, Bailey-López 2014) and extend the Harvey-Liu-Zhu 2016 paragraph with the new call sites.
- Role-notes follow the discipline #321 established — citations describe what the cited paper actually contributes; the FWER ∘ FDR composition is attributed to factrix's application, not HLZ's prescription; BRW's correlation result is described as such, not as a direct FWER recommendation.

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] `docs/api/bhy/` — Notes block renders; References resolve to bibliography anchors for HLZ 2016 and BRW 2008.
- [x] `docs/api/preprocess/` (`compute_forward_return`) — three-caveat Notes block renders; References resolve for FF 1988, JKM 2003, BRW 2008.
- [x] `docs/guides/batch-screening/` — new "Background" subsection renders above the FWER-procedures table; inline links resolve for HLZ 2016, BRW 2008, Bailey-López 2014.
- [x] Bibliography page renders all 4 new entries + updated HLZ paragraph with no broken refs.

Closes #330