### PR TITLE
refactor(api): align Warning.source to str | None

### DIFF
--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -82,6 +82,14 @@ class Warning:
     ``(code, source, message)`` so callers can filter on the metric
     that emitted the warning.
 
+    Source convention (uniform across every emission point):
+    a per-metric warning carries ``source == <metric name>`` (the
+    emitting :class:`MetricSpec`'s ``name``); a panel-level /
+    cross-metric warning carries ``source is None``. Callers filter on
+    this — ``w.source == name`` for one metric, ``w.source is None`` for
+    bundle diagnostics — so the two-state ``str | None`` is load-bearing,
+    not incidental.
+
     Attributes:
         code: The :class:`WarningCode` enum member.
         source: Metric name that emitted the warning, or ``None`` for

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -235,6 +235,29 @@ class TestPanelLevelWarnings:
         assert any("cross_section" in c for c in codes)
 
 
+class TestWarningSourceConvention:
+    """Guard the `Warning.source` convention across every emission point:
+    per-metric warnings carry `source == <metric name>`; panel-level
+    warnings carry `source is None`. See #499.
+    """
+
+    def test_per_metric_warnings_carry_their_metric_name(self):
+        # n_periods=25 puts NW-SE metrics in the degraded tier, n_assets=5
+        # trips the cross-section tier — both per-metric warning paths fire.
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=25))
+        emitted = 0
+        for m in info.metrics:
+            for w in m.warnings:
+                assert w.source == m.name
+                emitted += 1
+        assert emitted > 0  # the fixture actually exercises the per-metric path
+
+    def test_panel_level_warnings_carry_no_source(self):
+        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=25))
+        assert info.warnings  # fixture produces panel-level diagnostics
+        assert all(w.source is None for w in info.warnings)
+
+
 class TestToDict:
     def test_round_trips_through_json(self):
         import json


### PR DESCRIPTION
## Summary

Audit per #499. Every `Warning(...)` emission point already follows the
source convention, and `Warning.source` is already typed `str | None`, so
this PR **locks the convention down** rather than changing behaviour.

Emission-point audit (all consistent):

| site | `source` | class |
|------|----------|-------|
| `_inspect.py` degraded tiers (×2) | `spec.name` | per-metric |
| `_inspect.py` panel-level (×2) | `None` | panel |
| `_dag.py` upstream-unavailable | `spec.name` | per-metric |

Changes:
- Document the convention as the contract on the `Warning` docstring (the
  two-state `str | None` is load-bearing for the `source == name` /
  `source is None` filter split).
- Add a regression guard: per-metric `MetricApplicability` warnings carry
  `source == metric name` (previously untested); panel-level warnings
  carry no source.

## Out of scope (deferred to #493)

Metric-emitted `metadata["warning_codes"]` (in `concentration` / `caar` /
`fm_beta`) are not yet lifted into `EvaluationResult.warnings` as
`Warning(source=spec.name)`. That requires rewriting the `_dag.py`
result-assembly loop, which #493 already does — [noted there](https://github.com/awwesomeman/factrix/issues/493#issuecomment-4623586996).
The result types remain "types-only" pending runner wiring per `llms-full.txt`.

## Test plan

- `tests/test_inspect_panel.py::TestWarningSourceConvention` — asserts the
  per-metric and panel-level source convention on real `inspect_panel`
  output; fixtures verified to actually exercise both warning paths.
- Full suite green except 4 pre-existing `tests/bench` failures unrelated
  to this change.
- `ruff` clean.

Closes #499