### PR TITLE
refactor(api): add MetricApplicability.metric + name

### DIFF
--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import html
 import math
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
@@ -34,6 +34,9 @@ from factrix._axis import DataStructure, FactorDensity, FactorScope, Tier
 from factrix._codes import WarningCode, cross_section_tier
 from factrix._metric_index import MetricSpec, public_specs
 from factrix._results import Warning
+
+if TYPE_CHECKING:
+    from factrix.metrics._base import MetricBase
 
 _SPARSITY_THRESHOLD: float = 0.5
 
@@ -148,6 +151,14 @@ class MetricApplicability:
     """Per-metric pre-flight verdict against one panel's properties.
 
     Attributes:
+        metric: The :class:`~factrix.metrics._base.MetricBase` subclass
+            this verdict is about — the callable a caller would
+            instantiate to run it. Lets consumers reach the class (and
+            its ``compute`` / params) without going through
+            :attr:`spec`.
+        name: The metric's registry name (``metric.__name__`` ==
+            ``spec.name``), surfaced directly so callers can key on it
+            without reaching through :attr:`spec`.
         spec: The :class:`MetricSpec` being evaluated.
         usable: ``True`` iff the metric passes cell match AND every
             ``min_*`` floor on its :class:`SampleThreshold`. ``warn_*``
@@ -161,6 +172,8 @@ class MetricApplicability:
             ``usable`` is True.
     """
 
+    metric: type[MetricBase]
+    name: str
     spec: MetricSpec
     usable: bool
     warnings: list[Warning] = field(default_factory=list)
@@ -440,6 +453,8 @@ def inspect_panel(panel: Any) -> PanelInspection:
 def _evaluate_applicability(
     spec: MetricSpec, properties: PanelProperties
 ) -> MetricApplicability:
+    from factrix.metrics._registry import REGISTRY
+
     blockers: list[str] = []
     warnings: list[Warning] = []
 
@@ -478,6 +493,8 @@ def _evaluate_applicability(
                 )
 
     return MetricApplicability(
+        metric=REGISTRY[spec.name],
+        name=spec.name,
         spec=spec,
         usable=not blockers,
         warnings=warnings,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -625,11 +625,14 @@ types-only; runner wiring lands with the DAG executor.
   - `PanelInspection.reasoning: PanelReasoning` carries per-axis
     rationale strings.
   - `PanelInspection.metrics: list[MetricApplicability]` — one
-    verdict per `visibility=PUBLIC` spec. Each carries `usable:
-    bool`, a `warnings: list[Warning]` for degraded inference (above
-    HARD floor but below WARN floor), and `blockers: list[str]` for
-    unusable reasons (cell mismatch or HARD floor violation).
-    Caller partitions via list comprehension —
+    verdict per `visibility=PUBLIC` spec. Each carries `metric:
+    type[MetricBase]` (the callable class) and `name: str`
+    (`metric.__name__` == `spec.name`, the registry key) so callers
+    can identify the metric without reaching through `spec`, plus
+    `usable: bool`, a `warnings: list[Warning]` for degraded
+    inference (above HARD floor but below WARN floor), and
+    `blockers: list[str]` for unusable reasons (cell mismatch or HARD
+    floor violation). Caller partitions via list comprehension —
     `[m for m in info.metrics if m.usable]`.
   - `PanelInspection.warnings: list[Warning]` carries panel-level
     sample-shape diagnostics (`source=None`); per-metric degraded

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -104,6 +104,26 @@ class TestCellMatchGate:
         assert "ic" in names
 
 
+class TestMetricApplicabilityIdentity:
+    def test_metric_and_name_resolve_to_registry_class(self):
+        from factrix.metrics._base import MetricBase
+        from factrix.metrics._registry import REGISTRY
+
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        for m in info.metrics:
+            assert issubclass(m.metric, MetricBase)
+            # name is the registry key and agrees with both the class and spec
+            assert m.name == m.spec.name
+            assert m.name == m.metric.__name__
+            assert REGISTRY[m.name] is m.metric
+
+    def test_name_lets_caller_key_without_spec(self):
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        ic = _by_name(info, "ic")
+        assert ic.name == "ic"
+        assert ic.metric is _by_name(info, "ic").metric
+
+
 class TestSampleThresholdGate:
     def test_below_min_periods_is_unusable(self):
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))


### PR DESCRIPTION
## Summary

Surfaces metric identity directly on `MetricApplicability` per #476 §7,
so consumers of `inspect_panel(...).metrics` no longer have to reach
through `.spec`:

- `metric: type[MetricBase]` — the callable class a caller would
  instantiate to run the metric.
- `name: str` — the registry key (`metric.__name__` == `spec.name`).

`_evaluate_applicability` resolves the class via `REGISTRY[spec.name]`.
All 36 public specs are registered (post-#492), so both fields are
non-optional. `spec` is retained, so existing `m.spec.*` callers are
unaffected.

This unblocks the result-side metric identity that #497's
`evaluate(dict[str, Metric])` flow will rely on.

## Test plan

- `tests/test_inspect_panel.py::TestMetricApplicabilityIdentity` — asserts
  every verdict's `metric` is a `MetricBase` subclass and that
  `name == spec.name == metric.__name__ == REGISTRY[name].__name__`.
- Full suite green except 4 pre-existing `tests/bench` failures unrelated
  to this change (metric-name drift, e.g. `corrado_rank_test` vs
  `corrado_rank`).
- `ruff` + `mypy` clean on touched modules.

Closes #495