### PR TITLE
docs(refs): drop catalog-internal status notes (#321 follow-up)

### DIFF
--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -89,7 +89,7 @@ a one-period regression on a moving-average of the predictor — the
 test statistic is then size-correct in finite samples even when the
 implied MA(h−1) overlap is severe.
 
-Cited as background, not implemented. Hodrick 1B reformulates the
+Cited as background. Hodrick 1B reformulates the
 long-horizon regression as a one-period regression of `r_{t,t+1}` on
 the predictor sum `X_t = Σ_{j=0}^{h-1} x_{t-j}`, swapping which side
 carries the moving average. The coefficient has a different
@@ -256,8 +256,7 @@ Stock Returns." *Journal of Finance* 47(2), 427–465.
 
 Empirical anchor for size and value as cross-sectional risk premia;
 prototypical `Individual × Continuous` factor study in the
-Fama-MacBeth tradition. Catalog-only reference in factrix; no inline
-citation site at present.
+Fama-MacBeth tradition.
 
 ### Fama & French (1993)
 [](){ #fama-french-1993 }
@@ -268,8 +267,7 @@ Returns on Stocks and Bonds." *Journal of Financial Economics*
 
 Three-factor model; prototypical multi-factor spanning baseline of
 the kind that factrix's spanning-alpha procedure evaluates a
-candidate factor against. Catalog-only reference in factrix; no
-inline citation site at present.
+candidate factor against.
 
 ---
 
@@ -618,8 +616,6 @@ for Estimation, Testing, and Prediction*. Cambridge University Press.
 Empirical-Bayes alternative to FDR for large-scale multiple testing;
 reference work on local-fdr and shrinkage estimation as the
 empirical-Bayes counterpart to factrix's frequentist BHY stance.
-Catalog-only reference in factrix; no inline citation site at
-present.
 
 ### Bailey & López de Prado (2014)
 [](){ #bailey-lopez-de-prado-2014 }
@@ -683,8 +679,10 @@ Rousseeuw, P. J. & Croux, C. (1993). "Alternatives to the Median
 Absolute Deviation." *Journal of the American Statistical
 Association* 88(424), 1273–1283.
 
-Sn / Qn estimators as MAD alternatives; cited as the "considered
-but not implemented" alternative robust scale.
+$S_n$ / $Q_n$ estimators as higher-efficiency alternatives to MAD
+for robust scale (50% breakdown point, Gaussian efficiency ≈ 58% and
+82% respectively vs MAD's ≈ 37%); the catalog alternative robust
+scale to factrix's MAD-based winsorisation.
 
 ### Künsch (1989)
 [](){ #kunsch-1989 }


### PR DESCRIPTION
## Summary

Final cleanup surfaced by the post-merge overall review of the #321 audit. Five role-notes still carried *catalog-internal status* notes — meta-info about factrix's citation graph rather than about the paper itself. These drift the same way the "factrix does not implement / future upgrade / not yet implemented" notes did, and the same role-note layering discipline (codified on #321) applies.

### Changes

- **`hodrick-1992`** — "Cited as background, not implemented" → "Cited as background." Remove the trailing "not implemented" clause.
- **`rousseeuw-croux-1993`** — "cited as the 'considered but not implemented' alternative robust scale" → describe $S_n$ / $Q_n$ Gaussian efficiency advantage; frame as the catalog alternative to MAD without implementation-status framing.
- **`fama-french-1992`** / **`fama-french-1993`** / **`efron-2010`** — remove the trailing "Catalog-only reference in factrix; no inline citation site at present." disclaimer added in earlier audit cycles.

### Why drop the "catalog-only" disclaimer

The disclaimer is meta-info about the bibliography's anchor-citation graph (not about the paper). It drifts whenever someone adds an inline citation in a future PR — exactly the failure mode the layering discipline is meant to prevent. The role-notes' main content (`prototypical Individual × Continuous factor study in the Fama-MacBeth tradition`; `prototypical multi-factor spanning baseline`; `reference work on local-fdr and shrinkage estimation as the empirical-Bayes counterpart`) already describes each paper's role in factrix at the conceptual layer.

Orphan anchors are also not a build / reader problem in themselves — `autorefs` does not warn on them, and a reader browsing the catalog cares about the paper's role, not whether some specific docstring links to it. The right move is to drop the disclaimer from the 3 entries that had it, not to propagate it to the 10 others the overall review identified as unmarked orphans.

## Test plan

- [x] `uv run mkdocs build --strict` clean.
- [x] Grep `docs/reference/bibliography.md` for "not implemented", "future upgrade", "Catalog-only reference", "no inline citation site at present" — all return zero hits.
- [x] Net diff: +7 / −9 (the description gain on Rousseeuw-Croux outweighs the disclaimer removals).

## Notes

- Refs #321; the master accuracy-audit issue is already closed. This is the closing follow-up surfaced by the overall review — a small layer-discipline tightening, not a re-opening of the audit.

Refs #321