### PR TITLE
docs(bench): drop planning terms from baseline + preset docs

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -41,9 +41,9 @@ installed**. Run from the repo root so `bench` resolves on
 # run every scenario at the tiny preset (CI smoke)
 python -m bench --target tiny --output out/
 
-# baseline run (16 GB laptop) — cold-cache mode required for
-# reference baselines so OS page cache + numpy import state resets
-# between scenarios
+# reference baseline (small preset, cold-cache) — cold-cache mode
+# resets OS page cache + numpy import state between scenarios
+# (required so per-run timings stay comparable across reruns)
 python -m bench --target small --output out/baselines/v0.13.1/ --cold-cache
 
 # sparse-cell only
@@ -65,8 +65,8 @@ before invoking any `python -m bench.*` entry point.
 | `--target` | Preset | Scenarios |
 |---|---|---|
 | `tiny` | `tiny` | All scenarios listed below |
-| `small` | `small` | All scenarios — 16 GB laptop baseline |
-| `large` | `large` | All scenarios — 32 GB cloud, opt-in |
+| `small` | `small` | All scenarios — reference baseline preset |
+| `large` | `large` | All scenarios — opt-in, larger panel |
 | `event` | `small` | Sparse × Individual cell only |
 
 `--cold-cache` re-execs `python -m bench --run-one <id>` in a fresh
@@ -105,14 +105,15 @@ dimensions used by every scenario:
 | Preset | Cont: factors / assets / dates | Sparse: assets / dates / event_rate | Use |
 |---|---|---|---|
 | `tiny` | 8 / 20 / 60 | 20 / 60 / 0.05 | Tests + CI smoke; seconds-level |
-| `small` | 100 / 1000 / 1250 | 200 / 1250 / 0.0001 | 16 GB laptop baseline |
-| `large` | 500 / 1000 / 1250 | 500 / 1250 / 0.0002 | 32 GB cloud, opt-in |
-| `xlarge` | 1000 / 2000 / 2000 | 2000 / 2000 / 0.0002 | Cloud-only stress (UX validation) |
-| `user-realistic-high` | 500 / 3000 / 2500 | 3000 / 2500 / 0.0002 | Cloud-only (factor researcher upper bound) |
+| `small` | 100 / 1000 / 1250 | 200 / 1250 / 0.0001 | Reference baseline preset |
+| `large` | 500 / 1000 / 1250 | 500 / 1250 / 0.0002 | Opt-in, larger panel |
+| `xlarge` | 1000 / 2000 / 2000 | 2000 / 2000 / 0.0002 | Stress profile (UX validation) |
+| `user-realistic-high` | 500 / 3000 / 2500 | 3000 / 2500 / 0.0002 | Factor-researcher upper bound (UX validation) |
 
-`xlarge` and `user-realistic-high` will OOM a 32 GB laptop and are
-excluded from `make bench-bump` — they belong to the UX validation
-lane below, not to the reference baseline lane.
+`xlarge` and `user-realistic-high` exceed the reference-baseline RAM
+envelope (peak RSS pushes well past 32 GB) and are excluded from
+`make bench-bump` — they belong to the UX validation lane below,
+not to the reference baseline lane.
 
 Fixed-scale scenarios (`S2`=50 factors, `S3`=200, `M-*`=50 factors)
 override the preset's `n_factors` so the workload stays fixed
@@ -264,8 +265,8 @@ and event-clustering structure of real markets are not reproduced.
 
 ## Cross-machine rebaseline
 
-The primary baseline machine will eventually retire. The procedure
-that keeps history comparable:
+When the primary baseline machine retires, the procedure that keeps
+history comparable:
 
 1. **Anchor run** — on the **same `git_sha`**, run the `small`
    target cold-cache on both the outgoing machine and the incoming

--- a/bench/baselines/README.md
+++ b/bench/baselines/README.md
@@ -15,7 +15,7 @@ cross-machine rebaseline procedure.
 
 | Directory | factrix version | Commit SHA | Machine ID | CPU | RAM | `dataset_spec_version` | `metric_set_version` | `cache_state` | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| `v0.14.0-linux-x86_64-125g/` | 0.13.0 (pre-release pin) | `1dce8fb` | `linux-x86_64-125g` | x86_64 (8 phys / 16 logical) | 125.8 GB | 1 | 1 | cold | First reference baseline. Captured against `1dce8fb` (factrix 0.13.0) on a cloud runner ahead of the v0.14.0 release; the slug names the target version this baseline serves. `make bench-bump` rerun at v0.14.0 release time replaces these files with v0.14.0-versioned records. Not the eventual 16 GB-laptop primary — treat as cross-machine anchor candidate until a laptop baseline lands. |
+| `v0.14.0-linux-x86_64-125g/` | 0.13.0 (pre-release pin) | `1dce8fb` | `linux-x86_64-125g` | x86_64 (8 phys / 16 logical) | 125.8 GB | 1 | 1 | cold | Captured against `1dce8fb` (factrix 0.13.0) ahead of the v0.14.0 release; the slug names the target version this baseline serves. `make bench-bump` rerun at v0.14.0 release time overwrites these files with HEAD-versioned records — the captured `compute_s` shape reflects the commit it was pinned to (pre-batch-dispatch), not the current HEAD. |
 
 > The **JSONL `env` block** is the source of truth for any given
 > record's machine / version provenance. This index is a discovery

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -62,17 +62,17 @@ PRESETS: dict[str, ContinuousScale] = {
     # `tiny` is for tests and CI smoke — must complete in seconds on a
     # CI runner.
     "tiny": ContinuousScale(n_factors=8, n_assets=20, n_dates=60),
-    # `small` — 16 GB laptop baseline.
+    # `small` — reference baseline preset.
     "small": ContinuousScale(n_factors=100, n_assets=1000, n_dates=1250),
-    # `large` — 32 GB cloud baseline; opt-in.
+    # `large` — opt-in larger panel.
     "large": ContinuousScale(n_factors=500, n_assets=1000, n_dates=1250),
-    # `xlarge` — cloud-only stress preset for UX validation. Estimated
-    # peak RSS ≤ 100 GB on the 125 GB cloud host; will OOM a 32 GB
-    # laptop. Never used by `make bench-bump`.
+    # `xlarge` — stress preset for UX validation. Estimated peak RSS
+    # ≤ 100 GB; exceeds the reference-baseline envelope and is never
+    # used by `make bench-bump`.
     "xlarge": ContinuousScale(n_factors=1000, n_assets=2000, n_dates=2000),
     # `user-realistic-high` — upper end of a factor researcher's
     # real-world workflow (500 factors over a ~10-year window across
-    # the global liquid universe). Cloud-only.
+    # the global liquid universe). UX validation lane only.
     "user-realistic-high": ContinuousScale(n_factors=500, n_assets=3000, n_dates=2500),
 }
 


### PR DESCRIPTION
## Summary

Removes "16 GB laptop primary" / "until a laptop baseline lands" / "will eventually retire" planning terms from three bench-docs surfaces:

- `bench/baselines/README.md` — drops "Not the eventual 16 GB-laptop primary — treat as cross-machine anchor candidate until a laptop baseline lands" from the cloud baseline row; replaces with a factual note that the captured `compute_s` shape reflects the commit the baseline was pinned to (pre-batch-dispatch), not the current HEAD
- `bench/README.md` — Targets and Scale presets tables drop "16 GB laptop baseline" / "32 GB cloud, opt-in" / "Cloud-only..." labels in favour of role / envelope descriptions; "will eventually retire" softened to "When the primary baseline machine retires"
- `bench/scenarios/_helpers.py` — matching cleanup in the `PRESETS` dict comments

## Why

The "16 GB / 32 GB-laptop primary" framing was a planning aspiration about a future setup that may never land, baked into 6 active spots plus several merged PR / issue / commit bodies. Per the project no-forward-pointers convention, docs artifacts describe current state — roadmap belongs in the issue tracker.

The replacement labels describe what each preset IS for (role + envelope) without tying the project to a specific machine class. The factual note on the cloud baseline row (compute_s shape reflects pre-batch-dispatch commit, not HEAD) is useful for a different reason: a reader looking at the JSONL would otherwise reasonably assume the numbers reflect current code.

## Test plan

- [ ] `pytest tests/bench/` — green (78 passed); comments-only change in `_helpers.py`
- [ ] Visual review: `bench/README.md` Targets + Scale presets tables read cleanly without the machine-class labels