### PR TITLE
feat(api): tier-partitioned applicability properties on PanelInspection

### DIFF
--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -16,9 +16,9 @@ Two-stage applicability model:
 
 Each public spec receives one :class:`MetricApplicability` verdict
 exposing ``usable`` / ``warnings`` / ``blockers``. The flat
-``list[MetricApplicability]`` on :class:`PanelInspection` is the
-single source of truth; partitioning by ``.usable`` is a one-line
-list comprehension at the call site.
+``list[MetricApplicability]`` on :class:`PanelInspection.metrics` is
+the single source of truth; the ``usable`` / ``degraded`` /
+``unusable`` properties expose it as a mutually exclusive partition.
 """
 
 from __future__ import annotations
@@ -180,8 +180,9 @@ class PanelInspection:
             (scope / signal / mode).
         metrics: Flat ``list[MetricApplicability]`` — one verdict
             per ``visibility=PUBLIC`` spec the inspector considered.
-            Caller partitions via list comprehension:
-            ``usable = [m for m in info.metrics if m.usable]``.
+            Single source of truth; the :attr:`usable` /
+            :attr:`degraded` / :attr:`unusable` properties expose it
+            as a mutually exclusive partition.
         warnings: Panel-level sample-shape diagnostics (NW HAC SE
             unreliable, cross-asset df low). ``source=None`` on
             every entry because these are panel-level, not
@@ -193,6 +194,45 @@ class PanelInspection:
     reasoning: PanelReasoning
     metrics: list[MetricApplicability]
     warnings: list[Warning] = field(default_factory=list)
+
+    @property
+    def usable(self) -> list[MetricApplicability]:
+        """Metrics that are applicable AND carry no degraded warning.
+
+        The production-safe set: every verdict here passed cell match
+        and every ``min_*`` floor with zero ``warn_*`` violations.
+
+        ``usable`` / :attr:`degraded` / :attr:`unusable` form a
+        **mutually exclusive** partition of :attr:`metrics` — a
+        verdict appears in exactly one. ``usable`` deliberately
+        *excludes* degraded verdicts so it can be the single safe set
+        a bulk discovery flow runs without re-filtering. The
+        "usable but warned" verdicts live in :attr:`degraded`.
+        """
+        return [m for m in self.metrics if m.usable and not m.warnings]
+
+    @property
+    def degraded(self) -> list[MetricApplicability]:
+        """Applicable metrics that run but with degraded inference.
+
+        ``usable=True`` yet at least one ``warn_*``-tier
+        :class:`Warning` attached (e.g. NW HAC SE unreliable at short
+        ``n_periods``). They produce a value, but the caller should
+        read the warnings before trusting the inference. Disjoint from
+        :attr:`usable` and :attr:`unusable`.
+        """
+        return [m for m in self.metrics if m.usable and m.warnings]
+
+    @property
+    def unusable(self) -> list[MetricApplicability]:
+        """Metrics that cannot run on this panel.
+
+        ``usable=False`` — blocked by cell mismatch or a ``min_*``
+        floor violation; :attr:`MetricApplicability.blockers` carries
+        the concrete reasons. Disjoint from :attr:`usable` and
+        :attr:`degraded`.
+        """
+        return [m for m in self.metrics if not m.usable]
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-friendly nested dict view.
@@ -356,8 +396,7 @@ def inspect_panel(panel: Any) -> PanelInspection:
         >>> import factrix as fx
         >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
         >>> info = fx.inspect_panel(raw)
-        >>> usable = [m for m in info.metrics if m.usable]
-        >>> all(m.spec.cell.matches(info.detected.scope, info.detected.signal, info.detected.mode) for m in usable)
+        >>> all(m.spec.cell.matches(info.detected.scope, info.detected.signal, info.detected.mode) for m in info.usable)
         True
     """
     signal, signal_reason, sparse_ratio = _detect_signal(panel)

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -164,6 +164,45 @@ class TestSampleFloorGate:
         assert ic.warnings == []
 
 
+class TestTierPartition:
+    def test_three_tiers_partition_metrics_disjointly(self):
+        # n_dates=25 puts ic_newey_west between min and warn -> degraded.
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        usable = {m.spec.name for m in info.usable}
+        degraded = {m.spec.name for m in info.degraded}
+        unusable = {m.spec.name for m in info.unusable}
+        # Mutually exclusive.
+        assert usable & degraded == set()
+        assert usable & unusable == set()
+        assert degraded & unusable == set()
+        # Exhaustive: union covers every verdict exactly once.
+        assert len(info.usable) + len(info.degraded) + len(info.unusable) == len(
+            info.metrics
+        )
+        assert usable | degraded | unusable == {m.spec.name for m in info.metrics}
+
+    def test_usable_excludes_degraded(self):
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        nw = _by_name(info, "ic_newey_west")
+        assert nw.usable is True and nw.warnings  # the degraded case
+        assert nw not in info.usable
+        assert nw in info.degraded
+
+    def test_usable_is_clean_only(self):
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        assert all(m.usable and not m.warnings for m in info.usable)
+
+    def test_degraded_is_usable_with_warnings(self):
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        assert all(m.usable and m.warnings for m in info.degraded)
+
+    def test_unusable_is_not_usable(self):
+        info = inspect_panel(_single_asset_panel(n_dates=80))
+        assert all(not m.usable for m in info.unusable)
+        # ic (cell=PANEL) is unusable on a single-asset panel.
+        assert "ic" in {m.spec.name for m in info.unusable}
+
+
 class TestPanelLevelWarnings:
     def test_thin_panel_short_n_periods_emits_panel_warning(self):
         info = inspect_panel(_single_asset_panel(n_dates=25))


### PR DESCRIPTION
## Summary
- Add `usable` / `degraded` / `unusable` properties on `PanelInspection`, exposing the flat `metrics` list as a **mutually exclusive** partition.
- `usable` deliberately excludes degraded verdicts so it is the single production-safe set a bulk discovery flow can run without re-filtering; `degraded` holds usable-but-warned verdicts; `unusable` holds cell-mismatch / floor-blocked verdicts.
- The flat `metrics` list stays the single source of truth; this is additive (no removal), so non-breaking.
- Updates the module / field docstrings and the `inspect_panel` doctest that previously prescribed a call-site list comprehension.

Phase 1 (§7) of the #476 metric user-facing surface spec. Phase 2 will swap the property return type `list → MetricApplicabilityGroup` (a second, deliberate breaking step tracked in #476).

## Test plan
- [x] `pytest tests/test_inspect_panel.py` — 30 passed (5 new `TestTierPartition` cases: disjointness, exhaustiveness, `usable` excludes degraded, per-tier conditions)
- [x] `pytest --doctest-modules factrix/_inspect.py` — passed
- [x] `ruff check` + `ruff format --check` — clean

Refs #476