### PR TITLE
docs(refs): unit-root attribution chain + status-note cleanup (#321)

### DIFF
--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -785,9 +785,10 @@ than auto-correcting.
 Campbell, J. Y. & Yogo, M. (2006). "Efficient Tests of Stock Return
 Predictability." *Journal of Financial Economics* 81(1), 27–60.
 
-Bonferroni Q-test for predictive regressions under near-unit-root
-predictors; cited as the proper-inference alternative factrix does
-not implement.
+Bonferroni Q-test built on a DF-GLS confidence interval for the
+persistence parameter; a corrective-inference alternative to
+flag-only diagnostics for predictive regressions under near-unit-root
+predictors.
 
 ### Phillips & Magdalinos (2009)
 [](){ #phillips-magdalinos-2009 }
@@ -796,8 +797,11 @@ Phillips, P. C. B. & Magdalinos, T. (2009). "Econometric Inference
 in the Vicinity of Unity." Working paper, Singapore Management
 University.
 
-IVX predictive regression; foundation for the Kostakis et al. (2015)
-implementation that factrix does not include.
+Introduces IVX: mildly-integrated internal instruments yielding
+pivotal chi-square inference for predictive regression across
+integrated, near-integrated, and mildly-integrated regressors. The
+theoretical foundation for the Kostakis-Magdalinos-Stamatogiannis
+(2015) empirical implementation.
 
 ### Kostakis, Magdalinos & Stamatogiannis (2015)
 [](){ #kostakis-magdalinos-stamatogiannis-2015 }
@@ -806,8 +810,12 @@ Kostakis, A., Magdalinos, T. & Stamatogiannis, M. P. (2015). "Robust
 Econometric Inference for Stock Return Predictability." *Review of
 Financial Studies* 28(5), 1506–1553.
 
-Practical IVX implementation cited as background for the
-predictive-regression bias factrix flags but does not auto-correct.
+Empirical IVX-Wald test for stock-return predictability robust to
+regressor persistence (stationary through nonstationary), supporting
+multivariate and long-horizon predictive specifications; the
+practical complement to [Phillips-Magdalinos
+(2009)][phillips-magdalinos-2009] on the inference axis adjacent to
+factrix's ADF persistence flag.
 
 ### Richardson & Stock (1989)
 [](){ #richardson-stock-1989 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -735,9 +735,12 @@ Dickey, D. A. & Fuller, W. A. (1979). "Distribution of the Estimators
 for Autoregressive Time Series with a Unit Root." *Journal of the
 American Statistical Association* 74(366), 427–431.
 
-Augmented Dickey-Fuller (ADF) test on $H_0: \beta = 0$ in
-$\Delta y_t = \alpha + \beta\, y_{t-1} + \varepsilon$; the basis of
-factrix's ADF persistence diagnostic.
+Dickey-Fuller unit-root test on $H_0: \beta = 0$ in
+$\Delta y_t = \alpha + \beta\, y_{t-1} + \varepsilon$; the foundational
+unit-root null underlying factrix's ADF persistence diagnostic. The
+*augmented* form factrix actually applies (lagged differences added
+to whiten serially-correlated errors) is [Said-Dickey
+(1984)][said-dickey-1984], not this 1979 paper.
 
 ### Said & Dickey (1984)
 [](){ #said-dickey-1984 }
@@ -746,8 +749,12 @@ Said, S. E. & Dickey, D. A. (1984). "Testing for Unit Roots in
 Autoregressive-Moving Average Models of Unknown Order." *Biometrika*
 71(3), 599–607.
 
-ADF extension to ARMA errors; cited as background for the lag
-selection inside factrix's ADF persistence diagnostic.
+Approximates ARMA errors by a long autoregression and proves the
+Dickey-Fuller $t$-statistic retains its limit distribution at
+lag-order rate $o(T^{1/3})$. Justifies the augmentation form that
+factrix's ADF persistence diagnostic relies on; concrete data-driven
+lag-selection rules (AIC / BIC / Ng-Perron) sit in a separate
+literature.
 
 ### MacKinnon (1996)
 [](){ #mackinnon-1996 }
@@ -766,8 +773,11 @@ ADF statistic to a p-value.
 Stambaugh, R. F. (1999). "Predictive Regressions." *Journal of
 Financial Economics* 54(3), 375–421.
 
-Bias of ordinary least squares (OLS) $\hat\beta$ in predictive regressions when the predictor is
-persistent; factrix flags via ADF rather than auto-correcting.
+Finite-sample bias of ordinary least squares (OLS) $\hat\beta$ in
+predictive regressions when the predictor is persistent *and* its
+innovation is correlated with the return innovation (both conditions
+are necessary); factrix flags the persistence channel via ADF rather
+than auto-correcting.
 
 ### Campbell & Yogo (2006)
 [](){ #campbell-yogo-2006 }
@@ -806,8 +816,14 @@ Richardson, M. & Stock, J. H. (1989). "Drawing Inferences from
 Statistics Based on Multiyear Asset Returns." *Journal of Financial
 Economics* 25(2), 323–348.
 
-Asymptotic theory for overlapping multiyear returns; cited as
-background for the Hansen-Hodrick lag floor.
+Alternative asymptotic theory for overlapping multiyear-return
+statistics under a horizon-grows-with-sample limit, where
+conventional asymptotics misrepresent the finite-sample distribution
+of long-horizon predictive coefficients. The limit-theory backstop
+for the HAC and sub-sampling fixes factrix applies on long-horizon
+paths (the sub-sampling / lag-floor *remedies* themselves trace to
+[Hansen-Hodrick (1980)][hansen-hodrick-1980] and the broader HAC
+literature, not to this paper).
 
 ### Stock & Watson (1988)
 [](){ #stock-watson-1988 }

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -111,8 +111,9 @@ def _sample_non_overlapping(
     returns share h−1 bars of future data — the series has an MA(h−1)
     structure ([Hansen-Hodrick (1980)][hansen-hodrick-1980]). Sub-sampling at
     interval h breaks this dependence at the cost of throwing away h−1 of
-    every h observations. This is the most conservative of the
-    [Richardson-Stock (1989)][richardson-stock-1989] remedies;
+    every h observations. This is the most conservative overlap-aware
+    path on the long-horizon limit theory documented by
+    [Richardson-Stock (1989)][richardson-stock-1989];
     ``_newey_west_t_test`` is the less-lossy
     alternative (keeps all obs but corrects SE).
 

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -52,10 +52,15 @@ def ic_trend(
             beta_trend pass their own names so method / cache key /
             primitive name stay three-point unified.
         adf_threshold: Augmented Dickey-Fuller (ADF) p-value above which the input is flagged as
-            unit-root suspect. Default ``0.10`` matches the conventional
-            [Stock-Watson (1988)][stock-watson-1988] cutoff: at p > 0.10 we cannot reject
-            I(1), so ordinary least squares (OLS) / Theil-Sen on the series reject the slope null
-            at inflated rates regardless of the true trend. When
+            unit-root suspect. Default ``0.10`` is a conventional
+            practitioner cutoff from the unit-root literature (folklore
+            on the back of [Stock-Watson (1988)][stock-watson-1988]'s
+            broader review of trends in macroeconomic time series, with
+            the specific 10% threshold closer to Stock 1994 *Handbook of
+            Econometrics* §III than a direct prescription of the 1988
+            paper): at p > 0.10 we cannot reject I(1), so ordinary least
+            squares (OLS) / Theil-Sen on the series reject the slope
+            null at inflated rates regardless of the true trend. When
             ``None``, the ADF check is skipped entirely and no
             ``adf_stat`` / ``adf_p`` / ``unit_root_suspected`` keys are
             written. When a float is provided it must lie in (0, 1).


### PR DESCRIPTION
## Summary

Per-paper accuracy audit walks the "Unit-root, predictive regression, and persistence" entries of `docs/reference/bibliography.md`. Four methodological corrections, one precision tightening, three layer-policy enforcements landed; three entries verified accurate.

### Methodological corrections

**Dickey & Fuller (1979).** Role-note called the 1979 paper the "Augmented Dickey-Fuller (ADF) test". DF (1979) is the *non*-augmented unit-root test; the augmentation (lagged differences) is Said-Dickey (1984), which factrix actually applies. Re-attribute.

**Stambaugh (1999).** Role-note named only predictor persistence as the bias condition. Stambaugh's bias requires both persistence AND correlation between the predictor innovation and the return innovation; the innovation correlation is essential. Add the missing necessary condition.

**Richardson & Stock (1989).** Role-note + `_helpers.py:115` docstring both implied RS (1989) supplies a menu of "remedies" with sub-sampling being the most conservative. RS (1989) provides the *alternative asymptotic theory* under horizon-grows-with-sample; the sub-sampling and HAC remedies themselves trace to Hansen-Hodrick (1980) and the broader HAC literature. Reframe both sites.

**Stock & Watson (1988).** Code docstring at `factrix/metrics/trend.py:54-56` claimed factrix's default `adf_threshold = 0.10` "matches the conventional Stock-Watson (1988) cutoff". The bibliography role-note (post-#368) already states honestly that the threshold is folklore, not an SW88 prescription. Bring the docstring in line with the catalog.

### Precision tightening

**Said & Dickey (1984).** Role-note attributed "lag selection" to the paper. Said-Dickey gives the lag-order *rate condition* `o(T^(1/3))` that justifies the augmentation; concrete data-driven lag selection (AIC / BIC / Ng-Perron) is a separate literature. Tighten wording.

### Layer-policy enforcement

Three role-notes retained "factrix does not implement / include / auto-correct" status notes past the #368 retrofit. Status-note framing is prohibited because status flips silently when the procedure ships and the role-note then drifts into a lie. Reframe each at the conceptual layer:

- **Campbell & Yogo (2006)** — Bonferroni Q-test on a DF-GLS confidence interval for the persistence parameter; corrective-inference alternative to flag-only diagnostics.
- **Phillips & Magdalinos (2009)** — IVX as mildly-integrated internal instruments yielding pivotal chi-square inference; KMS (2015) as the empirical complement rather than as "what factrix does not include".
- **Kostakis, Magdalinos & Stamatogiannis (2015)** — empirical IVX-Wald test with persistence robustness; on the inference axis adjacent to factrix's ADF flag, without negative-status framing.

### Verified accurate, no edits needed

MacKinnon (1996), Fama & French (1988) (recently retrofitted, holds), Boudoukh-Richardson-Whitelaw (2008) (recently retrofitted, holds).

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] DF / Said-Dickey lineage: catalog now correctly attributes augmentation to Said-Dickey (1984).
- [x] Richardson-Stock: catalog credits RS (1989) for limit theory (not remedies); `_helpers.py:115` docstring matches.
- [x] Stock-Watson: `trend.py:54-56` matches catalog's honest "folklore" framing.
- [x] No remaining status notes in changed predictive-regression entries.

## Notes

- Three "does not" instances remain at unrelated sites (`bibliography.md:459, 590, 995` — BH-FDR, SPA, and a spanning entry) and will be handled by their respective per-section audit passes.
- Does **not** close #321 — three bibliography sections still pending (Factor zoo / Factor spanning / Methodology critique).

Refs #321