### PR TITLE
docs(refs): spanning attribution + finish status-note cleanup (#321)

### DIFF
--- a/docs/development/design-notes.md
+++ b/docs/development/design-notes.md
@@ -126,8 +126,8 @@ factrix's [`multi_factor.bhy`](../api/bhy.md) runs Benjamini-Yekutieli
 with the `c(m) = Σ 1/i` dependence correction. It does not implement
 Bayesian alternatives such as
 [Harvey-Liu 2020][harvey-liu-2020] "Lucky Factors" or
-[Bryzgalova-Huang-Julliard 2023][barillas-shanken-2018] BMA stochastic discount factor (SDF)
-search.
+Bryzgalova-Huang-Julliard 2023 BMA stochastic discount factor (SDF)
+search (not in factrix's bibliography catalog).
 
 - BHY is a frequentist recipe with a deterministic threshold given
   `(p, m)`. It composes cleanly with downstream business logic that

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -979,8 +979,11 @@ cite for post-publication IC decay.
 Barillas, F. & Shanken, J. (2017). "Which Alpha?" *Review of
 Financial Studies* 30(4), 1316–1338.
 
-Spanning-test framework for nested factor models; the methodology
-behind factrix's spanning-alpha procedure.
+Spanning-test framework for traded-factor model comparison: model
+comparison reduces to whether each model prices the *other* model's
+factors (left-hand-side = competing factors, not test assets), and
+the result applies to nested and non-nested comparisons alike. The
+methodology behind factrix's spanning-alpha procedure.
 
 ### Barillas & Shanken (2018)
 [](){ #barillas-shanken-2018 }
@@ -1038,8 +1041,9 @@ above factrix's per-date Spearman monotonicity metric.
 Novy-Marx, R. & Velikov, M. (2016). "A Taxonomy of Anomalies and
 Their Trading Costs." *Review of Financial Studies* 29(1), 104–147.
 
-Notional-turnover $\tau$ and breakeven-cost framework; the source of
-factrix's notional-turnover and breakeven-cost metrics.
+Turnover, generalised buy/hold spreads, and breakeven-cost analysis
+of anomaly portfolios; the lineage for turnover-aware and
+breakeven-cost diagnostics.
 
 ### DeMiguel, Martin-Utrera, Nogales & Uppal (2020)
 [](){ #demiguel-martin-utrera-nogales-uppal-2020 }

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -1001,10 +1001,9 @@ Feng, G., Giglio, S. & Xiu, D. (2020). "Taming the Factor Zoo: A
 Test of New Factors." *Journal of Finance* 75(3), 1327–1370.
 
 Two-pass model-selection-corrected stochastic discount factor (SDF)
-estimator for testing whether a candidate factor adds incremental
-pricing power; the principled alternative to greedy forward
-selection that factrix's spanning toolkit notes but does not
-implement.
+estimator with double-selection LASSO for testing whether a candidate
+factor adds incremental pricing power; the principled selection-aware
+counterpart to greedy stepwise factor spanning.
 
 ### Gibbons, Ross & Shanken (1989)
 [](){ #gibbons-ross-shanken-1989 }
@@ -1032,8 +1031,9 @@ Returns: New Tests with Applications to the Term Structure, the
 CAPM, and Portfolio Sorts." *Journal of Financial Economics* 98(3),
 605–625.
 
-Formal monotonicity tests for portfolio sorts; the rigour benchmark
-above factrix's per-date Spearman monotonicity metric.
+Bootstrap-based formal tests for monotonic relations across
+sorted-portfolio expected returns; the inference-grade benchmark for
+monotonicity diagnostics on portfolio sorts.
 
 ### Novy-Marx & Velikov (2016)
 [](){ #novy-marx-velikov-2016 }
@@ -1052,9 +1052,9 @@ DeMiguel, V., Martin-Utrera, A., Nogales, F. J. & Uppal, R. (2020).
 "A Transaction-cost Perspective on the Multitude of Firm
 Characteristics." *Review of Financial Studies* 33(5), 2180–2222.
 
-Transaction-cost-aware factor selection; the structural reason
-gross-spread metrics need a cost-deduction companion in factrix's
-spread/cost-net path.
+Transaction-cost-aware joint selection across firm characteristics;
+the structural reason gross-spread diagnostics require a
+cost-deduction counterpart for capacity-aware research.
 
 ### DeMiguel, Garlappi & Uppal (2009)
 [](){ #demiguel-garlappi-uppal-2009 }
@@ -1072,9 +1072,9 @@ optimisation" comparison.
 Asness, C. S., Moskowitz, T. J. & Pedersen, L. H. (2013). "Value and
 Momentum Everywhere." *Journal of Finance* 68(3), 929–985.
 
-Cross-asset factor evaluation methodology; cited in design notes as
-the cross-market evaluation pattern factrix does *not* aggregate at
-its scope boundary.
+Cross-asset, cross-market documentation of value and momentum premia
+with common factor structure across eight markets and asset classes;
+the canonical reference for cross-market factor-evaluation patterns.
 
 ### Ambachtsheer (1977)
 [](){ #ambachtsheer-1977 }


### PR DESCRIPTION
## Summary

Per-paper accuracy audit walks the "Factor spanning, selection, and active-management heuristics" entries of `docs/reference/bibliography.md`. Two methodological corrections + one design-notes cross-wire fix + four layer-policy enforcements landed; four entries verified accurate.

### Methodological corrections

**Barillas & Shanken (2017).** Role-note called the paper a "spanning-test framework for nested factor models". BS17's load-bearing result holds for *nested and non-nested* traded-factor model comparison — the contribution is that test assets are irrelevant; what matters is whether each model prices the *other* model's factors. Rewrite to name the actual mechanism and drop the "nested" restriction.

**Novy-Marx & Velikov (2016).** Role-note named "notional-turnover τ" as the paper's framework. The "τ" symbol is factrix's naming; the paper studies turnover, generalised buy/hold spreads, and breakeven-cost analysis under TAQ-based effective spreads. Rewrite at the conceptual layer.

### Design-notes anchor cross-wire

`docs/development/design-notes.md:129` — visible text reads "Bryzgalova-Huang-Julliard 2023" but the autorefs anchor pointed to `barillas-shanken-2018`. BHJ23 is a distinct BMA-SDF paper not in factrix's bibliography. Drop the broken anchor; mark BHJ23 as plain text with a parenthetical "not in factrix's bibliography catalog" (adding a new BHJ23 entry is content-add, out of scope for the accuracy audit).

### Layer-policy enforcement (follow-up to #368)

Four role-notes retained status notes or factrix-specific path / estimator labels:

- **Feng, Giglio & Xiu (2020)** — "factrix's spanning toolkit notes but does not implement" → conceptual layer with double-selection LASSO mechanism.
- **Patton & Timmermann (2010)** — "above factrix's per-date Spearman monotonicity metric" (names factrix's specific estimator) → conceptual layer with bootstrap-based monotonicity tests on portfolio sorts.
- **DeMiguel-Martin-Utrera-Nogales-Uppal (2020)** — "in factrix's spread/cost-net path" → conceptual layer.
- **Asness-Moskowitz-Pedersen (2013)** — "factrix does *not* aggregate at its scope boundary" → conceptual layer with the actual cross-market / cross-asset contribution.

### Verified accurate, no edits needed

Barillas & Shanken (2018), Gibbons-Ross-Shanken (1989), Kozak-Nagel-Santosh (2020), DeMiguel-Garlappi-Uppal (2009), Ambachtsheer (1977).

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] BS17 catalog now describes the actual model-comparison mechanism (LHS = competing factors, applies to non-nested too).
- [x] NMV16 catalog drops the factrix-specific "τ" symbol and names paper's actual contributions.
- [x] design-notes.md:129 — BHJ23 is now plain text; no broken anchor.
- [x] No remaining status notes / factrix-specific path labels in changed entries.

## Notes

- Does **not** close #321 — one bibliography section still pending (Methodology critique and composite-score design).

Refs #321