### PR TITLE
feat(api): polars-native input gateway

### DIFF
--- a/docs/guides/efficient-loading.md
+++ b/docs/guides/efficient-loading.md
@@ -1,0 +1,205 @@
+---
+title: Efficient data loading for large panels
+---
+
+When a factor exploration sweep reaches the 100–1000+ factor scale,
+the **data loading step** — not factrix's compute path — is usually
+what runs the machine out of memory. This guide shows the recipes
+that keep peak RSS bounded, and explains the contract `evaluate()` /
+`run_metrics()` follow at the API boundary.
+
+For the column contract itself, see
+[Panel schema](../api/panel-schema.md); for the reshape steps that
+turn raw inputs into a panel, see [Preparing data](preparing-data.md).
+This guide is purely about **getting that panel into memory without
+blowing up**.
+
+## The shape of the problem
+
+A typical large-panel workload: 1000 candidate factor columns,
+2500 trading dates, 3000 assets. Naïvely loading every factor in
+long format:
+
+```python
+# Don't do this.
+df = pl.read_parquet("factors.parquet")   # ~128 GB at long-format,
+                                          # ~32 GB at wide-format
+```
+
+…will OOM a 64 GB workstation in either layout. The fix is not a
+faster machine — it is **lazy loading with projection / predicate
+pushdown**, scoped to the columns and date range you actually need
+for the call you are about to make.
+
+## What factrix's API accepts
+
+factrix is polars-native. `evaluate()` and `run_metrics()` accept:
+
+| Input type | Behaviour at the boundary |
+|---|---|
+| `pl.DataFrame` | passes through unchanged |
+| `pl.LazyFrame` | `.collect()` is called immediately by factrix |
+| `pd.DataFrame` | **rejected** with a `TypeError` pointing at the conversion paths below |
+
+The `LazyFrame` branch is **convenience sugar at the boundary**, not
+end-to-end lazy execution. factrix does not apply projection or
+predicate pushdown for you — its internal pipeline is eager because
+the per-date `groupby` / rank / correlation / bootstrap operations
+need materialised arrays anyway. The win from `LazyFrame` comes
+entirely from the work you do **before** handing the frame over.
+
+### pandas users
+
+Two clean entry points, picked by what shape your pandas frame is in.
+
+**Vendor-named OHLCV / price source — use `adapt`** (converts + renames
+in one step; downstream you still attach the factor column and call
+`compute_forward_return` to assemble the 4-column panel
+`evaluate` / `run_metrics` expect):
+
+```python
+from factrix import adapt
+from factrix.preprocess import compute_forward_return
+
+raw = adapt(
+    my_pandas_df, date="trade_date", asset_id="ticker", price="close_adj",
+)
+raw = raw.with_columns(my_factor_expr.alias("factor"))
+panel = compute_forward_return(raw, forward_periods=5)
+profile = fx.evaluate(panel, cfg)
+```
+
+**Already-canonical 4-column panel — explicit Arrow conversion**:
+
+```python
+panel = pl.from_pandas(my_pandas_df)  # has date, asset_id, factor, forward_return
+profile = fx.evaluate(panel, cfg)
+```
+
+The conversion happens once at the seam between your data pipeline
+and factrix; from then on the panel lives in polars. This keeps the
+type contract honest (`evaluate` / `run_metrics` are polars-only) and
+makes the cost of pandas → polars visible at the call site instead of
+hidden in every API call.
+
+### Direct metric calls (`factrix.metrics.*`)
+
+The metric primitives in `factrix.metrics` (`compute_ic`,
+`quantile_spread`, `monotonicity`, …) are polars-only by signature
+and do not run the input gateway — they trust the caller. When using
+them directly (outside `evaluate` / `run_metrics`), convert pandas
+upstream with `pl.from_pandas` or `factrix.adapt` first, and
+materialise any `LazyFrame` with `.collect()` before passing in.
+Passing a non-`pl.DataFrame` will surface as a `polars` error (e.g.
+`AttributeError`, `ColumnNotFoundError`) at the first column access
+rather than the guiding `TypeError` the top-level entry points
+raise.
+
+## Recipe: `scan_parquet` + projection + predicate pushdown
+
+The five-line pattern that turns the load step from "OOM" into
+"hundreds of MB":
+
+```python
+from datetime import date
+
+import polars as pl
+import factrix as fx
+
+required = ["date", "asset_id", "forward_return", "momentum_12_1"]
+
+panel = (
+    pl.scan_parquet("factors.parquet")           # 1. lazy scan, no data loaded
+    .select(required)                            # 2. projection pushdown
+    .filter(pl.col("date").is_between(           # 3. predicate pushdown
+        date(2020, 1, 1), date(2024, 12, 31),
+    ))
+    .collect()                                   # 4. materialise the slice
+)
+
+profile = fx.evaluate(panel, cfg, factor_col="momentum_12_1")
+```
+
+Why this works:
+
+- `scan_parquet` opens the file but reads nothing.
+- `.select(...)` pushes the column list down into the parquet reader,
+  so only those columns leave disk.
+- `.filter(...)` on a partition / row-group-aligned column lets the
+  reader skip entire row groups instead of materialising and filtering
+  them.
+- The `.collect()` you write is the only `.collect()` in the chain.
+
+You can equally pass the `LazyFrame` directly to factrix and skip the
+explicit `.collect()` — factrix collects at the boundary either way:
+
+```python
+panel = (
+    pl.scan_parquet("factors.parquet")
+    .select(required)
+    .filter(pl.col("date").is_between(date(2020, 1, 1), date(2024, 12, 31)))
+)
+profile = fx.evaluate(panel, cfg, factor_col="momentum_12_1")  # collects inside
+```
+
+Either form materialises the same in-memory frame.
+
+## Renaming columns inside the lazy chain
+
+`factrix.adapt` preserves the input type, so column renaming composes
+inside a `LazyFrame` without breaking the lazy plan:
+
+```python
+from factrix import adapt
+
+panel = (
+    pl.scan_parquet("vendor.parquet")
+    .pipe(adapt, date="trade_date", asset_id="ticker", price="close_adj")
+    .select(["date", "asset_id", "price", "momentum_12_1"])
+    .collect()
+)
+```
+
+`adapt(LazyFrame)` returns `LazyFrame`; `adapt(pl.DataFrame)` returns
+`pl.DataFrame`; `adapt(pd.DataFrame)` returns `pl.DataFrame` (pandas
+has no lazy equivalent).
+
+## Batching across factors
+
+For a 1000-factor sweep, even with projection the union of all factor
+columns is too wide to hold simultaneously. Load and evaluate one
+batch of factors at a time:
+
+```python
+from itertools import batched
+
+all_factors = ["mom_1", "mom_3", "mom_6", ..., "value_1", "value_3"]
+results = []
+
+for batch in batched(all_factors, 50):
+    panel = (
+        pl.scan_parquet("factors.parquet")
+        .select(["date", "asset_id", "forward_return", *batch])
+        .filter(pl.col("date").is_between(date(2020, 1, 1), date(2024, 12, 31)))
+        .collect()
+    )
+    for col in batch:
+        results.append(fx.evaluate(panel, cfg, factor_col=col))
+    del panel   # release the thin panel before the next batch
+```
+
+Peak RSS is bounded by the **batch panel size**, not the full universe.
+For the 1000-factor example above, a batch of 50 keeps peak load to
+roughly `50 / 1000` of the naïve scenario.
+
+## What stays out of scope
+
+factrix's optimisation responsibility starts when `panel` enters
+`evaluate()` / `run_metrics()` and ends when the result is returned.
+Everything upstream — the parquet layout, your row-group partitioning,
+whether you stream from S3 or local disk, how often you refresh
+cached panels — is your data pipeline's concern. The recipes above
+are the canonical patterns; if your storage layer has different
+pushdown semantics (DuckDB views, Delta Lake, …), the principle is
+the same: project and filter as early as possible, hand factrix a
+thin frame.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -7,6 +7,7 @@ research-task framing; right column is the page title as it appears in
 the sidebar.
 
 - **Comparison-axes matrix and shared-keyword semantics (`expand_over`, regime dispatch)** — [Cross-function reference](../api/decision-tree.md)
+- **Loading large factor panels without OOM (lazy projection / predicate pushdown / factor batching)** — [Efficient data loading for large panels](efficient-loading.md)
 - **Raw data to a four-column factrix panel (sort order, frequency alignment, missing data)** — [Preparing data](preparing-data.md)
 - **Picking information coefficient (IC) vs FM (the `individual_continuous` cell only)** — [Information coefficient vs Fama-MacBeth](choosing-metric.md)  
   *Other cells dispatch to a single procedure; see [Concepts § Five analysis scenarios](../getting-started/concepts.md#five-analysis-scenarios) for the per-cell map.*

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -37,8 +37,6 @@ typical usage patterns in a single fetch. Two access paths::
     text = importlib.resources.files("factrix").joinpath("llms-full.txt").read_text()
 """
 
-from typing import Any
-
 from factrix import datasets, multi_factor, preprocess
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import (  # noqa: F401  Mode re-exported for namespace access; intentionally not in __all__
@@ -68,6 +66,7 @@ from factrix._errors import (
     UserInputError,
 )
 from factrix._evaluate import _evaluate as _evaluate
+from factrix._panel_input import PanelInput, _coerce_panel
 from factrix._profile import FactorProfile
 from factrix._run_metrics import MetricsBundle, run_metrics
 from factrix._types import MetricOutput
@@ -80,7 +79,7 @@ from factrix.slicing import (
 
 
 def evaluate(
-    panel: Any,
+    panel: PanelInput,
     config: AnalysisConfig | None = None,
     /,
     *,
@@ -142,9 +141,14 @@ def evaluate(
 
     Args:
         panel: Long-format panel satisfying the four-column floor
-            ``(date, asset_id, factor, forward_return)``. See
-            [Panel schema](panel-schema.md) for the canonical contract
-            and dtype semantics.
+            ``(date, asset_id, factor, forward_return)``. Accepts
+            ``pl.DataFrame`` or ``pl.LazyFrame`` (collected at the
+            boundary). pandas users go through ``factrix.adapt``
+            (which also renames columns) or ``pl.from_pandas`` first.
+            See
+            [Panel schema](panel-schema.md) for the column contract
+            and [Efficient data loading](../guides/efficient-loading.md)
+            for large-panel recipes.
         config: Validated ``AnalysisConfig`` selecting the dispatch cell
             (``Scope × Signal × Metric``). Construct via one of the four
             factories on the class.
@@ -199,6 +203,7 @@ def evaluate(
             "or see the Get Started guide: "
             "https://awwesomeman.github.io/factrix/getting-started/"
         )
+    panel = _coerce_panel(panel)
     return _evaluate(panel, config, factor_col=factor_col)
 
 
@@ -231,6 +236,7 @@ __all__ = [
     "FactorProfile",
     "MetricOutput",
     "MetricsBundle",
+    "PanelInput",
     "compare",
     "evaluate",
     "run_metrics",

--- a/factrix/_panel_input.py
+++ b/factrix/_panel_input.py
@@ -1,0 +1,54 @@
+"""Input-type gateway for public entry points.
+
+factrix is polars-native: ``fx.evaluate`` and ``fx.run_metrics`` accept
+``pl.DataFrame`` (canonical) or ``pl.LazyFrame`` (collected immediately
+at the boundary — no projection or predicate pushdown applied by
+factrix, so call ``.select(...)`` / ``.filter(...)`` upstream for
+memory efficiency on large sources).
+
+``pd.DataFrame`` is **not** accepted on these entry points by design.
+pandas users have two clean paths:
+
+- ``factrix.adapt(df, ...)`` — converts and renames columns in one
+  step; the natural entry point when pandas column names are not
+  already canonical.
+- ``pl.from_pandas(df)`` — when columns are already canonical and
+  only the type conversion is needed.
+
+This keeps the type contract honest (factrix's internal pipeline is
+polars throughout) and avoids hiding the pd → pl copy inside every
+``evaluate()`` call.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+type PanelInput = pl.DataFrame | pl.LazyFrame
+
+
+def _is_pandas_dataframe(obj: object) -> bool:
+    """Detect ``pd.DataFrame`` without importing pandas (optional dep)."""
+    return type(obj).__module__.split(".", 1)[0] == "pandas"
+
+
+def _coerce_panel(panel: PanelInput) -> pl.DataFrame:
+    """Coerce ``PanelInput`` to eager ``pl.DataFrame``.
+
+    ``pl.LazyFrame`` is collected immediately. ``pd.DataFrame`` is
+    rejected with a ``TypeError`` that points to the documented
+    conversion paths.
+    """
+    if isinstance(panel, pl.DataFrame):
+        return panel
+    if isinstance(panel, pl.LazyFrame):
+        return panel.collect()
+    if _is_pandas_dataframe(panel):
+        raise TypeError(
+            "panel must be pl.DataFrame or pl.LazyFrame; got pandas DataFrame. "
+            "factrix is polars-native — convert with `pl.from_pandas(df)`, "
+            "or use `factrix.adapt(df, ...)` if column renaming is needed."
+        )
+    raise TypeError(
+        f"panel must be pl.DataFrame or pl.LazyFrame; got {type(panel).__name__}."
+    )

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -31,6 +31,7 @@ from factrix._errors import (
     UserInputError,
 )
 from factrix._metric_index import _AUTO_DISCOVER_EXCLUDED, user_facing_rows
+from factrix._panel_input import PanelInput, _coerce_panel
 from factrix._types import MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
@@ -284,7 +285,7 @@ def _raise_factor_col_error(*, value: str, expected: str) -> None:
 
 
 def run_metrics(
-    panel: pl.DataFrame,
+    panel: PanelInput,
     cfg: AnalysisConfig,
     *,
     factor_col: str = "factor",
@@ -300,8 +301,13 @@ def run_metrics(
 
     Args:
         panel: Canonical-column panel (``date, asset_id, factor,
-            forward_return``). Renamed internally if ``factor_col`` is
-            not ``"factor"``, mirroring :func:`factrix.evaluate`.
+            forward_return``). Accepts ``pl.DataFrame`` or
+            ``pl.LazyFrame`` (collected at the boundary). pandas
+            users convert via :func:`factrix.adapt` or
+            ``pl.from_pandas`` first; see
+            :doc:`/guides/efficient-loading` for large-panel recipes.
+            Renamed internally if ``factor_col`` is not ``"factor"``,
+            mirroring :func:`factrix.evaluate`.
         cfg: Validated :class:`AnalysisConfig`. ``cfg.scope`` and
             ``cfg.signal`` route metric discovery; ``cfg.forward_periods``
             (a single int) is the horizon every metric sees. Cross-horizon
@@ -356,6 +362,7 @@ def run_metrics(
 
         >>> bundle = fx.run_metrics(panel, cfg, metrics=["ic"])
     """
+    panel = _coerce_panel(panel)
     missing = {"date", "asset_id", factor_col, "forward_return"} - set(panel.columns)
     if missing:
         hint = (

--- a/factrix/adapt.py
+++ b/factrix/adapt.py
@@ -29,28 +29,37 @@ Usage::
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import polars as pl
 import polars.selectors as cs
 
+from factrix._panel_input import _is_pandas_dataframe
 
-def _to_polars(df: pl.DataFrame) -> pl.DataFrame:
-    """Convert pandas DataFrame to polars if needed; pass through polars as-is."""
-    try:
-        import pandas as pd
+if TYPE_CHECKING:
+    import pandas as pd
 
-        if isinstance(df, pd.DataFrame):
-            return pl.from_pandas(df)
-    except ImportError:
-        pass
-    if isinstance(df, pl.DataFrame):
+type AdaptInput = pl.DataFrame | pl.LazyFrame | pd.DataFrame
+
+
+def _to_polars(df: AdaptInput) -> pl.DataFrame | pl.LazyFrame:
+    """Coerce ``adapt`` input to polars, preserving ``LazyFrame``.
+
+    ``pl.DataFrame`` / ``pl.LazyFrame`` pass through unchanged.
+    ``pd.DataFrame`` is converted via ``pl.from_pandas`` (pandas has
+    no lazy equivalent).
+    """
+    if isinstance(df, pl.DataFrame | pl.LazyFrame):
         return df
+    if _is_pandas_dataframe(df):
+        return pl.from_pandas(df)
     raise TypeError(
-        f"adapt: expected polars or pandas DataFrame, got {type(df).__name__}"
+        f"adapt: expected pl.DataFrame, pl.LazyFrame, or pd.DataFrame; got {type(df).__name__}"
     )
 
 
 def adapt(
-    df: pl.DataFrame,
+    df: AdaptInput,
     *,
     date: str = "date",
     asset_id: str = "asset_id",
@@ -60,15 +69,19 @@ def adapt(
     low: str | None = None,
     volume: str | None = None,
     fill_forward: bool = False,
-) -> pl.DataFrame:
+) -> pl.DataFrame | pl.LazyFrame:
     """Rename user columns to factrix canonical names.
 
-    Accepts both polars and pandas DataFrames (pandas is converted
-    to polars automatically).  Only renames columns that differ from
-    the canonical name.  All other columns are passed through unchanged.
+    Type-preserving for polars inputs: a ``pl.LazyFrame`` stays lazy
+    (rename / cast / fill happen inside the lazy chain, no implicit
+    ``.collect()``), a ``pl.DataFrame`` stays eager. ``pd.DataFrame``
+    is converted to ``pl.DataFrame`` (pandas has no lazy equivalent).
+    Only renames columns that differ from the canonical name; all other
+    columns pass through unchanged.
 
     Args:
-        df: Input DataFrame (polars or pandas).
+        df: Input frame — ``pl.DataFrame``, ``pl.LazyFrame``, or
+            ``pd.DataFrame``.
         date: User's date column name.
         asset_id: User's asset identifier column name.
         price: User's price column name.
@@ -85,13 +98,18 @@ def adapt(
             that may contain sporadic missing values.
 
     Returns:
-        Polars DataFrame with canonical column names.
+        Same polars type as input (``pl.DataFrame`` → ``pl.DataFrame``,
+        ``pl.LazyFrame`` → ``pl.LazyFrame``) with canonical column
+        names. ``pd.DataFrame`` input returns ``pl.DataFrame``.
 
     Raises:
-        TypeError: If *df* is neither polars nor pandas DataFrame.
+        TypeError: If *df* is none of ``pl.DataFrame``, ``pl.LazyFrame``,
+            ``pd.DataFrame``.
         ValueError: If any specified source column does not exist.
     """
     df = _to_polars(df)
+    schema = df.collect_schema()
+    columns = schema.names()
 
     renames: list[tuple[str, str | None]] = [
         ("date", date),
@@ -102,19 +120,17 @@ def adapt(
         ("low", low),
         ("volume", volume),
     ]
-    mapping = {}
+    mapping: dict[str, str] = {}
     for canonical, source in renames:
         if source is None or source == canonical:
             continue
-        if source not in df.columns:
+        if source not in columns:
             raise ValueError(
-                f"adapt: column '{source}' not found. Available: {df.columns}"
+                f"adapt: column '{source}' not found. Available: {columns}"
             )
-        if canonical in df.columns:
+        if canonical in columns:
             raise ValueError(
-                f"adapt: cannot rename '{source}' → '{canonical}' "
-                f"because '{canonical}' already exists in the DataFrame. "
-                f"Drop or rename the existing '{canonical}' column first."
+                f"adapt: cannot rename '{source}' → '{canonical}' because '{canonical}' already exists in the DataFrame. Drop or rename the existing '{canonical}' column first."
             )
         mapping[source] = canonical
 
@@ -126,7 +142,7 @@ def adapt(
     # common datetime dtype without the user writing an explicit cast.
     # Other Datetime variants (any time_unit, any TZ) pass through — the
     # library is TZ-agnostic and trusts the caller's precision choice.
-    if "date" in df.columns and df.schema["date"] == pl.Date:
+    if schema.get(date) == pl.Date:
         df = df.with_columns(pl.col("date").cast(pl.Datetime("ms")))
 
     if fill_forward:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -195,9 +195,18 @@ explicitly `HansenHodrick`. Downstream readers should use
 ### `evaluate`
 
 ```
-factrix.evaluate(panel: polars.DataFrame, config: AnalysisConfig,
+factrix.evaluate(panel: PanelInput, config: AnalysisConfig,
                  *, factor_col: str = "factor") -> FactorProfile
 ```
+
+`PanelInput = pl.DataFrame | pl.LazyFrame`. factrix is polars-native
+on its primary entry points; pandas users go through `factrix.adapt`
+(which also renames columns) or `pl.from_pandas` first. `LazyFrame`
+is collected at the API boundary (no projection / predicate pushdown
+applied by factrix — call `.select(...)` / `.filter(...)` upstream
+for memory efficiency on large sources). See
+`docs/guides/efficient-loading.md` for large-panel recipes.
+
 
 procedure. `factor_col=` lets a panel with a non-default signal column
 name (e.g. `"alpha"`) be evaluated without renaming first; looping over

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
       - How-to:
           - Overview: guides/index.md
           - Cross-function reference: api/decision-tree.md
+          - Efficient data loading for large panels: guides/efficient-loading.md
           - Preparing data: guides/preparing-data.md
           - Information coefficient vs Fama-MacBeth: guides/choosing-metric.md
           - Panel vs timeseries: guides/panel-timeseries.md

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -118,3 +118,70 @@ class TestDateDtypePromotion:
         )
         out = adapt(df, date="trade_date", asset_id="ticker", price="close_adj")
         assert out.schema["date"] == pl.Datetime("ms", time_zone="UTC")
+
+
+class TestTypePreservation:
+    """`adapt()` preserves polars input type — a LazyFrame stays lazy so
+    the caller controls when to collect."""
+
+    def test_lazyframe_input_returns_lazyframe(self):
+        lf = _raw_panel().lazy()
+        out = adapt(lf, date="trade_date", asset_id="ticker", price="close_adj")
+        assert isinstance(out, pl.LazyFrame)
+        collected = out.collect()
+        assert "date" in collected.columns
+        assert "asset_id" in collected.columns
+        assert "price" in collected.columns
+
+    def test_lazyframe_rename_matches_eager(self):
+        df = _raw_panel()
+        eager = adapt(df, date="trade_date", asset_id="ticker", price="close_adj")
+        lazy = adapt(
+            df.lazy(), date="trade_date", asset_id="ticker", price="close_adj"
+        ).collect()
+        assert eager.equals(lazy)
+
+    def test_lazyframe_date_promotion(self):
+        from datetime import date
+
+        lf = pl.DataFrame(
+            {
+                "trade_date": [date(2024, 1, 1), date(2024, 1, 2)],
+                "ticker": ["A", "A"],
+                "close_adj": [100.0, 101.0],
+            }
+        ).lazy()
+        out = adapt(lf, date="trade_date", asset_id="ticker", price="close_adj")
+        assert isinstance(out, pl.LazyFrame)
+        assert out.collect().schema["date"] == pl.Datetime("ms")
+
+    def test_lazyframe_fill_forward_stays_lazy(self):
+        lf = _raw_panel().lazy()
+        out = adapt(
+            lf,
+            date="trade_date",
+            asset_id="ticker",
+            price="close_adj",
+            fill_forward=True,
+        )
+        assert isinstance(out, pl.LazyFrame)
+        assert out.collect().height == 2
+
+    def test_pandas_input_returns_dataframe(self):
+        pd = pytest.importorskip("pandas")
+        pdf = pd.DataFrame(
+            {
+                "trade_date": [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+                "ticker": ["A", "A"],
+                "close_adj": [100.0, 101.0],
+            }
+        )
+        out = adapt(pdf, date="trade_date", asset_id="ticker", price="close_adj")
+        assert isinstance(out, pl.DataFrame)
+        assert "date" in out.columns
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(
+            TypeError, match=r"pl\.DataFrame, pl\.LazyFrame, or pd\.DataFrame"
+        ):
+            adapt([{"a": 1}], date="a", asset_id="a", price="a")

--- a/tests/test_panel_input.py
+++ b/tests/test_panel_input.py
@@ -1,0 +1,73 @@
+"""Tests for `_coerce_panel`, the strict polars-native API gateway.
+
+`fx.evaluate` and `fx.run_metrics` accept `pl.DataFrame` (passes
+through) and `pl.LazyFrame` (collected at the boundary). `pd.DataFrame`
+is rejected with a guiding `TypeError` that points to
+`factrix.adapt(df, ...)` or `pl.from_pandas(df)` as the documented
+conversion paths.
+"""
+
+from __future__ import annotations
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._panel_input import _coerce_panel
+from factrix.preprocess import compute_forward_return
+
+
+@pytest.fixture(scope="module")
+def panel_pl() -> pl.DataFrame:
+    raw = fx.datasets.make_cs_panel(n_assets=50, n_dates=120, seed=7)
+    return compute_forward_return(raw, forward_periods=5)
+
+
+def test_coerce_polars_dataframe_passthrough(panel_pl: pl.DataFrame) -> None:
+    out = _coerce_panel(panel_pl)
+    assert out is panel_pl
+
+
+def test_coerce_lazyframe_collects(panel_pl: pl.DataFrame) -> None:
+    out = _coerce_panel(panel_pl.lazy())
+    assert isinstance(out, pl.DataFrame)
+    assert out.equals(panel_pl)
+
+
+def test_coerce_pandas_dataframe_is_rejected_with_guidance() -> None:
+    pd = pytest.importorskip("pandas")
+    pdf = pd.DataFrame({"a": [1, 2]})
+    with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):
+        _coerce_panel(pdf)
+
+
+def test_coerce_unsupported_type_raises() -> None:
+    with pytest.raises(TypeError, match=r"pl\.DataFrame or pl\.LazyFrame"):
+        _coerce_panel([{"date": 1}])
+
+
+def test_evaluate_accepts_lazyframe_end_to_end(panel_pl: pl.DataFrame) -> None:
+    cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+    profile = fx.evaluate(panel_pl.lazy(), cfg)
+    assert profile.primary_p == fx.evaluate(panel_pl, cfg).primary_p
+
+
+def test_evaluate_rejects_pandas_with_guidance(panel_pl: pl.DataFrame) -> None:
+    pytest.importorskip("pandas")
+    pdf = panel_pl.to_pandas()
+    cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+    with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):
+        fx.evaluate(pdf, cfg)
+
+
+def test_run_metrics_rejects_pandas_with_guidance(panel_pl: pl.DataFrame) -> None:
+    pytest.importorskip("pandas")
+    pdf = panel_pl.to_pandas()
+    cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+    with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):
+        fx.run_metrics(pdf, cfg, metrics=["ic"])
+
+
+def test_evaluate_rejects_unsupported_type() -> None:
+    cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
+    with pytest.raises(TypeError, match=r"pl\.DataFrame or pl\.LazyFrame"):
+        fx.evaluate(object(), cfg)


### PR DESCRIPTION
## Summary

- `fx.evaluate` / `fx.run_metrics` accept only `pl.DataFrame` / `pl.LazyFrame`; pandas inputs raise a guiding `TypeError` pointing at `factrix.adapt(df, ...)` (rename + convert) or `pl.from_pandas(df)` (convert only).
- `pl.LazyFrame` is collected at the API boundary — convenience sugar for upstream `scan_parquet` / `select` / `filter`, not end-to-end lazy execution.
- `factrix.adapt` is now type-preserving: `pl.LazyFrame` stays lazy through rename / date promotion / fill-forward; `pd.DataFrame` still converts to `pl.DataFrame`.
- New guide `docs/guides/efficient-loading.md` documents the load recipe and the pandas seams.

## Test plan

- [x] `pytest tests/` — 1355 passed
- [x] `mypy factrix/` — clean
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — clean
- [x] Type-equivalence: `pl.DataFrame` vs `pl.LazyFrame` produce identical `primary_p` / `n_obs` / `mode` and identical `MetricsBundle` IC stat
- [x] Pandas rejected with actionable message; `factrix.adapt` round-trip through `LazyFrame` matches eager path
- [x] `pl.Date → pl.Datetime("ms")` promotion preserved in both eager and lazy branches

Closes #399.
Refs #378.
