### PR TITLE
feat(bench): scripts/bench_diff.py for ad-hoc before/after ratio (#389)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -210,6 +210,22 @@ rule of thumb when reading them:
 - **Cross-machine ratios** are valid; cross-machine absolute
   numbers are not. See "Cross-machine rebaseline" below.
 
+### Ad-hoc ratio table
+
+`scripts/bench_diff.py` renders a markdown ratio table from two output
+dirs for direct paste into PR descriptions:
+
+```
+python scripts/bench_diff.py <before-dir> <after-dir>
+```
+
+Gates on `schema_version` / `metric_set_version` /
+`env.dataset_spec_version` / `axis_cell` / `cache_state` — mismatched
+runs exit non-zero rather than silently coerce. Multi-scale scenarios
+(P1) align per `scale`. This is the PR-description helper for the
+#378 optimisation loop, **not** a long-term CLI; promoting to a
+proper `bench.compare` module is a separate decision.
+
 ## `cache_state` operating rules
 
 Every record carries `cache_state ∈ {"cold", "warm", "unknown"}`.

--- a/scripts/bench_diff.py
+++ b/scripts/bench_diff.py
@@ -1,0 +1,141 @@
+"""Ad-hoc before / after compute_s + peak_rss_mb ratio for two bench output dirs.
+
+Usage::
+
+    python scripts/bench_diff.py <before-dir> <after-dir>
+
+Prints a markdown table to stdout for direct paste into PR descriptions.
+Compatibility-gates schema_version / metric_set_version /
+env.dataset_spec_version / axis_cell / cache_state — refuses to compare
+mismatched runs (exit 1) rather than silently coercing.
+
+Scope: PR-description helper for the #378 optimisation loop. Not a
+long-term CLI; if it grows past ad-hoc shape, open a follow-up issue to
+promote into a proper ``bench.compare`` module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_COMPAT_FIELDS = (
+    "schema_version",
+    "metric_set_version",
+    "axis_cell",
+    "cache_state",
+)
+
+
+def _compat_fingerprint(record: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        *(record[k] for k in _COMPAT_FIELDS),
+        record["env"]["dataset_spec_version"],
+    )
+
+
+def _scale_key(record: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+    return tuple(sorted(record["scale"].items()))
+
+
+def _load(
+    dirpath: Path,
+) -> dict[tuple[str, tuple[tuple[str, Any], ...]], dict[str, Any]]:
+    if not dirpath.is_dir():
+        raise SystemExit(f"ERROR: not a directory: {dirpath}")
+    records: dict[tuple[str, tuple[tuple[str, Any], ...]], dict[str, Any]] = {}
+    for f in sorted(dirpath.glob("*.jsonl")):
+        for line in f.read_text().splitlines():
+            r = json.loads(line)
+            if r.get("is_warmup") or r.get("status") != "ok":
+                continue
+            key = (r["scenario_id"], _scale_key(r))
+            if key in records:
+                raise SystemExit(f"ERROR: duplicate scenario key {key!r} in {dirpath}")
+            records[key] = r
+    return records
+
+
+def _scale_label(scale: dict[str, Any]) -> str:
+    for k in ("n_factors", "n_events"):
+        if k in scale:
+            return f"{k}={scale[k]}"
+    return "-"
+
+
+def _format_table(
+    before: dict[tuple[str, Any], dict[str, Any]],
+    after: dict[tuple[str, Any], dict[str, Any]],
+) -> str:
+    lines = [
+        "| scenario_id | scale | compute_s_before | compute_s_after | ratio | peak_rss_mb_ratio |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for key in sorted(before):
+        scenario_id, scale_key = key
+        b = before[key]
+        a = after[key]
+        b_c = b["compute_s"]
+        a_c = a["compute_s"]
+        ratio = a_c / b_c if b_c else float("nan")
+        b_rss = b["peak_rss_mb"]
+        a_rss = a["peak_rss_mb"]
+        rss_ratio = a_rss / b_rss if b_rss else float("nan")
+        lines.append(
+            f"| {scenario_id} | {_scale_label(dict(scale_key))} | "
+            f"{b_c:.3f} | {a_c:.3f} | {ratio:.3f} | {rss_ratio:.3f} |"
+        )
+    return "\n".join(lines)
+
+
+def diff(before_dir: Path, after_dir: Path) -> str:
+    """Return the markdown ratio table. Raises SystemExit on incompatibility."""
+    before = _load(before_dir)
+    after = _load(after_dir)
+
+    missing_in_after = sorted(set(before) - set(after))
+    missing_in_before = sorted(set(after) - set(before))
+    if missing_in_after or missing_in_before:
+        lines = ["ERROR: scenario set mismatch between before and after"]
+        if missing_in_after:
+            lines.append(f"  missing in after: {missing_in_after}")
+        if missing_in_before:
+            lines.append(f"  missing in before: {missing_in_before}")
+        raise SystemExit("\n".join(lines))
+
+    mismatches: list[str] = []
+    for key in sorted(before):
+        b_fp = _compat_fingerprint(before[key])
+        a_fp = _compat_fingerprint(after[key])
+        if b_fp != a_fp:
+            diffs = {
+                field: (b_fp[i], a_fp[i])
+                for i, field in enumerate((*_COMPAT_FIELDS, "env.dataset_spec_version"))
+                if b_fp[i] != a_fp[i]
+            }
+            mismatches.append(f"  {key[0]} ({_scale_label(dict(key[1]))}): {diffs}")
+    if mismatches:
+        raise SystemExit(
+            "ERROR: compatibility mismatch — refusing to compare\n"
+            + "\n".join(mismatches)
+        )
+
+    return _format_table(before, after)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Ad-hoc before/after ratio for two bench output dirs."
+    )
+    p.add_argument("before_dir", type=Path)
+    p.add_argument("after_dir", type=Path)
+    args = p.parse_args(argv)
+    print(diff(args.before_dir, args.after_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_bench_diff.py
+++ b/tests/scripts/test_bench_diff.py
@@ -1,0 +1,203 @@
+"""Tests for ``scripts/bench_diff.py`` (#389)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+import bench_diff  # noqa: E402
+
+
+def _record(
+    *,
+    scenario_id: str = "S2",
+    n_factors: int = 50,
+    compute_s: float = 1.0,
+    peak_rss_mb: float = 100.0,
+    schema_version: str = "1",
+    metric_set_version: str = "1",
+    cache_state: str = "cold",
+    dataset_spec_version: str = "1",
+    is_warmup: bool = False,
+    status: str = "ok",
+    setup_s: float = 0.5,
+    wall_s: float | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": schema_version,
+        "scenario_id": scenario_id,
+        "metric_set": "core",
+        "metric_set_version": metric_set_version,
+        "axis_cell": "continuous_individual_panel",
+        "scale": {
+            "axis_cell": "continuous_individual_panel",
+            "n_factors": n_factors,
+            "n_dates": 250,
+            "n_assets": 100,
+        },
+        "run_idx": 0,
+        "is_warmup": is_warmup,
+        "cache_state": cache_state,
+        "status": status,
+        "error_message": None,
+        "started_at": "2026-05-17T00:00:00Z",
+        "wall_s": wall_s if wall_s is not None else setup_s + compute_s,
+        "setup_s": setup_s,
+        "compute_s": compute_s,
+        "cpu_s": compute_s,
+        "peak_rss_mb": peak_rss_mb,
+        "peak_alloc_mb": peak_rss_mb / 2,
+        "env": {
+            "git_sha": "deadbeef",
+            "factrix_version": "0.14.0",
+            "dataset_spec_version": dataset_spec_version,
+            "python": "3.13.0",
+            "numpy": "2.0.0",
+            "blas": "openblas",
+            "omp_threads": 1,
+            "cpu_model": "x86_64",
+            "cpu_cores": 1,
+            "ram_gb": 16.0,
+            "os": "linux",
+        },
+    }
+
+
+def _write_dir(path: Path, records: list[dict[str, object]]) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    by_scenario: dict[str, list[dict[str, object]]] = {}
+    for r in records:
+        by_scenario.setdefault(r["scenario_id"], []).append(r)  # type: ignore[index]
+    for scenario_id, rs in by_scenario.items():
+        (path / f"{scenario_id}.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rs) + "\n"
+        )
+    return path
+
+
+def test_happy_path_renders_ratio_table(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [
+            _record(scenario_id="S2", compute_s=2.0, peak_rss_mb=100.0),
+            _record(scenario_id="M-ic", compute_s=1.0, peak_rss_mb=80.0),
+        ],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [
+            _record(scenario_id="S2", compute_s=1.0, peak_rss_mb=110.0),
+            _record(scenario_id="M-ic", compute_s=0.5, peak_rss_mb=80.0),
+        ],
+    )
+    table = bench_diff.diff(before, after)
+    assert "| scenario_id | scale | compute_s_before" in table
+    assert "| M-ic |" in table
+    assert "0.500" in table  # M-ic ratio
+    assert "| S2 |" in table
+    assert "1.100" in table  # S2 peak_rss_mb ratio
+
+
+def test_warmup_and_failed_records_ignored(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [
+            _record(scenario_id="S2", compute_s=2.0, is_warmup=True),
+            _record(scenario_id="S2", compute_s=2.0),
+            _record(scenario_id="S3", compute_s=5.0, status="error"),
+            _record(scenario_id="S3", compute_s=5.0),
+        ],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [
+            _record(scenario_id="S2", compute_s=1.0),
+            _record(scenario_id="S3", compute_s=2.5),
+        ],
+    )
+    table = bench_diff.diff(before, after)
+    assert "S2" in table
+    assert "S3" in table
+
+
+def test_schema_version_mismatch_fails_loud(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [_record(scenario_id="S2", schema_version="1")],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [_record(scenario_id="S2", schema_version="2")],
+    )
+    with pytest.raises(SystemExit, match="compatibility mismatch"):
+        bench_diff.diff(before, after)
+
+
+def test_cache_state_mismatch_fails_loud(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [_record(scenario_id="S2", cache_state="cold")],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [_record(scenario_id="S2", cache_state="warm")],
+    )
+    with pytest.raises(SystemExit, match="cache_state"):
+        bench_diff.diff(before, after)
+
+
+def test_dataset_spec_version_mismatch_fails_loud(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [_record(scenario_id="S2", dataset_spec_version="1")],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [_record(scenario_id="S2", dataset_spec_version="2")],
+    )
+    with pytest.raises(SystemExit, match="dataset_spec_version"):
+        bench_diff.diff(before, after)
+
+
+def test_scenario_set_mismatch_fails_loud(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [
+            _record(scenario_id="S2"),
+            _record(scenario_id="S3"),
+        ],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [_record(scenario_id="S2")],
+    )
+    with pytest.raises(SystemExit, match="scenario set mismatch"):
+        bench_diff.diff(before, after)
+
+
+def test_multi_scale_scenarios_aligned_by_scale(tmp_path: Path) -> None:
+    """P1-style: same scenario_id, different n_factors → separate rows."""
+    before = _write_dir(
+        tmp_path / "before",
+        [
+            _record(scenario_id="P1", n_factors=10, compute_s=1.0),
+            _record(scenario_id="P1", n_factors=100, compute_s=10.0),
+        ],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [
+            _record(scenario_id="P1", n_factors=10, compute_s=0.5),
+            _record(scenario_id="P1", n_factors=100, compute_s=8.0),
+        ],
+    )
+    table = bench_diff.diff(before, after)
+    lines = [line for line in table.splitlines() if line.startswith("| P1 |")]
+    assert len(lines) == 2
+    assert "n_factors=10" in lines[0]
+    assert "n_factors=100" in lines[1]

--- a/tests/scripts/test_bench_diff.py
+++ b/tests/scripts/test_bench_diff.py
@@ -151,6 +151,36 @@ def test_cache_state_mismatch_fails_loud(tmp_path: Path) -> None:
         bench_diff.diff(before, after)
 
 
+def test_metric_set_version_mismatch_fails_loud(tmp_path: Path) -> None:
+    before = _write_dir(
+        tmp_path / "before",
+        [_record(scenario_id="S2", metric_set_version="1")],
+    )
+    after = _write_dir(
+        tmp_path / "after",
+        [_record(scenario_id="S2", metric_set_version="2")],
+    )
+    with pytest.raises(SystemExit, match="metric_set_version"):
+        bench_diff.diff(before, after)
+
+
+def test_axis_cell_mismatch_fails_loud(tmp_path: Path) -> None:
+    """Sparse vs continuous axis cells on the same scenario_id are incomparable."""
+    before = _write_dir(
+        tmp_path / "before",
+        [_record(scenario_id="S2")],
+    )
+    # Manually rewrite axis_cell on the after record (skip schema's
+    # nested scale validator — this is a fail-loud test fixture, the
+    # script's job is to refuse the comparison even if the input is
+    # inconsistent).
+    after_rec = _record(scenario_id="S2")
+    after_rec["axis_cell"] = "sparse_individual_panel"
+    after = _write_dir(tmp_path / "after", [after_rec])
+    with pytest.raises(SystemExit, match="axis_cell"):
+        bench_diff.diff(before, after)
+
+
 def test_dataset_spec_version_mismatch_fails_loud(tmp_path: Path) -> None:
     before = _write_dir(
         tmp_path / "before",


### PR DESCRIPTION
## Summary

- Add \`scripts/bench_diff.py\` (~135 lines) — reads two bench output dirs and prints a markdown ratio table to stdout
- Compatibility-gated on \`schema_version\` / \`metric_set_version\` / \`axis_cell\` / \`cache_state\` / \`env.dataset_spec_version\` — refuses to compare mismatched runs
- Scenario set mismatch fail-loud; multi-scale scenarios (P1) align per \`scale\`
- Adds 7 tests covering happy path, warmup/error-record filtering, three compatibility-mismatch cases, scenario-set mismatch, multi-scale alignment
- Adds \`bench/README.md\` "Ad-hoc ratio table" subsection under "Ratio reading" with usage example + "not a long-term CLI" discipline

## Example output

Running against the \`/tmp/bench-403-{before,after}\` dirs from #406:

\`\`\`
| scenario_id | scale | compute_s_before | compute_s_after | ratio | peak_rss_mb_ratio |
|---|---|---:|---:|---:|---:|
| M-corrado | n_events=19 | 0.023 | 0.020 | 0.852 | 0.968 |
| M-ic | n_factors=50 | 1.788 | 1.779 | 0.995 | 0.956 |
| S2 | n_factors=50 | 3.237 | 3.053 | 0.943 | 0.971 |
| S3 | n_factors=100 | 6.414 | 6.227 | 0.971 | 0.998 |
\`\`\`

## Test plan

- [x] \`pytest tests/\` — 1444 passed (+7 new)
- [x] \`pytest --doctest-modules factrix/\` — 73 passed
- [x] \`mypy factrix/\` — clean
- [x] \`ruff check factrix/ tests/ bench/ scripts/\` — clean
- [x] \`mkdocs build --strict\` — clean
- [x] Smoke run against real bench output (snippet above)

Closes #389