### PR TITLE
refactor(api)!: fold PanelReasoning into PanelProperties

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -59,7 +59,6 @@ from factrix._inspect import (
     MetricApplicability,
     PanelInspection,
     PanelProperties,
-    PanelReasoning,
     _detect_structure,
     inspect_panel,
 )
@@ -485,7 +484,6 @@ __all__ = [
     "MetricApplicability",
     "PanelInspection",
     "PanelProperties",
-    "PanelReasoning",
     "SampleThreshold",
     "inspect_panel",
     "list_estimators",

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -101,18 +101,25 @@ def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
 class PanelProperties:
     """Inspected panel properties driving cell dispatch.
 
-    Carries both the dispatch axes (``scope`` / ``density`` / ``structure``
-    as typed enums) and the panel-shape numerics the user typically
-    wants next to them (``n_assets`` / ``n_periods`` / ``n_pairs`` /
-    ``sparse_ratio``). Named ``Properties`` rather than ``Axes``
-    because the numeric fields are not axes — they are observations
-    supporting the axis decisions.
+    Carries the dispatch axes (``scope`` / ``density`` / ``structure``
+    as typed enums), the human-readable rationale for each axis decision
+    (``scope_reason`` / ``density_reason`` / ``structure_reason``), and
+    the panel-shape numerics the user typically wants next to them
+    (``n_assets`` / ``n_periods`` / ``n_pairs`` / ``sparse_ratio``).
+    Named ``Properties`` rather than ``Axes`` because the numeric fields
+    are not axes — they are observations supporting the axis decisions.
+
+    Each ``*_reason`` sits next to the enum it explains so detection
+    verdict and rationale travel together as one value.
 
     Attributes:
         scope: Detected :class:`FactorScope`.
+        scope_reason: Human-readable rationale for ``scope``.
         density: Detected :class:`FactorDensity`.
+        density_reason: Human-readable rationale for ``density``.
         structure: Detected :class:`DataStructure` — ``TIMESERIES`` iff
             ``n_assets == 1`` (single-asset panel), ``PANEL`` otherwise.
+        structure_reason: Human-readable rationale for ``structure``.
         n_assets: Unique ``asset_id`` count under any-non-null union.
         n_periods: Unique ``date`` count under any-non-null union.
         n_pairs: Non-null ``(date, asset_id)`` factor observation
@@ -125,25 +132,15 @@ class PanelProperties:
     """
 
     scope: FactorScope
+    scope_reason: str
     density: FactorDensity
+    density_reason: str
     structure: DataStructure
+    structure_reason: str
     n_assets: int
     n_periods: int
     n_pairs: int
     sparse_ratio: float
-
-
-@dataclass(frozen=True, slots=True)
-class PanelReasoning:
-    """Per-axis human-readable rationale for the panel's detection.
-
-    Three fields parallel the three axis enums on
-    :class:`PanelProperties` (``scope`` / ``density`` / ``structure``).
-    """
-
-    scope_reason: str
-    density_reason: str
-    structure_reason: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,10 +184,8 @@ class PanelInspection:
     Pure data — no execution methods.
 
     Attributes:
-        detected: :class:`PanelProperties` with typed enum axes and
-            shape numerics.
-        reasoning: :class:`PanelReasoning` carrying per-axis prose
-            (scope / density / structure).
+        detected: :class:`PanelProperties` with typed enum axes, the
+            per-axis rationale strings, and shape numerics.
         metrics: Flat ``list[MetricApplicability]`` — one verdict
             per ``visibility=PUBLIC`` spec the inspector considered.
             Single source of truth; the :attr:`usable` /
@@ -204,7 +199,6 @@ class PanelInspection:
     """
 
     detected: PanelProperties
-    reasoning: PanelReasoning
     metrics: list[MetricApplicability]
     warnings: list[Warning] = field(default_factory=list)
 
@@ -280,9 +274,9 @@ class PanelInspection:
                 ),
             },
             "reasoning": {
-                "scope": self.reasoning.scope_reason,
-                "density": self.reasoning.density_reason,
-                "structure": self.reasoning.structure_reason,
+                "scope": d.scope_reason,
+                "density": d.density_reason,
+                "structure": d.structure_reason,
             },
             "metrics": [
                 {
@@ -335,9 +329,9 @@ class PanelInspection:
             f"<tr><th style='text-align:left'>{axis}</th>"
             f"<td>{html.escape(reason)}</td></tr>"
             for axis, reason in (
-                ("scope", self.reasoning.scope_reason),
-                ("density", self.reasoning.density_reason),
-                ("structure", self.reasoning.structure_reason),
+                ("scope", d.scope_reason),
+                ("density", d.density_reason),
+                ("structure", d.structure_reason),
             )
         )
 
@@ -426,17 +420,15 @@ def inspect_panel(panel: Any) -> PanelInspection:
 
     properties = PanelProperties(
         scope=scope,
+        scope_reason=scope_reason,
         density=density,
+        density_reason=density_reason,
         structure=structure,
+        structure_reason=structure_reason,
         n_assets=n_assets,
         n_periods=n_periods,
         n_pairs=n_pairs,
         sparse_ratio=sparse_ratio,
-    )
-    reasoning = PanelReasoning(
-        scope_reason=scope_reason,
-        density_reason=density_reason,
-        structure_reason=structure_reason,
     )
 
     panel_warnings = _panel_level_warnings(properties)
@@ -444,7 +436,6 @@ def inspect_panel(panel: Any) -> PanelInspection:
 
     return PanelInspection(
         detected=properties,
-        reasoning=reasoning,
         metrics=metrics,
         warnings=panel_warnings,
     )

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -618,12 +618,14 @@ types-only; runner wiring lands with the DAG executor.
   pre-flight introspection that combines axis detection with a
   per-metric usability verdict.
   - `PanelInspection.detected: PanelProperties` carries the typed
-    enums (`scope` / `density` / `structure`) plus shape numerics
+    enums (`scope` / `density` / `structure`), the per-axis rationale
+    strings folded in alongside each enum (`scope_reason` /
+    `density_reason` / `structure_reason`), plus shape numerics
     (`n_assets` / `n_periods` / `n_pairs` / `sparse_ratio`).
     `n_pairs` counts non-null `(date, asset_id)` factor observations
     — the upper bound on sample size for pair-counting metrics.
-  - `PanelInspection.reasoning: PanelReasoning` carries per-axis
-    rationale strings.
+    (The standalone `PanelReasoning` type is retired; `to_dict()`
+    still emits a top-level `reasoning` block for serialization.)
   - `PanelInspection.metrics: list[MetricApplicability]` — one
     verdict per `visibility=PUBLIC` spec. Each carries `metric:
     type[MetricBase]` (the callable class) and `name: str`

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -10,7 +10,6 @@ from factrix._inspect import (
     MetricApplicability,
     PanelInspection,
     PanelProperties,
-    PanelReasoning,
     inspect_panel,
 )
 
@@ -49,7 +48,7 @@ class TestPanelPropertiesDetection:
         info = inspect_panel(_single_asset_panel(n_dates=80))
         assert info.detected.structure is fx.DataStructure.TIMESERIES
         assert info.detected.n_assets == 1
-        assert "TIMESERIES" in info.reasoning.structure_reason
+        assert "TIMESERIES" in info.detected.structure_reason
 
     def test_common_continuous_detection(self):
         info = inspect_panel(_common_continuous_panel())
@@ -78,9 +77,9 @@ class TestPanelPropertiesDetection:
 class TestPanelReasoning:
     def test_three_axis_fields_populated(self):
         info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
-        assert "INDIVIDUAL" in info.reasoning.scope_reason
-        assert "DENSE" in info.reasoning.density_reason
-        assert "PANEL" in info.reasoning.structure_reason
+        assert "INDIVIDUAL" in info.detected.scope_reason
+        assert "DENSE" in info.detected.density_reason
+        assert "PANEL" in info.detected.structure_reason
 
 
 class TestCellMatchGate:
@@ -276,7 +275,6 @@ class TestPublicSurface:
     def test_dataclass_types_exported(self):
         assert fx.PanelInspection is PanelInspection
         assert fx.PanelProperties is PanelProperties
-        assert fx.PanelReasoning is PanelReasoning
         assert fx.MetricApplicability is MetricApplicability
         assert fx.inspect_panel is inspect_panel
         assert fx.SampleThreshold is not None

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -62,8 +62,11 @@ class TestSampleThresholdHelpers:
 
         props_clean = PanelProperties(
             scope=FactorScope.INDIVIDUAL,
+            scope_reason="",
             density=FactorDensity.DENSE,
+            density_reason="",
             structure=DataStructure.PANEL,
+            structure_reason="",
             n_periods=30,
             n_assets=15,
             n_pairs=50,
@@ -78,8 +81,11 @@ class TestSampleThresholdHelpers:
 
         props_degraded = PanelProperties(
             scope=FactorScope.INDIVIDUAL,
+            scope_reason="",
             density=FactorDensity.DENSE,
+            density_reason="",
             structure=DataStructure.PANEL,
+            structure_reason="",
             n_periods=20,
             n_assets=15,
             n_pairs=50,
@@ -94,8 +100,11 @@ class TestSampleThresholdHelpers:
 
         props_unusable = PanelProperties(
             scope=FactorScope.INDIVIDUAL,
+            scope_reason="",
             density=FactorDensity.DENSE,
+            density_reason="",
             structure=DataStructure.PANEL,
+            structure_reason="",
             n_periods=20,
             n_assets=4,
             n_pairs=50,


### PR DESCRIPTION
## Summary

Folds the per-axis rationale strings onto `PanelProperties` per #476 §7,
retiring the standalone `PanelReasoning` container.

Before: detection verdict (`PanelInspection.detected: PanelProperties`)
and its prose (`PanelInspection.reasoning: PanelReasoning`) lived in two
separate values. After: each enum sits next to its `*_reason` on
`PanelProperties`, so verdict and rationale travel together:

```python
info = fx.inspect_panel(panel)
info.detected.scope          # FactorScope.INDIVIDUAL
info.detected.scope_reason   # "...INDIVIDUAL..."   (was info.reasoning.scope_reason)
```

`to_dict()` is intentionally unchanged — it still emits a top-level
`reasoning` block (now sourced from `detected`), so the JSON/serialization
contract is stable.

## Breaking change

- `PanelReasoning` is removed (dropped from `factrix` public exports).
- `PanelInspection.reasoning` is removed.
- Migration: `info.reasoning.<axis>_reason` -> `info.detected.<axis>_reason`.

## Test plan

- `tests/test_inspect_panel.py` updated to read `info.detected.*_reason`;
  `to_dict()` round-trip still asserts the top-level `reasoning` block.
- `tests/test_metric_index.py` `PanelProperties` constructions updated for
  the new fields.
- Full suite green except 4 pre-existing `tests/bench` failures unrelated
  to this change (metric-name drift, e.g. `corrado_rank_test` vs
  `corrado_rank`).
- `ruff` + `mypy` clean on touched modules.

Closes #496