### PR TITLE
refactor(api)!: evaluate() accepts dict[str, Metric] + strict + primary

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -70,7 +70,7 @@ Click any node to jump to its API page. Nodes are grouped into category subgraph
     - `bhy` / `partial_conjunction` / `bhy_hierarchical` consume `evaluate` outputs.
 - **Dashed `-.->` — suggested workflow.** The source is panel-derived, but the target's signature differs in shape.
     - `by_slice` / `slice_pairwise_test` / `slice_joint_test` accept `(metric, metric_df, label=…)`, where `metric_df` is a per-date frame the caller builds from the panel (e.g. `compute_ic(panel)`).
-    - `list_metrics` returns candidate names the caller forwards to `evaluate(metrics=[…])`.
+    - `list_metrics` returns the catalog; the caller constructs instances under labels for `evaluate(metrics={…})`.
 
 ---
 

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -43,14 +43,13 @@ No FDR claim is made.
 ```python
 import factrix as fx
 import polars as pl
-from factrix._metric_index import spec_by_name
+from factrix.metrics import ic
 
-specs = spec_by_name()
 horizons = [1, 5, 10, 20]
 results = [
     fx.evaluate(
         panel,
-        metrics=[specs["ic"]],
+        metrics={"ic": ic()},
         factor_cols=["mom_12_1"],
         forward_periods=h,
     )[0]
@@ -68,13 +67,12 @@ other declared `expand_over` key) so the step-up threshold is correct.
 
 ```python
 import factrix as fx
-from factrix._metric_index import spec_by_name
+from factrix.metrics import ic
 
-specs = spec_by_name()
 results = [
     fx.evaluate(
         panel,
-        metrics=[specs["ic"]],
+        metrics={"ic": ic()},
         factor_cols=["mom_12_1"],
         forward_periods=h,
     )[0]

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -49,11 +49,10 @@ Panels often arrive with the signal column named something other than
 caller's frame:
 
 ```python
-from factrix._metric_index import spec_by_name
-specs = spec_by_name()
+from factrix.metrics import ic
 results = fx.evaluate(
     panel,
-    metrics=[specs["ic"]],
+    metrics={"ic": ic()},
     factor_cols=["momentum_12_1"],
     forward_periods=5,
 )

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -11,14 +11,18 @@ for FDR-corrected screening.
 Single-factor::
 
     import factrix as fx
+    from factrix.metrics import ic_newey_west
 
-    ic = fx.spec_by_name("ic_newey_west")
-    [result] = fx.evaluate(panel, metrics=[ic], factor_cols=["factor"])
-    print(result.metrics["ic_newey_west"])
+    [result] = fx.evaluate(
+        panel, metrics={"ic": ic_newey_west()}, factor_cols=["factor"]
+    )
+    print(result.metrics["ic"])
 
 Batch + Benjamini-Hochberg-Yekutieli (BHY)::
 
-    results = fx.evaluate(panel, metrics=[ic], factor_cols=candidate_cols)
+    results = fx.evaluate(
+        panel, metrics={"ic": ic_newey_west()}, factor_cols=candidate_cols
+    )
     survivors = fx.multi_factor.bhy(results, primary=[ic], q=0.05)
 
 LLM agent reference: ``llms-full.txt`` covers concepts, public API, and
@@ -32,10 +36,15 @@ typical usage patterns in a single fetch. Two access paths::
     text = importlib.resources.files("factrix").joinpath("llms-full.txt").read_text()
 """
 
+import dataclasses
 import inspect
-from typing import Any
+import math
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
+
+if TYPE_CHECKING:
+    from factrix.metrics._base import MetricBase
 
 from factrix import datasets, estimators, multi_factor, preprocess
 from factrix._axis import (  # noqa: F401  DataStructure re-exported for namespace access; intentionally not in __all__
@@ -88,9 +97,11 @@ from factrix.stats import list_estimators
 def evaluate(
     panel: PanelInput,
     *,
-    metrics: list[MetricSpec],
+    metrics: "dict[str, MetricBase]",
     factor_cols: list[str],
     forward_periods: int | None = None,
+    primary: str | None = None,
+    strict: bool = True,
 ) -> list[EvaluationResult]:
     """Evaluate one or more factors against forward returns through the DAG executor.
 
@@ -111,48 +122,57 @@ def evaluate(
             column consumed by event-study metrics (caar /
             event_around_return / mfe_mae_summary), which short-circuit
             to NaN with a ``reason`` when ``price`` is absent.
-        metrics: User-facing :class:`MetricSpec` instances. Element type
-            is checked at runtime; ``str`` / ``Callable`` /
-            :class:`MetricResult` are rejected. The first entry is
-            tagged as the primary metric (drives ``EvaluationResult.n_obs``
-            and the primary / diagnostic partition on
-            :class:`MetricResultGroup`); the rest become diagnostics.
+        metrics: ``dict[str, Metric]`` mapping a caller-chosen label to a
+            metric **instance** from :mod:`factrix.metrics` (e.g.
+            ``{"ic_5d": ic(), "spread": quantile_spread(n_quantiles=5)}``).
+            Results key by these labels. Passing the bare class (``ic``
+            rather than ``ic()``), a ``str``, or a :class:`MetricSpec` is
+            rejected with a targeted error. Two labels may reuse one
+            metric class only with identical config (per-instance config
+            divergence — e.g. differing ``forward_periods`` — needs the
+            by-value DAG dedup in #494 and is rejected for now).
         factor_cols: Names of density columns on ``panel``. List-only —
             single ``str`` is rejected. Non-empty, no duplicates, every
             name must exist on ``panel``.
         forward_periods: Forward-return horizon in rows of the panel's
-            time axis. ``None`` (default) lets every metric's own
-            ``forward_periods=`` default fire; pass an explicit value
-            whenever the panel's forward-return horizon is not 5.
-            Injected into ``kwargs_by_metric`` only for specs whose
-            callable signature accepts the parameter.
+            time axis. ``None`` raises when any metric consumes the
+            forward return; pass an explicit value otherwise. (Per-instance
+            ``forward_periods`` override lands in #494; for now this is the
+            single horizon applied to every fwd-return metric.)
+        primary: Label of the primary metric — drives
+            ``EvaluationResult.n_obs`` and the primary / diagnostic
+            partition. ``None`` (default) uses the first ``metrics`` key
+            (insertion order). Must be a key of ``metrics``.
+        strict: When ``True`` (default), raise if any metric is
+            inapplicable to the panel (apply-time short-circuit to NaN).
+            When ``False``, keep those as NaN outputs with attached
+            warnings. Config-time / construct-time failures always raise.
 
     Returns:
         ``list[EvaluationResult]`` in ``factor_cols`` order. Always a
         list — single factor calls return a one-element list. The
-        ``cell`` tuple stamped on each result derives from the first
+        ``cell`` tuple stamped on each result derives from the primary
         metric's cell and is informational only; ``DagExecutor`` does
         not consult it for dispatch.
 
     Raises:
-        UserInputError: ``metrics`` not a ``list[MetricSpec]``;
-            ``factor_cols`` empty / single ``str`` / contains duplicates
-            / references a column not on ``panel``; ``panel`` missing
-            any of the baseline columns ``(date, asset_id, forward_return)``;
-            ``forward_periods=None`` but a closure metric's callable
-            declares a ``forward_periods`` parameter.
+        UserInputError: ``metrics`` not a ``dict[str, Metric]`` of
+            instances; ``primary`` not a metrics label; ``factor_cols``
+            empty / single ``str`` / contains duplicates / references a
+            column not on ``panel``; ``panel`` missing a baseline column;
+            ``forward_periods=None`` but a metric consumes it; under
+            ``strict=True``, a metric inapplicable to the panel.
 
     Examples:
         Single-factor IC + IC information ratio (IR):
 
         >>> import factrix as fx
-        >>> from factrix._metric_index import spec_by_name
+        >>> from factrix.metrics import ic, ic_ir
         >>> raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80)
         >>> panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
-        >>> specs = spec_by_name()
         >>> results = fx.evaluate(
         ...     panel,
-        ...     metrics=[specs["ic"], specs["ic_ir"]],
+        ...     metrics={"ic": ic(), "ic_ir": ic_ir()},
         ...     factor_cols=["factor"],
         ...     forward_periods=5,
         ... )
@@ -162,16 +182,30 @@ def evaluate(
         True
     """
     _validate_metrics_arg(metrics)
+    primary_label = _resolve_primary(metrics, primary)
     cols = _validate_factor_cols_arg(factor_cols)
     panel = _coerce_panel(panel)
     _validate_baseline_columns(panel)
     _validate_factor_cols_on_panel(panel, cols)
 
-    closure_specs = _close_requires(metrics)
-    _validate_forward_periods_when_required(closure_specs, forward_periods)
-    _validate_primary_metric_applicable(metrics[0], panel)
+    # label -> (spec, configured params), derived from the metric instances.
+    label_spec = {label: type(inst).spec() for label, inst in metrics.items()}
+    label_params = {label: inst._params() for label, inst in metrics.items()}
+    _guard_duplicate_classes(label_spec, label_params)
 
-    primary_cell = metrics[0].cell
+    # Distinct specs (by name) for the executor; first occurrence wins.
+    distinct: dict[str, MetricSpec] = {}
+    name_to_label: dict[str, str] = {}
+    for label, spec in label_spec.items():
+        distinct.setdefault(spec.name, spec)
+        name_to_label.setdefault(spec.name, label)
+
+    closure_specs = _close_requires(list(distinct.values()))
+    _validate_forward_periods_when_required(closure_specs, forward_periods)
+    primary_spec = label_spec[primary_label]
+    _validate_primary_metric_applicable(primary_spec, panel)
+
+    primary_cell = primary_spec.cell
     scope = (
         primary_cell.scope if primary_cell.scope is not None else FactorScope.INDIVIDUAL
     )
@@ -181,9 +215,19 @@ def evaluate(
         else FactorDensity.DENSE
     )
     fp = forward_periods if forward_periods is not None else 5
-    kwargs_by_metric = _build_kwargs_by_metric(closure_specs, forward_periods)
-    primary_names = (metrics[0].name,)
-    executor = DagExecutor(closure_specs, primary_names=primary_names)
+
+    # Per-instance params drive the executor; forward_periods stays top-level
+    # (per-instance forward_periods override lands in #494).
+    kwargs_by_metric: dict[str, dict[str, Any]] = {
+        spec.name: {
+            k: v for k, v in label_params[label].items() if k != "forward_periods"
+        }
+        for label, spec in label_spec.items()
+    }
+    for name, kw in _build_kwargs_by_metric(closure_specs, forward_periods).items():
+        kwargs_by_metric.setdefault(name, {}).update(kw)
+
+    executor = DagExecutor(closure_specs, primary_names=(primary_spec.name,))
     result_dict = executor.execute(
         panel,
         cols,
@@ -192,7 +236,12 @@ def evaluate(
         forward_periods=fp,
         kwargs_by_metric=kwargs_by_metric,
     )
-    return [result_dict[c] for c in cols]
+    return [
+        _relabel_result(
+            result_dict[c], label_spec, name_to_label, primary_label, strict
+        )
+        for c in cols
+    ]
 
 
 _DOCS_METRICS = "api/evaluate#metrics"
@@ -219,25 +268,27 @@ def _is_metrics_overview(metrics: object) -> bool:
 
 
 def _validate_metrics_arg(metrics: object) -> None:
+    from factrix.metrics._base import MetricBase
+
     if _is_metrics_overview(metrics):
         raise UserInputError(
             func_name="evaluate",
             field="metrics",
             value=f"<list_metrics() overview: {len(metrics)} families>",  # type: ignore[arg-type]
             expected=(
-                "an explicit list[MetricSpec]. fx.list_metrics() returns an "
-                "overview catalog (family -> specs), not a runnable list; "
-                "pick the specs you want, or pre-filter the panel with "
-                "[m.spec for m in factrix.inspect_panel(panel).usable]"
+                "a dict[str, Metric] of metric instances. fx.list_metrics() "
+                "returns an overview catalog (family -> specs), not runnable "
+                "metrics; construct the ones you want, e.g. {'ic': ic()}, or "
+                "pre-filter with factrix.inspect_panel(panel).usable"
             ),
             docs_path=_DOCS_METRICS,
         )
-    if not isinstance(metrics, list):
+    if not isinstance(metrics, dict):
         raise UserInputError(
             func_name="evaluate",
             field="metrics",
             value=type(metrics).__name__,
-            expected="list[MetricSpec] (non-empty)",
+            expected="dict[str, Metric] (label -> metric instance), e.g. {'ic_5d': ic()}",
             docs_path=_DOCS_METRICS,
         )
     if not metrics:
@@ -245,18 +296,147 @@ def _validate_metrics_arg(metrics: object) -> None:
             func_name="evaluate",
             field="metrics",
             value=metrics,
-            expected="a non-empty list of MetricSpec",
+            expected="a non-empty dict[str, Metric]",
             docs_path=_DOCS_METRICS,
         )
-    for m in metrics:
-        if not isinstance(m, MetricSpec):
+    for key, val in metrics.items():
+        if not isinstance(key, str):
             raise UserInputError(
                 func_name="evaluate",
                 field="metrics",
-                value=type(m).__name__,
-                expected="every element to be a MetricSpec",
+                value=type(key).__name__,
+                expected="every key to be a str label",
                 docs_path=_DOCS_METRICS,
             )
+        if isinstance(val, type) and issubclass(val, MetricBase):
+            raise UserInputError(
+                func_name="evaluate",
+                field="metrics",
+                value=f"{key!r} -> {val.__name__} (the class)",
+                expected=f"a metric instance, not the class — call it: {val.__name__}()",
+                docs_path=_DOCS_METRICS,
+            )
+        if not isinstance(val, MetricBase):
+            raise UserInputError(
+                func_name="evaluate",
+                field="metrics",
+                value=f"{key!r} -> {type(val).__name__}",
+                expected=(
+                    "every value to be a metric instance imported from "
+                    "factrix.metrics, e.g. ic() / quantile_spread(n_quantiles=5)"
+                ),
+                docs_path=_DOCS_METRICS,
+            )
+
+
+def _resolve_primary(metrics: "dict[str, MetricBase]", primary: str | None) -> str:
+    """Resolve the primary label — explicit ``primary`` or the first dict key."""
+    keys = list(metrics)
+    if primary is None:
+        return keys[0]
+    if primary not in metrics:
+        raise UserInputError(
+            func_name="evaluate",
+            field="primary",
+            value=primary,
+            expected=f"one of the metrics labels {keys!r}",
+            docs_path=_DOCS_METRICS,
+        )
+    return primary
+
+
+def _guard_duplicate_classes(
+    label_spec: "dict[str, MetricSpec]",
+    label_params: dict[str, dict[str, Any]],
+) -> None:
+    """Reject one metric class under several labels with differing config.
+
+    The same class under two labels with identical config is a harmless alias;
+    with *different* config (e.g. ``ic()`` vs ``ic(forward_periods=20)``) the
+    name-keyed executor cannot tell them apart — by-value DAG dedup lands in
+    #494. Surface it as a precise config-time error rather than silently
+    dropping one config.
+    """
+    by_name: dict[str, list[str]] = {}
+    for label, spec in label_spec.items():
+        by_name.setdefault(spec.name, []).append(label)
+    for name, labels in by_name.items():
+        if len(labels) < 2:
+            continue
+        first = label_params[labels[0]]
+        if any(label_params[other] != first for other in labels[1:]):
+            raise UserInputError(
+                func_name="evaluate",
+                field="metrics",
+                value=f"{name!r} under labels {labels!r}",
+                expected=(
+                    f"distinct metric classes — labels {labels!r} all use "
+                    f"{name!r} with different config. Running one metric under "
+                    f"multiple configs needs by-value DAG dedup (lands in #494); "
+                    f"for now give them a single config or a single label."
+                ),
+                docs_path=_DOCS_METRICS,
+            )
+
+
+def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
+    """Raise when any requested metric could not produce a value (``strict=True``).
+
+    Apply-time short-circuits surface as a ``MetricResult`` with NaN ``value``
+    and a ``metadata['reason']`` (panel missing data / sample / upstream skip).
+    Config-time / construct-time failures already raise upstream of ``strict``.
+    """
+    failed = [
+        (label, str(out.metadata.get("reason")))
+        for label, out in label_outputs.items()
+        if isinstance(out.value, float)
+        and math.isnan(out.value)
+        and out.metadata.get("reason")
+    ]
+    if failed:
+        detail = "; ".join(f"{label}: {reason}" for label, reason in failed)
+        raise UserInputError(
+            func_name="evaluate",
+            field="metrics",
+            value=f"{len(failed)} metric(s) inapplicable to this panel",
+            expected=(
+                f"all metrics applicable to the panel. Inapplicable — {detail}. "
+                f"Pass strict=False to keep them as NaN with warnings, or "
+                f"pre-filter with [m.name for m in factrix.inspect_panel(panel).usable]."
+            ),
+            docs_path=_DOCS_METRICS,
+        )
+
+
+def _relabel_result(
+    result: EvaluationResult,
+    label_spec: "dict[str, MetricSpec]",
+    name_to_label: dict[str, str],
+    primary_label: str,
+    strict: bool,
+) -> EvaluationResult:
+    """Re-key a name-keyed executor result onto the user's labels."""
+    name_outputs = result.metrics.outputs
+    label_outputs: dict[str, MetricResult] = {}
+    for label, spec in label_spec.items():
+        out = name_outputs.get(spec.name)
+        if out is not None:
+            label_outputs[label] = dataclasses.replace(out, name=label)
+    if strict:
+        _enforce_strict(label_outputs)
+    warnings = [
+        dataclasses.replace(w, source=name_to_label[w.source])
+        if w.source is not None and w.source in name_to_label
+        else w
+        for w in result.warnings
+    ]
+    group = MetricResultGroup(
+        applicable=list(label_spec),
+        primary=[primary_label],
+        diagnostic=[label for label in label_spec if label != primary_label],
+        outputs=label_outputs,
+    )
+    return dataclasses.replace(result, metrics=group, warnings=warnings)
 
 
 def _validate_factor_cols_arg(factor_cols: object) -> list[str]:

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -110,20 +110,23 @@ class MetricResultGroup:
     """Group of metric outputs for one factor at one cell.
 
     Mirrors the ``MetricGroups`` shape that #443 ``inspect_panel``
-    exposes: three ``list[str]`` (metric name) partitions plus dict-like
-    access to the produced :class:`MetricResult` instances.
+    exposes: three ``list[str]`` key partitions plus dict-like access to
+    the produced :class:`MetricResult` instances.
 
-    Iteration / membership / ``keys`` / ``values`` / ``items`` all key
-    by metric name; the partition lists hold those same names directly.
+    The key is the caller's label when produced by
+    :func:`factrix.evaluate` (the ``dict[str, Metric]`` key, #497) — so
+    two labels may reuse one metric class — and the metric name when
+    produced elsewhere. Iteration / membership / ``keys`` / ``values`` /
+    ``items`` and the partition lists all use that same key.
 
     Attributes:
-        applicable: Names of every metric applicable to the dispatched
-            cell (superset of ``primary + diagnostic``).
-        primary: Names of metrics whose ``MetricResult`` carries the
-            bundle's primary p-value (driver of downstream multi-factor FDR).
-        diagnostic: Names of metrics whose output is descriptive / supplementary.
-        outputs: ``metric_name -> MetricResult`` for every spec that
-            produced a value (including short-circuit outputs).
+        applicable: Every key applicable to the dispatched cell
+            (superset of ``primary + diagnostic``).
+        primary: Keys whose ``MetricResult`` carries the bundle's primary
+            p-value (driver of downstream multi-factor FDR).
+        diagnostic: Keys whose output is descriptive / supplementary.
+        outputs: ``key -> MetricResult`` for every metric that produced a
+            value (including short-circuit outputs).
     """
 
     applicable: list[str]

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -469,8 +469,8 @@ def custom_ic(panel):
     ...
 
 fx.metrics.register(custom_ic)
-# Now resolvable: getattr(fx.metrics, "custom_ic"), and pass
-# custom_ic.__metric_spec__ in fx.evaluate(metrics=[...]).
+# Now resolvable: getattr(fx.metrics, "custom_ic"), and pass an instance
+# under a label: fx.evaluate(metrics={"custom_ic": custom_ic()}, ...).
 ```
 
 `register(fn)` rejects duplicate names and clashes with first-party specs;

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -104,10 +104,9 @@ def compute_forward_return(
 
         The output panel is the canonical input to ``fx.evaluate``:
 
-        >>> from factrix._metric_index import spec_by_name
-        >>> ic = spec_by_name()["ic"]
+        >>> from factrix.metrics import ic
         >>> results = fx.evaluate(
-        ...     panel, metrics=[ic], factor_cols=["factor"], forward_periods=5
+        ...     panel, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
         ... )
         >>> isinstance(results, list) and len(results) == 1
         True

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,106 @@
+"""``fx.evaluate`` dict[str, Metric] API — labels, primary, strict (#497)."""
+
+from __future__ import annotations
+
+import factrix as fx
+import pytest
+from factrix._errors import UserInputError
+from factrix.metrics import ic, ic_ir
+
+
+def _panel(n_assets: int = 20, n_dates: int = 80, *, with_price: bool = True):
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    if not with_price and "price" in panel.columns:
+        # forward_return is already attached; dropping price now makes
+        # event-study metrics (caar) short-circuit at evaluate time.
+        panel = panel.drop("price")
+    return panel
+
+
+def _eval(metrics, panel=None, **kw):
+    panel = panel if panel is not None else _panel()
+    return fx.evaluate(
+        panel, metrics=metrics, factor_cols=["factor"], forward_periods=5, **kw
+    )
+
+
+class TestLabelKeying:
+    def test_results_key_by_user_label(self):
+        [er] = _eval({"my_ic": ic(), "my_ir": ic_ir()})
+        assert list(er.metrics.outputs) == ["my_ic", "my_ir"]
+        assert er.metrics["my_ic"].name == "my_ic"
+
+    def test_to_frame_uses_labels(self):
+        [er] = _eval({"my_ic": ic()})
+        assert er.to_frame()["metric_name"].to_list() == ["my_ic"]
+
+
+class TestPrimary:
+    def test_default_primary_is_first_key(self):
+        [er] = _eval({"a": ic(), "b": ic_ir()})
+        assert er.metrics.primary == ["a"]
+        assert er.metrics.diagnostic == ["b"]
+
+    def test_explicit_primary(self):
+        [er] = _eval({"a": ic(), "b": ic_ir()}, primary="b")
+        assert er.metrics.primary == ["b"]
+        assert er.metrics.diagnostic == ["a"]
+
+    def test_unknown_primary_raises(self):
+        with pytest.raises(UserInputError, match="one of the metrics labels"):
+            _eval({"a": ic()}, primary="zzz")
+
+
+class TestMetricsValidation:
+    def test_bare_class_gives_targeted_error(self):
+        with pytest.raises(UserInputError, match="call it: ic"):
+            _eval({"a": ic})
+
+    def test_list_is_rejected(self):
+        with pytest.raises(UserInputError, match="dict\\[str, Metric\\]"):
+            _eval([ic()])
+
+    def test_spec_value_rejected(self):
+        from factrix._metric_index import spec_by_name
+
+        with pytest.raises(UserInputError, match="metric instance"):
+            _eval({"a": spec_by_name()["ic"]})
+
+    def test_overview_rejected_with_guidance(self):
+        with pytest.raises(UserInputError, match="overview catalog"):
+            _eval(fx.list_metrics())
+
+
+class TestDuplicateClassGuard:
+    def test_same_config_alias_is_allowed(self):
+        [er] = _eval({"a": ic_ir(), "b": ic_ir()})
+        assert set(er.metrics.outputs) == {"a", "b"}
+
+    def test_different_config_via_params_raises(self):
+        from factrix.metrics import quantile_spread
+
+        with pytest.raises(UserInputError, match="different config"):
+            _eval({"a": quantile_spread(n_groups=5), "b": quantile_spread(n_groups=10)})
+
+
+class TestStrict:
+    # A 12-date panel is below IC's period floor, so ``ic`` short-circuits to
+    # NaN with reason ``insufficient_ic_periods`` — an apply-time failure.
+    def test_strict_true_raises_on_inapplicable(self):
+        thin = _panel(n_dates=12)
+        with pytest.raises(UserInputError, match="inapplicable"):
+            fx.evaluate(
+                thin, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
+            )
+
+    def test_strict_false_keeps_nan(self):
+        thin = _panel(n_dates=12)
+        [er] = fx.evaluate(
+            thin,
+            metrics={"ic": ic()},
+            factor_cols=["factor"],
+            forward_periods=5,
+            strict=False,
+        )
+        assert er.metrics["ic"].value != er.metrics["ic"].value  # NaN

--- a/tests/test_panel_input.py
+++ b/tests/test_panel_input.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import factrix as fx
 import polars as pl
 import pytest
-from factrix._metric_index import spec_by_name
 from factrix._panel_input import _coerce_panel
 from factrix.preprocess import compute_forward_return
 
@@ -47,12 +46,13 @@ def test_coerce_unsupported_type_raises() -> None:
 
 
 def test_evaluate_accepts_lazyframe_end_to_end(panel_pl: pl.DataFrame) -> None:
-    ic = spec_by_name()["ic"]
+    from factrix.metrics import ic
+
     eager = fx.evaluate(
-        panel_pl, metrics=[ic], factor_cols=["factor"], forward_periods=5
+        panel_pl, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
     )
     lazy = fx.evaluate(
-        panel_pl.lazy(), metrics=[ic], factor_cols=["factor"], forward_periods=5
+        panel_pl.lazy(), metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
     )
     assert eager[0].metrics["ic"].value == lazy[0].metrics["ic"].value
 
@@ -60,12 +60,18 @@ def test_evaluate_accepts_lazyframe_end_to_end(panel_pl: pl.DataFrame) -> None:
 def test_evaluate_rejects_pandas_with_guidance(panel_pl: pl.DataFrame) -> None:
     pytest.importorskip("pandas")
     pdf = panel_pl.to_pandas()
-    ic = spec_by_name()["ic"]
+    from factrix.metrics import ic
+
     with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):
-        fx.evaluate(pdf, metrics=[ic], factor_cols=["factor"], forward_periods=5)
+        fx.evaluate(
+            pdf, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
+        )
 
 
 def test_evaluate_rejects_unsupported_type() -> None:
-    ic = spec_by_name()["ic"]
+    from factrix.metrics import ic
+
     with pytest.raises(TypeError, match=r"pl\.DataFrame or pl\.LazyFrame"):
-        fx.evaluate(object(), metrics=[ic], factor_cols=["factor"], forward_periods=5)
+        fx.evaluate(
+            object(), metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
+        )

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -8,7 +8,6 @@ re-export is removed, this test fails before the README does.
 from __future__ import annotations
 
 import factrix as fx
-from factrix._metric_index import spec_by_name
 from factrix.preprocess import compute_forward_return
 
 
@@ -18,9 +17,10 @@ def test_readme_quickstart_runs_end_to_end() -> None:
     )
     panel = compute_forward_return(raw, forward_periods=5)
 
-    ic = spec_by_name()["ic"]
+    from factrix.metrics import ic
+
     results = fx.evaluate(
-        panel, metrics=[ic], factor_cols=["factor"], forward_periods=5
+        panel, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
     )
 
     assert len(results) == 1


### PR DESCRIPTION
## Summary

Per #476 §1/§4, `evaluate()` now takes a labelled `dict[str, Metric]` of
metric **instances** instead of `list[MetricSpec]`. **PR 1 of 2** for #497
(the `to_metrics_dict()` discovery hook is PR 2 — it depends on §7-Phase-2
group work that isn't built yet).

```python
from factrix.metrics import ic, quantile_spread

[result] = fx.evaluate(
    panel,
    metrics={"ic_5d": ic(), "spread": quantile_spread(n_quantiles=5)},
    factor_cols=["alpha"], forward_periods=5,
)
result.metrics["ic_5d"]          # keyed by the caller's label
result.metrics.primary           # ["ic_5d"]
```

- **Label-keyed results**: `MetricResultGroup` keys (`outputs` / `primary`
  / `diagnostic` / `applicable`) and `MetricResult.name` become the user's
  labels; per-metric warning `source`s are relabelled to match.
- **`primary`** (a label) drives `n_obs` + the primary/diagnostic
  partition; defaults to the first dict key.
- **`strict`**: `True` (default) raises if any metric is inapplicable to
  the panel (apply-time short-circuit to NaN); `False` keeps them as NaN +
  warnings. Config-time / construct-time failures always raise.
- Per-instance config (`quantile_spread(n_quantiles=5)`) flows through.

## Breaking change

`evaluate(metrics=...)` no longer accepts `list[MetricSpec]`. Migration:
- `metrics=[specs["ic"]]` → `metrics={"ic": ic()}` (instances from `factrix.metrics`).
- results key by your labels (was the metric name).
- primary: `metrics[0]` → `primary="<label>"`.
- inapplicable metrics now raise under the default `strict=True`; pass `strict=False` for the old NaN behaviour.

## Scope boundary with #494

Per-instance `forward_periods` override and the by-value DAG dedup that
lets one metric class appear under several labels with **different** config
(`ic_5d: ic()` vs `ic_20d: ic(forward_periods=20)`) are #494. Until then a
differing-config duplicate class raises a precise error; same-config
aliases are allowed.

## Test plan

- New `tests/test_evaluate.py` (13 tests): label-keying, `to_frame` labels,
  `primary` default/explicit/invalid, bare-class / list / spec / overview
  rejection, duplicate-class guard (same-config alias ok, differing-config
  raises), `strict` raise vs NaN.
- Migrated callers: `tests/test_panel_input.py`, `tests/test_readme_quickstart.py`.
- Full suite green except the 4 pre-existing `tests/bench` failures
  (unrelated metric-name drift); no new failures. `ruff` / `ruff format` /
  `mypy` clean; doc-validation green.

Closes #497