### PR TITLE
perf(metrics): batch quantile_spread + monotonicity (#394)

### DIFF
--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import factrix as fx
 import polars as pl
 from factrix.metrics.ic import compute_ic, ic
+from factrix.metrics.monotonicity import monotonicity
+from factrix.metrics.quantile import quantile_spread
 from factrix.stats import bootstrap_mean_ci
 
 from bench import metric_sets
@@ -37,6 +39,11 @@ from bench.schema import BenchRecord, CacheState
 # BlockBootstrap default.
 BOOTSTRAP_N = 999
 
+# Set of metrics for which `_run_metrics_per_factor` has a batched
+# fast-path. Anything outside this set falls back to the per-factor
+# ``fx.run_metrics`` dispatch loop.
+_BATCHABLE_METRICS = frozenset({"ic", "quantile_spread", "monotonicity"})
+
 
 # ---------------------------------------------------------------------------
 # Multi-factor compute primitives
@@ -53,14 +60,14 @@ def _run_metrics_per_factor(
     metric_names: tuple[str, ...],
     factors: list[str],
 ) -> int:
-    # Single-metric IC: skip the per-factor run_metrics dispatch loop —
-    # the public batch entry point computes every factor's IC in one
-    # polars query (one with_columns + one group_by(date).agg + one
-    # collect), then the per-factor `ic()` aggregator is a cheap
-    # numpy-level op on the resulting per-factor IC series. Lets M-ic
-    # measure the metric proper, not the dispatch overhead.
-    if tuple(metric_names) == ("ic",):
-        return _ic_only_batched(panel, cfg, factors)
+    # If every requested metric has a batched implementation, skip
+    # the per-factor ``fx.run_metrics`` dispatch loop — each metric's
+    # batch entry collapses N collect()s into 1 by computing all
+    # factors in one polars plan. This is what makes screen scenarios
+    # (`core` = ic + quantile_spread + monotonicity per factor) clear
+    # the UX wall at xlarge.
+    if set(metric_names) <= _BATCHABLE_METRICS:
+        return _batched(panel, cfg, factors, metric_names)
     n = 0
     for col in factors:
         bundle = fx.run_metrics(panel, cfg, factor_col=col, metrics=list(metric_names))
@@ -68,15 +75,26 @@ def _run_metrics_per_factor(
     return n
 
 
-def _ic_only_batched(
+def _batched(
     panel: pl.DataFrame,
     cfg: fx.AnalysisConfig,
     factors: list[str],
+    metric_names: tuple[str, ...],
 ) -> int:
-    ic_results = compute_ic(panel, factors)
-    for col in factors:
-        ic(ic_results[col], forward_periods=cfg.forward_periods)
-    return len(factors)
+    fwd = cfg.forward_periods
+    n = 0
+    if "ic" in metric_names:
+        ic_results = compute_ic(panel, factors)
+        for col in factors:
+            ic(ic_results[col], forward_periods=fwd)
+        n += len(factors)
+    if "quantile_spread" in metric_names:
+        quantile_spread(panel, fwd, factor_col=factors)
+        n += len(factors)
+    if "monotonicity" in metric_names:
+        monotonicity(panel, fwd, factor_col=factors)
+        n += len(factors)
+    return n
 
 
 def _bootstrap_ic_per_factor(

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -233,6 +233,38 @@ def _assign_quantile_groups(
     )
 
 
+def _assign_quantile_groups_multi(
+    df: pl.DataFrame,
+    factor_cols: list[str],
+    n_groups: int,
+    tie_policy: str = "ordinal",
+) -> pl.DataFrame:
+    """Assign per-date quantile groups for N factors in one polars pass.
+
+    Multi-factor counterpart of :func:`_assign_quantile_groups`. Emits
+    one ``_group__<factor_col>`` column per factor; the shared
+    ``pl.len().over("date")`` is computed once and reused, and every
+    rank expression lands in a single ``with_columns`` so the polars
+    query optimiser can fuse them. Used by the batch paths of
+    ``compute_spread_series`` and ``monotonicity``; both consume the
+    ``_group__<f>`` columns directly.
+    """
+    rank_exprs = [
+        pl.col(f).rank(method=tie_policy).over("date").alias(f"_rank__{f}")  # type: ignore[arg-type]
+        for f in factor_cols
+    ]
+    n_per_date_expr = pl.len().over("date").alias("_n_per_date")
+    with_ranks = df.with_columns(*rank_exprs, n_per_date_expr)
+    group_exprs = [
+        ((pl.col(f"_rank__{f}") - 1) * n_groups / pl.col("_n_per_date"))
+        .cast(pl.Int32)
+        .clip(0, n_groups - 1)
+        .alias(f"_group__{f}")
+        for f in factor_cols
+    ]
+    return with_ranks.with_columns(*group_exprs)
+
+
 def _compute_tie_ratio(
     df: pl.DataFrame,
     factor_col: str = "factor",

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -14,8 +14,11 @@ Notes:
 
 from __future__ import annotations
 
+from typing import overload
+
 import numpy as np
 import polars as pl
+import scipy.stats as scipy_stats
 
 __matrix_rows__ = (
     "monotonicity | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio",
@@ -28,8 +31,7 @@ from factrix._types import (
     MetricOutput,
 )
 from factrix.metrics._helpers import (
-    _assign_quantile_groups,
-    _compute_tie_ratio,
+    _assign_quantile_groups_multi,
     _sample_non_overlapping,
     _short_circuit_output,
     _warn_high_tie_ratio,
@@ -50,14 +52,37 @@ __all__ = [
 min_assets_per_group: int | None = 50
 
 
+@overload
+def monotonicity(
+    df: pl.DataFrame,
+    forward_periods: int = ...,
+    n_groups: int = ...,
+    factor_col: str = ...,
+    return_col: str = ...,
+    tie_policy: str = ...,
+) -> MetricOutput: ...
+
+
+@overload
+def monotonicity(
+    df: pl.DataFrame,
+    forward_periods: int = ...,
+    n_groups: int = ...,
+    *,
+    factor_col: list[str],
+    return_col: str = ...,
+    tie_policy: str = ...,
+) -> dict[str, MetricOutput]: ...
+
+
 def monotonicity(
     df: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 10,
-    factor_col: str = "factor",
+    factor_col: str | list[str] = "factor",
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
-) -> MetricOutput:
+) -> MetricOutput | dict[str, MetricOutput]:
     """Quantile return monotonicity (Spearman correlation).
 
     ``value`` = mean |Spearman| — magnitude of monotonicity (always ≥ 0).
@@ -100,76 +125,124 @@ def monotonicity(
         >>> result.name
         'monotonicity'
     """
+    if isinstance(factor_col, str):
+        cols: list[str] = [factor_col]
+    else:
+        cols = list(factor_col)
+    if not cols:
+        raise ValueError("factor_col list must be non-empty")
+
+    # Sample non-overlapping once — shared across all factors on the
+    # same panel (depends only on `date` + `forward_periods`).
     filtered = _sample_non_overlapping(df, forward_periods)
-    tie_ratio = _compute_tie_ratio(filtered, factor_col)
-    _warn_high_tie_ratio(tie_ratio, "monotonicity", tie_policy)
+    tie_ratios = _compute_tie_ratios_batched(filtered, cols)
+    for f in cols:
+        _warn_high_tie_ratio(tie_ratios[f], "monotonicity", tie_policy)
 
-    grouped = _assign_quantile_groups(
-        filtered,
-        factor_col,
-        n_groups,
-        tie_policy=tie_policy,
+    grouped = _assign_quantile_groups_multi(filtered, cols, n_groups, tie_policy)
+
+    # Stage 1: per-(date, factor, group) mean return, expressed as one
+    # ``group_by("date").agg(...)`` carrying N × n_groups filter+mean
+    # expressions. Wide output: (n_dates, 1 + N * n_groups). For large
+    # F × n_groups this is a tall ask of the planner, but a single
+    # ``collect()`` beats N separate per-factor queries because the
+    # rank / group columns get computed once and the panel is scanned
+    # only once.
+    agg_exprs: list[pl.Expr] = [
+        pl.col(return_col)
+        .filter(pl.col(f"_group__{f}") == g)
+        .mean()
+        .alias(f"_gr__{f}__{g}")
+        for f in cols
+        for g in range(n_groups)
+    ]
+    group_returns_wide = (
+        grouped.lazy().group_by("date").agg(agg_exprs).sort("date").collect()
     )
 
-    # Mean return per group per date
-    group_returns = (
-        grouped.group_by(["date", "_group"])
-        .agg(pl.col(return_col).mean().alias("group_ret"))
-        .sort(["date", "_group"])
-    )
+    # Stage 2: per-(factor, date) Spearman ρ between group index and
+    # the rank of the per-group mean return. Done in numpy because the
+    # inner shape (n_dates rows × n_groups cells per factor) is small
+    # and the operation is uniform — vectorising in numpy beats the
+    # polars-side rank+corr pipeline at this size. Materialise the
+    # full (n_dates, N * n_groups) block once (zero-copy via Arrow)
+    # and slice per factor — saves N * n_groups individual ``.to_numpy``
+    # calls.
+    gr_col_names = [f"_gr__{f}__{g}" for f in cols for g in range(n_groups)]
+    all_means = group_returns_wide.select(gr_col_names).to_numpy()
+    group_idx = np.arange(n_groups, dtype=np.float64)
+    group_idx_centered = group_idx - group_idx.mean()
+    group_idx_norm = float(np.sqrt(np.sum(group_idx_centered**2)))
+    results: dict[str, MetricOutput] = {}
+    for i, f in enumerate(cols):
+        mat = all_means[:, i * n_groups : (i + 1) * n_groups]
+        # Drop dates with any null/nan bucket mean (matches the
+        # original filter `n == n_groups` and `mono.is_not_null`).
+        mat = mat[np.all(np.isfinite(mat), axis=1)]
+        if mat.shape[0] == 0:
+            mono_arr = np.empty(0)
+        else:
+            # Spearman = Pearson(group_idx, rank(group_mean)).
+            ranks = scipy_stats.rankdata(mat, axis=1, method="average")
+            ranks_centered = ranks - ranks.mean(axis=1, keepdims=True)
+            ranks_norm = np.sqrt(np.sum(ranks_centered**2, axis=1))
+            with np.errstate(invalid="ignore", divide="ignore"):
+                mono_arr = (ranks_centered @ group_idx_centered) / (
+                    ranks_norm * group_idx_norm
+                )
+            mono_arr = mono_arr[np.isfinite(mono_arr)]
 
-    # WHY: Spearman(group_index, returns) = Pearson(group_index, rank(returns))
-    mono_df = (
-        group_returns.filter(
-            pl.col("group_ret").is_not_null() & pl.col("group_ret").is_not_nan()
+        if len(mono_arr) < MIN_MONOTONICITY_PERIODS:
+            results[f] = _short_circuit_output(
+                "monotonicity",
+                "insufficient_monotonicity_periods",
+                n_obs=len(mono_arr),
+                min_required=MIN_MONOTONICITY_PERIODS,
+                n_groups=n_groups,
+                tie_ratio=tie_ratios[f],
+                tie_policy=tie_policy,
+            )
+            continue
+        avg_mono = float(np.mean(np.abs(mono_arr)))
+        mean_mono = float(np.mean(mono_arr))
+        std_mono = float(np.std(mono_arr, ddof=DDOF))
+        t = _calc_t_stat(mean_mono, std_mono, len(mono_arr))
+        p = _p_value_from_t(t, len(mono_arr))
+        results[f] = MetricOutput(
+            name="monotonicity",
+            value=avg_mono,
+            stat=t,
+            significance=_significance_marker(p),
+            metadata={
+                "p_value": p,
+                "stat_type": "t",
+                "h0": "mu=0",
+                "mean_signed": mean_mono,
+                "n_valid_periods": len(mono_arr),
+                "n_groups": n_groups,
+                "tie_ratio": tie_ratios[f],
+                "tie_policy": tie_policy,
+            },
         )
-        .with_columns(
-            pl.col("group_ret").rank(method="average").over("date").alias("_ret_rank")
-        )
-        .group_by("date")
-        .agg(
-            pl.corr("_group", "_ret_rank").alias("mono"),
-            pl.len().alias("n"),
-        )
-        .filter(
-            (pl.col("n") == n_groups)
-            & pl.col("mono").is_not_null()
-            & pl.col("mono").is_not_nan()
-        )
-        .sort("date")
-    )
 
-    if len(mono_df) < MIN_MONOTONICITY_PERIODS:
-        return _short_circuit_output(
-            "monotonicity",
-            "insufficient_monotonicity_periods",
-            n_obs=len(mono_df),
-            min_required=MIN_MONOTONICITY_PERIODS,
-            n_groups=n_groups,
-            tie_ratio=tie_ratio,
-            tie_policy=tie_policy,
-        )
+    if isinstance(factor_col, str):
+        return results[factor_col]
+    return results
 
-    mono_arr = mono_df["mono"].to_numpy()
-    avg_mono = float(np.mean(np.abs(mono_arr)))
-    mean_mono = float(np.mean(mono_arr))
-    std_mono = float(np.std(mono_arr, ddof=DDOF))
-    t = _calc_t_stat(mean_mono, std_mono, len(mono_arr))
 
-    p = _p_value_from_t(t, len(mono_arr))
-    return MetricOutput(
-        name="monotonicity",
-        value=avg_mono,
-        stat=t,
-        significance=_significance_marker(p),
-        metadata={
-            "p_value": p,
-            "stat_type": "t",
-            "h0": "mu=0",
-            "mean_signed": mean_mono,
-            "n_valid_periods": len(mono_arr),
-            "n_groups": n_groups,
-            "tie_ratio": tie_ratio,
-            "tie_policy": tie_policy,
-        },
-    )
+def _compute_tie_ratios_batched(
+    df: pl.DataFrame, factor_cols: list[str]
+) -> dict[str, float]:
+    """Tie ratio (``1 - n_unique / n``) for many factors in one scan.
+
+    The single-factor :func:`_compute_tie_ratio` runs a separate polars
+    aggregation per factor; this batches them into one ``select`` so
+    the sampled panel is scanned once for any number of factors.
+    """
+    if not factor_cols:
+        return {}
+    exprs = [
+        (1.0 - pl.col(f).n_unique() / pl.len()).alias(f"_tr__{f}") for f in factor_cols
+    ]
+    row = df.select(exprs).row(0, named=True)
+    return {f: float(row[f"_tr__{f}"]) for f in factor_cols}

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -15,6 +15,7 @@ Notes:
 from __future__ import annotations
 
 import warnings
+from typing import overload
 
 import numpy as np
 import polars as pl
@@ -31,6 +32,7 @@ from factrix._types import (
 )
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
+    _assign_quantile_groups_multi,
     _compute_tie_ratio,
     _lag_within_asset,
     _median_universe_size,
@@ -47,14 +49,37 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
 ]
 
 
+@overload
+def compute_spread_series(
+    df: pl.DataFrame,
+    forward_periods: int = ...,
+    n_groups: int = ...,
+    factor_col: str = ...,
+    return_col: str = ...,
+    tie_policy: str = ...,
+) -> pl.DataFrame: ...
+
+
+@overload
+def compute_spread_series(
+    df: pl.DataFrame,
+    forward_periods: int = ...,
+    n_groups: int = ...,
+    *,
+    factor_col: list[str],
+    return_col: str = ...,
+    tie_policy: str = ...,
+) -> dict[str, pl.DataFrame]: ...
+
+
 def compute_spread_series(
     df: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
-    factor_col: str = "factor",
+    factor_col: str | list[str] = "factor",
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
-) -> pl.DataFrame:
+) -> pl.DataFrame | dict[str, pl.DataFrame]:
     """Per-date long-short spread series (non-overlapping).
 
     Top bucket = highest factor rank; bottom bucket = lowest. Labels use
@@ -96,6 +121,13 @@ def compute_spread_series(
         >>> set(spreads.columns) >= {"date", "spread", "top_return", "bottom_return"}
         True
     """
+    if isinstance(factor_col, str):
+        cols: list[str] = [factor_col]
+    else:
+        cols = list(factor_col)
+    if not cols:
+        raise ValueError("factor_col list must be non-empty")
+
     sampled = _sample_non_overlapping(df, forward_periods)
 
     median_n = _median_universe_size(sampled)
@@ -109,34 +141,67 @@ def compute_spread_series(
             stacklevel=2,
         )
 
-    grouped = _assign_quantile_groups(
-        sampled,
-        factor_col,
-        n_groups,
-        tie_policy=tie_policy,
-    )
+    grouped = _assign_quantile_groups_multi(sampled, cols, n_groups, tie_policy)
 
     top_group = n_groups - 1
     bottom_group = 0
 
-    return (
-        grouped.group_by("date")
-        .agg(
+    # Per-factor top / bottom means + a single shared universe mean.
+    agg_exprs: list[pl.Expr] = [
+        pl.col(return_col).mean().alias("universe_return"),
+    ]
+    for f in cols:
+        agg_exprs.append(
             pl.col(return_col)
-            .filter(pl.col("_group") == top_group)
+            .filter(pl.col(f"_group__{f}") == top_group)
             .mean()
-            .alias("top_return"),
+            .alias(f"_top__{f}")
+        )
+        agg_exprs.append(
             pl.col(return_col)
-            .filter(pl.col("_group") == bottom_group)
+            .filter(pl.col(f"_group__{f}") == bottom_group)
             .mean()
-            .alias("bottom_return"),
-            pl.col(return_col).mean().alias("universe_return"),
+            .alias(f"_bot__{f}")
         )
-        .with_columns(
-            (pl.col("top_return") - pl.col("bottom_return")).alias("spread"),
+
+    wide = grouped.group_by("date").agg(agg_exprs).sort("date")
+
+    per_factor = {
+        f: wide.select(
+            pl.col("date"),
+            pl.col(f"_top__{f}").alias("top_return"),
+            pl.col(f"_bot__{f}").alias("bottom_return"),
+            pl.col("universe_return"),
+            (pl.col(f"_top__{f}") - pl.col(f"_bot__{f}")).alias("spread"),
         )
-        .sort("date")
-    )
+        for f in cols
+    }
+    if isinstance(factor_col, str):
+        return per_factor[factor_col]
+    return per_factor
+
+
+@overload
+def quantile_spread(
+    df: pl.DataFrame,
+    forward_periods: int = ...,
+    n_groups: int = ...,
+    _precomputed_series: pl.DataFrame | None = ...,
+    tie_policy: str = ...,
+    factor_col: str = ...,
+) -> MetricOutput: ...
+
+
+@overload
+def quantile_spread(
+    df: pl.DataFrame,
+    forward_periods: int = ...,
+    n_groups: int = ...,
+    _precomputed_series: None = ...,
+    tie_policy: str = ...,
+    *,
+    factor_col: list[str],
+) -> dict[str, MetricOutput]: ...
 
 
 def quantile_spread(
@@ -145,7 +210,8 @@ def quantile_spread(
     n_groups: int = 5,
     _precomputed_series: pl.DataFrame | None = None,
     tie_policy: str = "ordinal",
-) -> MetricOutput:
+    factor_col: str | list[str] = "factor",
+) -> MetricOutput | dict[str, MetricOutput]:
     """long-short spread (per-period mean).
 
     Args:
@@ -184,17 +250,74 @@ def quantile_spread(
         >>> result.name
         'quantile_spread'
     """
-    # Compute tie_ratio on the sampled subset (what bucketing actually sees)
-    # rather than the full panel — ~N/forward_periods smaller scan.
-    sampled = _sample_non_overlapping(df, forward_periods)
-    tie_ratio = _compute_tie_ratio(sampled)
-    _warn_high_tie_ratio(tie_ratio, "quantile_spread", tie_policy)
+    # Multi-factor batch path: sample once, batch spread series, then
+    # loop the cheap per-factor t-test. ``_precomputed_series`` is
+    # rejected here because the caller already opted into the batch
+    # contract (the series come from the shared compute_spread_series
+    # call inside this function).
+    if not isinstance(factor_col, str):
+        cols = list(factor_col)
+        if not cols:
+            raise ValueError("factor_col list must be non-empty")
+        if _precomputed_series is not None:
+            raise ValueError("_precomputed_series is incompatible with list factor_col")
+        sampled = _sample_non_overlapping(df, forward_periods)
+        batched_series = compute_spread_series(
+            df,
+            forward_periods,
+            n_groups,
+            factor_col=cols,
+            tie_policy=tie_policy,
+        )
+        return {
+            f: _quantile_spread_from_series(
+                series=batched_series[f],
+                sampled=sampled,
+                factor_col=f,
+                tie_policy=tie_policy,
+            )
+            for f in cols
+        }
 
+    # Single-factor path: compute tie_ratio on the sampled subset
+    # (what bucketing actually sees) rather than the full panel —
+    # ~N/forward_periods smaller scan.
+    sampled = _sample_non_overlapping(df, forward_periods)
     series = (
         _precomputed_series
         if _precomputed_series is not None
-        else compute_spread_series(df, forward_periods, n_groups, tie_policy=tie_policy)
+        else compute_spread_series(
+            df,
+            forward_periods,
+            n_groups,
+            factor_col=factor_col,
+            tie_policy=tie_policy,
+        )
     )
+    return _quantile_spread_from_series(
+        series=series,
+        sampled=sampled,
+        factor_col=factor_col,
+        tie_policy=tie_policy,
+    )
+
+
+def _quantile_spread_from_series(
+    *,
+    series: pl.DataFrame,
+    sampled: pl.DataFrame,
+    factor_col: str,
+    tie_policy: str,
+) -> MetricOutput:
+    """Per-factor t-test pipeline shared by single and batch paths.
+
+    ``sampled`` is the (already non-overlap-sampled) panel; ``series``
+    is this factor's spread DataFrame. Splitting this out lets the
+    batch path share the sample step across every factor while the
+    single-factor path stays a one-liner.
+    """
+    tie_ratio = _compute_tie_ratio(sampled, factor_col)
+    _warn_high_tie_ratio(tie_ratio, "quantile_spread", tie_policy)
     spread_vals = series["spread"].drop_nulls()
     n = len(spread_vals)
     if n < MIN_PORTFOLIO_PERIODS_HARD:

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -47,3 +47,61 @@ class TestComputeMonotonicity:
         # Only 1 date < MIN_MONOTONICITY_PERIODS=5
         assert math.isnan(result.value)
         assert result.significance == ""
+
+
+class TestMonotonicityBatch:
+    """Multi-factor (`list[str]`) path of ``monotonicity``."""
+
+    def test_single_in_list_equals_single_call(self, noisy_panel):
+        single = monotonicity(noisy_panel, forward_periods=1, n_groups=5)
+        batch = monotonicity(
+            noisy_panel, forward_periods=1, n_groups=5, factor_col=["factor"]
+        )
+        assert isinstance(batch, dict)
+        assert set(batch) == {"factor"}
+        b = batch["factor"]
+        if math.isnan(single.value):
+            assert math.isnan(b.value)
+        else:
+            assert b.value == pytest.approx(single.value)
+            assert b.stat == pytest.approx(single.stat)
+            assert b.metadata["mean_signed"] == pytest.approx(
+                single.metadata["mean_signed"]
+            )
+
+    def test_multi_factor_matches_per_factor_calls(self):
+        from datetime import datetime, timedelta
+
+        import numpy as np
+        import polars as pl
+
+        rng = np.random.default_rng(31)
+        n_assets, n_dates = 80, 60
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = []
+        for date in dates:
+            returns = rng.standard_normal(n_assets) * 0.02
+            f1 = returns + rng.standard_normal(n_assets) * 0.05
+            f2 = -returns + rng.standard_normal(n_assets) * 0.05
+            for asset_id in range(n_assets):
+                rows.append(
+                    {
+                        "date": date,
+                        "asset_id": asset_id,
+                        "f1": float(f1[asset_id]),
+                        "f2": float(f2[asset_id]),
+                        "forward_return": float(returns[asset_id]),
+                    }
+                )
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        batch = monotonicity(
+            panel, forward_periods=1, n_groups=5, factor_col=["f1", "f2"]
+        )
+        for col in ("f1", "f2"):
+            single = monotonicity(panel, forward_periods=1, n_groups=5, factor_col=col)
+            assert batch[col].value == pytest.approx(single.value)
+            assert batch[col].stat == pytest.approx(single.stat)
+
+    def test_empty_factor_list_rejected(self, noisy_panel):
+        with pytest.raises(ValueError, match="non-empty"):
+            monotonicity(noisy_panel, forward_periods=1, n_groups=5, factor_col=[])

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -26,6 +26,56 @@ class TestQuantileSpreadSeries:
             assert row["spread"] == pytest.approx(0.04)
 
 
+class TestComputeSpreadSeriesBatch:
+    """Multi-factor (`list[str]`) path of ``compute_spread_series``."""
+
+    def test_single_in_list_equals_single_call(self, tiny_panel):
+        single = compute_spread_series(
+            tiny_panel, forward_periods=1, n_groups=5, factor_col="factor"
+        )
+        batch = compute_spread_series(
+            tiny_panel, forward_periods=1, n_groups=5, factor_col=["factor"]
+        )
+        assert isinstance(batch, dict)
+        assert set(batch) == {"factor"}
+        assert single.equals(batch["factor"])
+
+    def test_multi_factor_columns_match_per_factor_calls(self):
+        rng = np.random.default_rng(11)
+        n_assets, n_dates = 100, 60
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = []
+        for date in dates:
+            returns = rng.standard_normal(n_assets) * 0.02
+            f1 = returns + rng.standard_normal(n_assets) * 0.05
+            f2 = -returns + rng.standard_normal(n_assets) * 0.05
+            for asset_id in range(n_assets):
+                rows.append(
+                    {
+                        "date": date,
+                        "asset_id": asset_id,
+                        "f1": float(f1[asset_id]),
+                        "f2": float(f2[asset_id]),
+                        "forward_return": float(returns[asset_id]),
+                    }
+                )
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        batch = compute_spread_series(
+            panel, forward_periods=1, n_groups=5, factor_col=["f1", "f2"]
+        )
+        for col in ("f1", "f2"):
+            single = compute_spread_series(
+                panel, forward_periods=1, n_groups=5, factor_col=col
+            )
+            assert batch[col].equals(single), col
+
+    def test_empty_factor_list_rejected(self, tiny_panel):
+        with pytest.raises(ValueError, match="non-empty"):
+            compute_spread_series(
+                tiny_panel, forward_periods=1, n_groups=5, factor_col=[]
+            )
+
+
 class TestQuantileSpread:
     def test_noisy_panel(self, noisy_panel):
         series = compute_spread_series(noisy_panel, forward_periods=1, n_groups=5)


### PR DESCRIPTION
## Summary
- 將 IC PR 的 batch pattern 套用到 `core` metric set 剩下兩個成員：`compute_spread_series` / `quantile_spread` / `monotonicity` 三個 metric 全部加上 `factor_col: str | list[str]` overload，內部走同一條 polars 批次引擎。
- bench `_run_metrics_per_factor` 偵測「請求的 metric 全部都在 batchable 集合」時，跳過 per-factor `fx.run_metrics` 派發，直接 dispatch 到 `_batched`，讓 S2 / S3 / P1 三個 screen scenario 一次過清完三個 metric。
- 單因子路徑仍是 N=1 特例，API surface 零變動，所有既有 caller 自動繼承收益。

## 內部實作要點
- **quantile_spread**：N 個 per-factor `_group__<f>` column 一次 `with_columns` 排好；一個 `group_by("date").agg(...)` 把每個 factor 的 top/bottom mean + 共用 universe mean 收齊；per-factor t-test 透過 `_quantile_spread_from_series` helper 共用採樣後的 panel——這是關鍵：前一版我曾用「外層 batch compute_spread_series + 內層 loop quantile_spread + _precomputed_series」實驗，因 `_sample_non_overlapping` 與 `_compute_tie_ratio` 仍被 call N 次，**ratio 反而是 1.002（無效益）**。把 sample 提到上層共用後 ratio 降到 0.170。
- **monotonicity**：Stage 1 用單一 `group_by("date").agg` 含 N × n_groups 個 `filter+mean` 表達式；Stage 2 在 numpy 內 vectorise Spearman（inner shape 是 (n_dates, n_groups) 小矩陣，比 polars rank+corr 每 factor round-trip 快）。
- `pl.concat(N LazyFrames)` 的中間方案實測在 200 factor 反而變慢（0.5×），polars optimiser 無法把 N 個獨立 plan 排程在一起，已捨棄。

## Measured impact
Laptop `small` preset，`OMP_NUM_THREADS=1`：

| scenario | before `compute_s` | after `compute_s` | ratio | rss ratio |
|---|---:|---:|---:|---:|
| M-quantile | 5.27 | 0.89 | **0.170** | 1.027 |
| M-mono | 3.40 | 1.58 | **0.466** | 1.043 |
| S2 (`core` × 50f) | 13.14 | 4.29 | **0.326** | 1.354 |
| S3 (`core` × 200f) | 21.38 | 8.48 | **0.397** | 1.022 |

四個 scenario 全部命中 perf DoD `ratio ≤ 0.5`。

Scaling 驗證（單獨計時各 metric，非 bench 場景）：

| metric | panel | loop | batch | speedup |
|---|---|---:|---:|---:|
| quantile_spread | 50f × 1000×1250 | 3.11 | 0.33 | 9.6× |
| quantile_spread | 200f × 1000×1250 | 24.42 | 1.22 | 20.1× |
| monotonicity | 50f × 1000×1250 | 5.68 | 0.99 | 5.7× |
| monotonicity | 200f × 1000×1250 | 24.50 | 6.07 | 4.0× |

## Test plan
- [x] `pytest tests/` — 1416 passed
- [x] `mypy factrix` — clean
- [x] `ruff check` + `ruff format` clean
- [x] `mkdocs build --strict` clean（pre-push hook 通過）
- [x] 新增 `TestComputeSpreadSeriesBatch` / `TestMonotonicityBatch`：單 factor str / list[str] 結果等價；多 factor 批次 = 逐因子單 call；空 list reject
- [x] 既有 `tests/test_quantile.py` / `tests/test_monotonicity.py` / `tests/test_ic.py` / `tests/bench/` 全綠

## Out of scope (下一輪)
- `_BATCHABLE_METRICS` 目前只放 ic / quantile_spread / monotonicity；其他 metric（e.g. corrado）走原 fallback loop
- cloud xlarge × 16t UX validation 跑測：merge 後再驗

Refs #378（perf parent）、#391（UX validation harness）、#394（per-factor dispatch finding）