### PR TITLE
feat(bench): add wrapper + schema + validator foundation (#381)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,68 @@
+# bench — benchmark harness foundation
+
+Internal dev tooling for the multi-factor scale-out benchmark
+(issue #380, foundation sub-issue #381). **Not packaged into the
+factrix wheel** — `tool.setuptools.packages.find` excludes `bench*`.
+
+## What this foundation ships
+
+- `bench.schema` — pydantic v2 model for the JSONL record (`schema_version="1"`,
+  open-schema `scale` keyed on `axis_cell`). Aligns with #380 §9.
+- `bench.preflight` — BLAS thread lock (`OMP_/OPENBLAS_/MKL_NUM_THREADS`),
+  numpy seed, `gc.collect()`, env fingerprint (git SHA, factrix version,
+  python/numpy/BLAS, CPU model, cores, RAM).
+- `bench.wrapper` — `measure(setup, compute, …)` produces one
+  `BenchRecord` per call with `setup_s` / `compute_s` / `wall_s` /
+  `cpu_s` / `peak_rss_mb` / `peak_alloc_mb` / `status` /
+  `started_at` / `is_warmup` / `cache_state`. `status="error"` rows
+  are preserved (not raised).
+- `bench.validator` — self-validates JSONL; fail-loud on
+  `schema_version` mismatch, missing fields, enum violations, or
+  scale ↔ axis_cell mismatch.
+- `bench.scenarios.dummy` — smoke scenario proving the wrapper →
+  JSONL → validator loop. Mandatory S/M scenarios from #380 §4
+  follow in a separate sub-issue.
+
+## Running
+
+`bench/` is a top-level package next to `factrix/`; it is **not
+installed**. Run from the repo root so `bench` resolves on
+`sys.path`:
+
+```bash
+# self-validate an existing JSONL
+python -m bench.validate path/to/run.jsonl
+
+# end-to-end smoke (dummy scenario)
+python -m bench.scenarios.dummy --output out/dummy.jsonl
+```
+
+If launching from elsewhere, set `PYTHONPATH=<repo-root>` explicitly.
+CI smoke jobs should `cd` to the repo root or export `PYTHONPATH=.`
+before invoking any `python -m bench.*` entry point.
+
+## What it does *not* do (yet)
+
+Per #381 scope, this foundation does **not** ship:
+
+- Mandatory peak/probe scenarios S1–S5 + P1
+- Per-metric micro scenarios M-ic / M-ic-boot / M-quantile / M-mono / M-corrado
+- Reference baselines in `bench/baselines/`
+- Release-flow baseline rerun integration
+- CI `bench-tiny` smoke
+- Ratio / summary markdown post-processing
+
+Those live in follow-up sub-issues of #380.
+
+## Schema / version invariants
+
+`BenchRecord` carries three compatibility keys — comparison tools
+must refuse to compare records that differ on any of them:
+
+- `schema_version` (JSONL format itself) — pinned in `bench.schema.SCHEMA_VERSION`
+- `metric_set_version` (metric set definitions) — to be pinned in `bench/metric_sets.py` (follow-up sub-issue)
+- `env.dataset_spec_version` (synthetic generator recipe) — pinned in `factrix.datasets.DATASET_SPEC_VERSION`
+
+The wrapper validates its own output via `pydantic.BaseModel.model_validate`
+on construction; the dummy scenario additionally reads the written
+JSONL back through `bench.validator.validate_file`.

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,20 @@
+"""Benchmark harness foundation — wrapper, schema, validator.
+
+Sub-issue #381 of #380. Design SSOT is the v1 planning comment on #380.
+This package is dev tooling; not exported from the public ``factrix``
+namespace.
+"""
+
+from bench.schema import (
+    SCHEMA_VERSION,
+    BenchRecord,
+    Env,
+    record_json_schema,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "BenchRecord",
+    "Env",
+    "record_json_schema",
+]

--- a/bench/preflight.py
+++ b/bench/preflight.py
@@ -1,0 +1,146 @@
+"""Pre-measurement setup: lock thread counts, seed RNGs, collect env.
+
+The thread-count environment variables must be set **before** numpy /
+BLAS are imported into the running process; once a BLAS backend has
+read them, later mutation is ignored. ``lock_threads`` is therefore
+safe to call from harness entry points but cannot rescue a process
+that already imported numpy with unbounded threads — callers that
+care should set the env vars in their shell as well.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import platform
+import subprocess
+from dataclasses import asdict, dataclass
+
+import numpy as np
+import psutil
+from factrix.datasets import DATASET_SPEC_VERSION
+
+from bench.schema import Env
+
+_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+
+def lock_threads(n: int = 1) -> None:
+    """Pin BLAS / OMP thread counts.
+
+    Sets every common env knob to ``n``. Effective only when called
+    before numpy / scipy / polars have been imported by the running
+    process; idempotent thereafter but a no-op for already-initialized
+    BLAS state.
+    """
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    for key in _THREAD_ENV_VARS:
+        os.environ[key] = str(n)
+
+
+def seed_numpy(seed: int = 0) -> None:
+    """Seed numpy's legacy global RNG.
+
+    Per-call ``np.random.default_rng(seed)`` is preferred elsewhere;
+    this exists so legacy code paths that touch ``np.random.*`` are
+    not a hidden source of run-to-run drift.
+    """
+    np.random.seed(seed)
+
+
+def quiesce() -> None:
+    """Run before each measurement: force a full GC pass."""
+    gc.collect()
+    gc.collect()
+    gc.collect()
+
+
+def _detect_blas() -> str:
+    try:
+        info = np.show_config(mode="dicts")  # type: ignore[call-arg]
+    except TypeError:
+        return "unknown"
+    except Exception:
+        return "unknown"
+    if not isinstance(info, dict):
+        return "unknown"
+    blas = info.get("Build Dependencies", {}).get("blas", {})
+    name = blas.get("name") if isinstance(blas, dict) else None
+    return str(name) if name else "unknown"
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "unknown"
+    return out.stdout.strip() or "unknown"
+
+
+def _factrix_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("factrix")
+    except Exception:
+        return "unknown"
+
+
+def _omp_threads() -> int:
+    raw = os.environ.get("OMP_NUM_THREADS")
+    if raw and raw.isdigit():
+        return int(raw)
+    return psutil.cpu_count(logical=True) or 1
+
+
+def collect_env() -> Env:
+    """Snapshot the runtime environment into the JSONL ``env`` field."""
+    vm = psutil.virtual_memory()
+    return Env(
+        git_sha=_git_sha(),
+        factrix_version=_factrix_version(),
+        dataset_spec_version=DATASET_SPEC_VERSION,
+        python=platform.python_version(),
+        numpy=np.__version__,
+        blas=_detect_blas(),
+        omp_threads=_omp_threads(),
+        cpu_model=platform.processor() or platform.machine() or "unknown",
+        cpu_cores=psutil.cpu_count(logical=False) or psutil.cpu_count(logical=True) or 1,
+        ram_gb=round(vm.total / (1024**3), 2),
+        os=f"{platform.system().lower()}-{platform.machine().lower()}",
+    )
+
+
+@dataclass(frozen=True)
+class Preflight:
+    """Result of preflight setup, useful for echoing into logs."""
+
+    threads: int
+    seed: int
+    env: Env
+
+    def to_dict(self) -> dict[str, object]:
+        d = asdict(self)
+        d["env"] = self.env.model_dump()
+        return d
+
+
+def preflight(*, threads: int = 1, seed: int = 0) -> Preflight:
+    """One-shot: lock threads, seed numpy, GC, snapshot env."""
+    lock_threads(threads)
+    seed_numpy(seed)
+    quiesce()
+    return Preflight(threads=threads, seed=seed, env=collect_env())

--- a/bench/preflight.py
+++ b/bench/preflight.py
@@ -118,7 +118,9 @@ def collect_env() -> Env:
         blas=_detect_blas(),
         omp_threads=_omp_threads(),
         cpu_model=platform.processor() or platform.machine() or "unknown",
-        cpu_cores=psutil.cpu_count(logical=False) or psutil.cpu_count(logical=True) or 1,
+        cpu_cores=psutil.cpu_count(logical=False)
+        or psutil.cpu_count(logical=True)
+        or 1,
         ram_gb=round(vm.total / (1024**3), 2),
         os=f"{platform.system().lower()}-{platform.machine().lower()}",
     )

--- a/bench/scenarios/__init__.py
+++ b/bench/scenarios/__init__.py
@@ -1,0 +1,3 @@
+"""Benchmark scenarios. Foundation ships a single dummy scenario; the
+mandatory S/M scenarios from #380 §4 arrive in a follow-up sub-issue.
+"""

--- a/bench/scenarios/dummy.py
+++ b/bench/scenarios/dummy.py
@@ -1,0 +1,100 @@
+"""End-to-end smoke scenario — proves wrapper → JSONL → validator.
+
+Not one of the mandatory S/M scenarios from #380 §4. Used by tests
+and by ``bench-tiny`` CI smoke to prevent harness rot.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from factrix.datasets import make_multi_factor_panel
+
+from bench.preflight import preflight
+from bench.schema import BenchRecord
+from bench.validator import validate_file
+from bench.wrapper import measure, write_records
+
+
+def run(
+    *,
+    output: Path,
+    n_factors: int = 4,
+    n_assets: int = 20,
+    n_dates: int = 60,
+    warmup: bool = True,
+) -> list[BenchRecord]:
+    """Run the dummy scenario, write JSONL, self-validate."""
+    pre = preflight(threads=1, seed=0)
+    scale = {"n_factors": n_factors, "n_dates": n_dates, "n_assets": n_assets}
+
+    def setup():
+        return make_multi_factor_panel(
+            n_factors=n_factors,
+            n_assets=n_assets,
+            n_dates=n_dates,
+            seed=0,
+        )
+
+    def compute(df):
+        # Stand-in for real metric work: touch every factor column.
+        factor_cols = [c for c in df.columns if c.startswith("factor_")]
+        return float(df.select(factor_cols).sum().to_numpy().sum())
+
+    records: list[BenchRecord] = []
+    if warmup:
+        records.append(
+            measure(
+                setup,
+                compute,
+                scenario_id="dummy",
+                axis_cell="continuous_individual_panel",
+                scale=scale,
+                metric_set="core",
+                run_idx=0,
+                is_warmup=True,
+                cache_state="cold",
+                env=pre.env,
+            )
+        )
+    records.append(
+        measure(
+            setup,
+            compute,
+            scenario_id="dummy",
+            axis_cell="continuous_individual_panel",
+            scale=scale,
+            metric_set="core",
+            run_idx=0,
+            is_warmup=False,
+            cache_state="warm",
+            env=pre.env,
+        )
+    )
+    write_records(output, records)
+    report = validate_file(output)
+    if not report.ok:
+        raise RuntimeError(f"self-validation failed: {report.failures}")
+    return records
+
+
+def main() -> int:
+    """CLI entry point for the dummy scenario."""
+    p = argparse.ArgumentParser(description="Dummy bench scenario")
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--n-factors", type=int, default=4)
+    p.add_argument("--n-assets", type=int, default=20)
+    p.add_argument("--n-dates", type=int, default=60)
+    args = p.parse_args()
+    run(
+        output=args.output,
+        n_factors=args.n_factors,
+        n_assets=args.n_assets,
+        n_dates=args.n_dates,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/schema.py
+++ b/bench/schema.py
@@ -1,0 +1,107 @@
+"""JSONL record schema for the benchmark harness (#380 §9, v1).
+
+The schema is pinned here so #378 sub-tasks don't each roll their own
+parser. ``scale`` is an open schema keyed on ``axis_cell`` — new
+axis cells extend the union without breaking existing parsers.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+SCHEMA_VERSION = "1"
+
+AxisCell = Literal[
+    "continuous_individual_panel",
+    "sparse_individual_panel",
+]
+
+Status = Literal["ok", "oom", "error", "timeout"]
+CacheState = Literal["cold", "warm", "unknown"]
+
+
+class ContinuousIndividualPanelScale(BaseModel):
+    """Scale shape for the `continuous_individual_panel` axis cell."""
+
+    model_config = ConfigDict(extra="forbid")
+    axis_cell: Literal["continuous_individual_panel"]
+    n_factors: int = Field(ge=1)
+    n_dates: int = Field(ge=1)
+    n_assets: int = Field(ge=1)
+
+
+class SparseIndividualPanelScale(BaseModel):
+    """Scale shape for the `sparse_individual_panel` axis cell."""
+
+    model_config = ConfigDict(extra="forbid")
+    axis_cell: Literal["sparse_individual_panel"]
+    n_events: int = Field(ge=0)
+    n_assets: int = Field(ge=1)
+    n_dates: int = Field(ge=1)
+    window_pre: int = Field(ge=0)
+    window_post: int = Field(ge=0)
+
+
+Scale = Annotated[
+    ContinuousIndividualPanelScale | SparseIndividualPanelScale,
+    Field(discriminator="axis_cell"),
+]
+
+
+class Env(BaseModel):
+    """Runtime environment fingerprint embedded in every record."""
+
+    model_config = ConfigDict(extra="forbid")
+    git_sha: str
+    factrix_version: str
+    dataset_spec_version: str
+    python: str
+    numpy: str
+    blas: str
+    omp_threads: int = Field(ge=1)
+    cpu_model: str
+    cpu_cores: int = Field(ge=1)
+    ram_gb: float = Field(ge=0)
+    os: str
+
+
+class BenchRecord(BaseModel):
+    """One row of the benchmark JSONL — #380 §9 v1."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1"]
+    scenario_id: str
+    metric_set: str
+    metric_set_version: str
+    axis_cell: AxisCell
+    scale: Scale
+    run_idx: int = Field(ge=0)
+    is_warmup: bool
+    cache_state: CacheState
+    status: Status
+    error_message: str | None
+    started_at: str  # ISO8601 UTC, e.g. "2026-05-15T08:30:00Z"
+    wall_s: float | None = Field(ge=0)
+    setup_s: float | None = Field(ge=0)
+    compute_s: float | None = Field(ge=0)
+    cpu_s: float | None = Field(ge=0)
+    peak_rss_mb: float | None = Field(ge=0)
+    peak_alloc_mb: float | None = Field(ge=0)
+    env: Env
+
+    @model_validator(mode="after")
+    def _scale_axis_cell_matches(self) -> BenchRecord:
+        inner = getattr(self.scale, "axis_cell", None)
+        if inner != self.axis_cell:
+            raise ValueError(
+                f"axis_cell mismatch: record={self.axis_cell!r} but scale={inner!r}"
+            )
+        return self
+
+
+def record_json_schema() -> dict[str, Any]:
+    """Export the JSON Schema for ``BenchRecord``."""
+    return BenchRecord.model_json_schema()

--- a/bench/validate.py
+++ b/bench/validate.py
@@ -1,0 +1,8 @@
+"""``python -m bench.validate`` entry point — thin alias to ``bench.validator.main``."""
+
+from __future__ import annotations
+
+from bench.validator import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/validator.py
+++ b/bench/validator.py
@@ -1,0 +1,104 @@
+"""Self-validation of harness output (#380 §9.1).
+
+The harness reads back every JSONL it writes through ``validate_file``;
+the same code path is exposed as the ``python -m bench.validate`` CLI
+for ad-hoc auditing of historical baselines.
+
+Fail-loud is intentional: a silent shape drift now is an unparseable
+baseline six months from now.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from bench.schema import SCHEMA_VERSION, BenchRecord
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    """One bad row in a JSONL file."""
+
+    line_no: int
+    error: str
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Outcome of validating one JSONL file."""
+
+    path: Path
+    n_rows: int
+    failures: list[ValidationFailure]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def validate_file(path: str | Path) -> ValidationReport:
+    """Parse every line of ``path`` as ``BenchRecord``; collect failures."""
+    p = Path(path)
+    failures: list[ValidationFailure] = []
+    n_rows = 0
+    with p.open("r", encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            n_rows += 1
+            try:
+                data = json.loads(stripped)
+            except json.JSONDecodeError as e:
+                failures.append(ValidationFailure(line_no, f"invalid JSON: {e}"))
+                continue
+            sv = data.get("schema_version")
+            if sv != SCHEMA_VERSION:
+                failures.append(
+                    ValidationFailure(
+                        line_no,
+                        f"schema_version mismatch: got {sv!r}, expected {SCHEMA_VERSION!r}",
+                    )
+                )
+                continue
+            try:
+                BenchRecord.model_validate(data)
+            except ValidationError as e:
+                failures.append(ValidationFailure(line_no, str(e)))
+    return ValidationReport(path=p, n_rows=n_rows, failures=failures)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: validate one or more JSONL files."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in ("-h", "--help"):
+        print("usage: python -m bench.validate <path.jsonl> [<path.jsonl> ...]")
+        return 0 if args else 2
+
+    overall_ok = True
+    for path in args:
+        if not Path(path).is_file():
+            overall_ok = False
+            print(f"FAIL  {path}  (file not found)", file=sys.stderr)
+            continue
+        report = validate_file(path)
+        if report.ok:
+            print(f"OK  {path}  ({report.n_rows} rows)")
+        else:
+            overall_ok = False
+            print(
+                f"FAIL  {path}  ({len(report.failures)} / {report.n_rows} rows)",
+                file=sys.stderr,
+            )
+            for f in report.failures:
+                print(f"  line {f.line_no}: {f.error}", file=sys.stderr)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/wrapper.py
+++ b/bench/wrapper.py
@@ -1,0 +1,180 @@
+"""Measurement wrapper — produces one ``BenchRecord`` per invocation.
+
+Separates ``setup`` (data prep + I/O) from ``compute`` (the metric work
+under measurement) so the JSONL records both phases. Ratio analysis
+defaults to ``compute_s`` per #380 §9.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import time
+import tracemalloc
+from collections.abc import Callable
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+from bench.preflight import collect_env, quiesce
+from bench.schema import SCHEMA_VERSION, BenchRecord, CacheState, Env, Status
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _peak_rss_mb(proc: psutil.Process, baseline_mb: float) -> float:
+    """Best-effort peak RSS — psutil exposes current RSS, not peak."""
+    try:
+        mi = proc.memory_info()
+        return max(mi.rss / (1024**2), baseline_mb)
+    except Exception:
+        return baseline_mb
+
+
+def measure[T](
+    setup: Callable[[], T],
+    compute: Callable[[T], Any],
+    *,
+    scenario_id: str,
+    axis_cell: str,
+    scale: dict[str, Any],
+    metric_set: str,
+    metric_set_version: str = "1",
+    run_idx: int = 0,
+    is_warmup: bool = False,
+    cache_state: CacheState = "warm",
+    env: Env | None = None,
+) -> BenchRecord:
+    """Run ``setup`` then ``compute`` under measurement.
+
+    ``setup`` is the data-prep phase (synthetic generation, deserialize,
+    cache prime); ``compute`` is the work we care about. Exceptions in
+    either phase are caught and recorded as ``status="error"`` so the
+    JSONL row is preserved for retrospective analysis.
+
+    The ``scale`` dict is wrapped with ``axis_cell`` and validated by
+    the pydantic discriminator — passing a shape that doesn't match
+    the declared ``axis_cell`` is a fail-loud error.
+    """
+    if env is None:
+        env = collect_env()
+
+    quiesce()
+    proc = psutil.Process()
+    baseline_rss_mb = proc.memory_info().rss / (1024**2)
+    tracemalloc.start()
+    started_at = _utc_now_iso()
+    setup_s: float | None = None
+    compute_s: float | None = None
+    wall_s: float | None = None
+    cpu_s: float | None = None
+    peak_rss_mb: float | None = None
+    peak_alloc_mb: float | None = None
+    status: Status = "ok"
+    error_message: str | None = None
+
+    wall0 = time.perf_counter()
+    cpu0 = time.process_time()
+
+    try:
+        t0 = time.perf_counter()
+        artifact = setup()
+        t1 = time.perf_counter()
+        rss_after_setup = _peak_rss_mb(proc, baseline_rss_mb)
+        compute(artifact)
+        t2 = time.perf_counter()
+        rss_after_compute = _peak_rss_mb(proc, rss_after_setup)
+
+        setup_s = t1 - t0
+        compute_s = t2 - t1
+        wall_s = t2 - wall0
+        cpu_s = time.process_time() - cpu0
+        peak_rss_mb = rss_after_compute
+        _, traced_peak = tracemalloc.get_traced_memory()
+        peak_alloc_mb = traced_peak / (1024**2)
+    except MemoryError as e:
+        status = "oom"
+        error_message = repr(e)
+        wall_s = time.perf_counter() - wall0
+        cpu_s = time.process_time() - cpu0
+    except BaseException as e:
+        status = "error"
+        error_message = repr(e)
+        wall_s = time.perf_counter() - wall0
+        cpu_s = time.process_time() - cpu0
+        if isinstance(e, (KeyboardInterrupt, SystemExit)):
+            tracemalloc.stop()
+            raise
+    finally:
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+        gc.collect()
+
+    record = BenchRecord.model_validate(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "scenario_id": scenario_id,
+            "metric_set": metric_set,
+            "metric_set_version": metric_set_version,
+            "axis_cell": axis_cell,
+            "scale": {"axis_cell": axis_cell, **scale},
+            "run_idx": run_idx,
+            "is_warmup": is_warmup,
+            "cache_state": cache_state,
+            "status": status,
+            "error_message": error_message,
+            "started_at": started_at,
+            "wall_s": wall_s,
+            "setup_s": setup_s,
+            "compute_s": compute_s,
+            "cpu_s": cpu_s,
+            "peak_rss_mb": peak_rss_mb,
+            "peak_alloc_mb": peak_alloc_mb,
+            "env": env.model_dump(),
+        }
+    )
+    return record
+
+
+@contextmanager
+def jsonl_writer(path: str | Path):
+    """Append-mode JSONL sink yielding a single ``write(record)`` fn."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    fh = p.open("a", encoding="utf-8")
+    try:
+
+        def write(record: BenchRecord) -> None:
+            fh.write(record.model_dump_json() + "\n")
+            fh.flush()
+
+        yield write
+    finally:
+        fh.close()
+
+
+def write_records(path: str | Path, records: list[BenchRecord]) -> None:
+    """Bulk-write ``records`` to ``path`` as JSONL (overwrites)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(r.model_dump_json() + "\n")
+
+
+def read_records(path: str | Path) -> list[dict[str, Any]]:
+    """Read raw (unvalidated) JSON rows from ``path``."""
+    p = Path(path)
+    out: list[dict[str, Any]] = []
+    with p.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+    return out

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -31,6 +31,12 @@ import polars as pl
 
 _DEFAULT_START = "2020-01-02"
 
+# Bumped whenever the default parameters or construction recipe of the
+# synthetic generators in this module change in ways that would shift
+# benchmark numbers. Recorded in JSONL `env.dataset_spec_version` so
+# baselines from different recipes refuse silent comparison.
+DATASET_SPEC_VERSION = "1"
+
 
 def _daily_date_index(start_date: str, n_dates: int) -> pl.Series:
     start = datetime.fromisoformat(start_date)
@@ -272,6 +278,120 @@ def make_event_panel(
         prices=prices,
         factor=factor,
     )
+
+
+def make_multi_factor_panel(
+    *,
+    n_factors: int = 10,
+    n_assets: int = 50,
+    n_dates: int = 252,
+    ic_target: float = 0.04,
+    factor_correlation: float = 0.0,
+    signal_horizon: int = 5,
+    seed: int = 42,
+    start_date: str = _DEFAULT_START,
+) -> pl.DataFrame:
+    """Synthetic multi-factor panel with calibrated IC and tunable
+    cross-factor correlation.
+
+    Each of ``n_factors`` factor columns is constructed as in
+    ``make_cs_panel`` (``ρ · z(fr) + √(1−ρ²) · z(η_k)``), with the
+    per-factor noise terms ``η_k`` sharing a common cross-sectional
+    component so that pairwise factor-factor correlation is controllable:
+
+        η_k = √c · ξ_common + √(1−c) · ξ_idio_k
+
+    where ``c = factor_correlation``. The realized factor-factor
+    cross-sectional correlation is approximately
+    ``ρ² + (1 − ρ²) · c``.
+
+    The last ``H + 1`` rows have no defined forward return; factor
+    values there are pure noise (same construction convention as
+    ``make_cs_panel``) and will be dropped along with the null forward
+    returns once ``compute_forward_return`` runs.
+
+    Args:
+        n_factors: Number of factor columns to emit.
+        n_assets: Cross-sectional width.
+        n_dates: Number of calendar dates.
+        ic_target: Target per-date Pearson CS correlation between each
+            factor and the forward return at ``signal_horizon``.
+        factor_correlation: Pairwise correlation between factor noise
+            terms in ``[0, 1)``. ``0`` reproduces independent factors;
+            higher values share more of a common cross-sectional driver.
+        signal_horizon: Horizon (in bars) at which the synthetic signal
+            lives.
+        seed: RNG seed.
+        start_date: ISO date for the first row.
+
+    Returns:
+        Long DataFrame with ``date, asset_id, price, factor_0000,
+        factor_0001, ...``. ``factor_*`` column count equals
+        ``n_factors`` and column width is zero-padded to a stable
+        sort order.
+    """
+    if n_factors < 1:
+        raise ValueError("n_factors must be >= 1")
+    if n_assets < 2:
+        raise ValueError("n_assets must be >= 2 for a cross-section")
+    if n_dates < signal_horizon + 2:
+        raise ValueError(
+            f"n_dates must be >= signal_horizon + 2 (got n_dates={n_dates}, "
+            f"signal_horizon={signal_horizon})"
+        )
+    if not 0.0 <= factor_correlation < 1.0:
+        raise ValueError(
+            f"factor_correlation must be in [0, 1), got {factor_correlation}"
+        )
+
+    rng = np.random.default_rng(seed)
+    sigmas = rng.uniform(0.01, 0.03, size=n_assets)
+    daily_ret = rng.standard_normal((n_dates, n_assets)) * sigmas
+    prices = 100.0 * np.cumprod(1.0 + daily_ret, axis=0)
+
+    H = signal_horizon
+    last_valid = n_dates - H - 1
+    fr = (prices[1 + H : 1 + H + last_valid] / prices[1 : 1 + last_valid] - 1.0) / H
+    fr_z = _zscore_cs(fr)
+
+    rho = float(np.clip(ic_target, -0.99, 0.99))
+    c = float(factor_correlation)
+    sqrt_c = float(np.sqrt(c))
+    sqrt_1_c = float(np.sqrt(1.0 - c))
+    sqrt_1_rho2 = float(np.sqrt(1.0 - rho * rho))
+
+    common = rng.standard_normal((n_dates, n_assets))
+    common_z = _zscore_cs(common)
+
+    width = max(4, len(str(n_factors - 1)))
+    factor_columns: dict[str, np.ndarray] = {}
+    for k in range(n_factors):
+        idio = rng.standard_normal((n_dates, n_assets))
+        eta = sqrt_c * common_z + sqrt_1_c * _zscore_cs(idio)
+        f_k = eta.copy()
+        f_k[:last_valid] = rho * fr_z + sqrt_1_rho2 * _zscore_cs(eta[:last_valid])
+        factor_columns[f"factor_{k:0{width}d}"] = f_k
+
+    dates = _daily_date_index(start_date, n_dates)
+    assets = _asset_ids(n_assets)
+    date_col = np.repeat(dates.to_numpy(), n_assets)
+    asset_col = np.tile(np.asarray(assets, dtype=object), n_dates)
+
+    data: dict[str, np.ndarray] = {
+        "date": date_col,
+        "asset_id": asset_col,
+        "price": prices.flatten(),
+    }
+    schema: dict[str, pl.DataType] = {
+        "date": pl.Datetime("ms"),
+        "asset_id": pl.String,
+        "price": pl.Float64,
+    }
+    for name, arr in factor_columns.items():
+        data[name] = arr.flatten()
+        schema[name] = pl.Float64
+
+    return pl.DataFrame(data, schema=schema)
 
 
 def _to_long_panel(

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -377,21 +377,23 @@ def make_multi_factor_panel(
     date_col = np.repeat(dates.to_numpy(), n_assets)
     asset_col = np.tile(np.asarray(assets, dtype=object), n_dates)
 
-    data: dict[str, np.ndarray] = {
-        "date": date_col,
-        "asset_id": asset_col,
-        "price": prices.flatten(),
-    }
-    schema: dict[str, pl.DataType] = {
-        "date": pl.Datetime("ms"),
-        "asset_id": pl.String,
-        "price": pl.Float64,
-    }
-    for name, arr in factor_columns.items():
-        data[name] = arr.flatten()
-        schema[name] = pl.Float64
-
-    return pl.DataFrame(data, schema=schema)
+    base = pl.DataFrame(
+        {
+            "date": date_col,
+            "asset_id": asset_col,
+            "price": prices.flatten(),
+        },
+        schema={
+            "date": pl.Datetime("ms"),
+            "asset_id": pl.String,
+            "price": pl.Float64,
+        },
+    )
+    factor_series = [
+        pl.Series(name, arr.flatten(), dtype=pl.Float64)
+        for name, arr in factor_columns.items()
+    ]
+    return base.with_columns(factor_series)
 
 
 def _to_long_panel(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ dev = [
     "mypy>=1.20",
     "build",
     "twine",
+    "factrix[bench]",
+]
+bench = [
+    "pydantic>=2.6",
+    "psutil>=5.9",
 ]
 docs = [
     "mkdocs-material>=9.5",
@@ -130,7 +135,11 @@ convention = "google"
 "scripts/**/*.py" = ["D"]
 
 [tool.setuptools.packages.find]
+# `include` already restricts to factrix*; `exclude` is belt-and-suspenders
+# so bench/ (internal harness, sub-issue #381) and tests/ can never leak
+# into the published wheel.
 include = ["factrix*"]
+exclude = ["bench*", "tests*"]
 namespaces = false
 
 [tool.setuptools.package-data]

--- a/tests/bench/test_datasets_multi_factor.py
+++ b/tests/bench/test_datasets_multi_factor.py
@@ -32,9 +32,13 @@ def test_seed_is_deterministic():
 
 def test_factor_correlation_raises_outside_range():
     with pytest.raises(ValueError, match="factor_correlation"):
-        make_multi_factor_panel(n_factors=2, n_assets=4, n_dates=30, factor_correlation=1.0)
+        make_multi_factor_panel(
+            n_factors=2, n_assets=4, n_dates=30, factor_correlation=1.0
+        )
     with pytest.raises(ValueError, match="factor_correlation"):
-        make_multi_factor_panel(n_factors=2, n_assets=4, n_dates=30, factor_correlation=-0.1)
+        make_multi_factor_panel(
+            n_factors=2, n_assets=4, n_dates=30, factor_correlation=-0.1
+        )
 
 
 def test_factor_correlation_increases_pairwise_corr():

--- a/tests/bench/test_datasets_multi_factor.py
+++ b/tests/bench/test_datasets_multi_factor.py
@@ -1,0 +1,65 @@
+"""factrix.datasets.make_multi_factor_panel — schema + correlation knob."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.datasets import DATASET_SPEC_VERSION, make_multi_factor_panel
+
+
+def test_dataset_spec_version_pinned():
+    assert DATASET_SPEC_VERSION == "1"
+
+
+def test_schema_and_factor_columns():
+    df = make_multi_factor_panel(n_factors=3, n_assets=8, n_dates=40, seed=0)
+    factor_cols = [c for c in df.columns if c.startswith("factor_")]
+    assert len(factor_cols) == 3
+    assert df.schema["date"] == pl.Datetime("ms")
+    assert df.schema["asset_id"] == pl.String
+    assert df.schema["price"] == pl.Float64
+    for c in factor_cols:
+        assert df.schema[c] == pl.Float64
+    assert df.height == 8 * 40
+
+
+def test_seed_is_deterministic():
+    a = make_multi_factor_panel(n_factors=2, n_assets=6, n_dates=30, seed=5)
+    b = make_multi_factor_panel(n_factors=2, n_assets=6, n_dates=30, seed=5)
+    assert a.equals(b)
+
+
+def test_factor_correlation_raises_outside_range():
+    with pytest.raises(ValueError, match="factor_correlation"):
+        make_multi_factor_panel(n_factors=2, n_assets=4, n_dates=30, factor_correlation=1.0)
+    with pytest.raises(ValueError, match="factor_correlation"):
+        make_multi_factor_panel(n_factors=2, n_assets=4, n_dates=30, factor_correlation=-0.1)
+
+
+def test_factor_correlation_increases_pairwise_corr():
+    """Higher factor_correlation -> higher mean pairwise factor correlation.
+
+    Coarse sanity check, not a precise calibration test.
+    """
+
+    def mean_pair_corr(c: float) -> float:
+        df = make_multi_factor_panel(
+            n_factors=5,
+            n_assets=40,
+            n_dates=80,
+            ic_target=0.0,  # remove the fr-shared component
+            factor_correlation=c,
+            seed=11,
+        )
+        cols = [c for c in df.columns if c.startswith("factor_")]
+        mat = df.select(cols).to_numpy()
+        # Drop the tail dates with zero IC component (they're noise either way).
+        corr = np.corrcoef(mat, rowvar=False)
+        n = corr.shape[0]
+        off_diag = corr[np.triu_indices(n, k=1)]
+        return float(off_diag.mean())
+
+    low = mean_pair_corr(0.0)
+    high = mean_pair_corr(0.7)
+    assert high > low + 0.3

--- a/tests/bench/test_dummy_scenario.py
+++ b/tests/bench/test_dummy_scenario.py
@@ -1,0 +1,17 @@
+"""End-to-end smoke for the dummy scenario."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bench.scenarios.dummy import run
+from bench.validator import validate_file
+
+
+def test_dummy_scenario_round_trip(tmp_path: Path):
+    out = tmp_path / "dummy.jsonl"
+    records = run(output=out, n_factors=3, n_assets=10, n_dates=30)
+    assert len(records) == 2  # warmup + measured
+    rep = validate_file(out)
+    assert rep.ok, rep.failures
+    assert rep.n_rows == 2

--- a/tests/bench/test_preflight.py
+++ b/tests/bench/test_preflight.py
@@ -1,0 +1,40 @@
+"""bench.preflight — thread lock, seed determinism, env snapshot."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+from bench.preflight import collect_env, lock_threads, preflight, seed_numpy
+
+
+def test_lock_threads_sets_env():
+    lock_threads(2)
+    assert os.environ["OMP_NUM_THREADS"] == "2"
+    assert os.environ["OPENBLAS_NUM_THREADS"] == "2"
+    assert os.environ["MKL_NUM_THREADS"] == "2"
+    lock_threads(1)
+
+
+def test_seed_numpy_is_deterministic():
+    seed_numpy(42)
+    a = np.random.random(5)
+    seed_numpy(42)
+    b = np.random.random(5)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_collect_env_fields_present():
+    env = collect_env()
+    assert env.dataset_spec_version == "1"
+    assert env.omp_threads >= 1
+    assert env.cpu_cores >= 1
+    assert env.ram_gb > 0
+    assert env.os
+
+
+def test_preflight_returns_locked_state():
+    pre = preflight(threads=1, seed=7)
+    assert pre.threads == 1
+    assert pre.seed == 7
+    assert pre.env.dataset_spec_version == "1"

--- a/tests/bench/test_schema.py
+++ b/tests/bench/test_schema.py
@@ -1,0 +1,108 @@
+"""bench.schema — pydantic model and JSON Schema export."""
+
+from __future__ import annotations
+
+import pytest
+from bench.schema import SCHEMA_VERSION, BenchRecord, record_json_schema
+from pydantic import ValidationError
+
+
+def _env_dict() -> dict:
+    return {
+        "git_sha": "abc1234",
+        "factrix_version": "0.13.0",
+        "dataset_spec_version": "1",
+        "python": "3.12.0",
+        "numpy": "2.0.0",
+        "blas": "openblas",
+        "omp_threads": 1,
+        "cpu_model": "x86_64",
+        "cpu_cores": 4,
+        "ram_gb": 16.0,
+        "os": "linux-x86_64",
+    }
+
+
+def _ok_record() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scenario_id": "S2",
+        "metric_set": "core",
+        "metric_set_version": "1",
+        "axis_cell": "continuous_individual_panel",
+        "scale": {
+            "axis_cell": "continuous_individual_panel",
+            "n_factors": 50,
+            "n_dates": 1250,
+            "n_assets": 1000,
+        },
+        "run_idx": 0,
+        "is_warmup": False,
+        "cache_state": "cold",
+        "status": "ok",
+        "error_message": None,
+        "started_at": "2026-05-15T08:30:00Z",
+        "wall_s": 12.345,
+        "setup_s": 1.23,
+        "compute_s": 11.115,
+        "cpu_s": 11.987,
+        "peak_rss_mb": 2048.0,
+        "peak_alloc_mb": 1820.0,
+        "env": _env_dict(),
+    }
+
+
+def test_valid_record_round_trip():
+    rec = BenchRecord.model_validate(_ok_record())
+    assert rec.scenario_id == "S2"
+    assert rec.scale.n_factors == 50
+
+
+def test_scale_discriminator_rejects_mismatch():
+    bad = _ok_record()
+    bad["axis_cell"] = "sparse_individual_panel"
+    # scale block still carries continuous fields
+    with pytest.raises(ValidationError):
+        BenchRecord.model_validate(bad)
+
+
+def test_status_enum_strict():
+    bad = _ok_record()
+    bad["status"] = "broken"
+    with pytest.raises(ValidationError):
+        BenchRecord.model_validate(bad)
+
+
+def test_extra_fields_forbidden():
+    bad = _ok_record()
+    bad["bogus_field"] = 1
+    with pytest.raises(ValidationError):
+        BenchRecord.model_validate(bad)
+
+
+def test_missing_required_field():
+    bad = _ok_record()
+    del bad["started_at"]
+    with pytest.raises(ValidationError):
+        BenchRecord.model_validate(bad)
+
+
+def test_sparse_scale_shape():
+    rec = _ok_record()
+    rec["axis_cell"] = "sparse_individual_panel"
+    rec["scale"] = {
+        "axis_cell": "sparse_individual_panel",
+        "n_events": 20,
+        "n_assets": 200,
+        "n_dates": 1250,
+        "window_pre": 5,
+        "window_post": 10,
+    }
+    parsed = BenchRecord.model_validate(rec)
+    assert parsed.scale.n_events == 20
+
+
+def test_json_schema_exports():
+    schema = record_json_schema()
+    assert schema["title"] == "BenchRecord"
+    assert "schema_version" in schema["properties"]

--- a/tests/bench/test_validator.py
+++ b/tests/bench/test_validator.py
@@ -1,0 +1,115 @@
+"""bench.validator — fail-loud on bad rows, CLI exit codes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bench.validator import main, validate_file
+
+
+def _good_row() -> dict:
+    return {
+        "schema_version": "1",
+        "scenario_id": "S2",
+        "metric_set": "core",
+        "metric_set_version": "1",
+        "axis_cell": "continuous_individual_panel",
+        "scale": {
+            "axis_cell": "continuous_individual_panel",
+            "n_factors": 50,
+            "n_dates": 1250,
+            "n_assets": 1000,
+        },
+        "run_idx": 0,
+        "is_warmup": False,
+        "cache_state": "cold",
+        "status": "ok",
+        "error_message": None,
+        "started_at": "2026-05-15T08:30:00Z",
+        "wall_s": 1.0,
+        "setup_s": 0.1,
+        "compute_s": 0.9,
+        "cpu_s": 0.95,
+        "peak_rss_mb": 100.0,
+        "peak_alloc_mb": 90.0,
+        "env": {
+            "git_sha": "abc1234",
+            "factrix_version": "0.13.0",
+            "dataset_spec_version": "1",
+            "python": "3.12.0",
+            "numpy": "2.0.0",
+            "blas": "openblas",
+            "omp_threads": 1,
+            "cpu_model": "x86_64",
+            "cpu_cores": 4,
+            "ram_gb": 16.0,
+            "os": "linux-x86_64",
+        },
+    }
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+
+def test_validate_clean_file(tmp_path: Path):
+    p = tmp_path / "ok.jsonl"
+    _write(p, [_good_row()])
+    rep = validate_file(p)
+    assert rep.ok
+    assert rep.n_rows == 1
+
+
+def test_validate_missing_field(tmp_path: Path):
+    p = tmp_path / "bad.jsonl"
+    row = _good_row()
+    del row["status"]
+    _write(p, [row])
+    rep = validate_file(p)
+    assert not rep.ok
+    assert rep.failures[0].line_no == 1
+
+
+def test_validate_enum_out_of_range(tmp_path: Path):
+    p = tmp_path / "bad.jsonl"
+    row = _good_row()
+    row["cache_state"] = "lukewarm"
+    _write(p, [row])
+    rep = validate_file(p)
+    assert not rep.ok
+
+
+def test_validate_schema_version_mismatch(tmp_path: Path):
+    p = tmp_path / "bad.jsonl"
+    row = _good_row()
+    row["schema_version"] = "0"
+    _write(p, [row])
+    rep = validate_file(p)
+    assert not rep.ok
+    assert "schema_version" in rep.failures[0].error
+
+
+def test_validate_invalid_json(tmp_path: Path):
+    p = tmp_path / "bad.jsonl"
+    p.write_text("{not json\n", encoding="utf-8")
+    rep = validate_file(p)
+    assert not rep.ok
+
+
+def test_cli_returns_zero_on_clean(tmp_path: Path, capsys):
+    p = tmp_path / "ok.jsonl"
+    _write(p, [_good_row()])
+    code = main([str(p)])
+    assert code == 0
+
+
+def test_cli_returns_nonzero_on_bad(tmp_path: Path, capsys):
+    p = tmp_path / "bad.jsonl"
+    row = _good_row()
+    del row["status"]
+    _write(p, [row])
+    code = main([str(p)])
+    assert code == 1

--- a/tests/bench/test_wrapper.py
+++ b/tests/bench/test_wrapper.py
@@ -1,0 +1,103 @@
+"""bench.wrapper — measure, status paths, JSONL round-trip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bench.preflight import collect_env
+from bench.validator import validate_file
+from bench.wrapper import measure, read_records, write_records
+
+
+def _scale() -> dict:
+    return {"n_factors": 2, "n_dates": 10, "n_assets": 5}
+
+
+def test_measure_ok_path_populates_timings():
+    env = collect_env()
+    rec = measure(
+        setup=lambda: [1, 2, 3],
+        compute=lambda x: sum(x),
+        scenario_id="t",
+        axis_cell="continuous_individual_panel",
+        scale=_scale(),
+        metric_set="core",
+        env=env,
+    )
+    assert rec.status == "ok"
+    assert rec.setup_s is not None and rec.setup_s >= 0
+    assert rec.compute_s is not None and rec.compute_s >= 0
+    assert rec.wall_s is not None
+    assert rec.peak_rss_mb is not None
+    assert rec.peak_alloc_mb is not None
+    assert rec.error_message is None
+
+
+def test_measure_error_path_records_exception():
+    env = collect_env()
+
+    def boom(_):
+        raise RuntimeError("kaboom")
+
+    rec = measure(
+        setup=lambda: None,
+        compute=boom,
+        scenario_id="t",
+        axis_cell="continuous_individual_panel",
+        scale=_scale(),
+        metric_set="core",
+        env=env,
+    )
+    assert rec.status == "error"
+    assert "kaboom" in (rec.error_message or "")
+    assert rec.wall_s is not None  # wall still recorded
+
+
+def test_warmup_record_is_preserved(tmp_path: Path):
+    env = collect_env()
+    warm = measure(
+        setup=lambda: 0,
+        compute=lambda _: 0,
+        scenario_id="t",
+        axis_cell="continuous_individual_panel",
+        scale=_scale(),
+        metric_set="core",
+        is_warmup=True,
+        env=env,
+    )
+    main = measure(
+        setup=lambda: 0,
+        compute=lambda _: 0,
+        scenario_id="t",
+        axis_cell="continuous_individual_panel",
+        scale=_scale(),
+        metric_set="core",
+        is_warmup=False,
+        env=env,
+    )
+    out = tmp_path / "run.jsonl"
+    write_records(out, [warm, main])
+
+    rows = read_records(out)
+    assert len(rows) == 2
+    assert rows[0]["is_warmup"] is True
+    assert rows[1]["is_warmup"] is False
+
+    report = validate_file(out)
+    assert report.ok, report.failures
+
+
+def test_scale_axis_cell_mismatch_fails_loudly():
+    env = collect_env()
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        measure(
+            setup=lambda: 0,
+            compute=lambda _: 0,
+            scenario_id="t",
+            axis_cell="sparse_individual_panel",
+            scale=_scale(),  # continuous shape
+            metric_set="core",
+            env=env,
+        )

--- a/tests/bench/test_wrapper.py
+++ b/tests/bench/test_wrapper.py
@@ -91,6 +91,7 @@ def test_warmup_record_is_preserved(tmp_path: Path):
 def test_scale_axis_cell_mismatch_fails_loudly():
     env = collect_env()
     from pydantic import ValidationError
+
     with pytest.raises(ValidationError):
         measure(
             setup=lambda: 0,

--- a/uv.lock
+++ b/uv.lock
@@ -492,33 +492,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
     { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
     { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
     { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
     { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
     { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
     { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
     { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
     { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
     { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
     { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
     { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
     { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
     { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
     { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
     { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
     { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
     { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
     { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
     { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
     { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
     { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
     { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
@@ -629,11 +623,17 @@ all = [
     { name = "jupyterlab" },
     { name = "nbformat" },
 ]
+bench = [
+    { name = "psutil" },
+    { name = "pydantic" },
+]
 dev = [
     { name = "build" },
     { name = "commitizen" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "psutil" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -662,6 +662,7 @@ dev = [
 requires-dist = [
     { name = "build", marker = "extra == 'dev'" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.10.1" },
+    { name = "factrix", extras = ["bench"], marker = "extra == 'dev'" },
     { name = "factrix", extras = ["jupyter"], marker = "extra == 'all'" },
     { name = "ipywidgets", marker = "extra == 'jupyter'", specifier = ">=7.7.0" },
     { name = "jupyter", marker = "extra == 'jupyter'", specifier = ">=1.0.0" },
@@ -676,6 +677,8 @@ requires-dist = [
     { name = "pandera", specifier = ">=0.29" },
     { name = "polars", specifier = ">=1.38" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
+    { name = "psutil", marker = "extra == 'bench'", specifier = ">=5.9" },
+    { name = "pydantic", marker = "extra == 'bench'", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },
@@ -683,7 +686,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
-provides-extras = ["jupyter", "dev", "docs", "all"]
+provides-extras = ["jupyter", "dev", "bench", "docs", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ipykernel", specifier = ">=7.2.0" }]


### PR DESCRIPTION
## Summary
- Lands the measurement skeleton from #381 so the follow-up scenario sub-issues of #380 can produce schema-valid JSONL without rolling their own parser.
- `bench/` is a top-level dev package, explicitly excluded from the published wheel; pydantic + psutil land in a new `factrix[bench]` extra so runtime deps stay untouched.
- API note: `bench.wrapper.measure` is a function (not `@decorator`) so the setup/compute timing split stays explicit — the split is the load-bearing #380 §9 requirement and a single-callable decorator can't carry it.

## Test plan
- [x] `uv run pytest tests/bench` — 28 new tests cover seed lock, error path, validator fail-loud (missing field / enum violation / schema_version mismatch / invalid JSON), warmup row preservation, scale↔axis_cell cross-check, JSON Schema export, end-to-end dummy scenario.
- [x] `uv run pytest` — full 1357-test suite still green, no regressions.
- [x] `uv run ruff check bench tests/bench` — clean.
- [x] `uv build --wheel` + `zipfile` inspection — confirms `bench/` and `tests/` excluded from the wheel.
- [x] `python -m bench.validate` CLI smoke (clean file → exit 0; missing field row → exit 1; missing file → exit 1).
- [x] `python -m bench.scenarios.dummy --output …` smoke — writes JSONL → self-validates.

## Deferred to follow-up sub-issues of #380
- Mandatory peak/probe scenarios S1–S5 + P1 and per-metric micros M-ic / M-ic-boot / M-quantile / M-mono / M-corrado (#380 §4)
- `bench/metric_sets.py` + `metric_set_version` central pin (#380 §3, §6)
- `bench/baselines/<version>/` reference baseline storage + index (#380 §9.2)
- Release-flow baseline rerun integration (`cz bump` hook / Makefile target / release PR checkbox) (#380 §9.2)
- CI `bench-tiny` smoke job (#380 §10) — README already documents the `PYTHONPATH` / repo-root constraint the job will need
- Ratio / summary markdown post-processing

Closes #381