### PR TITLE
feat(api)!: split MetricSpec.family into family + agg_order

### DIFF
--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -23,7 +23,7 @@ access. Adding a new metric module just imports :class:`MetricSpec` and
         MetricSpec(
             name="my_metric",
             cell=cell(FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS, mode=PanelMode.PANEL),
-            family="cs-first",
+            agg_order="cs-first",
             inference="NW HAC / cross-asset t",
             primitives=("_calc_t_stat", "_p_value_from_t"),
         ),
@@ -38,7 +38,7 @@ import inspect
 import pathlib
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, overload
 
 from factrix._axis import FactorScope, FactorSignal, PanelMode, Visibility
 from factrix._errors import IncompatibleAxisError
@@ -158,11 +158,14 @@ class MetricSpec:
     - ``name``: function name in the declaring module.
     - ``cell``: applicable ``(scope, signal, mode)`` cell;
       ``None`` along any axis denotes ``*`` wildcard.
-    - ``family``: aggregation / inference family label —
+    - ``agg_order``: aggregation order — the order in which the
+      cross-section and time-series reductions compose:
       ``"cs-first"`` (cross-section step then time aggregation),
-      ``"per-event"``, ``"ts-only"``, ``"ts-first"``, ``"static-cs"``,
-      or free-form prose for special cases (e.g. spanning's
-      ``"factor-return-series consumer (post-PANEL pipeline)"``).
+      ``"per-event"``, ``"ts-only"``, ``"ts-first"``, ``"static-cs"``.
+      Load-bearing for the DAG executor / FDR. Distinct from the
+      *concept family* (``ic`` / ``decay`` / ``quantile``), which is
+      the declaring module's stem and is derived from file location
+      (the ``file = family`` invariant), never stored on the spec.
     - ``inference``: inference / standard-error family — e.g.
       ``"NW HAC / cross-asset t"``, ``"binomial"``,
       ``"nonparametric rank"``, ``"no formal H_0"``.
@@ -195,7 +198,7 @@ class MetricSpec:
 
     name: str
     cell: Cell
-    family: str
+    agg_order: str
     inference: str
     primitives: tuple[str, ...] = ()
     input_kind: Literal["panel", "scalar"] = "panel"
@@ -446,14 +449,51 @@ def register(fn: Callable[..., Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _metrics_overview() -> dict[str, list[MetricSpec]]:
+    """Family-grouped catalog of every public metric spec.
+
+    Keys are concept-family names (the declaring module stem, per the
+    ``file = family`` invariant); values are that module's public specs
+    in registry order — sorted, because :func:`public_specs` yields
+    ``(stem, name)`` sorted. See :func:`list_metrics` for the public
+    contract.
+    """
+    out: dict[str, list[MetricSpec]] = {}
+    for stem, spec in public_specs():
+        out.setdefault(stem, []).append(spec)
+    return out
+
+
+@overload
+def list_metrics() -> dict[str, list[MetricSpec]]: ...
+@overload
 def list_metrics(
     scope: FactorScope,
     signal: FactorSignal,
     *,
+    format: Literal["text", "json"] = ...,
+    with_import: bool = ...,
+) -> list[str] | list[dict[str, Any]]: ...
+def list_metrics(
+    scope: FactorScope | None = None,
+    signal: FactorSignal | None = None,
+    *,
     format: Literal["text", "json"] = "text",
     with_import: bool = False,
-) -> list[str] | list[dict[str, Any]]:
-    """Return standalone metrics applicable to ``(scope, signal)``.
+) -> dict[str, list[MetricSpec]] | list[str] | list[dict[str, Any]]:
+    """Discover standalone metrics — family-grouped overview or cell filter.
+
+    Two call shapes:
+
+    - **No arguments** → a family-grouped overview
+      ``dict[str, list[MetricSpec]]`` keyed by concept family (the
+      module stem). This is a catalog, *not* runnable — see
+      :func:`_metrics_overview`.
+    - **Both ``scope`` and ``signal``** → the metrics applicable to that
+      ``(scope, signal)`` cell, as names (``format="text"``) or
+      JSON-serialisable rows (``format="json"``).
+
+    Passing exactly one axis is a usage error.
 
     PanelMode is intentionally not an input — applicability does not change
     across PANEL / TIMESERIES (per ``docs/reference/metric-applicability.md``).
@@ -462,14 +502,18 @@ def list_metrics(
 
     Args:
         scope: Cell axis to filter on (``FactorScope.INDIVIDUAL`` or
-            ``FactorScope.COMMON``).
+            ``FactorScope.COMMON``). Omit together with ``signal`` for
+            the overview.
         signal: Cell axis to filter on (``FactorSignal.CONTINUOUS`` or
-            ``FactorSignal.SPARSE``).
+            ``FactorSignal.SPARSE``). Omit together with ``scope`` for
+            the overview.
         format: ``"text"`` (default) returns metric names sorted by
             ``(module, name)``. ``"json"`` returns ``list[dict]`` rows
-            with keys ``name``, ``module``, ``cell``, ``agg_order``,
-            ``inference_se``, ``import_path``, ``input_kind``,
-            ``docs_anchor`` — JSON-serialisable, suitable for tooling.
+            with keys ``name``, ``module``, ``family``, ``cell``,
+            ``agg_order``, ``inference_se``, ``import_path``,
+            ``input_kind``, ``docs_anchor`` — JSON-serialisable, suitable
+            for tooling. ``family`` is the concept family (module stem);
+            ``agg_order`` is the cross-section/time reduction order.
             ``docs_anchor`` follows
             :data:`factrix._metric_index.DOCS_ANCHOR_FMT` (a
             docs-root-relative path + mkdocstrings symbol fragment).
@@ -483,24 +527,40 @@ def list_metrics(
             present there).
 
     Raises:
+        ValueError: exactly one of ``scope`` / ``signal`` is given
+            (pass both for a filtered list, or neither for the overview).
         IncompatibleAxisError: ``(scope, signal)`` matches no
             registered metric. In practice all four combos are
             populated, so this is defensive.
 
     Examples:
-        Discover standalone metrics for an INDIVIDUAL × CONTINUOUS cell:
+        Family-grouped overview (no arguments):
 
         >>> import factrix as fx
+        >>> overview = fx.list_metrics()
+        >>> "ic" in overview
+        True
+
+        Discover standalone metrics for an INDIVIDUAL × CONTINUOUS cell:
+
         >>> names = fx.list_metrics(
         ...     fx.FactorScope.INDIVIDUAL, fx.FactorSignal.CONTINUOUS,
         ... )
 
-        JSON form (for tooling — adds module / cell / import_path keys):
+        JSON form (for tooling — adds module / family / import_path keys):
 
         >>> rows = fx.list_metrics(
         ...     fx.FactorScope.INDIVIDUAL, fx.FactorSignal.CONTINUOUS, format="json",
         ... )
     """
+    if scope is None and signal is None:
+        return _metrics_overview()
+    if scope is None or signal is None:
+        raise ValueError(
+            "list_metrics() takes either no arguments (family-grouped "
+            "overview) or both scope and signal (cell-filtered list); "
+            "got exactly one axis."
+        )
     matches = [
         (stem, spec)
         for stem, spec in public_specs()
@@ -516,8 +576,9 @@ def list_metrics(
             {
                 "name": spec.name,
                 "module": stem,
+                "family": stem,
                 "cell": spec.cell.raw,
-                "agg_order": spec.family,
+                "agg_order": spec.agg_order,
                 "inference_se": spec.inference,
                 "import_path": import_path_for(stem),
                 "input_kind": spec.input_kind,

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -588,7 +588,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_caar",
         cell=_CAAR_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference=_CAAR_INFERENCE,
         primitives=_CAAR_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -596,7 +596,7 @@ __metric_specs__ = (
     MetricSpec(
         name="caar",
         cell=_CAAR_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference=_CAAR_INFERENCE,
         primitives=_CAAR_PRIMITIVES,
         requires={"caar_df": compute_caar},
@@ -604,7 +604,7 @@ __metric_specs__ = (
     MetricSpec(
         name="bmp_test",
         cell=_CAAR_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference=_CAAR_INFERENCE,
         primitives=_CAAR_PRIMITIVES,
     ),

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -28,7 +28,7 @@ __metric_specs__ = (
     MetricSpec(
         name="clustering_hhi",
         cell=cell(None, FactorSignal.SPARSE, mode=PanelMode.PANEL),
-        family="static-cs",
+        agg_order="static-cs",
         inference="no formal H_0",
         primitives=("_short_circuit_output",),
     ),

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -47,7 +47,7 @@ __metric_specs__ = (
         cell=cell(
             FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS, mode=PanelMode.PANEL
         ),
-        family="cs-first",
+        agg_order="cs-first",
         inference="across-time t (one-sided H_0: ratio >= 0.5)",
         primitives=(
             "_calc_t_stat",

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -20,7 +20,7 @@ __metric_specs__ = (
     MetricSpec(
         name="corrado_rank",
         cell=cell(None, FactorSignal.SPARSE, mode=PanelMode.PANEL),
-        family="per-event",
+        agg_order="per-event",
         inference="nonparametric rank",
         primitives=(
             "_calc_t_stat",

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -32,7 +32,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_event_returns",
         cell=_EH_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference="binomial",
         primitives=_EH_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -40,7 +40,7 @@ __metric_specs__ = (
     MetricSpec(
         name="event_around_return",
         cell=_EH_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference="binomial",
         primitives=_EH_PRIMITIVES,
     ),

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -56,7 +56,7 @@ __metric_specs__ = tuple(
     MetricSpec(
         name=_name,
         cell=_EQ_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference=_EQ_INFERENCE,
         primitives=_EQ_PRIMITIVES,
     )

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -721,7 +721,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_fm_betas",
         cell=_FM_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_FM_INFERENCE,
         primitives=_FM_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -729,7 +729,7 @@ __metric_specs__ = (
     MetricSpec(
         name="fm_beta",
         cell=_FM_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_FM_INFERENCE,
         primitives=_FM_PRIMITIVES,
         requires={"beta_df": compute_fm_betas},
@@ -737,14 +737,14 @@ __metric_specs__ = (
     MetricSpec(
         name="pooled_beta",
         cell=_FM_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_FM_INFERENCE,
         primitives=_FM_PRIMITIVES,
     ),
     MetricSpec(
         name="beta_sign_consistency",
         cell=_FM_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_FM_INFERENCE,
         primitives=_FM_PRIMITIVES,
         requires={"beta_df": compute_fm_betas},

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -30,7 +30,7 @@ __metric_specs__ = (
     MetricSpec(
         name="hit_rate",
         cell=cell(None, FactorSignal.CONTINUOUS, mode=PanelMode.TIMESERIES),
-        family="ts-only",
+        agg_order="ts-only",
         inference="binomial",
         primitives=(
             "_binomial_two_sided_p",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -467,7 +467,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_ic",
         cell=_IC_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_IC_INFERENCE,
         primitives=_IC_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -476,7 +476,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ic",
         cell=_IC_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_IC_INFERENCE,
         primitives=_IC_PRIMITIVES,
         requires={"ic_df": compute_ic},
@@ -484,7 +484,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ic_newey_west",
         cell=_IC_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_IC_INFERENCE,
         primitives=_IC_PRIMITIVES,
         requires={"ic_df": compute_ic},
@@ -496,7 +496,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ic_ir",
         cell=_IC_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_IC_INFERENCE,
         primitives=_IC_PRIMITIVES,
         requires={"ic_df": compute_ic},

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -346,7 +346,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_mfe_mae",
         cell=_MFE_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference="no formal H_0",
         primitives=_MFE_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -354,7 +354,7 @@ __metric_specs__ = (
     MetricSpec(
         name="mfe_mae_summary",
         cell=_MFE_CELL,
-        family="per-event",
+        agg_order="per-event",
         inference="no formal H_0",
         primitives=_MFE_PRIMITIVES,
         requires={"mfe_mae_df": compute_mfe_mae},

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -45,7 +45,7 @@ __metric_specs__ = (
         cell=cell(
             FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS, mode=PanelMode.PANEL
         ),
-        family="cs-first",
+        agg_order="cs-first",
         inference="cross-asset t",
         batchable=True,
         primitives=(

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -29,7 +29,7 @@ __metric_specs__ = (
     MetricSpec(
         name="oos_decay",
         cell=cell(None, FactorSignal.CONTINUOUS, mode=PanelMode.TIMESERIES),
-        family="ts-only",
+        agg_order="ts-only",
         inference="no formal H_0",
         primitives=("_short_circuit_output",),
     ),

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -63,7 +63,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_spread_series",
         cell=_Q_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_Q_INFERENCE,
         primitives=_Q_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -71,7 +71,7 @@ __metric_specs__ = (
     MetricSpec(
         name="quantile_spread",
         cell=_Q_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_Q_INFERENCE,
         primitives=_Q_PRIMITIVES,
         batchable=True,
@@ -79,14 +79,14 @@ __metric_specs__ = (
     MetricSpec(
         name="quantile_spread_vw",
         cell=_Q_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_Q_INFERENCE,
         primitives=_Q_PRIMITIVES,
     ),
     MetricSpec(
         name="compute_group_returns",
         cell=_Q_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference=_Q_INFERENCE,
         primitives=_Q_PRIMITIVES,
         visibility=Visibility.INTERNAL,

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -59,14 +59,14 @@ __metric_specs__ = (
     MetricSpec(
         name="spanning_alpha",
         cell=_SPANNING_CELL,
-        family="ts-only",
+        agg_order="ts-only",
         inference="NW HAC / OLS t",
         primitives=_SPANNING_PRIMITIVES,
     ),
     MetricSpec(
         name="greedy_forward_selection",
         cell=_SPANNING_CELL,
-        family="ts-only",
+        agg_order="ts-only",
         inference="NW HAC / OLS t",
         primitives=_SPANNING_PRIMITIVES,
     ),

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -48,14 +48,14 @@ __metric_specs__ = (
     MetricSpec(
         name="notional_turnover",
         cell=_TR_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference="no formal H_0",
         primitives=_TR_CS_PRIMITIVES,
     ),
     MetricSpec(
         name="breakeven_cost",
         cell=_TR_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference="no formal H_0",
         primitives=_TR_CS_PRIMITIVES,
         input_kind="scalar",
@@ -63,7 +63,7 @@ __metric_specs__ = (
     MetricSpec(
         name="net_spread",
         cell=_TR_CELL,
-        family="cs-first",
+        agg_order="cs-first",
         inference="no formal H_0",
         primitives=_TR_CS_PRIMITIVES,
         input_kind="scalar",
@@ -71,7 +71,9 @@ __metric_specs__ = (
     MetricSpec(
         name="turnover",
         cell=_TR_CELL,
-        family="ts-only (rank autocorrelation across consecutive dates)",
+        # WHY: rank autocorrelation across consecutive dates — no cross-section
+        # step, so the aggregation order is pure time series.
+        agg_order="ts-only",
         inference="no formal H_0",
         primitives=("_short_circuit_output",),
     ),

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -28,7 +28,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ic_trend",
         cell=cell(None, FactorSignal.CONTINUOUS, mode=PanelMode.TIMESERIES),
-        family="ts-only",
+        agg_order="ts-only",
         inference="Theil-Sen rank-based CI",
         primitives=(
             "_significance_marker",

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -61,7 +61,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ts_asymmetry",
         cell=cell(FactorScope.COMMON, FactorSignal.CONTINUOUS, mode=PanelMode.PANEL),
-        family="cs-first",
+        agg_order="cs-first",
         inference="NW HAC Wald",
         primitives=(
             "_significance_marker",

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -45,7 +45,7 @@ _TSB_PRIMITIVES = (
     "_significance_marker",
     "_short_circuit_output",
 )
-_TSB_FAMILY = "ts-first"
+_TSB_AGG_ORDER = "ts-first"
 _TSB_INFERENCE = "cross-asset t"
 
 
@@ -541,7 +541,7 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_ts_betas",
         cell=_TSB_CELL,
-        family=_TSB_FAMILY,
+        agg_order=_TSB_AGG_ORDER,
         inference=_TSB_INFERENCE,
         primitives=_TSB_PRIMITIVES,
         visibility=Visibility.INTERNAL,
@@ -549,7 +549,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ts_beta",
         cell=_TSB_CELL,
-        family=_TSB_FAMILY,
+        agg_order=_TSB_AGG_ORDER,
         inference=_TSB_INFERENCE,
         primitives=_TSB_PRIMITIVES,
         requires={"ts_betas_df": compute_ts_betas},
@@ -557,7 +557,7 @@ __metric_specs__ = (
     MetricSpec(
         name="mean_r_squared",
         cell=_TSB_CELL,
-        family=_TSB_FAMILY,
+        agg_order=_TSB_AGG_ORDER,
         inference=_TSB_INFERENCE,
         primitives=_TSB_PRIMITIVES,
         requires={"ts_betas_df": compute_ts_betas},
@@ -565,14 +565,14 @@ __metric_specs__ = (
     MetricSpec(
         name="compute_rolling_mean_beta",
         cell=_TSB_CELL,
-        family=_TSB_FAMILY,
+        agg_order=_TSB_AGG_ORDER,
         inference=_TSB_INFERENCE,
         primitives=_TSB_PRIMITIVES,
     ),
     MetricSpec(
         name="ts_beta_sign_consistency",
         cell=_TSB_CELL,
-        family=_TSB_FAMILY,
+        agg_order=_TSB_AGG_ORDER,
         inference=_TSB_INFERENCE,
         primitives=_TSB_PRIMITIVES,
         requires={"ts_betas_df": compute_ts_betas},
@@ -580,7 +580,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ts_beta_single_asset_fallback",
         cell=_TSB_CELL,
-        family=_TSB_FAMILY,
+        agg_order=_TSB_AGG_ORDER,
         inference=_TSB_INFERENCE,
         primitives=_TSB_PRIMITIVES,
         visibility=Visibility.INTERNAL,

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -47,7 +47,7 @@ __metric_specs__ = (
     MetricSpec(
         name="ts_quantile_spread",
         cell=cell(FactorScope.COMMON, FactorSignal.CONTINUOUS, mode=PanelMode.PANEL),
-        family="cs-first",
+        agg_order="cs-first",
         inference="NW HAC Wald",
         primitives=(
             "_significance_marker",

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -37,28 +37,28 @@ _TABLE_HEADER = (
 
 @dataclass(frozen=True, slots=True)
 class _GroupedRow:
-    """One docs-matrix row: a ``(module, cell, family, inference)`` group."""
+    """One docs-matrix row: a ``(module, cell, agg_order, inference)`` group."""
 
     module: str
     cell_raw: str
-    family: str
+    agg_order: str
     inference: str
 
 
 def _group_specs(specs: tuple[tuple[str, MetricSpec], ...]) -> list[_GroupedRow]:
-    """Collapse per-callable specs into per-(module, cell, family, inference) rows.
+    """Collapse per-callable specs into per-(module, cell, agg_order, inference) rows.
 
     Stable on insertion order so the rendered table follows the
     spec-declaration order in each module.
     """
     seen: dict[tuple[str, str, str, str], _GroupedRow] = {}
     for stem, spec in specs:
-        key = (stem, spec.cell.raw, spec.family, spec.inference)
+        key = (stem, spec.cell.raw, spec.agg_order, spec.inference)
         if key not in seen:
             seen[key] = _GroupedRow(
                 module=stem,
                 cell_raw=spec.cell.raw,
-                family=spec.family,
+                agg_order=spec.agg_order,
                 inference=spec.inference,
             )
     return list(seen.values())
@@ -66,7 +66,7 @@ def _group_specs(specs: tuple[tuple[str, MetricSpec], ...]) -> list[_GroupedRow]
 
 def _render_row(row: _GroupedRow) -> str:
     module_cell = f"[`metrics.{row.module}`][factrix.metrics.{row.module}]"
-    return f"| {module_cell} | `{row.cell_raw}` | {row.family} | {row.inference} |\n"
+    return f"| {module_cell} | `{row.cell_raw}` | {row.agg_order} | {row.inference} |\n"
 
 
 def generate() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def make_spec(name: str) -> MetricSpec:
     return MetricSpec(
         name=name,
         cell=Cell(scope=None, signal=None, mode=None, raw="*"),
-        family="cs-first",
+        agg_order="cs-first",
         inference="test",
     )
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -27,7 +27,7 @@ def _make_spec(
     return MetricSpec(
         name=name,
         cell=cell(None, None),
-        family="test",
+        agg_order="test",
         inference="test",
         requires=requires or {},
         batchable=batchable,

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -18,6 +18,7 @@ import pytest
 from factrix._axis import FactorScope, FactorSignal, Visibility
 from factrix._errors import IncompatibleAxisError
 from factrix._metric_index import (
+    MetricSpec,
     _all_specs,
     import_path_for,
     public_specs,
@@ -187,6 +188,7 @@ def test_json_format_round_trips() -> None:
     assert set(sample) == {
         "name",
         "module",
+        "family",
         "cell",
         "agg_order",
         "inference_se",
@@ -304,11 +306,58 @@ def test_public_spec_fields_are_serialisable() -> None:
         {
             "name": spec.name,
             "module": stem,
+            "family": stem,
             "cell": spec.cell.raw,
-            "agg_order": spec.family,
+            "agg_order": spec.agg_order,
             "inference_se": spec.inference,
             "import_path": import_path_for(stem),
             "input_kind": spec.input_kind,
         }
     )
     assert json.loads(serialised)["name"] == spec.name
+
+
+class TestNoArgOverview:
+    def test_no_arg_returns_family_grouped_dict(self) -> None:
+        overview = fx.list_metrics()
+        assert isinstance(overview, dict)
+        # Keys are concept families (module stems); ic family present.
+        assert "ic" in overview
+        assert {s.name for s in overview["ic"]} >= {"ic", "ic_newey_west", "ic_ir"}
+
+    def test_overview_keys_match_public_spec_stems(self) -> None:
+        overview = fx.list_metrics()
+        assert set(overview) == {stem for stem, _ in public_specs()}
+
+    def test_overview_values_are_specs_not_callables(self) -> None:
+        overview = fx.list_metrics()
+        assert all(
+            isinstance(spec, MetricSpec)
+            for specs in overview.values()
+            for spec in specs
+        )
+
+    def test_overview_covers_every_public_spec_once(self) -> None:
+        overview = fx.list_metrics()
+        flattened = [spec for specs in overview.values() for spec in specs]
+        assert len(flattened) == len(public_specs())
+
+    def test_overview_keys_are_sorted(self) -> None:
+        overview = fx.list_metrics()
+        assert list(overview) == sorted(overview)
+
+    def test_single_axis_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="exactly one axis"):
+            fx.list_metrics(FactorScope.INDIVIDUAL)  # type: ignore[call-overload]
+        with pytest.raises(ValueError, match="exactly one axis"):
+            fx.list_metrics(signal=FactorSignal.CONTINUOUS)  # type: ignore[call-overload]
+
+
+def test_json_agg_order_and_family_are_distinct_fields() -> None:
+    rows = fx.list_metrics(
+        FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS, format="json"
+    )
+    by_name = {r["name"]: r for r in rows}
+    # agg_order is the reduction order; family is the concept group.
+    assert by_name["ic"]["agg_order"] == "cs-first"
+    assert by_name["ic"]["family"] == "ic"

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -24,7 +24,7 @@ class TestDefaults:
         spec = MetricSpec(
             name="probe",
             cell=cell(FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS),
-            family="cs-first",
+            agg_order="cs-first",
             inference="probe",
         )
         assert spec.requires == {}
@@ -33,7 +33,7 @@ class TestDefaults:
         spec = MetricSpec(
             name="probe",
             cell=cell(FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS),
-            family="cs-first",
+            agg_order="cs-first",
             inference="probe",
         )
         assert spec.batchable is False
@@ -42,7 +42,7 @@ class TestDefaults:
         spec = MetricSpec(
             name="probe",
             cell=cell(FactorScope.INDIVIDUAL, FactorSignal.CONTINUOUS),
-            family="cs-first",
+            agg_order="cs-first",
             inference="probe",
         )
         assert spec.visibility is Visibility.PUBLIC

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -31,7 +31,7 @@ def _isolate_registry():
 class TestMetricSpecDecorator:
     def test_stamps_metric_spec_attribute(self) -> None:
         spec = MetricSpec(
-            name="stamp_only", cell=cell(None, None), family="test", inference="test"
+            name="stamp_only", cell=cell(None, None), agg_order="test", inference="test"
         )
 
         @fx.metric_spec(spec)
@@ -44,7 +44,7 @@ class TestMetricSpecDecorator:
         spec = MetricSpec(
             name="no_auto_register",
             cell=cell(None, None),
-            family="test",
+            agg_order="test",
             inference="test",
         )
 
@@ -61,7 +61,7 @@ class TestRegister:
         spec = MetricSpec(
             name="custom_ic_smoke",
             cell=cell(None, None),
-            family="test",
+            agg_order="test",
             inference="test",
         )
 
@@ -81,7 +81,7 @@ class TestRegister:
         spec = MetricSpec(
             name="dag_resolves_me",
             cell=cell(None, None),
-            family="test",
+            agg_order="test",
             inference="test",
         )
 
@@ -107,7 +107,7 @@ class TestRegister:
         spec = MetricSpec(
             name="dup_metric",
             cell=cell(None, None),
-            family="test",
+            agg_order="test",
             inference="test",
         )
 
@@ -121,7 +121,7 @@ class TestRegister:
 
     def test_register_rejects_first_party_clash(self) -> None:
         clash_spec = MetricSpec(
-            name="ic", cell=cell(None, None), family="x", inference="x"
+            name="ic", cell=cell(None, None), agg_order="x", inference="x"
         )
 
         @fx.metric_spec(clash_spec)


### PR DESCRIPTION
## Summary
- Rename `MetricSpec.family` (which stored the cross-section/time aggregation order, not a concept family) to `agg_order`.
- "family" now means the concept group, derived from the module stem (file=family invariant), not stored.
- Add a no-arg `list_metrics()` family-grouped overview `dict[str, list[MetricSpec]]`; the `(scope, signal)` filter form is kept via typing overloads. JSON rows gain a `family` key.

Phase 1 (R1 + §6) of #476. `family` becoming `list[type[Metric]]` and retiring the filter form are Phase 2 (gated on #472).

## Test plan
- [x] `pytest` full suite — 1070 passed (4 pre-existing `tests/bench/` failures unrelated, tracked in #465)
- [x] `tests/test_list_metrics.py` — 24 passed incl. new `TestNoArgOverview` (grouping, keys=stems, spec-not-callable, coverage, sorted, one-axis ValueError)
- [x] `ruff check` + `--doctest-modules factrix/_metric_index.py` clean

Refs #476