### PR TITLE
refactor(metrics): drop _BATCH_PRIMITIVE_METRICS, route via signature introspection (#407)

### DIFF
--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -46,15 +46,6 @@ _logger = logging.getLogger("factrix.run_metrics")
 # ``compute_event_returns`` pipelines is tracked as v1.x follow-up.
 _IC_CONSUMERS: frozenset[str] = frozenset({"ic", "ic_newey_west", "ic_ir"})
 
-# Metrics whose primitive accepts ``factor_cols=list[str]`` and returns
-# ``dict[str, MetricOutput]`` keyed by factor column. run_metrics
-# dispatches these once across the full batch instead of looping
-# per-factor with the thin ``_project_factor`` projection used for the
-# non-batch metrics.
-_BATCH_PRIMITIVE_METRICS: frozenset[str] = frozenset(
-    {"quantile_spread", "monotonicity"}
-)
-
 
 @dataclass(frozen=True, slots=True, repr=False)
 class MetricsBundle:
@@ -502,14 +493,15 @@ def run_metrics(
                     stage = "consumer"
                 for c in cols:
                     results[c][name] = _safe_call(name, fn, ic_by_factor[c], kwargs)
-            elif name in _BATCH_PRIMITIVE_METRICS:
-                # Batch-native primitives raise InsufficientSampleError
-                # per-factor as a dict entry, not via exception — the
-                # short-circuit lives in the returned MetricOutput.
-                # If the call itself raises, the whole batch aborts
-                # (documented in Raises). Per-factor short-circuiting
-                # inside the primitive is the contract these metrics
-                # opt into by accepting factor_cols.
+            elif _accepts_kwarg(fn, "factor_cols"):
+                # Batch-native primitives (those whose signature accepts
+                # ``factor_cols``) take one call across the whole batch
+                # and return ``dict[str, MetricOutput]`` keyed per
+                # factor. They surface sample-floor failures as
+                # short-circuit entries inside that dict, not via
+                # exception (so no per-factor ``_safe_call`` wrap
+                # needed). An unexpected exception from the call aborts
+                # the whole batch — see ``Raises``.
                 out = fn(panel, factor_cols=cols, **kwargs)
                 for c in cols:
                     results[c][name] = out[c]

--- a/tests/test_run_metrics.py
+++ b/tests/test_run_metrics.py
@@ -14,6 +14,7 @@ from factrix._metric_index import _AUTO_DISCOVER_EXCLUDED
 from factrix._run_metrics import (
     _IC_CONSUMERS,
     MetricsBundle,
+    _accepts_kwarg,
     run_metrics,
 )
 from factrix._types import MetricOutput
@@ -388,3 +389,78 @@ def test_batch_of_n_matches_list_of_one_per_factor(
         ]
         for name in ("ic", "monotonicity"):
             _assert_output_equal(batch[c][name], solo[name], where=(c, name))
+
+
+# ---------------------------------------------------------------------------
+# Signature-driven batch dispatch (#407)
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_kwarg_routes_known_batch_primitives() -> None:
+    """Signature introspection identifies the post-#401 batch primitives."""
+    import factrix.metrics as metrics_pkg
+
+    assert _accepts_kwarg(metrics_pkg.quantile_spread, "factor_cols")
+    assert _accepts_kwarg(metrics_pkg.monotonicity, "factor_cols")
+
+
+def test_accepts_kwarg_rejects_non_batch_metric() -> None:
+    """Non-batch panel-direct metrics do not declare factor_cols in their signature."""
+    import factrix.metrics as metrics_pkg
+
+    assert not _accepts_kwarg(metrics_pkg.top_concentration, "factor_cols")
+    assert not _accepts_kwarg(metrics_pkg.turnover, "factor_cols")
+
+
+def test_batch_primitive_dispatched_once_across_factors(
+    cfg: AnalysisConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Metrics whose signature accepts factor_cols get one batched call."""
+    import functools
+
+    import factrix.metrics as metrics_pkg
+
+    panel = _build_panel(extra_factor="momentum")
+    counter = {"n": 0}
+    real = metrics_pkg.quantile_spread
+
+    @functools.wraps(real)
+    def counting(*args: object, **kwargs: object) -> object:
+        counter["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(metrics_pkg, "quantile_spread", counting)
+    run_metrics(
+        panel,
+        cfg,
+        factor_cols=["factor", "momentum"],
+        metrics=["quantile_spread"],
+    )
+    assert counter["n"] == 1
+
+
+def test_non_batch_metric_dispatched_per_factor(
+    cfg: AnalysisConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Metrics without factor_cols param get one call per factor on a projected panel."""
+    import functools
+
+    import factrix.metrics as metrics_pkg
+
+    panel = _build_panel(extra_factor="momentum")
+    counter = {"n": 0}
+    real = metrics_pkg.turnover
+
+    @functools.wraps(real)
+    def counting(*args: object, **kwargs: object) -> object:
+        counter["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(metrics_pkg, "turnover", counting)
+    run_metrics(
+        panel,
+        cfg,
+        factor_cols=["factor", "momentum"],
+        metrics=["turnover"],
+    )
+    assert counter["n"] == 2


### PR DESCRIPTION
## Summary

- Remove the hand-maintained `_BATCH_PRIMITIVE_METRICS = frozenset({"quantile_spread", "monotonicity"})` central registry from `factrix/_run_metrics.py`
- Route batch dispatch by `_accepts_kwarg(fn, "factor_cols")` — same `inspect.signature` helper already used for the `forward_periods` check
- Source of truth becomes the metric callable's own signature; future batch primitives only need their function to take `factor_cols: Sequence[str]`, no central registry touch
- Adds 4 regression tests pinning signature → dispatch routing

## Why

Flagged in #402 /simplify review (MED): the central frozenset duplicates information the function signature already carries, and drifts when new batch primitives land. Existing capability-resolver pattern in `factrix/metrics/_metric_capabilities.py` is module-level (wrong granularity here — `quantile_spread` is batch-eligible but `quantile_spread_vw` in the same module is not), so this PR uses function-level signature introspection instead.

## Test plan

- [x] `pytest tests/` — 1437 passed (+4 new)
- [x] `pytest --doctest-modules factrix/` — 73 passed
- [x] `mypy factrix/` — clean
- [x] `ruff check factrix/ tests/ bench/` — clean
- [x] New tests: `_accepts_kwarg` returns True for the two known batch primitives, False for two non-batch metrics, dispatched call counts match expected (1 batched / N per-factor)

Closes #407