### PR TITLE
feat(api): reject list_metrics() overview in evaluate with guidance

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -197,7 +197,37 @@ _DOCS_PANEL = "api/evaluate#panel"
 _DOCS_FORWARD_PERIODS = "api/evaluate#forward_periods"
 
 
+def _is_metrics_overview(metrics: object) -> bool:
+    """True when ``metrics`` is a ``list_metrics()`` family-grouped overview.
+
+    The overview is ``dict[str, list[MetricSpec]]`` — a catalog, not a
+    runnable argument. Recognising its exact shape lets ``evaluate``
+    point the user at the right path instead of a generic type error.
+    """
+    return (
+        isinstance(metrics, dict)
+        and bool(metrics)
+        and all(
+            isinstance(v, list) and all(isinstance(s, MetricSpec) for s in v)
+            for v in metrics.values()
+        )
+    )
+
+
 def _validate_metrics_arg(metrics: object) -> None:
+    if _is_metrics_overview(metrics):
+        raise UserInputError(
+            func_name="evaluate",
+            field="metrics",
+            value=f"<list_metrics() overview: {len(metrics)} families>",  # type: ignore[arg-type]
+            expected=(
+                "an explicit list[MetricSpec]. fx.list_metrics() returns an "
+                "overview catalog (family -> specs), not a runnable list; "
+                "pick the specs you want, or pre-filter the panel with "
+                "[m.spec for m in factrix.inspect_panel(panel).usable]"
+            ),
+            docs_path=_DOCS_METRICS,
+        )
     if not isinstance(metrics, list):
         raise UserInputError(
             func_name="evaluate",

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -14,6 +14,7 @@ import re
 from unittest.mock import patch
 
 import factrix as fx
+import polars as pl
 import pytest
 from factrix._axis import FactorScope, FactorSignal, Visibility
 from factrix._errors import IncompatibleAxisError
@@ -351,6 +352,34 @@ class TestNoArgOverview:
             fx.list_metrics(FactorScope.INDIVIDUAL)  # type: ignore[call-overload]
         with pytest.raises(ValueError, match="exactly one axis"):
             fx.list_metrics(signal=FactorSignal.CONTINUOUS)  # type: ignore[call-overload]
+
+
+class TestOverviewNotRunnable:
+    """The §6 overview is a catalog; evaluate must reject it with guidance."""
+
+    def test_is_metrics_overview_recognises_overview(self) -> None:
+        from factrix import _is_metrics_overview
+
+        assert _is_metrics_overview(fx.list_metrics()) is True
+
+    def test_is_metrics_overview_rejects_runnable_and_empty(self) -> None:
+        from factrix import _is_metrics_overview
+
+        _, spec = public_specs()[0]
+        assert _is_metrics_overview([spec]) is False  # a runnable list
+        assert _is_metrics_overview({}) is False  # empty dict
+        assert _is_metrics_overview({"x": [1, 2]}) is False  # not specs
+
+    def test_evaluate_rejects_overview_with_guidance(self) -> None:
+        from factrix._errors import UserInputError
+
+        with pytest.raises(UserInputError, match="overview catalog"):
+            fx.evaluate(
+                pl.DataFrame(),
+                metrics=fx.list_metrics(),  # type: ignore[arg-type]
+                factor_cols=["alpha"],
+                forward_periods=5,
+            )
 
 
 def test_json_agg_order_and_family_are_distinct_fields() -> None:


### PR DESCRIPTION
## Summary
- `evaluate(metrics=...)` takes a `list[MetricSpec]`; the no-arg `list_metrics()` overview is a `dict[str, list[MetricSpec]]` catalog that is easy to pass by mistake.
- Detect that exact shape and raise a `UserInputError` pointing at the runnable paths (explicit specs, or `[m.spec for m in fx.inspect_panel(panel).usable]`) instead of a generic type error.

Phase 1 §9a of #476. The Phase-2 `to_metrics_dict()` form (gated on #472) is intentionally not referenced — the message points only at APIs that exist today.

## Test plan
- [x] `pytest` full suite — 1072 passed (same 4 pre-existing `tests/bench/` failures, unrelated, tracked in #465)
- [x] `tests/test_list_metrics.py` — new `TestOverviewNotRunnable` (shape detection + evaluate rejection with guidance)
- [x] `ruff check` + `ruff format` clean

Refs #476