### PR TITLE
perf(metrics): batch compute_ic across factors (#394)

### DIFF
--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import factrix as fx
 import polars as pl
-from factrix.metrics.ic import compute_ic
+from factrix.metrics.ic import compute_ic, ic
 from factrix.stats import bootstrap_mean_ci
 
 from bench import metric_sets
@@ -53,11 +53,30 @@ def _run_metrics_per_factor(
     metric_names: tuple[str, ...],
     factors: list[str],
 ) -> int:
+    # Single-metric IC: skip the per-factor run_metrics dispatch loop —
+    # the public batch entry point computes every factor's IC in one
+    # polars query (one with_columns + one group_by(date).agg + one
+    # collect), then the per-factor `ic()` aggregator is a cheap
+    # numpy-level op on the resulting per-factor IC series. Lets M-ic
+    # measure the metric proper, not the dispatch overhead.
+    if tuple(metric_names) == ("ic",):
+        return _ic_only_batched(panel, cfg, factors)
     n = 0
     for col in factors:
         bundle = fx.run_metrics(panel, cfg, factor_col=col, metrics=list(metric_names))
         n += len(bundle.metrics)
     return n
+
+
+def _ic_only_batched(
+    panel: pl.DataFrame,
+    cfg: fx.AnalysisConfig,
+    factors: list[str],
+) -> int:
+    ic_results = compute_ic(panel, factors)
+    for col in factors:
+        ic(ic_results[col], forward_periods=cfg.forward_periods)
+    return len(factors)
 
 
 def _bootstrap_ic_per_factor(
@@ -66,14 +85,15 @@ def _bootstrap_ic_per_factor(
     *,
     seed: int,
 ) -> int:
-    n = 0
+    # Batch the IC compute across factors (one polars query), then loop
+    # the bootstrap inner step — bootstrap vectorisation is tracked
+    # separately (see Refs in PR description).
+    ic_results = compute_ic(panel, factors)
     for k, col in enumerate(factors):
-        ic_df = compute_ic(panel, factor_col=col)
-        arr = ic_df["ic"].to_numpy()
+        arr = ic_results[col]["ic"].to_numpy()
         # Seed per factor so each call is independent but reproducible.
         bootstrap_mean_ci(arr, n_bootstrap=BOOTSTRAP_N, seed=seed + k)
-        n += 1
-    return n
+    return len(factors)
 
 
 # ---------------------------------------------------------------------------

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import math
 import warnings as _warnings
+from typing import overload
 
 import polars as pl
 
@@ -91,20 +92,46 @@ def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
     return med
 
 
+@overload
 def compute_ic(
     df: pl.DataFrame,
-    factor_col: str = "factor",
+    factor_col: str = ...,
+    return_col: str = ...,
+) -> pl.DataFrame: ...
+
+
+@overload
+def compute_ic(
+    df: pl.DataFrame,
+    factor_col: list[str],
+    return_col: str = ...,
+) -> dict[str, pl.DataFrame]: ...
+
+
+def compute_ic(
+    df: pl.DataFrame,
+    factor_col: str | list[str] = "factor",
     return_col: str = "forward_return",
-) -> pl.DataFrame:
+) -> pl.DataFrame | dict[str, pl.DataFrame]:
     r"""Per-date Spearman Rank information coefficient (IC).
 
     Args:
         df: Panel with ``date``, ``asset_id``, ``factor_col``, ``return_col``.
+        factor_col: A single factor column name (``str``) or a list of
+            names to score together. Passing a list runs all factors in
+            a single polars query (one ``with_columns`` + one
+            ``group_by("date").agg(...)`` + one ``collect``), avoiding
+            the per-factor query-plan overhead of repeated single-factor
+            calls. The single-factor path is the N=1 case of the same
+            engine — there is no "fast path / slow path" divergence.
+        return_col: Forward-return column shared across factors.
 
     Returns:
-        DataFrame with columns ``date, ic, tie_ratio`` sorted by date.
-        Dates with fewer than ``MIN_ASSETS_PER_DATE_IC`` assets are dropped.
-        ``tie_ratio`` is the per-date factor tie density
+        Single factor (``str`` input) → DataFrame with columns
+        ``date, ic, tie_ratio`` sorted by date. List input → dict
+        mapping each factor name to the same per-factor DataFrame.
+        Dates with fewer than ``MIN_ASSETS_PER_DATE_IC`` assets are
+        dropped. ``tie_ratio`` is the per-date factor tie density
         $1 - n_{\mathrm{unique}} / n$ in $[0, 1]$.
 
     Notes:
@@ -150,21 +177,50 @@ def compute_ic(
         >>> set(ic_df.columns) >= {"date", "ic", "tie_ratio"}
         True
     """
-    ranked = df.with_columns(
-        pl.col(factor_col).rank(method="average").over("date").alias("_rank_factor"),
+    if isinstance(factor_col, str):
+        cols: list[str] = [factor_col]
+    else:
+        cols = list(factor_col)
+    if not cols:
+        raise ValueError("factor_col list must be non-empty")
+
+    # The "_rank__<col>" / "_ic__<col>" / "_tie__<col>" aliases are
+    # internal to this query and never escape — per-factor DataFrames
+    # are renamed back to the canonical ``ic`` / ``tie_ratio`` columns
+    # so the single-factor return shape stays drop-in identical.
+    rank_exprs: list[pl.Expr] = [
         pl.col(return_col).rank(method="average").over("date").alias("_rank_return"),
-    )
-    return (
-        ranked.group_by("date")
-        .agg(
-            pl.corr("_rank_factor", "_rank_return").alias("ic"),
-            pl.len().alias("n"),
-            (1.0 - pl.col(factor_col).n_unique() / pl.len()).alias("tie_ratio"),
-        )
+        *[
+            pl.col(f).rank(method="average").over("date").alias(f"_rank__{f}")
+            for f in cols
+        ],
+    ]
+    agg_exprs: list[pl.Expr] = [pl.len().alias("n")]
+    for f in cols:
+        agg_exprs.append(pl.corr(f"_rank__{f}", "_rank_return").alias(f"_ic__{f}"))
+        agg_exprs.append((1.0 - pl.col(f).n_unique() / pl.len()).alias(f"_tie__{f}"))
+
+    wide = (
+        df.lazy()
+        .with_columns(rank_exprs)
+        .group_by("date")
+        .agg(agg_exprs)
         .filter(pl.col("n") >= MIN_ASSETS_PER_DATE_IC)
         .sort("date")
-        .select("date", "ic", "tie_ratio")
+        .collect()
     )
+
+    per_factor = {
+        f: wide.select(
+            pl.col("date"),
+            pl.col(f"_ic__{f}").alias("ic"),
+            pl.col(f"_tie__{f}").alias("tie_ratio"),
+        )
+        for f in cols
+    }
+    if isinstance(factor_col, str):
+        return per_factor[factor_col]
+    return per_factor
 
 
 def ic(

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -137,6 +137,56 @@ class TestComputeIC:
             ic_ir(clean_ic)
 
 
+class TestComputeICBatch:
+    """Multi-factor (`list[str]`) path of ``compute_ic``.
+
+    Equivalence between the single-factor (`str`) and multi-factor
+    paths is the load-bearing contract — the batch path is the same
+    polars engine specialised at N=1, so a divergence here means a
+    silent numerics regression for every single-factor caller.
+    """
+
+    def test_single_in_list_equals_single_call(self, tiny_panel):
+        single = compute_ic(tiny_panel, factor_col="factor")
+        batch = compute_ic(tiny_panel, factor_col=["factor"])
+        assert isinstance(batch, dict)
+        assert set(batch) == {"factor"}
+        assert single.equals(batch["factor"])
+
+    def test_multi_factor_columns_match_per_factor_calls(self):
+        # Two correlated factor columns side-by-side; batch result must
+        # equal looping single-factor calls element-wise.
+        rng = np.random.default_rng(7)
+        n_assets, n_dates = 60, 40
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        records = []
+        for date in dates:
+            returns = rng.standard_normal(n_assets) * 0.02
+            f1 = returns + rng.standard_normal(n_assets) * 0.05
+            f2 = -returns + rng.standard_normal(n_assets) * 0.05
+            for asset_id in range(n_assets):
+                records.append(
+                    {
+                        "date": date,
+                        "asset_id": asset_id,
+                        "f1": float(f1[asset_id]),
+                        "f2": float(f2[asset_id]),
+                        "forward_return": float(returns[asset_id]),
+                    }
+                )
+        panel = pl.DataFrame(records).with_columns(
+            pl.col("date").cast(pl.Datetime("ms"))
+        )
+        batch = compute_ic(panel, factor_col=["f1", "f2"])
+        for col in ("f1", "f2"):
+            single = compute_ic(panel, factor_col=col)
+            assert batch[col].equals(single), col
+
+    def test_empty_factor_list_rejected(self, tiny_panel):
+        with pytest.raises(ValueError, match="non-empty"):
+            compute_ic(tiny_panel, factor_col=[])
+
+
 class TestIC:
     def test_positive_ic(self, noisy_panel):
         ic_df = compute_ic(noisy_panel)


### PR DESCRIPTION
## Summary
- `compute_ic` 加 `factor_col: str | list[str]` overload。傳 list 時一個 polars query 收掉所有 factor（一次 `with_columns` 排所有 rank、一次 `group_by("date").agg(...)` 收所有 corr + tie_ratio、一次 `collect`），消除 per-factor `collect()` 開銷與 `forward_return` 重複排名。
- 單因子路徑就是 list 路徑的 N=1 特例，**沒有快路徑 / 慢路徑分流**——既有單因子 caller 自動繼承 plan-fusion 收益、回傳形狀完全不變。
- bench `M-ic` 改走批次（同時繞過 `run_metrics` 派發，因為單 metric 不需要付派發成本）；`M-ic-boot` IC 部分批次、bootstrap inner loop 留給 #390。
- S2 / S3 / P1 / M-quantile / M-mono 等需要 quantile_spread + monotonicity 也批次後才一起切，本 PR 不動。

## Measured impact
Laptop `small` preset，`OMP_NUM_THREADS=1`：

| scenario | before `compute_s` | after `compute_s` | ratio | rss ratio |
|---|---:|---:|---:|---:|
| M-ic | 5.843 | 1.730 | **0.296** | 1.386 |
| M-ic-boot | 9.094 | 4.951 | 0.544 | 1.331 |

- `M-ic` 命中 perf DoD `ratio ≤ 0.5`。
- `M-ic-boot` 達 0.544，剩餘成本由 bootstrap 內迴圈主導（#390 接手後預期下降到 < 0.3）。
- `peak_rss_mb` 上升 30-40% 來自批次 in-flight 多存 N 個 rank columns；small preset 絕對量 ~500 MB，仍在 cloud host 預算內。

Scaling 驗證（單獨計時 IC compute，不含其他 metric）：

| panel | loop | batch | speedup |
|---|---:|---:|---:|
| 50f × 1000×1250 | 4.48s | 1.80s | 2.5× |
| 200f × 1000×1250 | 18.04s | 6.65s | 2.7× |
| 200f × 2000×2000 | 96.03s | 24.83s | 3.9× |

panel 越大 speedup 越好（plan fusion 收益相對 compute 增加）。

## Design notes
- **同 API 同引擎**：原 `compute_ic(df, factor_col="x")` 簽名零變動，內部直接用 `[factor_col]` 走多因子引擎；單因子是 N=1 特例，沒有冷熱路徑分歧。
- **不引入 `compute_ic_multi` 獨立函式**：避免將來每個 metric 都要對應一個 `_multi` 變體造成 surface 翻倍。
- **不引入 multi-DataFrames 輸入形狀**：目前 bench 場景都是「一張 wide panel + 多個 factor 欄」，需要時再加適配層。
- **`factor_col` 命名保留不改 `factor_cols`**：原參數名是公開 API 慣例，改名屬 deprecation cycle 議題，獨立於本 perf 改動。

## Test plan
- [x] `pytest tests/` — 1410 passed
- [x] `mypy factrix` — clean（`isinstance` narrowing 顯式分支處理 union 回傳）
- [x] `mkdocs build --strict` — clean
- [x] 新增 `TestComputeICBatch`：單 factor 包成 list 與直接傳 str 結果 column-for-column 相等；多 factor 批次與逐因子單 call 結果相等；空 list reject
- [x] 既有 `tests/test_ic.py` / `tests/test_ic_procedure.py` / `tests/bench/` 全綠

Refs #378（perf parent）、#391（UX validation harness）、#394（per-factor dispatch finding）