### PR TITLE
docs(refs): unify inline paper citations to autorefs-linked form (#359)

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -669,6 +669,27 @@ References:
 
 The uniform bullet form keeps every `References:` block visually identical regardless of paper count and removes the failure mode of forgetting blank-line separators when a second paper is added. The slug must match an anchor declared in `docs/reference/bibliography.md`; missing anchors produce an mkdocs `--strict` warning.
 
+#### Inline-prose citations — same hyperlink, hyphenated author form
+
+Paper citations appearing inside docstring prose (`Notes:`, argument descriptions, narrative paragraphs — not inside a `References:` block) use the same autorefs-linked shape with hyphenated multi-author surnames:
+
+```
+Shanken (1992) shows ...               # avoid (bare text — not clickable)
+[Shanken (1992)][shanken-1992] shows ...                                   # ok
+[Newey-West (1987)][newey-west-1987] HAC ...                               # ok (hyphenated)
+[Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011] two-way ...   # ok (hyphenated)
+```
+
+Conventions split by layer:
+
+- **Bibliography heading** (`bibliography.md`): formal `Author & Author (Year)` with ampersand (matches the paper's title-page citation, APA-style).
+- **Anchor ID**: lowercase hyphenated `author-author-year`.
+- **Docstring link text** (both `References:` bullets and inline prose): hyphenated `Author-Author (Year)` — consistent with how factrix's prose names the *method* (Newey-West estimator, Hansen-Hodrick SE, Fama-MacBeth regression) and with how `bibliography.md`'s own intro example reads (`[Newey-West 1987][newey-west-1987]`).
+
+Conversion rules when migrating from a bare citation: `&` and `and` in the visible text become hyphens; commas in 3+ author lists also become hyphens (`Black, Jensen & Scholes (1972)` → `[Black-Jensen-Scholes (1972)][black-jensen-scholes-1972]`); single-author citations stay single (`MacKinlay (1997)` → `[MacKinlay (1997)][mackinlay-1997]`). Year stays parenthesised.
+
+The rule applies uniformly to module-level docstrings and to public symbol (function / class / method) docstrings. It does **not** apply to Python `# comments` or to runtime string values (`StatCode` descriptions, `"method": "..."` dict literals, `refs=(...)` tuples on registry calls) — those render outside the mkdocs autorefs pipeline and the link would not resolve.
+
 #### `bibliography.md` as catalog, not single SSOT
 
 `docs/reference/bibliography.md` is a **catalog page**, not the SSOT for citation metadata: every cited paper appears there once with its full citation, an anchor, and a paragraph on the paper's role in factrix. It serves three roles:

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -106,6 +106,16 @@ Estimator and a Direct Test for Heteroskedasticity." *Econometrica*
 HC0 sandwich estimator; the heteroskedasticity-only ancestor of NW
 HAC. Cited as background.
 
+### Hansen (1982)
+[](){ #hansen-1982 }
+
+Hansen, L. P. (1982). "Large Sample Properties of Generalized Method
+of Moments Estimators." *Econometrica* 50(4), 1029–1054.
+
+GMM framework and the over-identifying-restrictions J-statistic;
+underlies the two-step efficient `GMM` ``MomentEstimator``
+(`factrix.stats.gmm`).
+
 ---
 
 ## Cross-section and panel pricing
@@ -358,6 +368,39 @@ weighted CAAR factrix computes (`compute_caar` with continuous
 `factor`) is a per-event regression-slope statistic in this lineage,
 distinct from the equal-weighted MacKinlay-style CAAR.
 
+### Jaffe (1974)
+[](){ #jaffe-1974 }
+
+Jaffe, J. F. (1974). "Special Information and Insider Trading."
+*Journal of Business* 47(3), 410–428.
+
+Calendar-time portfolio approach to event studies; densifying the
+event-indexed return series to a dense calendar grid (zero-fill on
+non-event dates) so HAC-style inference can assume a fixed period
+between observations. Cited from `_CAARSparsePanelProcedure` as the
+historical anchor for factrix's dense-calendar CAAR HAC t-test.
+
+### Mandelker (1974)
+[](){ #mandelker-1974 }
+
+Mandelker, G. (1974). "Risk and Return: The Case of Merging Firms."
+*Journal of Financial Economics* 1(4), 303–335.
+
+Independent contemporaneous application of the calendar-time
+portfolio approach; cited alongside Jaffe (1974) as the joint origin
+of the densification convention factrix's sparse-panel CAAR adopts.
+
+### Fama (1998)
+[](){ #fama-1998 }
+
+Fama, E. F. (1998). "Market Efficiency, Long-term Returns, and
+Behavioral Finance." *Journal of Financial Economics* 49(3), 283–306.
+
+§2 review and defence of the calendar-time portfolio approach
+against the buy-and-hold abnormal return alternative; cited as the
+modern reference for the densification rationale in
+`_CAARSparsePanelProcedure`.
+
 ---
 
 ## Multiple-testing correction and selection inference
@@ -409,6 +452,19 @@ Methodology." *Journal of the American Statistical Association*
 
 Hierarchical FDR with Simes as group representative; cited as the
 theoretical context for the BHY + Simes composition.
+
+### Benjamini & Bogomolov (2014)
+[](){ #benjamini-bogomolov-2014 }
+
+Benjamini, Y. & Bogomolov, M. (2014). "Selective Inference on
+Multiple Families of Hypotheses." *Journal of the Royal Statistical
+Society: Series B* 76(1), 297–318.
+
+Selective-inference framework for partitioning a hypothesis set into
+independent families with per-family FDR control; underlies the
+explicit ``expand_over`` per-bucket step-up convention in
+`multi_factor.bhy` (per-bucket adjusted p-values, no global
+cross-bucket adjustment).
 
 ### Harvey, Liu & Zhu (2016)
 [](){ #harvey-liu-zhu-2016 }

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -185,7 +185,7 @@ class StatCode(StrEnum):
     ``WALD`` (Wald χ²), ``F`` (Snedecor F), ``LR`` (likelihood ratio).
     Currently shipping: ``(T_NW, P_NW)`` for Newey-West,
     ``(T_HH, P_HH)`` for Hansen-Hodrick, ``(J_GMM, P_GMM)`` for
-    Hansen (1982) generalized method of moments (GMM) J-test
+    [Hansen (1982)][hansen-1982] generalized method of moments (GMM) J-test
     (over-identification is χ², not t, so GMM emits J rather than T),
     ``(WALD_NWCL, P_WALD_NWCL)`` for Newey-West (NW)
     heteroskedasticity-and-autocorrelation-consistent (HAC) + one-way

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -6,8 +6,8 @@ land alongside the v0.4 deletion sweep that retires the existing
 v0.4 ``redundancy_matrix`` / ``spanning`` modules.
 
 Family declaration is now explicit: the input list ``profiles`` *is*
-the family, optionally split per-bucket via ``expand_over`` (Benjamini
-& Bogomolov 2014 selective-inference framework). The previous
+the family, optionally split per-bucket via ``expand_over``
+([Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014] selective-inference framework). The previous
 auto-partition by dispatch cell × forward horizon was retired in #161 —
 caller responsibility now, both because the implicit policy was opaque
 and because ``identity`` already encodes ``forward_periods`` (and would
@@ -52,7 +52,7 @@ class Survivors:
         ``len(profiles) == len(adj_p)`` and entries align in input
         order. Per-bucket independent step-up uses bucket-local ``n``
         and ``p_array``; ``adj_p[i]`` reflects ``profiles[i]``'s own
-        bucket only (Benjamini & Bogomolov 2014 selective inference),
+        bucket only ([Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014] selective inference),
         not a global cross-bucket adjustment.
 
     Attributes:
@@ -70,8 +70,9 @@ class Survivors:
             case); ``partial_conjunction`` keys by ``identity`` tuple
             (``(factor_id, forward_periods)``) and records the ``m``
             condition count per identity.
-        pc_p: Raw partial-conjunction p-value per survivor (Benjamini
-            & Heller 2008 Bonferroni-style: ``(m - min_pass + 1) *
+        pc_p: Raw partial-conjunction p-value per survivor
+            ([Benjamini-Heller (2008)][benjamini-heller-2008] Bonferroni-style:
+            ``(m - min_pass + 1) *
             p_((min_pass))``, capped at 1). ``None`` when the producing
             function is not ``partial_conjunction``.
         min_pass: ``k`` in the ``k`` of ``m`` partial conjunction test.
@@ -406,8 +407,8 @@ def partial_conjunction(
 
     For "factor X is significant in universes A and B" style claims,
     naive ``set(survivors_A) & set(survivors_B)`` does not preserve FDR
-    [Benjamini & Bogomolov 2014]. The partial conjunction test
-    [Benjamini & Heller 2008] provides a contract-bearing path: per
+    [Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014]. The partial conjunction test
+    [Benjamini-Heller (2008)][benjamini-heller-2008] provides a contract-bearing path: per
     identity, combine the ``m`` per-condition p-values into a single
     PC p-value, then run Benjamini-Hochberg-Yekutieli (BHY) across identities.
 
@@ -662,7 +663,7 @@ def bhy_hierarchical(
     """Hierarchical Benjamini-Hochberg-Yekutieli (BHY): control false discovery rate (FDR) across groups then within groups.
 
     For factor sets with natural group structure (momentum / value /
-    quality families; cross-region universes), the Yekutieli 2008
+    quality families; cross-region universes), the [Yekutieli (2008)][yekutieli-2008]
     two-stage procedure controls *group-level* FDR ≤ ``q`` on the outer
     layer (Simes group representative + BHY) and *within-group* FDR
     ≤ ``q`` on the inner layer (BHY restricted to passing groups). Flat
@@ -720,7 +721,7 @@ def bhy_hierarchical(
 
     Notes:
         - **Simes as the outer representative**: dominates Bonferroni
-          ``m * min(p)`` and is the Yekutieli 2008 recommended choice.
+          ``m * min(p)`` and is the [Yekutieli (2008)][yekutieli-2008] recommended choice.
           The kwarg is not exposed at v1 (Edgington-style mean p has
           no valid null; Bonferroni-min is strictly worse than Simes
           under the procedure's positive regression dependence on a subset (PRDS) assumption).

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -315,8 +315,8 @@ class _CAARSparsePanelProcedure:
     indexed series to the **dense calendar** (zero-fill on non-event
     dates), then runs an HH-floored NW HAC t-test on the dense series.
 
-    Densification is the calendar-time portfolio approach (Jaffe 1974,
-    Mandelker 1974; Fama 1998 §2) — restores the lag rule's "consecutive
+    Densification is the calendar-time portfolio approach ([Jaffe (1974)][jaffe-1974],
+    [Mandelker (1974)][mandelker-1974]; [Fama (1998)][fama-1998] §2) — restores the lag rule's "consecutive
     observations are 1 calendar period apart" assumption that
     ``compute_caar``'s event-date filter would otherwise break. With it,
     sparse events let zero-padding zero out spurious autocovariance
@@ -533,7 +533,7 @@ def _compute_common_panel(
     The cross-asset SE assumes asset-level independence (plan §4.3 spec).
     Under contemporaneous return correlation across assets — common in
     market-driven panels — the standard t will over-state significance;
-    Petersen (2009) clustered SE is deferred per plan §11.
+    [Petersen (2009)][petersen-2009] clustered SE is deferred per plan §11.
     """
     import numpy as np
     import polars as pl

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -15,7 +15,7 @@ primitives those façades and the procedure layer call into.
 - ``hac``         — Newey-West (Bartlett) and Hansen-Hodrick
   (rectangular) HAC SE / t-test for a sample mean; shared
   ``_resolve_nw_lags`` bandwidth picker honouring the overlap horizon.
-- ``gmm``         — Hansen (1982) two-step efficient generalized method of moments (GMM) J-statistic
+- ``gmm``         — [Hansen (1982)][hansen-1982] two-step efficient generalized method of moments (GMM) J-statistic
   + Bartlett-kernel long-run covariance for multivariate moments.
 - ``ols``         — ordinary least squares (OLS) slope-only (``_ols_nw_slope_t``) and full
   multivariate (``_ols_nw_multivariate``) with Newey-West HAC
@@ -23,7 +23,7 @@ primitives those façades and the procedure layer call into.
 - ``wald``        — Wald χ² test for linear restrictions on an
   estimated coefficient vector.
 - ``unit_root``   — Augmented Dickey-Fuller (constant-only) test with
-  MacKinnon (1996) interpolated p-values.
+  [MacKinnon (1996)][mackinnon-1996] interpolated p-values.
 - ``diagnostics`` — Residual diagnostics (Ljung-Box portmanteau).
 
 BHY multiple-testing lives in ``factrix.stats.multiple_testing``; it

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -1,13 +1,14 @@
 """Block-bootstrap primitives backing the ``BlockBootstrap`` Estimator (#153).
 
-Two resampling schemes for dependent time series, plus the Politis-White
-(2004) automatic block-length selector and a paired-diff empirical p-value:
+Two resampling schemes for dependent time series, plus the
+[Politis-White (2004)][politis-white-2004] automatic block-length
+selector and a paired-diff empirical p-value:
 
-- **Stationary scheme** (Politis & Romano 1994) — geometric block lengths
-  with mean ``L``. Resamples are themselves stationary processes;
-  preferred when downstream estimators rely on stationarity (CI for
-  serially-correlated means, Sharpe).
-- **Fixed scheme** (Künsch 1989) — deterministic block length ``L``.
+- **Stationary scheme** ([Politis-Romano (1994)][politis-romano-1994]) —
+  geometric block lengths with mean ``L``. Resamples are themselves
+  stationary processes; preferred when downstream estimators rely on
+  stationarity (CI for serially-correlated means, Sharpe).
+- **Fixed scheme** ([Künsch (1989)][kunsch-1989]) — deterministic block length ``L``.
   Cleaner for variance estimation; loses stationarity at the join
   points but tighter at small ``B``.
 
@@ -47,7 +48,7 @@ def _flat_top_kernel(t: float) -> float:
     ``λ(t) = 1`` for ``|t| ≤ 0.5``; linear taper to 0 over ``0.5 < |t| < 1``;
     0 beyond. The flat top eliminates the small-bias term that hurts
     triangular / Bartlett kernels in spectral-density estimation at
-    frequency 0 — the load-bearing input to PW (2004).
+    frequency 0 — the load-bearing input to [Politis-White (2004)][politis-white-2004].
     """
     a = abs(t)
     if a <= 0.5:
@@ -62,7 +63,7 @@ def _politis_white_block_length(
     *,
     scheme: Scheme = "stationary",
 ) -> float:
-    """Politis-White (2004) automatic block length.
+    """[Politis-White (2004)][politis-white-2004] automatic block length.
 
     Implements the spectral plug-in described in PW §3-4:
     ``L̂ = (2 Ĝ² / D̂)^(1/3) · T^(1/3)`` where ``Ĝ`` and ``D̂`` are
@@ -142,7 +143,7 @@ def _stationary_block_indices(
     mean_block_length: float,
     rng: np.random.Generator,
 ) -> np.ndarray:
-    """Politis-Romano (1994) geometric-block index matrix, shape ``(B, n)``.
+    """[Politis-Romano (1994)][politis-romano-1994] geometric-block index matrix, shape ``(B, n)``.
 
     Block length at each step is geometric with mean ``mean_block_length``;
     sampling is circular. Mirrors ``factrix.stats.bootstrap`` resampler
@@ -170,7 +171,7 @@ def _fixed_block_indices(
     block_length: int,
     rng: np.random.Generator,
 ) -> np.ndarray:
-    """Künsch (1989) fixed-block index matrix, shape ``(B, n)``.
+    """[Künsch (1989)][kunsch-1989] fixed-block index matrix, shape ``(B, n)``.
 
     Picks ``ceil(n / L)`` random block starts per resample, lays the
     blocks contiguously (modulo ``n`` for circular wrap), then truncates
@@ -214,7 +215,7 @@ def _block_bootstrap_diff_p(
             the supplied length unchanged. Stationary scheme uses the
             mean of the geometric distribution; fixed scheme uses the
             integer directly.
-        n_resamples: ``B``. PW (2004) recommends ≥ 999 for two-sided
+        n_resamples: ``B``. [Politis-White (2004)][politis-white-2004] recommends ≥ 999 for two-sided
             5% tests; default matches.
         scheme: ``"fixed"`` (Künsch) or ``"stationary"`` (Politis-Romano).
         rng_seed: ``None`` draws from system entropy; the resolved seed

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -53,7 +53,7 @@ MIN_BROADCAST_EVENTS_WARN: int = 20
 
 
 def auto_bartlett(T: int) -> int:
-    """Newey & West (1994) automatic Bartlett-kernel lag.
+    """[Newey-West (1994)][newey-west-1994] automatic Bartlett-kernel lag.
 
     ``floor(4 * (T/100) ** (2/9))``, with a minimum of 1 lag so the
     heteroskedasticity-and-autocorrelation-consistent (HAC) sum always includes the first autocovariance.

--- a/factrix/_stats/gmm.py
+++ b/factrix/_stats/gmm.py
@@ -1,4 +1,4 @@
-"""Generalized method of moments (GMM, Hansen 1982) two-step efficient GMM.
+"""Generalized method of moments (GMM, [Hansen (1982)][hansen-1982]) two-step efficient GMM.
 
 Provides the J-statistic for over-identifying-restriction tests on a
 moment-condition system. Hand-rolled to keep the dep surface lean,
@@ -38,10 +38,10 @@ def _long_run_covariance(
     where Γ_j = (1/T) Σ_t (g_t - ḡ)(g_{t-j} - ḡ)' is the lag-j
     auto-covariance of the moment vector. Symmetrized via ``Γ_j + Γ_j'``
     so ``S`` is symmetric by construction; positive-semidefiniteness is
-    inherited from the Bartlett kernel (Newey-West 1987).
+    inherited from the Bartlett kernel ([Newey-West (1987)][newey-west-1987]).
 
-    Bandwidth defaults to the Newey-West (1987) ``floor(T^(1/3))``
-    fixed rule; Andrews (1991) data-driven bandwidth is the textbook
+    Bandwidth defaults to the [Newey-West (1987)][newey-west-1987] ``floor(T^(1/3))``
+    fixed rule; [Andrews (1991)][andrews-1991] data-driven bandwidth is the textbook
     GMM choice on high-dimensional or strongly persistent moment
     systems and may be added as an opt-in later.
 
@@ -76,7 +76,7 @@ def _two_step_gmm_j_stat(
     lags: int | None = None,
     max_iter: int = 2,
 ) -> tuple[float, int, int, bool]:
-    """Two-step efficient GMM J-statistic (Hansen 1982) under H₀: E[g] = 0.
+    """Two-step efficient GMM J-statistic ([Hansen (1982)][hansen-1982]) under H₀: E[g] = 0.
 
     For pure over-identification (``n_params = 0``) the parameter vector
     is empty and the test reduces to a Wald-style quadratic form on the

--- a/factrix/_stats/hac.py
+++ b/factrix/_stats/hac.py
@@ -47,7 +47,7 @@ def _newey_west_se(
         forward_periods: Overlap horizon of the input series. When set,
             enforces ``lags >= forward_periods - 1`` — the minimum
             consistent bandwidth for overlapping h-period returns
-            (Hansen-Hodrick 1980 MA(h-1) structure).
+            ([Hansen-Hodrick (1980)][hansen-hodrick-1980] MA(h-1) structure).
 
     Returns:
         HAC-adjusted standard error of the mean.
@@ -126,7 +126,7 @@ def _hansen_hodrick_se(
     values: np.ndarray,
     forward_periods: int,
 ) -> tuple[float, bool]:
-    """Hansen-Hodrick (1980) rectangular-kernel HAC SE for a sample mean.
+    """[Hansen-Hodrick (1980)][hansen-hodrick-1980] rectangular-kernel HAC SE for a sample mean.
 
     Closed-form variance under the textbook MA(h-1) overlap structure
     induced by h-period forward returns:
@@ -135,7 +135,7 @@ def _hansen_hodrick_se(
 
     Unlike the Bartlett kernel used by ``_newey_west_se``, weights are
     flat (1.0) inside ``j ≤ h-1`` and zero beyond. The estimator carries
-    no PSD guarantee (Andrews 1991 §3): on short / mildly anti-correlated
+    no PSD guarantee ([Andrews (1991)][andrews-1991] §3): on short / mildly anti-correlated
     samples the parenthesised sum can come out negative. Callers may map
     ``clamped=True`` to a degenerate-sample warning.
 

--- a/factrix/_stats/multiple_testing.py
+++ b/factrix/_stats/multiple_testing.py
@@ -8,10 +8,10 @@ the slice-test setting where a small number of hypotheses
 
 - **Bonferroni** — single-step ``p_adj_k = min(m * p_k, 1)``. Controls
   FWER under any dependence; uniformly the most conservative.
-- **Holm step-down** (Holm 1979) — uniformly dominates Bonferroni under
+- **Holm step-down** ([Holm (1979)][holm-1979]) — uniformly dominates Bonferroni under
   the same dependence assumptions; gains power by sequentially
   rejecting ordered p-values.
-- **Romano-Wolf step-down** (Romano & Wolf 2005) — bootstrap-based
+- **Romano-Wolf step-down** ([Romano-Wolf (2005)][romano-wolf-2005]) — bootstrap-based
   step-down that exploits the *joint* dependence structure of the
   test statistics. Needs the user to supply a bootstrap distribution
   (under H0); in return delivers tight FWER control even when tests
@@ -63,7 +63,7 @@ def bonferroni(p_values: Sequence[float] | npt.ArrayLike) -> list[float]:
 
 
 def holm_step_down(p_values: Sequence[float] | npt.ArrayLike) -> list[float]:
-    """Holm (1979) step-down adjusted p-values.
+    """[Holm (1979)][holm-1979] step-down adjusted p-values.
 
     Order ``p_(1) ≤ p_(2) ≤ … ≤ p_(m)`` and set
     ``p_adj_(k) = max_{j ≤ k} (m - j + 1) * p_(j)``, clipped at 1.
@@ -94,7 +94,7 @@ def romano_wolf(
     *,
     one_sided: bool = False,
 ) -> list[float]:
-    """Romano-Wolf (2005) step-down adjusted p-values.
+    """[Romano-Wolf (2005)][romano-wolf-2005] step-down adjusted p-values.
 
     The step-down critical sequence is built from the *max* of the
     bootstrap distribution restricted to the not-yet-rejected

--- a/factrix/_stats/unit_root.py
+++ b/factrix/_stats/unit_root.py
@@ -29,7 +29,7 @@ _ADF_CRITS_CONSTANT: tuple[tuple[float, float], ...] = (
 
 
 def _adf_pvalue_interp(tau: float) -> float:
-    """Linear interpolation of ADF p-value from MacKinnon (1996) crits.
+    """Linear interpolation of ADF p-value from [MacKinnon (1996)][mackinnon-1996] crits.
 
     Behaviour at the tails is driven by the outermost critical points
     in ``_ADF_CRITS_CONSTANT``: τ below the leftmost point clamps to
@@ -53,7 +53,7 @@ def _adf(y: np.ndarray, lags: int = 0) -> tuple[float, float]:
 
     Estimates Δy_t = α + β·y_{t-1} + Σ γ_i·Δy_{t-i} + ε and returns
     (τ, p_approx) where τ = β̂ / SE(β̂) and p_approx comes from linear
-    interpolation of MacKinnon (1996) asymptotic critical values for
+    interpolation of [MacKinnon (1996)][mackinnon-1996] asymptotic critical values for
     the constant-only specification. H0: unit root (β = 0); small τ
     rejects in favour of stationarity.
 

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -13,7 +13,7 @@ Three layers of heteroskedasticity-and-autocorrelation-consistent (HAC) / cluste
   ``WaldNWCluster`` Estimator (#153).
 - **Two-way cluster on (date, asset)** —
   ``_wald_two_way_cluster(y, X, *, R, q, date_ids, asset_ids)`` for
-  the raw asset-date panel. Cameron-Gelbach-Miller (2011)
+  the raw asset-date panel. [Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011]
   ``V_DC = V_date + V_asset - V_intersection`` shape. Backs the
   ``WaldTwoWayCluster`` Estimator — interface preserved this issue;
   no public function consumes it until ``factor_decomposition`` lands
@@ -155,7 +155,8 @@ def _cluster_meat(
 
     Sandwich pieces are cached at the cluster level; complexity is
     O(n · k²) regardless of cluster count. Used as the building block
-    for both single-cluster and CGM (2011) two-way cluster covariance.
+    for both single-cluster and [Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011]
+    two-way cluster covariance.
     """
     _, k = X.shape
     score = X * u[:, None]
@@ -179,7 +180,7 @@ def _wald_two_way_cluster(
 ) -> tuple[float, float]:
     """Wald χ² with two-way cluster covariance on (date, asset).
 
-    Cameron-Gelbach-Miller (2011) construction:
+    [Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011] construction:
     ``V_DC = V_date + V_asset - V_intersection``, with each piece a
     sandwich ``(X'X)^{-1} M_cluster (X'X)^{-1}``. ``V_intersection``
     clusters by the (date, asset) intersection — for a panel where

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -109,10 +109,11 @@ def _sample_non_overlapping(
 
     Why: with h-period forward returns, consecutive dates' forward
     returns share h−1 bars of future data — the series has an MA(h−1)
-    structure (Hansen & Hodrick 1980). Sub-sampling at interval h
-    breaks this dependence at the cost of throwing away h−1 of every
-    h observations. This is the most conservative of the Richardson-
-    Stock (1989) remedies; ``_newey_west_t_test`` is the less-lossy
+    structure ([Hansen-Hodrick (1980)][hansen-hodrick-1980]). Sub-sampling at
+    interval h breaks this dependence at the cost of throwing away h−1 of
+    every h observations. This is the most conservative of the
+    [Richardson-Stock (1989)][richardson-stock-1989] remedies;
+    ``_newey_west_t_test`` is the less-lossy
     alternative (keeps all obs but corrects SE).
 
     Logs a WARNING at ``factrix.metrics`` when the sampled series
@@ -299,8 +300,9 @@ def _is_sparse_magnitude_weighted(
     Sparse procedures and ``compute_caar`` accept ``{0, 1}`` event
     indicators or ``{0, R}, R ∈ ℝ`` magnitude-weighted columns. Mixed
     signs with non-unit magnitudes (e.g. ``{-2.5, 0, +1.3}``) yield the
-    Sefcik-Thompson (1986) magnitude-weighted statistic rather than the
-    MacKinlay (1997) signed CAAR — a different estimator at finite
+    [Sefcik-Thompson (1986)][sefcik-thompson-1986] magnitude-weighted
+    statistic rather than the [MacKinlay (1997)][mackinlay-1997] signed
+    CAAR — a different estimator at finite
     samples when the negative- and positive-leg vols disagree.
     ``{-1, 0, +1}`` does not trigger (sign and weight semantics coincide
     numerically); all-non-negative columns do not trigger (no flip

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -86,7 +86,7 @@ def compute_caar(
 
     Caveat on $\{-1, 0, +1\}$: it lands in the second row as a
     weight-$\pm 1$ case, which gives a magnitude-weighted CAAR, **not**
-    the textbook MacKinlay (1997) signed CAAR (the latter averages
+    the textbook [MacKinlay (1997)][mackinlay-1997] signed CAAR (the latter averages
     direction-flipped abnormal returns and is a different estimator at
     finite samples when the negative-leg vol differs from the positive-
     leg vol). If literature-standard signed CAAR is what you want,
@@ -121,12 +121,12 @@ def compute_caar(
         Magnitude of ``factor`` is preserved as a weight; only rows with
         ``factor == 0`` are dropped.
 
-        factrix follows the MacKinlay (1997) event-window vocabulary
+        factrix follows the [MacKinlay (1997)][mackinlay-1997] event-window vocabulary
         (factor as the event indicator / sign on the announcement date)
         but generalises ``signed_car`` to numeric factor magnitude. With
         a continuous ``factor`` column, the resulting CAAR is the
         per-event regression-slope statistic in the
-        Sefcik-Thompson (1986) lineage rather than the equal-weighted
+        [Sefcik-Thompson (1986)][sefcik-thompson-1986] lineage rather than the equal-weighted
         MacKinlay CAAR.
 
         When ``factor_col`` triggers ``_is_sparse_magnitude_weighted``
@@ -328,8 +328,9 @@ def bmp_test(
         forward_periods: Return horizon for vol scaling (default 5).
             When using price-derived daily vol, scales by
             ``1/sqrt(forward_periods)`` to match per-period forward_return.
-        kolari_pynnonen_adjust: When True, apply the Kolari-Pynnönen
-            (2010) adjustment for cross-sectional correlation of SAR:
+        kolari_pynnonen_adjust: When True, apply the
+            [Kolari-Pynnönen (2010)][kolari-pynnonen-2010] adjustment for
+            cross-sectional correlation of SAR:
             $z_{\mathrm{KP}} = z_{\mathrm{BMP}} \cdot \sqrt{(1 - \hat r) / (1 + (N_{\mathrm{eff}} - 1) \cdot \hat r)}$
             where $\hat r$ is the ICC-style within-date correlation of
             SAR and
@@ -343,7 +344,8 @@ def bmp_test(
             per-event standardiser by $\sqrt{1 + 1/T_{\mathrm{est}}}$
             (with $T_{\mathrm{est}}$ = ``estimation_window``) to absorb
             the prediction-error variance of the mean-adjusted residual
-            forecast — the strict BMP (1991) denominator. Default is
+            forecast — the strict [Boehmer-Musumeci-Poulsen (1991)][boehmer-musumeci-poulsen-1991]
+            denominator. Default is
             False, preserving the prior factrix denominator (residual
             std only). Under mean-adjusted residuals + a single
             ``estimation_window`` the correction scales every SAR by

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -178,14 +178,14 @@ def fama_macbeth(
             ``compute_fm_betas`` is itself an **estimated** quantity
             (rolling ordinary least squares (OLS) $\beta$ to another factor, PCA score,
             ML-predicted score, residual from a first-stage regression).
-            Shanken (1992) shows the naive FM SE ignores sampling error
+            [Shanken (1992)][shanken-1992] shows the naive FM SE ignores sampling error
             in the regressor, inflating $t$-stats. **Do NOT** set this
             on raw characteristics (book-to-market, momentum price
             signal, accounting ratios) — those are observed, not
             estimated, and enabling the correction will spuriously
             deflate $t$-stats.
 
-            Implementation: Kan-Zhang (1999) single-factor simplification
+            Implementation: [Kan-Zhang (1999)][kan-zhang-1999] single-factor simplification
             — the NW SE is scaled by $\sqrt{1 + \hat\lambda^2/\sigma^2_f}$.
             This *omits* the additive $+\sigma^2_f/T$ term of the full
             Shanken variance and is therefore only honest for large $T$.
@@ -215,9 +215,9 @@ def fama_macbeth(
         single-factor correction scales SE by
         $\sqrt{1 + \overline{\beta}^2 / \sigma^2_f}$.
 
-        factrix uses the Andrews (1991) $T^{1/3}$ bandwidth floored
+        factrix uses the [Andrews (1991)][andrews-1991] $T^{1/3}$ bandwidth floored
         against the Hansen-Hodrick overlap horizon rather than the
-        Newey-West (1994) data-adaptive plug-in — simpler, deterministic,
+        [Newey-West (1994)][newey-west-1994] data-adaptive plug-in — simpler, deterministic,
         and adequate at typical research $T$. The Kan-Zhang simplification
         omits the additive $+\sigma^2_f / T$ term of full Shanken EIV,
         so the correction is honest only for large $T$.
@@ -388,7 +388,7 @@ def pooled_ols(
 
     Clustering on date alone catches contemporaneous cross-sectional
     dependence but misses asset-level persistence; on asset alone the
-    reverse. Petersen (2009) shows panel data usually has both —
+    reverse. [Petersen (2009)][petersen-2009] shows panel data usually has both —
     single-way clusters understate SE by 20-50% in that regime.
 
     FM and single-way share the same point estimate under a balanced
@@ -424,7 +424,8 @@ def pooled_ols(
         $t = \hat\beta / \mathrm{SE}$, $\mathrm{df} = G - 1$.
 
         Two-way clustered sandwich SE (when ``two_way_cluster_col`` is
-        set — Cameron-Gelbach-Miller 2011 / Petersen 2009):
+        set — [Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011] /
+        [Petersen (2009)][petersen-2009]):
 
         $$
         V_{\text{two-way}} = V_A + V_B - V_{A \cap B}
@@ -433,14 +434,14 @@ def pooled_ols(
         where $V_A$, $V_B$, $V_{A \cap B}$ are single-way variances
         clustered on $A$, on $B$, and on the intersection cells
         $(A, B)$. Each component uses its own finite-sample correction.
-        $\mathrm{df} = \min(G_A, G_B) - 1$ (Thompson 2011).
+        $\mathrm{df} = \min(G_A, G_B) - 1$ ([Thompson (2011)][thompson-2011]).
 
     Notes:
         Pool ``(date, asset)`` rows and run a single OLS ``R = alpha +
         beta * Signal + eps`` with the appropriate cluster-robust
         sandwich covariance described above. Single-way: ``df = G - 1``
         with ``G`` the number of clusters; two-way:
-        ``df = min(G_A, G_B) - 1`` per Thompson (2011).
+        ``df = min(G_A, G_B) - 1`` per [Thompson (2011)][thompson-2011].
 
         factrix reports ``stat = None`` (rather than 0) when ``G < 3``
         because the cluster-robust variance is undefined with too few

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -270,12 +270,12 @@ def ic_newey_west(
         $t = \mathrm{mean}(\mathrm{IC}) / \mathrm{SE}_{\mathrm{NW}}(\mathrm{IC})$
         on the full overlapping IC series. Lag selection:
         $L = \max(\lfloor T^{1/3} \rfloor, h - 1)$ (with $h$ = ``forward_periods``)
-        — the Andrews (1991) Bartlett growth rate, floored against the
+        — the [Andrews (1991)][andrews-1991] Bartlett growth rate, floored against the
         Hansen-Hodrick MA($h-1$) overlap horizon so the kernel covers
         the induced dependence.
 
         factrix uses the Andrews fixed-rate rule rather than the
-        Newey-West (1994) data-adaptive bandwidth — simpler, deterministic
+        [Newey-West (1994)][newey-west-1994] data-adaptive bandwidth — simpler, deterministic
         across reruns, and adequate at the typical $T$ of factor research.
 
     References:

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -83,7 +83,7 @@ def compute_mfe_mae(
     $\sqrt{W \cdot \sigma^2}$; comparing raw MFE across horizons or vol
     regimes conflates time-scale with signal strength. The z-scored
     versions are the apples-to-apples quantity for cross-setup
-    comparisons (Campbell-Lo-MacKinlay 1997 Ch 4 on horizon scaling of
+    comparisons ([Campbell-Lo-MacKinlay (1997)][campbell-lo-mackinlay-1997] Ch 4 on horizon scaling of
     order statistics).
 
     Args:
@@ -94,7 +94,7 @@ def compute_mfe_mae(
             σ (default 60).
         min_estimation_samples: Minimum non-degenerate prior bars
             required to produce a finite ``est_sigma``. Default 20
-            mirrors the BMP (Boehmer-Musumeci-Poulsen 1991) daily-σ
+            mirrors the BMP ([Boehmer-Musumeci-Poulsen (1991)][boehmer-musumeci-poulsen-1991]) daily-σ
             convention; weekly panels can drop to ~8-10. Below the
             threshold, ``mfe_z`` / ``mae_z`` report ``NaN``. Must be
             ≥2 (the std degrees-of-freedom floor).

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -119,8 +119,8 @@ def multi_split_oos_decay(
         ``MIN_OOS_PERIODS`` floor would have power ≈ 0).
 
     References:
-        - McLean & Pontiff (2016): average OOS decay ~32%.
-        - de Prado (2018): CPCV for robust train/test split.
+        - [McLean-Pontiff (2016)][mclean-pontiff-2016]: average OOS decay ~32%.
+        - [Lopez-de-Prado (2018)][lopez-de-prado-2018]: CPCV for robust train/test split.
 
     Examples:
         Survival on a per-date information coefficient (IC) series from

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -320,7 +320,7 @@ def quantile_spread_vw(
         realized.
 
     References:
-        Hou, Xue & Zhang (2020): ~65% of factors disappear under VW.
+        [Hou-Xue-Zhang (2020)][hou-xue-zhang-2020]: ~65% of factors disappear under VW.
 
     Examples:
         >>> import polars as pl

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -1,7 +1,7 @@
 """Spanning regression — single-factor test and multi-factor selection.
 
 ``spanning_alpha``: does a single factor have alpha after controlling for
-base factors? Standard factor research tool (Barillas & Shanken 2017).
+base factors? Standard factor research tool ([Barillas-Shanken (2017)][barillas-shanken-2017]).
 
 ``greedy_forward_selection``: given a pool of PASS factors, iteratively
 select those with incremental alpha (Stage 2).
@@ -66,8 +66,9 @@ class ForwardSelectionResult:
     searches over the candidate pool and picks by |alpha|, so the
     t-statistics on ``selected_factors`` and ``eliminated_factors`` are
     conditioned on having been chosen. They do not have a valid
-    t-distribution null and must not be used for inference (White 2000;
-    Harvey-Liu-Zhu 2016). For post-selection significance, re-evaluate
+    t-distribution null and must not be used for inference
+    ([White (2000)][white-2000]; [Harvey-Liu-Zhu (2016)][harvey-liu-zhu-2016]).
+    For post-selection significance, re-evaluate
     survivors on a held-out sample or with a bootstrap.
     """
 
@@ -247,8 +248,8 @@ def greedy_forward_selection(
         they are conditional on survival, not draws from the t-null.
         Use this function as a **model-construction helper**, not as
         an inference tool. For post-selection significance, re-evaluate
-        the surviving set on a held-out window, or use a White (2000)
-        Reality Check / Hansen (2005) SPA procedure on the pre-selection
+        the surviving set on a held-out window, or use a [White (2000)][white-2000]
+        Reality Check / [Hansen (2005)][hansen-2005] SPA procedure on the pre-selection
         stage. The returned ``t_stats_inference_invalid=True`` flag
         encodes this contract.
 

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -7,7 +7,7 @@ Two flavours of turnover co-exist here, measuring different things:
   trading-fraction and should **not** be fed into ``breakeven_cost`` /
   ``net_spread``.
 - ``notional_turnover()`` — fraction of top-and-bottom quantile members
-  replaced per rebalance. Matches Novy-Marx & Velikov (2016) τ; this is
+  replaced per rebalance. Matches [Novy-Marx-Velikov (2016)][novy-marx-velikov-2016] τ; this is
   the quantity that drives bps trading cost for an equal-weight Q1/Qn
   long-short portfolio.
 
@@ -229,8 +229,9 @@ def notional_turnover(
     incur cost are changes in top-quantile and bottom-quantile membership
     — reshuffling within the middle deciles triggers no rebalancing and
     should not be counted. This is the metric whose units are directly
-    compatible with ``breakeven_cost`` / ``net_spread``: Novy-Marx &
-    Velikov (2016) τ = fraction of portfolio value replaced per rebalance.
+    compatible with ``breakeven_cost`` / ``net_spread``:
+    [Novy-Marx-Velikov (2016)][novy-marx-velikov-2016] τ = fraction of
+    portfolio value replaced per rebalance.
 
     Per-rebalance turnover is the mean of two one-sided overlap losses::
 
@@ -276,8 +277,8 @@ def notional_turnover(
         real portfolio would still book that liquidation cost.
 
     References:
-        Novy-Marx & Velikov (2016), "A Taxonomy of Anomalies and Their
-        Trading Costs."
+        [Novy-Marx-Velikov (2016)][novy-marx-velikov-2016], "A Taxonomy of
+        Anomalies and Their Trading Costs."
 
     Examples:
         >>> import factrix as fx
@@ -431,7 +432,8 @@ def breakeven_cost(
         grows with mid-rank churn.
 
     References:
-        Novy-Marx & Velikov (2016), "A Taxonomy of Anomalies and Their Trading Costs."
+        [Novy-Marx-Velikov (2016)][novy-marx-velikov-2016], "A Taxonomy of
+        Anomalies and Their Trading Costs."
 
     Examples:
         >>> from factrix.metrics.tradability import breakeven_cost
@@ -520,8 +522,8 @@ def net_spread(
         the cost drag.
 
     References:
-        DeMiguel, Martin-Utrera, Nogales & Uppal (2020), "A
-        Transaction-Cost Perspective on the Multitude of Firm
+        [DeMiguel-Martin-Utrera-Nogales-Uppal (2020)][demiguel-martin-utrera-nogales-uppal-2020],
+        "A Transaction-Cost Perspective on the Multitude of Firm
         Characteristics." *Review of Financial Studies* 33(5).
 
     Examples:

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -53,7 +53,7 @@ def ic_trend(
             primitive name stay three-point unified.
         adf_threshold: Augmented Dickey-Fuller (ADF) p-value above which the input is flagged as
             unit-root suspect. Default ``0.10`` matches the conventional
-            Stock-Watson (1988) cutoff: at p > 0.10 we cannot reject
+            [Stock-Watson (1988)][stock-watson-1988] cutoff: at p > 0.10 we cannot reject
             I(1), so ordinary least squares (OLS) / Theil-Sen on the series reject the slope null
             at inflated rates regardless of the true trend. When
             ``None``, the ADF check is skipped entirely and no

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -11,7 +11,7 @@ mean inference (#163). ``NeweyWest`` / ``HansenHodrick`` implement it.
 *, forward_periods) -> GMMResult`` for over-identifying-restriction
 tests on a moment-condition system (#191). ``GMM`` implements it.
 ``GMMResult`` — harmonized return shape for ``MomentEstimator.compute``.
-``GMM`` — Hansen (1982) two-step efficient J-test ``MomentEstimator``;
+``GMM`` — [Hansen (1982)][hansen-1982] two-step efficient J-test ``MomentEstimator``;
 opt-in via ``AnalysisConfig.moment_estimator``.
 ``NeweyWest`` — Newey-West heteroskedasticity-and-autocorrelation-consistent (HAC) ``HACEstimator``; default for
 ``AnalysisConfig.estimator``.

--- a/factrix/stats/_estimator.py
+++ b/factrix/stats/_estimator.py
@@ -191,7 +191,7 @@ class HACEstimator(Estimator, Protocol):
 @runtime_checkable
 class MomentEstimator(Estimator, Protocol):
     """``Estimator`` that runs an over-identifying-restriction test on
-    a moment-condition system (e.g. Hansen 1982 generalized method of moments (GMM) J-test).
+    a moment-condition system (e.g. [Hansen (1982)][hansen-1982] generalized method of moments (GMM) J-test).
 
     Symmetric to ``HACEstimator``: same selection-base contract, but
     ``compute`` consumes a multivariate moment matrix rather than a

--- a/factrix/stats/block_bootstrap.py
+++ b/factrix/stats/block_bootstrap.py
@@ -26,16 +26,17 @@ class BlockBootstrap:
     Resamples a paired-difference series under H₀: ``E[diff] = 0`` using
     one of two dependent-bootstrap schemes:
 
-    - ``"stationary"`` (Politis & Romano 1994) — geometric block lengths
-      with mean ``L``; each resample is itself a stationary process.
-      Default; preferred when downstream stats (CI, Sharpe) rely on
-      stationarity.
-    - ``"fixed"`` (Künsch 1989) — deterministic block length ``L``;
-      cleaner for variance estimation; loses stationarity at block
-      joins but tighter at small ``B``.
+    - ``"stationary"`` ([Politis-Romano (1994)][politis-romano-1994]) —
+      geometric block lengths with mean ``L``; each resample is itself a
+      stationary process. Default; preferred when downstream stats (CI,
+      Sharpe) rely on stationarity.
+    - ``"fixed"`` ([Künsch (1989)][kunsch-1989]) — deterministic block
+      length ``L``; cleaner for variance estimation; loses stationarity
+      at block joins but tighter at small ``B``.
 
     Block length resolves automatically from the input series via
-    Politis-White (2004) when ``block_length="auto"``; pass an integer
+    [Politis-White (2004)][politis-white-2004] when ``block_length="auto"``;
+    pass an integer
     to fix it.
 
     Applicability is restricted to ``(INDIVIDUAL, CONTINUOUS)`` —

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -1,4 +1,4 @@
-"""Stationary (Politis-Romano 1994) bootstrap for dependent time series.
+"""Stationary ([Politis-Romano (1994)][politis-romano-1994]) bootstrap for dependent time series.
 
 Parametric inference (standard t-test, Newey-West heteroskedasticity-and-autocorrelation-consistent (HAC)) breaks down when
 the sample is short relative to the dependence horizon or the marginal
@@ -26,12 +26,12 @@ import numpy as np
 
 
 def _default_block_length(n: int) -> float:
-    """Practical fallback per Politis-White (2004) commentary.
+    """Practical fallback per [Politis-White (2004)][politis-white-2004] commentary.
 
     Full PW picks ``L`` from a plug-in of the spectral density; that
     needs another set of choices we don't want to inherit here. The
     ``1.75 * T^(1/3)`` rule is the widely-cited pragmatic compromise
-    (same cube-root cadence as Newey-West 1994, slightly larger constant
+    (same cube-root cadence as [Newey-West (1994)][newey-west-1994], slightly larger constant
     because the stationary bootstrap's kernel is different).
     """
     if n < 2:
@@ -57,7 +57,7 @@ def stationary_bootstrap_resamples(
         values: 1-D array of the original time series.
         n_bootstrap: Number of resamples to draw.
         block_length: Mean geometric block length. Defaults to
-            ``1.75 * T^(1/3)`` (Politis-White 2004 practical rule).
+            ``1.75 * T^(1/3)`` ([Politis-White (2004)][politis-white-2004] practical rule).
             Must be ``>= 1``; block_length=1 reduces to the ordinary
             iid bootstrap (Efron).
         seed: Seed for ``np.random.default_rng`` to make the resample

--- a/factrix/stats/gmm.py
+++ b/factrix/stats/gmm.py
@@ -1,4 +1,4 @@
-"""``GMM`` MomentEstimator — Hansen (1982) two-step efficient J-test.
+"""``GMM`` MomentEstimator — [Hansen (1982)][hansen-1982] two-step efficient J-test.
 
 Names the over-identifying-restriction inference path that populates
 ``StatCode.J_GMM`` / ``StatCode.P_GMM``. ``compute(moments, *,
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class GMM:
-    """Hansen (1982) two-step efficient generalized method of moments (GMM) J-test estimator.
+    """[Hansen (1982)][hansen-1982] two-step efficient generalized method of moments (GMM) J-test estimator.
 
     Computes the J-statistic for a moment-condition system whose
     null is ``E[g] = 0`` (pure over-identification). The long-run

--- a/factrix/stats/hansen_hodrick.py
+++ b/factrix/stats/hansen_hodrick.py
@@ -1,6 +1,6 @@
 """``HansenHodrick`` heteroskedasticity-and-autocorrelation-consistent (HAC) estimator — rectangular-kernel HAC SE on a series mean.
 
-Names the Hansen-Hodrick (1980) overlapping-sample inference path
+Names the [Hansen-Hodrick (1980)][hansen-hodrick-1980] overlapping-sample inference path
 emitted to ``profile.stats`` as ``StatCode.P_HH`` / ``StatCode.T_HH``.
 ``compute(series, *, forward_periods)`` delegates to
 :func:`factrix._stats._hansen_hodrick_t_test`.
@@ -9,7 +9,7 @@ emitted to ``profile.stats`` as ``StatCode.P_HH`` / ``StatCode.T_HH``.
 and HH collapses to the iid SE — ``compute`` still delegates to the
 primitive, which returns the iid result.
 ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` surfaces when the
-rectangular-kernel sum comes out negative (Andrews 1991 §3).
+rectangular-kernel sum comes out negative ([Andrews (1991)][andrews-1991] §3).
 """
 
 from __future__ import annotations
@@ -28,11 +28,11 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class HansenHodrick:
-    """Hansen-Hodrick (HH) (1980) heteroskedasticity-and-autocorrelation-consistent (HAC) SE estimator → t-statistic → two-sided p-value.
+    """[Hansen-Hodrick (1980)][hansen-hodrick-1980] (HH) heteroskedasticity-and-autocorrelation-consistent (HAC) SE estimator → t-statistic → two-sided p-value.
 
     Rectangular-kernel HAC variance ``Var(mean) = (γ₀ + 2 Σ_{j=1..h-1}
     γⱼ) / n`` matched to the MA(h-1) overlap structure induced by
-    h-period forward returns. No PSD guarantee (Andrews 1991 §3): on
+    h-period forward returns. No PSD guarantee ([Andrews (1991)][andrews-1991] §3): on
     short / mildly anti-correlated samples the estimate can come out
     negative; ``compute`` clamps variance to 0 and surfaces
     ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` in the result.

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -1,9 +1,9 @@
 """Multiple-testing adjustments.
 
-Benjamini-Yekutieli (2001) step-up procedure for false discovery rate (FDR) control under
+[Benjamini-Yekutieli (2001)][benjamini-yekutieli-2001] step-up procedure for false discovery rate (FDR) control under
 arbitrary dependence among the tests. The BHY correction factor
 ``c(m) = sum_{i=1..m} 1/i`` makes the procedure conservative enough
-to handle dependent tests (as opposed to Benjamini-Hochberg (BH) 1995 which requires
+to handle dependent tests (as opposed to [Benjamini-Hochberg (1995)][benjamini-hochberg-1995] (BH) which requires
 independence or positive regression dependence on a subset (PRDS)).
 
 Rejection rule: order p-values ``p_(1) <= p_(2) <= ... <= p_(m)``.
@@ -173,7 +173,7 @@ def bhy_adjusted_p(
 
 
 def simes_p(p_values: npt.ArrayLike) -> float:
-    """Simes (1986) global-null p-value for a group of tests.
+    """[Simes (1986)][simes-1986] global-null p-value for a group of tests.
 
     Formula: ``p_Simes = min_{k=1..m} (m / k) * p_((k))`` where
     ``p_((k))`` is the ``k``-th smallest of the ``m`` p-values
@@ -181,7 +181,7 @@ def simes_p(p_values: npt.ArrayLike) -> float:
     "at least one alternative is true"; valid under independence and
     positive regression dependence on a subset (PRDS).
 
-    Yekutieli (2008) uses Simes as the default group representative
+    [Yekutieli (2008)][yekutieli-2008] uses Simes as the default group representative
     in hierarchical false discovery rate (FDR) procedures — it dominates Bonferroni
     (``m * min(p)``) and preserves group-level FDR control when fed
     to an outer Benjamini-Hochberg-Yekutieli (BHY) step-up.
@@ -220,7 +220,7 @@ def partial_conjunction_p(
     *,
     min_pass: int,
 ) -> float:
-    """Bonferroni-style partial conjunction p-value (Benjamini-Heller 2008).
+    """Bonferroni-style partial conjunction p-value ([Benjamini-Heller (2008)][benjamini-heller-2008]).
 
     Tests ``H_0^{k/m}``: at most ``k - 1`` of the ``m`` alternatives are
     true, against ``H_1^{k/m}``: at least ``k`` are true. The combined

--- a/factrix/stats/wald_cluster.py
+++ b/factrix/stats/wald_cluster.py
@@ -7,7 +7,7 @@ Two ``Estimator`` implementations targeting the slice-test setting
   consumes the stacked per-date metric panel. Emits
   ``StatCode.P_WALD_NWCL`` (paired with ``WALD_NWCL`` on the test
   statistic side).
-- ``WaldTwoWayCluster`` — Cameron-Gelbach-Miller (2011) two-way
+- ``WaldTwoWayCluster`` — [Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011] two-way
   cluster on (date, asset); consumes the raw asset-date panel.
   Emits ``StatCode.P_WALD_TWOWAY``. Interface ships this issue but
   no function consumes it until ``factor_decomposition`` lands
@@ -78,7 +78,7 @@ class WaldNWCluster:
 
 
 class WaldTwoWayCluster:
-    """Two-way cluster Wald χ² on (date, asset) — Cameron-Gelbach-Miller (2011).
+    """Two-way cluster Wald χ² on (date, asset) — [Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011].
 
     Backs the raw asset-date panel inference path (factor × slice
     interaction with full panel SE). Numerics live in


### PR DESCRIPTION
## Summary

Establishes a project-wide three-layer convention for inline paper citations and applies it across `factrix/**/*.py` docstrings:

- **Bibliography heading** — formal `Author & Author (Year)` (unchanged).
- **Anchor ID** — lowercase hyphenated `author-author-year`.
- **Inline link text** — hyphenated `[Author-Author (Year)][anchor-id]` in docstring prose, `References:` bullets, and future `.md` body text. Matches how factrix's prose names the underlying methods (Newey-West, Hansen-Hodrick, Fama-MacBeth) and the example in `bibliography.md`'s own intro.

Three atomic commits:

1. Add 5 missing `bibliography.md` entries surfaced by the sweep — `hansen-1982`, `jaffe-1974`, `mandelker-1974`, `fama-1998`, `benjamini-bogomolov-2014`.
2. Link ~72 bare-text citations across 29 Python files (module + public symbol docstrings).
3. Codify the convention under `docs/development/contributing.md` so future contributors have a canonical rule.

Scope strictly limited to `"""..."""` docstring content. Line comments, `warnings.warn` strings, `StatCode` description dicts, `"method": "..."` runtime values, and `refs=(...)` registry tuples were intentionally left bare — they render outside the mkdocs autorefs pipeline.

`uv run mkdocs build --strict` clean.

## Test plan

- [ ] `uv run mkdocs build --strict` clean — no autorefs warnings.
- [ ] Spot-check rendered pages (e.g. `docs/api/metrics/fama_macbeth/`, `docs/api/stats/`) — inline citations resolve to `bibliography.md` anchors.
- [ ] Diff sanity — no `# comment` / `warnings.warn` / `StatCode` / `refs=(...)` runtime strings touched.
- [ ] New `bibliography.md` entries render correctly on the catalog page.

## Notes

- The `fama-1998` role-note phrases the paper as a "defence... against the buy-and-hold abnormal return alternative". Fama (1998) is more evenhanded than "defence" connotes — flagged for #321 (citation accuracy axis), not fixed here to keep this PR a pure form-sweep.
- Bibliography heading style (`Author & Author (Year)` with ampersand) intentionally preserved — separate layer, formal-citation convention. Generalising to hyphenated would be a much larger reformat decision and is out of scope.

Closes #359