### PR TITLE
docs(guides): document run_metrics_chunked/iter recipe + chunk_size guidance (#414)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -160,7 +160,12 @@ for d in /tmp/A{1,2}-{xl,rh}; do python -m bench.ux_validate "$d"; done
 - Returns non-zero when any row fails its target (a *red flag*).
 - Records OOM / error / unknown-scenario rows as non-blocking
   incidents — OOM on a 1000-factor screen is real data, not a CI
-  failure.
+  failure. The recommended caller-side recipe for 1000-factor
+  workloads is documented in
+  [Efficient data loading for large panels](../docs/guides/efficient-loading.md)
+  (`run_metrics_chunked` + `scan_parquet`); the absolute RSS
+  numbers in `UX_TARGETS` are scenario thresholds, not user
+  guidance.
 
 Pair `--threads N` with `--cold-cache` whenever multi-thread effects
 actually matter: BLAS picks its thread count at numpy import time, so

--- a/docs/guides/efficient-loading.md
+++ b/docs/guides/efficient-loading.md
@@ -67,14 +67,14 @@ raw = adapt(
 )
 raw = raw.with_columns(my_factor_expr.alias("factor"))
 panel = compute_forward_return(raw, forward_periods=5)
-profile = fx.evaluate(panel, cfg)
+profile = fx.evaluate(panel, cfg)["factor"]
 ```
 
 **Already-canonical 4-column panel — explicit Arrow conversion**:
 
 ```python
 panel = pl.from_pandas(my_pandas_df)  # has date, asset_id, factor, forward_return
-profile = fx.evaluate(panel, cfg)
+profile = fx.evaluate(panel, cfg)["factor"]
 ```
 
 The conversion happens once at the seam between your data pipeline
@@ -118,7 +118,7 @@ panel = (
     .collect()                                   # 4. materialise the slice
 )
 
-profile = fx.evaluate(panel, cfg, factor_col="momentum_12_1")
+profile = fx.evaluate(panel, cfg, factor_cols=["momentum_12_1"])["momentum_12_1"]
 ```
 
 Why this works:
@@ -140,7 +140,7 @@ panel = (
     .select(required)
     .filter(pl.col("date").is_between(date(2020, 1, 1), date(2024, 12, 31)))
 )
-profile = fx.evaluate(panel, cfg, factor_col="momentum_12_1")  # collects inside
+profile = fx.evaluate(panel, cfg, factor_cols=["momentum_12_1"])["momentum_12_1"]  # collects inside
 ```
 
 Either form materialises the same in-memory frame.
@@ -174,9 +174,16 @@ batch-dispatch sharing. Pick by which axis matters for the call:
 
 | Variant | Return shape | First result lands after | Cross-factor sharing | Peak RSS bound |
 |---|---|---|---|---|
-| `run_metrics` (and `evaluate`) | `dict[factor_id, …]` | the whole batch finishes | IC stage-1 + batch-native primitives shared across **all** factors | full `factor_cols` panel + per-factor query intermediates |
+| `run_metrics` | `dict[factor_id, …]` | the whole batch finishes | IC stage-1 + batch-native primitives shared across **all** factors | full `factor_cols` panel + per-factor query intermediates |
 | `run_metrics_chunked` | iterator of `dict[factor_id, …]`, one entry per chunk | the first chunk finishes | shared **within** each chunk; recomputed per chunk | one `chunk_size`-wide slice at a time |
-| `run_metrics_iter` | iterator of `(factor_id, bundle)` pairs | one factor's per-factor metrics complete | shared across **all** factors before the first yield | full panel (no chunking) plus per-factor consumer pass |
+| `run_metrics_iter` | iterator of `(factor_id, bundle)` pairs | each factor finishes | shared across **all** factors before the first yield | full panel (no chunking); per-factor result released as soon as the caller consumes the yield |
+
+`evaluate` is the eager entry point for the `FactorProfile` shape and
+mirrors `run_metrics` at the boundary, but does **not** yet share
+IC stage-1 / batch primitives across factors — each factor is
+dispatched independently (`factrix/_evaluate.py`). Cross-factor
+sharing on the evaluate path is a tracked follow-up; once it lands,
+the chunked / iter siblings will extend the table above.
 
 Decision rule of thumb:
 
@@ -234,37 +241,31 @@ What this buys over a hand-rolled loop:
 
 ## Picking `chunk_size`
 
-`chunk_size=None` (default) is the right answer on most machines.
+`chunk_size=None` (default) is the right answer on most machines —
+the auto-sizer targets roughly a quarter of available RAM as the
+per-chunk peak, leaving slack for OS / BLAS / the downstream sink.
+
 Override when you have a reason: the sink batches at a different
-cadence, you are co-tenanting with another memory-hungry process, or
-you want deterministic chunk boundaries for testing.
+cadence, you are co-tenanting with another memory-hungry process,
+or you want deterministic chunk boundaries for testing.
 
-When sizing manually, the relationship the auto-sizer encodes is:
+When sizing manually, anchor on the observed reference:
 
-```
-peak_rss_per_chunk ≈ chunk_size × n_rows × 8 B × 4
-```
+| Preset (dims) | `chunk_size` | Observed peak RSS |
+|---|---:|---:|
+| `small` (1250 dates × 1000 assets) | 100 | ~3 GB |
 
-The `× 4` is empirical overhead factor — covers panel materialise plus
-the `_rank__<f>` intermediates `compute_ic` adds per factor. Tracks
-observed peak RSS within ±20% across the `small` / `large` benchmark
-presets (see [`bench/baselines/`](https://github.com/awwesomeman/factrix/tree/main/bench/baselines)).
+Peak scales roughly linearly in both `chunk_size` and panel rows
+(`n_dates × n_assets`). To pick a `chunk_size` for your panel:
 
-Reference: the `small` preset (cross-sectional, ~2500 dates ×
-500 assets) reaches roughly **3 GB peak RSS at `chunk_size=100`**
-(`n_rows × 8 × 4 × 100 ≈ 4 GB`, within the ±20% band). Linear in
-`chunk_size`, so:
+1. Take your RSS budget `B` (GB).
+2. Compute
+   `chunk_size ≈ 100 × (B / 3) × (1_250_000 / (n_dates × n_assets))`.
 
-| Budget (peak RSS) | Approx `chunk_size` on the `small` preset |
-|---:|---:|
-| 1 GB | 30 |
-| 4 GB | 100 |
-| 16 GB | 400 |
-| 32 GB | 800 |
-
-For your own panel, multiply by `small_n_rows / your_n_rows` — wider
-or longer panels need smaller chunks at the same RSS budget. The
-auto-sizer applies this proportionality directly.
+If you find yourself fighting the arithmetic, drop back to
+`chunk_size=None` and let the auto-sizer handle it. See
+[`bench/baselines/`](https://github.com/awwesomeman/factrix/tree/main/bench/baselines)
+for the JSONL these numbers come from.
 
 ## Streaming with `run_metrics_iter`
 
@@ -277,7 +278,7 @@ each factor's consumer pass finishes:
 ```python
 for fid, bundle in fx.run_metrics_iter(panel, cfg, factor_cols=cols):
     sink.write(fid, bundle.to_frame())
-    if bundle["ic"].headline_value > threshold:
+    if bundle["ic"].value > threshold:
         break
 ```
 

--- a/docs/guides/efficient-loading.md
+++ b/docs/guides/efficient-loading.md
@@ -164,33 +164,133 @@ panel = (
 `pl.DataFrame`; `adapt(pd.DataFrame)` returns `pl.DataFrame` (pandas
 has no lazy equivalent).
 
-## Batching across factors
+## Choosing an entry point
 
 For a 1000-factor sweep, even with projection the union of all factor
-columns is too wide to hold simultaneously. Load and evaluate one
-batch of factors at a time:
+columns is too wide to hold simultaneously. factrix exposes three
+entry points; pick by factor count, available RAM, and whether you
+need each factor's result the moment it is ready:
+
+| Entry point | Use when | Peak RSS bound |
+|---|---|---|
+| `run_metrics` (or `evaluate`) | All factors fit comfortably (~one batch of `chunk_size` factors at panel-width) | full `factor_cols` panel + per-factor query intermediates |
+| `run_metrics_chunked` | Factor count or panel width would OOM at full breadth | one `chunk_size`-wide slice at a time |
+| `run_metrics_iter` | Streaming-flow ergonomic: write to a sink / update progress / break early without paying the full-batch latency | full panel (no chunking) but per-factor consumer pass |
+
+Decision rule of thumb:
+
+- `n_factors × panel_height × 8 B × ~4` (per-factor overhead) fits in
+  ~25% of available RAM → `run_metrics` directly.
+- Otherwise → `run_metrics_chunked` (auto-sizes `chunk_size` against
+  `psutil.virtual_memory().available` when left as `None`).
+- Need first-factor latency / live sink writes → `run_metrics_iter`
+  (no chunk boundary, but full-batch RSS — combine with
+  `run_metrics_chunked` if you also need the memory bound).
+
+## Recipe: `scan_parquet` + `run_metrics_chunked` + streaming sink
+
+The canonical pattern for a 1000-factor screen on a single machine:
 
 ```python
-from itertools import batched
+import polars as pl
+import factrix as fx
 
-all_factors = ["mom_1", "mom_3", "mom_6", ..., "value_1", "value_3"]
-results = []
+all_factors = [f"alpha_{i}" for i in range(1000)]
 
-for batch in batched(all_factors, 50):
-    panel = (
-        pl.scan_parquet("factors.parquet")
-        .select(["date", "asset_id", "forward_return", *batch])
-        .filter(pl.col("date").is_between(date(2020, 1, 1), date(2024, 12, 31)))
-        .collect()
-    )
-    for col in batch:
-        results.append(fx.evaluate(panel, cfg, factor_col=col))
-    del panel   # release the thin panel before the next batch
+lazy_panel = (
+    pl.scan_parquet("factors.parquet")
+    .select(["date", "asset_id", "forward_return", *all_factors])
+)
+
+with sink.open("metrics.parquet") as out:
+    for bundles in fx.run_metrics_chunked(
+        lazy_panel, cfg, factor_cols=all_factors,
+    ):
+        for fid, bundle in bundles.items():
+            out.write(fid, bundle.to_frame())
 ```
 
-Peak RSS is bounded by the **batch panel size**, not the full universe.
-For the 1000-factor example above, a batch of 50 keeps peak load to
-roughly `50 / 1000` of the naïve scenario.
+What this buys over a hand-rolled loop:
+
+- **Projection pushdown per chunk**: passing the `LazyFrame` lets
+  `run_metrics_chunked` call `panel.select([base_cols + chunk]).collect()`
+  on each iteration, so only the chunk's factor columns leave disk
+  even though the lazy plan names all 1000.
+- **`chunk_size=None` auto-sizes** against
+  `psutil.virtual_memory().available` (requires `psutil`; install via
+  `pip install psutil` or `pip install 'factrix[bench]'`). Override
+  with an explicit integer when the downstream sink has its own
+  batching cadence.
+- **Base columns and `base_cols` defaults are wired in** (`date`,
+  `asset_id`, `forward_return`) — no per-call risk of dropping the
+  forward-return column from the projection list. Override `base_cols`
+  only when a metric needs an extra column (e.g. `weight_col` for
+  `quantile_spread_vw`).
+
+## Picking `chunk_size`
+
+`chunk_size=None` (default) is the right answer on most machines.
+Override when you have a reason: the sink batches at a different
+cadence, you are co-tenanting with another memory-hungry process, or
+you want deterministic chunk boundaries for testing.
+
+When sizing manually, the relationship the auto-sizer encodes is:
+
+```
+peak_rss_per_chunk ≈ chunk_size × n_rows × 8 B × 4
+```
+
+The `× 4` is empirical overhead factor — covers panel materialise plus
+the `_rank__<f>` intermediates `compute_ic` adds per factor. Tracks
+observed peak RSS within ±20% across the `small` / `large` benchmark
+presets (see [`bench/baselines/`](https://github.com/awwesomeman/factrix/tree/main/bench/baselines)).
+
+Reference: the `small` preset (cross-sectional, ~2500 dates ×
+500 assets) reaches roughly **3 GB peak RSS at `chunk_size=100`**
+(`n_rows × 8 × 4 × 100 ≈ 4 GB`, within the ±20% band). Linear in
+`chunk_size`, so:
+
+| Budget (peak RSS) | Approx `chunk_size` on the `small` preset |
+|---:|---:|
+| 1 GB | 30 |
+| 4 GB | 100 |
+| 16 GB | 400 |
+| 32 GB | 800 |
+
+For your own panel, multiply by `small_n_rows / your_n_rows` — wider
+or longer panels need smaller chunks at the same RSS budget. The
+auto-sizer applies this proportionality directly.
+
+## Streaming with `run_metrics_iter`
+
+When the friction is **per-factor latency** rather than peak RSS —
+you want to write each factor's bundle the moment it lands, drive a
+progress bar, or short-circuit on the first factor that meets a
+threshold — `run_metrics_iter` yields `(factor_id, bundle)` pairs as
+each factor's consumer pass finishes:
+
+```python
+for fid, bundle in fx.run_metrics_iter(panel, cfg, factor_cols=cols):
+    sink.write(fid, bundle.to_frame())
+    if bundle["ic"].headline_value > threshold:
+        break
+```
+
+Cross-factor work (IC stage-1, batch-native primitives) is still
+amortised once before the first yield. The trade-off is full-batch
+RSS — no chunking. Combine with `run_metrics_chunked` when you need
+both bounds:
+
+```python
+for bundles in fx.run_metrics_chunked(lazy_panel, cfg, factor_cols=all_factors):
+    for fid, bundle in bundles.items():     # already in-order within chunk
+        sink.write(fid, bundle.to_frame())
+```
+
+The chunked path's inner `dict` is already insertion-ordered by
+`factor_cols`, so iterating its items inside the outer loop gives the
+same per-factor streaming shape as `run_metrics_iter`, with the
+chunk-level RSS bound layered on top.
 
 ## What stays out of scope
 

--- a/docs/guides/efficient-loading.md
+++ b/docs/guides/efficient-loading.md
@@ -5,8 +5,9 @@ title: Efficient data loading for large panels
 When a factor exploration sweep reaches the 100–1000+ factor scale,
 the **data loading step** — not factrix's compute path — is usually
 what runs the machine out of memory. This guide shows the recipes
-that keep peak RSS bounded, and explains the contract `evaluate()` /
-`run_metrics()` follow at the API boundary.
+that keep peak RSS (Resident Set Size — the physical memory the
+process currently holds) bounded, and explains the contract
+`evaluate()` / `run_metrics()` follow at the API boundary.
 
 For the column contract itself, see
 [Panel schema](../api/panel-schema.md); for the reshape steps that
@@ -164,18 +165,18 @@ panel = (
 `pl.DataFrame`; `adapt(pd.DataFrame)` returns `pl.DataFrame` (pandas
 has no lazy equivalent).
 
-## Choosing an entry point
+## API variants: choosing an entry point
 
-For a 1000-factor sweep, even with projection the union of all factor
-columns is too wide to hold simultaneously. factrix exposes three
-entry points; pick by factor count, available RAM, and whether you
-need each factor's result the moment it is ready:
+`run_metrics` is the eager entry point; `run_metrics_chunked` and
+`run_metrics_iter` are variants that trade a different axis (peak
+RSS, first-result latency) at the cost of giving up part of the
+batch-dispatch sharing. Pick by which axis matters for the call:
 
-| Entry point | Use when | Peak RSS bound |
-|---|---|---|
-| `run_metrics` (or `evaluate`) | All factors fit comfortably (~one batch of `chunk_size` factors at panel-width) | full `factor_cols` panel + per-factor query intermediates |
-| `run_metrics_chunked` | Factor count or panel width would OOM at full breadth | one `chunk_size`-wide slice at a time |
-| `run_metrics_iter` | Streaming-flow ergonomic: write to a sink / update progress / break early without paying the full-batch latency | full panel (no chunking) but per-factor consumer pass |
+| Variant | Return shape | First result lands after | Cross-factor sharing | Peak RSS bound |
+|---|---|---|---|---|
+| `run_metrics` (and `evaluate`) | `dict[factor_id, …]` | the whole batch finishes | IC stage-1 + batch-native primitives shared across **all** factors | full `factor_cols` panel + per-factor query intermediates |
+| `run_metrics_chunked` | iterator of `dict[factor_id, …]`, one entry per chunk | the first chunk finishes | shared **within** each chunk; recomputed per chunk | one `chunk_size`-wide slice at a time |
+| `run_metrics_iter` | iterator of `(factor_id, bundle)` pairs | one factor's per-factor metrics complete | shared across **all** factors before the first yield | full panel (no chunking) plus per-factor consumer pass |
 
 Decision rule of thumb:
 
@@ -186,6 +187,10 @@ Decision rule of thumb:
 - Need first-factor latency / live sink writes → `run_metrics_iter`
   (no chunk boundary, but full-batch RSS — combine with
   `run_metrics_chunked` if you also need the memory bound).
+
+The same eager / chunked / iter shape is expected to appear on the
+`evaluate` family as its own variants land; when they do, they
+extend this table as additional rows under each variant.
 
 ## Recipe: `scan_parquet` + `run_metrics_chunked` + streaming sink
 

--- a/factrix/_run_metrics.py
+++ b/factrix/_run_metrics.py
@@ -636,6 +636,10 @@ def run_metrics_iter(
     letting callers write to a sink / update a progress bar / break
     early without paying the full-batch latency.
 
+    See :doc:`/guides/efficient-loading` for the streaming-sink
+    recipe and the chunked + iter combination for both RSS and
+    per-factor latency bounds.
+
     :func:`run_metrics` is now a one-line wrapper —
     ``dict(run_metrics_iter(...))`` — so eager and streaming paths
     share the same dispatcher and ``factor_cols`` / ``metrics``
@@ -922,6 +926,10 @@ def run_metrics_chunked(
     bounded by the chunk size rather than ``len(factor_cols)`` — so a
     1000-factor screen that would otherwise exceed RAM can stream
     through a fixed working-set budget.
+
+    See :doc:`/guides/efficient-loading` for the canonical
+    ``scan_parquet`` + ``run_metrics_chunked`` + streaming-sink
+    recipe and ``chunk_size`` selection guidance.
 
     Within a chunk the full batch-dispatch path runs unchanged: IC
     stage-1 is shared across the chunk's factors, batch-native


### PR DESCRIPTION
## Summary

- Extend `docs/guides/efficient-loading.md` with an entry-point decision table (`run_metrics` / `run_metrics_chunked` / `run_metrics_iter`), the canonical `scan_parquet` + `run_metrics_chunked` + streaming-sink recipe, the `chunk_size` sizing formula the auto-sizer encodes (with a `small`-preset reference table), and a `run_metrics_iter` section covering latency-vs-RSS trade-off plus the chunked-plus-iter combination.
- Add reverse `:doc:` cross-links from `run_metrics_chunked` and `run_metrics_iter` docstrings to the guide (`evaluate` / `run_metrics` already linked).
- Point `bench/README.md`'s 1000-factor incident note at the guide so absolute `UX_TARGETS` numbers are not mistaken for user guidance.

The previous version of the guide (landed via #399) predated the chunked / iter APIs (#417 / #419) and left each caller to hand-roll the factor-batching loop.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] `pytest --doctest-modules factrix/_run_metrics.py` clean
- [x] pre-push hooks (mkdocs strict + mypy) pass
- [ ] Reviewer: render the guide and sanity-check decision table + chunk_size formula readability

Closes #414