### PR TITLE
perf(metrics): fx.run_metrics batch interface — factor_cols → dict[str, MetricsBundle] (#402)

### DIFF
--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -68,11 +68,10 @@ def _run_metrics_per_factor(
     # the UX wall at xlarge.
     if set(metric_names) <= _BATCHABLE_METRICS:
         return _dispatch_batch(panel, cfg, factors, metric_names)
-    n = 0
-    for col in factors:
-        bundle = fx.run_metrics(panel, cfg, factor_col=col, metrics=list(metric_names))
-        n += len(bundle.metrics)
-    return n
+    bundles = fx.run_metrics(
+        panel, cfg, factor_cols=factors, metrics=list(metric_names)
+    )
+    return sum(len(b.metrics) for b in bundles.values())
 
 
 def _dispatch_batch(
@@ -138,7 +137,7 @@ def s1_evaluate(
         col = factor_columns(panel)[0]
         fx.evaluate(panel, cfg, factor_col=col)
         fx.run_metrics(
-            panel, cfg, factor_col=col, metrics=list(heavy.run_metrics_names)
+            panel, cfg, factor_cols=[col], metrics=list(heavy.run_metrics_names)
         )
         ic_df = compute_ic(panel, factor_cols=[col])[col]
         bootstrap_mean_ci(ic_df["ic"].to_numpy(), n_bootstrap=BOOTSTRAP_N, seed=seed)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -83,7 +83,7 @@ Click any node to jump to its API page. Nodes are grouped into category subgraph
 | Goal | Pipeline |
 |---|---|
 | Single-factor inference | `evaluate(panel, cfg)` → read `FactorProfile.primary_p` |
-| Single-factor descriptive scan | `run_metrics(panel, cfg, factor_col=...)` → read `MetricsBundle` |
+| Single-factor descriptive scan | `run_metrics(panel, cfg, factor_cols=[...])[name]` → read `MetricsBundle` |
 | Slice exploration (single axis) | `by_slice(metric, df, label="...")` → `SliceResult` |
 | Slice statistical test | `slice_pairwise_test(metric, df, label="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
 | Cell metric discovery | `list_metrics(scope, signal)` → names → `run_metrics(metrics=[...])` |

--- a/docs/api/metrics-bundle.md
+++ b/docs/api/metrics-bundle.md
@@ -25,7 +25,7 @@ artifact families row-by-row.
 import factrix as fx
 
 cfg    = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC, forward_periods=5)
-bundle = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+bundle = fx.run_metrics(panel, cfg, factor_cols=["momentum_12_1"])["momentum_12_1"]
 
 bundle.identity           # ('momentum_12_1', 5)
 bundle.metrics            # dict[str, MetricOutput]

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -47,7 +47,9 @@ import polars as pl
 cfg = fx.AnalysisConfig.individual_continuous(metric=fx.Metric.IC)
 horizons = [1, 5, 10, 20]
 bundles = [
-    fx.run_metrics(panel, cfg.replace(forward_periods=h), factor_col="mom_12_1")
+    fx.run_metrics(panel, cfg.replace(forward_periods=h), factor_cols=["mom_12_1"])[
+        "mom_12_1"
+    ]
     for h in horizons
 ]
 table = pl.concat([b.to_frame() for b in bundles])  # long-form: horizon x metric

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -50,19 +50,20 @@ caller's frame:
 
 ```python
 profile = fx.evaluate(panel, cfg, factor_col="alpha")
-bundle  = fx.run_metrics(panel, cfg, factor_col="momentum_12_1")
+bundle  = fx.run_metrics(panel, cfg, factor_cols=["momentum_12_1"])["momentum_12_1"]
 ```
 
 Behaviour:
 
-- The column is renamed to `"factor"` internally so every procedure's
-  `INPUT_SCHEMA` still sees the canonical schema.
-- `bundle.identity = (factor_col, cfg.forward_periods)` — looping
-  `factor_col=name` over a wide multi-factor panel is the canonical
-  pattern for batch screening; see
+- `evaluate` renames the chosen column to `"factor"` internally so
+  every procedure's `INPUT_SCHEMA` still sees the canonical schema.
+- `run_metrics(factor_cols=[...])` accepts factor column names
+  directly — pass a list to score multiple factors in one call; IC
+  stage-1 and batch-native primitives share one polars query across
+  the batch.
+- `bundle.identity = (factor_name, cfg.forward_periods)` per
+  per-factor bundle in the returned dict; see
   [Batch screening guide](../guides/batch-screening.md).
-- Each call repeats the per-date cross-section work, so cost scales as
-  `O(n_factors × per_date_cost)` — there is no shared-pass primitive.
 
 Error cases (both raise [`UserInputError`][factrix.UserInputError]):
 

--- a/docs/api/run-metrics.md
+++ b/docs/api/run-metrics.md
@@ -81,7 +81,7 @@ horizons = [1, 5, 21]
 
 # Descriptive sweep — no FDR claim
 bundles = [
-    fx.run_metrics(panel, cfg.replace(forward_periods=h))
+    fx.run_metrics(panel, cfg.replace(forward_periods=h))["factor"]
     for h in horizons
 ]
 # compare(bundles)  # descriptive cross-factor view; v1.x function, see #148

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -136,7 +136,7 @@ sample-restriction vs hypothesis-dimension splits.
 ## `MetricsBundle` — descriptive twin of `FactorProfile`
 
 ```python
-bundle = fx.run_metrics(panel, cfg)
+bundle = fx.run_metrics(panel, cfg)["factor"]
 ```
 
 `run_metrics` fans out the cell's standalone descriptive metrics; the

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -46,11 +46,11 @@ _logger = logging.getLogger("factrix.run_metrics")
 # ``compute_event_returns`` pipelines is tracked as v1.x follow-up.
 _IC_CONSUMERS: frozenset[str] = frozenset({"ic", "ic_newey_west", "ic_ir"})
 
-# Metrics whose primitive returns ``dict[str, MetricOutput]`` keyed by
-# factor column. run_metrics is single-factor at this layer: the panel
-# was renamed to the canonical ``"factor"`` column before dispatch, so
-# the dict carries exactly that key and must be unwrapped to a single
-# ``MetricOutput`` for the bundle.
+# Metrics whose primitive accepts ``factor_cols=list[str]`` and returns
+# ``dict[str, MetricOutput]`` keyed by factor column. run_metrics
+# dispatches these once across the full batch instead of looping
+# per-factor with the thin ``_project_factor`` projection used for the
+# non-batch metrics.
 _BATCH_PRIMITIVE_METRICS: frozenset[str] = frozenset(
     {"quantile_spread", "monotonicity"}
 )

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import html
 import inspect
 import logging
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -36,8 +36,6 @@ from factrix._types import MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from factrix._analysis_config import AnalysisConfig
 
 _logger = logging.getLogger("factrix.run_metrics")
@@ -96,7 +94,7 @@ class MetricsBundle:
         >>> from factrix.preprocess import compute_forward_return
         >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
         >>> panel = compute_forward_return(raw, forward_periods=5)
-        >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())
+        >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())["factor"]
         >>> isinstance(bundle, fx.MetricsBundle)
         True
         >>> "ic" in bundle
@@ -220,7 +218,7 @@ class MetricsBundle:
             >>> from factrix.preprocess import compute_forward_return
             >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
             >>> panel = compute_forward_return(raw, forward_periods=5)
-            >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())
+            >>> bundle = fx.run_metrics(panel, fx.AnalysisConfig.individual_continuous())["factor"]
             >>> df = bundle.to_frame()
             >>> set(df.columns) >= {"factor_id", "metric", "value", "p_value"}
             True
@@ -283,13 +281,13 @@ def _cell_label(cfg: AnalysisConfig) -> str:
     return f"{cfg.scope.value}/{cfg.signal.value}"
 
 
-def _raise_factor_col_error(*, value: str, expected: str) -> None:
+def _raise_factor_col_error(*, value: object, expected: str) -> None:
     raise UserInputError(
         func_name="run_metrics",
-        field="factor_col",
+        field="factor_cols",
         value=value,
         expected=expected,
-        docs_path="api/run_metrics#factor_col",
+        docs_path="api/run_metrics#factor_cols",
     )
 
 
@@ -297,26 +295,27 @@ def run_metrics(
     panel: PanelInput,
     cfg: AnalysisConfig,
     *,
-    factor_col: str = "factor",
+    factor_cols: Sequence[str] = ("factor",),
     metrics: list[str] | None = None,
-) -> MetricsBundle:
-    """Run every standalone descriptive metric the cell exposes.
+) -> dict[str, MetricsBundle]:
+    """Run every standalone descriptive metric the cell exposes, for one or many factors.
 
     Parallel to :func:`factrix.evaluate`: both consume ``(panel, cfg)``,
     each produces a disjoint result type. ``run_metrics`` collects the
-    cell's :mod:`factrix.metrics` surface — information coefficient (IC) family from one shared
-    ``compute_ic`` (cache), every other panel-direct metric called
-    directly — and returns a :class:`MetricsBundle` keyed by metric name.
+    cell's :mod:`factrix.metrics` surface — information coefficient (IC)
+    family from one shared ``compute_ic`` (cache, batched across
+    factors), batch-native primitives (``quantile_spread`` /
+    ``monotonicity``) in one call per metric, every other panel-direct
+    metric looped per factor on a thin projection — and returns one
+    :class:`MetricsBundle` per factor keyed by factor name.
 
     Args:
-        panel: Canonical-column panel (``date, asset_id, factor,
-            forward_return``). Accepts ``pl.DataFrame`` or
-            ``pl.LazyFrame`` (collected at the boundary). pandas
-            users convert via :func:`factrix.adapt` or
-            ``pl.from_pandas`` first; see
+        panel: Canonical-column panel (``date, asset_id, forward_return``
+            plus every name in ``factor_cols``). Accepts
+            ``pl.DataFrame`` or ``pl.LazyFrame`` (collected at the
+            boundary). pandas users convert via :func:`factrix.adapt`
+            or ``pl.from_pandas`` first; see
             :doc:`/guides/efficient-loading` for large-panel recipes.
-            Renamed internally if ``factor_col`` is not ``"factor"``,
-            mirroring :func:`factrix.evaluate`.
         cfg: Validated :class:`AnalysisConfig`. ``cfg.scope`` and
             ``cfg.signal`` route metric discovery; ``cfg.forward_periods``
             (a single int) is the horizon every metric sees. Cross-horizon
@@ -324,9 +323,12 @@ def run_metrics(
             or ``bhy(profiles, expand_over=["forward_periods"])`` —
             ``run_metrics`` itself does not loop horizons (#147 §E /
             #186).
-        factor_col: Name of the signal column on ``panel``. Renamed to
-            ``"factor"`` internally before dispatch so metric callables
-            see the canonical schema.
+        factor_cols: Factor column names on ``panel`` to score. N=1 is
+            the list-of-1 case of the general batch path. IC stage-1
+            and batch-native primitives share one polars query across
+            all factors; non-batch primitives are looped per factor on
+            a thin ``select`` projection that renames the chosen factor
+            to the canonical ``"factor"`` column.
         metrics: ``None`` (default) auto-discovers every applicable
             metric from :func:`factrix.list_metrics`. Pass an explicit
             list to run a subset; unknown or
@@ -336,10 +338,11 @@ def run_metrics(
             for stage-1 consumers).
 
     Returns:
-        A :class:`MetricsBundle` whose ``metrics`` map carries every
-        ``MetricOutput`` produced (including short-circuit outputs for
-        sample-floor failures) and whose ``skipped`` map carries
-        per-metric reasons for metrics that could not auto-run.
+        Dict mapping each factor name to its :class:`MetricsBundle`.
+        Each bundle's ``metrics`` map carries every ``MetricOutput``
+        produced (including short-circuit outputs for sample-floor
+        failures) and ``skipped`` map carries per-metric reasons for
+        metrics that could not auto-run.
 
     Raises:
         UserInputError: ``metrics`` contains an unknown name or a name
@@ -355,36 +358,60 @@ def run_metrics(
             ``MetricOutput`` entries inside the bundle, **not** raised.
 
     Examples:
-        Auto-discover every applicable metric for the cell:
+        Auto-discover every applicable metric for the canonical
+        single-factor panel:
 
         >>> import factrix as fx
         >>> from factrix.preprocess import compute_forward_return
         >>> raw = fx.datasets.make_cs_panel(n_assets=100, n_dates=250)
         >>> panel = compute_forward_return(raw, forward_periods=5)
         >>> cfg = fx.AnalysisConfig.individual_continuous(forward_periods=5)
-        >>> bundle = fx.run_metrics(panel, cfg)
+        >>> bundles = fx.run_metrics(panel, cfg)
+        >>> bundle = bundles["factor"]
         >>> ic_output = bundle["ic"]
         >>> long_frame = bundle.to_frame()
-        >>> skipped = dict(bundle.skipped)
 
         Restrict to a subset by name:
 
-        >>> bundle = fx.run_metrics(panel, cfg, metrics=["ic"])
+        >>> bundles = fx.run_metrics(panel, cfg, metrics=["ic"])
     """
     panel = _coerce_panel(panel)
-    missing = {"date", "asset_id", factor_col, "forward_return"} - set(panel.columns)
-    if missing:
+    cols = list(factor_cols)
+    if not cols:
+        _raise_factor_col_error(
+            value=cols,
+            expected="a non-empty list of factor column names",
+        )
+    if len(set(cols)) != len(cols):
+        _raise_factor_col_error(
+            value=cols,
+            expected="factor_cols with no duplicates",
+        )
+
+    base_required = {"date", "asset_id", "forward_return"}
+    missing_base = base_required - set(panel.columns)
+    if missing_base:
         hint = (
             "factrix.preprocess.compute_forward_return(panel) attaches forward_return"
-            if "forward_return" in missing
-            else f"add column(s) {sorted(missing)!r} to the panel"
+            if "forward_return" in missing_base
+            else f"add column(s) {sorted(missing_base)!r} to the panel"
         )
         _raise_factor_col_error(
-            value=factor_col,
+            value=cols,
             expected=(
                 f"panel with canonical columns "
-                f"{{date, asset_id, {factor_col!r}, forward_return}}; "
-                f"missing {sorted(missing)!r} ({hint})"
+                f"{{date, asset_id, forward_return}} plus every name in "
+                f"factor_cols; missing {sorted(missing_base)!r} ({hint})"
+            ),
+        )
+
+    missing_factors = [c for c in cols if c not in panel.columns]
+    if missing_factors:
+        _raise_factor_col_error(
+            value=missing_factors,
+            expected=(
+                f"every name in factor_cols to exist on panel; "
+                f"got columns {list(panel.columns)!r}"
             ),
         )
 
@@ -401,23 +428,6 @@ def run_metrics(
             ),
             docs_path="api/run_metrics#metrics",
         )
-
-    if factor_col != "factor":
-        if factor_col not in panel.columns:
-            _raise_factor_col_error(
-                value=factor_col,
-                expected=f"a column on panel; got columns {list(panel.columns)!r}",
-            )
-        if "factor" in panel.columns:
-            _raise_factor_col_error(
-                value=factor_col,
-                expected=(
-                    "panel without an existing 'factor' column when "
-                    "factor_col != 'factor' (drop the unused column "
-                    "before calling)"
-                ),
-            )
-        panel = panel.rename({factor_col: "factor"})
 
     candidates = _candidate_metric_names(cfg.scope, cfg.signal)
     runnable = [m for m in candidates if m not in _AUTO_DISCOVER_EXCLUDED]
@@ -461,36 +471,34 @@ def run_metrics(
             )
 
     skipped: dict[str, str] = dict(excluded_reasons) if metrics is None else {}
-    results: dict[str, MetricOutput] = {}
-    ic_df: pl.DataFrame | None = None
+    results: dict[str, dict[str, MetricOutput]] = {c: {} for c in cols}
+    ic_by_factor: dict[str, pl.DataFrame] | None = None
 
     import factrix.metrics as _metrics
 
     for name in targets:
         fn = getattr(_metrics, name)
+        kwargs: dict[str, Any] = {}
+        if _accepts_kwarg(fn, "forward_periods"):
+            kwargs["forward_periods"] = cfg.forward_periods
         stage = "consumer"
         try:
             if name in _IC_CONSUMERS:
-                if ic_df is None:
+                if ic_by_factor is None:
                     stage = "stage1"
-                    ic_df = _metrics.compute_ic(panel)["factor"]
+                    ic_by_factor = _metrics.compute_ic(panel, factor_cols=cols)
                     stage = "consumer"
-                first_arg: pl.DataFrame = ic_df
+                for c in cols:
+                    results[c][name] = _safe_call(name, fn, ic_by_factor[c], kwargs)
+            elif name in _BATCH_PRIMITIVE_METRICS:
+                out = fn(panel, factor_cols=cols, **kwargs)
+                for c in cols:
+                    results[c][name] = out[c]
             else:
-                first_arg = panel
-            kwargs: dict[str, Any] = {}
-            if _accepts_kwarg(fn, "forward_periods"):
-                kwargs["forward_periods"] = cfg.forward_periods
-            out = fn(first_arg, **kwargs)
-            results[name] = out["factor"] if name in _BATCH_PRIMITIVE_METRICS else out
-        except InsufficientSampleError as exc:
-            results[name] = _short_circuit_output(
-                name,
-                "insufficient_sample",
-                actual_periods=exc.actual_periods,
-                required_periods=exc.required_periods,
-            )
-        except RunMetricsError:
+                for c in cols:
+                    pf_panel = _project_factor(panel, c)
+                    results[c][name] = _safe_call(name, fn, pf_panel, kwargs)
+        except (InsufficientSampleError, RunMetricsError):
             raise
         except Exception as exc:
             raise RunMetricsError(
@@ -504,18 +512,58 @@ def run_metrics(
 
     if skipped:
         _logger.info(
-            "run_metrics(cell=%s, factor_id=%s, fwd=%d): ran=%d skipped=%d (%s)",
+            "run_metrics(cell=%s, factor_ids=%s, fwd=%d): ran=%d skipped=%d (%s)",
             _cell_label(cfg),
-            factor_col,
+            cols,
             cfg.forward_periods,
-            len(results),
+            len(targets),
             len(skipped),
             ", ".join(sorted(skipped)),
         )
 
-    return MetricsBundle(
-        identity=(factor_col, cfg.forward_periods),
-        metrics=MappingProxyType(results),
-        skipped=MappingProxyType(skipped),
-        context=MappingProxyType({}),
+    return {
+        c: MetricsBundle(
+            identity=(c, cfg.forward_periods),
+            metrics=MappingProxyType(results[c]),
+            skipped=MappingProxyType(skipped),
+            context=MappingProxyType({}),
+        )
+        for c in cols
+    }
+
+
+def _project_factor(panel: pl.DataFrame, col: str) -> pl.DataFrame:
+    """Thin per-factor projection: rename ``col`` to canonical ``"factor"``.
+
+    Non-batch primitives expect a panel whose factor column is literally
+    ``"factor"``. When the caller passes ``factor_cols`` other than (or
+    in addition to) ``"factor"``, we materialise a thin per-factor view
+    by selecting only the columns the primitive needs and aliasing the
+    chosen factor. Zero-copy at the polars layer for the kept columns.
+    """
+    if col == "factor":
+        return panel
+    return panel.select(
+        pl.col("date"),
+        pl.col("asset_id"),
+        pl.col("forward_return"),
+        pl.col(col).alias("factor"),
     )
+
+
+def _safe_call(
+    name: str,
+    fn: Callable[..., MetricOutput],
+    arg: pl.DataFrame,
+    kwargs: dict[str, Any],
+) -> MetricOutput:
+    """Invoke ``fn(arg, **kwargs)`` converting sample-floor errors to short-circuit outputs."""
+    try:
+        return fn(arg, **kwargs)
+    except InsufficientSampleError as exc:
+        return _short_circuit_output(
+            name,
+            "insufficient_sample",
+            actual_periods=exc.actual_periods,
+            required_periods=exc.required_periods,
+        )

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -357,6 +357,14 @@ def run_metrics(
             short-circuits are converted to short-circuit
             ``MetricOutput`` entries inside the bundle, **not** raised.
 
+            For shared-compute paths — IC stage-1 (``compute_ic`` across
+            all factors) and batch-native primitives (``quantile_spread``
+            / ``monotonicity`` with ``factor_cols=cols``) — an
+            unexpected exception aborts the entire batch; the cost of
+            per-factor isolation would be paying the per-factor query
+            plan we explicitly merged. Per-factor sample-floor
+            short-circuits remain entries inside the bundle.
+
     Examples:
         Auto-discover every applicable metric for the canonical
         single-factor panel:
@@ -473,6 +481,10 @@ def run_metrics(
     skipped: dict[str, str] = dict(excluded_reasons) if metrics is None else {}
     results: dict[str, dict[str, MetricOutput]] = {c: {} for c in cols}
     ic_by_factor: dict[str, pl.DataFrame] | None = None
+    # Per-factor projected views shared across every non-batch metric.
+    # Built once per factor (not per metric × factor) — the underlying
+    # polars buffers are refcounted so the projection is near-zero-copy.
+    projected: dict[str, pl.DataFrame] = {c: _project_factor(panel, c) for c in cols}
 
     import factrix.metrics as _metrics
 
@@ -491,13 +503,19 @@ def run_metrics(
                 for c in cols:
                     results[c][name] = _safe_call(name, fn, ic_by_factor[c], kwargs)
             elif name in _BATCH_PRIMITIVE_METRICS:
+                # Batch-native primitives raise InsufficientSampleError
+                # per-factor as a dict entry, not via exception — the
+                # short-circuit lives in the returned MetricOutput.
+                # If the call itself raises, the whole batch aborts
+                # (documented in Raises). Per-factor short-circuiting
+                # inside the primitive is the contract these metrics
+                # opt into by accepting factor_cols.
                 out = fn(panel, factor_cols=cols, **kwargs)
                 for c in cols:
                     results[c][name] = out[c]
             else:
                 for c in cols:
-                    pf_panel = _project_factor(panel, c)
-                    results[c][name] = _safe_call(name, fn, pf_panel, kwargs)
+                    results[c][name] = _safe_call(name, fn, projected[c], kwargs)
         except (InsufficientSampleError, RunMetricsError):
             raise
         except Exception as exc:
@@ -536,13 +554,11 @@ def _project_factor(panel: pl.DataFrame, col: str) -> pl.DataFrame:
     """Thin per-factor projection: rename ``col`` to canonical ``"factor"``.
 
     Non-batch primitives expect a panel whose factor column is literally
-    ``"factor"``. When the caller passes ``factor_cols`` other than (or
-    in addition to) ``"factor"``, we materialise a thin per-factor view
-    by selecting only the columns the primitive needs and aliasing the
-    chosen factor. Zero-copy at the polars layer for the kept columns.
+    ``"factor"``. Always projects to exactly the 4 canonical columns
+    so primitives see an identical schema regardless of whether the
+    caller's ``factor_cols`` happened to include ``"factor"`` itself
+    or a sibling extra column.
     """
-    if col == "factor":
-        return panel
     return panel.select(
         pl.col("date"),
         pl.col("asset_id"),

--- a/tests/test_run_metrics.py
+++ b/tests/test_run_metrics.py
@@ -344,6 +344,22 @@ def test_duplicate_factor_cols_rejected(
 # ---------------------------------------------------------------------------
 
 
+def _assert_output_equal(
+    a: MetricOutput, b: MetricOutput, *, where: tuple[str, ...]
+) -> None:
+    if np.isnan(a.value):
+        assert np.isnan(b.value), where
+    else:
+        assert a.value == pytest.approx(b.value), where
+    if a.stat is None:
+        assert b.stat is None, where
+    else:
+        assert b.stat is not None, where
+        assert a.stat == pytest.approx(b.stat), where
+    assert a.significance == b.significance, where
+    assert a.metadata.get("p_value") == pytest.approx(b.metadata.get("p_value")), where
+
+
 def test_batch_of_one_matches_default(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
     bundle_default = run_metrics(panel, cfg, metrics=["ic", "monotonicity"])["factor"]
     bundle_listed = run_metrics(
@@ -351,8 +367,8 @@ def test_batch_of_one_matches_default(panel: pl.DataFrame, cfg: AnalysisConfig) 
     )["factor"]
     assert bundle_default.identity == bundle_listed.identity
     for name in bundle_default.metrics:
-        assert bundle_default[name].value == pytest.approx(bundle_listed[name].value), (
-            name
+        _assert_output_equal(
+            bundle_default[name], bundle_listed[name], where=("default-vs-listed", name)
         )
 
 
@@ -371,4 +387,4 @@ def test_batch_of_n_matches_list_of_one_per_factor(
             c
         ]
         for name in ("ic", "monotonicity"):
-            assert batch[c][name].value == pytest.approx(solo[name].value), (c, name)
+            _assert_output_equal(batch[c][name], solo[name], where=(c, name))

--- a/tests/test_run_metrics.py
+++ b/tests/test_run_metrics.py
@@ -1,4 +1,4 @@
-"""``run_metrics`` v1 — IC-cell stage-1 cache + panel-direct metrics (#147)."""
+"""``run_metrics`` batch interface (#402) — IC-cell stage-1 cache + panel-direct metrics."""
 
 from __future__ import annotations
 
@@ -25,6 +25,7 @@ def _build_panel(
     n_assets: int = 25,
     seed: int = 0,
     factor_strength: float = 0.2,
+    extra_factor: str | None = None,
 ) -> pl.DataFrame:
     rng = np.random.default_rng(seed)
     start = dt.date(2024, 1, 1)
@@ -34,17 +35,19 @@ def _build_panel(
         fwd = rng.standard_normal(n_assets)
         noise = rng.standard_normal(n_assets)
         factor = factor_strength * fwd + (1.0 - factor_strength) * noise
+        extra = rng.standard_normal(n_assets) if extra_factor else None
         price = rng.uniform(50.0, 150.0, n_assets)
         for j in range(n_assets):
-            rows.append(
-                {
-                    "date": d,
-                    "asset_id": f"A{j:03d}",
-                    "factor": float(factor[j]),
-                    "forward_return": float(fwd[j]),
-                    "price": float(price[j]),
-                }
-            )
+            row: dict[str, object] = {
+                "date": d,
+                "asset_id": f"A{j:03d}",
+                "factor": float(factor[j]),
+                "forward_return": float(fwd[j]),
+                "price": float(price[j]),
+            }
+            if extra_factor and extra is not None:
+                row[extra_factor] = float(extra[j])
+            rows.append(row)
     return pl.DataFrame(rows)
 
 
@@ -59,14 +62,14 @@ def cfg() -> AnalysisConfig:
 
 
 # ---------------------------------------------------------------------------
-# Default auto-discover
+# Default auto-discover (single factor list-of-1 default)
 # ---------------------------------------------------------------------------
 
 
 def test_auto_discover_runs_ic_family_and_panel_direct(
     panel: pl.DataFrame, cfg: AnalysisConfig
 ) -> None:
-    bundle = run_metrics(panel, cfg)
+    bundle = run_metrics(panel, cfg)["factor"]
     assert _IC_CONSUMERS.issubset(set(bundle.metrics))
     assert "monotonicity" in bundle.metrics
     assert "turnover" in bundle.metrics
@@ -75,7 +78,7 @@ def test_auto_discover_runs_ic_family_and_panel_direct(
 def test_auto_discover_skipped_carries_excluded_reasons(
     panel: pl.DataFrame, cfg: AnalysisConfig
 ) -> None:
-    bundle = run_metrics(panel, cfg)
+    bundle = run_metrics(panel, cfg)["factor"]
     for name, reason in bundle.skipped.items():
         assert reason == _AUTO_DISCOVER_EXCLUDED[name]
 
@@ -100,7 +103,7 @@ def test_auto_discover_skipped_logs_one_summary(
 def test_explicit_subset_runs_only_named(
     panel: pl.DataFrame, cfg: AnalysisConfig
 ) -> None:
-    bundle = run_metrics(panel, cfg, metrics=["ic", "ic_ir"])
+    bundle = run_metrics(panel, cfg, metrics=["ic", "ic_ir"])["factor"]
     assert set(bundle.metrics) == {"ic", "ic_ir"}
     assert dict(bundle.skipped) == {}
 
@@ -129,7 +132,7 @@ def test_explicit_excluded_raises_with_reason(
 
 
 def test_bundle_dict_style_access(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
-    bundle = run_metrics(panel, cfg, metrics=["ic"])
+    bundle = run_metrics(panel, cfg, metrics=["ic"])["factor"]
     assert isinstance(bundle["ic"], MetricOutput)
     assert "ic" in bundle
     assert list(bundle) == ["ic"]
@@ -139,19 +142,19 @@ def test_bundle_dict_style_access(panel: pl.DataFrame, cfg: AnalysisConfig) -> N
 def test_bundle_identity_and_default_context(
     panel: pl.DataFrame, cfg: AnalysisConfig
 ) -> None:
-    bundle = run_metrics(panel, cfg, factor_col="factor", metrics=["ic"])
+    bundle = run_metrics(panel, cfg, factor_cols=["factor"], metrics=["ic"])["factor"]
     assert bundle.identity == ("factor", cfg.forward_periods)
     assert dict(bundle.context) == {}
 
 
 def test_bundle_is_unhashable(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
-    bundle = run_metrics(panel, cfg, metrics=["ic"])
+    bundle = run_metrics(panel, cfg, metrics=["ic"])["factor"]
     with pytest.raises(TypeError):
         hash(bundle)
 
 
 def test_bundle_repr_html_smoke(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
-    bundle = run_metrics(panel, cfg)
+    bundle = run_metrics(panel, cfg)["factor"]
     html = bundle._repr_html_()
     assert "MetricsBundle" in html
     assert "ic" in html
@@ -175,7 +178,7 @@ _TO_FRAME_SCHEMA = {
 
 
 def test_to_frame_schema_is_stable(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
-    bundle = run_metrics(panel, cfg, metrics=["ic"])
+    bundle = run_metrics(panel, cfg, metrics=["ic"])["factor"]
     frame = bundle.to_frame()
     assert dict(frame.schema) == _TO_FRAME_SCHEMA
     assert frame.height == 1
@@ -217,7 +220,7 @@ def test_stage1_compute_ic_called_once_for_ic_family(
     counter = {"n": 0}
     real_compute_ic = metrics_pkg.compute_ic
 
-    def counting_compute_ic(*args: object, **kwargs: object) -> pl.DataFrame:
+    def counting_compute_ic(*args: object, **kwargs: object) -> object:
         counter["n"] += 1
         return real_compute_ic(*args, **kwargs)
 
@@ -225,6 +228,30 @@ def test_stage1_compute_ic_called_once_for_ic_family(
     run_metrics(
         panel,
         cfg,
+        metrics=["ic", "ic_newey_west", "ic_ir"],
+    )
+    assert counter["n"] == 1
+
+
+def test_stage1_compute_ic_called_once_across_factors(
+    cfg: AnalysisConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multi-factor batch: IC stage-1 runs ONE polars query across N factors."""
+    import factrix.metrics as metrics_pkg
+
+    panel = _build_panel(extra_factor="momentum")
+    counter = {"n": 0}
+    real_compute_ic = metrics_pkg.compute_ic
+
+    def counting_compute_ic(*args: object, **kwargs: object) -> object:
+        counter["n"] += 1
+        return real_compute_ic(*args, **kwargs)
+
+    monkeypatch.setattr(metrics_pkg, "compute_ic", counting_compute_ic)
+    run_metrics(
+        panel,
+        cfg,
+        factor_cols=["factor", "momentum"],
         metrics=["ic", "ic_newey_west", "ic_ir"],
     )
     assert counter["n"] == 1
@@ -240,7 +267,7 @@ def test_class_a_short_circuit_keeps_other_metrics(
 ) -> None:
     # Tiny panel with too few periods for IC's non-overlap test.
     tiny = _build_panel(n_dates=5, n_assets=12)
-    bundle = run_metrics(tiny, cfg, metrics=["ic", "monotonicity"])
+    bundle = run_metrics(tiny, cfg, metrics=["ic", "monotonicity"])["factor"]
     ic_out = bundle["ic"]
     assert ic_out.metadata.get("reason", "").startswith(("insufficient", "no_"))
     assert "monotonicity" in bundle.metrics
@@ -264,23 +291,25 @@ def test_class_c_unexpected_exception_wrapped(
 
 
 # ---------------------------------------------------------------------------
-# factor_col rename path
+# factor_cols dispatch
 # ---------------------------------------------------------------------------
 
 
-def test_factor_col_renames_and_stamps_identity(
-    panel: pl.DataFrame, cfg: AnalysisConfig
+def test_factor_cols_user_named_stamps_identity(
+    cfg: AnalysisConfig,
 ) -> None:
-    renamed = panel.rename({"factor": "momentum_12_1"})
-    bundle = run_metrics(renamed, cfg, factor_col="momentum_12_1", metrics=["ic"])
+    panel = _build_panel().rename({"factor": "momentum_12_1"})
+    bundle = run_metrics(panel, cfg, factor_cols=["momentum_12_1"], metrics=["ic"])[
+        "momentum_12_1"
+    ]
     assert bundle.identity == ("momentum_12_1", cfg.forward_periods)
 
 
-def test_factor_col_missing_raises_user_input_error(
+def test_factor_cols_missing_raises_user_input_error(
     panel: pl.DataFrame, cfg: AnalysisConfig
 ) -> None:
     with pytest.raises(UserInputError):
-        run_metrics(panel, cfg, factor_col="nonexistent", metrics=["ic"])
+        run_metrics(panel, cfg, factor_cols=["nonexistent"], metrics=["ic"])
 
 
 def test_missing_forward_return_raises_actionable_error(
@@ -298,10 +327,48 @@ def test_empty_metrics_list_rejected(panel: pl.DataFrame, cfg: AnalysisConfig) -
     assert "non-empty" in str(exc_info.value)
 
 
-def test_factor_col_collision_raises_user_input_error(
+def test_empty_factor_cols_rejected(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    with pytest.raises(UserInputError):
+        run_metrics(panel, cfg, factor_cols=[], metrics=["ic"])
+
+
+def test_duplicate_factor_cols_rejected(
     panel: pl.DataFrame, cfg: AnalysisConfig
 ) -> None:
-    # both 'factor' (already present) and a new candidate column
-    panel_with_alias = panel.with_columns(pl.col("factor").alias("alt"))
     with pytest.raises(UserInputError):
-        run_metrics(panel_with_alias, cfg, factor_col="alt", metrics=["ic"])
+        run_metrics(panel, cfg, factor_cols=["factor", "factor"], metrics=["ic"])
+
+
+# ---------------------------------------------------------------------------
+# Multi-factor equivalence (fail-loud regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_batch_of_one_matches_default(panel: pl.DataFrame, cfg: AnalysisConfig) -> None:
+    bundle_default = run_metrics(panel, cfg, metrics=["ic", "monotonicity"])["factor"]
+    bundle_listed = run_metrics(
+        panel, cfg, factor_cols=["factor"], metrics=["ic", "monotonicity"]
+    )["factor"]
+    assert bundle_default.identity == bundle_listed.identity
+    for name in bundle_default.metrics:
+        assert bundle_default[name].value == pytest.approx(bundle_listed[name].value), (
+            name
+        )
+
+
+def test_batch_of_n_matches_list_of_one_per_factor(
+    cfg: AnalysisConfig,
+) -> None:
+    panel = _build_panel(extra_factor="momentum")
+    batch = run_metrics(
+        panel,
+        cfg,
+        factor_cols=["factor", "momentum"],
+        metrics=["ic", "monotonicity"],
+    )
+    for c in ("factor", "momentum"):
+        solo = run_metrics(panel, cfg, factor_cols=[c], metrics=["ic", "monotonicity"])[
+            c
+        ]
+        for name in ("ic", "monotonicity"):
+            assert batch[c][name].value == pytest.approx(solo[name].value), (c, name)


### PR DESCRIPTION
## Summary

- `fx.run_metrics(panel, cfg, factor_cols=...)` returns `dict[str, MetricsBundle]` (one bundle per factor); default `factor_cols=("factor",)` keeps the canonical N=1 case
- IC stage-1 batches across factors via `compute_ic(panel, factor_cols=cols)` — single polars query for the whole IC family across N factors
- Batch-native primitives (`quantile_spread` / `monotonicity`) dispatched once with `factor_cols=cols`; non-batch metrics looped per factor on a thin `select`/alias projection
- `factor_col` rename path removed (primitives now accept arbitrary factor column names); `evaluate` unchanged
- bench `_run_metrics_per_factor` non-batchable fallback switched from per-factor loop to one `fx.run_metrics(factor_cols=factors)` call

## Test plan

- [x] `pytest tests/` — 1433 passed
- [x] `pytest --doctest-modules factrix/` — 73 passed
- [x] `mypy factrix/` — clean
- [x] `ruff check factrix/ tests/ bench/` — clean
- [x] `mkdocs build --strict` — clean
- [x] New equivalence tests: `test_batch_of_one_matches_default`, `test_batch_of_n_matches_list_of_one_per_factor`
- [x] New stage-1 sharing test: `test_stage1_compute_ic_called_once_across_factors`

Closes #402