### PR TITLE
fix(bench): register xlarge / user-realistic-high in --target dispatch

### DIFF
--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -44,6 +44,11 @@ TARGETS: dict[str, dict[str, Any]] = {
     "tiny": {"preset": "tiny", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
     "small": {"preset": "small", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
     "large": {"preset": "large", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
+    "xlarge": {"preset": "xlarge", "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS},
+    "user-realistic-high": {
+        "preset": "user-realistic-high",
+        "scenarios": _CONT_ALGO_IDS + _SPARSE_IDS,
+    },
     "event": {"preset": "small", "scenarios": _SPARSE_IDS},
 }
 

--- a/tests/bench/test_cli.py
+++ b/tests/bench/test_cli.py
@@ -41,6 +41,19 @@ def test_tiny_target_runs_full_scenario_set(tmp_path: Path):
         assert rep.ok, (f.name, rep.failures)
 
 
+def test_cloud_targets_registered():
+    """Cloud-only presets must be reachable via --target; otherwise
+    UX validation runs fail at arg-parse time with no way to invoke
+    the preset short of --run-one. Regression: an earlier draft
+    added xlarge / user-realistic-high to PRESETS but forgot the
+    TARGETS dispatcher entry."""
+    from bench.__main__ import TARGETS
+
+    for name in ("xlarge", "user-realistic-high"):
+        assert name in TARGETS, name
+        assert TARGETS[name]["preset"] == name
+
+
 def test_event_target_runs_only_sparse_scenarios(tmp_path: Path):
     rc = main(["--target", "event", "--output", str(tmp_path)])
     assert rc == 0


### PR DESCRIPTION
## Summary
- 修補 #391 的疏漏：`xlarge` / `user-realistic-high` 雖然加到 `PRESETS` / `SPARSE_PRESETS`，但 `bench/__main__.py` 的 `TARGETS` dispatch 字典沒同步登錄，導致 `python -m bench --target xlarge ...` 在 argparse 階段就失敗，UX validation 跑測無法用文件記載的方式啟動。
- 將兩個 cloud preset 加入 `TARGETS`（與 `small` / `large` 同形：完整 continuous + algo + sparse 場景集合），讓 README 的 Plan A 指令真的能跑。
- 新增 `test_cloud_targets_registered` regression test：之後加 preset 必須一併接 dispatcher，否則 test fail。

## Test plan
- [x] `pytest tests/bench/test_cli.py` 10 passed（含新增 registry test）
- [x] 實機驗證：`OMP_NUM_THREADS=16 python -m bench --target xlarge --threads 16 --output /tmp/<dir>` 不再報 `invalid choice`（merge 後跑 Plan A 完整流程確認）

Refs #391