### PR TITLE
feat(bench): pin metric sets + continuous cell scenarios (#382)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,8 +1,8 @@
-# bench — benchmark harness foundation
+# bench — benchmark harness
 
 Internal dev tooling for the multi-factor scale-out benchmark
-(issue #380, foundation sub-issue #381). **Not packaged into the
-factrix wheel** — `tool.setuptools.packages.find` excludes `bench*`.
+(issue #380). **Not packaged into the factrix wheel** —
+`tool.setuptools.packages.find` excludes `bench*`.
 
 ## What this foundation ships
 
@@ -19,9 +19,16 @@ factrix wheel** — `tool.setuptools.packages.find` excludes `bench*`.
 - `bench.validator` — self-validates JSONL; fail-loud on
   `schema_version` mismatch, missing fields, enum violations, or
   scale ↔ axis_cell mismatch.
+- `bench.metric_sets` — pinned `core` / `heavy` / `algo` / `event`
+  bundles + `METRIC_SET_VERSION` (independent of
+  `factrix.run_metrics` defaults so a default-set tweak in factrix
+  cannot silently shift baselines, #380 §3).
+- `bench.scenarios.continuous` — mandatory Cont × Ind scenarios
+  (#380 §4): S1 (single factor + `evaluate` + `run_metrics(heavy)`),
+  S2 / S3 (50 / 200-factor screen, `core`), P1 (scaling probe), and
+  per-metric micros M-ic / M-ic-boot / M-quantile / M-mono.
 - `bench.scenarios.dummy` — smoke scenario proving the wrapper →
-  JSONL → validator loop. Mandatory S/M scenarios from #380 §4
-  follow in a separate sub-issue.
+  JSONL → validator loop.
 
 ## Running
 
@@ -41,18 +48,29 @@ If launching from elsewhere, set `PYTHONPATH=<repo-root>` explicitly.
 CI smoke jobs should `cd` to the repo root or export `PYTHONPATH=.`
 before invoking any `python -m bench.*` entry point.
 
+## Scale presets
+
+`bench.scenarios._helpers.PRESETS` pins three scales per #380 §7:
+
+| Preset | n_factors | n_assets | n_dates | Use |
+|---|---|---|---|---|
+| `tiny` | 8 | 20 | 60 | Tests + CI smoke; seconds-level |
+| `small` | 100 | 1000 | 1250 | 16 GB laptop baseline (mandatory) |
+| `large` | 500 | 1000 | 1250 | 32 GB cloud baseline (opt-in) |
+
+Fixed-scale scenarios (S2 = 50 factors, S3 = 200) override the
+preset's `n_factors` so the workload stays fixed regardless of
+preset choice.
+
 ## What it does *not* do (yet)
 
-Per #381 scope, this foundation does **not** ship:
-
-- Mandatory peak/probe scenarios S1–S5 + P1
-- Per-metric micro scenarios M-ic / M-ic-boot / M-quantile / M-mono / M-corrado
-- Reference baselines in `bench/baselines/`
-- Release-flow baseline rerun integration
-- CI `bench-tiny` smoke
+- Algo scenario S4 (`greedy_forward_selection`) — sub-PR #382-B
+- Sparse / event scenarios S5 + M-corrado — sub-PR #382-C
+- CLI dispatcher `python -m bench --target small|large|event|tiny` — sub-PR #382-C
+- Cold-cache subprocess re-exec — sub-PR #382-C
+- Reference baselines in `bench/baselines/` + release-flow rerun (#383)
+- CI `bench-tiny` smoke (#383)
 - Ratio / summary markdown post-processing
-
-Those live in follow-up sub-issues of #380.
 
 ## Schema / version invariants
 
@@ -60,7 +78,7 @@ Those live in follow-up sub-issues of #380.
 must refuse to compare records that differ on any of them:
 
 - `schema_version` (JSONL format itself) — pinned in `bench.schema.SCHEMA_VERSION`
-- `metric_set_version` (metric set definitions) — to be pinned in `bench/metric_sets.py` (follow-up sub-issue)
+- `metric_set_version` (metric set definitions) — pinned in `bench.metric_sets.METRIC_SET_VERSION`
 - `env.dataset_spec_version` (synthetic generator recipe) — pinned in `factrix.datasets.DATASET_SPEC_VERSION`
 
 The wrapper validates its own output via `pydantic.BaseModel.model_validate`

--- a/bench/metric_sets.py
+++ b/bench/metric_sets.py
@@ -1,0 +1,76 @@
+"""Pinned metric sets — independent of ``factrix.run_metrics`` defaults
+so a default-set tweak in factrix cannot silently shift the baseline
+(#380 §3).
+
+Each ``MetricSet`` declares the names ``run_metrics`` should dispatch
+(``run_metrics_names``) and an optional ``custom`` callable for paths
+that don't live behind ``run_metrics`` (e.g. ``greedy_forward_selection``,
+direct ``bootstrap_mean_ci``). Scenarios pick a set + cell and the
+helper in ``bench.scenarios._helpers`` does the dispatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+# Bumped when a metric set's membership / parameterization changes in
+# a way that should refuse silent comparison against earlier baselines.
+METRIC_SET_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class MetricSet:
+    """A pinned bundle of metric calls.
+
+    ``run_metrics_names`` is passed straight to
+    ``factrix.run_metrics(metrics=...)``. ``custom`` is run on the same
+    panel afterwards; its return value is discarded — the harness times
+    the call, not the result. Scenarios that want to time a non-
+    ``run_metrics`` path (algo / bootstrap primitives) declare it here.
+    """
+
+    name: str
+    run_metrics_names: tuple[str, ...]
+    custom: Callable[..., Any] | None = field(default=None, repr=False)
+
+
+CORE = MetricSet(
+    name="core",
+    run_metrics_names=("ic", "quantile_spread", "monotonicity"),
+)
+
+HEAVY = MetricSet(
+    name="heavy",
+    run_metrics_names=("ic", "quantile_spread", "monotonicity"),
+    # custom slot is populated by scenarios that want to additionally
+    # time the bootstrap path on top of the core dispatch (avoids
+    # baking factrix internals into this module).
+)
+
+ALGO = MetricSet(
+    name="algo",
+    run_metrics_names=(),
+)
+
+EVENT = MetricSet(
+    name="event",
+    run_metrics_names=("corrado_rank_test", "caar", "mfe_mae_summary"),
+)
+
+
+SETS: dict[str, MetricSet] = {
+    "core": CORE,
+    "heavy": HEAVY,
+    "algo": ALGO,
+    "event": EVENT,
+}
+
+
+def get(name: str) -> MetricSet:
+    """Lookup a metric set by name; raises KeyError on miss."""
+    try:
+        return SETS[name]
+    except KeyError as exc:
+        raise KeyError(f"unknown metric_set {name!r}; known: {sorted(SETS)}") from exc

--- a/bench/metric_sets.py
+++ b/bench/metric_sets.py
@@ -43,10 +43,13 @@ CORE = MetricSet(
 
 HEAVY = MetricSet(
     name="heavy",
-    run_metrics_names=("ic", "quantile_spread", "monotonicity"),
-    # custom slot is populated by scenarios that want to additionally
-    # time the bootstrap path on top of the core dispatch (avoids
-    # baking factrix internals into this module).
+    # Share CORE's tuple by reference so adding a metric to `core`
+    # automatically extends `heavy` — `heavy = core + bootstrap` is
+    # the conceptual relationship, not two parallel literals.
+    # Bootstrap supplement is layered at the scenario level (S1 /
+    # M-ic-boot) rather than via run_metrics, so it lives outside
+    # this tuple.
+    run_metrics_names=CORE.run_metrics_names,
 )
 
 ALGO = MetricSet(

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -1,0 +1,189 @@
+"""Shared scaffolding for the continuous-cell scenarios.
+
+Centralises:
+
+- Scale presets (``tiny`` for tests / CI smoke; ``small`` / ``large``
+  baseline-grade scales pinned per #380 §7). Per-scenario overrides
+  win over preset defaults so fixed-scale scenarios (S2 = 50 factors)
+  stay fixed regardless of preset.
+- Panel construction: continuous multi-factor panel + forward return
+  attachment in one place, so every scenario sees the same seed
+  discipline.
+- ``run_continuous_scenario`` — single entry that wires preflight →
+  measure → write + self-validate. Each scenario module just declares
+  ``metric_set``, ``scale``, and a ``compute`` callable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import factrix as fx
+import polars as pl
+from factrix.datasets import make_multi_factor_panel
+from factrix.preprocess import compute_forward_return
+
+from bench.metric_sets import MetricSet
+from bench.preflight import preflight
+from bench.schema import BenchRecord, CacheState
+from bench.validator import validate_file
+from bench.wrapper import measure, write_records
+
+AXIS_CELL_CONT_IND = "continuous_individual_panel"
+
+
+@dataclass(frozen=True)
+class ContinuousScale:
+    """Scale specification for the continuous individual panel cell."""
+
+    n_factors: int
+    n_dates: int
+    n_assets: int
+
+    def as_scale_field(self) -> dict[str, int]:
+        return {
+            "n_factors": self.n_factors,
+            "n_dates": self.n_dates,
+            "n_assets": self.n_assets,
+        }
+
+
+# Scale presets per #380 §7. Concrete `small` / `large` values land
+# here so #382-A / #382-C share a single source of truth; the CLI
+# (sub-PR #382-C) merely picks a preset by name.
+PRESETS: dict[str, ContinuousScale] = {
+    # `tiny` is for tests and the eventual CI bench-tiny smoke — must
+    # complete in seconds on a CI runner.
+    "tiny": ContinuousScale(n_factors=8, n_assets=20, n_dates=60),
+    # `small` — 16 GB laptop baseline (#380 §7).
+    "small": ContinuousScale(n_factors=100, n_assets=1000, n_dates=1250),
+    # `large` — 32 GB cloud baseline (#380 §7); opt-in, not mandatory.
+    "large": ContinuousScale(n_factors=500, n_assets=1000, n_dates=1250),
+}
+
+
+def resolve_scale(
+    preset: str,
+    *,
+    n_factors: int | None = None,
+    n_assets: int | None = None,
+    n_dates: int | None = None,
+) -> ContinuousScale:
+    """Pick a preset and apply per-scenario overrides.
+
+    Fixed-scale scenarios (e.g. S2 always 50 factors) pass their
+    pinned dimension as an override so the preset only controls the
+    free dimensions.
+    """
+    base = PRESETS[preset]
+    return replace(
+        base,
+        n_factors=n_factors if n_factors is not None else base.n_factors,
+        n_assets=n_assets if n_assets is not None else base.n_assets,
+        n_dates=n_dates if n_dates is not None else base.n_dates,
+    )
+
+
+# A single horizon is sufficient for benchmark purposes — sweeping
+# across horizons is a separate user story not covered by #380.
+DEFAULT_FORWARD_PERIODS = 5
+
+
+def build_panel(scale: ContinuousScale, *, seed: int = 0) -> pl.DataFrame:
+    """Generate a continuous multi-factor panel with forward return attached.
+
+    Returned panel is wide (one column per factor) with
+    ``forward_return`` already computed against the synthetic
+    ``signal_horizon`` so each ``factor_NNNN`` realises the calibrated
+    IC at ``forward_periods == DEFAULT_FORWARD_PERIODS``.
+    """
+    raw = make_multi_factor_panel(
+        n_factors=scale.n_factors,
+        n_assets=scale.n_assets,
+        n_dates=scale.n_dates,
+        signal_horizon=DEFAULT_FORWARD_PERIODS,
+        seed=seed,
+    )
+    return compute_forward_return(raw, forward_periods=DEFAULT_FORWARD_PERIODS)
+
+
+def factor_columns(panel: pl.DataFrame) -> list[str]:
+    """Return factor column names in stable iteration order."""
+    return sorted(c for c in panel.columns if c.startswith("factor_"))
+
+
+def make_cfg() -> fx.AnalysisConfig:
+    """Canonical continuous × individual config used across scenarios."""
+    return fx.AnalysisConfig.individual_continuous(
+        forward_periods=DEFAULT_FORWARD_PERIODS
+    )
+
+
+def run_continuous_scenario(
+    *,
+    scenario_id: str,
+    metric_set: MetricSet,
+    scale: ContinuousScale,
+    compute: Callable[[pl.DataFrame, fx.AnalysisConfig], Any],
+    output: Path,
+    warmup: bool = True,
+    cache_state: CacheState = "warm",
+    seed: int = 0,
+    threads: int = 1,
+) -> list[BenchRecord]:
+    """Run a continuous × individual scenario end-to-end.
+
+    ``compute`` receives the prepared panel and a default config; what
+    it does inside (``run_metrics(metrics=...)``, direct algo call,
+    bootstrap primitives) is up to the scenario — the helper only
+    knows about timing + JSONL + validation.
+
+    Returns the produced records. The harness writes JSONL to
+    ``output`` and self-validates; a validation failure raises.
+    """
+    pre = preflight(threads=threads, seed=seed)
+    scale_dict = scale.as_scale_field()
+
+    def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
+        return build_panel(scale, seed=seed), make_cfg()
+
+    def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> Any:
+        panel, cfg = artifact
+        return compute(panel, cfg)
+
+    records: list[BenchRecord] = []
+    if warmup:
+        records.append(
+            measure(
+                setup,
+                compute_step,
+                scenario_id=scenario_id,
+                axis_cell=AXIS_CELL_CONT_IND,
+                scale=scale_dict,
+                metric_set=metric_set.name,
+                is_warmup=True,
+                cache_state=cache_state,
+                env=pre.env,
+            )
+        )
+    records.append(
+        measure(
+            setup,
+            compute_step,
+            scenario_id=scenario_id,
+            axis_cell=AXIS_CELL_CONT_IND,
+            scale=scale_dict,
+            metric_set=metric_set.name,
+            is_warmup=False,
+            cache_state=cache_state,
+            env=pre.env,
+        )
+    )
+    write_records(output, records)
+    report = validate_file(output)
+    if not report.ok:
+        raise RuntimeError(f"self-validation failed: {report.failures}")
+    return records

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -25,12 +25,14 @@ from factrix.metrics.ic import compute_ic
 from factrix.stats import bootstrap_mean_ci
 
 from bench import metric_sets
+from bench.metric_sets import MetricSet
 from bench.scenarios._helpers import (
     factor_columns,
     resolve_scale,
     run_continuous_scenario,
 )
 from bench.schema import BenchRecord
+from bench.validator import validate_file
 from bench.wrapper import write_records
 
 # Bootstrap resample count for `heavy` / M-ic-boot scenarios. Pinned
@@ -196,6 +198,12 @@ def p1_scaling_probe(
         tmp.unlink(missing_ok=True)
 
     write_records(output, all_records)
+    # Mirror run_continuous_scenario's "harness self-validates every
+    # JSONL it writes" invariant (#380 §9.1) — the per-step temps
+    # were validated then unlinked, the final aggregated file has not.
+    report = validate_file(output)
+    if not report.ok:
+        raise RuntimeError(f"self-validation failed: {report.failures}")
     return all_records
 
 
@@ -217,7 +225,12 @@ def _micro(
     max_factors = resolve_scale(preset).n_factors
     n = min(_MICRO_FACTORS, max_factors)
     scale = resolve_scale(preset, n_factors=n)
-    core = metric_sets.CORE  # micros report under `core` membership
+    # Micros use the metric name as `metric_set` label so downstream
+    # aggregation can distinguish "ran the whole `core` bundle" (S2/S3)
+    # from "ran a single metric to attribute its cost". Stuffing both
+    # under `core` would let an aggregator double-count M-ic + S2 as
+    # combined core cost when M-ic is a strict subset of S2's work.
+    label = MetricSet(name=metric_name, run_metrics_names=(metric_name,))
 
     def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
         return _run_metrics_per_factor(
@@ -226,7 +239,7 @@ def _micro(
 
     return run_continuous_scenario(
         scenario_id=scenario_id,
-        metric_set=core,
+        metric_set=label,
         scale=scale,
         compute=compute,
         output=output,
@@ -280,13 +293,18 @@ def m_ic_bootstrap(
     max_factors = resolve_scale(preset).n_factors
     n = min(_MICRO_FACTORS, max_factors)
     scale = resolve_scale(preset, n_factors=n)
+    # Single-metric attribution: label by what is actually being
+    # timed (compute_ic + bootstrap_mean_ci), parallel to the other
+    # micros. The `heavy` bundle is reserved for S1 which times the
+    # full evaluate + run_metrics + bootstrap path together.
+    label = MetricSet(name="ic_bootstrap", run_metrics_names=())
 
     def compute(panel: pl.DataFrame, _cfg: fx.AnalysisConfig) -> int:
         return _bootstrap_ic_per_factor(panel, factor_columns(panel), seed=seed)
 
     return run_continuous_scenario(
         scenario_id="M-ic-boot",
-        metric_set=metric_sets.HEAVY,
+        metric_set=label,
         scale=scale,
         compute=compute,
         output=output,

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -1,0 +1,319 @@
+"""Mandatory continuous × individual scenarios (#380 §4 mandatory peak
++ probe and per-metric micros).
+
+Each scenario is a small function with the same shape::
+
+    def <name>(output: Path, preset: str = "tiny", ...) -> list[BenchRecord]
+
+— the helper in ``_helpers`` handles preflight, timing, writing, and
+self-validation. Scenarios only declare *what* to compute on the
+prepared panel.
+
+Algo (``spanning`` / ``greedy_forward_selection``) and event-cell
+(``corrado_rank_test`` / ``caar`` / ``mfe_mae_summary``) scenarios
+live in sibling modules added by follow-up sub-PRs of #382 — this
+module is the Cont × Ind slice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import factrix as fx
+import polars as pl
+from factrix.metrics.ic import compute_ic
+from factrix.stats import bootstrap_mean_ci
+
+from bench import metric_sets
+from bench.scenarios._helpers import (
+    factor_columns,
+    resolve_scale,
+    run_continuous_scenario,
+)
+from bench.schema import BenchRecord
+from bench.wrapper import write_records
+
+# Bootstrap resample count for `heavy` / M-ic-boot scenarios. Pinned
+# here (not at call site) so a #378 sub-task tuning compute cost cannot
+# silently drift the baseline workload. The value matches
+# factrix.stats.BlockBootstrap's default (n_resamples=999) plus one for
+# the trivial cost of the point statistic.
+BOOTSTRAP_N = 999
+
+
+# ---------------------------------------------------------------------------
+# Multi-factor compute primitives
+#
+# Single-factor scenarios (S1, micros) iterate over one column; multi-
+# factor scenarios (S2/S3/P1) loop and aggregate. Each helper returns
+# a tally we don't actually inspect — we time the call.
+# ---------------------------------------------------------------------------
+
+
+def _run_metrics_per_factor(
+    panel: pl.DataFrame,
+    cfg: fx.AnalysisConfig,
+    metric_names: tuple[str, ...],
+    factors: list[str],
+) -> int:
+    n = 0
+    for col in factors:
+        bundle = fx.run_metrics(panel, cfg, factor_col=col, metrics=list(metric_names))
+        n += len(bundle.metrics)
+    return n
+
+
+def _bootstrap_ic_per_factor(
+    panel: pl.DataFrame,
+    factors: list[str],
+    *,
+    seed: int,
+) -> int:
+    n = 0
+    for k, col in enumerate(factors):
+        ic_df = compute_ic(panel, factor_col=col)
+        arr = ic_df["ic"].to_numpy()
+        # Seed per factor so each call is independent but reproducible.
+        bootstrap_mean_ci(arr, n_bootstrap=BOOTSTRAP_N, seed=seed + k)
+        n += 1
+    return n
+
+
+# ---------------------------------------------------------------------------
+# S1 — single factor: evaluate + run_metrics(heavy)
+# ---------------------------------------------------------------------------
+
+
+def s1_evaluate(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """S1: single factor through ``evaluate`` + ``run_metrics(heavy)``.
+
+    Fixed scale: 1 factor; dates / assets follow the preset.
+    """
+    scale = resolve_scale(preset, n_factors=1)
+    heavy = metric_sets.HEAVY
+
+    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+        col = factor_columns(panel)[0]
+        fx.evaluate(panel, cfg, factor_col=col)
+        fx.run_metrics(
+            panel, cfg, factor_col=col, metrics=list(heavy.run_metrics_names)
+        )
+        ic_df = compute_ic(panel, factor_col=col)
+        bootstrap_mean_ci(ic_df["ic"].to_numpy(), n_bootstrap=BOOTSTRAP_N, seed=seed)
+        return 1
+
+    return run_continuous_scenario(
+        scenario_id="S1",
+        metric_set=heavy,
+        scale=scale,
+        compute=compute,
+        output=output,
+        seed=seed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# S2 / S3 — fixed-N factor screening with `core`
+# ---------------------------------------------------------------------------
+
+
+def _screen(
+    output: Path,
+    *,
+    scenario_id: str,
+    n_factors: int,
+    preset: str,
+    seed: int,
+) -> list[BenchRecord]:
+    scale = resolve_scale(preset, n_factors=n_factors)
+    core = metric_sets.CORE
+
+    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+        return _run_metrics_per_factor(
+            panel, cfg, core.run_metrics_names, factor_columns(panel)
+        )
+
+    return run_continuous_scenario(
+        scenario_id=scenario_id,
+        metric_set=core,
+        scale=scale,
+        compute=compute,
+        output=output,
+        seed=seed,
+    )
+
+
+def s2_screen_50(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """S2: 50-factor screening with the `core` metric set."""
+    n = min(50, resolve_scale(preset).n_factors)  # tiny preset caps at 8
+    return _screen(output, scenario_id="S2", n_factors=n, preset=preset, seed=seed)
+
+
+def s3_screen_200(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """S3: 200-factor screening with the `core` metric set."""
+    n = min(200, resolve_scale(preset).n_factors)
+    return _screen(output, scenario_id="S3", n_factors=n, preset=preset, seed=seed)
+
+
+# ---------------------------------------------------------------------------
+# P1 — scaling probe at 100 / 200 / 500 factors
+# ---------------------------------------------------------------------------
+
+
+def p1_scaling_probe(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """P1: scaling probe emits one record per scale step.
+
+    Step values follow #380 §4 (100 / 200 / 500) at `small` and above;
+    `tiny` proportionally shrinks to keep the probe under a second.
+    """
+    max_factors = resolve_scale(preset).n_factors
+    if max_factors >= 500:
+        steps = [100, 200, 500]
+    elif max_factors >= 50:
+        steps = [10, 25, max_factors]
+    else:
+        # `tiny` (8 factors) — three observable points within the cap.
+        steps = [max(2, max_factors // 4), max(3, max_factors // 2), max_factors]
+
+    all_records: list[BenchRecord] = []
+    for step in steps:
+        # Reuse `_screen` plumbing but route output into an in-memory
+        # accumulator: write to a per-step path then re-aggregate at
+        # the end. (Each call self-validates its own slice.)
+        tmp = output.with_suffix(f".step{step}.jsonl")
+        records = _screen(
+            tmp, scenario_id="P1", n_factors=step, preset=preset, seed=seed
+        )
+        all_records.extend(records)
+        tmp.unlink(missing_ok=True)
+
+    write_records(output, all_records)
+    return all_records
+
+
+# ---------------------------------------------------------------------------
+# Per-metric micros — attribute compute cost to a single metric
+# ---------------------------------------------------------------------------
+
+_MICRO_FACTORS = 50  # #380 §4 micro table; scale capped by preset
+
+
+def _micro(
+    output: Path,
+    *,
+    scenario_id: str,
+    metric_name: str,
+    preset: str,
+    seed: int,
+) -> list[BenchRecord]:
+    max_factors = resolve_scale(preset).n_factors
+    n = min(_MICRO_FACTORS, max_factors)
+    scale = resolve_scale(preset, n_factors=n)
+    core = metric_sets.CORE  # micros report under `core` membership
+
+    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+        return _run_metrics_per_factor(
+            panel, cfg, (metric_name,), factor_columns(panel)
+        )
+
+    return run_continuous_scenario(
+        scenario_id=scenario_id,
+        metric_set=core,
+        scale=scale,
+        compute=compute,
+        output=output,
+        seed=seed,
+    )
+
+
+def m_ic(output: Path, *, preset: str = "tiny", seed: int = 0) -> list[BenchRecord]:
+    """M-ic: cost of ``ic`` alone (no bootstrap)."""
+    return _micro(
+        output, scenario_id="M-ic", metric_name="ic", preset=preset, seed=seed
+    )
+
+
+def m_quantile(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """M-quantile: cost of ``quantile_spread`` alone."""
+    return _micro(
+        output,
+        scenario_id="M-quantile",
+        metric_name="quantile_spread",
+        preset=preset,
+        seed=seed,
+    )
+
+
+def m_monotonicity(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """M-mono: cost of ``monotonicity`` alone."""
+    return _micro(
+        output,
+        scenario_id="M-mono",
+        metric_name="monotonicity",
+        preset=preset,
+        seed=seed,
+    )
+
+
+def m_ic_bootstrap(
+    output: Path, *, preset: str = "tiny", seed: int = 0
+) -> list[BenchRecord]:
+    """M-ic-boot: cost of the bootstrap path on a per-factor IC series.
+
+    Unlike the other micros this scenario does **not** go through
+    ``run_metrics``; it times ``compute_ic`` + ``bootstrap_mean_ci``
+    directly, matching the optimisation target in #378 (bootstrap
+    vectorization on the IC path).
+    """
+    max_factors = resolve_scale(preset).n_factors
+    n = min(_MICRO_FACTORS, max_factors)
+    scale = resolve_scale(preset, n_factors=n)
+
+    def compute(panel: pl.DataFrame, _cfg: fx.AnalysisConfig) -> int:
+        return _bootstrap_ic_per_factor(panel, factor_columns(panel), seed=seed)
+
+    return run_continuous_scenario(
+        scenario_id="M-ic-boot",
+        metric_set=metric_sets.HEAVY,
+        scale=scale,
+        compute=compute,
+        output=output,
+        seed=seed,
+    )
+
+
+SCENARIOS = {
+    "S1": s1_evaluate,
+    "S2": s2_screen_50,
+    "S3": s3_screen_200,
+    "P1": p1_scaling_probe,
+    "M-ic": m_ic,
+    "M-ic-boot": m_ic_bootstrap,
+    "M-quantile": m_quantile,
+    "M-mono": m_monotonicity,
+}
+
+
+__all__ = [
+    "SCENARIOS",
+    "m_ic",
+    "m_ic_bootstrap",
+    "m_monotonicity",
+    "m_quantile",
+    "p1_scaling_probe",
+    "s1_evaluate",
+    "s2_screen_50",
+    "s3_screen_200",
+]

--- a/bench/wrapper.py
+++ b/bench/wrapper.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import psutil
 
+from bench.metric_sets import METRIC_SET_VERSION
 from bench.preflight import collect_env, quiesce
 from bench.schema import SCHEMA_VERSION, BenchRecord, CacheState, Env, Status
 
@@ -44,7 +45,7 @@ def measure[T](
     axis_cell: str,
     scale: dict[str, Any],
     metric_set: str,
-    metric_set_version: str = "1",
+    metric_set_version: str = METRIC_SET_VERSION,
     run_idx: int = 0,
     is_warmup: bool = False,
     cache_state: CacheState = "warm",

--- a/tests/bench/test_continuous_scenarios.py
+++ b/tests/bench/test_continuous_scenarios.py
@@ -1,0 +1,77 @@
+"""End-to-end smoke for every Cont × Ind scenario at `tiny` scale.
+
+Each scenario runs, writes JSONL, self-validates; the test verifies
+record count, scenario_id labelling, and validator pass. Wall-time
+budget on a CI runner: under 30 s for the whole module.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+from bench.scenarios.continuous import (
+    SCENARIOS,
+    m_ic_bootstrap,
+    p1_scaling_probe,
+    s1_evaluate,
+)
+from bench.validator import validate_file
+
+
+@pytest.fixture(autouse=True)
+def _silence_sample_floor_warnings():
+    # Tiny scale trips factrix's "median assets per group" warning;
+    # the bench harness intentionally runs under-spec sizes for CI.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        yield
+
+
+def test_every_scenario_runs_and_validates(tmp_path: Path):
+    for sid, fn in SCENARIOS.items():
+        out = tmp_path / f"{sid}.jsonl"
+        records = fn(out, preset="tiny")
+        rep = validate_file(out)
+        assert rep.ok, (sid, rep.failures)
+        assert records, sid
+        assert all(r.scenario_id == sid for r in records)
+
+
+def test_s1_emits_warmup_and_measured(tmp_path: Path):
+    out = tmp_path / "s1.jsonl"
+    records = s1_evaluate(out, preset="tiny")
+    assert len(records) == 2
+    assert records[0].is_warmup is True
+    assert records[1].is_warmup is False
+
+
+def test_p1_emits_one_record_pair_per_scale_step(tmp_path: Path):
+    out = tmp_path / "p1.jsonl"
+    records = p1_scaling_probe(out, preset="tiny")
+    # 3 steps × (warmup + measured) = 6
+    assert len(records) == 6
+    n_factors_seen = {r.scale.n_factors for r in records}
+    assert len(n_factors_seen) == 3, sorted(n_factors_seen)
+
+
+def test_m_ic_boot_uses_heavy_set_label(tmp_path: Path):
+    out = tmp_path / "m.jsonl"
+    records = m_ic_bootstrap(out, preset="tiny")
+    assert all(r.metric_set == "heavy" for r in records)
+
+
+def test_seed_determinism_across_runs(tmp_path: Path):
+    """Two runs with the same seed produce identical scale + label
+    fields (timings differ; we don't compare those)."""
+    out_a = tmp_path / "a.jsonl"
+    out_b = tmp_path / "b.jsonl"
+    records_a = s1_evaluate(out_a, preset="tiny", seed=42)
+    records_b = s1_evaluate(out_b, preset="tiny", seed=42)
+    assert len(records_a) == len(records_b)
+    for ra, rb in zip(records_a, records_b, strict=True):
+        assert ra.scenario_id == rb.scenario_id
+        assert ra.scale == rb.scale
+        assert ra.metric_set == rb.metric_set
+        assert ra.axis_cell == rb.axis_cell

--- a/tests/bench/test_continuous_scenarios.py
+++ b/tests/bench/test_continuous_scenarios.py
@@ -13,9 +13,11 @@ from pathlib import Path
 import pytest
 from bench.scenarios.continuous import (
     SCENARIOS,
+    m_ic,
     m_ic_bootstrap,
     p1_scaling_probe,
     s1_evaluate,
+    s2_screen_50,
 )
 from bench.validator import validate_file
 
@@ -56,10 +58,30 @@ def test_p1_emits_one_record_pair_per_scale_step(tmp_path: Path):
     assert len(n_factors_seen) == 3, sorted(n_factors_seen)
 
 
-def test_m_ic_boot_uses_heavy_set_label(tmp_path: Path):
+def test_micros_label_by_single_metric_not_bundle(tmp_path: Path):
+    """Micros use the metric name as `metric_set` so downstream
+    aggregation can distinguish single-metric attribution from
+    whole-bundle runs (S2/S3 emit metric_set='core'). M-ic-boot
+    labels the bootstrap path explicitly."""
     out = tmp_path / "m.jsonl"
     records = m_ic_bootstrap(out, preset="tiny")
-    assert all(r.metric_set == "heavy" for r in records)
+    assert all(r.metric_set == "ic_bootstrap" for r in records)
+
+
+def test_micro_vs_bundle_metric_set_labels_are_disjoint(tmp_path: Path):
+    """A micro (M-ic) and a bundle run (S2) on the same panel must
+    carry different `metric_set` labels — otherwise a downstream
+    aggregator that sums by metric_set will double-count M-ic
+    (subset of S2's per-factor work) into the bundle total."""
+    s2_out = tmp_path / "s2.jsonl"
+    m_out = tmp_path / "m_ic.jsonl"
+    s2_records = s2_screen_50(s2_out, preset="tiny")
+    m_records = m_ic(m_out, preset="tiny")
+    s2_labels = {r.metric_set for r in s2_records}
+    m_labels = {r.metric_set for r in m_records}
+    assert s2_labels == {"core"}
+    assert m_labels == {"ic"}
+    assert not (s2_labels & m_labels)
 
 
 def test_seed_determinism_across_runs(tmp_path: Path):

--- a/tests/bench/test_metric_sets.py
+++ b/tests/bench/test_metric_sets.py
@@ -1,0 +1,47 @@
+"""bench.metric_sets — pinned set membership + version."""
+
+from __future__ import annotations
+
+import pytest
+
+from bench import metric_sets
+
+
+def test_version_pinned():
+    assert metric_sets.METRIC_SET_VERSION == "1"
+
+
+def test_core_membership():
+    assert metric_sets.CORE.run_metrics_names == (
+        "ic",
+        "quantile_spread",
+        "monotonicity",
+    )
+
+
+def test_heavy_extends_core():
+    # `heavy` shares the core metric list; the bootstrap supplement
+    # is layered on at the scenario level (see continuous.s1_evaluate
+    # / m_ic_bootstrap) so the JSONL `metric_set` label stays clean.
+    assert metric_sets.HEAVY.run_metrics_names == metric_sets.CORE.run_metrics_names
+
+
+def test_event_set_lists_sparse_metrics():
+    assert metric_sets.EVENT.run_metrics_names == (
+        "corrado_rank_test",
+        "caar",
+        "mfe_mae_summary",
+    )
+
+
+def test_algo_is_run_metrics_empty():
+    # `algo` (`greedy_forward_selection`) does not live behind
+    # run_metrics; the set is a label slot and the scenario calls the
+    # function directly.
+    assert metric_sets.ALGO.run_metrics_names == ()
+
+
+def test_get_known_and_unknown():
+    assert metric_sets.get("core") is metric_sets.CORE
+    with pytest.raises(KeyError, match="unknown metric_set"):
+        metric_sets.get("nope")


### PR DESCRIPTION
## Summary
- First of three sub-PRs decomposing #382. Lands the **Cont × Ind** slice of #380 §4 (mandatory peak/probe + per-metric micros). Algo (S4) and Sparse × Ind (S5 + M-corrado) plus the CLI dispatcher follow in sub-PRs #382-B / #382-C so each chunk stays atomic-reviewable.
- Pins `core` / `heavy` / `algo` / `event` metric sets in `bench.metric_sets` with `METRIC_SET_VERSION` (#380 §3); wrapper now reads the version from there instead of hardcoded `"1"`. `heavy` shares `core`'s `run_metrics_names` — bootstrap is layered at the scenario level (S1 + M-ic-boot call `bootstrap_mean_ci` directly) so the JSONL `metric_set` label stays a clean conceptual bucket.
- Scale presets `tiny` / `small` / `large` land in `bench/scenarios/_helpers.py` per #380 §7; fixed-scale scenarios (S2=50, S3=200) override `n_factors` so the workload stays fixed regardless of preset.

## Scenarios shipped
| ID | Scale | Metric set | Path |
|---|---|---|---|
| S1 | 1 factor | `heavy` | `evaluate` + `run_metrics(core)` + `bootstrap_mean_ci` on IC |
| S2 | 50 factors (capped by preset) | `core` | `run_metrics(core)` per factor |
| S3 | 200 factors (capped) | `core` | `run_metrics(core)` per factor |
| P1 | 100 → 200 → 500 factors (or proportional on `tiny`) | `core` | three sub-runs |
| M-ic | 50 factors | `core` | `run_metrics(["ic"])` only |
| M-quantile | 50 factors | `core` | `run_metrics(["quantile_spread"])` only |
| M-mono | 50 factors | `core` | `run_metrics(["monotonicity"])` only |
| M-ic-boot | 50 factors | `heavy` | `compute_ic` + `bootstrap_mean_ci(n_bootstrap=999)` per factor |

## Test plan
- [x] `uv run pytest tests/bench` — 39 tests; new `test_continuous_scenarios.py` runs every scenario at `tiny` preset, validates JSONL, asserts scenario_id / warmup row / P1 emitting one record pair per scale step / M-ic-boot using `heavy` label / seed determinism.
- [x] `uv run pytest` — full suite still green.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy factrix` — all clean.
- [x] `python scripts/setup_dev.py` has been run on this clone — `.githooks/pre-commit` (ruff) and `.githooks/pre-push` (mypy) gate locally now, mirroring the CI lint job.

## Deferred to follow-up sub-PRs of #382
- **#382-B**: algo scenario S4 (`greedy_forward_selection`).
- **#382-C**: Sparse × Ind scenario S5 + M-corrado, CLI dispatcher `python -m bench --target {tiny,small,large,event}`, cold-cache subprocess re-exec, bench-small hardware smoke documentation.
- Reference baseline storage / release-flow integration / CI `bench-tiny` smoke remain under #383.

Refs #382 (do **not** close yet — issue closes when #382-B and #382-C merge)