### PR TITLE
docs(refs): event-study role-note accuracy (#321)

### DIFF
--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -370,8 +370,10 @@ of the Sign Test in Event Study Hypothesis Tests Using Daily Stock
 Returns." *Journal of Financial and Quantitative Analysis* 27(3),
 465–478.
 
-Sign-test variant of the Corrado rank test; cited as the source of
-the direction-adjustment idea adopted by `corrado_rank_test`.
+Sign test for event-study abnormal returns and a modified rank-test
+variant for two-sided / cumulative inference (re-rank within the
+event window); cited as the source of the direction-adjustment idea
+adopted by `corrado_rank_test`.
 
 ### Kolari & Pynnönen (2010)
 [](){ #kolari-pynnonen-2010 }
@@ -380,10 +382,12 @@ Kolari, J. W. & Pynnönen, S. (2010). "Event Study Testing with
 Cross-sectional Correlation of Abnormal Returns." *Review of
 Financial Studies* 23(11), 3996–4025.
 
-Clustering-adjusted BMP variant; `EventConfig.adjust_clustering=
-'kolari_pynnonen'` is reserved for this but the adjustment is not
-yet implemented (high-Herfindahl-Hirschman index (HHI) events should fall back to manual
-calendar-block bootstrap until it ships).
+Clustering-adjusted BMP variant; implemented as
+`bmp_test(kolari_pynnonen_adjust=True)`, which scales the BMP $z$ by
+$\sqrt{(1 - \hat r)/(1 + (N_{\mathrm{eff}}-1)\,\hat r)}$ to absorb
+same-date abnormal-return cross-correlation. Recommended when the
+`clustering_hhi` diagnostic flags high event-date concentration
+(`hhi ≥ 0.3`).
 
 ### Sefcik & Thompson (1986)
 [](){ #sefcik-thompson-1986 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -327,8 +327,7 @@ Campbell, J. Y., Lo, A. W. & MacKinlay, A. C. (1997). *The
 Econometrics of Financial Markets*. Princeton University Press.
 
 Textbook treatment of event-study test statistics; cited from
-`mfe_mae` for the path-excursion vocabulary and elsewhere as a
-general econometrics reference.
+`mfe_mae` for the path-excursion / horizon-scaling vocabulary.
 
 ### Boehmer, Musumeci & Poulsen (1991)
 [](){ #boehmer-musumeci-poulsen-1991 }
@@ -338,9 +337,12 @@ Methodology Under Conditions of Event-induced Variance." *Journal of
 Financial Economics* 30(2), 253–272.
 
 BMP standardised AR test. factrix's `bmp_test` is a **BMP-style**
-simplification: it uses mean-adjusted abnormal returns and omits the
-prediction-error correction of the original BMP formulation, so
-results will not match a textbook BMP implementation byte-for-byte.
+implementation using mean-adjusted (not market-model) abnormal
+returns; the prediction-error variance correction
+$\sigma_i \sqrt{1 + 1/T_{\mathrm{est}}}$ of the original BMP
+formulation is opt-in via `include_prediction_error_variance=True`
+and off by default, so default-setting results will not match a
+textbook BMP byte-for-byte.
 
 ### Patell (1976)
 [](){ #patell-1976 }
@@ -409,11 +411,14 @@ distinct from the equal-weighted MacKinlay-style CAAR.
 Jaffe, J. F. (1974). "Special Information and Insider Trading."
 *Journal of Business* 47(3), 410–428.
 
-Calendar-time portfolio approach to event studies; densifying the
-event-indexed return series to a dense calendar grid (zero-fill on
-non-event dates) so HAC-style inference can assume a fixed period
-between observations. Cited from `_CAARSparsePanelProcedure` as the
-historical anchor for factrix's dense-calendar CAAR HAC t-test.
+Calendar-time portfolio approach to event studies — recasts
+event-indexed inference onto a calendar grid by forming each
+calendar period's portfolio of all firms with a recent event and
+analysing portfolio returns. Cited from `_CAARSparsePanelProcedure`
+as the historical anchor for factrix's dense-calendar CAAR HAC
+t-test, which adapts the calendar-time idea by zero-filling
+non-event dates on the per-event series rather than forming a
+calendar-period portfolio across event firms.
 
 ### Mandelker (1974)
 [](){ #mandelker-1974 }
@@ -421,9 +426,12 @@ historical anchor for factrix's dense-calendar CAAR HAC t-test.
 Mandelker, G. (1974). "Risk and Return: The Case of Merging Firms."
 *Journal of Financial Economics* 1(4), 303–335.
 
-Independent contemporaneous application of the calendar-time
-portfolio approach; cited alongside Jaffe (1974) as the joint origin
-of the densification convention factrix's sparse-panel CAAR adopts.
+Independent contemporaneous calendar-time portfolio paper; cited
+alongside Jaffe (1974) as the joint origin of the calendar-time
+inference idea that factrix's sparse-panel CAAR adapts (factrix's
+zero-fill densification on the per-event series is a related but
+distinct operation from the original cross-event calendar-portfolio
+construction).
 
 ### Fama (1998)
 [](){ #fama-1998 }

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -393,8 +393,8 @@ def bmp_test(
         - [Kolari & Pynnönen (2010)][kolari-pynnonen-2010]. "Event Study
           Testing with Cross-sectional Correlation of Abnormal Returns."
           Review of Financial Studies, 23(11), 3996–4025. Clustering-
-          adjusted BMP variant referenced by ``EventConfig.adjust_clustering``
-          (not yet implemented).
+          adjusted BMP variant; enabled via
+          ``kolari_pynnonen_adjust=True`` on this function.
 
     Examples:
         >>> import factrix as fx


### PR DESCRIPTION
## Summary

Continuation of #321's per-paper accuracy audit. Walks the "Event study" entries of `docs/reference/bibliography.md` (fourteen entries — eleven original + the three calendar-time additions from #359). Two methodological misattributions corrected, three precision drifts tightened, and nine entries verified accurate.

### Methodological corrections

**Corrado & Zivney (1992).** Role-note framed the paper as a "sign-test variant of the Corrado rank test". The paper's primary contribution is the sign test on event-window abnormal returns, with a re-ranking modification of the Corrado rank test for two-sided / cumulative inference as the secondary result — not a "variant of" the rank test. Rewrite to name both contributions correctly while preserving the role-note's direction-adjustment lineage statement.

**Kolari & Pynnönen (2010).** Role-note said the clustering-adjusted BMP variant was "not yet implemented" and pointed at a non-existent `EventConfig.adjust_clustering='kolari_pynnonen'` field. The adjustment ships as `bmp_test(kolari_pynnonen_adjust=True)`. Update catalog role-note + matching `References:` block entry in `factrix/metrics/caar.py` to point at the actual API.

### Precision drifts

**Campbell, Lo & MacKinlay (1997).** "Cited from `mfe_mae` for the path-excursion vocabulary and elsewhere as a general econometrics reference" — grep finds only the `mfe_mae` site. Drop the unsupported "elsewhere" claim and name the actual call site precisely.

**Boehmer, Musumeci & Poulsen (1991).** Role-note said factrix "omits the prediction-error correction of the original BMP formulation". Since `include_prediction_error_variance=True` shipped on `bmp_test`, the correction is opt-in rather than absent. Rewrite to name the flag and clarify the default-off → default-result-differs reasoning.

**Jaffe (1974) + Mandelker (1974).** Both role-notes equated their calendar-time portfolio construction with factrix's zero-fill densification. The operations share the goal (recast event-indexed inference onto a calendar grid) but differ structurally — Jaffe / Mandelker form a calendar-period portfolio across event firms, while factrix zero-fills the per-event series so HAC sees fixed period spacing. Frame factrix's path as an *adaptation* of the calendar-time idea.

### Verified accurate, no edits needed

Brown & Warner (1985), Brown & Warner (1980), Fama-Fisher-Jensen-Roll (1969), MacKinlay (1997), Patell (1976), Corrado (1989), Sefcik & Thompson (1986), Fama (1998) post-#362.

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] Independent correctness + consistency review — both new role-notes match the actual `bmp_test` API (`kolari_pynnonen_adjust=True`, `include_prediction_error_variance=True`); no stale `EventConfig.adjust_clustering` residue outside `docs/plans/archive/`; CLM scope tightening verified against the single grep hit at `mfe_mae.py`; Jaffe + Mandelker both frame factrix as adaptation.
- [ ] Spot-check rendered pages — `docs/reference/bibliography/#corrado-zivney-1992`, `#kolari-pynnonen-2010`, `#jaffe-1974`, `#mandelker-1974` read consistently with the corrected attributions.

## Notes

- Does **not** close #321 — six of nine bibliography sections still pending.
- A per-section audit comment will be posted to #321 after merge.

Refs #321