### PR TITLE
docs(refs): cross-section pricing role-note accuracy (#321)

### DIFF
--- a/docs/development/design-notes.md
+++ b/docs/development/design-notes.md
@@ -107,9 +107,8 @@ market and comparing the returned `FactorProfile`s.
 - The global-vs-local pricing debate is unsettled empirically
   ([Asness-Moskowitz-Pedersen 2013][asness-moskowitz-pedersen-2013]
   argues for substantial commonality; the Fama-French international
-  evidence ([Fama-French 1993][fama-french-1993] and the 2012/2017
-  international tests, the latter not in bibliography) shows local
-  models price local cross-sections better). Either aggregation
+  tests (Fama-French 1998 / 2012 / 2017 — not in bibliography) show
+  local models price local cross-sections better). Either aggregation
   choice would foreclose a research path.
 - Standardisation across markets has industry conventions but no
   canonical academic answer. Picking one inside the library would

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -172,8 +172,15 @@ Black, F., Jensen, M. C. & Scholes, M. (1972). "The Capital Asset
 Pricing Model: Some Empirical Tests." In Jensen, M. (ed.), *Studies
 in the Theory of Capital Markets*. Praeger.
 
-Per-asset time-series β then cross-asset t on E[β]. The
-`common_continuous` cell mirrors this aggregation order.
+Beta-sorted-portfolio time-series test of the zero-beta CAPM:
+sort assets into beta-ranked portfolios, then run a time-series
+regression of each portfolio's excess return on the market. The
+contribution is the time-series-then-cross-section aggregation order
+(per-asset / per-portfolio time series first, then cross-asset
+inspection) that factrix's `common_continuous` cell adopts; the
+`ts_beta` cross-asset t on the mean of per-asset β is a simplified
+analogue of this aggregation order rather than a replication of BJS's
+grouped-portfolio intercept test.
 
 ### Petersen (2009)
 [](){ #petersen-2009 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -132,9 +132,13 @@ underlies the two-step efficient `GMM` ``MomentEstimator``
 Treynor, J. L. & Black, F. (1973). "How to Use Security Analysis to
 Improve Portfolio Selection." *Journal of Business* 46(1), 66–86.
 
-Original derivation of the alpha-vs-residual-risk active-management
-optimisation that yields the $\mathrm{IR} \approx \mathrm{IC} \times \sqrt{\mathrm{breadth}}$ decomposition that
-[Grinold 1989][grinold-1989] later popularised.
+Original derivation of the alpha-over-residual-risk appraisal-ratio
+optimisation for active management — the single-asset appraisal
+ratio that [Grinold (1989)][grinold-1989] later generalised across
+many independent bets to derive the
+$\mathrm{IR} \approx \mathrm{IC} \times \sqrt{\mathrm{breadth}}$
+identity. Conceptual ancestor of the breadth decomposition; the
+identity itself is Grinold's, not Treynor-Black's.
 
 ### Grinold (1989)
 [](){ #grinold-1989 }
@@ -191,8 +195,8 @@ Data Sets: Comparing Approaches." *Review of Financial Studies* 22(1),
 
 Comparison of FM, clustered, and two-way SE under firm/time
 correlation; supports FM + Newey-West as the default for time-effect
-panels and motivates the future clustered-SE extension noted in
-architecture.
+panels and motivates the two-way (date+asset) clustered SE option
+exposed in `pooled_ols` and `factrix.stats.WaldTwoWayCluster`.
 
 ### Cameron, Gelbach & Miller (2011)
 [](){ #cameron-gelbach-miller-2011 }
@@ -201,8 +205,10 @@ Cameron, A. C., Gelbach, J. B. & Miller, D. L. (2011). "Robust
 Inference With Multiway Clustering." *Journal of Business & Economic
 Statistics* 29(2), 238–249.
 
-Two-way clustering formula `V_AB = V_A + V_B − V_{A∩B}`; reference
-for the future date+asset clustered-SE upgrade in `pooled_ols`.
+Two-way clustering formula `V_AB = V_A + V_B − V_{A∩B}`; backs the
+date+asset two-way clustered SE option in `pooled_ols`
+(`two_way_cluster_col`) and the `factrix.stats.WaldTwoWayCluster`
+estimator.
 
 ### Thompson (2011)
 [](){ #thompson-2011 }
@@ -251,8 +257,9 @@ Fama, E. F. & French, K. R. (1992). "The Cross-Section of Expected
 Stock Returns." *Journal of Finance* 47(2), 427–465.
 
 Empirical anchor for size and value as cross-sectional risk premia;
-cited as the canonical example of an `Individual × Continuous` factor
-study in factrix's choosing-metric guide.
+prototypical `Individual × Continuous` factor study in the
+Fama-MacBeth tradition. Catalog-only reference in factrix; no inline
+citation site at present.
 
 ### Fama & French (1993)
 [](){ #fama-french-1993 }
@@ -1005,9 +1012,10 @@ Ambachtsheer, K. P. (1977). "Where Are the Customers' Alphas?"
 *Journal of Portfolio Management* 4(1), 52–56.
 
 Early operational use of IC-based alpha attribution in pension-fund
-performance discussion; the formal $\mathrm{IR} \approx \mathrm{IC} \times \sqrt{\mathrm{breadth}}$
-decomposition itself traces to Treynor & Black (1973) and is
-canonically stated in [Grinold 1989][grinold-1989].
+performance discussion; the appraisal-ratio ancestor of the formal
+$\mathrm{IR} \approx \mathrm{IC} \times \sqrt{\mathrm{breadth}}$
+decomposition is Treynor & Black (1973), and the breadth identity
+itself is canonically derived in [Grinold 1989][grinold-1989].
 
 ---
 

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -268,8 +268,10 @@ Fama, E. F. & French, K. R. (1993). "Common Risk Factors in the
 Returns on Stocks and Bonds." *Journal of Financial Economics*
 33(1), 3–56.
 
-Three-factor model; the prototypical multi-factor spanning baseline
-that `spanning_alpha` evaluates against.
+Three-factor model; prototypical multi-factor spanning baseline of
+the kind that `spanning_alpha` evaluates a candidate factor against.
+Catalog-only reference in factrix; no inline citation site at
+present.
 
 ---
 

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -133,9 +133,10 @@ def compute_ic(
         [Grinold 1989][grinold-1989]:
         $\mathrm{IR} \approx \mathrm{IC} \times \sqrt{\mathrm{breadth}}$
         motivates
-        IC as the canonical signal-quality measure (the formal
-        decomposition is older — see [Treynor-Black
-        1973][treynor-black-1973]).
+        IC as the canonical signal-quality measure. The appraisal-ratio
+        single-asset ancestor is [Treynor-Black
+        1973][treynor-black-1973]; the breadth identity itself is
+        Grinold's generalisation.
 
     Examples:
         >>> import factrix as fx

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -70,8 +70,9 @@ def compute_ts_betas(
         Per asset ``i``, run OLS ``R_{i,t} = alpha_i + beta_i * F_t +
         eps`` over the asset's full sample with homoskedastic SE; emit
         ``beta_i, alpha_i, t_i, R^2_i, n_i``. The output is the
-        per-asset stage feeding the cross-asset Black-Jensen-Scholes
-        style aggregation in ``ts_beta``.
+        per-asset stage feeding the cross-asset aggregation in
+        ``ts_beta`` (time-series-then-cross-section order in the
+        Black-Jensen-Scholes (BJS) tradition).
 
         factrix reports homoskedastic per-asset t (not Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC)) at this
         stage because the inferential burden lives downstream — the
@@ -80,9 +81,13 @@ def compute_ts_betas(
         per-asset diagnostic without affecting stage-2 inference.
 
     References:
-        [Black-Jensen-Scholes 1972][black-jensen-scholes-1972]: per-
-        asset time-series beta then cross-asset aggregation; the
-        order this two-stage path mirrors.
+        [Black-Jensen-Scholes 1972][black-jensen-scholes-1972]:
+        beta-sorted-portfolio time-series CAPM tests; the two-stage
+        time-series-then-cross-section aggregation order is what
+        ``ts_beta`` adopts. The cross-asset t on mean β here is a
+        simplified analogue of that aggregation order, not a
+        replication of the original BJS grouped-portfolio intercept
+        test.
 
     Examples:
         >>> import factrix as fx
@@ -216,7 +221,7 @@ def ts_beta(ts_betas_df: pl.DataFrame) -> MetricOutput:
     Uses the cross-sectional distribution of per-asset betas.
 
     Notes:
-        Stage 2 of the BJS aggregation:
+        Stage 2 of the BJS-style aggregation order:
         $\overline{\beta} = \mathrm{mean}_i \beta_i$;
         $t = \overline{\beta} / (\mathrm{std}(\beta) / \sqrt{N})$
         with $H_0: \mathbb{E}[\beta] = 0$ across assets. The std is the
@@ -229,8 +234,11 @@ def ts_beta(ts_betas_df: pl.DataFrame) -> MetricOutput:
         latent common factor links them.
 
     References:
-        [Black-Jensen-Scholes 1972][black-jensen-scholes-1972]: the
-        cross-asset t on E[beta] this function implements.
+        [Black-Jensen-Scholes 1972][black-jensen-scholes-1972]:
+        beta-sorted-portfolio time-series CAPM tests. factrix's
+        cross-asset t on mean β is a simplified analogue of the BJS
+        aggregation order, not a replication of the grouped-portfolio
+        intercept test BJS run on assets sorted into beta deciles.
 
     Examples:
         Chain from :func:`compute_ts_betas` output:


### PR DESCRIPTION
## Summary

Continuation of #321's per-paper accuracy audit. Walks the "Cross-section and panel pricing" entries of `docs/reference/bibliography.md` (twelve entries). Two methodological misattributions corrected, four precision drifts tightened, and six entries verified accurate against source papers.

### Methodological corrections

**Black-Jensen-Scholes (1972).** Bibliography role-note + `ts_beta` docstrings credited BJS for a "per-asset time-series β → cross-asset t on E[β]" procedure. BJS actually run beta-sorted grouped-portfolio time-series CAPM tests; their contribution is the time-series-then-cross-section aggregation *order*, not the cross-asset t-test on the mean of per-asset betas. Reframe `ts_beta` as a *simplified analogue* of the BJS aggregation order rather than a replication.

**Fama-French (1993).** `docs/development/design-notes.md:107-111` cited FF (1993) as part of "the Fama-French international evidence". FF (1993) is a US-only study of stocks and bonds; the international Fama-French tests are FF (1998) / FF (2012) / FF (2017), none currently in the bibliography. Drop the FF93 anchor at this site and refer to the international tests by year without a link.

### Precision drifts

**Treynor-Black (1973).** Bibliography role-note + `ic.py` `compute_ic` References implied TB derived the IR ≈ IC × √breadth identity. TB derived the single-asset appraisal-ratio optimisation; the breadth identity itself is Grinold (1989)'s generalisation. Same fix applied to the cross-reference in `ambachtsheer-1977`.

**Cameron-Gelbach-Miller (2011) + Petersen (2009).** Both role-notes described two-way (date+asset) clustered SE as a "future upgrade". That extension shipped: `pooled_ols(two_way_cluster_col=...)` and `factrix.stats.WaldTwoWayCluster` are public APIs. Update both to describe the current call sites.

**Fama-French (1992) + Fama-French (1993).** Both role-notes claimed call sites (FF92 in `choosing-metric` guide, FF93 in `spanning_alpha`) that grep proves do not exist. Drop the unsupported claims and mark catalog-only. Adding the inline citations is a content-add, out of scope for the accuracy audit.

### Verified accurate, no edits needed

Grinold (1989), Grinold & Kahn (2000), Fama-MacBeth (1973), Petersen (2009) *primary claim*, Shanken (1992) *post-PR #362*, Kan-Zhang (1999) *post-PR #362*.

### Non-blocking observation (deferred)

`thompson-2011` role-note attributes `df = min(G_A, G_B) − 1` finite-sample df rule to Thompson (2011). The formula is widely attributed to Thompson in software docs but the audit could not independently verify the specific section pointer from public sources. Method is sound; future tightening could either add the section number or soften the attribution wording. Left as-is.

## Test plan

- [x] `uv run mkdocs build --strict` clean — no autorefs / link warnings.
- [x] Independent correctness + consistency review — Treynor-Black appraisal-ratio vs Grinold breadth identity story consistent across catalog + `ic.py` + `ambachtsheer-1977`; BJS framing aligned across catalog + `ts_beta.py`; two-way cluster role-notes match the actual public API at `factrix.stats.__init__`; mkdocs build clean.
- [ ] Spot-check rendered pages — Treynor-Black + Grinold + Ambachtsheer entries on `docs/reference/bibliography/` read as one coherent story; `ts_beta` API page describes the BJS aggregation order without implying replication of the grouped-portfolio test.

## Notes

- Does **not** close #321 — the cross-section pricing entries are one of nine bibliography sections; the per-paper accuracy audit closes when every section has been walked at least once.
- A per-section audit comment will be posted to #321 after merge.

Refs #321