### PR TITLE
docs(refs): factor-zoo and OOS-decay attribution drift (#321)

### DIFF
--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -901,9 +901,11 @@ OOS-decay procedure.
 Hou, K., Xue, C. & Zhang, L. (2020). "Replicating Anomalies."
 *Review of Financial Studies* 33(5), 2019–2133.
 
-Large-scale replication of published anomalies under value-weighted
-testing; the headline reason factrix prefers value-weighted over
-equal-weighted spreads in capacity-constrained settings.
+Large-scale replication of published anomalies under NYSE-breakpoint,
+value-weighted testing that jointly mitigates microcap influence —
+~65% of 452 anomalies fail $|t| \geq 1.96$ once both microcap
+mitigations are applied. The headline reason factrix prefers
+value-weighted spreads in capacity-constrained settings.
 
 ### Chen & Zimmermann (2022)
 [](){ #chen-zimmermann-2022 }
@@ -911,10 +913,11 @@ equal-weighted spreads in capacity-constrained settings.
 Chen, A. Y. & Zimmermann, T. (2022). "Open Source Cross-Sectional
 Asset Pricing." *Critical Finance Review* 11(2), 207–264.
 
-Open-source replication of 200+ anomalies with code; cited as the
-empirical motivation for regime-stratified IC analysis (now
-expressed via factrix's slice-pairwise IC path under a regime
-label).
+Open-source reproduction of 300+ cross-sectional anomalies with
+public data and code; the empirical reproducibility anchor for
+factrix's downstream slice-conditional IC analyses (regime, universe,
+or other slice-axis stratifications layered on top of a reproducible
+characteristic set).
 
 ### López de Prado (2018)
 [](){ #lopez-de-prado-2018 }
@@ -933,8 +936,13 @@ Green, J., Hand, J. R. M. & Zhang, X. F. (2017). "The Characteristics
 that Provide Independent Information about Average U.S. Monthly
 Stock Returns." *Review of Financial Studies* 30(12), 4389–4436.
 
-Cross-sectional IC ranking of ~100 firm characteristics; cited as
-empirical anchor for IC-based screening.
+Simultaneous Fama-MacBeth regression of ~90 firm characteristics on
+cross-sectional returns, identifying the small subset that retains
+independent explanatory power and documenting the post-2003 collapse
+of the broader characteristic zoo. Empirical anchor for taking
+characteristic redundancy seriously in multi-factor screening (not
+for univariate IC ranking, which is the simpler — and weaker —
+methodology factrix exposes alongside the multi-factor BHY path).
 
 ### Jensen, Kelly & Pedersen (2023)
 [](){ #jensen-kelly-pedersen-2023 }

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -119,7 +119,10 @@ def multi_split_oos_decay(
         ``MIN_OOS_PERIODS`` floor would have power ≈ 0).
 
     References:
-        - [McLean-Pontiff (2016)][mclean-pontiff-2016]: average OOS decay ~32%.
+        - [McLean-Pontiff (2016)][mclean-pontiff-2016]: post-publication
+          returns ~58% lower than in-sample, with ~32% of that drop
+          attributable to publication itself (the remaining ~26% is
+          the pure out-of-sample decay).
         - [Lopez-de-Prado (2018)][lopez-de-prado-2018]: CPCV for robust train/test split.
 
     Examples:

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -320,7 +320,9 @@ def quantile_spread_vw(
         realized.
 
     References:
-        [Hou-Xue-Zhang (2020)][hou-xue-zhang-2020]: ~65% of factors disappear under VW.
+        [Hou-Xue-Zhang (2020)][hou-xue-zhang-2020]: ~65% of anomalies
+        fail $|t| \geq 1.96$ once microcaps are mitigated via NYSE
+        breakpoints and value weighting jointly.
 
     Examples:
         >>> import polars as pl

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -86,10 +86,12 @@ def ic_trend(
 
     References:
         [Sen 1968][sen-1968]: Theil-Sen median pairwise slope.
-        [Lou-Polk 2022][lou-polk-2022]: factor-crowding decay
-        mechanism that motivates a slope test on IC.
+        [Lou-Polk 2022][lou-polk-2022]: momentum-crowding evidence
+        as one suggestive economic channel for time-varying IC;
+        [McLean-Pontiff 2016][mclean-pontiff-2016] is the cleaner
+        cite for post-publication IC decay specifically.
         [Stock-Watson 1988][stock-watson-1988]: practitioner
-        unit-root concerns — backs the default `adf_threshold=0.10`.
+        unit-root background for the ADF persistence flag.
         [Dickey-Fuller 1979][dickey-fuller-1979]: ADF persistence
         diagnostic on the input series.
         [MacKinnon 1996][mackinnon-1996]: ADF p-value response surface


### PR DESCRIPTION
## Summary

Per-paper accuracy audit walks the "Factor zoo, replication, and OOS decay" entries of `docs/reference/bibliography.md`. Five methodological corrections landed; two entries verified accurate; layer policy already clean.

### Corrections

**Hou, Xue & Zhang (2020).** Catalog and `quantile.py` References block credited the ~65% replication-failure rate to "value-weighted testing" alone. HXZ's microcap mitigation is the *joint* effect of NYSE breakpoints + value weighting; single-axis attribution underestimates what reproducing the HXZ result requires.

**Green, Hand & Zhang (2017).** Catalog called the paper "cross-sectional IC ranking of ~100 firm characteristics". GHZ runs *simultaneous Fama-MacBeth regressions* of 94 characteristics — the contribution is precisely the multivariate redundancy diagnosis (only ~12 survive 1980-2014; ~2 post-2003). Re-attribute to FM regressions; credit the post-2003 collapse finding.

**Chen & Zimmermann (2022).** Catalog said CZ is "the empirical motivation for regime-stratified IC analysis". CZ's contribution is open-source reproduction of 300+ anomalies with public data and code; the regime-stratification framing was factrix's own downstream use, mis-attributed as the paper's motivation. Re-attribute as the reproducibility anchor; position factrix's slice-conditional path as a downstream layer.

**McLean & Pontiff (2016).** `oos.py:122` References block said "average OOS decay ~32%". The 32% figure is the *publication-attributable* component of the 58% post-publication return drop; the remaining ~26% is pure OOS decay. Restate with the full decomposition. Catalog role-note was already correct.

**Lou & Polk (2022).** `trend.py:89-90` said the paper provides a "factor-crowding decay mechanism that motivates a slope test on IC". LP studies momentum-return comomentum specifically (predicts momentum crashes — conditional, regime-switching), not a generic monotone IC-slope mechanism. The catalog role-note already hedged this and pointed at McLean-Pontiff as the cleaner IC-decay cite; the docstring contradicted that hedge. Bring docstring in line.

### Verified accurate, no edits needed

López de Prado (2018) post-#368, Jensen-Kelly-Pedersen (2023).

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] HXZ catalog + `quantile.py` References both name NYSE breakpoints + value weighting jointly.
- [x] GHZ catalog credits Fama-MacBeth methodology + post-2003 collapse finding.
- [x] CZ catalog credits open-source reproduction (not the regime-stratification claim).
- [x] `oos.py:122` decomposes 58% drop into 32% publication effect + 26% OOS decay.
- [x] `trend.py:89-92` redirects IC-decay-specific cite to McLean-Pontiff; frames Lou-Polk as suggestive economic channel only.

## Notes

- Does **not** close #321 — two bibliography sections still pending (Factor spanning / Methodology critique).

Refs #321