### PR TITLE
refactor(metrics): unify primitive batch signature to factor_cols → dict (#401)

### DIFF
--- a/bench/scenarios/algo.py
+++ b/bench/scenarios/algo.py
@@ -54,16 +54,13 @@ def _build_spread_dict(
     panel: pl.DataFrame, factors: list[str]
 ) -> dict[str, pl.DataFrame]:
     """Per-factor ``(date, spread)`` series, ready for spanning."""
-    spreads: dict[str, pl.DataFrame] = {}
-    for col in factors:
-        series = compute_spread_series(
-            panel,
-            forward_periods=DEFAULT_FORWARD_PERIODS,
-            factor_col=col,
-            n_groups=_N_GROUPS,
-        )
-        spreads[col] = series.select(["date", "spread"])
-    return spreads
+    series_by_factor = compute_spread_series(
+        panel,
+        forward_periods=DEFAULT_FORWARD_PERIODS,
+        factor_cols=factors,
+        n_groups=_N_GROUPS,
+    )
+    return {col: series_by_factor[col].select(["date", "spread"]) for col in factors}
 
 
 def s4_greedy_forward_selection(

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -84,15 +84,15 @@ def _dispatch_batch(
     fwd = cfg.forward_periods
     n = 0
     if "ic" in metric_names:
-        ic_results = compute_ic(panel, factors)
+        ic_results = compute_ic(panel, factor_cols=factors)
         for col in factors:
             ic(ic_results[col], forward_periods=fwd)
         n += len(factors)
     if "quantile_spread" in metric_names:
-        quantile_spread(panel, fwd, factor_col=factors)
+        quantile_spread(panel, fwd, factor_cols=factors)
         n += len(factors)
     if "monotonicity" in metric_names:
-        monotonicity(panel, fwd, factor_col=factors)
+        monotonicity(panel, fwd, factor_cols=factors)
         n += len(factors)
     return n
 
@@ -106,7 +106,7 @@ def _bootstrap_ic_per_factor(
     # Batch the IC compute across factors (one polars query), then loop
     # the bootstrap inner step — bootstrap vectorisation is tracked
     # separately (see Refs in PR description).
-    ic_results = compute_ic(panel, factors)
+    ic_results = compute_ic(panel, factor_cols=factors)
     for k, col in enumerate(factors):
         arr = ic_results[col]["ic"].to_numpy()
         # Seed per factor so each call is independent but reproducible.
@@ -140,7 +140,7 @@ def s1_evaluate(
         fx.run_metrics(
             panel, cfg, factor_col=col, metrics=list(heavy.run_metrics_names)
         )
-        ic_df = compute_ic(panel, factor_col=col)
+        ic_df = compute_ic(panel, factor_cols=[col])[col]
         bootstrap_mean_ci(ic_df["ic"].to_numpy(), n_bootstrap=BOOTSTRAP_N, seed=seed)
         return 1
 

--- a/docs/api/metrics/hit_rate.md
+++ b/docs/api/metrics/hit_rate.md
@@ -69,7 +69,7 @@ title: factrix.metrics.hit_rate
 
     # The series diagnostic consumes (date, value); the value column on
     # the compute_ic output is named ``ic``.
-    ic_df = compute_ic(panel)
+    ic_df = compute_ic(panel)["factor"]
     out   = hit_rate(ic_df, value_col="ic", forward_periods=5)
     print(out.value, out.stat, out.metadata["p_value"], out.metadata["method"])
     # 0.62  19  0.011   exact-binomial   (approximate)

--- a/docs/api/metrics/ic.md
+++ b/docs/api/metrics/ic.md
@@ -77,7 +77,7 @@ output without the inference framing.
     )
     panel = compute_forward_return(raw, forward_periods=5)
 
-    ic_df = compute_ic(panel)
+    ic_df = compute_ic(panel)["factor"]
     print(ic_df.head())
     # ┌────────────┬───────────┬───────────┐
     # │ date       ┆ ic        ┆ tie_ratio │

--- a/docs/api/metrics/oos.md
+++ b/docs/api/metrics/oos.md
@@ -80,7 +80,7 @@ title: factrix.metrics.oos
 
     # The series diagnostic consumes (date, value); the value column on
     # the compute_ic output is named ``ic``.
-    ic_df = compute_ic(panel)
+    ic_df = compute_ic(panel)["factor"]
     out   = multi_split_oos_decay(ic_df, value_col="ic")
     print(out.value, out.metadata["status"], out.metadata["sign_flipped"])
     # 0.94   PASS   False   (approximate)

--- a/docs/api/metrics/spanning.md
+++ b/docs/api/metrics/spanning.md
@@ -99,7 +99,7 @@ title: factrix.metrics.spanning
         ]
     }
     spreads = {
-        name: compute_spread_series(p, forward_periods=5, n_groups=5)
+        name: compute_spread_series(p, forward_periods=5, n_groups=5)["factor"]
         for name, p in panels.items()
     }
 

--- a/docs/api/metrics/trend.md
+++ b/docs/api/metrics/trend.md
@@ -74,7 +74,7 @@ title: factrix.metrics.trend
 
     # The series diagnostic consumes (date, value); the value column on
     # the compute_ic output is named ``ic``.
-    ic_df = compute_ic(panel)
+    ic_df = compute_ic(panel)["factor"]
     out   = ic_trend(ic_df, value_col="ic")
     print(out.value, out.stat, out.metadata["p_value"])
     # -3.2e-05  -0.91  0.36   (approximate; flat slope)

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -52,7 +52,7 @@ vol_labels = vix.with_columns(
 Join the labels onto the metric's per-date input upstream:
 
 ```python
-ic_df = compute_ic(panel).join(vol_labels, on="date", how="inner")
+ic_df = compute_ic(panel)["factor"].join(vol_labels, on="date", how="inner")
 ```
 
 !!! warning "Lookahead bias when constructing labels"

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -89,7 +89,7 @@ from factrix.metrics import compute_ic, ic
 
 # compute_ic builds the per-date IC frame consumed by the ic metric;
 # see docs/api/metrics/ic.md for the schema.
-ic_df = compute_ic(panel, factor_col="value", return_col="forward_return")
+ic_df = compute_ic(panel, factor_cols=["value"], return_col="forward_return")["value"]
 merged = ic_df.join(vol_labels, on="date", how="inner")
 
 # Dispatcher — raw per-regime IC summaries (SliceResult is dict-shaped)

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -71,8 +71,8 @@ raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, seed=
 panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
 profile = fx.evaluate(panel, fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC))
 
-spread = fx.metrics.quantile_spread(panel, forward_periods=5, n_groups=5)
-mono = fx.metrics.monotonicity(panel, forward_periods=5, n_groups=5)
+spread = fx.metrics.quantile_spread(panel, forward_periods=5, n_groups=5)["factor"]
+mono = fx.metrics.monotonicity(panel, forward_periods=5, n_groups=5)["factor"]
 ```
 
 ### 2. Event panel `{factor ∈ {0, R}}` — sparse signal cells
@@ -128,8 +128,8 @@ side needs to know about the other:
 profile = fx.evaluate(panel, fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC))
 diagnostics = {
     "primary_p": profile.primary_p,
-    "spread": fx.metrics.quantile_spread(panel, forward_periods=5).value,
-    "monotonicity_p": fx.metrics.monotonicity(panel, forward_periods=5).p_value,
+    "spread": fx.metrics.quantile_spread(panel, forward_periods=5)["factor"].value,
+    "monotonicity_p": fx.metrics.monotonicity(panel, forward_periods=5)["factor"].p_value,
     "breakeven_bps": fx.metrics.breakeven_cost(panel).value,
 }
 ```

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -117,16 +117,16 @@ _AUTO_DISCOVER_EXCLUDED: dict[str, str] = {
     # a panel. Compose explicitly with compute_ic / compute_spread_series.
     "hit_rate": (
         "consumes a (date, value) series; e.g. "
-        "hit_rate(compute_ic(panel).rename({'ic': 'value'}))"
+        "hit_rate(compute_ic(panel)['factor'].rename({'ic': 'value'}))"
     ),
     "multi_split_oos_decay": (
         "consumes a (date, value) series; e.g. "
-        "multi_split_oos_decay(compute_spread_series(panel)"
+        "multi_split_oos_decay(compute_spread_series(panel)['factor']"
         ".rename({'spread': 'value'}))"
     ),
     "ic_trend": (
         "consumes a (date, value) series; e.g. "
-        "ic_trend(compute_ic(panel).rename({'ic': 'value'}))"
+        "ic_trend(compute_ic(panel)['factor'].rename({'ic': 'value'}))"
     ),
     # Multi-factor spread inputs — require a list/dict of factor spreads,
     # not a single panel.

--- a/factrix/_procedures.py
+++ b/factrix/_procedures.py
@@ -221,7 +221,7 @@ class _ICContPanelProcedure:
         # ``compute_ic`` filters by MIN_ASSETS_PER_DATE_IC but does not drop nulls;
         # ``pl.corr`` returns null for zero-variance dates (degenerate
         # factor / tied returns) so the explicit drop is reachable.
-        ic_values = compute_ic(raw)["ic"].drop_nulls().to_numpy()
+        ic_values = compute_ic(raw)["factor"]["ic"].drop_nulls().to_numpy()
         n_periods = len(ic_values)
         n_pairs, n_periods_raw, n_assets = _panel_envelope(raw)
         ic_mean = float(np.mean(ic_values)) if n_periods > 0 else 0.0

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -48,6 +48,15 @@ _logger = logging.getLogger("factrix.run_metrics")
 # ``compute_event_returns`` pipelines is tracked as v1.x follow-up.
 _IC_CONSUMERS: frozenset[str] = frozenset({"ic", "ic_newey_west", "ic_ir"})
 
+# Metrics whose primitive returns ``dict[str, MetricOutput]`` keyed by
+# factor column. run_metrics is single-factor at this layer: the panel
+# was renamed to the canonical ``"factor"`` column before dispatch, so
+# the dict carries exactly that key and must be unwrapped to a single
+# ``MetricOutput`` for the bundle.
+_BATCH_PRIMITIVE_METRICS: frozenset[str] = frozenset(
+    {"quantile_spread", "monotonicity"}
+)
+
 
 @dataclass(frozen=True, slots=True, repr=False)
 class MetricsBundle:
@@ -464,7 +473,7 @@ def run_metrics(
             if name in _IC_CONSUMERS:
                 if ic_df is None:
                     stage = "stage1"
-                    ic_df = _metrics.compute_ic(panel)
+                    ic_df = _metrics.compute_ic(panel)["factor"]
                     stage = "consumer"
                 first_arg: pl.DataFrame = ic_df
             else:
@@ -472,7 +481,8 @@ def run_metrics(
             kwargs: dict[str, Any] = {}
             if _accepts_kwarg(fn, "forward_periods"):
                 kwargs["forward_periods"] = cfg.forward_periods
-            results[name] = fn(first_arg, **kwargs)
+            out = fn(first_arg, **kwargs)
+            results[name] = out["factor"] if name in _BATCH_PRIMITIVE_METRICS else out
         except InsufficientSampleError as exc:
             results[name] = _short_circuit_output(
                 name,

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -98,7 +98,7 @@ def hit_rate(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> series = compute_ic(panel).rename({"ic": "value"}).select("date", "value")
+        >>> series = compute_ic(panel)["factor"].rename({"ic": "value"}).select("date", "value")
         >>> result = hit_rate(series, forward_periods=5)
         >>> result.name
         'hit_rate'

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 import warnings as _warnings
-from typing import overload
+from collections.abc import Sequence
 
 import polars as pl
 
@@ -92,46 +92,28 @@ def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
     return med
 
 
-@overload
 def compute_ic(
     df: pl.DataFrame,
-    factor_col: str = ...,
-    return_col: str = ...,
-) -> pl.DataFrame: ...
-
-
-@overload
-def compute_ic(
-    df: pl.DataFrame,
-    factor_col: list[str],
-    return_col: str = ...,
-) -> dict[str, pl.DataFrame]: ...
-
-
-def compute_ic(
-    df: pl.DataFrame,
-    factor_col: str | list[str] = "factor",
+    factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
-) -> pl.DataFrame | dict[str, pl.DataFrame]:
+) -> dict[str, pl.DataFrame]:
     r"""Per-date Spearman Rank information coefficient (IC).
 
     Args:
-        df: Panel with ``date``, ``asset_id``, ``factor_col``, ``return_col``.
-        factor_col: A single factor column name (``str``) or a list of
-            names to score together. Passing a list runs all factors in
-            a single polars query (one ``with_columns`` + one
-            ``group_by("date").agg(...)`` + one ``collect``), avoiding
-            the per-factor query-plan overhead of repeated single-factor
-            calls. The single-factor path is the N=1 case of the same
-            engine — there is no "fast path / slow path" divergence.
+        df: Panel with ``date``, ``asset_id``, every name in
+            ``factor_cols``, and ``return_col``.
+        factor_cols: Factor column names to score. All factors run in a
+            single polars query (one ``with_columns`` + one
+            ``group_by("date").agg(...)`` + one ``collect``) regardless
+            of N. The N=1 case is just the general path specialised —
+            no fast/slow path divergence.
         return_col: Forward-return column shared across factors.
 
     Returns:
-        Single factor (``str`` input) → DataFrame with columns
-        ``date, ic, tie_ratio`` sorted by date. List input → dict
-        mapping each factor name to the same per-factor DataFrame.
-        Dates with fewer than ``MIN_ASSETS_PER_DATE_IC`` assets are
-        dropped. ``tie_ratio`` is the per-date factor tie density
+        Dict mapping each factor name to a DataFrame with columns
+        ``date, ic, tie_ratio`` sorted by date. Dates with fewer than
+        ``MIN_ASSETS_PER_DATE_IC`` assets are dropped. ``tie_ratio`` is
+        the per-date factor tie density
         $1 - n_{\mathrm{unique}} / n$ in $[0, 1]$.
 
     Notes:
@@ -173,21 +155,19 @@ def compute_ic(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=120, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> ic_df = compute_ic(panel)
+        >>> ic_by_factor = compute_ic(panel)
+        >>> ic_df = ic_by_factor["factor"]
         >>> set(ic_df.columns) >= {"date", "ic", "tie_ratio"}
         True
     """
-    if isinstance(factor_col, str):
-        cols: list[str] = [factor_col]
-    else:
-        cols = list(factor_col)
+    cols = list(factor_cols)
     if not cols:
-        raise ValueError("factor_col list must be non-empty")
+        raise ValueError("factor_cols must be non-empty")
 
     # The "_rank__<col>" / "_ic__<col>" / "_tie__<col>" aliases are
     # internal to this query and never escape — per-factor DataFrames
     # are renamed back to the canonical ``ic`` / ``tie_ratio`` columns
-    # so the single-factor return shape stays drop-in identical.
+    # before being placed in the returned dict.
     rank_exprs: list[pl.Expr] = [
         pl.col(return_col).rank(method="average").over("date").alias("_rank_return"),
         *[
@@ -210,7 +190,7 @@ def compute_ic(
         .collect()
     )
 
-    per_factor = {
+    return {
         f: wide.select(
             pl.col("date"),
             pl.col(f"_ic__{f}").alias("ic"),
@@ -218,9 +198,6 @@ def compute_ic(
         )
         for f in cols
     }
-    if isinstance(factor_col, str):
-        return per_factor[factor_col]
-    return per_factor
 
 
 def ic(
@@ -264,7 +241,7 @@ def ic(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> ic_df = compute_ic(panel)
+        >>> ic_df = compute_ic(panel)["factor"]
         >>> result = ic(ic_df, forward_periods=5)
         >>> result.name
         'ic'
@@ -354,7 +331,7 @@ def ic_newey_west(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> ic_df = compute_ic(panel)
+        >>> ic_df = compute_ic(panel)["factor"]
         >>> result = ic_newey_west(ic_df, forward_periods=5)
         >>> result.name
         'ic_newey_west'
@@ -432,7 +409,7 @@ def ic_ir(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> ic_df = compute_ic(panel)
+        >>> ic_df = compute_ic(panel)["factor"]
         >>> result = ic_ir(ic_df)
         >>> result.name
         'ic_ir'

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -14,7 +14,7 @@ Notes:
 
 from __future__ import annotations
 
-from typing import overload
+from collections.abc import Sequence
 
 import numpy as np
 import polars as pl
@@ -52,37 +52,14 @@ __all__ = [
 min_assets_per_group: int | None = 50
 
 
-@overload
-def monotonicity(
-    df: pl.DataFrame,
-    forward_periods: int = ...,
-    n_groups: int = ...,
-    factor_col: str = ...,
-    return_col: str = ...,
-    tie_policy: str = ...,
-) -> MetricOutput: ...
-
-
-@overload
-def monotonicity(
-    df: pl.DataFrame,
-    forward_periods: int = ...,
-    n_groups: int = ...,
-    *,
-    factor_col: list[str],
-    return_col: str = ...,
-    tie_policy: str = ...,
-) -> dict[str, MetricOutput]: ...
-
-
 def monotonicity(
     df: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 10,
-    factor_col: str | list[str] = "factor",
+    factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
-) -> MetricOutput | dict[str, MetricOutput]:
+) -> dict[str, MetricOutput]:
     """Quantile return monotonicity (Spearman correlation).
 
     ``value`` = mean |Spearman| — magnitude of monotonicity (always ≥ 0).
@@ -122,15 +99,12 @@ def monotonicity(
         ...     forward_periods=5,
         ... )
         >>> result = monotonicity(panel, forward_periods=5, n_groups=5)
-        >>> result.name
+        >>> result["factor"].name
         'monotonicity'
     """
-    if isinstance(factor_col, str):
-        cols: list[str] = [factor_col]
-    else:
-        cols = list(factor_col)
+    cols = list(factor_cols)
     if not cols:
-        raise ValueError("factor_col list must be non-empty")
+        raise ValueError("factor_cols must be non-empty")
 
     # Sample non-overlapping once — shared across all factors on the
     # same panel (depends only on `date` + `forward_periods`).
@@ -225,8 +199,6 @@ def monotonicity(
             },
         )
 
-    if isinstance(factor_col, str):
-        return results[factor_col]
     return results
 
 

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -137,7 +137,7 @@ def multi_split_oos_decay(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=240, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> series = compute_ic(panel).rename({"ic": "value"}).select("date", "value")
+        >>> series = compute_ic(panel)["factor"].rename({"ic": "value"}).select("date", "value")
         >>> result = multi_split_oos_decay(series)
         >>> result.name
         'oos_decay'

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -15,7 +15,7 @@ Notes:
 from __future__ import annotations
 
 import warnings
-from typing import overload
+from collections.abc import Sequence
 
 import numpy as np
 import polars as pl
@@ -49,37 +49,14 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
 ]
 
 
-@overload
-def compute_spread_series(
-    df: pl.DataFrame,
-    forward_periods: int = ...,
-    n_groups: int = ...,
-    factor_col: str = ...,
-    return_col: str = ...,
-    tie_policy: str = ...,
-) -> pl.DataFrame: ...
-
-
-@overload
-def compute_spread_series(
-    df: pl.DataFrame,
-    forward_periods: int = ...,
-    n_groups: int = ...,
-    *,
-    factor_col: list[str],
-    return_col: str = ...,
-    tie_policy: str = ...,
-) -> dict[str, pl.DataFrame]: ...
-
-
 def compute_spread_series(
     df: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
-    factor_col: str | list[str] = "factor",
+    factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
-) -> pl.DataFrame | dict[str, pl.DataFrame]:
+) -> dict[str, pl.DataFrame]:
     """Per-date long-short spread series (non-overlapping).
 
     Top bucket = highest factor rank; bottom bucket = lowest. Labels use
@@ -118,15 +95,13 @@ def compute_spread_series(
         ...     forward_periods=5,
         ... )
         >>> spreads = compute_spread_series(panel, forward_periods=5, n_groups=5)
-        >>> set(spreads.columns) >= {"date", "spread", "top_return", "bottom_return"}
+        >>> spread_df = spreads["factor"]
+        >>> set(spread_df.columns) >= {"date", "spread", "top_return", "bottom_return"}
         True
     """
-    if isinstance(factor_col, str):
-        cols: list[str] = [factor_col]
-    else:
-        cols = list(factor_col)
+    cols = list(factor_cols)
     if not cols:
-        raise ValueError("factor_col list must be non-empty")
+        raise ValueError("factor_cols must be non-empty")
 
     sampled = _sample_non_overlapping(df, forward_periods)
 
@@ -166,7 +141,7 @@ def compute_spread_series(
 
     wide = grouped.group_by("date").agg(agg_exprs).sort("date")
 
-    per_factor = {
+    return {
         f: wide.select(
             pl.col("date"),
             pl.col(f"_top__{f}").alias("top_return"),
@@ -176,42 +151,17 @@ def compute_spread_series(
         )
         for f in cols
     }
-    if isinstance(factor_col, str):
-        return per_factor[factor_col]
-    return per_factor
-
-
-@overload
-def quantile_spread(
-    df: pl.DataFrame,
-    forward_periods: int = ...,
-    n_groups: int = ...,
-    _precomputed_series: pl.DataFrame | None = ...,
-    tie_policy: str = ...,
-    factor_col: str = ...,
-) -> MetricOutput: ...
-
-
-@overload
-def quantile_spread(
-    df: pl.DataFrame,
-    forward_periods: int = ...,
-    n_groups: int = ...,
-    _precomputed_series: None = ...,
-    tie_policy: str = ...,
-    *,
-    factor_col: list[str],
-) -> dict[str, MetricOutput]: ...
 
 
 def quantile_spread(
     df: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
-    _precomputed_series: pl.DataFrame | None = None,
+    factor_cols: Sequence[str] = ("factor",),
     tie_policy: str = "ordinal",
-    factor_col: str | list[str] = "factor",
-) -> MetricOutput | dict[str, MetricOutput]:
+    *,
+    _precomputed_series: dict[str, pl.DataFrame] | None = None,
+) -> dict[str, MetricOutput]:
     """long-short spread (per-period mean).
 
     Args:
@@ -247,59 +197,42 @@ def quantile_spread(
         ...     forward_periods=5,
         ... )
         >>> result = quantile_spread(panel, forward_periods=5, n_groups=5)
-        >>> result.name
+        >>> result["factor"].name
         'quantile_spread'
     """
-    # Multi-factor batch path: sample once, batch spread series, then
-    # loop the cheap per-factor t-test. ``_precomputed_series`` is
-    # rejected here because the caller already opted into the batch
-    # contract (the series come from the shared compute_spread_series
-    # call inside this function).
-    if not isinstance(factor_col, str):
-        cols = list(factor_col)
-        if not cols:
-            raise ValueError("factor_col list must be non-empty")
-        if _precomputed_series is not None:
-            raise ValueError("_precomputed_series is incompatible with list factor_col")
-        sampled = _sample_non_overlapping(df, forward_periods)
-        batched_series = compute_spread_series(
-            df,
-            forward_periods,
-            n_groups,
-            factor_col=cols,
-            tie_policy=tie_policy,
+    cols = list(factor_cols)
+    if not cols:
+        raise ValueError("factor_cols must be non-empty")
+    if _precomputed_series is not None and set(_precomputed_series) != set(cols):
+        raise ValueError(
+            "_precomputed_series keys must match factor_cols "
+            f"(got {sorted(_precomputed_series)} vs {sorted(cols)})"
         )
-        return {
-            f: _quantile_spread_from_series(
-                series=batched_series[f],
-                sampled=sampled,
-                factor_col=f,
-                tie_policy=tie_policy,
-            )
-            for f in cols
-        }
 
-    # Single-factor path: compute tie_ratio on the sampled subset
-    # (what bucketing actually sees) rather than the full panel —
-    # ~N/forward_periods smaller scan.
+    # Sample once across all factors; bucketing tie_ratio is computed
+    # on the sampled subset (what bucketing actually sees) rather than
+    # the full panel — ~N/forward_periods smaller scan.
     sampled = _sample_non_overlapping(df, forward_periods)
-    series = (
+    series_by_factor = (
         _precomputed_series
         if _precomputed_series is not None
         else compute_spread_series(
             df,
             forward_periods,
             n_groups,
-            factor_col=factor_col,
+            factor_cols=cols,
             tie_policy=tie_policy,
         )
     )
-    return _quantile_spread_from_series(
-        series=series,
-        sampled=sampled,
-        factor_col=factor_col,
-        tie_policy=tie_policy,
-    )
+    return {
+        f: _quantile_spread_from_series(
+            series=series_by_factor[f],
+            sampled=sampled,
+            factor_col=f,
+            tie_policy=tie_policy,
+        )
+        for f in cols
+    }
 
 
 def _quantile_spread_from_series(

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -167,7 +167,7 @@ def spanning_alpha(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> spread = compute_spread_series(panel, forward_periods=5)
+        >>> spread = compute_spread_series(panel, forward_periods=5)["factor"]
         >>> result = spanning_alpha(spread)
         >>> result.name
         'spanning_alpha'
@@ -317,7 +317,7 @@ def greedy_forward_selection(
         ...             forward_periods=5,
         ...         ),
         ...         forward_periods=5,
-        ...     )
+        ...     )["factor"]
         ...     for s in seeds
         ... }
         >>> result = greedy_forward_selection(

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -109,7 +109,7 @@ def ic_trend(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> ic_df = compute_ic(panel)
+        >>> ic_df = compute_ic(panel)["factor"]
         >>> result = ic_trend(ic_df, value_col="ic")
         >>> result.name
         'ic_trend'

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -74,7 +74,7 @@ def by_slice(
         >>> from factrix.metrics import ic, compute_ic
         >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=500)
         >>> panel = compute_forward_return(raw, forward_periods=5)
-        >>> ic_df = compute_ic(panel).with_columns(
+        >>> ic_df = compute_ic(panel)["factor"].with_columns(
         ...     pl.col("date").dt.year().alias("year")
         ... )
         >>> per_year = fx.by_slice(ic, ic_df, label="year")

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -170,7 +170,7 @@ def slice_pairwise_test(
         ...     pl.col("asset_id").replace_strict(sector_map).alias("sector")
         ... )
         >>> per_sector_ic = pl.concat([
-        ...     compute_ic(panel_sec.filter(pl.col("sector") == s))
+        ...     compute_ic(panel_sec.filter(pl.col("sector") == s))["factor"]
         ...        .with_columns(pl.lit(s).alias("sector"))
         ...     for s in ("tech", "fin")
         ... ])
@@ -315,7 +315,7 @@ def slice_joint_test(
         ...     pl.col("asset_id").replace_strict(sector_map).alias("sector")
         ... )
         >>> per_sector_ic = pl.concat([
-        ...     compute_ic(panel_sec.filter(pl.col("sector") == s))
+        ...     compute_ic(panel_sec.filter(pl.col("sector") == s))["factor"]
         ...        .with_columns(pl.lit(s).alias("sector"))
         ...     for s in ("tech", "fin")
         ... ])

--- a/factrix/slicing/result.py
+++ b/factrix/slicing/result.py
@@ -50,7 +50,7 @@ class SliceResult(Mapping[str, MetricOutput]):
         >>> from factrix.metrics import ic, compute_ic
         >>> raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=240)
         >>> panel = compute_forward_return(raw, forward_periods=5)
-        >>> ic_df = compute_ic(panel).with_columns(
+        >>> ic_df = compute_ic(panel)["factor"].with_columns(
         ...     pl.col("date").dt.year().alias("year")
         ... )
         >>> per_year = fx.by_slice(ic, ic_df, label="year")
@@ -100,7 +100,7 @@ class SliceResult(Mapping[str, MetricOutput]):
             >>> from factrix.metrics import ic, compute_ic
             >>> raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=240)
             >>> panel = compute_forward_return(raw, forward_periods=5)
-            >>> ic_df = compute_ic(panel).with_columns(
+            >>> ic_df = compute_ic(panel)["factor"].with_columns(
             ...     pl.col("date").dt.year().alias("year")
             ... )
             >>> per_year = fx.by_slice(ic, ic_df, label="year")

--- a/tests/test_estimator_dispatch.py
+++ b/tests/test_estimator_dispatch.py
@@ -54,7 +54,7 @@ class TestDefaultNWBitEqual:
         cfg = AnalysisConfig.individual_continuous(metric=Metric.IC, forward_periods=5)
         profile = evaluate(panel, cfg)
 
-        ic_values = compute_ic(panel)["ic"].drop_nulls().to_numpy()
+        ic_values = compute_ic(panel)["factor"]["ic"].drop_nulls().to_numpy()
         n = len(ic_values)
         nw_lags = _resolve_nw_lags(n, auto_bartlett(n), 5)
         t_expected, p_expected, _ = _newey_west_t_test(ic_values, lags=nw_lags)
@@ -86,7 +86,7 @@ class TestHHDispatch:
         )
         profile = evaluate(panel, cfg)
 
-        ic_values = compute_ic(panel)["ic"].drop_nulls().to_numpy()
+        ic_values = compute_ic(panel)["factor"]["ic"].drop_nulls().to_numpy()
         t_expected, p_expected, _, _ = _hansen_hodrick_t_test(
             ic_values, forward_periods=5
         )

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -11,7 +11,7 @@ from factrix.metrics.ic import compute_ic, ic, ic_ir
 
 class TestComputeIC:
     def test_perfect_rank(self, tiny_panel):
-        result = compute_ic(tiny_panel)
+        result = compute_ic(tiny_panel)["factor"]
         # factor and return have identical ranking → IC = 1.0
         for ic_val in result["ic"].to_list():
             assert ic_val == pytest.approx(1.0)
@@ -21,7 +21,7 @@ class TestComputeIC:
         inverted = tiny_panel.with_columns(
             (0.06 - pl.col("forward_return")).alias("forward_return")
         )
-        result = compute_ic(inverted)
+        result = compute_ic(inverted)["factor"]
         for ic_val in result["ic"].to_list():
             assert ic_val == pytest.approx(-1.0)
 
@@ -39,16 +39,16 @@ class TestComputeIC:
             for i in range(3)
         ]
         df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
-        result = compute_ic(df)
+        result = compute_ic(df)["factor"]
         assert len(result) == 0
 
     def test_output_schema(self, noisy_panel):
-        result = compute_ic(noisy_panel)
+        result = compute_ic(noisy_panel)["factor"]
         assert result.columns == ["date", "ic", "tie_ratio"]
         assert result["date"].dtype == pl.Datetime("ms")
 
     def test_tie_ratio_zero_on_unique_factor(self, noisy_panel):
-        result = compute_ic(noisy_panel)
+        result = compute_ic(noisy_panel)["factor"]
         # noisy_panel factor is continuous noise — no per-date ties expected.
         assert result["tie_ratio"].max() == pytest.approx(0.0)
 
@@ -67,7 +67,7 @@ class TestComputeIC:
             for i in range(n_assets)
         ]
         df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
-        result = compute_ic(df)
+        result = compute_ic(df)["factor"]
         # 12 obs, 3 unique → tie_ratio = 1 - 3/12 = 0.75
         assert result["tie_ratio"].max() == pytest.approx(0.75)
         assert result["tie_ratio"].min() == pytest.approx(0.75)
@@ -75,7 +75,7 @@ class TestComputeIC:
     def test_tie_ratio_propagated_to_metadata(self, noisy_panel):
         from factrix.metrics.ic import ic, ic_ir, ic_newey_west
 
-        ic_df = compute_ic(noisy_panel)
+        ic_df = compute_ic(noisy_panel)["factor"]
         for out in (
             ic(ic_df, forward_periods=1),
             ic_newey_west(ic_df, forward_periods=1),
@@ -105,7 +105,7 @@ class TestComputeIC:
             for i in range(n_assets)
         ]
         df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
-        ic_df = compute_ic(df)
+        ic_df = compute_ic(df)["factor"]
         for fn in (
             lambda d: ic(d, forward_periods=1),
             lambda d: ic_newey_west(d, forward_periods=1),
@@ -129,7 +129,7 @@ class TestComputeIC:
         clean = pl.DataFrame(clean_rows).with_columns(
             pl.col("date").cast(pl.Datetime("ms"))
         )
-        clean_ic = compute_ic(clean)
+        clean_ic = compute_ic(clean)["factor"]
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             ic(clean_ic, forward_periods=1)
@@ -138,24 +138,14 @@ class TestComputeIC:
 
 
 class TestComputeICBatch:
-    """Multi-factor (`list[str]`) path of ``compute_ic``.
+    """Multi-factor path of ``compute_ic``.
 
-    Equivalence between the single-factor (`str`) and multi-factor
-    paths is the load-bearing contract — the batch path is the same
-    polars engine specialised at N=1, so a divergence here means a
-    silent numerics regression for every single-factor caller.
+    Each element of a multi-factor batch must equal the corresponding
+    list-of-1 call — divergence means a silent numerics regression for
+    callers that consume one factor at a time from a shared panel.
     """
 
-    def test_single_in_list_equals_single_call(self, tiny_panel):
-        single = compute_ic(tiny_panel, factor_col="factor")
-        batch = compute_ic(tiny_panel, factor_col=["factor"])
-        assert isinstance(batch, dict)
-        assert set(batch) == {"factor"}
-        assert single.equals(batch["factor"])
-
-    def test_multi_factor_columns_match_per_factor_calls(self):
-        # Two correlated factor columns side-by-side; batch result must
-        # equal looping single-factor calls element-wise.
+    def test_multi_factor_columns_match_list_of_one(self):
         rng = np.random.default_rng(7)
         n_assets, n_dates = 60, 40
         dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
@@ -177,19 +167,19 @@ class TestComputeICBatch:
         panel = pl.DataFrame(records).with_columns(
             pl.col("date").cast(pl.Datetime("ms"))
         )
-        batch = compute_ic(panel, factor_col=["f1", "f2"])
+        batch = compute_ic(panel, factor_cols=["f1", "f2"])
         for col in ("f1", "f2"):
-            single = compute_ic(panel, factor_col=col)
+            single = compute_ic(panel, factor_cols=[col])[col]
             assert batch[col].equals(single), col
 
     def test_empty_factor_list_rejected(self, tiny_panel):
         with pytest.raises(ValueError, match="non-empty"):
-            compute_ic(tiny_panel, factor_col=[])
+            compute_ic(tiny_panel, factor_cols=[])
 
 
 class TestIC:
     def test_positive_ic(self, noisy_panel):
-        ic_df = compute_ic(noisy_panel)
+        ic_df = compute_ic(noisy_panel)["factor"]
         result = ic(ic_df, forward_periods=1)
         assert result.name == "ic"
         assert result.value > 0  # noisy_panel has positive IC
@@ -209,7 +199,7 @@ class TestIC:
 
 class TestICIR:
     def test_positive_ir(self, noisy_panel):
-        ic_df = compute_ic(noisy_panel)
+        ic_df = compute_ic(noisy_panel)["factor"]
         result = ic_ir(ic_df)
         assert result.value > 0
         assert result.name == "ic_ir"

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -15,7 +15,7 @@ class TestComputeMonotonicity:
         perfect = noisy_panel.with_columns(
             pl.col("factor").rank(method="average").over("date").alias("forward_return")
         )
-        result = monotonicity(perfect, forward_periods=1, n_groups=5)
+        result = monotonicity(perfect, forward_periods=1, n_groups=5)["factor"]
         assert result.value == pytest.approx(1.0)
 
     def test_inverse_monotonic(self, noisy_panel):
@@ -26,7 +26,7 @@ class TestComputeMonotonicity:
                 "forward_return"
             )
         )
-        result = monotonicity(inverted, forward_periods=1, n_groups=5)
+        result = monotonicity(inverted, forward_periods=1, n_groups=5)["factor"]
         assert result.value == pytest.approx(1.0)
         assert result.metadata["mean_signed"] == pytest.approx(-1.0)
 
@@ -43,33 +43,16 @@ class TestComputeMonotonicity:
                 "forward_return": [0.01, 0.02, 0.03, 0.04, 0.05],
             }
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
-        result = monotonicity(df, forward_periods=1, n_groups=5)
+        result = monotonicity(df, forward_periods=1, n_groups=5)["factor"]
         # Only 1 date < MIN_MONOTONICITY_PERIODS=5
         assert math.isnan(result.value)
         assert result.significance == ""
 
 
 class TestMonotonicityBatch:
-    """Multi-factor (`list[str]`) path of ``monotonicity``."""
+    """Multi-factor path of ``monotonicity``."""
 
-    def test_single_in_list_equals_single_call(self, noisy_panel):
-        single = monotonicity(noisy_panel, forward_periods=1, n_groups=5)
-        batch = monotonicity(
-            noisy_panel, forward_periods=1, n_groups=5, factor_col=["factor"]
-        )
-        assert isinstance(batch, dict)
-        assert set(batch) == {"factor"}
-        b = batch["factor"]
-        if math.isnan(single.value):
-            assert math.isnan(b.value)
-        else:
-            assert b.value == pytest.approx(single.value)
-            assert b.stat == pytest.approx(single.stat)
-            assert b.metadata["mean_signed"] == pytest.approx(
-                single.metadata["mean_signed"]
-            )
-
-    def test_multi_factor_matches_per_factor_calls(self):
+    def test_multi_factor_matches_list_of_one(self):
         from datetime import datetime, timedelta
 
         import numpy as np
@@ -95,13 +78,15 @@ class TestMonotonicityBatch:
                 )
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         batch = monotonicity(
-            panel, forward_periods=1, n_groups=5, factor_col=["f1", "f2"]
+            panel, forward_periods=1, n_groups=5, factor_cols=["f1", "f2"]
         )
         for col in ("f1", "f2"):
-            single = monotonicity(panel, forward_periods=1, n_groups=5, factor_col=col)
+            single = monotonicity(
+                panel, forward_periods=1, n_groups=5, factor_cols=[col]
+            )[col]
             assert batch[col].value == pytest.approx(single.value)
             assert batch[col].stat == pytest.approx(single.stat)
 
     def test_empty_factor_list_rejected(self, noisy_panel):
         with pytest.raises(ValueError, match="non-empty"):
-            monotonicity(noisy_panel, forward_periods=1, n_groups=5, factor_col=[])
+            monotonicity(noisy_panel, forward_periods=1, n_groups=5, factor_cols=[])

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -15,7 +15,9 @@ from factrix.metrics.quantile import (
 
 class TestQuantileSpreadSeries:
     def test_perfect_panel(self, tiny_panel):
-        series = compute_spread_series(tiny_panel, forward_periods=1, n_groups=5)
+        series = compute_spread_series(tiny_panel, forward_periods=1, n_groups=5)[
+            "factor"
+        ]
         assert "spread" in series.columns
         assert "top_return" in series.columns
         assert "bottom_return" in series.columns
@@ -27,20 +29,9 @@ class TestQuantileSpreadSeries:
 
 
 class TestComputeSpreadSeriesBatch:
-    """Multi-factor (`list[str]`) path of ``compute_spread_series``."""
+    """Multi-factor path of ``compute_spread_series``."""
 
-    def test_single_in_list_equals_single_call(self, tiny_panel):
-        single = compute_spread_series(
-            tiny_panel, forward_periods=1, n_groups=5, factor_col="factor"
-        )
-        batch = compute_spread_series(
-            tiny_panel, forward_periods=1, n_groups=5, factor_col=["factor"]
-        )
-        assert isinstance(batch, dict)
-        assert set(batch) == {"factor"}
-        assert single.equals(batch["factor"])
-
-    def test_multi_factor_columns_match_per_factor_calls(self):
+    def test_multi_factor_columns_match_list_of_one(self):
         rng = np.random.default_rng(11)
         n_assets, n_dates = 100, 60
         dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
@@ -61,24 +52,26 @@ class TestComputeSpreadSeriesBatch:
                 )
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         batch = compute_spread_series(
-            panel, forward_periods=1, n_groups=5, factor_col=["f1", "f2"]
+            panel, forward_periods=1, n_groups=5, factor_cols=["f1", "f2"]
         )
         for col in ("f1", "f2"):
             single = compute_spread_series(
-                panel, forward_periods=1, n_groups=5, factor_col=col
-            )
+                panel, forward_periods=1, n_groups=5, factor_cols=[col]
+            )[col]
             assert batch[col].equals(single), col
 
     def test_empty_factor_list_rejected(self, tiny_panel):
         with pytest.raises(ValueError, match="non-empty"):
             compute_spread_series(
-                tiny_panel, forward_periods=1, n_groups=5, factor_col=[]
+                tiny_panel, forward_periods=1, n_groups=5, factor_cols=[]
             )
 
 
 class TestQuantileSpread:
     def test_noisy_panel(self, noisy_panel):
-        series = compute_spread_series(noisy_panel, forward_periods=1, n_groups=5)
+        series = compute_spread_series(noisy_panel, forward_periods=1, n_groups=5)[
+            "factor"
+        ]
         assert len(series) >= 5
         assert series["spread"].null_count() == 0
 
@@ -96,19 +89,21 @@ class TestQuantileSpread:
                 "forward_return": [0.01, 0.02, 0.03, 0.04, 0.05] * 2,
             }
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
-        result = quantile_spread(df, forward_periods=1, n_groups=5)
+        result = quantile_spread(df, forward_periods=1, n_groups=5)["factor"]
         assert math.isnan(result.value)
 
     def test_decomposition_in_metadata(self, tiny_panel):
         """spread = long_alpha + short_alpha (per-period)."""
-        series = compute_spread_series(tiny_panel, forward_periods=1, n_groups=5)
+        series = compute_spread_series(tiny_panel, forward_periods=1, n_groups=5)[
+            "factor"
+        ]
         for row in series.iter_rows(named=True):
             long = row["top_return"] - row["universe_return"]
             short = row["universe_return"] - row["bottom_return"]
             assert long + short == pytest.approx(row["spread"])
 
     def test_metadata_has_long_short(self, noisy_panel):
-        result = quantile_spread(noisy_panel, forward_periods=1, n_groups=5)
+        result = quantile_spread(noisy_panel, forward_periods=1, n_groups=5)["factor"]
         if result.value != 0.0:
             assert "long_alpha" in result.metadata
             assert "short_alpha" in result.metadata

--- a/tests/test_slice_test_reference_cells.py
+++ b/tests/test_slice_test_reference_cells.py
@@ -43,7 +43,7 @@ def test_pairwise_universe_block_bootstrap_romano_wolf() -> None:
 
     per_universe_ic = pl.concat(
         [
-            compute_ic(panel.filter(pl.col("universe") == u)).with_columns(
+            compute_ic(panel.filter(pl.col("universe") == u))["factor"].with_columns(
                 pl.lit(u).alias("universe")
             )
             for u in ["large_cap", "small_cap"]
@@ -90,7 +90,7 @@ def test_joint_sector_wald_nw_cluster() -> None:
 
     per_sector_ic = pl.concat(
         [
-            compute_ic(panel.filter(pl.col("sector") == s)).with_columns(
+            compute_ic(panel.filter(pl.col("sector") == s))["factor"].with_columns(
                 pl.lit(s).alias("sector")
             )
             for s in ["tech", "finance", "consumer"]


### PR DESCRIPTION
## Summary

- Drop `factor_col: str | list[str]` overload on `compute_ic` / `compute_spread_series` / `quantile_spread` / `monotonicity`; unify to `factor_cols: Sequence[str] = ("factor",)` → `dict[str, ResultT]`
- All internal callers (`factrix._run_metrics` IC stage-1, `factrix._procedures`, bench scenarios, doctests) updated to unwrap with `["factor"]`
- `_run_metrics` carries `_BATCH_PRIMITIVE_METRICS` frozenset to unwrap `quantile_spread` / `monotonicity` dict results in the single-factor dispatch loop (load until #402 lifts the loop itself)
- `quantile_spread` `_precomputed_series` moved to keyword-only with `dict[str, pl.DataFrame]` shape matching new contract

## Test plan

- [x] `pytest tests/` — 1429 passed
- [x] `pytest --doctest-modules` on touched metric modules — 12 passed
- [x] `mypy factrix/` — clean
- [x] `ruff check factrix/ tests/ bench/` — clean
- [x] `mkdocs build --strict` — clean

Closes #401