### PR TITLE
docs(refs): multiple-testing role-note accuracy (#321)

### DIFF
--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -508,10 +508,13 @@ Multiple Families of Hypotheses." *Journal of the Royal Statistical
 Society: Series B* 76(1), 297–318.
 
 Selective-inference framework for partitioning a hypothesis set into
-independent families with per-family FDR control; underlies the
-explicit ``expand_over`` per-bucket step-up convention in
-`multi_factor.bhy` (per-bucket adjusted p-values, no global
-cross-bucket adjustment).
+families and controlling FDR per family. The paper's recommended
+form inflates the within-family level by `R/m` (the fraction of
+families flagged by an outer selection step); factrix's
+``expand_over`` adopts the family-partition idea but applies plain
+per-bucket BHY without the BB14 selection-adjusted inflation —
+cross-bucket selection-bias control is the caller's responsibility
+(e.g. via `bhy_hierarchical`'s hierarchical procedure).
 
 ### Harvey, Liu & Zhu (2016)
 [](){ #harvey-liu-zhu-2016 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -522,12 +522,15 @@ cross-bucket selection-bias control is the caller's responsibility
 Harvey, C. R., Liu, Y. & Zhu, H. (2016). "…and the Cross-Section of
 Expected Returns." *Review of Financial Studies* 29(1), 5–68.
 
-Empirical case for raising t-thresholds in factor research; backs
-the single-factor `t ≥ 2.0` threshold and the BHY-first multi-factor
-discipline in `greedy_forward_selection`, and the family-wise error rate (FWER)-across-horizons
-∘ FDR-within-horizon discipline at `factrix.multi_factor.bhy` and the
-"Horizon-shopping correction" section of
-`docs/guides/batch-screening.md`.
+Empirical case that conventional single-factor `t ≥ 2.0` is too lax
+once the cross-section of tried factors and horizons is accounted
+for; HLZ argues a meaningfully higher threshold (typically `t ≳ 3`)
+under multiplicity-aware procedures. Cited as motivation for
+factrix's BHY-first multi-factor discipline in
+`greedy_forward_selection` and the family-wise error rate (FWER)-
+across-horizons ∘ FDR-within-horizon discipline at
+`factrix.multi_factor.bhy` and the "Horizon-shopping correction"
+section of `docs/guides/batch-screening.md`.
 
 ### Harvey (2017)
 [](){ #harvey-2017 }
@@ -544,8 +547,10 @@ factrix's pre-registered procedures and BHY-first stance.
 Harvey, C. R. & Liu, Y. (2020). "False (and Missed) Discoveries in
 Financial Economics." *Journal of Finance* 75(5), 2503–2553.
 
-FDR-adjusted t-thresholds for asset-pricing tests; complements
-Harvey-Liu-Zhu (2016).
+Double-bootstrap procedure that jointly calibrates Type I (FDR) and
+Type II (miss-rate) error in asset-pricing multiple tests; the
+"missed-discovery" axis complements Harvey-Liu-Zhu (2016)'s
+Type-I-only focus by adding power-aware hurdles.
 
 ### Holm (1979)
 [](){ #holm-1979 }
@@ -613,8 +618,11 @@ alongside Berk et al. (2013).
 Efron, B. (2010). *Large-Scale Inference: Empirical Bayes Methods
 for Estimation, Testing, and Prediction*. Cambridge University Press.
 
-Empirical-Bayes alternative to FDR; cited in design notes as the
-"why not Bayesian" comparison anchor.
+Empirical-Bayes alternative to FDR for large-scale multiple testing;
+reference work on local-fdr and shrinkage estimation as the
+empirical-Bayes counterpart to factrix's frequentist BHY stance.
+Catalog-only reference in factrix; no inline citation site at
+present.
 
 ### Bailey & López de Prado (2014)
 [](){ #bailey-lopez-de-prado-2014 }

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -7,7 +7,9 @@ v0.4 ``redundancy_matrix`` / ``spanning`` modules.
 
 Family declaration is now explicit: the input list ``profiles`` *is*
 the family, optionally split per-bucket via ``expand_over``
-([Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014] selective-inference framework). The previous
+(family-partition idea from [Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014];
+factrix applies plain per-bucket BHY without BB14's selection-
+adjusted within-family level — see catalog role-note). The previous
 auto-partition by dispatch cell × forward horizon was retired in #161 —
 caller responsibility now, both because the implicit policy was opaque
 and because ``identity`` already encodes ``forward_periods`` (and would
@@ -52,8 +54,10 @@ class Survivors:
         ``len(profiles) == len(adj_p)`` and entries align in input
         order. Per-bucket independent step-up uses bucket-local ``n``
         and ``p_array``; ``adj_p[i]`` reflects ``profiles[i]``'s own
-        bucket only ([Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014] selective inference),
-        not a global cross-bucket adjustment.
+        bucket only (family-partition idea from
+        [Benjamini-Bogomolov (2014)][benjamini-bogomolov-2014];
+        factrix does not apply BB14's selection-adjusted within-
+        family level inflation), not a global cross-bucket adjustment.
 
     Attributes:
         profiles: Survivors in input order.


### PR DESCRIPTION
## Summary

Continuation of #321's per-paper accuracy audit. Walks the "Multiple-testing correction and selection inference" entries of `docs/reference/bibliography.md` (seventeen entries). One methodological misattribution corrected, three precision drifts tightened, thirteen entries verified accurate.

### Methodological correction

**Benjamini & Bogomolov (2014).** Catalog role-note added by #359 and two `_multi_factor.py` docstring sites implied BB14 endorses factrix's `expand_over` per-bucket plain-BHY convention. BB14's recommended construction inflates the within-family level by `R/m` (the fraction of families flagged by an outer selection step); factrix applies plain per-bucket BHY without that inflation. Rewrite to frame the family-partition idea as the BB14 contribution factrix adopts, and explicitly state factrix does NOT apply BB14's within-family level inflation — cross-bucket selection-bias control directed to `bhy_hierarchical` instead.

(The third BB14 cite at `_multi_factor.py:414` cites the paper for the *problem statement* — "naive set intersection does not preserve FDR" — and is accurate as-is.)

### Precision drifts

**Harvey, Liu & Zhu (2016).** Role-note said HLZ "backs the single-factor `t ≥ 2.0` threshold". HLZ argues the opposite — `t ≥ 2.0` is too lax under realistic multiplicity, with a higher threshold (typically `t ≳ 3`) warranted under multiplicity-aware procedures. Rewrite to name HLZ's actual position.

**Harvey & Liu (2020).** Role-note "FDR-adjusted t-thresholds for asset-pricing tests" understates the paper. HL2020's contribution is a double-bootstrap that *jointly* calibrates Type I (FDR) and Type II (miss-rate) error — the "False (and Missed) Discoveries" title points at the Type-II axis as the novel complement to HLZ's Type-I focus. Rewrite to name the double-bootstrap and the miss-rate axis.

**Efron (2010).** Role-note claimed the book is "cited in design notes as the 'why not Bayesian' comparison anchor" — grep finds no inline citation anywhere in factrix or docs. Same orphan-call-site pattern as `fama-french-1992` / `fama-french-1993` earlier in the audit. Drop the unsupported claim and mark catalog-only.

### Verified accurate, no edits needed

Benjamini-Hochberg (1995), Benjamini-Yekutieli (2001), Simes (1986), Benjamini-Heller (2008), Yekutieli (2008), Harvey (2017), Holm (1979), Romano-Wolf (2005), White (2000), Hansen (2005), Berk-Brown-Buja-Zhang-Zhao (2013), Leeb-Pötscher (2005), Bailey-López de Prado (2014).

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] Methodological review — BB14 R/m inflation rule vs factrix's plain per-bucket BHY divergence is now explicit at catalog + `_multi_factor.py` module docstring + `Survivors.adj_p` invariant. HLZ inversion and HL2020 understatement corrected against the source papers (verified via SSRN abstracts + JoF DOI).
- [ ] Spot-check rendered pages — bibliography entries for the four corrected anchors read consistently with the per-paper audit findings.

## Notes

- Does **not** close #321 — five of nine bibliography sections still pending.
- A per-section audit comment will be posted to #321 after merge.

Refs #321