### PR TITLE
refactor(metrics): unify batch-variant suffix to `_batch` (#397)

### DIFF
--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -67,7 +67,7 @@ def _run_metrics_per_factor(
     # (`core` = ic + quantile_spread + monotonicity per factor) clear
     # the UX wall at xlarge.
     if set(metric_names) <= _BATCHABLE_METRICS:
-        return _batched(panel, cfg, factors, metric_names)
+        return _dispatch_batch(panel, cfg, factors, metric_names)
     n = 0
     for col in factors:
         bundle = fx.run_metrics(panel, cfg, factor_col=col, metrics=list(metric_names))
@@ -75,7 +75,7 @@ def _run_metrics_per_factor(
     return n
 
 
-def _batched(
+def _dispatch_batch(
     panel: pl.DataFrame,
     cfg: fx.AnalysisConfig,
     factors: list[str],

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -1,6 +1,12 @@
 """Shared helpers used across multiple tool modules.
 
 These are internal utilities — not part of the public API.
+
+Naming convention: helpers that process N factors in a single polars
+pass use the ``_batch`` suffix (e.g. ``_assign_quantile_groups_batch``).
+The bare name (``_assign_quantile_groups``) is the single-factor variant.
+``_multi*`` is reserved for structural multivariate concepts, not for
+"this function handles many factors".
 """
 
 from __future__ import annotations
@@ -233,7 +239,7 @@ def _assign_quantile_groups(
     )
 
 
-def _assign_quantile_groups_multi(
+def _assign_quantile_groups_batch(
     df: pl.DataFrame,
     factor_cols: list[str],
     n_groups: int,
@@ -241,7 +247,7 @@ def _assign_quantile_groups_multi(
 ) -> pl.DataFrame:
     """Assign per-date quantile groups for N factors in one polars pass.
 
-    Multi-factor counterpart of :func:`_assign_quantile_groups`. Emits
+    Batch counterpart of :func:`_assign_quantile_groups`. Emits
     one ``_group__<factor_col>`` column per factor; the shared
     ``pl.len().over("date")`` is computed once and reused, and every
     rank expression lands in a single ``with_columns`` so the polars

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -31,7 +31,7 @@ from factrix._types import (
     MetricOutput,
 )
 from factrix.metrics._helpers import (
-    _assign_quantile_groups_multi,
+    _assign_quantile_groups_batch,
     _sample_non_overlapping,
     _short_circuit_output,
     _warn_high_tie_ratio,
@@ -135,11 +135,11 @@ def monotonicity(
     # Sample non-overlapping once — shared across all factors on the
     # same panel (depends only on `date` + `forward_periods`).
     filtered = _sample_non_overlapping(df, forward_periods)
-    tie_ratios = _compute_tie_ratios_batched(filtered, cols)
+    tie_ratios = _compute_tie_ratios_batch(filtered, cols)
     for f in cols:
         _warn_high_tie_ratio(tie_ratios[f], "monotonicity", tie_policy)
 
-    grouped = _assign_quantile_groups_multi(filtered, cols, n_groups, tie_policy)
+    grouped = _assign_quantile_groups_batch(filtered, cols, n_groups, tie_policy)
 
     # Stage 1: per-(date, factor, group) mean return, expressed as one
     # ``group_by("date").agg(...)`` carrying N × n_groups filter+mean
@@ -230,7 +230,7 @@ def monotonicity(
     return results
 
 
-def _compute_tie_ratios_batched(
+def _compute_tie_ratios_batch(
     df: pl.DataFrame, factor_cols: list[str]
 ) -> dict[str, float]:
     """Tie ratio (``1 - n_unique / n``) for many factors in one scan.

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -32,7 +32,7 @@ from factrix._types import (
 )
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
-    _assign_quantile_groups_multi,
+    _assign_quantile_groups_batch,
     _compute_tie_ratio,
     _lag_within_asset,
     _median_universe_size,
@@ -141,7 +141,7 @@ def compute_spread_series(
             stacklevel=2,
         )
 
-    grouped = _assign_quantile_groups_multi(sampled, cols, n_groups, tie_policy)
+    grouped = _assign_quantile_groups_batch(sampled, cols, n_groups, tie_policy)
 
     top_group = n_groups - 1
     bottom_group = 0


### PR DESCRIPTION
## Summary
- Rename `_assign_quantile_groups_multi` → `_assign_quantile_groups_batch`, `_compute_tie_ratios_batched` → `_compute_tie_ratios_batch`, bench `_batched` → `_dispatch_batch`.
- Document the `_batch` suffix convention in `factrix/metrics/_helpers.py` module docstring; free `_multi*` for structural multivariate concepts.
- Pure rename + docstring touch; no behavior change.

## Test plan
- [x] `pytest tests/test_quantile.py tests/test_monotonicity.py tests/test_multi_factor.py tests/test_helpers.py` — 66 passed
- [x] `python -c "import bench.scenarios.continuous"` — imports clean
- [x] mypy on the four touched files — no new errors (pre-existing psutil-stub warnings in `bench/preflight.py` / `bench/wrapper.py` unaffected)

Closes #397