### PR TITLE
refactor(metrics): typed MetricSpec SSOT (#424)

### DIFF
--- a/docs/reference/_generated_metric_matrix.md
+++ b/docs/reference/_generated_metric_matrix.md
@@ -1,21 +1,21 @@
 | Module | Cell scope | Aggregation order | Inference SE |
 |---|---|---|---|
 | [`metrics.caar`][factrix.metrics.caar] | `(*, SPARSE, *, PANEL)` | per-event | non-overlapping t / z |
-| [`metrics.clustering`][factrix.metrics.clustering] | `(*, SPARSE, *, PANEL)` | static-cs | no formal H₀ |
-| [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) |
+| [`metrics.clustering`][factrix.metrics.clustering] | `(*, SPARSE, *, PANEL)` | static-cs | no formal H_0 |
+| [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | across-time t (one-sided H_0: ratio >= 0.5) |
 | [`metrics.corrado`][factrix.metrics.corrado] | `(*, SPARSE, *, PANEL)` | per-event | nonparametric rank |
 | [`metrics.event_horizon`][factrix.metrics.event_horizon] | `(*, SPARSE, *, PANEL)` | per-event | binomial |
 | [`metrics.event_quality`][factrix.metrics.event_quality] | `(*, SPARSE, *, PANEL)` | per-event | binomial / nonparametric rank |
 | [`metrics.fama_macbeth`][factrix.metrics.fama_macbeth] | `(INDIVIDUAL, CONTINUOUS, FM, PANEL)` | cs-first | NW HAC / clustered t |
 | [`metrics.hit_rate`][factrix.metrics.hit_rate] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | binomial |
 | [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, CONTINUOUS, IC, PANEL)` | cs-first | NW HAC / cross-asset t |
-| [`metrics.mfe_mae`][factrix.metrics.mfe_mae] | `(*, SPARSE, *, PANEL)` | per-event | no formal H₀ |
+| [`metrics.mfe_mae`][factrix.metrics.mfe_mae] | `(*, SPARSE, *, PANEL)` | per-event | no formal H_0 |
 | [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
-| [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | no formal H₀ |
+| [`metrics.oos`][factrix.metrics.oos] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | no formal H_0 |
 | [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | cross-asset t |
 | [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | ts-only | NW HAC / OLS t |
-| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | no formal H₀ |
-| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ |
+| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | cs-first | no formal H_0 |
+| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, CONTINUOUS, *, PANEL)` | ts-only (rank autocorrelation across consecutive dates) | no formal H_0 |
 | [`metrics.trend`][factrix.metrics.trend] | `(*, CONTINUOUS, *, TIMESERIES)` | ts-only | Theil-Sen rank-based CI |
 | [`metrics.ts_asymmetry`][factrix.metrics.ts_asymmetry] | `(COMMON, CONTINUOUS, *, PANEL)` | cs-first | NW HAC Wald |
 | [`metrics.ts_beta`][factrix.metrics.ts_beta] | `(COMMON, CONTINUOUS, *, PANEL)` | ts-first | cross-asset t |

--- a/factrix/_describe.py
+++ b/factrix/_describe.py
@@ -512,8 +512,8 @@ def list_metrics(
 
     Mode is intentionally not an input — applicability does not change
     across PANEL / TIMESERIES (per ``docs/reference/metric-applicability.md``).
-    Source of truth is the ``Matrix-row:`` tag in each metric module's
-    docstring, parsed by :mod:`factrix._metric_index`.
+    Source of truth is the module-level ``__metric_specs__`` tuple in
+    each metric module, loaded by :mod:`factrix._metric_index`.
 
     Args:
         scope: Cell axis to filter on (``FactorScope.INDIVIDUAL`` or

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -1,39 +1,41 @@
-"""Shared parser for ``__matrix_rows__`` tuples in ``factrix/metrics/*.py``.
+"""Typed metric-spec SSOT for ``factrix/metrics/*.py`` modules.
 
-Single source of truth for "which standalone metrics live in which
-cell." Consumed by:
+Each public metric module declares a module-level ``__metric_specs__``
+tuple of :class:`MetricSpec` dataclasses, one entry per public callable.
+This is the single source of truth for "which standalone metrics live
+in which cell" and drives:
 
-- ``scripts/mkdocs_hooks/gen_metric_matrix.py`` — renders the docs
-  matrix in ``docs/reference/_generated_metric_matrix.md``.
-- ``factrix.list_metrics`` — runtime API exposing the same data.
+- :func:`factrix.list_metrics` — runtime metric discovery API
+- ``scripts/mkdocs_hooks/gen_metric_matrix.py`` — docs matrix table
+- ``scripts/mkdocs_hooks/gen_metric_name_index.py`` — docs name index
+- ``scripts/mkdocs_hooks/gen_evaluate_metric_table.py`` — dispatch table
+- ``tests/test_docs_matrix.py`` — coverage + invariant tests
 
-Each metric module declares a module-level ``__matrix_rows__`` tuple
-of strings, one entry per row, each with the format::
+Why typed: IDE completion, mypy-checkable axes, refactor-safe field
+access. Adding a new metric module just imports :class:`MetricSpec` and
+:func:`cell` and declares::
 
-    {public_functions} | {cell_scope} | {agg_order} | {inference_se} | {primitives}
+    __metric_specs__ = (
+        MetricSpec(
+            name="my_metric",
+            cell=cell(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, mode=Mode.PANEL),
+            family="cs-first",
+            inference="NW HAC / cross-asset t",
+            primitives=("_calc_t_stat", "_p_value_from_t"),
+        ),
+    )
 
-``public_functions`` is a comma-separated list. ``cell_scope`` is
-either a 4-tuple ``(scope, signal, metric, mode)`` (``*`` denotes
-wildcard) or — uniquely for ``factrix.metrics.spanning`` — the
-literal label ``factor-return-series consumer (post-PANEL pipeline)``,
-which is mapped to ``(INDIVIDUAL, CONTINUOUS, *, *)`` since spanning
-metrics consume the spread series produced by the Individual ×
-Continuous pipeline.
-
-Stage-1 aggregation helpers that produce intermediate panels / series
-(rather than a ``MetricOutput``) are filtered out by ``user_facing``
-rows — they are listed in ``__matrix_rows__`` for primitive-graph
-completeness but are not metrics a user would call directly. The
-exclusion set is explicit (not a ``compute_*`` prefix rule) because
-``compute_rolling_mean_beta`` is a genuine user-facing metric.
+Per-spec ``is_stage1`` / ``input_kind`` / ``emitted_name`` flags replace
+the legacy module-level side tables (``_STAGE1_HELPERS`` /
+``_SCALAR_INPUT_METRICS`` / ``_EMITTED_NAME_OVERRIDES``) so the per-
+metric properties travel with the spec that declares them.
 """
 
 from __future__ import annotations
 
-import ast
 import functools
+import importlib
 import pathlib
-import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -42,49 +44,22 @@ from factrix._axis import FactorScope, Metric, Mode, Signal
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 _METRICS_DIR = _REPO_ROOT / "factrix" / "metrics"
 
-_TUPLE_RE = re.compile(r"^\((.*)\)$")
-
-_SPANNING_CELL_LABEL = "factor-return-series consumer (post-PANEL pipeline)"
-
-# Stage-1 helpers: produce intermediate panels / series consumed by the
-# user-facing metric in the same module. Listed in ``Matrix-row:`` for
-# primitive-graph completeness; excluded from ``user_facing`` rows.
-_STAGE1_HELPERS: frozenset[str] = frozenset(
-    {
-        "compute_caar",
-        "compute_event_returns",
-        "compute_fm_betas",
-        "compute_group_returns",
-        "compute_ic",
-        "compute_mfe_mae",
-        "compute_spread_series",
-        "compute_ts_betas",
-        # Single-asset fallback wired into the dispatch registry, not a
-        # standalone callable (``ts_beta`` itself dispatches to it).
-        "ts_beta_single_asset_fallback",
-    }
-)
-
-# Scalar-input metrics: pre-aggregated-scalar utilities that consume
-# scalars (``gross_spread: float``, ``turnover: float``, ...) rather
-# than the standard ``(date-keyed DataFrame, **kwargs) -> MetricOutput``
-# panel contract. Not eligible for date-slicing dispatchers like
-# ``by_slice``. Hard-coded exception set rather than a Matrix-row tag
-# extension — the population is small and stable; YAGNI applies until
-# it isn't.
-_SCALAR_INPUT_METRICS: frozenset[str] = frozenset({"breakeven_cost", "net_spread"})
+# Canonical reverse-index URL convention for ``MetricRow.docs_anchor``
+# (#125): docs-root-relative path + mkdocstrings symbol fragment.
+# Centralised here so a future docs URL change touches one literal —
+# external prose in ``factrix._describe.list_metrics`` and
+# ``docs/api/metric-output.md`` cite this constant by name rather
+# than restating the string.
+DOCS_ANCHOR_FMT: str = "api/metrics/{module}.md#factrix.metrics.{module}.{name}"
 
 # Metrics that ``run_metrics`` cannot auto-discover even though their
-# Matrix-row is user-facing. Each entry carries a short reason rendered
-# into ``MetricsBundle.skipped`` and into the ``UserInputError`` raised
-# when a caller names one explicitly via ``metrics=[...]``. v2 may
-# promote this to a Matrix-row tag once the population is stable.
+# spec is user-facing. Each entry carries a short reason rendered into
+# ``MetricsBundle.skipped`` and into the ``UserInputError`` raised when
+# a caller names one explicitly via ``metrics=[...]``. Stays as a side
+# table — these reasons describe cross-cutting dispatcher-wiring gaps
+# (stage-2 frame the runner cannot synthesise, series-input shape, etc.),
+# not properties intrinsic to a single metric.
 _AUTO_DISCOVER_EXCLUDED: dict[str, str] = {
-    # Stage-1 consumers without v1 dispatch wiring. These metrics are
-    # callable directly from ``factrix.metrics`` once the caller has the
-    # stage-1 frame; v1 ``run_metrics`` does not yet thread that wiring.
-    # Tracked as v1.x follow-up; not blocking the IC-cell stage-1 pattern
-    # validated in v1.
     "caar": (
         "consumes caar_df; call factrix.metrics.compute_event_returns + "
         "compute_caar then caar(caar_df) directly"
@@ -113,23 +88,19 @@ _AUTO_DISCOVER_EXCLUDED: dict[str, str] = {
         "consumes mfe_mae_df; call factrix.metrics.compute_mfe_mae then "
         "mfe_mae_summary(mfe_mae_df) directly"
     ),
-    # Series-input diagnostics — operate on a (date, value) series, not
-    # a panel. Compose explicitly with compute_ic / compute_spread_series.
     "hit_rate": (
         "consumes a (date, value) series; e.g. "
-        "hit_rate(compute_ic(panel)['factor'].rename({'ic': 'value'}))"
+        "hit_rate(compute_ic(panel).rename({'ic': 'value'}))"
     ),
     "multi_split_oos_decay": (
         "consumes a (date, value) series; e.g. "
-        "multi_split_oos_decay(compute_spread_series(panel)['factor']"
+        "multi_split_oos_decay(compute_spread_series(panel)"
         ".rename({'spread': 'value'}))"
     ),
     "ic_trend": (
         "consumes a (date, value) series; e.g. "
-        "ic_trend(compute_ic(panel)['factor'].rename({'ic': 'value'}))"
+        "ic_trend(compute_ic(panel).rename({'ic': 'value'}))"
     ),
-    # Multi-factor spread inputs — require a list/dict of factor spreads,
-    # not a single panel.
     "spanning_alpha": (
         "consumes factor_spread; call after compute_spread_series on the "
         "challenger factor"
@@ -140,27 +111,10 @@ _AUTO_DISCOVER_EXCLUDED: dict[str, str] = {
     ),
 }
 
-# Function name → emitted ``MetricOutput.name`` literal, where the two
-# diverge. Most metrics emit ``name=<function_name>``; the entries here
-# are the historical exceptions and the source of truth for the
-# ``MetricOutput.name`` reverse index (#125). Audit against
-# ``factrix/metrics/*.py``: every ``MetricOutput(name="X")`` literal in
-# a registered metric must either match the function name or appear here.
-_EMITTED_NAME_OVERRIDES: dict[str, str] = {
-    "clustering_diagnostic": "clustering_hhi",
-    "corrado_rank_test": "corrado_rank",
-    "fama_macbeth": "fm_beta",
-    "multi_split_oos_decay": "oos_decay",
-    "pooled_ols": "pooled_beta",
-}
 
-# Canonical reverse-index URL convention for ``MetricRow.docs_anchor``
-# (#125): docs-root-relative path + mkdocstrings symbol fragment.
-# Centralised here so a future docs URL change touches one literal —
-# external prose in ``factrix._describe.list_metrics`` and
-# ``docs/api/metric-output.md`` cite this constant by name rather
-# than restating the string.
-DOCS_ANCHOR_FMT: str = "api/metrics/{module}.md#factrix.metrics.{module}.{name}"
+# ---------------------------------------------------------------------------
+# Cell + Spec dataclasses
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,10 +122,10 @@ class Cell:
     """Parsed ``(scope, signal, metric, mode)`` cell tuple.
 
     ``None`` represents the ``*`` wildcard along an axis. ``raw``
-    preserves the original string for matrix rendering. ``metric`` and
-    ``mode`` are parsed for completeness — :meth:`matches` only filters
-    on ``scope`` / ``signal`` (the public ``list_metrics`` axes); the
-    matrix renderer reads ``raw`` directly.
+    preserves the canonical display label rendered into the docs
+    matrix. :meth:`matches` only filters on ``scope`` / ``signal`` (the
+    public :func:`factrix.list_metrics` axes); the matrix renderer reads
+    ``raw`` directly.
     """
 
     scope: FactorScope | None
@@ -187,36 +141,101 @@ class Cell:
         )
 
 
-@dataclass(frozen=True, slots=True)
-class _MatrixEntry:
-    """One ``Matrix-row:`` tag, un-exploded — drives matrix rendering."""
+def _axis_token(value: FactorScope | Signal | Metric | Mode | None) -> str:
+    """Render an axis enum (or ``None`` = wildcard) as its uppercase token."""
+    if value is None:
+        return "*"
+    return value.value.upper()
 
-    module: str
-    names: tuple[str, ...]
+
+def cell(
+    scope: FactorScope | None,
+    signal: Signal | None,
+    metric: Metric | None = None,
+    mode: Mode | None = None,
+    *,
+    raw: str | None = None,
+) -> Cell:
+    """Build a :class:`Cell` with an auto-rendered uppercase ``raw`` label.
+
+    Pass ``raw=`` explicitly only when the prose label carries
+    information not encoded in the axis tuple — the only current case
+    is ``factrix.metrics.spanning`` whose metrics consume a
+    post-pipeline factor-return series.
+    """
+    if raw is None:
+        raw = (
+            f"({_axis_token(scope)}, {_axis_token(signal)}, "
+            f"{_axis_token(metric)}, {_axis_token(mode)})"
+        )
+    return Cell(scope=scope, signal=signal, metric=metric, mode=mode, raw=raw)
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSpec:
+    """Per-callable typed spec declared via module-level ``__metric_specs__``.
+
+    One :class:`MetricSpec` per public callable in the declaring
+    ``factrix/metrics/*.py`` module.
+
+    Fields:
+
+    - ``name``: function name in the declaring module.
+    - ``cell``: applicable ``(scope, signal, metric, mode)`` cell;
+      ``None`` along any axis denotes ``*`` wildcard.
+    - ``family``: aggregation / inference family label —
+      ``"cs-first"`` (cross-section step then time aggregation),
+      ``"per-event"``, ``"ts-only"``, ``"ts-first"``, ``"static-cs"``,
+      or free-form prose for special cases (e.g. spanning's
+      ``"factor-return-series consumer (post-PANEL pipeline)"``).
+    - ``inference``: inference / standard-error family — e.g.
+      ``"NW HAC / cross-asset t"``, ``"binomial"``,
+      ``"nonparametric rank"``, ``"no formal H_0"``.
+    - ``primitives``: informational tuple of underlying helper-function
+      names the public callable composes. Surfaces in the docs matrix
+      for primitive-graph completeness.
+    - ``input_kind``: ``"panel"`` (date-keyed DataFrame, eligible for
+      date-slicing dispatchers like :func:`factrix.by_slice`) or
+      ``"scalar"`` (pre-aggregated-scalar utility like
+      :func:`factrix.metrics.breakeven_cost`).
+    - ``is_stage1``: ``True`` for intermediate-frame producers
+      (typically ``compute_*``) that are user-callable but do not
+      themselves return ``MetricOutput``. Excluded from
+      :func:`user_facing_rows`.
+    - ``emitted_name``: literal ``MetricOutput.name`` string at
+      runtime. ``None`` (default) means the runtime label matches
+      ``name`` — the common case. Set explicitly when the callable
+      emits a different label (e.g. ``fama_macbeth`` emits
+      ``fm_beta``). Consumers holding a :class:`~factrix.MetricOutput`
+      should resolve via :attr:`MetricRow.emitted_name`.
+    """
+
+    name: str
     cell: Cell
-    agg_order: str
-    inference_se: str
+    family: str
+    inference: str
+    primitives: tuple[str, ...] = ()
+    input_kind: Literal["panel", "scalar"] = "panel"
+    is_stage1: bool = False
+    emitted_name: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class MetricRow:
-    """One ``(metric_name, module, cell)`` triple parsed from ``Matrix-row:``.
+    """User-facing view of one :class:`MetricSpec` plus derived metadata.
 
-    ``import_path`` is the fully-qualified submodule (``factrix.metrics.<module>``)
-    — every public metric is also re-exported from ``factrix.metrics``,
-    so ``from factrix.metrics import <name>`` works regardless. ``input_kind``
-    distinguishes the standard date-keyed-DataFrame contract (``"panel"``)
-    from pre-aggregated-scalar utilities (``"scalar"``); only ``"panel"``
-    metrics are eligible for date-slicing dispatchers like ``by_slice``.
-    ``docs_anchor`` is the docs-root-relative path + mkdocstrings symbol
-    anchor (``api/metrics/<module>.md#factrix.metrics.<module>.<name>``),
-    so a consumer holding the function name can resolve the API page
-    without scraping module conventions. ``emitted_name`` is the literal
-    string the metric writes into ``MetricOutput.name`` at runtime; for
-    most metrics this matches ``name``, but a small set of historical
-    exceptions (e.g. ``fama_macbeth`` → ``fm_beta``) emit a different
-    label. Consumers holding a ``MetricOutput`` value should look up
-    by ``emitted_name``.
+    Augments the declaring-module spec with ``import_path`` (every
+    public metric is also re-exported from ``factrix.metrics``),
+    ``docs_anchor`` (docs-root-relative path + mkdocstrings symbol
+    fragment per :data:`DOCS_ANCHOR_FMT`), and the resolved
+    ``emitted_name`` (falls back to ``name`` when the spec leaves it
+    ``None``).
+
+    ``agg_order`` and ``inference_se`` are aliases for the spec's
+    ``family`` / ``inference`` fields — preserved under their original
+    names so docs-hook and test-suite consumers do not have to change
+    field references when the source-of-truth migrates from string
+    parsing to typed spec.
     """
 
     name: str
@@ -230,153 +249,98 @@ class MetricRow:
     emitted_name: str
 
 
-def _parse_axis(token: str, enum_cls: type) -> object | None:
-    """Map a Matrix-row axis token (``*`` or enum value) to enum or None."""
-    token = token.strip()
-    if token == "*":
-        return None
-    try:
-        return enum_cls(token.lower())
-    except ValueError as exc:
-        raise ValueError(
-            f"unknown {enum_cls.__name__} token {token!r} in Matrix-row cell"
-        ) from exc
+# ---------------------------------------------------------------------------
+# Loader + caches
+# ---------------------------------------------------------------------------
 
 
-def _parse_cell(raw: str) -> Cell:
-    raw = raw.strip()
-    if raw == _SPANNING_CELL_LABEL:
-        return Cell(
-            scope=FactorScope.INDIVIDUAL,
-            signal=Signal.CONTINUOUS,
-            metric=None,
-            mode=None,
-            raw=raw,
-        )
-    m = _TUPLE_RE.match(raw)
-    if not m:
-        raise ValueError(f"unparseable Matrix-row cell: {raw!r}")
-    parts = [p.strip() for p in m.group(1).split(",")]
-    if len(parts) != 4:
-        raise ValueError(
-            f"Matrix-row cell tuple has {len(parts)} fields (expected 4): {raw!r}"
-        )
-    return Cell(
-        scope=_parse_axis(parts[0], FactorScope),  # type: ignore[arg-type]
-        signal=_parse_axis(parts[1], Signal),  # type: ignore[arg-type]
-        metric=_parse_axis(parts[2], Metric),  # type: ignore[arg-type]
-        mode=_parse_axis(parts[3], Mode),  # type: ignore[arg-type]
-        raw=raw,
+def _public_metric_stems() -> list[str]:
+    """Return sorted stems of every public ``factrix/metrics/*.py``."""
+    return sorted(
+        p.stem for p in _METRICS_DIR.glob("*.py") if not p.stem.startswith("_")
     )
 
 
-def _public_metric_modules() -> list[pathlib.Path]:
-    return sorted(p for p in _METRICS_DIR.glob("*.py") if not p.stem.startswith("_"))
+def _load_module_specs(stem: str) -> tuple[MetricSpec, ...]:
+    """Import ``factrix.metrics.<stem>`` and return its ``__metric_specs__``.
 
-
-def _extract_matrix_rows(path: pathlib.Path) -> list[str]:
-    """Return the module-level ``__matrix_rows__`` literal as a list of strings.
-
-    Parses the source via AST and looks for an ``Assign`` node binding the
-    name ``__matrix_rows__`` to a tuple or list of string constants. Returns
-    an empty list when the dunder is absent — the registered metric modules
-    are enumerated by directory scan, so a missing dunder simply means that
-    module contributes no rows (a coverage test in ``tests/test_docs_matrix.py``
-    enforces presence on every public ``factrix/metrics/*.py``).
+    Raises ``ValueError`` when the module does not declare a non-empty
+    ``__metric_specs__`` tuple — coverage enforced by
+    ``tests/test_docs_matrix.py``.
     """
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except SyntaxError:
-        return []
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        if not (
-            len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-            and node.targets[0].id == "__matrix_rows__"
-        ):
-            continue
-        if not isinstance(node.value, (ast.Tuple, ast.List)):
-            raise ValueError(
-                f"{path.name}: __matrix_rows__ must be a tuple or list literal"
-            )
-        rows: list[str] = []
-        for elt in node.value.elts:
-            if not (isinstance(elt, ast.Constant) and isinstance(elt.value, str)):
-                raise ValueError(
-                    f"{path.name}: __matrix_rows__ entries must be string literals"
-                )
-            rows.append(elt.value.strip())
-        return rows
-    return []
-
-
-def _parse_module_entries(path: pathlib.Path) -> list[_MatrixEntry]:
-    entries: list[_MatrixEntry] = []
-    for raw_value in _extract_matrix_rows(path):
-        parts = [p.strip() for p in raw_value.split("|")]
-        if len(parts) != 5:
-            raise ValueError(
-                f"{path.name}: Matrix-row has {len(parts)} pipe-separated"
-                f" fields (expected 5): {raw_value!r}"
-            )
-        names_csv, cell_str, agg_order, inference_se, _primitives = parts
-        names = tuple(n for n in (n.strip() for n in names_csv.split(",")) if n)
-        entries.append(
-            _MatrixEntry(
-                module=path.stem,
-                names=names,
-                cell=_parse_cell(cell_str),
-                agg_order=agg_order,
-                inference_se=inference_se,
-            )
+    mod = importlib.import_module(f"factrix.metrics.{stem}")
+    specs = getattr(mod, "__metric_specs__", None)
+    if not specs:
+        raise ValueError(
+            f"factrix.metrics.{stem}: module-level `__metric_specs__` tuple "
+            f"is required (one MetricSpec per public callable). See "
+            f"factrix._metric_index.MetricSpec docstring."
         )
-    return entries
+    if not all(isinstance(s, MetricSpec) for s in specs):
+        raise TypeError(
+            f"factrix.metrics.{stem}: every `__metric_specs__` entry must be "
+            f"a MetricSpec instance."
+        )
+    return tuple(specs)
 
 
 @functools.cache
-def _matrix_entries() -> tuple[_MatrixEntry, ...]:
-    """Return one entry per ``Matrix-row:`` tag (un-exploded by name).
+def _all_specs() -> tuple[tuple[str, MetricSpec], ...]:
+    """Return ``((module_stem, spec), ...)`` across every public metric module.
 
-    Sorted by module. Cached — metric module docstrings do not change
-    at runtime, so repeated callers (``list_metrics`` in agentic loops)
-    avoid re-parsing every public ``factrix/metrics/*.py``.
+    Cached — spec tuples are module-level constants, so repeated
+    callers (``list_metrics`` in agentic loops, docs-hook regeneration)
+    avoid re-importing every public module.
     """
-    out: list[_MatrixEntry] = []
-    for path in _public_metric_modules():
-        out.extend(_parse_module_entries(path))
-    out.sort(key=lambda e: e.module)
+    out: list[tuple[str, MetricSpec]] = []
+    for stem in _public_metric_stems():
+        for spec in _load_module_specs(stem):
+            out.append((stem, spec))
     return tuple(out)
+
+
+def _row_from_spec(stem: str, spec: MetricSpec) -> MetricRow:
+    return MetricRow(
+        name=spec.name,
+        module=stem,
+        cell=spec.cell,
+        agg_order=spec.family,
+        inference_se=spec.inference,
+        import_path=f"factrix.metrics.{stem}",
+        input_kind=spec.input_kind,
+        docs_anchor=DOCS_ANCHOR_FMT.format(module=stem, name=spec.name),
+        emitted_name=spec.emitted_name or spec.name,
+    )
 
 
 @functools.cache
 def _all_rows() -> list[MetricRow]:
-    """Return every parsed ``Matrix-row:`` row, exploded one per metric name.
-
-    Sorted by ``(module, name)``. Includes stage-1 helpers; for the
-    user-facing subset call :func:`user_facing_rows`.
+    """Return every spec exploded into a :class:`MetricRow`, sorted by
+    ``(module, name)``. Includes stage-1 helpers; for the user-facing
+    subset call :func:`user_facing_rows`.
     """
-    rows = [
-        MetricRow(
-            name=name,
-            module=entry.module,
-            cell=entry.cell,
-            agg_order=entry.agg_order,
-            inference_se=entry.inference_se,
-            import_path=f"factrix.metrics.{entry.module}",
-            input_kind="scalar" if name in _SCALAR_INPUT_METRICS else "panel",
-            docs_anchor=DOCS_ANCHOR_FMT.format(module=entry.module, name=name),
-            emitted_name=_EMITTED_NAME_OVERRIDES.get(name, name),
-        )
-        for entry in _matrix_entries()
-        for name in entry.names
-    ]
+    rows = [_row_from_spec(stem, spec) for stem, spec in _all_specs()]
     rows.sort(key=lambda r: (r.module, r.name))
     return rows
 
 
 @functools.cache
 def user_facing_rows() -> list[MetricRow]:
-    """Return parsed rows excluding stage-1 helpers."""
-    return [r for r in _all_rows() if r.name not in _STAGE1_HELPERS]
+    """Return parsed rows excluding stage-1 helpers, sorted by ``(module, name)``."""
+    return [r for r in _all_rows() if r.name not in stage1_helper_names()]
+
+
+@functools.cache
+def stage1_helper_names() -> frozenset[str]:
+    """Return the set of stage-1 helper callable names across all modules.
+
+    Derived from each spec's ``is_stage1`` flag so the per-metric
+    property travels with the spec that declares it.
+    """
+    return frozenset(spec.name for _, spec in _all_specs() if spec.is_stage1)
+
+
+@functools.cache
+def module_specs(stem: str) -> tuple[MetricSpec, ...]:
+    """Return the spec tuple declared by one metric module."""
+    return _load_module_specs(stem)

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -26,11 +26,9 @@ import warnings
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_caar, caar, bmp_test | (*, SPARSE, *, PANEL) | per-event | non-overlapping t / z | _calc_t_stat, _p_value_from_t, _p_value_from_z, _significance_marker, _sample_non_overlapping, _short_circuit_output",
-)
-
+from factrix._axis import Mode, Signal
 from factrix._codes import WarningCode
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _calc_t_stat,
     _p_value_from_t,
@@ -57,6 +55,42 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "caar",
     "bmp_test",
 ]
+
+_CAAR_CELL = cell(None, Signal.SPARSE, mode=Mode.PANEL)
+_CAAR_PRIMITIVES = (
+    "_calc_t_stat",
+    "_p_value_from_t",
+    "_p_value_from_z",
+    "_significance_marker",
+    "_sample_non_overlapping",
+    "_short_circuit_output",
+)
+_CAAR_INFERENCE = "non-overlapping t / z"
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_caar",
+        cell=_CAAR_CELL,
+        family="per-event",
+        inference=_CAAR_INFERENCE,
+        primitives=_CAAR_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(
+        name="caar",
+        cell=_CAAR_CELL,
+        family="per-event",
+        inference=_CAAR_INFERENCE,
+        primitives=_CAAR_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="bmp_test",
+        cell=_CAAR_CELL,
+        family="per-event",
+        inference=_CAAR_INFERENCE,
+        primitives=_CAAR_PRIMITIVES,
+    ),
+)
 
 # Slice-test contract (#153 §5): CAAR is event-driven; the
 # cross-section is the event sample, not a bucketed asset universe,

--- a/factrix/metrics/clustering.py
+++ b/factrix/metrics/clustering.py
@@ -19,12 +19,21 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "clustering_diagnostic | (*, SPARSE, *, PANEL) | static-cs | no formal H₀ | _short_circuit_output",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._types import MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
+
+__metric_specs__ = (
+    MetricSpec(
+        name="clustering_diagnostic",
+        cell=cell(None, Signal.SPARSE, mode=Mode.PANEL),
+        family="static-cs",
+        inference="no formal H_0",
+        primitives=("_short_circuit_output",),
+        emitted_name="clustering_hhi",
+    ),
+)
 
 __all__ = [
     "clustering_diagnostic",

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -19,11 +19,9 @@ import warnings
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "top_concentration | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | across-time t (one-sided H₀: ratio ≥ 0.5) | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _compute_tie_ratio",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
 from factrix._codes import WarningCode
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
     DDOF,
@@ -42,6 +40,23 @@ from factrix.metrics._helpers import (
 __all__ = [
     "top_concentration",
 ]
+
+__metric_specs__ = (
+    MetricSpec(
+        name="top_concentration",
+        cell=cell(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, mode=Mode.PANEL),
+        family="cs-first",
+        inference="across-time t (one-sided H_0: ratio >= 0.5)",
+        primitives=(
+            "_calc_t_stat",
+            "_p_value_from_t",
+            "_significance_marker",
+            "_sample_non_overlapping",
+            "_short_circuit_output",
+            "_compute_tie_ratio",
+        ),
+    ),
+)
 
 
 def top_concentration(

--- a/factrix/metrics/corrado.py
+++ b/factrix/metrics/corrado.py
@@ -10,13 +10,27 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "corrado_rank_test | (*, SPARSE, *, PANEL) | per-event | nonparametric rank | _calc_t_stat, _p_value_from_z, _significance_marker, _short_circuit_output",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import _calc_t_stat, _p_value_from_z, _significance_marker
 from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
+
+__metric_specs__ = (
+    MetricSpec(
+        name="corrado_rank_test",
+        cell=cell(None, Signal.SPARSE, mode=Mode.PANEL),
+        family="per-event",
+        inference="nonparametric rank",
+        primitives=(
+            "_calc_t_stat",
+            "_p_value_from_z",
+            "_significance_marker",
+            "_short_circuit_output",
+        ),
+        emitted_name="corrado_rank",
+    ),
+)
 
 __all__ = [
     "corrado_rank_test",

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -20,12 +20,31 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_event_returns, event_around_return | (*, SPARSE, *, PANEL) | per-event | binomial | _short_circuit_output",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._types import EPSILON, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
+
+_EH_CELL = cell(None, Signal.SPARSE, mode=Mode.PANEL)
+_EH_PRIMITIVES = ("_short_circuit_output",)
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_event_returns",
+        cell=_EH_CELL,
+        family="per-event",
+        inference="binomial",
+        primitives=_EH_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(
+        name="event_around_return",
+        cell=_EH_CELL,
+        family="per-event",
+        inference="binomial",
+        primitives=_EH_PRIMITIVES,
+    ),
+)
 
 __all__ = [
     "compute_event_returns",

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -60,7 +60,13 @@ __metric_specs__ = tuple(
         inference=_EQ_INFERENCE,
         primitives=_EQ_PRIMITIVES,
     )
-    for _name in ("event_hit_rate", "event_ic", "profit_factor", "event_skewness", "signal_density")
+    for _name in (
+        "event_hit_rate",
+        "event_ic",
+        "profit_factor",
+        "event_skewness",
+        "signal_density",
+    )
 )
 
 

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -24,10 +24,8 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "event_hit_rate, event_ic, profit_factor, event_skewness, signal_density | (*, SPARSE, *, PANEL) | per-event | binomial / nonparametric rank | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _signed_car",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _BINOMIAL_EXACT_CUTOFF,
     _binomial_test_method_name,
@@ -44,6 +42,26 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "event_skewness",
     "signal_density",
 ]
+
+_EQ_CELL = cell(None, Signal.SPARSE, mode=Mode.PANEL)
+_EQ_PRIMITIVES = (
+    "_binomial_two_sided_p",
+    "_significance_marker",
+    "_short_circuit_output",
+    "_signed_car",
+)
+_EQ_INFERENCE = "binomial / nonparametric rank"
+
+__metric_specs__ = tuple(
+    MetricSpec(
+        name=_name,
+        cell=_EQ_CELL,
+        family="per-event",
+        inference=_EQ_INFERENCE,
+        primitives=_EQ_PRIMITIVES,
+    )
+    for _name in ("event_hit_rate", "event_ic", "profit_factor", "event_skewness", "signal_density")
+)
 
 
 def event_hit_rate(

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -49,7 +49,10 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
 ]
 
 _FM_CELL = cell(
-    FactorScope.INDIVIDUAL, Signal.CONTINUOUS, metric=Metric.FM, mode=Mode.PANEL,
+    FactorScope.INDIVIDUAL,
+    Signal.CONTINUOUS,
+    metric=Metric.FM,
+    mode=Mode.PANEL,
 )
 _FM_PRIMITIVES = (
     "_newey_west_t_test",

--- a/factrix/metrics/fama_macbeth.py
+++ b/factrix/metrics/fama_macbeth.py
@@ -29,11 +29,9 @@ import warnings
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_fm_betas, fama_macbeth, pooled_ols, beta_sign_consistency | (INDIVIDUAL, CONTINUOUS, FM, PANEL) | cs-first | NW HAC / clustered t | _newey_west_t_test, _p_value_from_t, _significance_marker, _short_circuit_output",
-)
-
+from factrix._axis import FactorScope, Metric, Mode, Signal
 from factrix._codes import WarningCode
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _newey_west_t_test,
     _p_value_from_t,
@@ -49,6 +47,51 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "pooled_ols",
     "beta_sign_consistency",
 ]
+
+_FM_CELL = cell(
+    FactorScope.INDIVIDUAL, Signal.CONTINUOUS, metric=Metric.FM, mode=Mode.PANEL,
+)
+_FM_PRIMITIVES = (
+    "_newey_west_t_test",
+    "_p_value_from_t",
+    "_significance_marker",
+    "_short_circuit_output",
+)
+_FM_INFERENCE = "NW HAC / clustered t"
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_fm_betas",
+        cell=_FM_CELL,
+        family="cs-first",
+        inference=_FM_INFERENCE,
+        primitives=_FM_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(
+        name="fama_macbeth",
+        cell=_FM_CELL,
+        family="cs-first",
+        inference=_FM_INFERENCE,
+        primitives=_FM_PRIMITIVES,
+        emitted_name="fm_beta",
+    ),
+    MetricSpec(
+        name="pooled_ols",
+        cell=_FM_CELL,
+        family="cs-first",
+        inference=_FM_INFERENCE,
+        primitives=_FM_PRIMITIVES,
+        emitted_name="pooled_beta",
+    ),
+    MetricSpec(
+        name="beta_sign_consistency",
+        cell=_FM_CELL,
+        family="cs-first",
+        inference=_FM_INFERENCE,
+        primitives=_FM_PRIMITIVES,
+    ),
+)
 
 # Slice-test contract (#153 §5): Fama-MacBeth runs a per-date
 # OLS regression on the cross-section, not a bucket sort, so slice

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -15,10 +15,8 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "hit_rate | (*, CONTINUOUS, *, TIMESERIES) | ts-only | binomial | _binomial_two_sided_p, _significance_marker, _short_circuit_output, _sample_non_overlapping",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _BINOMIAL_EXACT_CUTOFF,
     _binomial_test_method_name,
@@ -27,6 +25,21 @@ from factrix._stats import (
 )
 from factrix._types import MIN_ASSETS_PER_DATE_IC, MetricOutput
 from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
+
+__metric_specs__ = (
+    MetricSpec(
+        name="hit_rate",
+        cell=cell(None, Signal.CONTINUOUS, mode=Mode.TIMESERIES),
+        family="ts-only",
+        inference="binomial",
+        primitives=(
+            "_binomial_two_sided_p",
+            "_significance_marker",
+            "_short_circuit_output",
+            "_sample_non_overlapping",
+        ),
+    ),
+)
 
 __all__ = [
     "hit_rate",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -49,7 +49,10 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
 ]
 
 _IC_CELL = cell(
-    FactorScope.INDIVIDUAL, Signal.CONTINUOUS, metric=Metric.IC, mode=Mode.PANEL,
+    FactorScope.INDIVIDUAL,
+    Signal.CONTINUOUS,
+    metric=Metric.IC,
+    mode=Mode.PANEL,
 )
 _IC_PRIMITIVES = (
     "_newey_west_t_test",
@@ -70,9 +73,27 @@ __metric_specs__ = (
         primitives=_IC_PRIMITIVES,
         is_stage1=True,
     ),
-    MetricSpec(name="ic", cell=_IC_CELL, family="cs-first", inference=_IC_INFERENCE, primitives=_IC_PRIMITIVES),
-    MetricSpec(name="ic_newey_west", cell=_IC_CELL, family="cs-first", inference=_IC_INFERENCE, primitives=_IC_PRIMITIVES),
-    MetricSpec(name="ic_ir", cell=_IC_CELL, family="cs-first", inference=_IC_INFERENCE, primitives=_IC_PRIMITIVES),
+    MetricSpec(
+        name="ic",
+        cell=_IC_CELL,
+        family="cs-first",
+        inference=_IC_INFERENCE,
+        primitives=_IC_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="ic_newey_west",
+        cell=_IC_CELL,
+        family="cs-first",
+        inference=_IC_INFERENCE,
+        primitives=_IC_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="ic_ir",
+        cell=_IC_CELL,
+        family="cs-first",
+        inference=_IC_INFERENCE,
+        primitives=_IC_PRIMITIVES,
+    ),
 )
 
 # Slice-test contract (#153 §5): IC is per-date Spearman rank

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -19,10 +19,8 @@ from collections.abc import Sequence
 
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_ic, ic, ic_newey_west, ic_ir | (INDIVIDUAL, CONTINUOUS, IC, PANEL) | cs-first | NW HAC / cross-asset t | _newey_west_t_test, _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output",
-)
-
+from factrix._axis import FactorScope, Metric, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _calc_t_stat,
     _newey_west_t_test,
@@ -49,6 +47,33 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "ic_newey_west",
     "ic_ir",
 ]
+
+_IC_CELL = cell(
+    FactorScope.INDIVIDUAL, Signal.CONTINUOUS, metric=Metric.IC, mode=Mode.PANEL,
+)
+_IC_PRIMITIVES = (
+    "_newey_west_t_test",
+    "_calc_t_stat",
+    "_p_value_from_t",
+    "_significance_marker",
+    "_sample_non_overlapping",
+    "_short_circuit_output",
+)
+_IC_INFERENCE = "NW HAC / cross-asset t"
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_ic",
+        cell=_IC_CELL,
+        family="cs-first",
+        inference=_IC_INFERENCE,
+        primitives=_IC_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(name="ic", cell=_IC_CELL, family="cs-first", inference=_IC_INFERENCE, primitives=_IC_PRIMITIVES),
+    MetricSpec(name="ic_newey_west", cell=_IC_CELL, family="cs-first", inference=_IC_INFERENCE, primitives=_IC_PRIMITIVES),
+    MetricSpec(name="ic_ir", cell=_IC_CELL, family="cs-first", inference=_IC_INFERENCE, primitives=_IC_PRIMITIVES),
+)
 
 # Slice-test contract (#153 §5): IC is per-date Spearman rank
 # correlation, not a bucketed metric — slice tests never need to

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -22,10 +22,8 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_mfe_mae, mfe_mae_summary | (*, SPARSE, *, PANEL) | per-event | no formal H₀ | _short_circuit_output",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._types import EPSILON, MIN_EVENTS_HARD, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
 
@@ -33,6 +31,27 @@ __all__ = [
     "compute_mfe_mae",
     "mfe_mae_summary",
 ]
+
+_MFE_CELL = cell(None, Signal.SPARSE, mode=Mode.PANEL)
+_MFE_PRIMITIVES = ("_short_circuit_output",)
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_mfe_mae",
+        cell=_MFE_CELL,
+        family="per-event",
+        inference="no formal H_0",
+        primitives=_MFE_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(
+        name="mfe_mae_summary",
+        cell=_MFE_CELL,
+        family="per-event",
+        inference="no formal H_0",
+        primitives=_MFE_PRIMITIVES,
+    ),
+)
 
 DEFAULT_MIN_ESTIMATION_SAMPLES: int = 20
 

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -20,10 +20,8 @@ import numpy as np
 import polars as pl
 import scipy.stats as scipy_stats
 
-__matrix_rows__ = (
-    "monotonicity | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
     DDOF,
@@ -41,6 +39,24 @@ from factrix.metrics._protocol import batch_primitive
 __all__ = [
     "monotonicity",
 ]
+
+__metric_specs__ = (
+    MetricSpec(
+        name="monotonicity",
+        cell=cell(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, mode=Mode.PANEL),
+        family="cs-first",
+        inference="cross-asset t",
+        primitives=(
+            "_calc_t_stat",
+            "_p_value_from_t",
+            "_significance_marker",
+            "_sample_non_overlapping",
+            "_short_circuit_output",
+            "_assign_quantile_groups",
+            "_compute_tie_ratio",
+        ),
+    ),
+)
 
 # Slice-test contract (#153 §5): monotonicity buckets the
 # cross-section into `n_groups` (default 10) and computes Spearman ρ

--- a/factrix/metrics/oos.py
+++ b/factrix/metrics/oos.py
@@ -22,12 +22,21 @@ from typing import Literal
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "multi_split_oos_decay | (*, CONTINUOUS, *, TIMESERIES) | ts-only | no formal H₀ | _short_circuit_output",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._types import EPSILON, MIN_OOS_PERIODS, MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
+
+__metric_specs__ = (
+    MetricSpec(
+        name="multi_split_oos_decay",
+        cell=cell(None, Signal.CONTINUOUS, mode=Mode.TIMESERIES),
+        family="ts-only",
+        inference="no formal H_0",
+        primitives=("_short_circuit_output",),
+        emitted_name="oos_decay",
+    ),
+)
 
 __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "multi_split_oos_decay",

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -20,10 +20,8 @@ from collections.abc import Sequence
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_spread_series, quantile_spread, quantile_spread_vw, compute_group_returns | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups, _compute_tie_ratio, _lag_within_asset",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
     DDOF,
@@ -48,6 +46,52 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "quantile_spread",
     "quantile_spread_vw",
 ]
+
+_Q_CELL = cell(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, mode=Mode.PANEL)
+_Q_PRIMITIVES = (
+    "_calc_t_stat",
+    "_p_value_from_t",
+    "_significance_marker",
+    "_sample_non_overlapping",
+    "_short_circuit_output",
+    "_assign_quantile_groups",
+    "_compute_tie_ratio",
+    "_lag_within_asset",
+)
+_Q_INFERENCE = "cross-asset t"
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_spread_series",
+        cell=_Q_CELL,
+        family="cs-first",
+        inference=_Q_INFERENCE,
+        primitives=_Q_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(
+        name="quantile_spread",
+        cell=_Q_CELL,
+        family="cs-first",
+        inference=_Q_INFERENCE,
+        primitives=_Q_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="quantile_spread_vw",
+        cell=_Q_CELL,
+        family="cs-first",
+        inference=_Q_INFERENCE,
+        primitives=_Q_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="compute_group_returns",
+        cell=_Q_CELL,
+        family="cs-first",
+        inference=_Q_INFERENCE,
+        primitives=_Q_PRIMITIVES,
+        is_stage1=True,
+    ),
+)
 
 
 def compute_spread_series(

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -22,10 +22,6 @@ References:
 
 from __future__ import annotations
 
-__matrix_rows__ = (
-    "spanning_alpha, greedy_forward_selection | factor-return-series consumer (post-PANEL pipeline) | ts-only | NW HAC / OLS t | _p_value_from_t, _significance_marker, _short_circuit_output, _ols_alpha",
-)
-
 import logging
 import warnings
 from dataclasses import dataclass, field
@@ -33,6 +29,8 @@ from dataclasses import dataclass, field
 import numpy as np
 import polars as pl
 
+from factrix._axis import FactorScope, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._ols import ols_alpha as _ols_alpha
 from factrix._stats import _p_value_from_t, _significance_marker
 from factrix._types import MetricOutput
@@ -44,6 +42,35 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "SpanningResult",
     "ForwardSelectionResult",
 ]
+
+_SPANNING_CELL = cell(
+    FactorScope.INDIVIDUAL,
+    Signal.CONTINUOUS,
+    raw="factor-return-series consumer (post-PANEL pipeline)",
+)
+_SPANNING_PRIMITIVES = (
+    "_p_value_from_t",
+    "_significance_marker",
+    "_short_circuit_output",
+    "_ols_alpha",
+)
+
+__metric_specs__ = (
+    MetricSpec(
+        name="spanning_alpha",
+        cell=_SPANNING_CELL,
+        family="ts-only",
+        inference="NW HAC / OLS t",
+        primitives=_SPANNING_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="greedy_forward_selection",
+        cell=_SPANNING_CELL,
+        family="ts-only",
+        inference="NW HAC / OLS t",
+        primitives=_SPANNING_PRIMITIVES,
+    ),
+)
 
 logger = logging.getLogger(__name__)
 

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -28,16 +28,53 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "notional_turnover, breakeven_cost, net_spread | (INDIVIDUAL, CONTINUOUS, *, PANEL) | cs-first | no formal H₀ | _sample_non_overlapping, _short_circuit_output, _assign_quantile_groups",
-    "turnover | (INDIVIDUAL, CONTINUOUS, *, PANEL) | ts-only (rank autocorrelation across consecutive dates) | no formal H₀ | _short_circuit_output",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._types import DDOF, EPSILON, MetricOutput
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
     _sample_non_overlapping,
     _short_circuit_output,
+)
+
+_TR_CELL = cell(FactorScope.INDIVIDUAL, Signal.CONTINUOUS, mode=Mode.PANEL)
+_TR_CS_PRIMITIVES = (
+    "_sample_non_overlapping",
+    "_short_circuit_output",
+    "_assign_quantile_groups",
+)
+
+__metric_specs__ = (
+    MetricSpec(
+        name="notional_turnover",
+        cell=_TR_CELL,
+        family="cs-first",
+        inference="no formal H_0",
+        primitives=_TR_CS_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="breakeven_cost",
+        cell=_TR_CELL,
+        family="cs-first",
+        inference="no formal H_0",
+        primitives=_TR_CS_PRIMITIVES,
+        input_kind="scalar",
+    ),
+    MetricSpec(
+        name="net_spread",
+        cell=_TR_CELL,
+        family="cs-first",
+        inference="no formal H_0",
+        primitives=_TR_CS_PRIMITIVES,
+        input_kind="scalar",
+    ),
+    MetricSpec(
+        name="turnover",
+        cell=_TR_CELL,
+        family="ts-only (rank autocorrelation across consecutive dates)",
+        inference="no formal H_0",
+        primitives=("_short_circuit_output",),
+    ),
 )
 
 __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -18,13 +18,26 @@ import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
 
-__matrix_rows__ = (
-    "ic_trend | (*, CONTINUOUS, *, TIMESERIES) | ts-only | Theil-Sen rank-based CI | _significance_marker, _short_circuit_output, _adf, _p_value_from_t",
-)
-
+from factrix._axis import Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import _adf, _p_value_from_t, _significance_marker
 from factrix._types import MetricOutput
 from factrix.metrics._helpers import _short_circuit_output
+
+__metric_specs__ = (
+    MetricSpec(
+        name="ic_trend",
+        cell=cell(None, Signal.CONTINUOUS, mode=Mode.TIMESERIES),
+        family="ts-only",
+        inference="Theil-Sen rank-based CI",
+        primitives=(
+            "_significance_marker",
+            "_short_circuit_output",
+            "_adf",
+            "_p_value_from_t",
+        ),
+    ),
+)
 
 __all__ = [
     "ic_trend",

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -39,10 +39,8 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "ts_asymmetry | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _ols_nw_multivariate,
     _resolve_nw_lags,
@@ -58,6 +56,22 @@ from factrix.metrics._helpers import (
 __all__ = [
     "ts_asymmetry",
 ]
+
+__metric_specs__ = (
+    MetricSpec(
+        name="ts_asymmetry",
+        cell=cell(FactorScope.COMMON, Signal.CONTINUOUS, mode=Mode.PANEL),
+        family="cs-first",
+        inference="NW HAC Wald",
+        primitives=(
+            "_significance_marker",
+            "_short_circuit_output",
+            "_aggregate_to_per_date",
+            "_ols_nw_multivariate",
+            "_wald_p_linear",
+        ),
+    ),
+)
 
 
 def ts_asymmetry(

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -20,10 +20,8 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__matrix_rows__ = (
-    "compute_ts_betas, ts_beta, mean_r_squared, compute_rolling_mean_beta, ts_beta_sign_consistency, ts_beta_single_asset_fallback | (COMMON, CONTINUOUS, *, PANEL) | ts-first | cross-asset t | _calc_t_stat, _p_value_from_t, _significance_marker, _short_circuit_output",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _calc_t_stat,
     _p_value_from_t,
@@ -39,6 +37,63 @@ __all__ = [  # noqa: RUF022 (teaching order, see #322 SSOT note)
     "ts_beta_sign_consistency",
     "compute_rolling_mean_beta",
 ]
+
+_TSB_CELL = cell(FactorScope.COMMON, Signal.CONTINUOUS, mode=Mode.PANEL)
+_TSB_PRIMITIVES = (
+    "_calc_t_stat",
+    "_p_value_from_t",
+    "_significance_marker",
+    "_short_circuit_output",
+)
+_TSB_FAMILY = "ts-first"
+_TSB_INFERENCE = "cross-asset t"
+
+__metric_specs__ = (
+    MetricSpec(
+        name="compute_ts_betas",
+        cell=_TSB_CELL,
+        family=_TSB_FAMILY,
+        inference=_TSB_INFERENCE,
+        primitives=_TSB_PRIMITIVES,
+        is_stage1=True,
+    ),
+    MetricSpec(
+        name="ts_beta",
+        cell=_TSB_CELL,
+        family=_TSB_FAMILY,
+        inference=_TSB_INFERENCE,
+        primitives=_TSB_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="mean_r_squared",
+        cell=_TSB_CELL,
+        family=_TSB_FAMILY,
+        inference=_TSB_INFERENCE,
+        primitives=_TSB_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="compute_rolling_mean_beta",
+        cell=_TSB_CELL,
+        family=_TSB_FAMILY,
+        inference=_TSB_INFERENCE,
+        primitives=_TSB_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="ts_beta_sign_consistency",
+        cell=_TSB_CELL,
+        family=_TSB_FAMILY,
+        inference=_TSB_INFERENCE,
+        primitives=_TSB_PRIMITIVES,
+    ),
+    MetricSpec(
+        name="ts_beta_single_asset_fallback",
+        cell=_TSB_CELL,
+        family=_TSB_FAMILY,
+        inference=_TSB_INFERENCE,
+        primitives=_TSB_PRIMITIVES,
+        is_stage1=True,
+    ),
+)
 
 MIN_TS_OBS: int = 20
 

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -25,10 +25,8 @@ import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
 
-__matrix_rows__ = (
-    "ts_quantile_spread | (COMMON, CONTINUOUS, *, PANEL) | cs-first | NW HAC Wald | _significance_marker, _short_circuit_output, _aggregate_to_per_date, _ols_nw_multivariate, _wald_p_linear",
-)
-
+from factrix._axis import FactorScope, Mode, Signal
+from factrix._metric_index import MetricSpec, cell
 from factrix._stats import (
     _ols_nw_multivariate,
     _resolve_nw_lags,
@@ -44,6 +42,22 @@ from factrix.metrics._helpers import (
 __all__ = [
     "ts_quantile_spread",
 ]
+
+__metric_specs__ = (
+    MetricSpec(
+        name="ts_quantile_spread",
+        cell=cell(FactorScope.COMMON, Signal.CONTINUOUS, mode=Mode.PANEL),
+        family="cs-first",
+        inference="NW HAC Wald",
+        primitives=(
+            "_significance_marker",
+            "_short_circuit_output",
+            "_aggregate_to_per_date",
+            "_ols_nw_multivariate",
+            "_wald_p_linear",
+        ),
+    ),
+)
 
 
 def ts_quantile_spread(

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -66,10 +66,7 @@ def _group_specs(specs: tuple[tuple[str, MetricSpec], ...]) -> list[_GroupedRow]
 
 def _render_row(row: _GroupedRow) -> str:
     module_cell = f"[`metrics.{row.module}`][factrix.metrics.{row.module}]"
-    return (
-        f"| {module_cell} | `{row.cell_raw}` | "
-        f"{row.family} | {row.inference} |\n"
-    )
+    return f"| {module_cell} | `{row.cell_raw}` | {row.family} | {row.inference} |\n"
 
 
 def generate() -> None:

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -1,9 +1,14 @@
 """Build-time generator for the standalone-metrics matrix table.
 
 Renders a Markdown table to ``docs/reference/_generated_metric_matrix.md``
-from the parsed ``Matrix-row:`` tags exposed by
+from the typed ``__metric_specs__`` declarations exposed by
 :mod:`factrix._metric_index` (single source of truth, also consumed at
 runtime by ``factrix.list_metrics``).
+
+One table row per distinct ``(module, cell.raw, family, inference)``
+group — modules whose specs cover multiple cells (e.g. ``tradability``
+splitting its panel-aggregated and rank-autocorrelation metrics across
+two rows) surface as multiple rows.
 
 Usage (manual)::
 
@@ -18,8 +23,9 @@ MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
 from __future__ import annotations
 
 import pathlib
+from dataclasses import dataclass
 
-from factrix._metric_index import _matrix_entries, _MatrixEntry
+from factrix._metric_index import MetricSpec, _all_specs
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_metric_matrix.md"
@@ -29,21 +35,50 @@ _TABLE_HEADER = (
 )
 
 
-def _render_row(entry: _MatrixEntry) -> str:
-    module_cell = f"[`metrics.{entry.module}`][factrix.metrics.{entry.module}]"
+@dataclass(frozen=True, slots=True)
+class _GroupedRow:
+    """One docs-matrix row: a ``(module, cell, family, inference)`` group."""
+
+    module: str
+    cell_raw: str
+    family: str
+    inference: str
+
+
+def _group_specs(specs: tuple[tuple[str, MetricSpec], ...]) -> list[_GroupedRow]:
+    """Collapse per-callable specs into per-(module, cell, family, inference) rows.
+
+    Stable on insertion order so the rendered table follows the
+    spec-declaration order in each module.
+    """
+    seen: dict[tuple[str, str, str, str], _GroupedRow] = {}
+    for stem, spec in specs:
+        key = (stem, spec.cell.raw, spec.family, spec.inference)
+        if key not in seen:
+            seen[key] = _GroupedRow(
+                module=stem,
+                cell_raw=spec.cell.raw,
+                family=spec.family,
+                inference=spec.inference,
+            )
+    return list(seen.values())
+
+
+def _render_row(row: _GroupedRow) -> str:
+    module_cell = f"[`metrics.{row.module}`][factrix.metrics.{row.module}]"
     return (
-        f"| {module_cell} | `{entry.cell.raw}` | "
-        f"{entry.agg_order} | {entry.inference_se} |\n"
+        f"| {module_cell} | `{row.cell_raw}` | "
+        f"{row.family} | {row.inference} |\n"
     )
 
 
 def generate() -> None:
-    """Generate ``_generated_metric_matrix.md`` from module docstrings."""
-    entries = _matrix_entries()
-    lines = [_TABLE_HEADER, *(_render_row(e) for e in entries)]
+    """Generate ``_generated_metric_matrix.md`` from ``__metric_specs__``."""
+    rows = _group_specs(_all_specs())
+    lines = [_TABLE_HEADER, *(_render_row(r) for r in rows)]
     _OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     _OUT_FILE.write_text("".join(lines), encoding="utf-8")
-    print(f"gen_metric_matrix: wrote {len(entries)} row(s) to {_OUT_FILE}")
+    print(f"gen_metric_matrix: wrote {len(rows)} row(s) to {_OUT_FILE}")
 
 
 def on_pre_build(config: object) -> None:

--- a/tests/test_docs_matrix.py
+++ b/tests/test_docs_matrix.py
@@ -1,14 +1,18 @@
-"""Coverage test: ``__matrix_rows__`` tuples in ``factrix/metrics/`` modules.
+"""Coverage tests: ``__metric_specs__`` tuples in ``factrix/metrics/`` modules.
 
 Validates that:
-1. Every public metric module (non-underscore *.py) declares a non-empty
-   module-level ``__matrix_rows__`` tuple of strings.
-2. Every ``__matrix_rows__`` entry has exactly 5 pipe-separated fields
-   (public_functions | cell_scope | aggregation_order | inference_se | primitives).
-3. ``docs/reference/_generated_metric_matrix.md`` exists and is non-empty
-   (only meaningful after a build; skipped if the file is absent).
-
-Decision rationale: ARCHITECTURE.md §Docs SSOT strategy (Option B).
+1. Every public metric module (non-underscore ``*.py``) declares a
+   non-empty module-level ``__metric_specs__`` tuple of
+   :class:`~factrix._metric_index.MetricSpec` instances.
+2. ``docs/reference/_generated_metric_matrix.md`` exists and is
+   non-empty (only meaningful after a build; skipped if the file is
+   absent).
+3. Each spec's resolved ``emitted_name`` matches the literal in
+   ``MetricOutput(name=...)`` inside the declaring module.
+4. The generated docs-name-index file matches the live renderer
+   output (drift guard for #125).
+5. The generated evaluate-metric table file matches the live renderer
+   output (drift guard for #144).
 """
 
 from __future__ import annotations
@@ -31,36 +35,25 @@ def _public_metric_modules() -> set[str]:
     return {p.stem for p in METRICS_DIR.glob("*.py") if not p.stem.startswith("_")}
 
 
-def _matrix_rows_for(stem: str) -> list[str]:
-    """Return entries of the module-level ``__matrix_rows__`` tuple."""
-    from factrix._metric_index import _extract_matrix_rows
-
-    return _extract_matrix_rows(METRICS_DIR / f"{stem}.py")
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("stem", sorted(_public_metric_modules()))
-def test_module_has_matrix_row_tag(stem: str) -> None:
-    """Every public metric module must declare ``__matrix_rows__``."""
-    rows = _matrix_rows_for(stem)
-    assert rows, (
-        f"metrics/{stem}.py has no '__matrix_rows__' tuple at module scope. "
-        "Add one so the build-time generator can include it."
+def test_module_declares_metric_specs(stem: str) -> None:
+    """Every public metric module must declare a non-empty ``__metric_specs__``."""
+    from factrix._metric_index import MetricSpec, module_specs
+
+    specs = module_specs(stem)
+    assert specs, (
+        f"metrics/{stem}.py has no '__metric_specs__' tuple at module "
+        f"scope. Declare one MetricSpec per public callable."
     )
-
-
-@pytest.mark.parametrize("stem", sorted(_public_metric_modules()))
-def test_matrix_row_has_five_fields(stem: str) -> None:
-    """Every ``__matrix_rows__`` entry must have exactly 5 pipe-separated fields."""
-    for row in _matrix_rows_for(stem):
-        fields = [f.strip() for f in row.split("|")]
-        assert len(fields) == 5, (
-            f"metrics/{stem}.py: __matrix_rows__ entry has {len(fields)}"
-            f" pipe-separated fields (expected 5): {row!r}"
+    for spec in specs:
+        assert isinstance(spec, MetricSpec), (
+            f"metrics/{stem}.py: every __metric_specs__ entry must be a "
+            f"MetricSpec instance; got {type(spec).__name__}"
         )
 
 
@@ -82,17 +75,18 @@ def test_generated_matrix_exists_and_nonempty() -> None:
     )
 
 
-def test_emitted_name_overrides_match_source() -> None:
-    """``_EMITTED_NAME_OVERRIDES`` must reflect every divergent literal.
+def test_emitted_name_matches_metric_output_literal() -> None:
+    """Every ``MetricOutput(name=...)`` literal must match its spec's resolved
+    ``emitted_name``.
 
-    AST-grep every ``MetricOutput(name="<lit>")`` in
-    ``factrix/metrics/*.py``; for each registered user-facing function
-    name, the literal must equal either the function name or the
-    override map's value. Catches the case where someone adds a new
-    metric that emits a non-matching ``name=`` and forgets to update
-    the override map (#125 SSOT contract).
+    AST-greps every ``MetricOutput(name="<lit>")`` call in
+    ``factrix/metrics/*.py``; for each registered user-facing callable
+    the literal must equal the spec's resolved ``emitted_name`` (i.e.
+    ``spec.emitted_name or spec.name``). Catches the case where a
+    metric is added that emits a non-matching ``name=`` and the spec
+    author forgets to set ``emitted_name``.
     """
-    from factrix._metric_index import _EMITTED_NAME_OVERRIDES, user_facing_rows
+    from factrix._metric_index import user_facing_rows
 
     fn_to_emitted: dict[str, str] = {}
     for path in METRICS_DIR.glob("*.py"):
@@ -112,18 +106,19 @@ def test_emitted_name_overrides_match_source() -> None:
                         if kw.arg == "name" and isinstance(kw.value, ast.Constant):
                             fn_to_emitted.setdefault(fn.name, kw.value.value)
 
-    user_fns = {r.name for r in user_facing_rows()}
+    expected_by_name = {r.name: r.emitted_name for r in user_facing_rows()}
     mismatches: list[str] = []
     for fn, emitted in fn_to_emitted.items():
-        if fn not in user_fns or emitted == fn:
+        if fn not in expected_by_name:
             continue
-        expected = _EMITTED_NAME_OVERRIDES.get(fn)
+        expected = expected_by_name[fn]
         if expected != emitted:
             mismatches.append(
-                f"{fn}: emits MetricOutput(name={emitted!r}) but override map says {expected!r}"
+                f"{fn}: emits MetricOutput(name={emitted!r}) but spec "
+                f"resolves emitted_name={expected!r}"
             )
     assert not mismatches, (
-        "Emitted MetricOutput.name does not match _EMITTED_NAME_OVERRIDES:\n  "
+        "MetricOutput.name does not match MetricSpec.emitted_name:\n  "
         + "\n  ".join(mismatches)
     )
 
@@ -132,8 +127,8 @@ def test_generated_name_index_matches_renderer() -> None:
     """Generated name-index file must match what the renderer produces.
 
     Drift guard for #125: catches a stale checked-in file that no longer
-    reflects the ``Matrix-row:`` SSOT (e.g. a metric was added but mkdocs
-    wasn't rerun before commit).
+    reflects the spec SSOT (e.g. a metric was added but mkdocs wasn't
+    rerun before commit).
     """
     if not GENERATED_NAME_INDEX.exists():
         pytest.skip(

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -17,7 +17,7 @@ import factrix as fx
 import pytest
 from factrix._axis import FactorScope, Signal
 from factrix._errors import IncompatibleAxisError
-from factrix._metric_index import _STAGE1_HELPERS, MetricRow, user_facing_rows
+from factrix._metric_index import MetricRow, stage1_helper_names, user_facing_rows
 
 _APPLICABILITY_DOC = pathlib.Path("docs/reference/metric-applicability.md")
 
@@ -143,7 +143,7 @@ def test_list_metrics_matches_applicability_doc(
 
 def test_stage1_helpers_excluded_from_user_facing_rows() -> None:
     names = {row.name for row in user_facing_rows()}
-    assert _STAGE1_HELPERS.isdisjoint(names)
+    assert stage1_helper_names().isdisjoint(names)
 
 
 def test_compute_rolling_mean_beta_remains_user_facing() -> None:


### PR DESCRIPTION
## Summary

- 19 metric modules migrate from free-form `__matrix_rows__` string + AST source parsing to typed `__metric_specs__: tuple[MetricSpec, ...]` loaded via import.
- Per-metric side tables (`_STAGE1_HELPERS`, `_SCALAR_INPUT_METRICS`, `_EMITTED_NAME_OVERRIDES`) collapse into `MetricSpec` fields so per-metric properties travel with the declaring module.
- `MetricRow.agg_order` / `inference_se` aliases preserved — public `list_metrics(format="json")` schema unchanged.
- Trade-off: docs hooks now import every metric module (and transitive numpy / polars deps) on first `_all_specs()` access instead of pure source-AST parse. Accepted in exchange for IDE completion, mypy / runtime axis validation, and refactor-safe field access.

Sets up the typed-spec base layer for the small-N allocation metric callables added under #424's B section in subsequent PRs.

## Test plan

- [ ] `pytest tests/` — full suite passes (1479 tests)
- [ ] `ruff check` clean on touched paths
- [ ] `mypy factrix/_metric_index.py factrix/metrics/` clean
- [ ] `python scripts/mkdocs_hooks/gen_metric_matrix.py` regenerates `docs/reference/_generated_metric_matrix.md` with stable content
- [ ] `python scripts/mkdocs_hooks/gen_metric_name_index.py` regenerates `docs/reference/_generated_metric_name_index.md`
- [ ] `python scripts/mkdocs_hooks/gen_evaluate_metric_table.py` regenerates `docs/reference/_generated_evaluate_metric_table.md`
- [ ] Spot-check `list_metrics(scope, signal, format="json")` payload — `agg_order` / `inference_se` / `import_path` / `docs_anchor` / `emitted_name` keys intact

Refs #424 (part A — typed metric spec base layer; part B small-N allocation callables in follow-up PRs)