### PR TITLE
refactor(inspect): rename _derive_mode to _detect_mode

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -602,7 +602,7 @@ factrix/
 ├── _registry.py             # _DispatchKey, _RegistryEntry, _SCOPE_COLLAPSED, register()
 ├── _procedures.py           # 7 FactorProcedure classes; bootstrap-registered at import
 ├── _profile.py              # FactorProfile dataclass + diagnose
-├── _evaluate.py             # _derive_mode + _evaluate dispatch wrapper
+├── _evaluate.py             # _detect_mode + _evaluate dispatch wrapper
 ├── _describe.py             # describe_analysis_modes + suggest_config + SuggestConfigResult
 ├── _family.py               # _resolve_family + _FamilyEntry (shared invariants)
 ├── _multi_factor.py         # bhy on the resolution layer

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -59,7 +59,7 @@ from factrix._inspect import (
     PanelInspection,
     PanelProperties,
     PanelReasoning,
-    _derive_mode,
+    _detect_mode,
     inspect_panel,
 )
 from factrix._metric_index import (
@@ -427,7 +427,7 @@ def _validate_primary_metric_applicable(
     cell_mode = primary.cell.mode
     if cell_mode is None:
         return
-    panel_mode = _derive_mode(panel)
+    panel_mode = _detect_mode(panel)
     if cell_mode is panel_mode:
         return
     n_assets = int(panel["asset_id"].n_unique())

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -38,7 +38,7 @@ from factrix._results import Warning
 _SPARSITY_THRESHOLD: float = 0.5
 
 
-def _derive_mode(panel: Any) -> PanelMode:
+def _detect_mode(panel: Any) -> PanelMode:
     """Return ``TIMESERIES`` if the panel has a single asset, else ``PANEL``."""
     return (
         PanelMode.TIMESERIES if panel["asset_id"].n_unique() <= 1 else PanelMode.PANEL
@@ -108,7 +108,7 @@ class PanelProperties:
     Attributes:
         scope: Detected :class:`FactorScope`.
         signal: Detected :class:`FactorSignal`.
-        mode: Derived :class:`PanelMode` — ``TIMESERIES`` iff
+        mode: Detected :class:`PanelMode` — ``TIMESERIES`` iff
             ``n_assets == 1`` (single-asset panel), ``PANEL`` otherwise.
         n_assets: Unique ``asset_id`` count under any-non-null union.
         n_periods: Unique ``date`` count under any-non-null union.
@@ -401,7 +401,7 @@ def inspect_panel(panel: Any) -> PanelInspection:
     """
     signal, signal_reason, sparse_ratio = _detect_signal(panel)
     scope, scope_reason = _detect_scope(panel)
-    mode = _derive_mode(panel)
+    mode = _detect_mode(panel)
     n_assets = int(panel["asset_id"].n_unique())
     n_periods = int(panel["date"].n_unique())
     n_pairs = int(panel.drop_nulls("factor").height)


### PR DESCRIPTION
## Summary
- Rename private `_derive_mode` → `_detect_mode` to align with `_detect_signal` / `_detect_scope`; align the `PanelProperties.mode` docstring ("Derived" → "Detected").
- Private helper only — no public API change.

First (zero-risk) #472 sub-issue.

## Test plan
- [x] `pytest tests/test_inspect_panel.py tests/test_panel_input.py` — 35 passed
- [x] `ruff check` clean; import + `inspect_panel` smoke

Refs #472