### PR TITLE
refactor(dag): unify dispatch into a __call_batch__ protocol

### DIFF
--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -162,51 +162,39 @@ class DagExecutor:
         structure = DataStructure.PANEL if n_assets > 1 else DataStructure.TIMESERIES
         projections: dict[str, pl.DataFrame] = {}
 
+        def project(c: str) -> pl.DataFrame:
+            view = projections.get(c)
+            if view is None:
+                view = _project_factor(panel, c)
+                projections[c] = view
+            return view
+
         producer_outputs: dict[tuple[str, str], Any] = {}
         metric_outputs: dict[tuple[str, str], MetricResult] = {}
 
         for spec in (step.spec for step in self._plan_steps):
-            fn = self._fn(spec)
-            kwargs = dict(kwargs_by_metric.get(spec.name, {}))
-            if spec.batchable:
-                upstream_batch = self._gather_upstream_batch(
-                    spec, cols, producer_outputs
-                )
-                result = fn(panel, factor_cols=cols, **upstream_batch, **kwargs)
-                if not isinstance(result, Mapping):
-                    raise TypeError(
-                        f"{spec.name}: batchable=True spec must return a "
-                        f"Mapping[factor, output]; got {type(result).__name__}."
+            handle = self._batch_handle(spec, kwargs_by_metric.get(spec.name, {}))
+
+            # Split factors by upstream short-circuit: dead factors get the
+            # propagated skip output and never reach the metric.
+            live: list[str] = []
+            for c in cols:
+                skip = _check_upstream_short_circuit(spec, c, producer_outputs)
+                if skip is not None:
+                    producer_outputs[(spec.name, c)] = skip
+                    metric_outputs[(spec.name, c)] = dataclasses.replace(
+                        skip, name=spec.name
                     )
-                for c in cols:
-                    if c not in result:
-                        raise KeyError(
-                            f"{spec.name}: batchable result missing factor {c!r}"
-                        )
-                    producer_outputs[(spec.name, c)] = result[c]
-                    if isinstance(result[c], MetricResult):
-                        metric_outputs[(spec.name, c)] = dataclasses.replace(
-                            result[c], name=spec.name
-                        )
+                else:
+                    live.append(c)
+            if not live:
                 continue
 
-            for c in cols:
-                short_circuit = _check_upstream_short_circuit(spec, c, producer_outputs)
-                if short_circuit is not None:
-                    out = short_circuit
-                else:
-                    upstream_kwargs = {
-                        key: producer_outputs[(producer.__name__, c)]
-                        for key, producer in spec.requires.items()
-                    }
-                    if spec.requires:
-                        out = fn(**upstream_kwargs, **kwargs)
-                    else:
-                        view = projections.get(c)
-                        if view is None:
-                            view = _project_factor(panel, c)
-                            projections[c] = view
-                        out = fn(view, **kwargs)
+            upstream = self._gather_upstream_batch(spec, live, producer_outputs)
+            result = handle(panel, live, project=project, upstream=upstream)
+            _validate_batch_result(spec, live, result)
+            for c in live:
+                out = result[c]
                 producer_outputs[(spec.name, c)] = out
                 if isinstance(out, MetricResult):
                     metric_outputs[(spec.name, c)] = dataclasses.replace(
@@ -216,6 +204,46 @@ class DagExecutor:
         return self._assemble(
             cols, scope, density, forward_periods, structure, n_assets, metric_outputs
         )
+
+    def _batch_handle(
+        self, spec: MetricSpec, kwargs: Mapping[str, Any]
+    ) -> Callable[..., dict[str, Any]]:
+        """Return the spec's unified batch dispatcher.
+
+        Registry ``MetricBase`` classes expose ``__call_batch__`` directly
+        (bound to a configured instance); bare ``fn_resolver`` callables are
+        wrapped through the same :func:`_dispatch_batch` so both paths share
+        one dispatch body.
+        """
+        from factrix.metrics._base import MetricBase, _dispatch_batch
+
+        fn = self._fn(spec)
+        kw = dict(kwargs)
+        if isinstance(fn, type) and issubclass(fn, MetricBase):
+            return fn(**kw).__call_batch__
+
+        bare: Callable[..., Any] = fn
+
+        def handle(
+            panel: pl.DataFrame,
+            factor_cols: Sequence[str],
+            *,
+            project: Callable[[str], pl.DataFrame],
+            upstream: dict[str, dict[str, Any]],
+        ) -> dict[str, Any]:
+            return _dispatch_batch(
+                call_one=lambda df: bare(df, **kw),
+                run_batch=lambda: bare(
+                    panel, factor_cols=list(factor_cols), **upstream, **kw
+                ),
+                batchable=spec.batchable,
+                requires=tuple(spec.requires),
+                factor_cols=factor_cols,
+                project=project,
+                upstream=upstream,
+            )
+
+        return handle
 
     def _gather_upstream_batch(
         self,
@@ -318,6 +346,24 @@ def _registry_callable_table() -> dict[str, Callable[..., Any]]:
         if callable(fn):
             table[name] = fn
     return table
+
+
+def _validate_batch_result(
+    spec: MetricSpec, factor_cols: Sequence[str], result: Any
+) -> None:
+    """Check a batch dispatch returned a ``{factor: output}`` mapping.
+
+    Surfaces meaningfully for ``batchable`` specs whose ``_impl`` builds the
+    mapping itself; per-factor results are always well-formed dicts.
+    """
+    if not isinstance(result, Mapping):
+        raise TypeError(
+            f"{spec.name}: batchable=True spec must return a "
+            f"Mapping[factor, output]; got {type(result).__name__}."
+        )
+    for c in factor_cols:
+        if c not in result:
+            raise KeyError(f"{spec.name}: batchable result missing factor {c!r}")
 
 
 def _check_upstream_short_circuit(

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -587,7 +587,12 @@ types-only; runner wiring lands with the DAG executor.
   `fx.Warning` after `import factrix as fx`.
 - **`DagExecutor`** — programmatic executor for a closed set of
   `MetricSpec`. Topologically orders the graph
-  (`MetricSpec.requires` -> upstream callable), dispatches
+  (`MetricSpec.requires` -> upstream callable), then invokes every
+  metric through one unified `MetricBase.__call_batch__(panel,
+  factor_cols, *, project, upstream) -> {factor: output}` protocol
+  (the batchable / requires / thin-view shapes are unified in
+  `factrix.metrics._base._dispatch_batch`; the executor memoises the
+  thin-view `project` and keeps short-circuit handling). It dispatches
   `batchable=True` producers once per batch and `batchable=False`
   callables once per factor on a thin projection, caches every
   producer output per `(spec, factor)` so any number of downstream

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, ClassVar
 
 from factrix._axis import (
@@ -96,9 +96,74 @@ class MetricBase(metaclass=MetricMeta):
             sample_threshold=cls.sample_threshold,
         )
 
+    def _params(self) -> dict[str, Any]:
+        """Configured parameter values, pulled from the instance's slots."""
+        return {name: getattr(self, name) for name in self._param_names}
+
     def __call__(self, df: Any) -> Any:
-        """Evaluate the metric on the given input DataFrame or series."""
-        # Fast extraction of parameters using pre-cached slot field names
-        kwargs = {name: getattr(self, name) for name in self._param_names}
-        # Call the underlying implementation function (accessed via __class__ to avoid binding)
-        return self.__class__._impl(df, **kwargs)
+        """Evaluate the metric on a single input (one factor's view / upstream)."""
+        # Accessed via __class__ to avoid binding ``_impl`` as a method.
+        return self.__class__._impl(df, **self._params())
+
+    def __call_batch__(
+        self,
+        panel: Any,
+        factor_cols: Sequence[str],
+        *,
+        project: Callable[[str], Any],
+        upstream: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Run this metric across a factor batch; return ``{factor: output}``.
+
+        The single dispatch entry the DAG executor calls for every metric.
+        ``project(col)`` returns the thin per-factor view (executor-memoised,
+        auto-projected); ``upstream[requires_key][factor]`` is an upstream
+        producer's per-factor output. The three historical call shapes —
+        ``batchable`` (whole panel), ``requires`` (consume upstream), plain
+        (thin view) — are unified in :func:`_dispatch_batch`.
+        """
+        return _dispatch_batch(
+            call_one=self,
+            run_batch=lambda: self.__class__._impl(
+                panel,
+                **{**self._params(), "factor_cols": list(factor_cols), **upstream},
+            ),
+            batchable=self.batchable,
+            requires=tuple(self.requires),
+            factor_cols=factor_cols,
+            project=project,
+            upstream=upstream,
+        )
+
+
+def _dispatch_batch(
+    *,
+    call_one: Callable[[Any], Any],
+    run_batch: Callable[[], dict[str, Any]],
+    batchable: bool,
+    requires: tuple[str, ...],
+    factor_cols: Sequence[str],
+    project: Callable[[str], Any],
+    upstream: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Single source of truth for the three metric dispatch shapes.
+
+    Shared by :meth:`MetricBase.__call_batch__` and the DAG executor's
+    bare-callable (``fn_resolver``) path so the batchable / requires / thin-view
+    distinction lives in exactly one place.
+
+    - ``batchable`` → one whole-panel call returning ``{factor: output}``.
+    - ``requires``  → per factor, feed the upstream producer's output.
+    - otherwise     → per factor, feed the thin per-factor view.
+    """
+    if batchable:
+        return run_batch()
+    out: dict[str, Any] = {}
+    for c in factor_cols:
+        if requires:
+            # Every current consumer declares exactly one upstream; the impl's
+            # first parameter is that requires key (validated at load time).
+            out[c] = call_one(upstream[requires[0]][c])
+        else:
+            out[c] = call_one(project(c))
+    return out


### PR DESCRIPTION
## Summary

`DagExecutor.execute()` dispatched three ways inline per spec — batchable
(whole panel), `requires` (consume upstream), plain (thin per-factor view) —
with projection and upstream-unpacking scattered through one ~50-line loop.
This collapses it onto a single protocol per #472.

- **`MetricBase.__call_batch__(panel, factor_cols, *, project, upstream) -> {factor: output}`**
  is the one entry the executor calls for every metric. The three shapes are
  unified in `factrix.metrics._base._dispatch_batch` — the single source of
  truth shared by the protocol and the executor's bare-callable
  (`fn_resolver`) path.
- The executor now builds a **memoised thin-view `project` closure**
  (auto-projection, no per-metric re-projection), splits factors by upstream
  short-circuit so metrics only ever see live factors, then makes one
  `__call_batch__` call and caches/stamps the result. The batchable /
  requires / thin-view branching no longer lives in the executor.
- `__call__` is unchanged (single-input entry); the param-dict build is
  factored into `MetricBase._params()` and reused.

## Non-breaking

`execute()`'s signature, the plan string, warnings, and `n_obs` assembly
(`_assemble`) are untouched, so `evaluate` output is unchanged. The `@metric`
decorator and all 30 metric signatures are untouched — batchable metrics keep
`factor_cols` as a defaulted field; `__call_batch__` injects the batch value.

Scope is protocol unification only; the deferred warning-lifting stays out
(re-homed separately).

## Test plan

- `tests/test_dag.py` (13 tests) — batchable single-call, per-factor,
  stage-1 producer sharing, short-circuit propagation, `fn_resolver`
  isolation, plan string — all green.
- `tests/test_evaluation_result.py` + `tests/test_inspect_panel.py` +
  `tests/test_two_tier_guards.py` — end-to-end through `evaluate`, green.
- Full suite green except the 4 pre-existing `tests/bench` failures unrelated
  to this change (metric-name drift); zero new failures.
- `ruff check` / `ruff format --check` / `mypy factrix` clean.

Closes #493