### PR TITLE
feat(bench): UX latency validation profile (#391)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -100,6 +100,12 @@ dimensions used by every scenario:
 | `tiny` | 8 / 20 / 60 | 20 / 60 / 0.05 | Tests + CI smoke; seconds-level |
 | `small` | 100 / 1000 / 1250 | 200 / 1250 / 0.0001 | 16 GB laptop baseline |
 | `large` | 500 / 1000 / 1250 | 500 / 1250 / 0.0002 | 32 GB cloud, opt-in |
+| `xlarge` | 1000 / 2000 / 2000 | 2000 / 2000 / 0.0002 | Cloud-only stress (UX validation) |
+| `user-realistic-high` | 500 / 3000 / 2500 | 3000 / 2500 / 0.0002 | Cloud-only (factor researcher upper bound) |
+
+`xlarge` and `user-realistic-high` will OOM a 32 GB laptop and are
+excluded from `make bench-bump` — they belong to the UX validation
+lane below, not to the reference baseline lane.
 
 Fixed-scale scenarios (`S2`=50 factors, `S3`=200, `M-*`=50 factors)
 override the preset's `n_factors` so the workload stays fixed
@@ -107,6 +113,58 @@ regardless of preset choice. Sparse-cell `n_events` is reported back
 from the realised event panel rather than configured directly — the
 seeded `make_event_panel` produces Binomial events whose count
 depends on `(n_dates × n_assets × event_rate)` and the seed.
+
+## UX validation
+
+The reference baseline measures *algorithm cost lower bound* —
+single-thread BLAS, cold cache, fixed seed — for cross-version
+regression detection. It does not answer "would a real user hit a
+perf wall?". UX validation is a separate lane on the same harness
+that does.
+
+| Axis | Reference baseline | UX validation |
+|---|---|---|
+| BLAS threads | locked to 1 | `--threads N` (typical 4 / 16) |
+| Cache | cold | warm |
+| Measurement target | `compute_s` ratio | `wall_s` absolute |
+| Acceptance | ratio vs history | assert vs `bench.ux_targets.UX_TARGETS` |
+| Frequency | per minor release | per release + ad-hoc |
+
+Run UX validation by combining `--threads` with the cloud-only
+presets, then pipe the output directory through `bench.ux_validate`:
+
+```bash
+python -m bench --target xlarge              --threads 16 --output /tmp/A1-xl
+python -m bench --target user-realistic-high --threads 16 --output /tmp/A1-rh
+python -m bench --target xlarge              --threads 4  --output /tmp/A2-xl
+python -m bench --target user-realistic-high --threads 4  --output /tmp/A2-rh
+
+for d in /tmp/A{1,2}-{xl,rh}; do python -m bench.ux_validate "$d"; done
+```
+
+`bench.ux_validate`:
+
+- Reads every `*.jsonl` under the directory, picks measured rows
+  (`is_warmup=false ∧ status="ok"`), and asserts each row's `wall_s`
+  against `UX_TARGETS`.
+- Prints a markdown table to stdout (scenario / `n_factors` /
+  `wall_s` / target / verdict / `peak_rss_mb` / `n_threads`).
+- Returns non-zero when any row fails its target (a *red flag*).
+- Records OOM / error / unknown-scenario rows as non-blocking
+  incidents — OOM on a 1000-factor screen is real data, not a CI
+  failure.
+
+Pair `--threads N` with `--cold-cache` whenever multi-thread effects
+actually matter: BLAS picks its thread count at numpy import time, so
+in single-process warm mode the in-process flag is partly cosmetic
+(it stamps `env.omp_threads=N` into every record but cannot re-thread
+an already-initialised BLAS). The cold-cache path forks a fresh
+subprocess per scenario with the thread env vars set before import.
+
+`bench.ux_targets.UX_TARGETS_VERSION` is bumped whenever the target
+table is edited so a stored report can be re-interpreted against the
+version it was produced under. The validator stamps the version it
+used into its markdown header.
 
 ## Schema / version invariants
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -76,6 +76,13 @@ ad-hoc warm runs skip the subprocess overhead.
 
 ### Scenarios
 
+`scenario_id` prefix encodes the role rather than running order:
+
+- `S*` — baseline screen scenarios (full pipeline at one workload size).
+- `P*` — scaling probe (one scenario emits multiple records across scale steps).
+- `M-*` — per-metric micro attribution (isolates one metric so its cost is
+  separable from the bundled screen scenarios).
+
 | `scenario_id` | Cell | Compute |
 |---|---|---|
 | `S1` | Continuous × Individual | Single factor through `evaluate` + `run_metrics` + bootstrap CI on the IC series |

--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from bench.preflight import lock_threads
 from bench.scenarios.algo import SCENARIOS as ALGO_SCENARIOS
 from bench.scenarios.continuous import SCENARIOS as CONTINUOUS_SCENARIOS
 from bench.scenarios.sparse import SCENARIOS as SPARSE_SCENARIOS
@@ -53,16 +54,19 @@ def _run_one(
     preset: str,
     output_dir: Path,
     cache_state: str,
+    threads: int,
 ) -> Path:
     """Invoke one scenario directly (in this process)."""
     fn = ALL_SCENARIOS[scenario_id]
     output = output_dir / f"{scenario_id}.jsonl"
     output.parent.mkdir(parents=True, exist_ok=True)
-    fn(output, preset=preset, cache_state=cache_state)
+    fn(output, preset=preset, cache_state=cache_state, threads=threads)
     return output
 
 
-def _run_cold_cache(scenario_ids: list[str], *, preset: str, output_dir: Path) -> None:
+def _run_cold_cache(
+    scenario_ids: list[str], *, preset: str, output_dir: Path, threads: int
+) -> None:
     """Re-exec one subprocess per scenario for cold-cache mode."""
     for sid in scenario_ids:
         cmd = [
@@ -77,9 +81,12 @@ def _run_cold_cache(scenario_ids: list[str], *, preset: str, output_dir: Path) -
             str(output_dir),
             "--cache-state",
             "cold",
+            "--threads",
+            str(threads),
         ]
-        # Inherit env (preflight thread locks already in env via
-        # lock_threads); fail-fast on any subprocess error.
+        # Inherit env (lock_threads already set the thread env vars
+        # in this process, so the subprocess sees them before numpy
+        # initialises BLAS); fail-fast on any subprocess error.
         subprocess.run(cmd, check=True)
 
 
@@ -109,6 +116,17 @@ def main(argv: list[str] | None = None) -> int:
             "scenarios. Required for reference-baseline runs."
         ),
     )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=1,
+        help=(
+            "BLAS / OMP thread count. Default 1 matches reference-"
+            "baseline measurement. Multi-thread runs are for UX "
+            "validation; pair with `--cold-cache` so the subprocess "
+            "inherits the thread lock before numpy initialises BLAS."
+        ),
+    )
     # Internal flags used by --cold-cache subprocess invocations.
     parser.add_argument("--run-one", help=argparse.SUPPRESS, default=None)
     parser.add_argument("--preset", help=argparse.SUPPRESS, default=None)
@@ -121,6 +139,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     output_dir: Path = args.output
+    # Set thread env vars in this process so the cold-cache subprocess
+    # inherits them before numpy / BLAS initialise. In single-process
+    # warm mode this is mostly cosmetic — numpy has already imported
+    # via the scenario modules at the top of this file — but the env
+    # snapshot in each record will reflect the requested count.
+    lock_threads(args.threads)
 
     if args.run_one is not None:
         if args.preset is None:
@@ -130,6 +154,7 @@ def main(argv: list[str] | None = None) -> int:
             preset=args.preset,
             output_dir=output_dir,
             cache_state=args.cache_state,
+            threads=args.threads,
         )
         return 0
 
@@ -141,10 +166,18 @@ def main(argv: list[str] | None = None) -> int:
     scenarios = target["scenarios"]
 
     if args.cold_cache:
-        _run_cold_cache(scenarios, preset=preset, output_dir=output_dir)
+        _run_cold_cache(
+            scenarios, preset=preset, output_dir=output_dir, threads=args.threads
+        )
     else:
         for sid in scenarios:
-            _run_one(sid, preset=preset, output_dir=output_dir, cache_state="warm")
+            _run_one(
+                sid,
+                preset=preset,
+                output_dir=output_dir,
+                cache_state="warm",
+                threads=args.threads,
+            )
     return 0
 
 

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -66,6 +66,14 @@ PRESETS: dict[str, ContinuousScale] = {
     "small": ContinuousScale(n_factors=100, n_assets=1000, n_dates=1250),
     # `large` — 32 GB cloud baseline; opt-in.
     "large": ContinuousScale(n_factors=500, n_assets=1000, n_dates=1250),
+    # `xlarge` — cloud-only stress preset for UX validation. Estimated
+    # peak RSS ≤ 100 GB on the 125 GB cloud host; will OOM a 32 GB
+    # laptop. Never used by `make bench-bump`.
+    "xlarge": ContinuousScale(n_factors=1000, n_assets=2000, n_dates=2000),
+    # `user-realistic-high` — upper end of a factor researcher's
+    # real-world workflow (500 factors over a ~10-year window across
+    # the global liquid universe). Cloud-only.
+    "user-realistic-high": ContinuousScale(n_factors=500, n_assets=3000, n_dates=2500),
 }
 
 
@@ -153,6 +161,12 @@ SPARSE_PRESETS: dict[str, SparseScale] = {
     ),
     "large": SparseScale(
         n_assets=500, n_dates=1250, window_pre=5, window_post=10, event_rate=0.0002
+    ),
+    "xlarge": SparseScale(
+        n_assets=2000, n_dates=2000, window_pre=5, window_post=10, event_rate=0.0002
+    ),
+    "user-realistic-high": SparseScale(
+        n_assets=3000, n_dates=2500, window_pre=5, window_post=10, event_rate=0.0002
     ),
 }
 

--- a/bench/scenarios/algo.py
+++ b/bench/scenarios/algo.py
@@ -72,6 +72,7 @@ def s4_greedy_forward_selection(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """Greedy forward selection over a candidate factor pool.
 
@@ -81,7 +82,7 @@ def s4_greedy_forward_selection(
     max_factors = resolve_scale(preset).n_factors
     n = min(_S4_CANDIDATES, max_factors)
     scale = resolve_scale(preset, n_factors=n)
-    pre = preflight(threads=1, seed=seed)
+    pre = preflight(threads=threads, seed=seed)
 
     def setup() -> dict[str, pl.DataFrame]:
         panel = build_panel(scale, seed=seed)

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -87,6 +87,7 @@ def s1_evaluate(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """S1: single factor through ``evaluate`` + ``run_metrics(heavy)``.
 
@@ -113,6 +114,7 @@ def s1_evaluate(
         output=output,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -129,6 +131,7 @@ def _screen(
     preset: str,
     seed: int,
     cache_state: CacheState,
+    threads: int = 1,
 ) -> list[BenchRecord]:
     scale = resolve_scale(preset, n_factors=n_factors)
     core = metric_sets.CORE
@@ -146,6 +149,7 @@ def _screen(
         output=output,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -155,6 +159,7 @@ def s2_screen_50(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """S2: 50-factor screening with the `core` metric set."""
     n = min(50, resolve_scale(preset).n_factors)  # tiny preset caps at 8
@@ -165,6 +170,7 @@ def s2_screen_50(
         preset=preset,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -174,6 +180,7 @@ def s3_screen_200(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """S3: 200-factor screening with the `core` metric set."""
     n = min(200, resolve_scale(preset).n_factors)
@@ -184,6 +191,7 @@ def s3_screen_200(
         preset=preset,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -198,6 +206,7 @@ def p1_scaling_probe(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """Scaling probe — emits one record per scale step.
 
@@ -225,6 +234,7 @@ def p1_scaling_probe(
             preset=preset,
             seed=seed,
             cache_state=cache_state,
+            threads=threads,
         )
         all_records.extend(records)
 
@@ -247,6 +257,7 @@ def _micro(
     preset: str,
     seed: int,
     cache_state: CacheState,
+    threads: int = 1,
 ) -> list[BenchRecord]:
     max_factors = resolve_scale(preset).n_factors
     n = min(_MICRO_FACTORS, max_factors)
@@ -271,6 +282,7 @@ def _micro(
         output=output,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -280,6 +292,7 @@ def m_ic(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """M-ic: cost of ``ic`` alone (no bootstrap)."""
     return _micro(
@@ -289,6 +302,7 @@ def m_ic(
         preset=preset,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -298,6 +312,7 @@ def m_quantile(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """M-quantile: cost of ``quantile_spread`` alone."""
     return _micro(
@@ -307,6 +322,7 @@ def m_quantile(
         preset=preset,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -316,6 +332,7 @@ def m_monotonicity(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """M-mono: cost of ``monotonicity`` alone."""
     return _micro(
@@ -325,6 +342,7 @@ def m_monotonicity(
         preset=preset,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -334,6 +352,7 @@ def m_ic_bootstrap(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """Cost of the bootstrap path on a per-factor IC series.
 
@@ -362,6 +381,7 @@ def m_ic_bootstrap(
         output=output,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 

--- a/bench/scenarios/sparse.py
+++ b/bench/scenarios/sparse.py
@@ -53,6 +53,7 @@ def s5_event_study(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """Event-study bundle: corrado rank test + CAAR + MFE/MAE."""
     return run_sparse_scenario(
@@ -63,6 +64,7 @@ def s5_event_study(
         output=output,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 
@@ -72,6 +74,7 @@ def m_corrado(
     preset: str = "tiny",
     seed: int = 0,
     cache_state: CacheState = "warm",
+    threads: int = 1,
 ) -> list[BenchRecord]:
     """Cost of ``corrado_rank_test`` alone on the sparse cell.
 
@@ -95,6 +98,7 @@ def m_corrado(
         output=output,
         seed=seed,
         cache_state=cache_state,
+        threads=threads,
     )
 
 

--- a/bench/ux_targets.py
+++ b/bench/ux_targets.py
@@ -1,0 +1,89 @@
+"""UX latency targets — absolute ``wall_s`` ceilings the harness asserts
+records against in the UX validation lane.
+
+These targets express *user-visible* wait time on multi-thread BLAS +
+warm cache + realistic scale. They are deliberately distinct from the
+single-thread / cold-cache ``compute_s`` ratios used by the daily
+before/after lane and the release-time reference baseline — see
+``bench/README.md`` for the lane split.
+
+``UX_TARGETS_VERSION`` is bumped whenever the table is edited so an old
+report can be re-interpreted against the version it was produced under.
+The validator stamps the version it used into its markdown output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+UX_TARGETS_VERSION = "1"
+
+# Scale dimension above which a record is treated as "stretch" — its
+# wall_s is recorded in the report but not asserted, regardless of the
+# scenario's wall_s_max. Mirrors the "1000-factor stretch row" from the
+# UX latency target table.
+STRETCH_N_FACTORS = 1000
+
+
+@dataclass(frozen=True)
+class UxTarget:
+    """One row of the UX latency target table.
+
+    ``wall_s_max`` is the absolute upper bound in seconds. ``None``
+    marks a stretch row — the validator records the measurement but
+    does not raise a red flag if it overshoots.
+    """
+
+    wall_s_max: float | None
+    description: str
+
+
+# Keyed by ``scenario_id``. Scenarios not in this dict are reported as
+# ``skip`` (no UX expectation registered yet). Adding a new scenario to
+# the harness does not silently demote its measurement — the validator
+# surfaces unknown ``scenario_id``s in its report.
+UX_TARGETS: dict[str, UxTarget] = {
+    "S1": UxTarget(
+        wall_s_max=5.0,
+        description="Single factor evaluate + run_metrics — interactive notebook",
+    ),
+    "S2": UxTarget(
+        wall_s_max=30.0,
+        description="50-factor screen — user willing to wait",
+    ),
+    "S3": UxTarget(
+        wall_s_max=120.0,
+        description="200-factor screen — user switches to other tasks",
+    ),
+    "P1": UxTarget(
+        wall_s_max=600.0,
+        description="Scaling probe (up to 500-factor) — not perceived as crashed",
+    ),
+}
+
+
+def lookup_target(scenario_id: str, *, n_factors: int | None) -> UxTarget | None:
+    """Return the target for ``scenario_id`` or ``None`` if unregistered.
+
+    Stretch demotion (``n_factors >= STRETCH_N_FACTORS``) returns a
+    target with ``wall_s_max=None`` so callers can render the row
+    without asserting against it.
+    """
+    base = UX_TARGETS.get(scenario_id)
+    if base is None:
+        return None
+    if n_factors is not None and n_factors >= STRETCH_N_FACTORS:
+        return UxTarget(
+            wall_s_max=None,
+            description=f"{base.description} (stretch: n_factors≥{STRETCH_N_FACTORS})",
+        )
+    return base
+
+
+__all__ = [
+    "STRETCH_N_FACTORS",
+    "UX_TARGETS",
+    "UX_TARGETS_VERSION",
+    "UxTarget",
+    "lookup_target",
+]

--- a/bench/ux_validate.py
+++ b/bench/ux_validate.py
@@ -1,0 +1,191 @@
+"""``python -m bench.ux_validate <jsonl-dir>`` — assert UX latency targets.
+
+Reads every ``*.jsonl`` under the given directory, picks the measured
+rows (``is_warmup=false ∧ status="ok"``), and asserts each row's
+``wall_s`` against ``bench.ux_targets.UX_TARGETS``.
+
+Output is a markdown table to stdout. Exit code is non-zero when any
+row fails its target (a *red flag*); stretch rows, scenarios not in
+the target table, and ``status="oom" / "error"`` rows are reported
+but do not block. The latter matters at ``xlarge`` — an OOM on a
+1000-factor screen is real data, not a CI failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from bench.ux_targets import UX_TARGETS_VERSION, UxTarget, lookup_target
+
+RowVerdict = Literal["pass", "fail", "stretch", "skip"]
+
+
+@dataclass(frozen=True)
+class RowReport:
+    """One asserted row in the UX validation report."""
+
+    scenario_id: str
+    wall_s: float | None
+    wall_s_max: float | None
+    verdict: RowVerdict
+    peak_rss_mb: float | None
+    n_threads: int
+    n_factors: int | None
+    status: str
+    source_file: str
+
+
+@dataclass(frozen=True)
+class IncidentReport:
+    """Non-blocking row (oom / error / unknown scenario)."""
+
+    scenario_id: str
+    status: str
+    error_message: str | None
+    source_file: str
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+    return out
+
+
+def _extract_n_factors(scale: dict[str, Any]) -> int | None:
+    value = scale.get("n_factors")
+    return int(value) if isinstance(value, int) else None
+
+
+def _classify(row: dict[str, Any], target: UxTarget | None) -> RowVerdict:
+    if target is None:
+        return "skip"
+    if target.wall_s_max is None:
+        return "stretch"
+    wall_s = row.get("wall_s")
+    if wall_s is None:
+        return "fail"
+    return "pass" if wall_s <= target.wall_s_max else "fail"
+
+
+def evaluate_dir(jsonl_dir: Path) -> tuple[list[RowReport], list[IncidentReport]]:
+    """Read every JSONL in ``jsonl_dir`` and classify each measured row.
+
+    Returns ``(row_reports, incidents)`` where ``incidents`` collects
+    OOM / error / unknown-scenario rows that should appear in the
+    report but not gate the exit code.
+    """
+    rows: list[RowReport] = []
+    incidents: list[IncidentReport] = []
+    for path in sorted(jsonl_dir.glob("*.jsonl")):
+        for raw in _read_jsonl(path):
+            scenario_id = raw["scenario_id"]
+            status = raw["status"]
+            if status != "ok":
+                incidents.append(
+                    IncidentReport(
+                        scenario_id=scenario_id,
+                        status=status,
+                        error_message=raw.get("error_message"),
+                        source_file=path.name,
+                    )
+                )
+                continue
+            if raw.get("is_warmup", False):
+                continue
+            scale = raw.get("scale", {})
+            n_factors = _extract_n_factors(scale)
+            target = lookup_target(scenario_id, n_factors=n_factors)
+            verdict = _classify(raw, target)
+            rows.append(
+                RowReport(
+                    scenario_id=scenario_id,
+                    wall_s=raw.get("wall_s"),
+                    wall_s_max=target.wall_s_max if target else None,
+                    verdict=verdict,
+                    peak_rss_mb=raw.get("peak_rss_mb"),
+                    n_threads=int(raw.get("env", {}).get("omp_threads", 1)),
+                    n_factors=n_factors,
+                    status=status,
+                    source_file=path.name,
+                )
+            )
+    return rows, incidents
+
+
+_VERDICT_GLYPH: dict[RowVerdict, str] = {
+    "pass": "✅ pass",
+    "fail": "❌ fail",
+    "stretch": "➖ stretch",
+    "skip": "➖ skip",
+}
+
+
+def _fmt(value: float | None, spec: str = ".2f") -> str:
+    return format(value, spec) if isinstance(value, (int, float)) else "—"
+
+
+def render_markdown(rows: list[RowReport], incidents: list[IncidentReport]) -> str:
+    """Render the asserted rows + non-blocking incidents as markdown."""
+    lines: list[str] = []
+    lines.append(f"## UX validation (UX_TARGETS_VERSION={UX_TARGETS_VERSION})")
+    lines.append("")
+    lines.append(
+        "| scenario | n_factors | wall_s | target | verdict | "
+        "peak_rss_mb | n_threads | source |"
+    )
+    lines.append("|---|---:|---:|---:|---|---:|---:|---|")
+    for r in rows:
+        lines.append(
+            f"| {r.scenario_id} | {r.n_factors if r.n_factors is not None else '—'} "
+            f"| {_fmt(r.wall_s)} | {_fmt(r.wall_s_max)} | "
+            f"{_VERDICT_GLYPH[r.verdict]} | {_fmt(r.peak_rss_mb, '.0f')} | "
+            f"{r.n_threads} | {r.source_file} |"
+        )
+    if incidents:
+        lines.append("")
+        lines.append("### Incidents (non-blocking)")
+        lines.append("")
+        lines.append("| scenario | status | message | source |")
+        lines.append("|---|---|---|---|")
+        for inc in incidents:
+            msg = (inc.error_message or "").replace("|", "\\|")
+            lines.append(
+                f"| {inc.scenario_id} | {inc.status} | {msg} | {inc.source_file} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point — assert JSONL dir vs UX targets."""
+    parser = argparse.ArgumentParser(
+        prog="python -m bench.ux_validate",
+        description="Assert benchmark JSONL records against UX latency targets.",
+    )
+    parser.add_argument(
+        "jsonl_dir",
+        type=Path,
+        help="Directory containing <scenario_id>.jsonl files to validate.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.jsonl_dir.is_dir():
+        parser.error(f"not a directory: {args.jsonl_dir}")
+
+    rows, incidents = evaluate_dir(args.jsonl_dir)
+    sys.stdout.write(render_markdown(rows, incidents))
+    red_flag = any(r.verdict == "fail" for r in rows)
+    return 1 if red_flag else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bench/test_cli.py
+++ b/tests/bench/test_cli.py
@@ -57,6 +57,37 @@ def test_cold_cache_labels_jsonl_cold(tmp_path: Path):
             assert row["cache_state"] == "cold"
 
 
+def test_threads_flag_stamps_omp_threads_into_env(tmp_path: Path):
+    """``--threads N`` must show up in ``env.omp_threads`` of the
+    measured rows. We use ``--run-one`` against a single short
+    scenario so the test stays bounded."""
+    rc = main(
+        [
+            "--run-one",
+            "M-ic",
+            "--preset",
+            "tiny",
+            "--output",
+            str(tmp_path),
+            "--threads",
+            "4",
+        ]
+    )
+    assert rc == 0
+    with (tmp_path / "M-ic.jsonl").open() as fh:
+        for line in fh:
+            row = json.loads(line)
+            assert row["env"]["omp_threads"] == 4
+
+
+def test_threads_default_is_one(tmp_path: Path):
+    rc = main(["--run-one", "M-ic", "--preset", "tiny", "--output", str(tmp_path)])
+    assert rc == 0
+    with (tmp_path / "M-ic.jsonl").open() as fh:
+        first = json.loads(fh.readline())
+    assert first["env"]["omp_threads"] == 1
+
+
 def test_cold_cache_labels_continuous_scenarios_cold(tmp_path: Path):
     """Regression: an earlier draft of the CLI silently dropped
     `cache_state` for Continuous + algo scenarios because their

--- a/tests/bench/test_helpers.py
+++ b/tests/bench/test_helpers.py
@@ -1,0 +1,31 @@
+"""Preset table invariants — dimensions and laptop / cloud split."""
+
+from __future__ import annotations
+
+from bench.scenarios._helpers import PRESETS, SPARSE_PRESETS
+
+
+def test_xlarge_preset_dimensions():
+    p = PRESETS["xlarge"]
+    assert (p.n_factors, p.n_assets, p.n_dates) == (1000, 2000, 2000)
+
+
+def test_user_realistic_high_preset_dimensions():
+    p = PRESETS["user-realistic-high"]
+    assert (p.n_factors, p.n_assets, p.n_dates) == (500, 3000, 2500)
+
+
+def test_sparse_presets_track_continuous_presets():
+    # Cloud-only presets must exist on both tables so a UX run with
+    # --target xlarge / user-realistic-high resolves cleanly on the
+    # sparse cell too.
+    for name in ("xlarge", "user-realistic-high"):
+        assert name in SPARSE_PRESETS, name
+
+
+def test_laptop_presets_unchanged():
+    # `small` and `large` size the laptop reference baseline; their
+    # dimensions are pinned and must not drift when cloud presets get
+    # added.
+    assert PRESETS["small"].n_factors == 100
+    assert PRESETS["large"].n_factors == 500

--- a/tests/bench/test_ux_targets.py
+++ b/tests/bench/test_ux_targets.py
@@ -1,0 +1,39 @@
+"""UX target table — structure, version, stretch demotion."""
+
+from __future__ import annotations
+
+from bench.ux_targets import (
+    STRETCH_N_FACTORS,
+    UX_TARGETS,
+    UX_TARGETS_VERSION,
+    UxTarget,
+    lookup_target,
+)
+
+
+def test_version_is_string():
+    assert isinstance(UX_TARGETS_VERSION, str) and UX_TARGETS_VERSION
+
+
+def test_core_scenarios_have_targets():
+    for sid in ("S1", "S2", "S3", "P1"):
+        target = UX_TARGETS[sid]
+        assert isinstance(target, UxTarget)
+        assert target.wall_s_max is not None
+        assert target.wall_s_max > 0
+
+
+def test_lookup_unknown_returns_none():
+    assert lookup_target("nonexistent-scenario", n_factors=10) is None
+
+
+def test_lookup_demotes_to_stretch_at_threshold():
+    asserted = lookup_target("S2", n_factors=50)
+    stretch = lookup_target("S2", n_factors=STRETCH_N_FACTORS)
+    assert asserted is not None and asserted.wall_s_max is not None
+    assert stretch is not None and stretch.wall_s_max is None
+
+
+def test_lookup_no_demotion_below_threshold():
+    target = lookup_target("S3", n_factors=STRETCH_N_FACTORS - 1)
+    assert target is not None and target.wall_s_max is not None

--- a/tests/bench/test_ux_validate.py
+++ b/tests/bench/test_ux_validate.py
@@ -1,0 +1,163 @@
+"""``bench.ux_validate`` CLI — happy / red flag / OOM / unknown rows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from bench.ux_targets import UX_TARGETS, UX_TARGETS_VERSION
+from bench.ux_validate import evaluate_dir, main, render_markdown
+
+_BASE_ROW: dict = {
+    "schema_version": "1",
+    "metric_set": "core",
+    "metric_set_version": "1",
+    "axis_cell": "continuous_individual_panel",
+    "run_idx": 0,
+    "is_warmup": False,
+    "cache_state": "warm",
+    "error_message": None,
+    "started_at": "2026-05-16T00:00:00Z",
+    "setup_s": 0.1,
+    "compute_s": 0.1,
+    "cpu_s": 0.2,
+    "peak_rss_mb": 256.0,
+    "peak_alloc_mb": 64.0,
+    "env": {
+        "git_sha": "abc1234",
+        "factrix_version": "0.13.0",
+        "dataset_spec_version": "1",
+        "python": "3.13.0",
+        "numpy": "2.0.0",
+        "blas": "openblas",
+        "omp_threads": 4,
+        "cpu_model": "x86",
+        "cpu_cores": 8,
+        "ram_gb": 32.0,
+        "os": "linux-x86_64",
+    },
+}
+
+
+def _make_row(
+    scenario_id: str,
+    *,
+    wall_s: float | None,
+    status: str = "ok",
+    is_warmup: bool = False,
+    n_factors: int = 50,
+    n_assets: int = 100,
+    n_dates: int = 60,
+    error_message: str | None = None,
+) -> dict:
+    row = dict(_BASE_ROW)
+    row.update(
+        {
+            "scenario_id": scenario_id,
+            "scale": {
+                "axis_cell": "continuous_individual_panel",
+                "n_factors": n_factors,
+                "n_assets": n_assets,
+                "n_dates": n_dates,
+            },
+            "wall_s": wall_s,
+            "status": status,
+            "is_warmup": is_warmup,
+            "error_message": error_message,
+        }
+    )
+    return row
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+
+def test_happy_path_all_pass(tmp_path: Path):
+    _write_jsonl(
+        tmp_path / "S2.jsonl",
+        [
+            _make_row("S2", wall_s=1.0, is_warmup=True),
+            _make_row("S2", wall_s=2.0),
+        ],
+    )
+    rc = main([str(tmp_path)])
+    assert rc == 0
+
+
+def test_red_flag_overshoot_exit_nonzero(tmp_path: Path):
+    overshoot = UX_TARGETS["S2"].wall_s_max + 1.0
+    _write_jsonl(tmp_path / "S2.jsonl", [_make_row("S2", wall_s=overshoot)])
+    rc = main([str(tmp_path)])
+    assert rc != 0
+
+
+def test_warmup_rows_ignored(tmp_path: Path):
+    # An overshooting warmup must not flip the verdict to fail.
+    overshoot = UX_TARGETS["S2"].wall_s_max + 100.0
+    _write_jsonl(
+        tmp_path / "S2.jsonl",
+        [
+            _make_row("S2", wall_s=overshoot, is_warmup=True),
+            _make_row("S2", wall_s=1.0),
+        ],
+    )
+    rc = main([str(tmp_path)])
+    assert rc == 0
+
+
+def test_oom_is_non_blocking_incident(tmp_path: Path):
+    _write_jsonl(
+        tmp_path / "S2.jsonl",
+        [
+            _make_row("S2", wall_s=1.0),
+            _make_row(
+                "S2", wall_s=None, status="oom", error_message="MemoryError(...)"
+            ),
+        ],
+    )
+    rows, incidents = evaluate_dir(tmp_path)
+    assert len(rows) == 1 and rows[0].verdict == "pass"
+    assert len(incidents) == 1 and incidents[0].status == "oom"
+    assert main([str(tmp_path)]) == 0
+
+
+def test_stretch_n_factors_recorded_but_not_asserted(tmp_path: Path):
+    # n_factors >= STRETCH_N_FACTORS demotes to stretch — wildly
+    # overshooting the per-scenario target must not fail.
+    _write_jsonl(
+        tmp_path / "S2.jsonl",
+        [_make_row("S2", wall_s=9999.0, n_factors=1000)],
+    )
+    rows, _ = evaluate_dir(tmp_path)
+    assert rows[0].verdict == "stretch"
+    assert main([str(tmp_path)]) == 0
+
+
+def test_unknown_scenario_is_skip(tmp_path: Path):
+    _write_jsonl(tmp_path / "X.jsonl", [_make_row("X-unknown", wall_s=1.0)])
+    rows, _ = evaluate_dir(tmp_path)
+    assert rows[0].verdict == "skip"
+    assert main([str(tmp_path)]) == 0
+
+
+def test_render_markdown_includes_version_and_columns(tmp_path: Path):
+    _write_jsonl(tmp_path / "S2.jsonl", [_make_row("S2", wall_s=1.0)])
+    rows, incidents = evaluate_dir(tmp_path)
+    md = render_markdown(rows, incidents)
+    assert f"UX_TARGETS_VERSION={UX_TARGETS_VERSION}" in md
+    assert "wall_s" in md and "target" in md and "n_threads" in md
+    assert "S2" in md
+
+
+def test_missing_jsonl_field_fails_loud(tmp_path: Path):
+    # ``scenario_id`` missing — raises KeyError on read rather than
+    # silently passing.
+    row = _make_row("S2", wall_s=1.0)
+    del row["scenario_id"]
+    _write_jsonl(tmp_path / "broken.jsonl", [row])
+    with pytest.raises(KeyError):
+        evaluate_dir(tmp_path)


### PR DESCRIPTION
## Summary
- 在 `bench/` 加入第三條 lane（UX validation），與既有 reference baseline、daily before/after 正交：多執行緒 BLAS、warm cache，斷言絕對 `wall_s` 對應 `bench.ux_targets.UX_TARGETS`。
- `--threads N` 旗標從 `__main__` → scenarios → `preflight` 全鏈打通。在 spawn cold-cache subprocess 之前先把 thread env vars 鎖好，確保子行程在 numpy 初始化 BLAS 前就吃到正確的執行緒數。
- 新增兩個 cloud-only preset：`xlarge`（1000/2000/2000）與 `user-realistic-high`（500/3000/2500）；皆排除於 `make bench-bump`，不會進入 `bench/baselines/`。
- `bench.ux_targets`（`UX_TARGETS_VERSION="1"`）：S1 ≤ 5 s、S2 ≤ 30 s、S3 ≤ 120 s、P1 ≤ 600 s。`n_factors ≥ 1000` 自動降級為 stretch（記錄但不斷言），對應 #380 UX latency 表的 1000-factor 列。
- `bench.ux_validate <jsonl-dir>` CLI：產 markdown report 至 stdout、出現任何 red flag 時 exit code 非零；OOM／error／未登錄 scenario 的列以 non-blocking incident 呈現（1000-factor 跑爆是有效資料，不能讓 CI 變紅）。

Closes #391。

註：cloud 上的四組 Plan A 跑測（`{xlarge,user-realistic-high}` × `{4,16}` threads）不在此 PR 內，merge 後再跑，結果用來決定 #378 後續優化排序。

## Test plan
- [x] `pytest tests/bench/` 77 passed（含新增的 `test_helpers.py`、`test_ux_targets.py`、`test_ux_validate.py`，以及 `test_cli.py` 對 `--threads` 的擴充）。
- [x] Laptop smoke：`python -m bench --target tiny --threads 2 --output /tmp/ux-smoke` → `python -m bench.ux_validate /tmp/ux-smoke` 走完整條管線、`env.omp_threads=2` 正確傳遞、validator exit code 0。實測輸出：

```
## UX validation (UX_TARGETS_VERSION=1)

| scenario | n_factors | wall_s | target | verdict | peak_rss_mb | n_threads | source |
|---|---:|---:|---:|---|---:|---:|---|
| M-corrado | — | 0.01 | — | ➖ skip | 164 | 2 | M-corrado.jsonl |
| M-ic-boot | 8 | 0.05 | — | ➖ skip | 161 | 2 | M-ic-boot.jsonl |
| M-ic | 8 | 0.04 | — | ➖ skip | 161 | 2 | M-ic.jsonl |
| M-mono | 8 | 0.06 | — | ➖ skip | 161 | 2 | M-mono.jsonl |
| M-quantile | 8 | 0.06 | — | ➖ skip | 161 | 2 | M-quantile.jsonl |
| P1 | 2 | 0.04 | 600.00 | ✅ pass | 161 | 2 | P1.jsonl |
| P1 | 4 | 0.08 | 600.00 | ✅ pass | 161 | 2 | P1.jsonl |
| P1 | 8 | 0.15 | 600.00 | ✅ pass | 161 | 2 | P1.jsonl |
| S1 | 1 | 0.03 | 5.00 | ✅ pass | 158 | 2 | S1.jsonl |
| S2 | 8 | 0.14 | 30.00 | ✅ pass | 160 | 2 | S2.jsonl |
| S3 | 8 | 0.14 | 120.00 | ✅ pass | 161 | 2 | S3.jsonl |
| S4 | 8 | 0.05 | — | ➖ skip | 163 | 2 | S4.jsonl |
| S5 | — | 0.03 | — | ➖ skip | 164 | 2 | S5.jsonl |
```

- [ ] Merge 後 cloud 跑 Plan A 四組（`xlarge`／`user-realistic-high` × `--threads 4`／`16`），結果決定 #378 後續優化排序。

## Reviewer 建議關注點
- `bench/__main__.py`：`lock_threads(args.threads)` 必須在 subprocess fork 之前呼叫，warm 單行程模式只能標記 `env.omp_threads`（BLAS 已初始化無法重新綁定），這個 caveat 已寫在 README「UX validation」段。
- `bench/ux_targets.py`：`STRETCH_N_FACTORS=1000` 與 `UX_TARGETS_VERSION="1"` 是 user-visible 契約，未來改動需 bump version。
- 所有 scenario 函式新增 `threads: int = 1` kwarg，預設值維持 reference baseline 既有行為，現有 caller／test 不需改動。