### PR TITLE
refactor(api): n_pairs + sparse_ratio on PanelProperties (#443)

### DIFF
--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -47,10 +47,10 @@ class PanelProperties:
 
     Carries both the dispatch axes (``scope`` / ``signal`` / ``mode``
     as typed enums) and the panel-shape numerics the user typically
-    wants next to them (``n_assets`` / ``n_periods`` / ``sparsity``).
-    Named ``Properties`` rather than ``Axes`` because the numeric
-    fields are not axes — they are observations supporting the axis
-    decisions.
+    wants next to them (``n_assets`` / ``n_periods`` / ``n_pairs`` /
+    ``sparse_ratio``). Named ``Properties`` rather than ``Axes``
+    because the numeric fields are not axes — they are observations
+    supporting the axis decisions.
 
     Attributes:
         scope: Detected :class:`FactorScope`.
@@ -59,8 +59,13 @@ class PanelProperties:
             ``n_assets == 1`` (single-asset panel), ``PANEL`` otherwise.
         n_assets: Unique ``asset_id`` count under any-non-null union.
         n_periods: Unique ``date`` count under any-non-null union.
-        sparsity: Zero-ratio in the ``factor`` column.
-            ``math.nan`` for an empty panel.
+        n_pairs: Non-null ``(date, asset_id)`` factor observation
+            count — the upper bound on usable sample size for any
+            pair-counting metric (IC, rank-IC, FM cross-section).
+            Equals ``panel.height`` for a dense panel; smaller when
+            the factor column has nulls.
+        sparse_ratio: Zero-ratio in the ``factor`` column (denominator
+            is non-null cell count). ``math.nan`` for an empty panel.
     """
 
     scope: FactorScope
@@ -68,7 +73,8 @@ class PanelProperties:
     mode: Mode
     n_assets: int
     n_periods: int
-    sparsity: float
+    n_pairs: int
+    sparse_ratio: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,8 +147,9 @@ class PanelInspection:
         Layout (top-level keys, stable order):
 
         - ``detected``: ``{scope, signal, mode, n_assets, n_periods,
-          sparsity}`` — enum fields rendered as their ``.value``
-          string; ``sparsity`` ``NaN`` emitted as ``None``.
+          n_pairs, sparse_ratio}`` — enum fields rendered as their
+          ``.value`` string; ``sparse_ratio`` ``NaN`` emitted as
+          ``None``.
         - ``reasoning``: ``{scope, signal, mode}``.
         - ``metrics``: list of per-spec dicts
           ``{name, cell, usable, warnings, blockers}`` — same row
@@ -161,7 +168,10 @@ class PanelInspection:
                 "mode": d.mode.value,
                 "n_assets": d.n_assets,
                 "n_periods": d.n_periods,
-                "sparsity": None if math.isnan(d.sparsity) else d.sparsity,
+                "n_pairs": d.n_pairs,
+                "sparse_ratio": (
+                    None if math.isnan(d.sparse_ratio) else d.sparse_ratio
+                ),
             },
             "reasoning": {
                 "scope": self.reasoning.scope_reason,
@@ -203,9 +213,10 @@ class PanelInspection:
             ("mode", d.mode.value),
             ("n_assets", d.n_assets),
             ("n_periods", d.n_periods),
+            ("n_pairs", d.n_pairs),
             (
-                "sparsity",
-                f"{d.sparsity:.3f}" if not math.isnan(d.sparsity) else "nan",
+                "sparse_ratio",
+                f"{d.sparse_ratio:.3f}" if not math.isnan(d.sparse_ratio) else "nan",
             ),
         ]
         header_html = "".join(
@@ -296,11 +307,12 @@ def inspect_panel(panel: Any) -> PanelInspection:
         >>> all(m.spec.cell.matches(info.detected.scope, info.detected.signal, info.detected.mode) for m in usable)
         True
     """
-    signal, signal_reason, sparsity = _detect_signal(panel)
+    signal, signal_reason, sparse_ratio = _detect_signal(panel)
     scope, scope_reason = _detect_scope(panel)
     mode = _derive_mode(panel)
     n_assets = int(panel["asset_id"].n_unique())
     n_periods = int(panel["date"].n_unique())
+    n_pairs = int(panel.drop_nulls("factor").height)
 
     mode_reason = (
         f"n_assets={n_assets} → "
@@ -313,7 +325,8 @@ def inspect_panel(panel: Any) -> PanelInspection:
         mode=mode,
         n_assets=n_assets,
         n_periods=n_periods,
-        sparsity=sparsity,
+        n_pairs=n_pairs,
+        sparse_ratio=sparse_ratio,
     )
     reasoning = PanelReasoning(
         scope_reason=scope_reason,
@@ -375,6 +388,21 @@ def _evaluate_applicability(
                 warnings.append(
                     Warning(code=tier, source=spec.name, message=tier.description)
                 )
+        if floor.min_pairs is not None and properties.n_pairs < floor.min_pairs:
+            blockers.append(
+                f"n_pairs={properties.n_pairs} < min_pairs={floor.min_pairs}"
+            )
+        elif floor.warn_pairs is not None and properties.n_pairs < floor.warn_pairs:
+            warnings.append(
+                Warning(
+                    code=WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+                    source=spec.name,
+                    message=(
+                        f"n_pairs={properties.n_pairs} < warn_pairs="
+                        f"{floor.warn_pairs}: inference degraded"
+                    ),
+                )
+            )
 
     return MetricApplicability(
         spec=spec,

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -204,6 +204,8 @@ class SampleFloor:
     warn_periods: int | None = None
     min_assets: int | None = None
     warn_assets: int | None = None
+    min_pairs: int | None = None
+    warn_pairs: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -917,7 +917,9 @@ in v0.14.0 as types-only; runner wiring lands with the DAG executor.
   per-metric usability verdict.
   - `PanelInspection.detected: PanelProperties` carries the typed
     enums (`scope` / `signal` / `mode`) plus shape numerics
-    (`n_assets` / `n_periods` / `sparsity`).
+    (`n_assets` / `n_periods` / `n_pairs` / `sparse_ratio`).
+    `n_pairs` counts non-null `(date, asset_id)` factor observations
+    — the upper bound on sample size for pair-counting metrics.
   - `PanelInspection.reasoning: PanelReasoning` carries per-axis
     rationale strings.
   - `PanelInspection.metrics: list[MetricApplicability]` — one
@@ -934,9 +936,10 @@ in v0.14.0 as types-only; runner wiring lands with the DAG executor.
     — mode is integral so e.g. `IC` (cell declares `mode=PANEL`) is
     unusable on a single-asset panel, not just degraded. (2)
     `MetricSpec.sample_floor: SampleFloor | None` — declarative
-    `min_periods` / `warn_periods` / `min_assets` / `warn_assets`
-    gates evaluated against `PanelProperties`. Specs without
-    `sample_floor` only get the cell-match check.
+    `min_periods` / `warn_periods` / `min_assets` / `warn_assets` /
+    `min_pairs` / `warn_pairs` gates evaluated against
+    `PanelProperties`. Specs without `sample_floor` only get the
+    cell-match check.
 - **`Cell.matches(scope, signal, mode=None)`** — gains optional
   `mode` argument. Existing `list_metrics` callers stay backward
   compatible (default `None` skips the mode axis); `inspect_panel`

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -42,7 +42,8 @@ class TestPanelPropertiesDetection:
         assert info.detected.mode is fx.Mode.PANEL
         assert info.detected.n_assets == 20
         assert info.detected.n_periods == 80
-        assert 0.0 <= info.detected.sparsity < 0.5
+        assert info.detected.n_pairs == 20 * 80
+        assert 0.0 <= info.detected.sparse_ratio < 0.5
 
     def test_n1_routes_to_timeseries(self):
         info = inspect_panel(_single_asset_panel(n_dates=80))
@@ -55,10 +56,23 @@ class TestPanelPropertiesDetection:
         assert info.detected.scope is fx.FactorScope.COMMON
         assert info.detected.signal is fx.Signal.CONTINUOUS
 
-    def test_empty_panel_sparsity_is_nan(self):
+    def test_empty_panel_sparse_ratio_is_nan(self):
         empty = fx.datasets.make_cs_panel(n_assets=4, n_dates=10).head(0)
         info = inspect_panel(empty)
-        assert math.isnan(info.detected.sparsity)
+        assert math.isnan(info.detected.sparse_ratio)
+        assert info.detected.n_pairs == 0
+
+    def test_n_pairs_counts_non_null_factor_only(self):
+        raw = fx.datasets.make_cs_panel(n_assets=4, n_dates=10)
+        with_nulls = raw.with_columns(
+            pl.when(pl.int_range(0, raw.height) % 3 == 0)
+            .then(None)
+            .otherwise(pl.col("factor"))
+            .alias("factor")
+        )
+        info = inspect_panel(with_nulls)
+        assert info.detected.n_pairs == with_nulls.drop_nulls("factor").height
+        assert info.detected.n_pairs < raw.height
 
 
 class TestPanelReasoning:
@@ -110,6 +124,38 @@ class TestSampleFloorGate:
         assert nw.usable is True
         assert nw.warnings == []
 
+    def test_below_min_pairs_is_unusable(self):
+        from factrix._metric_index import SampleFloor
+
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        floor = SampleFloor(min_pairs=info.detected.n_pairs + 1)
+        spec = next(m.spec for m in info.metrics if m.spec.name == "ic_newey_west")
+        from dataclasses import replace
+
+        from factrix._inspect import _evaluate_applicability
+
+        verdict = _evaluate_applicability(
+            replace(spec, sample_floor=floor), info.detected
+        )
+        assert verdict.usable is False
+        assert any("min_pairs" in b for b in verdict.blockers)
+
+    def test_between_min_and_warn_pairs_is_usable_with_warning(self):
+        from dataclasses import replace
+
+        from factrix._inspect import _evaluate_applicability
+        from factrix._metric_index import SampleFloor
+
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        n = info.detected.n_pairs
+        floor = SampleFloor(min_pairs=n - 1, warn_pairs=n + 1)
+        spec = next(m.spec for m in info.metrics if m.spec.name == "ic_newey_west")
+        verdict = _evaluate_applicability(
+            replace(spec, sample_floor=floor), info.detected
+        )
+        assert verdict.usable is True
+        assert any("n_pairs" in w.message for w in verdict.warnings)
+
     def test_metric_without_sample_floor_only_cell_checked(self):
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
         ic = _by_name(info, "ic")
@@ -147,10 +193,11 @@ class TestToDict:
         assert nw["usable"] is True
         assert any(w["code"] == "unreliable_se_short_periods" for w in nw["warnings"])
 
-    def test_nan_sparsity_becomes_null(self):
+    def test_nan_sparse_ratio_becomes_null(self):
         empty = fx.datasets.make_cs_panel(n_assets=4, n_dates=10).head(0)
         d = inspect_panel(empty).to_dict()
-        assert d["detected"]["sparsity"] is None
+        assert d["detected"]["sparse_ratio"] is None
+        assert d["detected"]["n_pairs"] == 0
 
     def test_panel_level_warnings_serialised(self):
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))


### PR DESCRIPTION
## Summary

- `PanelProperties`: rename `sparsity` → `sparse_ratio` (clearer that it is a ratio quantity); add `n_pairs` = non-null `(date, asset_id)` factor observation count, the upper-bound sample size for any pair-counting metric (IC, rank-IC, FM cross-section).
- `SampleFloor`: add `min_pairs` / `warn_pairs`. Pair-floor warn tier reuses `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` — same degraded-inference semantic as the periods axis; per-axis warning codes can be split when populating the broader spec audit (tracked in #458).
- `ic_newey_west` / `ic_ir` floors unchanged — period-gated; pair gates are wired but not populated, awaiting the cross-spec floor audit called out as follow-up in `#443` scope notes.
- `_describe.py` untouched (`suggest_config` retiree per #438).
- `factrix/llms-full.txt` PanelInspection section updated to reflect new shape numerics and gate enumeration.

## Test plan

- [x] `uv run pytest tests/test_inspect_panel.py` — 25 pass (4 new: `n_pairs` non-null counting, empty-panel `n_pairs == 0`, min_pairs blocker, warn_pairs degraded warning)
- [x] `uv run pytest` full suite — 1569 pass, 4 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy factrix/_inspect.py factrix/_metric_index.py tests/test_inspect_panel.py` — no issues
- [ ] reviewer to sanity-check pair-floor warn-code reuse is acceptable as scaffolding (see commit body + #458 concern 5)

Refs #443. Follow-up audits (`MetricResult` / `MetricOutput` / `MetricSpec` surface) tracked in #458.