### PR TITLE
refactor(api)!: rename SampleFloor to SampleThreshold + min<=warn invariant

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -64,7 +64,7 @@ from factrix._inspect import (
 )
 from factrix._metric_index import (
     MetricSpec,
-    SampleFloor,
+    SampleThreshold,
     list_metrics,
     metric_spec,
     spec_by_name,
@@ -480,7 +480,7 @@ __all__ = [
     "PanelInspection",
     "PanelProperties",
     "PanelReasoning",
-    "SampleFloor",
+    "SampleThreshold",
     "inspect_panel",
     "list_estimators",
     "list_metrics",

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -150,7 +150,7 @@ class MetricApplicability:
     Attributes:
         spec: The :class:`MetricSpec` being evaluated.
         usable: ``True`` iff the metric passes cell match AND every
-            ``min_*`` floor on its :class:`SampleFloor`. ``warn_*``
+            ``min_*`` floor on its :class:`SampleThreshold`. ``warn_*``
             violations do NOT flip ``usable`` to ``False`` — they
             attach a degraded :class:`Warning` to :attr:`warnings`.
         warnings: ``warn_*``-tier diagnostics (the metric will run
@@ -378,7 +378,7 @@ def inspect_panel(panel: Any) -> PanelInspection:
     ``visibility=PUBLIC`` :class:`MetricSpec` in the registry, a
     :class:`MetricApplicability` verdict combining (a) cell-match
     against the detected ``(scope, signal, mode)`` and (b) the
-    spec's optional :class:`SampleFloor` against the panel's
+    spec's optional :class:`SampleThreshold` against the panel's
     ``n_periods`` / ``n_assets``.
 
     Sample-floor checks against ``n_events`` (factor-column-dependent)

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -38,7 +38,7 @@ import inspect
 import pathlib
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal, overload
+from typing import Any, ClassVar, Literal, overload
 
 from factrix._axis import FactorScope, FactorSignal, PanelMode, Visibility
 from factrix._errors import IncompatibleAxisError
@@ -123,7 +123,7 @@ def cell(
 
 
 @dataclass(frozen=True, slots=True)
-class SampleFloor:
+class SampleThreshold:
     """Per-metric statistical pre-flight gates against panel shape.
 
     Declares the sample-size floors below which a metric is
@@ -136,6 +136,12 @@ class SampleFloor:
     The same constants are read by the metric's own short-circuit
     logic at run time — single source of truth for what counts as
     "thin sample" per metric.
+
+    Per axis the ``min_*`` floor must not exceed the ``warn_*`` floor:
+    a metric is unusable below ``min``, degraded between ``min`` and
+    ``warn``, and clean at or above ``warn``, so ``min <= warn`` is
+    required for that ordering to hold. :meth:`__post_init__` enforces
+    it at construction.
     """
 
     min_periods: int | None = None
@@ -144,6 +150,20 @@ class SampleFloor:
     warn_assets: int | None = None
     min_pairs: int | None = None
     warn_pairs: int | None = None
+
+    _AXES: ClassVar[tuple[str, ...]] = ("periods", "assets", "pairs")
+
+    def __post_init__(self) -> None:
+        for axis in self._AXES:
+            lo, hi = self._bounds(axis)
+            if lo is not None and hi is not None and lo > hi:
+                raise ValueError(
+                    f"SampleThreshold.{axis}: min ({lo}) must not exceed warn ({hi})"
+                )
+
+    def _bounds(self, axis: str) -> tuple[int | None, int | None]:
+        """Return ``(min_<axis>, warn_<axis>)`` for one shape axis."""
+        return getattr(self, f"min_{axis}"), getattr(self, f"warn_{axis}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,7 +209,7 @@ class MetricSpec:
       ``INTERNAL`` for stage-1 helpers (excluded from
       ``list_metrics`` / ``inspection.metrics.*`` / result dict keys
       but pulled by the DAG via ``requires``).
-    - ``sample_floor``: optional :class:`SampleFloor` declaring the
+    - ``sample_floor``: optional :class:`SampleThreshold` declaring the
       panel-shape thresholds below which the metric is statistically
       unusable / degraded. ``None`` (default) means no pre-flight
       sample-size gate is declared; :func:`inspect_panel` will only
@@ -205,7 +225,7 @@ class MetricSpec:
     requires: dict[str, Callable] = field(default_factory=dict)
     batchable: bool = False
     visibility: Visibility = Visibility.PUBLIC
-    sample_floor: SampleFloor | None = None
+    sample_floor: SampleThreshold | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -637,7 +637,7 @@ types-only; runner wiring lands with the DAG executor.
   - Two-stage applicability: (1) `Cell.matches(scope, signal, mode)`
     — mode is integral so e.g. `IC` (cell declares `mode=PANEL`) is
     unusable on a single-asset panel, not just degraded. (2)
-    `MetricSpec.sample_floor: SampleFloor | None` — declarative
+    `MetricSpec.sample_floor: SampleThreshold | None` — declarative
     `min_periods` / `warn_periods` / `min_assets` / `warn_assets` /
     `min_pairs` / `warn_pairs` gates evaluated against
     `PanelProperties`. Specs without `sample_floor` only get the
@@ -646,7 +646,7 @@ types-only; runner wiring lands with the DAG executor.
   `mode` argument. Existing `list_metrics` callers stay backward
   compatible (default `None` skips the mode axis); `inspect_panel`
   passes the detected mode.
-- **`MetricSpec.sample_floor: SampleFloor | None`** — new optional
+- **`MetricSpec.sample_floor: SampleThreshold | None`** — new optional
   field carrying per-metric pre-flight thresholds. Currently
   populated on `ic_newey_west` / `ic_ir` (representative
   demonstration); other metrics get the cell-match-only check.

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 import polars as pl
 
 from factrix._axis import FactorScope, FactorSignal, PanelMode, Visibility
-from factrix._metric_index import MetricSpec, SampleFloor, cell
+from factrix._metric_index import MetricSpec, SampleThreshold, cell
 from factrix._stats import (
     _calc_t_stat,
     _newey_west_t_test,
@@ -488,7 +488,7 @@ __metric_specs__ = (
         inference=_IC_INFERENCE,
         primitives=_IC_PRIMITIVES,
         requires={"ic_df": compute_ic},
-        sample_floor=SampleFloor(
+        sample_floor=SampleThreshold(
             min_periods=MIN_PERIODS_HARD,
             warn_periods=MIN_PERIODS_WARN,
         ),
@@ -500,7 +500,7 @@ __metric_specs__ = (
         inference=_IC_INFERENCE,
         primitives=_IC_PRIMITIVES,
         requires={"ic_df": compute_ic},
-        sample_floor=SampleFloor(
+        sample_floor=SampleThreshold(
             min_periods=MIN_PERIODS_HARD,
             warn_periods=MIN_PERIODS_WARN,
         ),

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -104,7 +104,7 @@ class TestCellMatchGate:
         assert "ic" in names
 
 
-class TestSampleFloorGate:
+class TestSampleThresholdGate:
     def test_below_min_periods_is_unusable(self):
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
         nw = _by_name(info, "ic_newey_west")
@@ -125,10 +125,10 @@ class TestSampleFloorGate:
         assert nw.warnings == []
 
     def test_below_min_pairs_is_unusable(self):
-        from factrix._metric_index import SampleFloor
+        from factrix._metric_index import SampleThreshold
 
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
-        floor = SampleFloor(min_pairs=info.detected.n_pairs + 1)
+        floor = SampleThreshold(min_pairs=info.detected.n_pairs + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_newey_west")
         from dataclasses import replace
 
@@ -144,11 +144,11 @@ class TestSampleFloorGate:
         from dataclasses import replace
 
         from factrix._inspect import _evaluate_applicability
-        from factrix._metric_index import SampleFloor
+        from factrix._metric_index import SampleThreshold
 
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
         n = info.detected.n_pairs
-        floor = SampleFloor(min_pairs=n - 1, warn_pairs=n + 1)
+        floor = SampleThreshold(min_pairs=n - 1, warn_pairs=n + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_newey_west")
         verdict = _evaluate_applicability(
             replace(spec, sample_floor=floor), info.detected
@@ -259,7 +259,7 @@ class TestPublicSurface:
         assert fx.PanelReasoning is PanelReasoning
         assert fx.MetricApplicability is MetricApplicability
         assert fx.inspect_panel is inspect_panel
-        assert fx.SampleFloor is not None
+        assert fx.SampleThreshold is not None
 
 
 class TestCellMatchesSignature:

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -9,14 +9,34 @@ callable.
 
 from __future__ import annotations
 
+import pytest
 from factrix._axis import FactorScope, FactorSignal, Visibility
 from factrix._metric_index import (
     MetricSpec,
+    SampleThreshold,
     _all_specs,
     cell,
     public_specs,
     spec_by_name,
 )
+
+
+class TestSampleThresholdInvariant:
+    def test_min_above_warn_rejected_per_axis(self) -> None:
+        for axis in ("periods", "assets", "pairs"):
+            with pytest.raises(ValueError, match=f"{axis}: min"):
+                SampleThreshold(**{f"min_{axis}": 30, f"warn_{axis}": 10})
+
+    def test_min_equal_warn_allowed(self) -> None:
+        assert SampleThreshold(min_periods=20, warn_periods=20).min_periods == 20
+
+    def test_min_below_warn_allowed(self) -> None:
+        st = SampleThreshold(min_periods=20, warn_periods=30)
+        assert (st.min_periods, st.warn_periods) == (20, 30)
+
+    def test_one_sided_floor_allowed(self) -> None:
+        assert SampleThreshold(min_pairs=100).warn_pairs is None
+        assert SampleThreshold(warn_assets=5).min_assets is None
 
 
 class TestDefaults:


### PR DESCRIPTION
## Summary
- Rename `SampleFloor` → `SampleThreshold` (export `fx.SampleFloor` → `fx.SampleThreshold`); the type gates three tiers (unusable / degraded / clean), not a single floor.
- Add a `__post_init__` invariant: `min_<axis> <= warn_<axis>` per axis, so the tier ordering can't be authored inverted. Adds private `_AXES` / `_bounds`.
- `MetricSpec.sample_floor` keeps its field name (field rename belongs to the later MetricSpec consolidation); only the type changes.

Scope note: the design's `verdict()` / `per_axis_verdict()` tier helpers are **deferred** to the `_inspect`/short-circuit refactor that consumes them — adding them here would be dead code (YAGNI).

#472 sub-issue.

## Test plan
- [x] `pytest` metric_index / inspect / list_metrics / docs_matrix / ic / register — passing; new `TestSampleThresholdInvariant` (min>warn rejected per axis, min==warn ok, one-sided ok)
- [x] `ruff check` clean; `fx.SampleThreshold(...)` export smoke

Refs #472