### PR TITLE
fix(docs): scope sidebar active style; soften TOC active (#360)

### DIFF
--- a/docs/stylesheets/nav.css
+++ b/docs/stylesheets/nav.css
@@ -19,10 +19,12 @@
 }
 
 /* Stronger active-page highlight than Material's default (text-tint only is
- * easy to miss on a long nav list).
+ * easy to miss on a long nav list). Scoped to the primary sidebar so the
+ * secondary TOC (right-side, in-page headings) keeps a lighter treatment —
+ * the filled-block style swallows the TOC item's text node (#360).
  */
-.md-nav__item--active > .md-nav__link--active,
-.md-nav__link--active {
+.md-nav--primary .md-nav__item--active > .md-nav__link--active,
+.md-nav--primary .md-nav__link--active {
   font-weight: 700;
   background: var(--md-primary-fg-color);
   color: #fff;
@@ -31,9 +33,24 @@
   position: static;
 }
 
-[data-md-color-scheme="slate"] .md-nav__item--active > .md-nav__link--active,
-[data-md-color-scheme="slate"] .md-nav__link--active {
+[data-md-color-scheme="slate"] .md-nav--primary .md-nav__item--active > .md-nav__link--active,
+[data-md-color-scheme="slate"] .md-nav--primary .md-nav__link--active {
   background: var(--md-primary-fg-color--light);
   color: #fff;
   box-shadow: inset 0.2rem 0 0 var(--md-primary-fg-color);
+}
+
+/* Secondary TOC (right-side, in-page headings): use a tinted-text + left-border
+ * accent. Keeps the heading text readable while still distinguishing the
+ * currently-in-view section from inactive entries.
+ */
+.md-nav--secondary .md-nav__link--active {
+  font-weight: 700;
+  color: var(--md-primary-fg-color);
+  box-shadow: inset 0.15rem 0 0 var(--md-primary-fg-color);
+}
+
+[data-md-color-scheme="slate"] .md-nav--secondary .md-nav__link--active {
+  color: var(--md-primary-fg-color--light);
+  box-shadow: inset 0.15rem 0 0 var(--md-primary-fg-color--light);
 }


### PR DESCRIPTION
## Summary
- `.md-nav__link--active` from #345 was unscoped, so the right-side TOC's active heading inherited the filled-indigo + white-text treatment and rendered as a solid block with the heading text effectively hidden.
- Scope the filled style to `.md-nav--primary`; give `.md-nav--secondary` a lighter accent (tinted text + 0.15rem left-border via `inset box-shadow`) in both light and slate schemes.

Closes #360. Refs #345.

## Test plan
- [ ] `mkdocs build --strict` passes
- [ ] Primary sidebar active state across User guide / Concepts / Reference looks identical to before (filled indigo + white text)
- [ ] Right-side TOC active heading shows readable text + left-border accent in light scheme
- [ ] Same in slate scheme
- [ ] Hover state unchanged on both surfaces