### PR TITLE
feat(bench): add greedy forward selection scenario (#382)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -27,6 +27,9 @@ Internal dev tooling for the multi-factor scale-out benchmark
   (#380 §4): S1 (single factor + `evaluate` + `run_metrics(heavy)`),
   S2 / S3 (50 / 200-factor screen, `core`), P1 (scaling probe), and
   per-metric micros M-ic / M-ic-boot / M-quantile / M-mono.
+- `bench.scenarios.algo` — S4 greedy forward selection. Setup phase
+  pre-computes per-factor spread series (rank → bucket → spread);
+  compute phase runs the greedy + backward-elimination loop.
 - `bench.scenarios.dummy` — smoke scenario proving the wrapper →
   JSONL → validator loop.
 
@@ -64,10 +67,9 @@ preset choice.
 
 ## What it does *not* do (yet)
 
-- Algo scenario S4 (`greedy_forward_selection`) — sub-PR #382-B
-- Sparse / event scenarios S5 + M-corrado — sub-PR #382-C
-- CLI dispatcher `python -m bench --target small|large|event|tiny` — sub-PR #382-C
-- Cold-cache subprocess re-exec — sub-PR #382-C
+- Sparse / event scenarios S5 + M-corrado — follow-up sub-PR of #382
+- CLI dispatcher `python -m bench --target small|large|event|tiny` — follow-up sub-PR of #382
+- Cold-cache subprocess re-exec — follow-up sub-PR of #382
 - Reference baselines in `bench/baselines/` + release-flow rerun (#383)
 - CI `bench-tiny` smoke (#383)
 - Ratio / summary markdown post-processing

--- a/bench/README.md
+++ b/bench/README.md
@@ -4,7 +4,10 @@ Internal dev tooling for the multi-factor scale-out benchmark
 (issue #380). **Not packaged into the factrix wheel** —
 `tool.setuptools.packages.find` excludes `bench*`.
 
-## What this foundation ships
+For the harness roadmap and open work, see issue #380 and its open
+sub-issues. This README describes the current surface only.
+
+## Modules
 
 - `bench.schema` — pydantic v2 model for the JSONL record (`schema_version="1"`,
   open-schema `scale` keyed on `axis_cell`). Aligns with #380 §9.
@@ -64,15 +67,6 @@ before invoking any `python -m bench.*` entry point.
 Fixed-scale scenarios (S2 = 50 factors, S3 = 200) override the
 preset's `n_factors` so the workload stays fixed regardless of
 preset choice.
-
-## What it does *not* do (yet)
-
-- Sparse / event scenarios S5 + M-corrado — follow-up sub-PR of #382
-- CLI dispatcher `python -m bench --target small|large|event|tiny` — follow-up sub-PR of #382
-- Cold-cache subprocess re-exec — follow-up sub-PR of #382
-- Reference baselines in `bench/baselines/` + release-flow rerun (#383)
-- CI `bench-tiny` smoke (#383)
-- Ratio / summary markdown post-processing
 
 ## Schema / version invariants
 

--- a/bench/scenarios/__init__.py
+++ b/bench/scenarios/__init__.py
@@ -1,3 +1,9 @@
-"""Benchmark scenarios. Foundation ships a single dummy scenario; the
-mandatory S/M scenarios from #380 §4 arrive in a follow-up sub-issue.
+"""Benchmark scenario modules — one per analysis-axis cell (#380 §2).
+
+- ``continuous`` — Continuous × Individual scenarios (S1 / S2 / S3 /
+  P1 plus per-metric micros).
+- ``algo`` — algo scenarios that bypass ``run_metrics`` (S4 greedy
+  forward selection).
+- ``dummy`` — minimal end-to-end smoke proving wrapper → JSONL →
+  validator.
 """

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -1,4 +1,4 @@
-"""Shared scaffolding for the continuous-cell scenarios.
+"""Shared scaffolding for scenario modules.
 
 Centralises:
 
@@ -6,12 +6,16 @@ Centralises:
   baseline-grade scales pinned per #380 §7). Per-scenario overrides
   win over preset defaults so fixed-scale scenarios (S2 = 50 factors)
   stay fixed regardless of preset.
-- Panel construction: continuous multi-factor panel + forward return
-  attachment in one place, so every scenario sees the same seed
+- Continuous multi-factor panel construction + forward-return
+  attachment, so every Cont × Ind scenario sees the same seed
   discipline.
-- ``run_continuous_scenario`` — single entry that wires preflight →
-  measure → write + self-validate. Each scenario module just declares
-  ``metric_set``, ``scale``, and a ``compute`` callable.
+- ``run_scenario`` — generic measure / write / self-validate loop,
+  independent of axis cell.
+- ``run_continuous_scenario`` — Cont × Ind specialisation that
+  builds the panel + config and delegates to ``run_scenario``.
+  Algo scenarios call ``run_scenario`` directly because their
+  setup phase produces a per-factor spread dict, not the canonical
+  (panel, cfg) pair.
 """
 
 from __future__ import annotations
@@ -51,9 +55,9 @@ class ContinuousScale:
         }
 
 
-# Scale presets per #380 §7. Concrete `small` / `large` values land
-# here so #382-A / #382-C share a single source of truth; the CLI
-# (sub-PR #382-C) merely picks a preset by name.
+# Scale presets per #380 §7. Every scenario module reads these so
+# preset-named runs are guaranteed identical in dimensionality
+# regardless of which scenarios are exercised.
 PRESETS: dict[str, ContinuousScale] = {
     # `tiny` is for tests and the eventual CI bench-tiny smoke — must
     # complete in seconds on a CI runner.

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -28,7 +28,7 @@ from factrix.preprocess import compute_forward_return
 
 from bench.metric_sets import MetricSet
 from bench.preflight import preflight
-from bench.schema import BenchRecord, CacheState
+from bench.schema import BenchRecord, CacheState, Env
 from bench.validator import validate_file
 from bench.wrapper import measure, write_records
 
@@ -122,6 +122,63 @@ def make_cfg() -> fx.AnalysisConfig:
     )
 
 
+def run_scenario(
+    *,
+    scenario_id: str,
+    axis_cell: str,
+    metric_set: MetricSet,
+    scale: dict[str, Any],
+    setup: Callable[[], Any],
+    compute: Callable[[Any], Any],
+    output: Path,
+    env: Env,
+    warmup: bool = True,
+    cache_state: CacheState = "warm",
+) -> list[BenchRecord]:
+    """Run ``setup`` then ``compute`` (warmup + measured), write JSONL,
+    self-validate.
+
+    Generic over axis_cell / scale shape — the cell-specific helper
+    (e.g. ``run_continuous_scenario``) chooses panel construction,
+    config, and scale serialisation, then delegates here for the
+    measure / write / validate loop. Mirrors the §9.1 self-validation
+    invariant exactly once instead of per-cell.
+    """
+    records: list[BenchRecord] = []
+    if warmup:
+        records.append(
+            measure(
+                setup,
+                compute,
+                scenario_id=scenario_id,
+                axis_cell=axis_cell,
+                scale=scale,
+                metric_set=metric_set.name,
+                is_warmup=True,
+                cache_state=cache_state,
+                env=env,
+            )
+        )
+    records.append(
+        measure(
+            setup,
+            compute,
+            scenario_id=scenario_id,
+            axis_cell=axis_cell,
+            scale=scale,
+            metric_set=metric_set.name,
+            is_warmup=False,
+            cache_state=cache_state,
+            env=env,
+        )
+    )
+    write_records(output, records)
+    report = validate_file(output)
+    if not report.ok:
+        raise RuntimeError(f"self-validation failed: {report.failures}")
+    return records
+
+
 def run_continuous_scenario(
     *,
     scenario_id: str,
@@ -134,18 +191,14 @@ def run_continuous_scenario(
     seed: int = 0,
     threads: int = 1,
 ) -> list[BenchRecord]:
-    """Run a continuous × individual scenario end-to-end.
+    """Run a Continuous × Individual scenario end-to-end.
 
     ``compute`` receives the prepared panel and a default config; what
     it does inside (``run_metrics(metrics=...)``, direct algo call,
     bootstrap primitives) is up to the scenario — the helper only
     knows about timing + JSONL + validation.
-
-    Returns the produced records. The harness writes JSONL to
-    ``output`` and self-validates; a validation failure raises.
     """
     pre = preflight(threads=threads, seed=seed)
-    scale_dict = scale.as_scale_field()
 
     def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
         return build_panel(scale, seed=seed), make_cfg()
@@ -154,36 +207,15 @@ def run_continuous_scenario(
         panel, cfg = artifact
         return compute(panel, cfg)
 
-    records: list[BenchRecord] = []
-    if warmup:
-        records.append(
-            measure(
-                setup,
-                compute_step,
-                scenario_id=scenario_id,
-                axis_cell=AXIS_CELL_CONT_IND,
-                scale=scale_dict,
-                metric_set=metric_set.name,
-                is_warmup=True,
-                cache_state=cache_state,
-                env=pre.env,
-            )
-        )
-    records.append(
-        measure(
-            setup,
-            compute_step,
-            scenario_id=scenario_id,
-            axis_cell=AXIS_CELL_CONT_IND,
-            scale=scale_dict,
-            metric_set=metric_set.name,
-            is_warmup=False,
-            cache_state=cache_state,
-            env=pre.env,
-        )
+    return run_scenario(
+        scenario_id=scenario_id,
+        axis_cell=AXIS_CELL_CONT_IND,
+        metric_set=metric_set,
+        scale=scale.as_scale_field(),
+        setup=setup,
+        compute=compute_step,
+        output=output,
+        env=pre.env,
+        warmup=warmup,
+        cache_state=cache_state,
     )
-    write_records(output, records)
-    report = validate_file(output)
-    if not report.ok:
-        raise RuntimeError(f"self-validation failed: {report.failures}")
-    return records

--- a/bench/scenarios/algo.py
+++ b/bench/scenarios/algo.py
@@ -1,0 +1,122 @@
+"""Algo scenarios — ``greedy_forward_selection`` (#380 §4 S4).
+
+`greedy_forward_selection` does not live behind ``factrix.run_metrics``;
+it consumes a ``dict[str, pl.DataFrame]`` of per-factor spread series.
+The scenario therefore splits the work explicitly:
+
+- **setup** builds the panel, then computes each factor's spread series
+  via ``factrix.metrics.quantile.compute_spread_series``. Spread
+  construction (rank → bucket → spread per date) is itself non-trivial
+  but is the algorithm's prerequisite, not its hotspot — accounting
+  it under ``setup_s`` matches the §9 distinction between
+  preparation cost and the work under measurement.
+- **compute** runs the greedy + backward-elimination loop. This is
+  the per-iteration O(K²) hotspot #378 is targeting.
+
+`suppress_snooping_warning=True` is set unconditionally — the bench
+runs are not inference, and emitting one warning per scenario per
+preset would flood the harness log.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import factrix as fx
+import polars as pl
+from factrix.metrics.quantile import compute_spread_series
+
+from bench.metric_sets import ALGO
+from bench.preflight import preflight
+from bench.scenarios._helpers import (
+    AXIS_CELL_CONT_IND,
+    DEFAULT_FORWARD_PERIODS,
+    build_panel,
+    factor_columns,
+    resolve_scale,
+    run_scenario,
+)
+from bench.schema import BenchRecord, CacheState
+
+# Greedy selection runs to convergence by default; cap candidates so
+# the inner loop terminates predictably under the benchmark budget.
+# #380 §4 pins S4 at "50 candidates"; capped further by preset for
+# tiny smoke runs.
+_S4_CANDIDATES = 50
+
+# Long-short bucket count for the spread series fed into spanning.
+# Pinned (not at call site) so a #378 sub-task cannot silently shift
+# the workload by tuning quantile granularity.
+_N_GROUPS = 5
+
+
+def _build_spread_dict(
+    panel: pl.DataFrame, factors: list[str]
+) -> dict[str, pl.DataFrame]:
+    """Per-factor ``(date, spread)`` series, ready for spanning."""
+    spreads: dict[str, pl.DataFrame] = {}
+    for col in factors:
+        series = compute_spread_series(
+            panel,
+            forward_periods=DEFAULT_FORWARD_PERIODS,
+            factor_col=col,
+            n_groups=_N_GROUPS,
+        )
+        spreads[col] = series.select(["date", "spread"])
+    return spreads
+
+
+def s4_greedy_forward_selection(
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
+) -> list[BenchRecord]:
+    """S4: greedy forward selection over a candidate factor pool.
+
+    Candidate pool size follows the preset (capped at 50 per #380 §4).
+    The base set is empty — every selected factor competes on its
+    own merit, matching the §4 "greedy forward selection" framing.
+    """
+    max_factors = resolve_scale(preset).n_factors
+    n = min(_S4_CANDIDATES, max_factors)
+    scale = resolve_scale(preset, n_factors=n)
+    pre = preflight(threads=1, seed=seed)
+
+    def setup() -> dict[str, pl.DataFrame]:
+        panel = build_panel(scale, seed=seed)
+        return _build_spread_dict(panel, factor_columns(panel))
+
+    def compute(spreads: dict[str, pl.DataFrame]) -> int:
+        with warnings.catch_warnings():
+            # Snooping warning is one-shot per process; the algo
+            # also emits sample-floor warnings on tiny presets that
+            # are not the work under measurement.
+            warnings.simplefilter("ignore", UserWarning)
+            result = fx.metrics.spanning.greedy_forward_selection(
+                spreads,
+                significance_threshold=2.0,
+                max_factors=n,
+                suppress_snooping_warning=True,
+            )
+        return len(result.selected_factors)
+
+    return run_scenario(
+        scenario_id="S4",
+        axis_cell=AXIS_CELL_CONT_IND,
+        metric_set=ALGO,
+        scale=scale.as_scale_field(),
+        setup=setup,
+        compute=compute,
+        output=output,
+        env=pre.env,
+        cache_state=cache_state,
+    )
+
+
+SCENARIOS = {"S4": s4_greedy_forward_selection}
+
+
+__all__ = ["SCENARIOS", "s4_greedy_forward_selection"]

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -1,5 +1,5 @@
-"""Mandatory continuous × individual scenarios (#380 §4 mandatory peak
-+ probe and per-metric micros).
+"""Continuous × Individual scenarios (#380 §4 mandatory peak + probe
+and per-metric micros).
 
 Each scenario is a small function with the same shape::
 
@@ -9,10 +9,7 @@ Each scenario is a small function with the same shape::
 self-validation. Scenarios only declare *what* to compute on the
 prepared panel.
 
-Algo (``spanning`` / ``greedy_forward_selection``) and event-cell
-(``corrado_rank_test`` / ``caar`` / ``mfe_mae_summary``) scenarios
-live in sibling modules added by follow-up sub-PRs of #382 — this
-module is the Cont × Ind slice.
+Algo scenarios (``greedy_forward_selection``) live in ``algo.py``.
 """
 
 from __future__ import annotations

--- a/tests/bench/test_algo_scenarios.py
+++ b/tests/bench/test_algo_scenarios.py
@@ -1,0 +1,46 @@
+"""End-to-end smoke for the greedy forward selection scenario."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+from bench.scenarios.algo import SCENARIOS, s4_greedy_forward_selection
+from bench.validator import validate_file
+
+
+@pytest.fixture(autouse=True)
+def _silence_sample_floor_warnings():
+    # Tiny scale trips factrix's sample-floor warnings; the algo
+    # itself also emits a snooping warning that the scenario already
+    # suppresses inside `compute`.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        yield
+
+
+def test_s4_runs_and_validates(tmp_path: Path):
+    out = tmp_path / "S4.jsonl"
+    records = s4_greedy_forward_selection(out, preset="tiny")
+    rep = validate_file(out)
+    assert rep.ok, rep.failures
+    assert len(records) == 2
+    assert records[0].is_warmup is True
+    assert records[1].is_warmup is False
+    assert all(r.scenario_id == "S4" for r in records)
+    assert all(r.metric_set == "algo" for r in records)
+
+
+def test_s4_setup_compute_split(tmp_path: Path):
+    """Spread series construction is `setup`, greedy loop is `compute` —
+    both phases must report non-zero timings."""
+    out = tmp_path / "S4.jsonl"
+    records = s4_greedy_forward_selection(out, preset="tiny")
+    measured = records[1]
+    assert measured.setup_s is not None and measured.setup_s > 0
+    assert measured.compute_s is not None and measured.compute_s > 0
+
+
+def test_scenarios_dict_exports_s4():
+    assert set(SCENARIOS) == {"S4"}


### PR DESCRIPTION
## Summary
- Second of the #382 sub-PRs. Lands the algo path: `bench.scenarios.algo` wraps `greedy_forward_selection` over a candidate factor pool (forward selection + backward elimination).
- The algo consumes a per-factor spread-series dict, not a wide panel. `setup` builds the panel and pre-computes each factor's `(date, spread)` series via `compute_spread_series`; `compute` runs the greedy + backward-elimination loop alone. This puts the O(K²) inner loop under `compute_s` and the spread construction under `setup_s`, matching #380 §9.
- Refactor along the way: the measure-pair + write + self-validate plumbing was duplicated once between `run_continuous_scenario` and the new algo scenario. Extracted into a generic `run_scenario(...)` helper; `run_continuous_scenario` becomes a Cont × Ind-specific wrapper on top. The follow-up Sparse / event sub-PR will use the generic helper directly.

## Test plan
- [x] `uv run pytest tests/bench` — 43 tests; new `test_algo_scenarios.py` covers tiny-preset run + validator pass + setup/compute split + warmup row + `metric_set="algo"`.
- [x] Continuous tests still green after `run_scenario` refactor (helper behaviour identical, just centralised).
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy factrix` — clean.

## Deferred to the remaining #382 sub-PR
- Sparse × Ind scenario S5 + M-corrado
- CLI dispatcher `python -m bench --target {tiny,small,large,event}`
- Cold-cache subprocess re-exec
- bench-small hardware smoke documentation

Refs #382 (do **not** close yet — the Sparse / CLI sub-PR finalises the issue)