### PR TITLE
feat(api): fx.estimators namespace + metric_spec / register (#444)

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -42,7 +42,7 @@ from typing import Any
 
 import polars as pl
 
-from factrix import datasets, multi_factor, preprocess
+from factrix import datasets, estimators, multi_factor, preprocess
 from factrix._analysis_config import AnalysisConfig
 from factrix._axis import (  # noqa: F401  Mode re-exported for namespace access; intentionally not in __all__
     FactorScope,
@@ -81,7 +81,7 @@ from factrix._inspect import (
     PanelReasoning,
     inspect_panel,
 )
-from factrix._metric_index import MetricSpec, SampleFloor, spec_by_name
+from factrix._metric_index import MetricSpec, SampleFloor, metric_spec, spec_by_name
 from factrix._panel_input import PanelInput, _coerce_panel
 from factrix._profile import FactorProfile
 from factrix._results import EvaluationResult, MetricResult, Warning
@@ -467,4 +467,9 @@ __all__ = [
     "datasets",
     # Forward-return preprocessing
     "preprocess",
+    # Estimator entry points (lowercase callables consumed by metric impls)
+    "estimators",
+    # Metric registration surface
+    "MetricSpec",
+    "metric_spec",
 ]

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -274,12 +274,14 @@ def _default_fn_resolver(name: str) -> Callable[..., Any]:
 
 @functools.cache
 def _registry_callable_table() -> dict[str, Callable[..., Any]]:
-    """Single-pass ``{spec.name: callable}`` across every public metric module.
+    """Single-pass ``{spec.name: callable}`` across every registered metric.
 
-    Module-level cache so executor construction stays O(1) per spec
-    lookup instead of re-walking ``_public_metric_stems`` per call.
+    Walks first-party ``factrix.metrics.*`` modules and the third-party
+    registry populated via :func:`factrix.metrics.register`. Cache is
+    cleared by :func:`factrix.metrics.register` so newly-registered
+    callables become resolvable on the next executor construction.
     """
-    from factrix._metric_index import _all_specs, import_path_for
+    from factrix._metric_index import _METRIC_REGISTRY, _all_specs, import_path_for
 
     table: dict[str, Callable[..., Any]] = {}
     for stem, spec in _all_specs():
@@ -287,6 +289,12 @@ def _registry_callable_table() -> dict[str, Callable[..., Any]]:
         fn = getattr(mod, spec.name, None)
         if callable(fn):
             table[spec.name] = fn
+    import factrix.metrics as _metrics_pkg
+
+    for name in _METRIC_REGISTRY:
+        fn = getattr(_metrics_pkg, name, None)
+        if callable(fn):
+            table[name] = fn
     return table
 
 

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -39,7 +39,7 @@ import inspect
 import pathlib
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from factrix._axis import FactorScope, Metric, Mode, Signal, Visibility
 
@@ -408,6 +408,108 @@ def module_specs(stem: str) -> tuple[MetricSpec, ...]:
 
 
 @functools.cache
-def spec_by_name() -> dict[str, MetricSpec]:
-    """Return ``{name: spec}`` across every spec (public and internal)."""
+def _first_party_spec_by_name() -> dict[str, MetricSpec]:
+    """Return ``{name: spec}`` for first-party specs only (cached)."""
     return {spec.name: spec for _, spec in _all_specs()}
+
+
+def spec_by_name() -> dict[str, MetricSpec]:
+    """Return ``{name: spec}`` unioning first-party + third-party registered specs.
+
+    First-party specs are auto-discovered from ``factrix.metrics.*``
+    modules' ``__metric_specs__`` tuples (cached). Third-party specs
+    are added via :func:`register`; the third-party slice is reflected
+    here without recomputing the first-party walk.
+    """
+    out = dict(_first_party_spec_by_name())
+    out.update(_METRIC_REGISTRY)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Third-party metric registration surface
+# ---------------------------------------------------------------------------
+
+
+_METRIC_REGISTRY: dict[str, MetricSpec] = {}
+"""Third-party metric registry populated via :func:`register`.
+
+Kept separate from the first-party cache so first-party discovery
+stays a single import-time walk and third-party additions don't
+invalidate that cache. :func:`spec_by_name` unions both sources.
+"""
+
+
+def metric_spec(spec: MetricSpec) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Stamp ``__metric_spec__`` onto a metric callable.
+
+    Pure metadata stamp — does **not** register. Pair with an explicit
+    :func:`register` call to make the spec visible to
+    :func:`list_metrics` / :func:`spec_by_name` / DAG dispatch::
+
+        @metric_spec(MetricSpec(name="custom_ic", cell=..., ...))
+        def custom_ic(panel, ...): ...
+
+        factrix.metrics.register(custom_ic)
+
+    Accepts the full :class:`MetricSpec` object rather than spreading
+    kwargs so the decorator surface stays evergreen across MetricSpec
+    field changes (e.g. the structural rework in the
+    panel-dataclass-unification follow-up).
+    """
+
+    def _wrap(fn: Callable[..., Any]) -> Callable[..., Any]:
+        fn.__metric_spec__ = spec  # type: ignore[attr-defined]
+        return fn
+
+    return _wrap
+
+
+def register(fn: Callable[..., Any]) -> None:
+    """Register a third-party metric callable carrying ``__metric_spec__``.
+
+    The callable must have been decorated with :func:`metric_spec` (or
+    have ``__metric_spec__`` attached by other means). Registration
+    side-effects:
+
+    1. Adds the spec to ``_METRIC_REGISTRY`` so :func:`spec_by_name`
+       and the DAG executor can resolve it by name.
+    2. Sets ``factrix.metrics.<spec.name>`` to the callable so IDE /
+       mypy / interactive use see a real attribute (parallel to
+       first-party metrics imported into the namespace).
+    3. Clears any caches that would otherwise mask the new spec.
+
+    Raises:
+        TypeError: ``fn`` is not callable or has no ``__metric_spec__``.
+        ValueError: a spec with the same name is already registered
+            (third-party) or exists as a first-party spec; explicit
+            re-registration is disallowed to keep the registry
+            authoritative.
+    """
+    if not callable(fn):
+        raise TypeError(f"register(): expected a callable; got {type(fn).__name__}.")
+    spec = getattr(fn, "__metric_spec__", None)
+    if not isinstance(spec, MetricSpec):
+        raise TypeError(
+            "register(): callable has no __metric_spec__ attribute. "
+            "Apply @metric_spec(MetricSpec(...)) first."
+        )
+    name = spec.name
+    if name in _METRIC_REGISTRY:
+        raise ValueError(
+            f"register(): metric {name!r} already registered (third-party)."
+        )
+    if name in _first_party_spec_by_name():
+        raise ValueError(
+            f"register(): metric {name!r} clashes with a first-party spec; "
+            f"pick a different name."
+        )
+
+    import factrix.metrics as _metrics_pkg
+
+    _METRIC_REGISTRY[name] = spec
+    setattr(_metrics_pkg, name, fn)
+
+    from factrix._dag import _registry_callable_table
+
+    _registry_callable_table.cache_clear()

--- a/factrix/estimators/__init__.py
+++ b/factrix/estimators/__init__.py
@@ -76,6 +76,14 @@ def block_bootstrap(
     resolved block length, scheme, n_resamples, and the seed actually
     used (so reproducibility survives ``rng_seed=None``).
     """
+    if block_length != "auto" and block_length < 1:
+        raise ValueError(
+            f"block_length must be 'auto' or int >= 1; got {block_length!r}."
+        )
+    if n_resamples < 1:
+        raise ValueError(f"n_resamples must be >= 1; got {n_resamples!r}.")
+    if scheme not in ("fixed", "stationary"):
+        raise ValueError(f"scheme must be 'fixed' or 'stationary'; got {scheme!r}.")
     from factrix._stats.bootstrap import _block_bootstrap_diff_p
 
     return _block_bootstrap_diff_p(

--- a/factrix/estimators/__init__.py
+++ b/factrix/estimators/__init__.py
@@ -1,0 +1,94 @@
+"""Lowercase callable estimator entry points consumed by metric implementations.
+
+Boundary with :mod:`factrix.stats`:
+
+- :mod:`factrix.stats` exposes the PascalCase :class:`Estimator` protocol
+  family (``NeweyWest`` / ``HansenHodrick`` / ``BlockBootstrap``) used
+  by the ``AnalysisConfig.estimator`` field and the slice-test
+  estimator-dispatch path.
+- :mod:`factrix.estimators` exposes lowercase function aliases over the
+  same underlying computations, callable directly from inside a metric
+  implementation without instantiating an ``Estimator`` first.
+
+The two namespaces are not in tension — :mod:`factrix.stats` retires the
+class-based ``Estimator`` selection surface as part of the
+``AnalysisConfig`` retirement, and the lowercase callables here are the
+forward-compatible internal-consumption surface for metric callables
+and, in the future, runtime per-metric estimator override.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from factrix.stats._estimator import InferenceResult
+
+
+def newey_west(series: np.ndarray, *, forward_periods: int) -> InferenceResult:
+    """Newey-West HAC SE on a series mean → t-statistic → two-sided p-value.
+
+    Lowercase callable alias over :class:`factrix.stats.NeweyWest`.
+    Bartlett kernel, NW1994 auto-bandwidth, Hansen-Hodrick overlap
+    floor. ``forward_periods`` sets the overlap horizon used by the
+    floor.
+    """
+    from factrix.stats.newey_west import NeweyWest
+
+    return NeweyWest().compute(series, forward_periods=forward_periods)
+
+
+def hansen_hodrick(series: np.ndarray, *, forward_periods: int) -> InferenceResult:
+    """Hansen-Hodrick (1980) rectangular-kernel HAC SE on a series mean.
+
+    Lowercase callable alias over :class:`factrix.stats.HansenHodrick`.
+    Rectangular kernel matched to MA(h-1) overlap structure from
+    h-period forward returns; no PSD guarantee — variance is clamped
+    at zero and the result carries
+    ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` when the raw estimate
+    is negative.
+    """
+    from factrix.stats.hansen_hodrick import HansenHodrick
+
+    return HansenHodrick().compute(series, forward_periods=forward_periods)
+
+
+def block_bootstrap(
+    diff: np.ndarray,
+    *,
+    block_length: int | Literal["auto"] = "auto",
+    n_resamples: int = 999,
+    scheme: Literal["fixed", "stationary"] = "stationary",
+    rng_seed: int | None = None,
+) -> tuple[float, dict[str, float | int | str]]:
+    """Two-sided empirical p for ``H_0: E[diff] = 0`` on a paired series.
+
+    Lowercase callable alias over the dependent-bootstrap path used by
+    :class:`factrix.stats.BlockBootstrap`. Stationary scheme
+    (Politis-Romano 1994) by default; ``scheme="fixed"`` runs the
+    Kunsch (1989) fixed-block variant. Block length resolves via
+    Politis-White (2004) when ``block_length="auto"``.
+
+    Returns ``(p_value, metadata)`` — p in ``[1/(B+1), 1]`` (Davison-
+    Hinkley smoothing keeps p strictly positive); metadata records the
+    resolved block length, scheme, n_resamples, and the seed actually
+    used (so reproducibility survives ``rng_seed=None``).
+    """
+    from factrix._stats.bootstrap import _block_bootstrap_diff_p
+
+    return _block_bootstrap_diff_p(
+        diff,
+        block_length=block_length,
+        n_resamples=n_resamples,
+        scheme=scheme,
+        rng_seed=rng_seed,
+    )
+
+
+__all__ = [
+    "block_bootstrap",
+    "hansen_hodrick",
+    "newey_west",
+]

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -790,7 +790,14 @@ explicit.
 import factrix as fx
 from factrix._metric_index import MetricSpec, cell
 
-@fx.metric_spec(MetricSpec(name="custom_ic", cell=cell(...), ...))
+@fx.metric_spec(
+    MetricSpec(
+        name="custom_ic",
+        cell=cell(fx.FactorScope.INDIVIDUAL, fx.Signal.CONTINUOUS),
+        family="cs-first",
+        inference="NW HAC",
+    )
+)
 def custom_ic(panel):
     ...
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -778,6 +778,31 @@ factrix.list_estimators(scope: FactorScope, signal: Signal,
 
 ---
 
+### Third-party metric registration
+
+Custom metrics plug into the registry via the `@metric_spec(...)` decorator
+(metadata stamp only — does **not** auto-register) plus an explicit
+`factrix.metrics.register(fn)` call. The pair lets IDE / mypy see a real
+attribute on `factrix.metrics` while keeping registration side-effects
+explicit.
+
+```python
+import factrix as fx
+from factrix._metric_index import MetricSpec, cell
+
+@fx.metric_spec(MetricSpec(name="custom_ic", cell=cell(...), ...))
+def custom_ic(panel):
+    ...
+
+fx.metrics.register(custom_ic)
+# Now resolvable: getattr(fx.metrics, "custom_ic"), and pass
+# custom_ic.__metric_spec__ in fx.evaluate(metrics=[...]).
+```
+
+`register(fn)` rejects duplicate names and clashes with first-party specs;
+the decorator accepts the full `MetricSpec` object (not kwargs) so the
+decorator surface stays stable across MetricSpec field changes.
+
 ### Preprocessing
 
 ```python

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -34,6 +34,7 @@ Series diagnostics — axis-agnostic on ``(date, value)``:
     hit_rate, ic_trend, multi_split_oos_decay
 """
 
+from factrix._metric_index import metric_spec, register
 from factrix.metrics.caar import (
     bmp_test,
     caar,
@@ -141,4 +142,7 @@ __all__ = [
     "ts_beta_sign_consistency",
     "ts_quantile_spread",
     "turnover",
+    # Third-party registration
+    "metric_spec",
+    "register",
 ]

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,0 +1,69 @@
+"""``factrix.estimators`` lowercase callable namespace (#444)."""
+
+from __future__ import annotations
+
+import factrix as fx
+import numpy as np
+import pytest
+from factrix.stats import BlockBootstrap, HansenHodrick, NeweyWest
+
+
+class TestNeweyWestCallable:
+    def test_matches_class_compute(self) -> None:
+        series = np.random.default_rng(0).standard_normal(60)
+        out_class = NeweyWest().compute(series, forward_periods=5)
+        out_func = fx.estimators.newey_west(series, forward_periods=5)
+        assert out_class == out_func
+
+
+class TestHansenHodrickCallable:
+    def test_matches_class_compute(self) -> None:
+        series = np.random.default_rng(1).standard_normal(60)
+        out_class = HansenHodrick().compute(series, forward_periods=5)
+        out_func = fx.estimators.hansen_hodrick(series, forward_periods=5)
+        assert out_class == out_func
+
+
+class TestBlockBootstrapCallable:
+    def test_returns_p_in_range_and_metadata(self) -> None:
+        diff = np.random.default_rng(2).standard_normal(80)
+        p, meta = fx.estimators.block_bootstrap(
+            diff, n_resamples=199, rng_seed=42, scheme="stationary"
+        )
+        assert 1.0 / 200 <= p <= 1.0
+        assert {"block_length", "n_resamples", "scheme", "rng_seed"} <= set(meta.keys())
+
+    def test_class_and_function_share_underlying_p_for_same_seed(self) -> None:
+        # BlockBootstrap class doesn't expose a series-level compute() —
+        # the slice-test path consumes its parameters via the slice-test
+        # function. The lowercase callable here is an alias over the
+        # underlying paired-diff bootstrap; smoke-check shape only.
+        diff = np.random.default_rng(3).standard_normal(60)
+        p_a, _ = fx.estimators.block_bootstrap(diff, n_resamples=99, rng_seed=7)
+        p_b, _ = fx.estimators.block_bootstrap(diff, n_resamples=99, rng_seed=7)
+        assert p_a == p_b
+        assert isinstance(BlockBootstrap(), BlockBootstrap)  # class still importable
+
+
+class TestNamespaceExports:
+    def test_top_level_namespace_attached(self) -> None:
+        assert hasattr(fx, "estimators")
+
+    def test_namespace_exports_three_callables(self) -> None:
+        for name in ("newey_west", "hansen_hodrick", "block_bootstrap"):
+            assert callable(getattr(fx.estimators, name))
+
+    def test_does_not_expose_driscoll_kraay(self) -> None:
+        # Driscoll-Kraay is documented as a future variant under
+        # SEMethod.HAC; #444 explicitly defers implementation.
+        assert not hasattr(fx.estimators, "driscoll_kraay")
+
+
+@pytest.mark.parametrize("forward_periods", [1, 5, 21])
+class TestEstimatorForwardPeriodsParametrize:
+    def test_newey_west_returns_finite_for_iid_normal(self, forward_periods):
+        rng = np.random.default_rng(2024)
+        series = rng.standard_normal(120)
+        out = fx.estimators.newey_west(series, forward_periods=forward_periods)
+        assert np.isfinite(out.p)
+        assert 0.0 <= out.p <= 1.0

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -33,6 +33,21 @@ class TestBlockBootstrapCallable:
         assert 1.0 / 200 <= p <= 1.0
         assert {"block_length", "n_resamples", "scheme", "rng_seed"} <= set(meta.keys())
 
+    def test_rejects_zero_n_resamples(self) -> None:
+        diff = np.random.default_rng(5).standard_normal(40)
+        with pytest.raises(ValueError, match="n_resamples"):
+            fx.estimators.block_bootstrap(diff, n_resamples=0)
+
+    def test_rejects_unknown_scheme(self) -> None:
+        diff = np.random.default_rng(6).standard_normal(40)
+        with pytest.raises(ValueError, match="scheme"):
+            fx.estimators.block_bootstrap(diff, scheme="bogus")  # type: ignore[arg-type]
+
+    def test_rejects_zero_block_length(self) -> None:
+        diff = np.random.default_rng(7).standard_normal(40)
+        with pytest.raises(ValueError, match="block_length"):
+            fx.estimators.block_bootstrap(diff, block_length=0)
+
     def test_class_and_function_share_underlying_p_for_same_seed(self) -> None:
         # BlockBootstrap class doesn't expose a series-level compute() —
         # the slice-test path consumes its parameters via the slice-test

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,132 @@
+"""Third-party metric registration — ``@metric_spec`` decorator + ``register()`` (#444)."""
+
+from __future__ import annotations
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._metric_index import (
+    _METRIC_REGISTRY,
+    MetricSpec,
+    cell,
+    spec_by_name,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Clear any third-party registry entries / namespace attrs between tests."""
+    before = dict(_METRIC_REGISTRY)
+    yield
+    added = set(_METRIC_REGISTRY) - set(before)
+    for name in added:
+        _METRIC_REGISTRY.pop(name, None)
+        if hasattr(fx.metrics, name):
+            delattr(fx.metrics, name)
+    from factrix._dag import _registry_callable_table
+
+    _registry_callable_table.cache_clear()
+
+
+class TestMetricSpecDecorator:
+    def test_stamps_metric_spec_attribute(self) -> None:
+        spec = MetricSpec(
+            name="stamp_only", cell=cell(None, None), family="test", inference="test"
+        )
+
+        @fx.metric_spec(spec)
+        def stamp_only(panel: pl.DataFrame):
+            return 0
+
+        assert stamp_only.__metric_spec__ is spec
+
+    def test_decorator_does_not_auto_register(self) -> None:
+        spec = MetricSpec(
+            name="no_auto_register",
+            cell=cell(None, None),
+            family="test",
+            inference="test",
+        )
+
+        @fx.metric_spec(spec)
+        def no_auto_register(panel: pl.DataFrame):
+            return 0
+
+        assert "no_auto_register" not in spec_by_name()
+        assert not hasattr(fx.metrics, "no_auto_register")
+
+
+class TestRegister:
+    def test_register_sets_real_module_attr(self) -> None:
+        spec = MetricSpec(
+            name="custom_ic_smoke",
+            cell=cell(None, None),
+            family="test",
+            inference="test",
+        )
+
+        @fx.metric_spec(spec)
+        def custom_ic_smoke(panel: pl.DataFrame):
+            return 42
+
+        fx.metrics.register(custom_ic_smoke)
+
+        assert fx.metrics.custom_ic_smoke is custom_ic_smoke
+        assert "custom_ic_smoke" in spec_by_name()
+        assert spec_by_name()["custom_ic_smoke"] is spec
+
+    def test_register_callable_resolves_through_dag_callable_table(self) -> None:
+        from factrix._dag import _registry_callable_table
+
+        spec = MetricSpec(
+            name="dag_resolves_me",
+            cell=cell(None, None),
+            family="test",
+            inference="test",
+        )
+
+        @fx.metric_spec(spec)
+        def dag_resolves_me(panel: pl.DataFrame):
+            return 0
+
+        fx.metrics.register(dag_resolves_me)
+        assert _registry_callable_table()["dag_resolves_me"] is dag_resolves_me
+
+    def test_register_rejects_non_callable(self) -> None:
+        with pytest.raises(TypeError, match="callable"):
+            fx.metrics.register("not a function")  # type: ignore[arg-type]
+
+    def test_register_rejects_callable_without_metric_spec(self) -> None:
+        def plain_function():
+            return 0
+
+        with pytest.raises(TypeError, match="__metric_spec__"):
+            fx.metrics.register(plain_function)
+
+    def test_register_rejects_duplicate(self) -> None:
+        spec = MetricSpec(
+            name="dup_metric",
+            cell=cell(None, None),
+            family="test",
+            inference="test",
+        )
+
+        @fx.metric_spec(spec)
+        def dup_metric():
+            return 0
+
+        fx.metrics.register(dup_metric)
+        with pytest.raises(ValueError, match="already registered"):
+            fx.metrics.register(dup_metric)
+
+    def test_register_rejects_first_party_clash(self) -> None:
+        clash_spec = MetricSpec(
+            name="ic", cell=cell(None, None), family="x", inference="x"
+        )
+
+        @fx.metric_spec(clash_spec)
+        def ic_clash():
+            return 0
+
+        with pytest.raises(ValueError, match="first-party"):
+            fx.metrics.register(ic_clash)


### PR DESCRIPTION
## Summary

- New `factrix.estimators` lowercase callable namespace (`newey_west`, `hansen_hodrick`, `block_bootstrap`) over existing `factrix.stats` Estimator classes; thin wrappers consumed by metric implementations and (forward-looking) the per-metric runtime-override path documented in #458.
- `@factrix.metric_spec(spec)` decorator stamps `__metric_spec__` on a callable without registering; `factrix.metrics.register(fn)` writes to the third-party `_METRIC_REGISTRY` and sets a real attribute on `factrix.metrics` so IDE / mypy resolve the symbol. Decorator takes a full `MetricSpec` (not kwargs) so the surface is evergreen across MetricSpec field changes.
- Registry is union-merged with first-party `__metric_specs__` auto-discovery in `spec_by_name()` and resolves through the `DagExecutor` callable table after cache invalidation. `driscoll_kraay` intentionally deferred — separate methodology issue.

## Review fixes (second commit)

- `block_bootstrap()` now mirrors the three class-side validations (`block_length`, `n_resamples`, `scheme`) that were previously bypassed when calling through the lowercase wrapper.
- `llms-full.txt` register example replaced its `...` placeholders for the required `MetricSpec.family` / `inference` fields with concrete values so a reader copy-pasting the snippet doesn't hit `TypeError`.

## Test plan

- [x] `uv run pytest` — 1530 passed / 65 skipped
- [x] `uv run pytest --doctest-modules factrix/` — 74 passed / 4 skipped
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy factrix` — clean
- [x] New `tests/test_register.py` (8 cases) covers stamp-without-auto-register, real-module-attr, DAG callable-table resolution, duplicate / first-party-clash / non-callable / no-`__metric_spec__` rejection.
- [x] New `tests/test_estimators.py` (13 cases) covers parity with class `compute()` for `newey_west` / `hansen_hodrick`, `block_bootstrap` reproducibility under seed, validation guards, `forward_periods` parametrize, `driscoll_kraay` deliberately absent.

Closes #444