### PR TITLE
feat(api): add SampleThreshold verdict helpers

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -42,6 +42,7 @@ from factrix._axis import (  # noqa: F401  DataStructure re-exported for namespa
     DataStructure,
     FactorDensity,
     FactorScope,
+    Tier,
 )
 from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._compare import compare
@@ -458,6 +459,7 @@ __all__ = [
     # factrix._axis for internal callers.)
     "FactorScope",
     "FactorDensity",
+    "Tier",
     # Code enums
     "InfoCode",
     "StatCode",

--- a/factrix/_axis.py
+++ b/factrix/_axis.py
@@ -173,3 +173,20 @@ class OutputShape(Enum):
     SCALAR = "scalar"
     SERIES = "series"
     PANEL = "panel"
+
+
+class Tier(StrEnum):
+    """Usability tier for a metric on a given panel shape axis.
+
+    Reflects the sample-floor verdict only (cell-match is evaluated
+    separately by ``inspect_panel``):
+
+    CLEAN: at or above the ``warn`` floor — fully usable, no warning.
+    DEGRADED: between the ``min`` and ``warn`` floors — usable but inference
+        degraded (e.g. borderline sample size).
+    UNUSABLE: below the ``min`` floor — sample too thin to run.
+    """
+
+    CLEAN = "clean"
+    DEGRADED = "degraded"
+    UNUSABLE = "unusable"

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import polars as pl
 
-from factrix._axis import DataStructure, FactorDensity, FactorScope
+from factrix._axis import DataStructure, FactorDensity, FactorScope, Tier
 from factrix._codes import WarningCode, cross_section_tier
 from factrix._metric_index import MetricSpec, public_specs
 from factrix._results import Warning
@@ -454,32 +454,28 @@ def _evaluate_applicability(
         )
 
     floor = spec.sample_threshold
-    for axis, n_actual in (
-        ("periods", properties.n_periods),
-        ("pairs", properties.n_pairs),
-    ):
-        min_v = getattr(floor, f"min_{axis}")
-        warn_v = getattr(floor, f"warn_{axis}")
-        if min_v is not None and n_actual < min_v:
-            blockers.append(f"n_{axis}={n_actual} < min_{axis}={min_v}")
-        elif warn_v is not None and n_actual < warn_v:
-            warnings.append(
-                Warning(
-                    code=WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
-                    source=spec.name,
-                    message=f"n_{axis}={n_actual} < warn_{axis}={warn_v}: inference degraded",
+    for av in floor.iter_verdicts(properties):
+        if av.tier is Tier.UNUSABLE:
+            blockers.append(f"n_{av.axis}={av.n} < min_{av.axis}={av.floor}")
+        elif av.tier is Tier.DEGRADED:
+            # The assets axis gates DEGRADED on the spec's warn_assets, but the
+            # emitted warning is the inference-stage cross-section tier, keyed on
+            # the global MIN_ASSETS / MIN_ASSETS_WARN constants — so it can be
+            # None here even though the axis verdict is DEGRADED.
+            if av.axis == "assets":
+                code = cross_section_tier(properties.n_assets)
+                if code is not None:
+                    warnings.append(
+                        Warning(code=code, source=spec.name, message=code.description)
+                    )
+            else:
+                warnings.append(
+                    Warning(
+                        code=WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+                        source=spec.name,
+                        message=f"n_{av.axis}={av.n} < warn_{av.axis}={av.warn}: inference degraded",
+                    )
                 )
-            )
-    if floor.min_assets is not None and properties.n_assets < floor.min_assets:
-        blockers.append(
-            f"n_assets={properties.n_assets} < min_assets={floor.min_assets}"
-        )
-    elif floor.warn_assets is not None and properties.n_assets < floor.warn_assets:
-        tier = cross_section_tier(properties.n_assets)
-        if tier is not None:
-            warnings.append(
-                Warning(code=tier, source=spec.name, message=tier.description)
-            )
 
     return MetricApplicability(
         spec=spec,

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -36,9 +36,9 @@ import functools
 import importlib
 import inspect
 import pathlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, overload
 
 from factrix._axis import (
     Aggregation,
@@ -50,10 +50,12 @@ from factrix._axis import (
     SEMethod,
     SpecRole,
     TestMethod,
+    Tier,
 )
 from factrix._errors import IncompatibleAxisError
 
 if TYPE_CHECKING:
+    from factrix._inspect import PanelProperties
     from factrix.metrics._base import MetricBase
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -139,6 +141,20 @@ def cell(
     return Cell(scope=scope, density=density, structure=structure, raw=raw)
 
 
+class AxisVerdict(NamedTuple):
+    """One shape axis's tier together with the data the decision used.
+
+    ``floor`` / ``warn`` are the spec's ``min_<axis>`` / ``warn_<axis>``
+    bounds (``None`` when ungated); ``n`` is the panel's actual count.
+    """
+
+    axis: str
+    n: int
+    floor: int | None
+    warn: int | None
+    tier: Tier
+
+
 @dataclass(frozen=True, slots=True)
 class SampleThreshold:
     """Per-metric statistical pre-flight gates against panel shape.
@@ -181,6 +197,41 @@ class SampleThreshold:
     def _bounds(self, axis: str) -> tuple[int | None, int | None]:
         """Return ``(min_<axis>, warn_<axis>)`` for one shape axis."""
         return getattr(self, f"min_{axis}"), getattr(self, f"warn_{axis}")
+
+    def iter_verdicts(self, properties: PanelProperties) -> Iterator[AxisVerdict]:
+        """Yield the per-axis verdict for each shape axis, in ``_AXES`` order.
+
+        Single source of truth for the tier decision: ``per_axis_verdict``,
+        ``verdict`` and ``factrix.inspect_panel``'s blocker/warning assembly
+        all consume this so the floor → tier mapping lives in exactly one
+        place. Each yielded record also carries the actual ``n`` and the
+        ``floor``/``warn`` bounds the decision was made against, so callers
+        can build messages without re-reading the spec.
+        """
+        for axis in self._AXES:
+            floor, warn = self._bounds(axis)
+            n = getattr(properties, f"n_{axis}")
+            if floor is not None and n < floor:
+                tier = Tier.UNUSABLE
+            elif warn is not None and n < warn:
+                tier = Tier.DEGRADED
+            else:
+                tier = Tier.CLEAN
+            yield AxisVerdict(axis=axis, n=n, floor=floor, warn=warn, tier=tier)
+
+    def per_axis_verdict(self, properties: PanelProperties) -> dict[str, Tier]:
+        """Return the usability tier for each shape axis (periods, assets, pairs)."""
+        return {v.axis: v.tier for v in self.iter_verdicts(properties)}
+
+    def verdict(self, properties: PanelProperties) -> Tier:
+        """Return the worst usability tier across all shape axes."""
+        worst = Tier.CLEAN
+        for v in self.iter_verdicts(properties):
+            if v.tier is Tier.UNUSABLE:
+                return Tier.UNUSABLE
+            if v.tier is Tier.DEGRADED:
+                worst = Tier.DEGRADED
+        return worst
 
 
 @dataclass(frozen=True, slots=True)

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -642,6 +642,11 @@ types-only; runner wiring lands with the DAG executor.
     `min_pairs` / `warn_pairs` gates evaluated against
     `PanelProperties`. Specs without `sample_floor` only get the
     cell-match check.
+- **`Tier`** — StrEnum representing usability tiers returned by `SampleThreshold.verdict` / `per_axis_verdict`:
+  - `CLEAN` — metric is fully usable with zero warnings.
+  - `DEGRADED` — metric is usable but with degraded inference warnings (between HARD and WARN floors).
+  - `UNUSABLE` — metric is unusable (below HARD floor). Cell mismatch is a
+    separate `inspect_panel` blocker and does not flow through `Tier`.
 - **`Cell.matches(scope, density, structure=None)`** — gains optional
   `structure` argument. Existing `list_metrics` callers stay backward
   compatible (default `None` skips the structure axis); `inspect_panel`

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 import pytest
 from factrix._axis import (
     Aggregation,
+    DataStructure,
     FactorDensity,
     FactorScope,
     SEMethod,
     SpecRole,
     TestMethod,
+    Tier,
 )
+from factrix._inspect import PanelProperties
 from factrix._metric_index import (
     MetricSpec,
     SampleThreshold,
@@ -44,6 +47,74 @@ class TestSampleThresholdInvariant:
     def test_one_sided_floor_allowed(self) -> None:
         assert SampleThreshold(min_pairs=100).warn_pairs is None
         assert SampleThreshold(warn_assets=5).min_assets is None
+
+
+class TestSampleThresholdHelpers:
+    def test_verdict_and_per_axis_verdict(self) -> None:
+        st = SampleThreshold(
+            min_periods=10,
+            warn_periods=30,
+            min_assets=5,
+            warn_assets=15,
+            min_pairs=20,
+            warn_pairs=50,
+        )
+
+        props_clean = PanelProperties(
+            scope=FactorScope.INDIVIDUAL,
+            density=FactorDensity.DENSE,
+            structure=DataStructure.PANEL,
+            n_periods=30,
+            n_assets=15,
+            n_pairs=50,
+            sparse_ratio=0.0,
+        )
+        assert st.per_axis_verdict(props_clean) == {
+            "periods": Tier.CLEAN,
+            "assets": Tier.CLEAN,
+            "pairs": Tier.CLEAN,
+        }
+        assert st.verdict(props_clean) is Tier.CLEAN
+
+        props_degraded = PanelProperties(
+            scope=FactorScope.INDIVIDUAL,
+            density=FactorDensity.DENSE,
+            structure=DataStructure.PANEL,
+            n_periods=20,
+            n_assets=15,
+            n_pairs=50,
+            sparse_ratio=0.0,
+        )
+        assert st.per_axis_verdict(props_degraded) == {
+            "periods": Tier.DEGRADED,
+            "assets": Tier.CLEAN,
+            "pairs": Tier.CLEAN,
+        }
+        assert st.verdict(props_degraded) is Tier.DEGRADED
+
+        props_unusable = PanelProperties(
+            scope=FactorScope.INDIVIDUAL,
+            density=FactorDensity.DENSE,
+            structure=DataStructure.PANEL,
+            n_periods=20,
+            n_assets=4,
+            n_pairs=50,
+            sparse_ratio=0.0,
+        )
+        assert st.per_axis_verdict(props_unusable) == {
+            "periods": Tier.DEGRADED,
+            "assets": Tier.UNUSABLE,
+            "pairs": Tier.CLEAN,
+        }
+        assert st.verdict(props_unusable) is Tier.UNUSABLE
+
+        st_empty = SampleThreshold()
+        assert st_empty.per_axis_verdict(props_unusable) == {
+            "periods": Tier.CLEAN,
+            "assets": Tier.CLEAN,
+            "pairs": Tier.CLEAN,
+        }
+        assert st_empty.verdict(props_unusable) is Tier.CLEAN
 
 
 class TestDefaults:


### PR DESCRIPTION
## Summary

Adds a `Tier` enum (`clean` / `degraded` / `unusable`) and the
`SampleThreshold.verdict` / `per_axis_verdict` helpers so callers can ask
"is this metric usable on this panel?" without re-deriving the sample-floor
logic themselves.

The tier decision is routed through a single `iter_verdicts` generator
(yielding `AxisVerdict(axis, n, floor, warn, tier)`). `per_axis_verdict`,
`verdict`, and `inspect_panel`'s blocker/warning assembly all consume it,
so the floor-to-tier mapping lives in one place — the `inspect_panel` call
site no longer recomputes bounds or reaches into private helpers.

Semantics clarified in docstrings + `llms-full.txt`:
- `Tier` reflects the **sample-floor** verdict only; cell-match remains a
  separate `inspect_panel` blocker and does not flow through `Tier`.
- The assets axis keeps its existing split — `DEGRADED` is gated on the
  spec's `warn_assets`, but the emitted warning is the inference-stage
  `cross_section_tier` (global `MIN_ASSETS` constants), so the two can
  diverge. Documented at the call site.

## Test plan

- `tests/test_metric_index.py::TestSampleThresholdHelpers` covers
  clean / degraded / unusable verdicts and the empty-threshold case.
- `inspect_panel` behaviour preserved: full suite green except 4
  pre-existing `tests/bench` failures unrelated to this change
  (metric-name drift, e.g. `corrado_rank_test` vs `corrado_rank`).
- `ruff check` and `mypy` clean on the touched modules.

Closes #491