### PR TITLE
docs(refs): citation accuracy — Shanken EIV + Fama (1998) framing (#321)

### DIFF
--- a/docs/api/metrics/fama_macbeth.md
+++ b/docs/api/metrics/fama_macbeth.md
@@ -41,7 +41,8 @@ title: factrix.metrics.fama_macbeth
 
     Set `is_estimated_factor=True` (with `factor_return_var=` where the
     factor-mimicking-portfolio return series is available) to apply the
-    Kan-Zhang (1999) single-factor simplification of Shanken (1992) EIV.
+    Shanken (1992) single-factor EIV correction (the multi-factor
+    multiplicative term collapses to $1 + \hat\lambda^2/\sigma^2_f$).
     Required when the Signal column is itself estimated — rolling beta,
     PCA score, ML prediction.
 
@@ -120,7 +121,7 @@ title: factrix.metrics.fama_macbeth
     ---
 
     NW HAC SE, Andrews bandwidth, Hansen-Hodrick overlap floor, and the
-    Kan-Zhang simplification of the Shanken EIV correction.
+    Shanken (1992) single-factor EIV correction.
 
     [reference/statistical-methods →](../../reference/statistical-methods.md)
 

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -207,9 +207,15 @@ when two-way clustering is enabled.
 Shanken, J. (1992). "On the Estimation of Beta-Pricing Models."
 *Review of Financial Studies* 5(1), 1–33.
 
-Errors-in-variables correction for FM stage-2 t when the regressor is
-itself an estimated factor (rolling β, PCA score). Used in `fama_macbeth`
-when `is_estimated_factor=True`.
+Errors-in-variables correction for the Fama-MacBeth stage-2 $t$-stat
+when the stage-1 regressor is itself an estimated quantity (rolling
+$\beta$, PCA score, ML predictor). Used in `fama_macbeth` when
+`is_estimated_factor=True`. The general multi-factor multiplicative
+term $1 + \lambda'\Sigma_f^{-1}\lambda$ collapses to
+$1 + \hat\lambda^2/\sigma^2_f$ in the single-factor case factrix
+implements; factrix's simplification additionally drops the full
+variance's additive $+\sigma^2_f/T$ term and is therefore honest only
+for large $T$.
 
 ### Kan & Zhang (1999)
 [](){ #kan-zhang-1999 }
@@ -217,10 +223,13 @@ when `is_estimated_factor=True`.
 Kan, R. & Zhang, C. (1999). "Two-Pass Tests of Asset Pricing Models
 with Useless Factors." *Journal of Finance* 54(1), 203–235.
 
-Single-factor simplification $\mathrm{SE} \times \sqrt{1 + \hat\lambda^2/\sigma^2_f}$
-of the full Shanken EIV correction; the form factrix actually applies
-(omits the additive $+\sigma^2_f/T$ term and is therefore honest only
-for large $T$).
+Useless-factor diagnostics for two-pass cross-sectional tests: weak
+or unidentified factors yield spuriously significant Fama-MacBeth
+$t$-stats on risk premia even when the factor has no true pricing
+power. Cited from ``fama_macbeth`` as cautionary background on factor
+validity, separate from the errors-in-variables sampling-error
+correction (which is the [Shanken (1992)][shanken-1992] single-factor
+case that factrix's ``is_estimated_factor`` flag implements).
 
 ### Fama & French (1992)
 [](){ #fama-french-1992 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -405,10 +405,14 @@ of the densification convention factrix's sparse-panel CAAR adopts.
 Fama, E. F. (1998). "Market Efficiency, Long-term Returns, and
 Behavioral Finance." *Journal of Financial Economics* 49(3), 283–306.
 
-§2 review and defence of the calendar-time portfolio approach
-against the buy-and-hold abnormal return alternative; cited as the
-modern reference for the densification rationale in
-`_CAARSparsePanelProcedure`.
+Methodological comparison of calendar-time portfolio averaging
+(average abnormal returns / cumulative abnormal returns) against
+buy-and-hold abnormal returns (BHARs), strongly recommending the
+calendar-time approach on the grounds that monthly returns are less
+susceptible to the bad-model problem and that monthly portfolio
+formation automatically absorbs cross-correlations of event-firm
+abnormal returns. Cited as the modern reference for the densification
+rationale in `_CAARSparsePanelProcedure`.
 
 ---
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -84,14 +84,15 @@ For the FM-cell, the NW HAC sits at stage 2
 ([Fama-MacBeth 1973][fama-macbeth-1973]). When the Stage-1 regressor
 is itself an estimated quantity (rolling β, PCA score, ML predictor),
 [`fama_macbeth(is_estimated_factor=True)`](../api/metrics/fama_macbeth.md)
-applies the [Kan-Zhang 1999][kan-zhang-1999] single-factor
-simplification of the [Shanken 1992][shanken-1992] errors-in-variables
-correction, scaling SE by $\sqrt{1 + \hat\lambda^2 / \sigma^2_f}$. The
-full Shanken variance has an additional $+\sigma^2_f / T$ term that
-factrix omits: at finite $T$ the omission **understates** the EIV
-inflation and so **overstates** the resulting $t$. The simplification
-is honest only when $T$ is large enough that the dropped term is
-negligible.
+applies the [Shanken (1992)][shanken-1992] single-factor case of the
+errors-in-variables correction, scaling SE by
+$\sqrt{1 + \hat\lambda^2 / \sigma^2_f}$ (Shanken's general multi-factor
+multiplicative term $1 + \lambda'\Sigma_f^{-1}\lambda$ collapses to
+$1 + \hat\lambda^2 / \sigma^2_f$ when there is one factor). The full
+Shanken variance has an additional $+\sigma^2_f / T$ term that factrix
+omits: at finite $T$ the omission **understates** the EIV inflation
+and so **overstates** the resulting $t$. The simplification is honest
+only when $T$ is large enough that the dropped term is negligible.
 
 When `factor_return_var` is not supplied, factrix falls back to
 $\mathrm{var}(\hat\beta_t)$ as a proxy for $\sigma^2_f$. Because

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -185,10 +185,22 @@ def fama_macbeth(
             estimated, and enabling the correction will spuriously
             deflate $t$-stats.
 
-            Implementation: [Kan-Zhang (1999)][kan-zhang-1999] single-factor simplification
-            — the NW SE is scaled by $\sqrt{1 + \hat\lambda^2/\sigma^2_f}$.
-            This *omits* the additive $+\sigma^2_f/T$ term of the full
-            Shanken variance and is therefore only honest for large $T$.
+            Implementation: [Shanken (1992)][shanken-1992] single-factor
+            special case — the NW SE is scaled by
+            $\sqrt{1 + \hat\lambda^2/\sigma^2_f}$ (Shanken's general
+            multi-factor multiplicative term $1 + \lambda'\Sigma_f^{-1}\lambda$
+            collapses to $1 + \hat\lambda^2/\sigma^2_f$ when there is
+            one factor). factrix's simplification *omits* the additive
+            $+\sigma^2_f/T$ term of the full Shanken variance and is
+            therefore only honest for large $T$.
+
+            Note: ``is_estimated_factor`` corrects the **sampling-error**
+            dimension of using an estimated regressor. A separate failure
+            mode — the estimated factor itself being weak or unidentified
+            — produces its own spuriously-significant FM $t$-stats and is
+            not addressed by this scaling; see
+            [Kan-Zhang (1999)][kan-zhang-1999] for the useless-factor
+            diagnostic literature.
 
         factor_return_var: $\sigma^2_f$, the time-series variance of the
             factor-mimicking portfolio return. Prefer supplying this when
@@ -211,15 +223,15 @@ def fama_macbeth(
         $t = \overline{\beta} / \mathrm{SE}_{\mathrm{NW}}(\beta)$
         with kernel lag
         $L = \max(\lfloor T^{1/3} \rfloor,\, h - 1)$.
-        With ``is_estimated_factor=True``, the Shanken-Kan-Zhang
-        single-factor correction scales SE by
-        $\sqrt{1 + \overline{\beta}^2 / \sigma^2_f}$.
+        With ``is_estimated_factor=True``, the
+        [Shanken (1992)][shanken-1992] single-factor correction scales
+        SE by $\sqrt{1 + \overline{\beta}^2 / \sigma^2_f}$.
 
         factrix uses the [Andrews (1991)][andrews-1991] $T^{1/3}$ bandwidth floored
         against the Hansen-Hodrick overlap horizon rather than the
         [Newey-West (1994)][newey-west-1994] data-adaptive plug-in — simpler, deterministic,
-        and adequate at typical research $T$. The Kan-Zhang simplification
-        omits the additive $+\sigma^2_f / T$ term of full Shanken EIV,
+        and adequate at typical research $T$. factrix's simplification
+        of the Shanken variance omits the additive $+\sigma^2_f / T$ term,
         so the correction is honest only for large $T$.
 
     References:
@@ -243,8 +255,9 @@ def fama_macbeth(
           regressor is itself estimated.
         - [Kan & Zhang (1999)][kan-zhang-1999]. "Two-Pass Tests of Asset
           Pricing Models with Useless Factors." Journal of Finance,
-          54(1), 203–235. Single-factor simplification of the Shanken
-          EIV correction that factrix actually applies.
+          54(1), 203–235. Useless-factor diagnostic; cited as cautionary
+          background on factor validity beyond the EIV inflation that
+          ``is_estimated_factor`` addresses.
 
     Examples:
         Chain from :func:`compute_fm_betas` output:


### PR DESCRIPTION
## Summary

First batch on #321 — addresses the 3 sub-items currently listed in the DoD. The per-paper pass (DoD bullet 1, ~80 entries) is a separate cycle and is **not** closed by this PR.

### 1. Andrews (1991) and the $T^{1/3}$ Bartlett kernel rate — verified, no change

Audit finds factrix's attribution is textbook-correct: Andrews (1991) is the canonical source of the $T^{1/3}$ MSE-optimal rate for the **Bartlett kernel** specifically; higher-order kernels (QS, Parzen) achieve $T^{1/5}$. Newey-West (1987) used a different empirical rule (≈ $T^{2/9}$); NW (1994) is a data-adaptive plug-in whose rate matches Andrews's optimal rate per kernel. The original DoD bullet's claim that $T^{1/3}$ is the NW rule was itself off.

No code edits for this item.

### 2. Kan-Zhang (1999) → Shanken (1992) re-attribution

The $\sqrt{1 + \hat\lambda^2/\sigma^2_f}$ scaling factrix applies under `is_estimated_factor=True` was attributed to Kan-Zhang (1999) across `fama_macbeth.py`, `statistical-methods.md`, the API page, and the bibliography role-note. Kan-Zhang (1999) is the useless-factor / two-pass diagnostics paper and does not contain this correction. The scaling is the **single-factor special case of Shanken (1992)**: the general multi-factor multiplicative term $1 + \lambda'\Sigma_f^{-1}\lambda$ collapses to $1 + \hat\lambda^2/\sigma^2_f$ in the one-factor case.

Changes:
- `fama_macbeth.py` (Args / Notes / References) — re-attribute formula to Shanken (1992); explicitly name the multi-factor → single-factor collapse.
- `statistical-methods.md` — same.
- `docs/api/metrics/fama_macbeth.md` — narrative card bodies aligned with the corrected attribution.
- `bibliography.md` `kan-zhang-1999` role-note — rewrite to describe the paper's actual contribution (useless-factor diagnostics).
- `fama_macbeth.py` `is_estimated_factor` Args — retain a one-line cautionary mention pointing to Kan-Zhang for the *adjacent but distinct* useless-factor failure mode so the bibliography entry isn't orphaned.
- `bibliography.md` `shanken-1992` role-note — expand to document the multi-factor → single-factor collapse and the additive-term omission.

### 3. Fama (1998) "defence" framing — tightened

The `fama-1998` role-note added by #359 referenced "§2" and called the paper a "review and defence" of CTPA. Two adjustments:
- The methodological argument sits across §3 (bad-model problem) and §4, not §2 — drop the imprecise section pointer.
- Replace "defence" with substantive grounds: bad-model robustness of monthly returns + automatic absorption of cross-event-firm correlation in monthly portfolios.

## Test plan

- [x] `uv run mkdocs build --strict` clean — no autorefs / link warnings.
- [x] `/simplify` review (methodological + consistency, 4/4 + 5/5 pass after the API-page fixup).
- [ ] Spot-check rendered pages — `docs/api/metrics/fama_macbeth/`, `docs/reference/statistical-methods/`, `docs/reference/bibliography/#shanken-1992` / `#kan-zhang-1999` / `#fama-1998` — citations and role-notes read as intended.
- [ ] Grep `Kan-Zhang` / `kan-zhang-1999` across the tree returns only the 3 expected sites: cautionary mention in `fama_macbeth.py:202`, References block entry at `fama_macbeth.py:256`, anchor definition at `bibliography.md:221`.

## Notes

- Does **not** close #321 — the per-paper pass across all ~80 bibliography entries is a separate audit cycle (to be picked up after the next content-add batch settles, per the `feedback_audit_after_content_additions` convention).
- A summary comment with evidence links will be posted to #321 after merge.

Refs #321