### PR TITLE
feat(bench): sparse scenarios + CLI dispatcher (#382)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -33,6 +33,9 @@ sub-issues. This README describes the current surface only.
 - `bench.scenarios.algo` — S4 greedy forward selection. Setup phase
   pre-computes per-factor spread series (rank → bucket → spread);
   compute phase runs the greedy + backward-elimination loop.
+- `bench.scenarios.sparse` — Sparse × Individual scenarios (#380 §4):
+  S5 (event-study bundle: `corrado_rank_test` + `compute_caar` +
+  `compute_mfe_mae`) and the M-corrado micro.
 - `bench.scenarios.dummy` — smoke scenario proving the wrapper →
   JSONL → validator loop.
 
@@ -43,30 +46,59 @@ installed**. Run from the repo root so `bench` resolves on
 `sys.path`:
 
 ```bash
+# run every mandatory scenario at the tiny preset (CI smoke)
+python -m bench --target tiny --output out/
+
+# baseline run (16 GB laptop) — cold-cache mode required for
+# reference baselines so OS page cache + numpy import state resets
+# between scenarios
+python -m bench --target small --output out/baselines/v0.13.1/ --cold-cache
+
+# sparse-cell only
+python -m bench --target event --output out/
+
+# re-run one scenario without spawning the full set
+python -m bench --run-one S2 --preset small --output out/
+
 # self-validate an existing JSONL
 python -m bench.validate path/to/run.jsonl
-
-# end-to-end smoke (dummy scenario)
-python -m bench.scenarios.dummy --output out/dummy.jsonl
 ```
 
 If launching from elsewhere, set `PYTHONPATH=<repo-root>` explicitly.
 CI smoke jobs should `cd` to the repo root or export `PYTHONPATH=.`
 before invoking any `python -m bench.*` entry point.
 
+### Targets
+
+| `--target` | Preset | Scenarios |
+|---|---|---|
+| `tiny` | `tiny` | All 11 mandatory scenarios (`#380` §4) |
+| `small` | `small` | All 11 — 16 GB laptop baseline |
+| `large` | `large` | All 11 — 32 GB cloud, opt-in |
+| `event` | `small` | Sparse × Individual only (S5 + M-corrado) |
+
+`--cold-cache` re-execs `python -m bench --run-one <id>` in a fresh
+subprocess per scenario, resetting OS page cache / numpy import /
+BLAS thread state. Reference baselines must run in cold-cache mode;
+ad-hoc warm runs skip the subprocess overhead.
+
 ## Scale presets
 
-`bench.scenarios._helpers.PRESETS` pins three scales per #380 §7:
+`bench.scenarios._helpers.PRESETS` / `SPARSE_PRESETS` pin scales per
+#380 §7:
 
-| Preset | n_factors | n_assets | n_dates | Use |
-|---|---|---|---|---|
-| `tiny` | 8 | 20 | 60 | Tests + CI smoke; seconds-level |
-| `small` | 100 | 1000 | 1250 | 16 GB laptop baseline (mandatory) |
-| `large` | 500 | 1000 | 1250 | 32 GB cloud baseline (opt-in) |
+| Preset | Cont: factors / assets / dates | Sparse: assets / dates / event_rate | Use |
+|---|---|---|---|
+| `tiny` | 8 / 20 / 60 | 20 / 60 / 0.05 | Tests + CI smoke; seconds-level |
+| `small` | 100 / 1000 / 1250 | 200 / 1250 / 0.0001 | 16 GB laptop baseline |
+| `large` | 500 / 1000 / 1250 | 500 / 1250 / 0.0002 | 32 GB cloud, opt-in |
 
-Fixed-scale scenarios (S2 = 50 factors, S3 = 200) override the
-preset's `n_factors` so the workload stays fixed regardless of
-preset choice.
+Fixed-scale scenarios (S2 = 50 factors, S3 = 200, M-* = 50) override
+the preset's `n_factors` so the workload stays fixed regardless of
+preset choice. Sparse-cell `n_events` is reported back from the
+realised event panel rather than configured directly — the seeded
+`make_event_panel` produces Binomial events whose count depends on
+`(n_dates × n_assets × event_rate)`.
 
 ## Schema / version invariants
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -17,8 +17,10 @@ sub-issues. This README describes the current surface only.
 - `bench.wrapper` — `measure(setup, compute, …)` produces one
   `BenchRecord` per call with `setup_s` / `compute_s` / `wall_s` /
   `cpu_s` / `peak_rss_mb` / `peak_alloc_mb` / `status` /
-  `started_at` / `is_warmup` / `cache_state`. `status="error"` rows
-  are preserved (not raised).
+  `started_at` / `is_warmup` / `cache_state`. Regular exceptions
+  become `status="error"` rows (preserved, not raised);
+  `KeyboardInterrupt` and `SystemExit` propagate so an interrupted
+  run does not poison the JSONL with partial state.
 - `bench.validator` — self-validates JSONL; fail-loud on
   `schema_version` mismatch, missing fields, enum violations, or
   scale ↔ axis_cell mismatch.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,7 +1,7 @@
 # bench — benchmark harness
 
-Internal dev tooling for the multi-factor scale-out benchmark
-(issue #380). **Not packaged into the factrix wheel** —
+Internal dev tooling for the multi-factor scale-out benchmark.
+**Not packaged into the factrix wheel** —
 `tool.setuptools.packages.find` excludes `bench*`.
 
 For the harness roadmap and open work, see issue #380 and its open
@@ -9,8 +9,8 @@ sub-issues. This README describes the current surface only.
 
 ## Modules
 
-- `bench.schema` — pydantic v2 model for the JSONL record (`schema_version="1"`,
-  open-schema `scale` keyed on `axis_cell`). Aligns with #380 §9.
+- `bench.schema` — pydantic v2 model for the JSONL record
+  (`schema_version="1"`, open-schema `scale` keyed on `axis_cell`).
 - `bench.preflight` — BLAS thread lock (`OMP_/OPENBLAS_/MKL_NUM_THREADS`),
   numpy seed, `gc.collect()`, env fingerprint (git SHA, factrix version,
   python/numpy/BLAS, CPU model, cores, RAM).
@@ -23,21 +23,11 @@ sub-issues. This README describes the current surface only.
   `schema_version` mismatch, missing fields, enum violations, or
   scale ↔ axis_cell mismatch.
 - `bench.metric_sets` — pinned `core` / `heavy` / `algo` / `event`
-  bundles + `METRIC_SET_VERSION` (independent of
+  bundles + `METRIC_SET_VERSION`, independent of
   `factrix.run_metrics` defaults so a default-set tweak in factrix
-  cannot silently shift baselines, #380 §3).
-- `bench.scenarios.continuous` — mandatory Cont × Ind scenarios
-  (#380 §4): S1 (single factor + `evaluate` + `run_metrics(heavy)`),
-  S2 / S3 (50 / 200-factor screen, `core`), P1 (scaling probe), and
-  per-metric micros M-ic / M-ic-boot / M-quantile / M-mono.
-- `bench.scenarios.algo` — S4 greedy forward selection. Setup phase
-  pre-computes per-factor spread series (rank → bucket → spread);
-  compute phase runs the greedy + backward-elimination loop.
-- `bench.scenarios.sparse` — Sparse × Individual scenarios (#380 §4):
-  S5 (event-study bundle: `corrado_rank_test` + `compute_caar` +
-  `compute_mfe_mae`) and the M-corrado micro.
-- `bench.scenarios.dummy` — smoke scenario proving the wrapper →
-  JSONL → validator loop.
+  cannot silently shift baselines.
+- `bench.scenarios.*` — scenario implementations grouped by
+  analysis-axis cell (see scenario reference below).
 
 ## Running
 
@@ -46,7 +36,7 @@ installed**. Run from the repo root so `bench` resolves on
 `sys.path`:
 
 ```bash
-# run every mandatory scenario at the tiny preset (CI smoke)
+# run every scenario at the tiny preset (CI smoke)
 python -m bench --target tiny --output out/
 
 # baseline run (16 GB laptop) — cold-cache mode required for
@@ -72,20 +62,36 @@ before invoking any `python -m bench.*` entry point.
 
 | `--target` | Preset | Scenarios |
 |---|---|---|
-| `tiny` | `tiny` | All 11 mandatory scenarios (`#380` §4) |
-| `small` | `small` | All 11 — 16 GB laptop baseline |
-| `large` | `large` | All 11 — 32 GB cloud, opt-in |
-| `event` | `small` | Sparse × Individual only (S5 + M-corrado) |
+| `tiny` | `tiny` | All scenarios listed below |
+| `small` | `small` | All scenarios — 16 GB laptop baseline |
+| `large` | `large` | All scenarios — 32 GB cloud, opt-in |
+| `event` | `small` | Sparse × Individual cell only |
 
 `--cold-cache` re-execs `python -m bench --run-one <id>` in a fresh
 subprocess per scenario, resetting OS page cache / numpy import /
 BLAS thread state. Reference baselines must run in cold-cache mode;
 ad-hoc warm runs skip the subprocess overhead.
 
+### Scenarios
+
+| `scenario_id` | Cell | Compute |
+|---|---|---|
+| `S1` | Continuous × Individual | Single factor through `evaluate` + `run_metrics` + bootstrap CI on the IC series |
+| `S2` | Continuous × Individual | 50-factor screen with the `core` metric set per factor |
+| `S3` | Continuous × Individual | 200-factor screen with the `core` metric set per factor |
+| `S4` | Continuous × Individual | Greedy forward selection over a candidate factor pool |
+| `S5` | Sparse × Individual | Event-study bundle: corrado rank test + CAAR + MFE/MAE |
+| `P1` | Continuous × Individual | Scaling probe — three sub-runs at 100 / 200 / 500 factors |
+| `M-ic` | Continuous × Individual | Per-factor `ic` only — attributes cost to one metric |
+| `M-ic-boot` | Continuous × Individual | Per-factor `compute_ic` + `bootstrap_mean_ci` |
+| `M-quantile` | Continuous × Individual | Per-factor `quantile_spread` only |
+| `M-mono` | Continuous × Individual | Per-factor `monotonicity` only |
+| `M-corrado` | Sparse × Individual | `corrado_rank_test` only on the event panel |
+
 ## Scale presets
 
-`bench.scenarios._helpers.PRESETS` / `SPARSE_PRESETS` pin scales per
-#380 §7:
+`bench.scenarios._helpers.PRESETS` / `SPARSE_PRESETS` pin the
+dimensions used by every scenario:
 
 | Preset | Cont: factors / assets / dates | Sparse: assets / dates / event_rate | Use |
 |---|---|---|---|
@@ -93,12 +99,12 @@ ad-hoc warm runs skip the subprocess overhead.
 | `small` | 100 / 1000 / 1250 | 200 / 1250 / 0.0001 | 16 GB laptop baseline |
 | `large` | 500 / 1000 / 1250 | 500 / 1250 / 0.0002 | 32 GB cloud, opt-in |
 
-Fixed-scale scenarios (S2 = 50 factors, S3 = 200, M-* = 50) override
-the preset's `n_factors` so the workload stays fixed regardless of
-preset choice. Sparse-cell `n_events` is reported back from the
-realised event panel rather than configured directly — the seeded
-`make_event_panel` produces Binomial events whose count depends on
-`(n_dates × n_assets × event_rate)`.
+Fixed-scale scenarios (`S2`=50 factors, `S3`=200, `M-*`=50 factors)
+override the preset's `n_factors` so the workload stays fixed
+regardless of preset choice. Sparse-cell `n_events` is reported back
+from the realised event panel rather than configured directly — the
+seeded `make_event_panel` produces Binomial events whose count
+depends on `(n_dates × n_assets × event_rate)` and the seed.
 
 ## Schema / version invariants
 
@@ -110,5 +116,5 @@ must refuse to compare records that differ on any of them:
 - `env.dataset_spec_version` (synthetic generator recipe) — pinned in `factrix.datasets.DATASET_SPEC_VERSION`
 
 The wrapper validates its own output via `pydantic.BaseModel.model_validate`
-on construction; the dummy scenario additionally reads the written
-JSONL back through `bench.validator.validate_file`.
+on construction; every scenario reads the written JSONL back through
+`bench.validator.validate_file` before returning.

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,8 +1,6 @@
-"""Benchmark harness foundation — wrapper, schema, validator.
+"""Benchmark harness — wrapper, schema, validator, scenarios.
 
-Sub-issue #381 of #380. Design SSOT is the v1 planning comment on #380.
-This package is dev tooling; not exported from the public ``factrix``
-namespace.
+Dev tooling; not exported from the public ``factrix`` namespace.
 """
 
 from bench.schema import (

--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -1,0 +1,157 @@
+"""``python -m bench`` — run scenarios at a chosen scale preset.
+
+Usage::
+
+    python -m bench --target tiny --output out/
+    python -m bench --target small --output out/baselines/v0.13.1/
+    python -m bench --target small --output out/ --cold-cache
+
+Each scenario writes ``<scenario_id>.jsonl`` under ``--output``. The
+harness self-validates every file as it lands; CI smoke jobs and
+reference-baseline reruns share the same entry.
+
+`--cold-cache` re-execs ``python -m bench --run-one <id>`` per
+scenario in a fresh subprocess so OS-page-cache / numpy-import /
+BLAS-thread state is reset between scenarios. This is the cold-cache
+mode required for reference-baseline runs (#380 §1, §9.2); ad-hoc
+warm-cache runs (default) skip the subprocess overhead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from bench.scenarios.algo import SCENARIOS as ALGO_SCENARIOS
+from bench.scenarios.continuous import SCENARIOS as CONTINUOUS_SCENARIOS
+from bench.scenarios.sparse import SCENARIOS as SPARSE_SCENARIOS
+
+# Default scenario coverage per target. `event` is a Sparse-only
+# subset; `tiny` / `small` / `large` run the full Continuous + algo
+# + Sparse coverage so a single run produces a complete baseline.
+CONT_ALGO_IDS = list(CONTINUOUS_SCENARIOS) + list(ALGO_SCENARIOS)
+SPARSE_IDS = list(SPARSE_SCENARIOS)
+
+TARGETS: dict[str, dict[str, Any]] = {
+    "tiny": {"preset": "tiny", "scenarios": CONT_ALGO_IDS + SPARSE_IDS},
+    "small": {"preset": "small", "scenarios": CONT_ALGO_IDS + SPARSE_IDS},
+    "large": {"preset": "large", "scenarios": CONT_ALGO_IDS + SPARSE_IDS},
+    "event": {"preset": "small", "scenarios": SPARSE_IDS},
+}
+
+
+def _all_scenarios() -> dict[str, Callable[..., Any]]:
+    merged: dict[str, Callable[..., Any]] = {}
+    merged.update(CONTINUOUS_SCENARIOS)
+    merged.update(ALGO_SCENARIOS)
+    merged.update(SPARSE_SCENARIOS)
+    return merged
+
+
+def _run_one(
+    scenario_id: str,
+    *,
+    preset: str,
+    output_dir: Path,
+    cache_state: str,
+) -> Path:
+    """Invoke one scenario directly (in this process)."""
+    fn = _all_scenarios()[scenario_id]
+    output = output_dir / f"{scenario_id}.jsonl"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fn(output, preset=preset, cache_state=cache_state)
+    return output
+
+
+def _run_cold_cache(scenario_ids: list[str], *, preset: str, output_dir: Path) -> None:
+    """Re-exec one subprocess per scenario for cold-cache mode."""
+    for sid in scenario_ids:
+        cmd = [
+            sys.executable,
+            "-m",
+            "bench",
+            "--run-one",
+            sid,
+            "--preset",
+            preset,
+            "--output",
+            str(output_dir),
+            "--cache-state",
+            "cold",
+        ]
+        # Inherit env (preflight thread locks already in env via
+        # lock_threads); fail-fast on any subprocess error.
+        subprocess.run(cmd, check=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point — parse args and dispatch to one of the modes."""
+    parser = argparse.ArgumentParser(
+        prog="python -m bench",
+        description="Run benchmark scenarios at a chosen scale preset.",
+    )
+    parser.add_argument(
+        "--target",
+        choices=sorted(TARGETS),
+        help="Named target (selects preset + scenario set).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output directory for <scenario_id>.jsonl files.",
+    )
+    parser.add_argument(
+        "--cold-cache",
+        action="store_true",
+        help=(
+            "Re-exec one subprocess per scenario so OS page cache, "
+            "numpy import, and BLAS thread state reset between "
+            "scenarios. Required for reference-baseline runs."
+        ),
+    )
+    # Internal flags used by --cold-cache subprocess invocations.
+    parser.add_argument("--run-one", help=argparse.SUPPRESS, default=None)
+    parser.add_argument("--preset", help=argparse.SUPPRESS, default=None)
+    parser.add_argument(
+        "--cache-state",
+        choices=("cold", "warm", "unknown"),
+        default="warm",
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args(argv)
+
+    output_dir: Path = args.output
+
+    if args.run_one is not None:
+        if args.preset is None:
+            parser.error("--run-one requires --preset")
+        _run_one(
+            args.run_one,
+            preset=args.preset,
+            output_dir=output_dir,
+            cache_state=args.cache_state,
+        )
+        return 0
+
+    if not args.target:
+        parser.error("--target is required (or use --run-one for one scenario)")
+
+    target = TARGETS[args.target]
+    preset = target["preset"]
+    scenarios = target["scenarios"]
+
+    if args.cold_cache:
+        _run_cold_cache(scenarios, preset=preset, output_dir=output_dir)
+    else:
+        for sid in scenarios:
+            _run_one(sid, preset=preset, output_dir=output_dir, cache_state="warm")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -30,26 +30,21 @@ from bench.scenarios.algo import SCENARIOS as ALGO_SCENARIOS
 from bench.scenarios.continuous import SCENARIOS as CONTINUOUS_SCENARIOS
 from bench.scenarios.sparse import SCENARIOS as SPARSE_SCENARIOS
 
-# Default scenario coverage per target. `event` is a Sparse-only
-# subset; `tiny` / `small` / `large` run the full Continuous + algo
-# + Sparse coverage so a single run produces a complete baseline.
-CONT_ALGO_IDS = list(CONTINUOUS_SCENARIOS) + list(ALGO_SCENARIOS)
-SPARSE_IDS = list(SPARSE_SCENARIOS)
+# All scenarios, indexed by `scenario_id`. Targets pick subsets by name.
+ALL_SCENARIOS: dict[str, Callable[..., Any]] = {
+    **CONTINUOUS_SCENARIOS,
+    **ALGO_SCENARIOS,
+    **SPARSE_SCENARIOS,
+}
+_CONT_ALGO_IDS = list(CONTINUOUS_SCENARIOS) + list(ALGO_SCENARIOS)
+_SPARSE_IDS = list(SPARSE_SCENARIOS)
 
 TARGETS: dict[str, dict[str, Any]] = {
-    "tiny": {"preset": "tiny", "scenarios": CONT_ALGO_IDS + SPARSE_IDS},
-    "small": {"preset": "small", "scenarios": CONT_ALGO_IDS + SPARSE_IDS},
-    "large": {"preset": "large", "scenarios": CONT_ALGO_IDS + SPARSE_IDS},
-    "event": {"preset": "small", "scenarios": SPARSE_IDS},
+    "tiny": {"preset": "tiny", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
+    "small": {"preset": "small", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
+    "large": {"preset": "large", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
+    "event": {"preset": "small", "scenarios": _SPARSE_IDS},
 }
-
-
-def _all_scenarios() -> dict[str, Callable[..., Any]]:
-    merged: dict[str, Callable[..., Any]] = {}
-    merged.update(CONTINUOUS_SCENARIOS)
-    merged.update(ALGO_SCENARIOS)
-    merged.update(SPARSE_SCENARIOS)
-    return merged
 
 
 def _run_one(
@@ -60,7 +55,7 @@ def _run_one(
     cache_state: str,
 ) -> Path:
     """Invoke one scenario directly (in this process)."""
-    fn = _all_scenarios()[scenario_id]
+    fn = ALL_SCENARIOS[scenario_id]
     output = output_dir / f"{scenario_id}.jsonl"
     output.parent.mkdir(parents=True, exist_ok=True)
     fn(output, preset=preset, cache_state=cache_state)

--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -12,9 +12,9 @@ reference-baseline reruns share the same entry.
 
 `--cold-cache` re-execs ``python -m bench --run-one <id>`` per
 scenario in a fresh subprocess so OS-page-cache / numpy-import /
-BLAS-thread state is reset between scenarios. This is the cold-cache
-mode required for reference-baseline runs (#380 §1, §9.2); ad-hoc
-warm-cache runs (default) skip the subprocess overhead.
+BLAS-thread state is reset between scenarios. Reference-baseline
+runs must use this mode; ad-hoc warm-cache runs (default) skip the
+subprocess overhead.
 """
 
 from __future__ import annotations

--- a/bench/metric_sets.py
+++ b/bench/metric_sets.py
@@ -1,6 +1,5 @@
 """Pinned metric sets — independent of ``factrix.run_metrics`` defaults
-so a default-set tweak in factrix cannot silently shift the baseline
-(#380 §3).
+so a default-set tweak in factrix cannot silently shift the baseline.
 
 Each ``MetricSet`` declares the names ``run_metrics`` should dispatch
 (``run_metrics_names``) and an optional ``custom`` callable for paths

--- a/bench/metric_sets.py
+++ b/bench/metric_sets.py
@@ -58,7 +58,13 @@ ALGO = MetricSet(
 
 EVENT = MetricSet(
     name="event",
-    run_metrics_names=("corrado_rank_test", "caar", "mfe_mae_summary"),
+    # Only `corrado_rank_test` dispatches through ``run_metrics``;
+    # ``caar`` and ``mfe_mae_summary`` require pre-computed event-row
+    # inputs and are called directly by the sparse scenario. The set
+    # name is the JSONL label for the conceptual bundle; the
+    # ``run_metrics_names`` tuple reflects what ``run_metrics`` can
+    # actually take.
+    run_metrics_names=("corrado_rank_test",),
 )
 
 

--- a/bench/scenarios/__init__.py
+++ b/bench/scenarios/__init__.py
@@ -1,11 +1,9 @@
-"""Benchmark scenario modules — one per analysis-axis cell (#380 §2).
+"""Benchmark scenario modules, grouped by analysis-axis cell.
 
-- ``continuous`` — Continuous × Individual scenarios (S1 / S2 / S3 /
-  P1 plus per-metric micros).
-- ``algo`` — algo scenarios that bypass ``run_metrics`` (S4 greedy
-  forward selection).
-- ``sparse`` — Sparse × Individual scenarios (S5 event-study bundle
-  + M-corrado).
+- ``continuous`` — Continuous × Individual scenarios.
+- ``algo`` — scenarios that bypass ``run_metrics`` (greedy forward
+  selection).
+- ``sparse`` — Sparse × Individual scenarios (event-study).
 - ``dummy`` — minimal end-to-end smoke proving wrapper → JSONL →
   validator.
 """

--- a/bench/scenarios/__init__.py
+++ b/bench/scenarios/__init__.py
@@ -4,6 +4,8 @@
   P1 plus per-metric micros).
 - ``algo`` — algo scenarios that bypass ``run_metrics`` (S4 greedy
   forward selection).
+- ``sparse`` — Sparse × Individual scenarios (S5 event-study bundle
+  + M-corrado).
 - ``dummy`` — minimal end-to-end smoke proving wrapper → JSONL →
   validator.
 """

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -203,6 +203,20 @@ def make_cfg() -> fx.AnalysisConfig:
     )
 
 
+def write_and_validate(output: Path, records: list[BenchRecord]) -> None:
+    """Write records as JSONL and read them back through ``validate_file``.
+
+    The harness must self-validate every JSONL it produces — a silent
+    shape drift now is an unparseable baseline six months from now.
+    Centralised here so every code path that emits JSONL flows
+    through the same fail-loud check.
+    """
+    write_records(output, records)
+    report = validate_file(output)
+    if not report.ok:
+        raise RuntimeError(f"self-validation failed: {report.failures}")
+
+
 def run_scenario(
     *,
     scenario_id: str,
@@ -211,19 +225,22 @@ def run_scenario(
     scale: dict[str, Any],
     setup: Callable[[], Any],
     compute: Callable[[Any], Any],
-    output: Path,
+    output: Path | None,
     env: Env,
     warmup: bool = True,
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
-    """Run ``setup`` then ``compute`` (warmup + measured), write JSONL,
-    self-validate.
+    """Run ``setup`` then ``compute`` (warmup + measured) and return records.
 
     Generic over axis_cell / scale shape — the cell-specific helper
-    (e.g. ``run_continuous_scenario``) chooses panel construction,
-    config, and scale serialisation, then delegates here for the
-    measure / write / validate loop. Mirrors the §9.1 self-validation
-    invariant exactly once instead of per-cell.
+    (``run_continuous_scenario`` / ``run_sparse_scenario``) chooses
+    panel construction, config, and scale serialisation, then
+    delegates here for the measure loop.
+
+    When ``output`` is given, records are written to JSONL and the
+    file is read back through the validator. Pass ``output=None`` to
+    skip the write (e.g. a multi-step scenario that aggregates
+    sub-runs and writes once at the end).
     """
     records: list[BenchRecord] = []
     if warmup:
@@ -253,10 +270,8 @@ def run_scenario(
             env=env,
         )
     )
-    write_records(output, records)
-    report = validate_file(output)
-    if not report.ok:
-        raise RuntimeError(f"self-validation failed: {report.failures}")
+    if output is not None:
+        write_and_validate(output, records)
     return records
 
 
@@ -266,18 +281,20 @@ def run_continuous_scenario(
     metric_set: MetricSet,
     scale: ContinuousScale,
     compute: Callable[[pl.DataFrame, fx.AnalysisConfig], Any],
-    output: Path,
+    output: Path | None,
     warmup: bool = True,
     cache_state: CacheState = "warm",
     seed: int = 0,
     threads: int = 1,
 ) -> list[BenchRecord]:
-    """Run a Continuous × Individual scenario end-to-end.
+    """Run a Continuous × Individual scenario.
 
     ``compute`` receives the prepared panel and a default config; what
     it does inside (``run_metrics(metrics=...)``, direct algo call,
     bootstrap primitives) is up to the scenario — the helper only
     knows about timing + JSONL + validation.
+
+    ``output=None`` skips the write (see ``run_scenario``).
     """
     pre = preflight(threads=threads, seed=seed)
 
@@ -293,6 +310,55 @@ def run_continuous_scenario(
         axis_cell=AXIS_CELL_CONT_IND,
         metric_set=metric_set,
         scale=scale.as_scale_field(),
+        setup=setup,
+        compute=compute_step,
+        output=output,
+        env=pre.env,
+        warmup=warmup,
+        cache_state=cache_state,
+    )
+
+
+def run_sparse_scenario(
+    *,
+    scenario_id: str,
+    metric_set: MetricSet,
+    scale: SparseScale,
+    compute: Callable[[pl.DataFrame, fx.AnalysisConfig], Any],
+    output: Path | None,
+    warmup: bool = True,
+    cache_state: CacheState = "warm",
+    seed: int = 0,
+    threads: int = 1,
+) -> list[BenchRecord]:
+    """Run a Sparse × Individual scenario.
+
+    Mirrors ``run_continuous_scenario`` for the sparse cell. A probe
+    panel is built once before the measured runs to read the realised
+    event count for the scale field; the measured ``setup`` rebuilds
+    the panel each call so ``setup_s`` reflects construction cost on
+    every record. The probe and measured panels are seeded identically
+    so the realised event count matches by construction.
+    """
+    pre = preflight(threads=threads, seed=seed)
+    n_events = count_events(build_event_panel(scale, seed=seed))
+    scale_dict = scale.as_scale_field(n_events=n_events)
+
+    def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
+        panel = build_event_panel(scale, seed=seed)
+        return panel, fx.AnalysisConfig.individual_sparse(
+            forward_periods=DEFAULT_FORWARD_PERIODS
+        )
+
+    def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> Any:
+        panel, cfg = artifact
+        return compute(panel, cfg)
+
+    return run_scenario(
+        scenario_id=scenario_id,
+        axis_cell=AXIS_CELL_SPARSE_IND,
+        metric_set=metric_set,
+        scale=scale_dict,
         setup=setup,
         compute=compute_step,
         output=output,

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -3,9 +3,8 @@
 Centralises:
 
 - Scale presets (``tiny`` for tests / CI smoke; ``small`` / ``large``
-  baseline-grade scales pinned per #380 §7). Per-scenario overrides
-  win over preset defaults so fixed-scale scenarios (S2 = 50 factors)
-  stay fixed regardless of preset.
+  baseline-grade scales). Per-scenario overrides win over preset
+  defaults so fixed-scale scenarios stay fixed regardless of preset.
 - Continuous multi-factor panel construction + forward-return
   attachment, so every Cont × Ind scenario sees the same seed
   discipline.
@@ -56,16 +55,16 @@ class ContinuousScale:
         }
 
 
-# Scale presets per #380 §7. Every scenario module reads these so
-# preset-named runs are guaranteed identical in dimensionality
-# regardless of which scenarios are exercised.
+# Scale presets. Every scenario module reads these so preset-named
+# runs are guaranteed identical in dimensionality regardless of which
+# scenarios are exercised.
 PRESETS: dict[str, ContinuousScale] = {
-    # `tiny` is for tests and the eventual CI bench-tiny smoke — must
-    # complete in seconds on a CI runner.
+    # `tiny` is for tests and CI smoke — must complete in seconds on a
+    # CI runner.
     "tiny": ContinuousScale(n_factors=8, n_assets=20, n_dates=60),
-    # `small` — 16 GB laptop baseline (#380 §7).
+    # `small` — 16 GB laptop baseline.
     "small": ContinuousScale(n_factors=100, n_assets=1000, n_dates=1250),
-    # `large` — 32 GB cloud baseline (#380 §7); opt-in, not mandatory.
+    # `large` — 32 GB cloud baseline; opt-in.
     "large": ContinuousScale(n_factors=500, n_assets=1000, n_dates=1250),
 }
 
@@ -93,7 +92,7 @@ def resolve_scale(
 
 
 # A single horizon is sufficient for benchmark purposes — sweeping
-# across horizons is a separate user story not covered by #380.
+# across horizons is a separate user story not handled here.
 DEFAULT_FORWARD_PERIODS = 5
 
 
@@ -142,9 +141,9 @@ class SparseScale:
         }
 
 
-# Sparse-cell presets per #380 §4 (S5 spec: "20 events × 200 assets ×
-# 1250 dates"). Event rate at `small` is tuned to give ~20 events
-# expected; `tiny` mirrors the Cont preset's seconds-level budget.
+# Sparse-cell presets. Event rate at `small` is tuned to give an
+# expected event count comparable to the continuous panel's factor
+# count; `tiny` mirrors the continuous preset's seconds-level budget.
 SPARSE_PRESETS: dict[str, SparseScale] = {
     "tiny": SparseScale(
         n_assets=20, n_dates=60, window_pre=3, window_post=5, event_rate=0.05

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -31,12 +31,12 @@ from factrix.preprocess import compute_forward_return
 
 from bench.metric_sets import MetricSet
 from bench.preflight import preflight
-from bench.schema import BenchRecord, CacheState, Env
+from bench.schema import AxisCell, BenchRecord, CacheState, Env
 from bench.validator import validate_file
 from bench.wrapper import measure, write_records
 
-AXIS_CELL_CONT_IND = "continuous_individual_panel"
-AXIS_CELL_SPARSE_IND = "sparse_individual_panel"
+AXIS_CELL_CONT_IND: AxisCell = "continuous_individual_panel"
+AXIS_CELL_SPARSE_IND: AxisCell = "sparse_individual_panel"
 
 
 @dataclass(frozen=True)

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -206,7 +206,7 @@ def make_cfg() -> fx.AnalysisConfig:
 def run_scenario(
     *,
     scenario_id: str,
-    axis_cell: str,
+    axis_cell: AxisCell,
     metric_set: MetricSet,
     scale: dict[str, Any],
     setup: Callable[[], Any],

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -27,7 +27,7 @@ from typing import Any
 
 import factrix as fx
 import polars as pl
-from factrix.datasets import make_multi_factor_panel
+from factrix.datasets import make_event_panel, make_multi_factor_panel
 from factrix.preprocess import compute_forward_return
 
 from bench.metric_sets import MetricSet
@@ -37,6 +37,7 @@ from bench.validator import validate_file
 from bench.wrapper import measure, write_records
 
 AXIS_CELL_CONT_IND = "continuous_individual_panel"
+AXIS_CELL_SPARSE_IND = "sparse_individual_panel"
 
 
 @dataclass(frozen=True)
@@ -112,6 +113,83 @@ def build_panel(scale: ContinuousScale, *, seed: int = 0) -> pl.DataFrame:
         seed=seed,
     )
     return compute_forward_return(raw, forward_periods=DEFAULT_FORWARD_PERIODS)
+
+
+@dataclass(frozen=True)
+class SparseScale:
+    """Scale specification for the sparse individual panel cell.
+
+    `n_events` is reported back from the realised event panel rather
+    than configured directly — the seeded `make_event_panel` produces
+    `Binomial(n_dates × n_assets, event_rate)` events, with mean
+    `n_dates * n_assets * event_rate`. We pin `event_rate` instead so
+    the workload stays Poisson-deterministic given the seed.
+    """
+
+    n_assets: int
+    n_dates: int
+    window_pre: int
+    window_post: int
+    event_rate: float
+
+    def as_scale_field(self, *, n_events: int) -> dict[str, int]:
+        return {
+            "n_events": n_events,
+            "n_assets": self.n_assets,
+            "n_dates": self.n_dates,
+            "window_pre": self.window_pre,
+            "window_post": self.window_post,
+        }
+
+
+# Sparse-cell presets per #380 §4 (S5 spec: "20 events × 200 assets ×
+# 1250 dates"). Event rate at `small` is tuned to give ~20 events
+# expected; `tiny` mirrors the Cont preset's seconds-level budget.
+SPARSE_PRESETS: dict[str, SparseScale] = {
+    "tiny": SparseScale(
+        n_assets=20, n_dates=60, window_pre=3, window_post=5, event_rate=0.05
+    ),
+    "small": SparseScale(
+        n_assets=200, n_dates=1250, window_pre=5, window_post=10, event_rate=0.0001
+    ),
+    "large": SparseScale(
+        n_assets=500, n_dates=1250, window_pre=5, window_post=10, event_rate=0.0002
+    ),
+}
+
+
+def resolve_sparse_scale(
+    preset: str,
+    *,
+    n_assets: int | None = None,
+    n_dates: int | None = None,
+    event_rate: float | None = None,
+) -> SparseScale:
+    """Pick a sparse preset and apply per-scenario overrides."""
+    base = SPARSE_PRESETS[preset]
+    return replace(
+        base,
+        n_assets=n_assets if n_assets is not None else base.n_assets,
+        n_dates=n_dates if n_dates is not None else base.n_dates,
+        event_rate=event_rate if event_rate is not None else base.event_rate,
+    )
+
+
+def build_event_panel(scale: SparseScale, *, seed: int = 0) -> pl.DataFrame:
+    """Generate a sparse event panel with forward return attached."""
+    raw = make_event_panel(
+        n_assets=scale.n_assets,
+        n_dates=scale.n_dates,
+        event_rate=scale.event_rate,
+        signal_horizon=DEFAULT_FORWARD_PERIODS,
+        seed=seed,
+    )
+    return compute_forward_return(raw, forward_periods=DEFAULT_FORWARD_PERIODS)
+
+
+def count_events(panel: pl.DataFrame) -> int:
+    """Count non-zero factor cells (= event count) in a sparse panel."""
+    return int((panel["factor"] != 0).sum())
 
 
 def factor_columns(panel: pl.DataFrame) -> list[str]:

--- a/bench/scenarios/algo.py
+++ b/bench/scenarios/algo.py
@@ -1,4 +1,4 @@
-"""Algo scenarios — ``greedy_forward_selection`` (#380 §4 S4).
+"""Algo scenarios — ``greedy_forward_selection``.
 
 `greedy_forward_selection` does not live behind ``factrix.run_metrics``;
 it consumes a ``dict[str, pl.DataFrame]`` of per-factor spread series.
@@ -8,10 +8,10 @@ The scenario therefore splits the work explicitly:
   via ``factrix.metrics.quantile.compute_spread_series``. Spread
   construction (rank → bucket → spread per date) is itself non-trivial
   but is the algorithm's prerequisite, not its hotspot — accounting
-  it under ``setup_s`` matches the §9 distinction between
-  preparation cost and the work under measurement.
-- **compute** runs the greedy + backward-elimination loop. This is
-  the per-iteration O(K²) hotspot #378 is targeting.
+  it under ``setup_s`` keeps the per-iteration loop alone under
+  ``compute_s``.
+- **compute** runs the greedy + backward-elimination loop, an O(K²)
+  inner loop in the candidate pool size.
 
 `suppress_snooping_warning=True` is set unconditionally — the bench
 runs are not inference, and emitting one warning per scenario per
@@ -41,13 +41,12 @@ from bench.schema import BenchRecord, CacheState
 
 # Greedy selection runs to convergence by default; cap candidates so
 # the inner loop terminates predictably under the benchmark budget.
-# #380 §4 pins S4 at "50 candidates"; capped further by preset for
-# tiny smoke runs.
+# Capped further by preset for tiny smoke runs.
 _S4_CANDIDATES = 50
 
 # Long-short bucket count for the spread series fed into spanning.
-# Pinned (not at call site) so a #378 sub-task cannot silently shift
-# the workload by tuning quantile granularity.
+# Pinned (not at call site) so tuning quantile granularity does not
+# silently shift the workload.
 _N_GROUPS = 5
 
 
@@ -74,11 +73,10 @@ def s4_greedy_forward_selection(
     seed: int = 0,
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
-    """S4: greedy forward selection over a candidate factor pool.
+    """Greedy forward selection over a candidate factor pool.
 
-    Candidate pool size follows the preset (capped at 50 per #380 §4).
-    The base set is empty — every selected factor competes on its
-    own merit, matching the §4 "greedy forward selection" framing.
+    Candidate pool size follows the preset, capped at 50. The base set
+    is empty — every selected factor competes on its own merit.
     """
     max_factors = resolve_scale(preset).n_factors
     n = min(_S4_CANDIDATES, max_factors)

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -28,7 +28,7 @@ from bench.scenarios._helpers import (
     resolve_scale,
     run_continuous_scenario,
 )
-from bench.schema import BenchRecord
+from bench.schema import BenchRecord, CacheState
 from bench.validator import validate_file
 from bench.wrapper import write_records
 
@@ -84,7 +84,11 @@ def _bootstrap_ic_per_factor(
 
 
 def s1_evaluate(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """S1: single factor through ``evaluate`` + ``run_metrics(heavy)``.
 
@@ -110,6 +114,7 @@ def s1_evaluate(
         compute=compute,
         output=output,
         seed=seed,
+        cache_state=cache_state,
     )
 
 
@@ -125,6 +130,7 @@ def _screen(
     n_factors: int,
     preset: str,
     seed: int,
+    cache_state: CacheState,
 ) -> list[BenchRecord]:
     scale = resolve_scale(preset, n_factors=n_factors)
     core = metric_sets.CORE
@@ -141,23 +147,46 @@ def _screen(
         compute=compute,
         output=output,
         seed=seed,
+        cache_state=cache_state,
     )
 
 
 def s2_screen_50(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """S2: 50-factor screening with the `core` metric set."""
     n = min(50, resolve_scale(preset).n_factors)  # tiny preset caps at 8
-    return _screen(output, scenario_id="S2", n_factors=n, preset=preset, seed=seed)
+    return _screen(
+        output,
+        scenario_id="S2",
+        n_factors=n,
+        preset=preset,
+        seed=seed,
+        cache_state=cache_state,
+    )
 
 
 def s3_screen_200(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """S3: 200-factor screening with the `core` metric set."""
     n = min(200, resolve_scale(preset).n_factors)
-    return _screen(output, scenario_id="S3", n_factors=n, preset=preset, seed=seed)
+    return _screen(
+        output,
+        scenario_id="S3",
+        n_factors=n,
+        preset=preset,
+        seed=seed,
+        cache_state=cache_state,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +195,11 @@ def s3_screen_200(
 
 
 def p1_scaling_probe(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """P1: scaling probe emits one record per scale step.
 
@@ -189,7 +222,12 @@ def p1_scaling_probe(
         # the end. (Each call self-validates its own slice.)
         tmp = output.with_suffix(f".step{step}.jsonl")
         records = _screen(
-            tmp, scenario_id="P1", n_factors=step, preset=preset, seed=seed
+            tmp,
+            scenario_id="P1",
+            n_factors=step,
+            preset=preset,
+            seed=seed,
+            cache_state=cache_state,
         )
         all_records.extend(records)
         tmp.unlink(missing_ok=True)
@@ -218,6 +256,7 @@ def _micro(
     metric_name: str,
     preset: str,
     seed: int,
+    cache_state: CacheState,
 ) -> list[BenchRecord]:
     max_factors = resolve_scale(preset).n_factors
     n = min(_MICRO_FACTORS, max_factors)
@@ -241,18 +280,34 @@ def _micro(
         compute=compute,
         output=output,
         seed=seed,
+        cache_state=cache_state,
     )
 
 
-def m_ic(output: Path, *, preset: str = "tiny", seed: int = 0) -> list[BenchRecord]:
+def m_ic(
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
+) -> list[BenchRecord]:
     """M-ic: cost of ``ic`` alone (no bootstrap)."""
     return _micro(
-        output, scenario_id="M-ic", metric_name="ic", preset=preset, seed=seed
+        output,
+        scenario_id="M-ic",
+        metric_name="ic",
+        preset=preset,
+        seed=seed,
+        cache_state=cache_state,
     )
 
 
 def m_quantile(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """M-quantile: cost of ``quantile_spread`` alone."""
     return _micro(
@@ -261,11 +316,16 @@ def m_quantile(
         metric_name="quantile_spread",
         preset=preset,
         seed=seed,
+        cache_state=cache_state,
     )
 
 
 def m_monotonicity(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """M-mono: cost of ``monotonicity`` alone."""
     return _micro(
@@ -274,11 +334,16 @@ def m_monotonicity(
         metric_name="monotonicity",
         preset=preset,
         seed=seed,
+        cache_state=cache_state,
     )
 
 
 def m_ic_bootstrap(
-    output: Path, *, preset: str = "tiny", seed: int = 0
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """M-ic-boot: cost of the bootstrap path on a per-factor IC series.
 
@@ -306,6 +371,7 @@ def m_ic_bootstrap(
         compute=compute,
         output=output,
         seed=seed,
+        cache_state=cache_state,
     )
 
 

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -27,10 +27,9 @@ from bench.scenarios._helpers import (
     factor_columns,
     resolve_scale,
     run_continuous_scenario,
+    write_and_validate,
 )
 from bench.schema import BenchRecord, CacheState
-from bench.validator import validate_file
-from bench.wrapper import write_records
 
 # Bootstrap resample count for the heavy / bootstrap scenarios.
 # Pinned here (not at call site) so tuning compute cost does not
@@ -123,7 +122,7 @@ def s1_evaluate(
 
 
 def _screen(
-    output: Path,
+    output: Path | None,
     *,
     scenario_id: str,
     n_factors: int,
@@ -216,12 +215,11 @@ def p1_scaling_probe(
 
     all_records: list[BenchRecord] = []
     for step in steps:
-        # Reuse `_screen` plumbing but route output into an in-memory
-        # accumulator: write to a per-step path then re-aggregate at
-        # the end. (Each call self-validates its own slice.)
-        tmp = output.with_suffix(f".step{step}.jsonl")
+        # Collect records without writing; aggregate and write once
+        # at the end so the JSONL holds all sub-runs and the harness
+        # self-validates the aggregated file exactly once.
         records = _screen(
-            tmp,
+            None,
             scenario_id="P1",
             n_factors=step,
             preset=preset,
@@ -229,15 +227,8 @@ def p1_scaling_probe(
             cache_state=cache_state,
         )
         all_records.extend(records)
-        tmp.unlink(missing_ok=True)
 
-    write_records(output, all_records)
-    # Mirror run_continuous_scenario's "harness self-validates every
-    # JSONL it writes" invariant — the per-step temps were validated
-    # then unlinked, the final aggregated file has not been.
-    report = validate_file(output)
-    if not report.ok:
-        raise RuntimeError(f"self-validation failed: {report.failures}")
+    write_and_validate(output, all_records)
     return all_records
 
 

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -1,5 +1,4 @@
-"""Continuous × Individual scenarios (#380 §4 mandatory peak + probe
-and per-metric micros).
+"""Continuous × Individual scenarios.
 
 Each scenario is a small function with the same shape::
 
@@ -9,7 +8,8 @@ Each scenario is a small function with the same shape::
 self-validation. Scenarios only declare *what* to compute on the
 prepared panel.
 
-Algo scenarios (``greedy_forward_selection``) live in ``algo.py``.
+Algo scenarios (``greedy_forward_selection``) live in ``algo.py``;
+sparse-cell scenarios live in ``sparse.py``.
 """
 
 from __future__ import annotations
@@ -32,11 +32,10 @@ from bench.schema import BenchRecord, CacheState
 from bench.validator import validate_file
 from bench.wrapper import write_records
 
-# Bootstrap resample count for `heavy` / M-ic-boot scenarios. Pinned
-# here (not at call site) so a #378 sub-task tuning compute cost cannot
-# silently drift the baseline workload. The value matches
-# factrix.stats.BlockBootstrap's default (n_resamples=999) plus one for
-# the trivial cost of the point statistic.
+# Bootstrap resample count for the heavy / bootstrap scenarios.
+# Pinned here (not at call site) so tuning compute cost does not
+# silently drift the baseline workload. The value matches factrix's
+# BlockBootstrap default.
 BOOTSTRAP_N = 999
 
 
@@ -201,9 +200,9 @@ def p1_scaling_probe(
     seed: int = 0,
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
-    """P1: scaling probe emits one record per scale step.
+    """Scaling probe — emits one record per scale step.
 
-    Step values follow #380 §4 (100 / 200 / 500) at `small` and above;
+    Step values are 100 / 200 / 500 factors at `small` and above;
     `tiny` proportionally shrinks to keep the probe under a second.
     """
     max_factors = resolve_scale(preset).n_factors
@@ -234,8 +233,8 @@ def p1_scaling_probe(
 
     write_records(output, all_records)
     # Mirror run_continuous_scenario's "harness self-validates every
-    # JSONL it writes" invariant (#380 §9.1) — the per-step temps
-    # were validated then unlinked, the final aggregated file has not.
+    # JSONL it writes" invariant — the per-step temps were validated
+    # then unlinked, the final aggregated file has not been.
     report = validate_file(output)
     if not report.ok:
         raise RuntimeError(f"self-validation failed: {report.failures}")
@@ -246,7 +245,7 @@ def p1_scaling_probe(
 # Per-metric micros — attribute compute cost to a single metric
 # ---------------------------------------------------------------------------
 
-_MICRO_FACTORS = 50  # #380 §4 micro table; scale capped by preset
+_MICRO_FACTORS = 50  # capped by preset for tiny smoke runs
 
 
 def _micro(
@@ -345,12 +344,12 @@ def m_ic_bootstrap(
     seed: int = 0,
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
-    """M-ic-boot: cost of the bootstrap path on a per-factor IC series.
+    """Cost of the bootstrap path on a per-factor IC series.
 
-    Unlike the other micros this scenario does **not** go through
-    ``run_metrics``; it times ``compute_ic`` + ``bootstrap_mean_ci``
-    directly, matching the optimisation target in #378 (bootstrap
-    vectorization on the IC path).
+    Unlike the other single-metric scenarios this one does **not** go
+    through ``run_metrics``; it times ``compute_ic`` +
+    ``bootstrap_mean_ci`` directly so the bootstrap cost is
+    attributable separately from the IC computation.
     """
     max_factors = resolve_scale(preset).n_factors
     n = min(_MICRO_FACTORS, max_factors)

--- a/bench/scenarios/dummy.py
+++ b/bench/scenarios/dummy.py
@@ -1,7 +1,7 @@
 """End-to-end smoke scenario — proves wrapper → JSONL → validator.
 
-Not one of the mandatory S/M scenarios from #380 §4. Used by tests
-and by ``bench-tiny`` CI smoke to prevent harness rot.
+Used by tests and by CI smoke jobs to prevent harness rot. The real
+benchmark workloads live in sibling modules under ``bench.scenarios``.
 """
 
 from __future__ import annotations

--- a/bench/scenarios/dummy.py
+++ b/bench/scenarios/dummy.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import polars as pl
 from factrix.datasets import make_multi_factor_panel
 
+from bench.metric_sets import MetricSet
 from bench.preflight import preflight
+from bench.scenarios._helpers import AXIS_CELL_CONT_IND, run_scenario
 from bench.schema import BenchRecord
-from bench.validator import validate_file
-from bench.wrapper import measure, write_records
+
+_DUMMY_SET = MetricSet(name="dummy", run_metrics_names=())
 
 
 def run(
@@ -23,13 +26,11 @@ def run(
     n_factors: int = 4,
     n_assets: int = 20,
     n_dates: int = 60,
-    warmup: bool = True,
 ) -> list[BenchRecord]:
     """Run the dummy scenario, write JSONL, self-validate."""
     pre = preflight(threads=1, seed=0)
-    scale = {"n_factors": n_factors, "n_dates": n_dates, "n_assets": n_assets}
 
-    def setup():
+    def setup() -> pl.DataFrame:
         return make_multi_factor_panel(
             n_factors=n_factors,
             n_assets=n_assets,
@@ -37,46 +38,21 @@ def run(
             seed=0,
         )
 
-    def compute(df):
+    def compute(df: pl.DataFrame) -> float:
         # Stand-in for real metric work: touch every factor column.
         factor_cols = [c for c in df.columns if c.startswith("factor_")]
         return float(df.select(factor_cols).sum().to_numpy().sum())
 
-    records: list[BenchRecord] = []
-    if warmup:
-        records.append(
-            measure(
-                setup,
-                compute,
-                scenario_id="dummy",
-                axis_cell="continuous_individual_panel",
-                scale=scale,
-                metric_set="core",
-                run_idx=0,
-                is_warmup=True,
-                cache_state="cold",
-                env=pre.env,
-            )
-        )
-    records.append(
-        measure(
-            setup,
-            compute,
-            scenario_id="dummy",
-            axis_cell="continuous_individual_panel",
-            scale=scale,
-            metric_set="core",
-            run_idx=0,
-            is_warmup=False,
-            cache_state="warm",
-            env=pre.env,
-        )
+    return run_scenario(
+        scenario_id="dummy",
+        axis_cell=AXIS_CELL_CONT_IND,
+        metric_set=_DUMMY_SET,
+        scale={"n_factors": n_factors, "n_dates": n_dates, "n_assets": n_assets},
+        setup=setup,
+        compute=compute,
+        output=output,
+        env=pre.env,
     )
-    write_records(output, records)
-    report = validate_file(output)
-    if not report.ok:
-        raise RuntimeError(f"self-validation failed: {report.failures}")
-    return records
 
 
 def main() -> int:

--- a/bench/scenarios/sparse.py
+++ b/bench/scenarios/sparse.py
@@ -1,4 +1,4 @@
-"""Sparse × Individual scenarios (#380 §4 S5 + M-corrado).
+"""Sparse × Individual scenarios — event-study workloads.
 
 The sparse cell exercises a different factrix code path from the
 continuous one: ``corrado_rank_test`` is loop-heavy with a
@@ -34,10 +34,9 @@ from bench.scenarios._helpers import (
 )
 from bench.schema import BenchRecord, CacheState
 
-# MFE/MAE window parameters — pinned so a #378 sub-task tuning the
-# windows cannot silently shift the workload. Values match factrix's
-# function defaults at small/large preset; tiny shrinks via scenario
-# overrides below.
+# MFE/MAE window parameters — pinned so tuning the windows cannot
+# silently shift the workload. Values match factrix's function
+# defaults at small/large preset.
 _MFE_WINDOW = 10
 _MFE_ESTIMATION_WINDOW = 30
 
@@ -101,7 +100,7 @@ def s5_event_study(
     seed: int = 0,
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
-    """S5: event-study bundle (corrado + caar + mfe_mae)."""
+    """Event-study bundle: corrado rank test + CAAR + MFE/MAE."""
     scale = resolve_sparse_scale(preset)
     return _run_sparse_scenario(
         output,
@@ -121,10 +120,10 @@ def m_corrado(
     seed: int = 0,
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
-    """M-corrado: cost of ``corrado_rank_test`` alone on the sparse cell.
+    """Cost of ``corrado_rank_test`` alone on the sparse cell.
 
     Attributes the permutation-bootstrap cost to a single metric,
-    parallel to the M-ic / M-quantile / M-mono pattern on the
+    parallel to the single-metric attribution scenarios on the
     continuous cell.
     """
     scale = resolve_sparse_scale(preset)

--- a/bench/scenarios/sparse.py
+++ b/bench/scenarios/sparse.py
@@ -1,0 +1,153 @@
+"""Sparse × Individual scenarios (#380 §4 S5 + M-corrado).
+
+The sparse cell exercises a different factrix code path from the
+continuous one: ``corrado_rank_test`` is loop-heavy with a
+permutation-style bootstrap, ``compute_caar`` and ``compute_mfe_mae``
+are direct (not behind ``run_metrics``) and run on the same panel.
+
+`compute_caar` / `compute_mfe_mae` consume the canonical event panel
+(``date, asset_id, factor, forward_return`` with sparse ``factor``)
+directly — not the per-event-row ``compute_event_returns`` output —
+so the setup phase is just panel construction; the compute phase
+runs all three metrics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import factrix as fx
+import polars as pl
+from factrix.metrics.caar import caar, compute_caar
+from factrix.metrics.mfe_mae import compute_mfe_mae, mfe_mae_summary
+
+from bench.metric_sets import EVENT, MetricSet
+from bench.preflight import preflight
+from bench.scenarios._helpers import (
+    AXIS_CELL_SPARSE_IND,
+    SparseScale,
+    build_event_panel,
+    count_events,
+    resolve_sparse_scale,
+    run_scenario,
+)
+from bench.schema import BenchRecord, CacheState
+
+# MFE/MAE window parameters — pinned so a #378 sub-task tuning the
+# windows cannot silently shift the workload. Values match factrix's
+# function defaults at small/large preset; tiny shrinks via scenario
+# overrides below.
+_MFE_WINDOW = 10
+_MFE_ESTIMATION_WINDOW = 30
+
+
+def _run_event_bundle(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+    """Run the three event-cell metrics on the panel."""
+    fx.run_metrics(panel, cfg, metrics=["corrado_rank_test"])
+    caar(compute_caar(panel))
+    mfe_mae_summary(
+        compute_mfe_mae(
+            panel, window=_MFE_WINDOW, estimation_window=_MFE_ESTIMATION_WINDOW
+        )
+    )
+    return 3
+
+
+def _run_sparse_scenario(
+    output: Path,
+    *,
+    scenario_id: str,
+    metric_set: MetricSet,
+    scale: SparseScale,
+    compute: Callable[[pl.DataFrame, fx.AnalysisConfig], int],
+    seed: int,
+    cache_state: CacheState,
+) -> list[BenchRecord]:
+    pre = preflight(threads=1, seed=seed)
+
+    # Probe build once to read the realised event count for the scale
+    # field; measure rebuilds the panel inside `setup` for accurate
+    # `setup_s` timing. The probe is deterministic given the seed, so
+    # the count matches the measured panel's count by construction.
+    n_events = count_events(build_event_panel(scale, seed=seed))
+    scale_dict = scale.as_scale_field(n_events=n_events)
+
+    def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
+        panel = build_event_panel(scale, seed=seed)
+        return panel, fx.AnalysisConfig.individual_sparse(forward_periods=5)
+
+    def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> int:
+        panel, cfg = artifact
+        return compute(panel, cfg)
+
+    return run_scenario(
+        scenario_id=scenario_id,
+        axis_cell=AXIS_CELL_SPARSE_IND,
+        metric_set=metric_set,
+        scale=scale_dict,
+        setup=setup,
+        compute=compute_step,
+        output=output,
+        env=pre.env,
+        cache_state=cache_state,
+    )
+
+
+def s5_event_study(
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
+) -> list[BenchRecord]:
+    """S5: event-study bundle (corrado + caar + mfe_mae)."""
+    scale = resolve_sparse_scale(preset)
+    return _run_sparse_scenario(
+        output,
+        scenario_id="S5",
+        metric_set=EVENT,
+        scale=scale,
+        compute=_run_event_bundle,
+        seed=seed,
+        cache_state=cache_state,
+    )
+
+
+def m_corrado(
+    output: Path,
+    *,
+    preset: str = "tiny",
+    seed: int = 0,
+    cache_state: CacheState = "warm",
+) -> list[BenchRecord]:
+    """M-corrado: cost of ``corrado_rank_test`` alone on the sparse cell.
+
+    Attributes the permutation-bootstrap cost to a single metric,
+    parallel to the M-ic / M-quantile / M-mono pattern on the
+    continuous cell.
+    """
+    scale = resolve_sparse_scale(preset)
+    label = MetricSet(
+        name="corrado_rank_test", run_metrics_names=("corrado_rank_test",)
+    )
+
+    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+        fx.run_metrics(panel, cfg, metrics=["corrado_rank_test"])
+        return 1
+
+    return _run_sparse_scenario(
+        output,
+        scenario_id="M-corrado",
+        metric_set=label,
+        scale=scale,
+        compute=compute,
+        seed=seed,
+        cache_state=cache_state,
+    )
+
+
+SCENARIOS = {"S5": s5_event_study, "M-corrado": m_corrado}
+
+
+__all__ = ["SCENARIOS", "m_corrado", "s5_event_study"]

--- a/bench/scenarios/sparse.py
+++ b/bench/scenarios/sparse.py
@@ -14,7 +14,6 @@ runs all three metrics.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 
 import factrix as fx
@@ -23,15 +22,9 @@ from factrix.metrics.caar import caar, compute_caar
 from factrix.metrics.mfe_mae import compute_mfe_mae, mfe_mae_summary
 
 from bench.metric_sets import EVENT, MetricSet
-from bench.preflight import preflight
 from bench.scenarios._helpers import (
-    AXIS_CELL_SPARSE_IND,
-    DEFAULT_FORWARD_PERIODS,
-    SparseScale,
-    build_event_panel,
-    count_events,
     resolve_sparse_scale,
-    run_scenario,
+    run_sparse_scenario,
 )
 from bench.schema import BenchRecord, CacheState
 
@@ -54,48 +47,6 @@ def _run_event_bundle(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
     return 3
 
 
-def _run_sparse_scenario(
-    output: Path,
-    *,
-    scenario_id: str,
-    metric_set: MetricSet,
-    scale: SparseScale,
-    compute: Callable[[pl.DataFrame, fx.AnalysisConfig], int],
-    seed: int,
-    cache_state: CacheState,
-) -> list[BenchRecord]:
-    pre = preflight(threads=1, seed=seed)
-
-    # Probe build once to read the realised event count for the scale
-    # field; measure rebuilds the panel inside `setup` for accurate
-    # `setup_s` timing. The probe is deterministic given the seed, so
-    # the count matches the measured panel's count by construction.
-    n_events = count_events(build_event_panel(scale, seed=seed))
-    scale_dict = scale.as_scale_field(n_events=n_events)
-
-    def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
-        panel = build_event_panel(scale, seed=seed)
-        return panel, fx.AnalysisConfig.individual_sparse(
-            forward_periods=DEFAULT_FORWARD_PERIODS
-        )
-
-    def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> int:
-        panel, cfg = artifact
-        return compute(panel, cfg)
-
-    return run_scenario(
-        scenario_id=scenario_id,
-        axis_cell=AXIS_CELL_SPARSE_IND,
-        metric_set=metric_set,
-        scale=scale_dict,
-        setup=setup,
-        compute=compute_step,
-        output=output,
-        env=pre.env,
-        cache_state=cache_state,
-    )
-
-
 def s5_event_study(
     output: Path,
     *,
@@ -104,13 +55,12 @@ def s5_event_study(
     cache_state: CacheState = "warm",
 ) -> list[BenchRecord]:
     """Event-study bundle: corrado rank test + CAAR + MFE/MAE."""
-    scale = resolve_sparse_scale(preset)
-    return _run_sparse_scenario(
-        output,
+    return run_sparse_scenario(
         scenario_id="S5",
         metric_set=EVENT,
-        scale=scale,
+        scale=resolve_sparse_scale(preset),
         compute=_run_event_bundle,
+        output=output,
         seed=seed,
         cache_state=cache_state,
     )
@@ -129,7 +79,6 @@ def m_corrado(
     parallel to the single-metric attribution scenarios on the
     continuous cell.
     """
-    scale = resolve_sparse_scale(preset)
     label = MetricSet(
         name="corrado_rank_test", run_metrics_names=("corrado_rank_test",)
     )
@@ -138,12 +87,12 @@ def m_corrado(
         fx.run_metrics(panel, cfg, metrics=["corrado_rank_test"])
         return 1
 
-    return _run_sparse_scenario(
-        output,
+    return run_sparse_scenario(
         scenario_id="M-corrado",
         metric_set=label,
-        scale=scale,
+        scale=resolve_sparse_scale(preset),
         compute=compute,
+        output=output,
         seed=seed,
         cache_state=cache_state,
     )

--- a/bench/scenarios/sparse.py
+++ b/bench/scenarios/sparse.py
@@ -26,6 +26,7 @@ from bench.metric_sets import EVENT, MetricSet
 from bench.preflight import preflight
 from bench.scenarios._helpers import (
     AXIS_CELL_SPARSE_IND,
+    DEFAULT_FORWARD_PERIODS,
     SparseScale,
     build_event_panel,
     count_events,
@@ -74,7 +75,9 @@ def _run_sparse_scenario(
 
     def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
         panel = build_event_panel(scale, seed=seed)
-        return panel, fx.AnalysisConfig.individual_sparse(forward_periods=5)
+        return panel, fx.AnalysisConfig.individual_sparse(
+            forward_periods=DEFAULT_FORWARD_PERIODS
+        )
 
     def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> int:
         panel, cfg = artifact

--- a/bench/schema.py
+++ b/bench/schema.py
@@ -1,6 +1,6 @@
-"""JSONL record schema for the benchmark harness (#380 §9, v1).
+"""JSONL record schema for the benchmark harness.
 
-The schema is pinned here so #378 sub-tasks don't each roll their own
+Pinned here so downstream consumers do not need to roll their own
 parser. ``scale`` is an open schema keyed on ``axis_cell`` — new
 axis cells extend the union without breaking existing parsers.
 """
@@ -68,7 +68,7 @@ class Env(BaseModel):
 
 
 class BenchRecord(BaseModel):
-    """One row of the benchmark JSONL — #380 §9 v1."""
+    """One row of the benchmark JSONL."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/bench/validator.py
+++ b/bench/validator.py
@@ -1,4 +1,4 @@
-"""Self-validation of harness output (#380 §9.1).
+"""Self-validation of harness output.
 
 The harness reads back every JSONL it writes through ``validate_file``;
 the same code path is exposed as the ``python -m bench.validate`` CLI

--- a/bench/wrapper.py
+++ b/bench/wrapper.py
@@ -13,7 +13,6 @@ import json
 import time
 import tracemalloc
 from collections.abc import Callable
-from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -22,7 +21,14 @@ import psutil
 
 from bench.metric_sets import METRIC_SET_VERSION
 from bench.preflight import collect_env, quiesce
-from bench.schema import SCHEMA_VERSION, BenchRecord, CacheState, Env, Status
+from bench.schema import (
+    SCHEMA_VERSION,
+    AxisCell,
+    BenchRecord,
+    CacheState,
+    Env,
+    Status,
+)
 
 
 def _utc_now_iso() -> str:
@@ -43,7 +49,7 @@ def measure[T](
     compute: Callable[[T], Any],
     *,
     scenario_id: str,
-    axis_cell: str,
+    axis_cell: AxisCell,
     scale: dict[str, Any],
     metric_set: str,
     metric_set_version: str = METRIC_SET_VERSION,
@@ -141,23 +147,6 @@ def measure[T](
         }
     )
     return record
-
-
-@contextmanager
-def jsonl_writer(path: str | Path):
-    """Append-mode JSONL sink yielding a single ``write(record)`` fn."""
-    p = Path(path)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    fh = p.open("a", encoding="utf-8")
-    try:
-
-        def write(record: BenchRecord) -> None:
-            fh.write(record.model_dump_json() + "\n")
-            fh.flush()
-
-        yield write
-    finally:
-        fh.close()
 
 
 def write_records(path: str | Path, records: list[BenchRecord]) -> None:

--- a/bench/wrapper.py
+++ b/bench/wrapper.py
@@ -2,7 +2,8 @@
 
 Separates ``setup`` (data prep + I/O) from ``compute`` (the metric work
 under measurement) so the JSONL records both phases. Ratio analysis
-defaults to ``compute_s`` per #380 §9.
+defaults to ``compute_s`` (the measured phase) over ``wall_s`` so
+machine-to-machine I/O differences do not pollute comparisons.
 """
 
 from __future__ import annotations

--- a/tests/bench/conftest.py
+++ b/tests/bench/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures for bench tests.
+
+`tiny` preset scales trip factrix's "median assets per group" /
+small-sample warnings. The harness intentionally runs under-spec
+sizes for CI smoke; these warnings are not the work under test.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _silence_sample_floor_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        yield

--- a/tests/bench/test_algo_scenarios.py
+++ b/tests/bench/test_algo_scenarios.py
@@ -2,22 +2,10 @@
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
-import pytest
 from bench.scenarios.algo import SCENARIOS, s4_greedy_forward_selection
 from bench.validator import validate_file
-
-
-@pytest.fixture(autouse=True)
-def _silence_sample_floor_warnings():
-    # Tiny scale trips factrix's sample-floor warnings; the algo
-    # itself also emits a snooping warning that the scenario already
-    # suppresses inside `compute`.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        yield
 
 
 def test_s4_runs_and_validates(tmp_path: Path):

--- a/tests/bench/test_algo_scenarios.py
+++ b/tests/bench/test_algo_scenarios.py
@@ -32,3 +32,17 @@ def test_s4_setup_compute_split(tmp_path: Path):
 
 def test_scenarios_dict_exports_s4():
     assert set(SCENARIOS) == {"S4"}
+
+
+def test_seed_determinism(tmp_path: Path):
+    """Same seed must produce identical scale + label fields across runs."""
+    out_a = tmp_path / "a.jsonl"
+    out_b = tmp_path / "b.jsonl"
+    a = s4_greedy_forward_selection(out_a, preset="tiny", seed=42)
+    b = s4_greedy_forward_selection(out_b, preset="tiny", seed=42)
+    assert len(a) == len(b)
+    for ra, rb in zip(a, b, strict=True):
+        assert ra.scenario_id == rb.scenario_id
+        assert ra.scale == rb.scale
+        assert ra.metric_set == rb.metric_set
+        assert ra.axis_cell == rb.axis_cell

--- a/tests/bench/test_cli.py
+++ b/tests/bench/test_cli.py
@@ -100,3 +100,20 @@ def test_run_one_invocation(tmp_path: Path):
 def test_target_required_when_no_run_one(tmp_path: Path):
     with pytest.raises(SystemExit):
         main(["--output", str(tmp_path)])
+
+
+def test_scenario_id_matches_registry_key(tmp_path: Path):
+    """Every scenario must stamp its `scenario_id` field to match the
+    key it is registered under. Drift between the two means a future
+    CLI dispatch by `scenario_id` (e.g. `--run-one`) would land on
+    the wrong function."""
+    from bench.__main__ import ALL_SCENARIOS
+
+    for sid, fn in ALL_SCENARIOS.items():
+        out = tmp_path / f"{sid}.jsonl"
+        records = fn(out, preset="tiny")
+        assert records, sid
+        assert all(r.scenario_id == sid for r in records), (
+            sid,
+            [r.scenario_id for r in records],
+        )

--- a/tests/bench/test_cli.py
+++ b/tests/bench/test_cli.py
@@ -1,0 +1,110 @@
+"""CLI dispatcher smoke (``python -m bench``).
+
+The full continuous + algo + sparse coverage at `tiny` runs in
+~20 seconds on a CI runner. Cold-cache mode re-execs Python per
+scenario; tested on a 2-scenario subset (`event` target) so the
+subprocess fork cost is bounded.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+from bench.__main__ import main
+from bench.validator import validate_file
+
+
+@pytest.fixture(autouse=True)
+def _silence_sample_floor_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        yield
+
+
+def test_tiny_target_runs_full_scenario_set(tmp_path: Path):
+    rc = main(["--target", "tiny", "--output", str(tmp_path)])
+    assert rc == 0
+    files = sorted(tmp_path.glob("*.jsonl"))
+    file_names = {f.name for f in files}
+    # Mandatory #380 §4 coverage.
+    expected = {
+        "S1.jsonl",
+        "S2.jsonl",
+        "S3.jsonl",
+        "S4.jsonl",
+        "S5.jsonl",
+        "P1.jsonl",
+        "M-ic.jsonl",
+        "M-ic-boot.jsonl",
+        "M-quantile.jsonl",
+        "M-mono.jsonl",
+        "M-corrado.jsonl",
+    }
+    assert expected.issubset(file_names), file_names
+    for f in files:
+        rep = validate_file(f)
+        assert rep.ok, (f.name, rep.failures)
+
+
+def test_event_target_runs_only_sparse_scenarios(tmp_path: Path):
+    rc = main(["--target", "event", "--output", str(tmp_path)])
+    assert rc == 0
+    files = {f.name for f in tmp_path.glob("*.jsonl")}
+    assert files == {"S5.jsonl", "M-corrado.jsonl"}
+
+
+def test_cold_cache_labels_jsonl_cold(tmp_path: Path):
+    rc = main(["--target", "event", "--output", str(tmp_path), "--cold-cache"])
+    assert rc == 0
+    with (tmp_path / "S5.jsonl").open() as fh:
+        for line in fh:
+            row = json.loads(line)
+            assert row["cache_state"] == "cold"
+
+
+def test_cold_cache_labels_continuous_scenarios_cold(tmp_path: Path):
+    """Regression: an earlier draft of the CLI silently dropped
+    `cache_state` for Continuous + algo scenarios because their
+    signatures lacked the kwarg. Every cell must label cold."""
+    rc = main(
+        [
+            "--run-one",
+            "S2",
+            "--preset",
+            "tiny",
+            "--output",
+            str(tmp_path),
+            "--cache-state",
+            "cold",
+        ]
+    )
+    assert rc == 0
+    with (tmp_path / "S2.jsonl").open() as fh:
+        for line in fh:
+            assert json.loads(line)["cache_state"] == "cold"
+
+
+def test_run_one_invocation(tmp_path: Path):
+    """The --run-one entry point used internally by --cold-cache is
+    also useful for ad-hoc single-scenario reruns."""
+    rc = main(
+        [
+            "--run-one",
+            "S2",
+            "--preset",
+            "tiny",
+            "--output",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    rep = validate_file(tmp_path / "S2.jsonl")
+    assert rep.ok
+
+
+def test_target_required_when_no_run_one(tmp_path: Path):
+    with pytest.raises(SystemExit):
+        main(["--output", str(tmp_path)])

--- a/tests/bench/test_cli.py
+++ b/tests/bench/test_cli.py
@@ -9,19 +9,11 @@ subprocess fork cost is bounded.
 from __future__ import annotations
 
 import json
-import warnings
 from pathlib import Path
 
 import pytest
 from bench.__main__ import main
 from bench.validator import validate_file
-
-
-@pytest.fixture(autouse=True)
-def _silence_sample_floor_warnings():
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        yield
 
 
 def test_tiny_target_runs_full_scenario_set(tmp_path: Path):

--- a/tests/bench/test_continuous_scenarios.py
+++ b/tests/bench/test_continuous_scenarios.py
@@ -28,6 +28,16 @@ def test_every_scenario_runs_and_validates(tmp_path: Path):
         assert rep.ok, (sid, rep.failures)
         assert records, sid
         assert all(r.scenario_id == sid for r in records)
+        assert all(r.axis_cell == "continuous_individual_panel" for r in records)
+
+
+def test_setup_compute_split(tmp_path: Path):
+    """Panel construction is setup; the metric work is compute."""
+    out = tmp_path / "S2.jsonl"
+    records = s2_screen_50(out, preset="tiny")
+    measured = records[1]
+    assert measured.setup_s is not None and measured.setup_s > 0
+    assert measured.compute_s is not None and measured.compute_s > 0
 
 
 def test_s1_emits_warmup_and_measured(tmp_path: Path):

--- a/tests/bench/test_continuous_scenarios.py
+++ b/tests/bench/test_continuous_scenarios.py
@@ -7,10 +7,8 @@ budget on a CI runner: under 30 s for the whole module.
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
-import pytest
 from bench.scenarios.continuous import (
     SCENARIOS,
     m_ic,
@@ -20,15 +18,6 @@ from bench.scenarios.continuous import (
     s2_screen_50,
 )
 from bench.validator import validate_file
-
-
-@pytest.fixture(autouse=True)
-def _silence_sample_floor_warnings():
-    # Tiny scale trips factrix's "median assets per group" warning;
-    # the bench harness intentionally runs under-spec sizes for CI.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        yield
 
 
 def test_every_scenario_runs_and_validates(tmp_path: Path):

--- a/tests/bench/test_metric_sets.py
+++ b/tests/bench/test_metric_sets.py
@@ -26,12 +26,12 @@ def test_heavy_extends_core():
     assert metric_sets.HEAVY.run_metrics_names == metric_sets.CORE.run_metrics_names
 
 
-def test_event_set_lists_sparse_metrics():
-    assert metric_sets.EVENT.run_metrics_names == (
-        "corrado_rank_test",
-        "caar",
-        "mfe_mae_summary",
-    )
+def test_event_set_lists_only_run_metrics_dispatchable():
+    # `caar` and `mfe_mae_summary` are part of the event bundle
+    # conceptually but require pre-computed event-row inputs;
+    # `run_metrics_names` must contain only metrics `run_metrics`
+    # can dispatch directly.
+    assert metric_sets.EVENT.run_metrics_names == ("corrado_rank_test",)
 
 
 def test_algo_is_run_metrics_empty():

--- a/tests/bench/test_sparse_scenarios.py
+++ b/tests/bench/test_sparse_scenarios.py
@@ -46,3 +46,25 @@ def test_scale_records_realised_event_count(tmp_path: Path):
     out2 = tmp_path / "S5b.jsonl"
     records2 = s5_event_study(out2, preset="tiny", seed=0)
     assert records[0].scale.n_events == records2[0].scale.n_events
+
+
+def test_setup_compute_split(tmp_path: Path):
+    """Panel construction is setup; the metric work is compute."""
+    out = tmp_path / "S5.jsonl"
+    records = s5_event_study(out, preset="tiny")
+    measured = records[1]
+    assert measured.setup_s is not None and measured.setup_s > 0
+    assert measured.compute_s is not None and measured.compute_s > 0
+
+
+def test_seed_determinism(tmp_path: Path):
+    """Same seed must produce identical scale + label fields across runs."""
+    out_a = tmp_path / "a.jsonl"
+    out_b = tmp_path / "b.jsonl"
+    a = s5_event_study(out_a, preset="tiny", seed=7)
+    b = s5_event_study(out_b, preset="tiny", seed=7)
+    for ra, rb in zip(a, b, strict=True):
+        assert ra.scenario_id == rb.scenario_id
+        assert ra.scale == rb.scale
+        assert ra.metric_set == rb.metric_set
+        assert ra.axis_cell == rb.axis_cell

--- a/tests/bench/test_sparse_scenarios.py
+++ b/tests/bench/test_sparse_scenarios.py
@@ -1,0 +1,57 @@
+"""End-to-end smoke for the Sparse × Individual scenarios."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+from bench.scenarios.sparse import SCENARIOS, m_corrado, s5_event_study
+from bench.validator import validate_file
+
+
+@pytest.fixture(autouse=True)
+def _silence_sample_floor_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        yield
+
+
+def test_every_sparse_scenario_runs_and_validates(tmp_path: Path):
+    for sid, fn in SCENARIOS.items():
+        out = tmp_path / f"{sid}.jsonl"
+        records = fn(out, preset="tiny")
+        rep = validate_file(out)
+        assert rep.ok, (sid, rep.failures)
+        assert records, sid
+        assert all(r.scenario_id == sid for r in records)
+        assert all(r.axis_cell == "sparse_individual_panel" for r in records)
+
+
+def test_s5_uses_event_bundle_label(tmp_path: Path):
+    out = tmp_path / "S5.jsonl"
+    records = s5_event_study(out, preset="tiny")
+    assert all(r.metric_set == "event" for r in records)
+
+
+def test_m_corrado_labels_by_single_metric(tmp_path: Path):
+    """Like Continuous-cell micros, M-corrado labels by metric name —
+    not by the `event` bundle — so downstream aggregation can
+    distinguish single-metric attribution from whole-bundle runs."""
+    out = tmp_path / "M.jsonl"
+    records = m_corrado(out, preset="tiny")
+    assert all(r.metric_set == "corrado_rank_test" for r in records)
+
+
+def test_scale_records_realised_event_count(tmp_path: Path):
+    """`n_events` reflects the realised count from the seeded panel,
+    not a configured value — `make_event_panel` produces Binomial
+    events whose count depends on (n_dates × n_assets × event_rate)
+    and the seed."""
+    out = tmp_path / "S5.jsonl"
+    records = s5_event_study(out, preset="tiny", seed=0)
+    assert all(r.scale.n_events > 0 for r in records)
+    # Determinism: same seed → same n_events.
+    out2 = tmp_path / "S5b.jsonl"
+    records2 = s5_event_study(out2, preset="tiny", seed=0)
+    assert records[0].scale.n_events == records2[0].scale.n_events

--- a/tests/bench/test_sparse_scenarios.py
+++ b/tests/bench/test_sparse_scenarios.py
@@ -2,19 +2,10 @@
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
-import pytest
 from bench.scenarios.sparse import SCENARIOS, m_corrado, s5_event_study
 from bench.validator import validate_file
-
-
-@pytest.fixture(autouse=True)
-def _silence_sample_floor_warnings():
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        yield
 
 
 def test_every_sparse_scenario_runs_and_validates(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Third and final sub-PR closing the mandatory scenarios issue. Lands the Sparse × Individual cell and the `python -m bench` entry point so a single command produces a complete baseline.
- `bench.scenarios.sparse` ships the event-study bundle (`corrado_rank_test` + `compute_caar` + `compute_mfe_mae`) and a corrado-only attribution scenario. `n_events` is reported back from the realised event panel rather than configured directly — `make_event_panel` produces Binomial events whose count depends on `(n_dates × n_assets × event_rate)` and the seed.
- `python -m bench --target {tiny,small,large,event} --output <dir>` dispatches scenarios at the chosen scale. `--cold-cache` re-execs `python -m bench --run-one <id>` per scenario in a fresh subprocess so OS page cache / numpy import / BLAS thread state reset between scenarios — the cold-cache mode required for reference-baseline runs.
- `cache_state` now an explicit kwarg on every scenario callable so cold-cache mode labels JSONL correctly across all cells. An earlier draft silently dropped the kwarg on Continuous + algo scenarios (signatures lacked it); a regression test pins this.
- Follow-up commit scrubs planning-issue cross-references (`#380 §N`, "mandatory peak/probe", "per-metric micros") from every bench/ docstring and README section so code describes current behaviour rather than planning provenance.

## Coverage delivered
| Target | Preset | Scenarios |
|---|---|---|
| `tiny` | `tiny` | All 11 scenario IDs (`S1`–`S5`, `P1`, `M-ic` / `M-ic-boot` / `M-quantile` / `M-mono` / `M-corrado`) |
| `small` | `small` | All 11 — 16 GB laptop baseline |
| `large` | `large` | All 11 — 32 GB cloud, opt-in |
| `event` | `small` | Sparse × Individual only (`S5` + `M-corrado`) |

## Test plan
- [x] `uv run pytest tests/bench` — 53 tests; new `test_sparse_scenarios.py` covers Sparse cell smoke + `n_events` determinism; `test_cli.py` covers `--target tiny` running the full 11-scenario set, `--target event` running only Sparse, `--cold-cache` labelling JSONL `cache_state="cold"` for both Sparse and Continuous cells, `--run-one` direct invocation.
- [x] `uv run pytest` — full repo suite still green.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy factrix` — clean.
- [x] CLI smoke `python -m bench --target tiny --output /tmp/...` produces 11 JSONL files, all validate.

Closes #382