### PR TITLE
refactor(api)!: retire list_metrics(scope, density) overload

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -79,7 +79,7 @@ triggers and fix paths:
 
 | Message hint | Trigger | Fix |
 |---|---|---|
-| `unknown metric='...'` | Typo or metric not applicable to the cell | `list_metrics(scope, signal)` enumerates the applicable set; `exc.suggestions` carries the top-3 fuzzy candidates. See [`list_metrics`](list-metrics.md). |
+| `unknown metric='...'` | Typo or metric not applicable to the cell | `inspect_panel(panel).usable` enumerates the metrics applicable to a panel; `exc.suggestions` carries the top-3 fuzzy candidates. See [`list_metrics`](list-metrics.md) for the full catalog. |
 | `unknown estimator='...'` | Typo or estimator not applicable to the cell | `list_estimators(scope, signal)` enumerates the applicable set. See [`list_estimators`](list-estimators.md). |
 | `unknown expand_over='...'` | Context key not present on every profile in the family | All profiles in the family must carry the key in `.context`; check that the caller is populating it consistently at `evaluate` time. See [Cross-function reference § `expand_over`](decision-tree.md#expand_over-is-not-one-concept) for the three different `expand_over` semantics across functions. |
 | `expand_over=[...] requires every profile to carry key 'X'` | One or more profiles missing the key | Confirm the upstream `evaluate` call records the key in `context=...`. |
@@ -146,12 +146,13 @@ renders its own message:
 ```python
 import factrix as fx
 
-if metric_name not in fx.list_metrics(cfg):
+known = {spec.name for specs in fx.list_metrics().values() for spec in specs}
+if metric_name not in known:
     raise fx.UserInputError(
         func_name="run_metrics",
         field="metrics",
         value=metric_name,
-        candidates=fx.list_metrics(cfg),
+        candidates=sorted(known),
         docs_path="api/run_metrics#metrics",
     )
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -81,7 +81,8 @@ Click any node to jump to its API page. Nodes are grouped into category subgraph
 | Single-factor inference | `evaluate(panel, cfg)` → read `primary_p` |
 | Slice exploration (single axis) | `by_slice(metric, df, label="...")` → `SliceResult` |
 | Slice statistical test | `slice_pairwise_test(metric, df, label="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
-| Cell metric discovery | `list_metrics(scope, signal)` → names → `evaluate(metrics=[...])` |
+| Metric catalog discovery | `list_metrics()` → family-grouped `dict` of specs |
+| Per-panel applicability | `inspect_panel(panel)` → `.usable` / `.degraded` / `.unusable` |
 | Multi-factor screening with false discovery rate (FDR) | `[evaluate(panel, cfg_i) for cfg_i in cfgs]` → `multi_factor.bhy(profiles)` |
 | Cross-factor leaderboard | `compare(profiles)` / `compare(survivors)` → `pl.DataFrame` |
 
@@ -100,7 +101,7 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 | [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction p-values (Benjamini-Heller 2008) → BHY. | "Factor X passes in ≥ k of m contexts." |
 | [`bhy_hierarchical`](bhy-hierarchical.md) | Screening (FDR) | Hierarchical FDR (Yekutieli 2008) — outer BHY on group representatives, inner BHY within passing groups. | Factor families / nested-context structure. |
 | [`compare`](compare.md) | Descriptive view | Cross-factor leaderboard — stacks evaluation / `Survivors` artifacts into a `pl.DataFrame` (no recompute). | Ranking N candidate factors. |
-| [`list_metrics`](list-metrics.md) | Introspection | Programmatic discovery of standalone `factrix.metrics.*` callables applicable to a `(scope, signal)` cell. | Picking a follow-up metric after `evaluate()`. |
+| [`list_metrics`](list-metrics.md) | Introspection | Family-grouped catalog of standalone `factrix.metrics.*` callables (no-arg). | Browsing the metric catalog; pair with `inspect_panel` for per-panel applicability. |
 | [`list_estimators`](list-estimators.md) | Introspection | Estimators applicable to a cell — inference-side twin of `list_metrics`. | Picking `estimator=` for screening functions. |
 | [`Metrics`](metrics/index.md) | Catalogue | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly. |
 | [`stats`](stats.md) | Catalogue | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking an inference method to pass through `estimator=`. |

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -4,116 +4,51 @@ title: factrix.list_metrics
 
 ::: factrix.list_metrics
 
-Programmatic discovery of standalone metrics applicable to a given
-analysis cell. Complements [`describe_analysis_modes`](
-../reference/metric-applicability.md) — that helper enumerates the
-*primary procedure* per cell (IC / FM / CAAR / TS-β); `list_metrics`
-returns the full set of standalone callables under
-[`factrix.metrics`](metrics/index.md) that the user can additionally
-invoke once `evaluate()` has produced a `FactorProfile`.
-
-## DataStructure axis is not an input
-
-`DataStructure` is intentionally not a parameter — applicability does not
-change across PANEL / TIMESERIES (see
-[Metric applicability](../reference/metric-applicability.md) for the
-underlying matrix). See the docstring Examples block above for the
-canonical text-list and JSON-form calls.
-
-## Discover-then-import workflow
-
-Pass `with_import=True` to render a copy-paste-ready two-column view
-that pairs each metric with its submodule path:
+Programmatic discovery of the standalone metrics under
+[`factrix.metrics`](metrics/index.md). `list_metrics()` takes **no
+arguments** and returns a family-grouped catalog —
+a `dict[str, list[MetricSpec]]` keyed by concept family (the declaring
+module stem), values being that family's public specs:
 
 ```python
-print("\n".join(fx.list_metrics(
-    fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE, with_import=True,
-)))
-# ic                       → factrix.metrics.ic
-# ic_ir                    → factrix.metrics.ic
-# fm_beta             → factrix.metrics.fm_beta
-# breakeven_cost           → factrix.metrics.tradability
-# ...
+import factrix as fx
+
+overview = fx.list_metrics()
+overview["ic"]       # [MetricSpec(name="ic", ...), MetricSpec(name="ic_ir", ...), ...]
+sorted(overview)     # ['caar', 'fm_beta', 'ic', ...] — the concept families
 ```
 
-Every name on the right is also re-exported from `factrix.metrics`,
-so the canonical wire-up is always:
+The catalog is a *reference*, not a runnable input. Wire concrete
+callables up from `factrix.metrics` and pass them to
+[`evaluate`](evaluate.md):
 
 ```python
 from factrix.metrics import ic, fm_beta, breakeven_cost
 ```
 
-The submodule path is shown so you know *where the implementation
-lives* — useful when reading source, jumping in an IDE, or checking
-the module-level `Matrix-row:` tag.
+## Per-cell applicability → `inspect_panel`
 
-## Structured output for tooling
-
-```python
-fx.list_metrics(
-    fx.FactorScope.INDIVIDUAL,
-    fx.FactorDensity.DENSE,
-    format="json",
-)
-# -> [
-#     {
-#         "name": "ic",
-#         "module": "ic",
-#         "cell": "(INDIVIDUAL, DENSE, IC, PANEL)",
-#         "agg_order": "cs-first",
-#         "inference_se": "NW HAC / cross-asset t",
-#         "import_path": "factrix.metrics.ic",
-#         "input_kind": "panel",
-#     },
-#     ...
-# ]
-```
-
-The JSON form is the single-source-of-truth row produced by parsing
-the `Matrix-row:` tag in each metric module's docstring (the same
-parser MkDocs uses to render
-[the cross-metric matrix](../reference/metric-pipelines.md)). Keys:
-
-| Key | Meaning |
-|---|---|
-| `name` | Function name as exported under `factrix.metrics` |
-| `module` | Submodule stem (e.g. `ic`, `fm_beta`) |
-| `cell` | Raw cell string from the `Matrix-row:` tag |
-| `agg_order` | Aggregation order (`cs-first`, `ts-first`, `ts-only`, `static-cs`, `per-event`) |
-| `inference_se` | Inference / SE method or `no formal H₀` for descriptive metrics |
-| `import_path` | Fully-qualified submodule (`factrix.metrics.<module>`) — also re-exported from `factrix.metrics` |
-| `input_kind` | `"panel"` for the standard `(date-keyed DataFrame, **kwargs) -> MetricResult` contract; `"scalar"` for pre-aggregated-scalar utilities |
-
-### `panel` vs `scalar` — and why it matters
-
-Most metrics take a date-keyed DataFrame as their first positional
-argument; a few (`breakeven_cost`, `net_spread` in
-`factrix.metrics.tradability`) consume pre-aggregated scalars
-(`gross_spread: float`, `turnover: float`, …) and return a
-`MetricResult` directly. The date-slicing dispatcher
-[`by_slice`](by-slice.md) only accepts the `panel` shape — there is
-no date column in a scalar to slice on.
-
-Filter the JSON output to enumerate `by_slice`-eligible metrics:
+The former `list_metrics(scope, density)` cell filter — together with
+its `format="json"` and `with_import` knobs — is **retired** (#498). To
+learn which metrics actually run on a given panel, and which are
+degraded or blocked by sample floors, inspect a real panel with
+`inspect_panel`:
 
 ```python
-panel_metrics = [
-    r for r in fx.list_metrics(
-        fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE, format="json",
-    )
-    if r["input_kind"] == "panel"
-]
+info = fx.inspect_panel(panel)
+[m.name for m in info.usable]     # production-safe metrics for this panel
+[m.name for m in info.degraded]   # run, but inference degraded
+[m.name for m in info.unusable]   # blocked (cell mismatch / sample floor)
 ```
 
-## Errors
-
-[`IncompatibleAxisError`][factrix.IncompatibleAxisError] is raised when `(scope, signal)` matches no
-registered metric. All four real combinations are populated, so this
-is defensive — surfaced for symmetry with the rest of the API.
+`inspect_panel` subsumes the old cell filter with a structure-aware,
+sample-floor-aware verdict: each `MetricApplicability` carries the
+metric `name`, its callable class, and any `blockers` / `warnings`.
+Unlike the static cell filter, it accounts for the actual panel shape
+(`n_periods` / `n_assets` / `n_pairs`).
 
 ## Source of truth
 
-`list_metrics` and the docs matrix share one parser
-(`factrix._metric_index`). Adding a new metric only requires adding a
-`Matrix-row:` tag to the new module's docstring; both surfaces pick it
-up automatically.
+The catalog is built from the registered `@metric` classes in each
+`factrix/metrics/*.py` module (`factrix._metric_index`). Adding a metric
+makes it appear in the overview automatically.

--- a/docs/api/metric-output.md
+++ b/docs/api/metric-output.md
@@ -35,12 +35,10 @@ carries its declaring spec, so the metric name is `result.spec.name`.
 
 The metric name maps back to its API page two ways:
 
-- **Programmatic** —
-  [`list_metrics(..., format="json")`](list-metrics.md) rows carry an
-  `emitted_name` field (the metric's runtime name) and a `docs_anchor`
-  field following the `DOCS_ANCHOR_FMT` convention defined in
-  `factrix._metric_index` (docs-root-relative path + mkdocstrings
-  symbol fragment), resolvable without scraping.
+- **Programmatic** — the docs-build hooks resolve each metric's page
+  anchor through `docs_anchor_for` in `factrix._metric_index`, which
+  follows the `DOCS_ANCHOR_FMT` convention (docs-root-relative path +
+  mkdocstrings symbol fragment), resolvable without scraping.
 - **Static** — the auto-generated table below maps every emitted
   metric name to the function that produced it and the API page
   anchor. Regenerated from the same `Matrix-row:` SSOT on every docs

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -65,17 +65,16 @@ ic_df = compute_ic(panel)["factor"].join(vol_labels, on="date", how="inner")
 
 ## Discovering eligible metrics
 
-`by_slice` accepts any metric whose primary input is a date-keyed DataFrame. The inference functions additionally require the metric module to declare a `per_date_series` capability. Use [`list_metrics`](../api/list-metrics.md) with `format="json"` and filter on `input_kind == "panel"` to enumerate the candidate set:
+`by_slice` accepts any metric whose primary input is a date-keyed DataFrame. The inference functions additionally require the metric module to declare a `per_date_series` capability. Enumerate the candidate set from the [`list_metrics()`](../api/list-metrics.md) catalog by filtering each spec's `input_shape`:
 
 ```python
 import factrix as fx
 
 panel_metrics = [
-    r["name"]
-    for r in fx.list_metrics(
-        fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE, format="json",
-    )
-    if r["input_kind"] == "panel"
+    spec.name
+    for specs in fx.list_metrics().values()
+    for spec in specs
+    if spec.input_shape.value == "panel"
 ]
 ```
 

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -134,11 +134,18 @@ separate pass after BHY narrows the candidate set.
 
 ## Discovery
 
-[`list_metrics(scope, signal)`](../api/list-metrics.md) returns the
-standalone subset for a given cell, sorted by module then function.
-Use it as the runtime equivalent of the static matrix:
+[`list_metrics()`](../api/list-metrics.md) returns the family-grouped
+catalog of every standalone metric (a `dict` keyed by concept family):
 
 ```python
-fx.list_metrics(fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE)
-# ['concentration.top_concentration', 'fm_beta.beta_sign_consistency', ...]
+overview = fx.list_metrics()
+overview["ic"]    # [MetricSpec(name="ic", ...), MetricSpec(name="ic_ir", ...), ...]
+```
+
+For the subset applicable to a *specific panel* — accounting for its
+actual shape — inspect the panel and read the verdict partitions:
+
+```python
+info = fx.inspect_panel(panel)
+[m.name for m in info.usable]   # production-safe metrics for this panel
 ```

--- a/docs/reference/metric-pipelines.md
+++ b/docs/reference/metric-pipelines.md
@@ -31,8 +31,7 @@ and internal primitives, click the module link to the source.
 ## Aggregation vocabulary
 
 The `agg_order` column uses one canonical lowercase-hyphen form across
-the matrix, every `Matrix-row:` tag in `factrix/metrics/*.py`, and the
-`list_metrics()` JSON output:
+the matrix and every `Matrix-row:` tag in `factrix/metrics/*.py`:
 
 - **`cs-first`** — aggregate cross-section per date first, then aggregate
   the resulting time series. Pairs with the

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -38,7 +38,7 @@ import inspect
 import pathlib
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from factrix._axis import (
     Aggregation,
@@ -52,7 +52,6 @@ from factrix._axis import (
     TestMethod,
     Tier,
 )
-from factrix._errors import IncompatibleAxisError
 
 if TYPE_CHECKING:
     from factrix._inspect import PanelProperties
@@ -623,133 +622,29 @@ def _metrics_overview() -> dict[str, list[MetricSpec]]:
     return out
 
 
-@overload
-def list_metrics() -> dict[str, list[MetricSpec]]: ...
-@overload
-def list_metrics(
-    scope: FactorScope,
-    density: FactorDensity,
-    *,
-    format: Literal["text", "json"] = ...,
-    with_import: bool = ...,
-) -> list[str] | list[dict[str, Any]]: ...
-def list_metrics(
-    scope: FactorScope | None = None,
-    density: FactorDensity | None = None,
-    *,
-    format: Literal["text", "json"] = "text",
-    with_import: bool = False,
-) -> dict[str, list[MetricSpec]] | list[str] | list[dict[str, Any]]:
-    """Discover standalone metrics — family-grouped overview or cell filter.
+def list_metrics() -> dict[str, list[MetricSpec]]:
+    """Family-grouped catalog of every public standalone metric.
 
-    Two call shapes:
+    Returns a ``dict[str, list[MetricSpec]]`` keyed by concept family
+    (the declaring module stem, per the ``file = family`` invariant);
+    values are that module's public specs in registry order. This is a
+    catalog, *not* runnable — pass concrete metric callables to
+    :func:`factrix.evaluate`.
 
-    - **No arguments** → a family-grouped overview
-      ``dict[str, list[MetricSpec]]`` keyed by concept family (the
-      module stem). This is a catalog, *not* runnable — see
-      :func:`_metrics_overview`.
-    - **Both ``scope`` and ``density``** → the metrics applicable to that
-      ``(scope, density)`` cell, as names (``format="text"``) or
-      JSON-serialisable rows (``format="json"``).
+    For per-cell applicability — which metrics actually run on a given
+    panel, and which are degraded or blocked — inspect a real panel with
+    :func:`factrix.inspect_panel` and read its ``usable`` / ``degraded``
+    / ``unusable`` partitions. (The former ``list_metrics(scope, density)``
+    cell filter is retired; ``inspect_panel`` subsumes it with a
+    structure-aware, sample-floor-aware verdict.)
 
-    Passing exactly one axis is a usage error.
-
-    DataStructure is intentionally not an input — applicability does not change
-    across PANEL / TIMESERIES (per ``docs/reference/metric-applicability.md``).
-    Source of truth is the module-level ``__metric_specs__`` tuple in
-    each metric module, loaded by :mod:`factrix._metric_index`.
-
-    Args:
-        scope: Cell axis to filter on (``FactorScope.INDIVIDUAL`` or
-            ``FactorScope.COMMON``). Omit together with ``density`` for
-            the overview.
-        density: Cell axis to filter on (``FactorDensity.DENSE`` or
-            ``FactorDensity.SPARSE``). Omit together with ``scope`` for
-            the overview.
-        format: ``"text"`` (default) returns metric names sorted by
-            ``(module, name)``. ``"json"`` returns ``list[dict]`` rows
-            with keys ``name``, ``module``, ``family``, ``cell``,
-            ``aggregation``, ``test_method``, ``se_method``,
-            ``import_path``, ``input_shape``, ``docs_anchor`` —
-            JSON-serialisable, suitable for tooling. ``family`` is the
-            concept family (module stem); ``aggregation`` is the
-            cross-section/time reduction order.
-            ``docs_anchor`` follows
-            :data:`factrix._metric_index.DOCS_ANCHOR_FMT` (a
-            docs-root-relative path + mkdocstrings symbol fragment).
-            ``name`` == ``MetricResult.name`` for all current specs
-            (function name = registry key = emitted label).
-        with_import: ``"text"`` only. When ``True``, returns a
-            two-column ``"name → factrix.metrics.<module>"`` list so
-            each row is copy-paste-ready into
-            ``from factrix.metrics import <name>``. Ignored under
-            ``format="json"`` (the ``import_path`` field is always
-            present there).
-
-    Raises:
-        ValueError: exactly one of ``scope`` / ``density`` is given
-            (pass both for a filtered list, or neither for the overview).
-        IncompatibleAxisError: ``(scope, density)`` matches no
-            registered metric. In practice all four combos are
-            populated, so this is defensive.
+    Source of truth is the registered ``@metric`` classes in each
+    ``factrix/metrics/*.py`` module, loaded by :mod:`factrix._metric_index`.
 
     Examples:
-        Family-grouped overview (no arguments):
-
         >>> import factrix as fx
         >>> overview = fx.list_metrics()
         >>> "ic" in overview
         True
-
-        Discover standalone metrics for an INDIVIDUAL × DENSE cell:
-
-        >>> names = fx.list_metrics(
-        ...     fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE,
-        ... )
-
-        JSON form (for tooling — adds module / family / import_path keys):
-
-        >>> rows = fx.list_metrics(
-        ...     fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE, format="json",
-        ... )
     """
-    if scope is None and density is None:
-        return _metrics_overview()
-    if scope is None or density is None:
-        raise ValueError(
-            "list_metrics() takes either no arguments (family-grouped "
-            "overview) or both scope and density (cell-filtered list); "
-            "got exactly one axis."
-        )
-    matches = [
-        (stem, spec)
-        for stem, spec in public_specs()
-        if spec.cell.matches(scope, density)
-    ]
-    if not matches:
-        raise IncompatibleAxisError(
-            f"no standalone metrics registered for "
-            f"(scope={scope.value}, density={density.value})"
-        )
-    if format == "json":
-        return [
-            {
-                "name": spec.name,
-                "module": stem,
-                "family": stem,
-                "cell": spec.cell.raw,
-                "aggregation": spec.aggregation.value,
-                "test_method": spec.test_method.value,
-                "se_method": spec.se_method.value,
-                "import_path": import_path_for(stem),
-                "input_shape": spec.input_shape.value,
-                "docs_anchor": docs_anchor_for(stem, spec.name),
-            }
-            for stem, spec in matches
-        ]
-    if with_import:
-        width = max(len(spec.name) for _, spec in matches)
-        return [
-            f"{spec.name:<{width}} → {import_path_for(stem)}" for stem, spec in matches
-        ]
-    return [spec.name for _, spec in matches]
+    return _metrics_overview()

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -417,19 +417,15 @@ schema).
 ### `list_metrics` / `list_estimators`
 
 ```
-factrix.list_metrics(scope: FactorScope, density: FactorDensity,
-                     *, format: Literal["text", "json"] = "text"
-                     ) -> list[str] | list[dict[str, Any]]
-    # Standalone metrics applicable to a (scope, density) cell.
-    # text → list[str] sorted by (module, name); json → rows with
-    # {name, module, cell, agg_order, inference_se, import_path,
-    #  input_kind, docs_anchor, emitted_name}. docs_anchor is a
-    # docs-root-relative path + mkdocstrings symbol fragment;
-    # emitted_name is the literal MetricResult.name (usually equals
-    # name, but a few metrics emit a different label — fama_macbeth
-    # → fm_beta, etc.). DataStructure is not an input — applicability does
-    # not change across PANEL / TIMESERIES.
-    # Raises IncompatibleAxisError if the pair has no registered metrics.
+factrix.list_metrics() -> dict[str, list[MetricSpec]]
+    # No-arg family-grouped catalog: keyed by concept family (module
+    # stem), values are that family's public specs in registry order.
+    # A reference catalog, not runnable — pass concrete factrix.metrics
+    # callables to evaluate(). For per-panel applicability (which metrics
+    # run / are degraded / are blocked on an actual panel) use
+    # inspect_panel(panel).usable / .degraded / .unusable. The former
+    # list_metrics(scope, density) cell filter + format/with_import knobs
+    # are retired (#498).
 
 factrix.list_estimators(scope: FactorScope, density: FactorDensity,
                         *, format: Literal["text", "json"] = "text",

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -11,13 +11,11 @@ from __future__ import annotations
 import json
 import pathlib
 import re
-from unittest.mock import patch
 
 import factrix as fx
 import polars as pl
 import pytest
 from factrix._axis import FactorDensity, FactorScope, SpecRole
-from factrix._errors import IncompatibleAxisError
 from factrix._metric_index import (
     MetricSpec,
     _all_specs,
@@ -26,6 +24,19 @@ from factrix._metric_index import (
 )
 
 _APPLICABILITY_DOC = pathlib.Path("docs/reference/metric-applicability.md")
+
+
+def _names_for_cell(scope: FactorScope, density: FactorDensity) -> set[str]:
+    """Public metric names applicable to a ``(scope, density)`` cell.
+
+    The cell filter ``list_metrics(scope, density)`` exposed was retired
+    (#498); the underlying mechanism — ``spec.cell.matches`` over
+    ``public_specs()`` — is what drives both this drift guard and
+    ``inspect_panel``'s per-metric verdict.
+    """
+    return {
+        spec.name for _, spec in public_specs() if spec.cell.matches(scope, density)
+    }
 
 
 # Cell-canonical primaries: SSOT moved to the auto-generated dispatch
@@ -134,7 +145,7 @@ def test_list_metrics_matches_applicability_doc(
 ) -> None:
     expected = _parse_applicability_doc()[(scope, density)]
     assert expected, "applicability doc parser found no rows for this cell"
-    actual = set(fx.list_metrics(scope, density))
+    actual = _names_for_cell(scope, density)
     assert actual == expected, (
         f"({scope.value}, {density.value}) drift\n"
         f"  only in list_metrics: {sorted(actual - expected)}\n"
@@ -163,117 +174,18 @@ def test_compute_rolling_mean_beta_remains_user_facing() -> None:
 
 
 # ---------------------------------------------------------------------------
-# sort stability + format
+# import-path resolution
 # ---------------------------------------------------------------------------
 
 
-def test_text_output_is_sorted_by_module_then_name() -> None:
-    out = fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE)
-    json_rows = fx.list_metrics(
-        FactorScope.INDIVIDUAL, FactorDensity.DENSE, format="json"
-    )
-    expected_order = [r["name"] for r in json_rows]
-    assert out == expected_order
-    keys = [(r["module"], r["name"]) for r in json_rows]
-    assert keys == sorted(keys)
-
-
-def test_json_format_round_trips() -> None:
-    rows = fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE, format="json")
-    text = json.dumps(rows)
-    decoded = json.loads(text)
-    assert decoded == rows
-    sample = rows[0]
-    assert set(sample) == {
-        "name",
-        "module",
-        "family",
-        "cell",
-        "aggregation",
-        "test_method",
-        "se_method",
-        "import_path",
-        "input_shape",
-        "docs_anchor",
-    }
-
-
-def test_json_carries_import_path_and_input_kind() -> None:
-    rows = fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE, format="json")
-    by_name = {r["name"]: r for r in rows}
-
-    # ``ic`` is the canonical panel-input metric.
-    assert by_name["ic"]["import_path"] == "factrix.metrics.ic"
-    assert by_name["ic"]["input_shape"] == "panel"
-    assert by_name["ic"]["docs_anchor"] == "api/metrics/ic.md#factrix.metrics.ic.ic"
-
-    # ``breakeven_cost`` / ``net_spread`` are the scalar-input utilities.
-    assert by_name["breakeven_cost"]["import_path"] == "factrix.metrics.tradability"
-    assert by_name["breakeven_cost"]["input_shape"] == "scalar"
-    assert by_name["net_spread"]["input_shape"] == "scalar"
-
-    # Every other row is panel-input.
-    panels = {r["name"] for r in rows if r["input_shape"] == "panel"}
-    scalars = {r["name"] for r in rows if r["input_shape"] == "scalar"}
-    assert scalars == {"breakeven_cost", "net_spread"}
-    assert panels.isdisjoint(scalars)
-
-
-def test_import_path_resolves_for_every_row() -> None:
-    # Walk every cell so the assertion covers cross-cell rows too.
+def test_import_path_resolves_for_every_public_spec() -> None:
     import importlib
 
-    seen: set[str] = set()
-    for scope in FactorScope:
-        for density in FactorDensity:
-            for r in fx.list_metrics(scope, density, format="json"):
-                if r["name"] in seen:
-                    continue
-                seen.add(r["name"])
-                module = importlib.import_module(r["import_path"])
-                assert hasattr(module, r["name"]), (
-                    f"{r['import_path']} is missing {r['name']}"
-                )
-
-
-def test_with_import_renders_two_column_text() -> None:
-    rendered = fx.list_metrics(
-        FactorScope.INDIVIDUAL, FactorDensity.DENSE, with_import=True
-    )
-    assert all(" → factrix.metrics." in line for line in rendered)
-    # Same row order as the plain text output — only the rendering changes.
-    plain = fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE)
-    assert [line.split(" → ", 1)[0].rstrip() for line in rendered] == plain
-
-
-def test_with_import_is_ignored_under_json_format() -> None:
-    # ``with_import`` is a text-only knob; JSON always carries the field.
-    a = fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE, format="json")
-    b = fx.list_metrics(
-        FactorScope.INDIVIDUAL, FactorDensity.DENSE, format="json", with_import=True
-    )
-    assert a == b
-
-
-def test_json_output_is_stable_across_calls() -> None:
-    a = fx.list_metrics(FactorScope.COMMON, FactorDensity.DENSE, format="json")
-    b = fx.list_metrics(FactorScope.COMMON, FactorDensity.DENSE, format="json")
-    assert a == b
-
-
-# ---------------------------------------------------------------------------
-# unrepresented (scope, density) pair
-# ---------------------------------------------------------------------------
-
-
-def test_incompatible_axis_pair_raises() -> None:
-    # All four real (scope, density) combos are populated; simulate a
-    # genuinely unrepresented pair by monkeypatching the index empty.
-    with (
-        patch("factrix._metric_index.public_specs", return_value=()),
-        pytest.raises(IncompatibleAxisError),
-    ):
-        fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE)
+    for stem, spec in public_specs():
+        module = importlib.import_module(import_path_for(stem))
+        assert hasattr(module, spec.name), (
+            f"{import_path_for(stem)} missing {spec.name}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -282,8 +194,8 @@ def test_incompatible_axis_pair_raises() -> None:
 
 
 def test_spanning_metrics_appear_for_individual_continuous_only() -> None:
-    ind = set(fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE))
-    com = set(fx.list_metrics(FactorScope.COMMON, FactorDensity.DENSE))
+    ind = _names_for_cell(FactorScope.INDIVIDUAL, FactorDensity.DENSE)
+    com = _names_for_cell(FactorScope.COMMON, FactorDensity.DENSE)
     assert {"spanning_alpha", "greedy_forward_selection"}.issubset(ind)
     assert {"spanning_alpha", "greedy_forward_selection"}.isdisjoint(com)
 
@@ -345,11 +257,11 @@ class TestNoArgOverview:
         overview = fx.list_metrics()
         assert list(overview) == sorted(overview)
 
-    def test_single_axis_raises_value_error(self) -> None:
-        with pytest.raises(ValueError, match="exactly one axis"):
-            fx.list_metrics(FactorScope.INDIVIDUAL)  # type: ignore[call-overload]
-        with pytest.raises(ValueError, match="exactly one axis"):
-            fx.list_metrics(density=FactorDensity.DENSE)  # type: ignore[call-overload]
+    def test_positional_args_are_rejected(self) -> None:
+        # The retired cell filter took (scope, density); the no-arg form
+        # takes none, so any positional argument is now a TypeError.
+        with pytest.raises(TypeError):
+            fx.list_metrics(FactorScope.INDIVIDUAL)  # type: ignore[call-arg]
 
 
 class TestOverviewNotRunnable:
@@ -378,11 +290,3 @@ class TestOverviewNotRunnable:
                 factor_cols=["alpha"],
                 forward_periods=5,
             )
-
-
-def test_json_agg_order_and_family_are_distinct_fields() -> None:
-    rows = fx.list_metrics(FactorScope.INDIVIDUAL, FactorDensity.DENSE, format="json")
-    by_name = {r["name"]: r for r in rows}
-    # aggregation is the reduction order; family is the concept group.
-    assert by_name["ic"]["aggregation"] == "cs_then_ts"
-    assert by_name["ic"]["family"] == "ic"


### PR DESCRIPTION
## Summary

Retires the parametrized `list_metrics(scope, density, *, format=, with_import=)`
cell filter, leaving the no-arg family-grouped overview (#481) as the
only shape of `list_metrics`.

```python
fx.list_metrics()                       # -> dict[str, list[MetricSpec]]  (family-grouped catalog)
# per-panel applicability now via inspect_panel:
info = fx.inspect_panel(panel)
[m.name for m in info.usable]           # production-safe metrics for this panel
```

`inspect_panel` subsumes the old cell lookup with a structure-aware,
sample-floor-aware verdict against a real panel, rather than a static
`(scope, density)` table.

## Changes

- **Code**: `list_metrics()` reduces to `() -> dict[str, list[MetricSpec]]`;
  removed the overloads, `format` / `with_import` knobs, the JSON-row
  branch, and the `IncompatibleAxisError` raise (the error type stays —
  `list_estimators` still uses it). Dropped now-unused imports.
- **Tests**: the applicability-doc drift guard and the spanning-metric
  check are rewritten onto `public_specs()` + `spec.cell.matches` (the
  mechanism the overload wrapped) so coverage is preserved; the JSON /
  `with_import` / single-axis / incompatible-axis tests are removed.
- **Docs**: `list-metrics.md` rewritten to the catalog + `inspect_panel`
  story; `standalone-metrics`, `slice-analysis`, `errors`, `index`,
  `metric-output`, `metric-pipelines`, and `llms-full.txt` updated off
  the retired form (the `input_shape` filter example now reads specs
  from the no-arg overview).

## Breaking change

`list_metrics(scope, density, ...)` is removed. Migration:
- catalog of all metrics → `list_metrics()`
- metrics applicable to a panel → `inspect_panel(panel).usable` / `.degraded` / `.unusable`

## Test plan

- `tests/test_list_metrics.py` (19 tests) green — drift guard and
  spanning check preserved via the rewrite.
- Doc-validation suites (`test_docs_pages` / `test_docs_llms` /
  `test_docs_matrix`) green.
- Full suite green except 4 pre-existing `tests/bench` failures unrelated
  to this change (bench tests do not use `list_metrics`).
- `ruff` + `mypy` clean.

Closes #498