### PR TITLE
feat(api): add MetricApplicabilityGroup.to_metrics_dict() discovery bridge

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -66,6 +66,7 @@ from factrix._errors import (
 )
 from factrix._inspect import (
     MetricApplicability,
+    MetricApplicabilityGroup,
     PanelInspection,
     PanelProperties,
     _detect_structure,
@@ -662,6 +663,7 @@ __all__ = [
     "evaluate",
     # Introspection
     "MetricApplicability",
+    "MetricApplicabilityGroup",
     "PanelInspection",
     "PanelProperties",
     "SampleThreshold",

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import html
 import math
-from dataclasses import dataclass, field
+from dataclasses import MISSING, dataclass, field, fields
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -177,6 +177,50 @@ class MetricApplicability:
     blockers: list[str] = field(default_factory=list)
 
 
+def _default_constructible(metric: Any) -> bool:
+    """True when the metric class can be instantiated with no arguments.
+
+    Scalar-input utilities (e.g. ``breakeven_cost`` / ``net_spread``) declare
+    required parameters (``turnover`` / ``forward_periods`` …) and consume
+    pre-aggregated scalars rather than a panel, so they are not part of the
+    zero-config discovery -> :func:`factrix.evaluate` flow.
+    """
+    return all(
+        f.default is not MISSING or f.default_factory is not MISSING
+        for f in fields(metric)
+    )
+
+
+class MetricApplicabilityGroup(list["MetricApplicability"]):
+    """A tier partition of :class:`MetricApplicability` verdicts.
+
+    A ``list`` subclass — every list operation works — with discovery
+    helpers layered on. Returned by :attr:`PanelInspection.usable` /
+    ``degraded`` / ``unusable``.
+    """
+
+    @property
+    def names(self) -> list[str]:
+        """The metric name of each verdict, in order."""
+        return [m.name for m in self]
+
+    def to_metrics_dict(self) -> dict[str, MetricBase]:
+        """Normalise the group into ``{name: metric_instance}`` for ``evaluate``.
+
+        The canonical discovery bridge: pick a tier (usually ``usable``) and
+        feed its default-constructed instances straight to
+        :func:`factrix.evaluate`::
+
+            info = fx.inspect_panel(panel)
+            results = fx.evaluate(panel, metrics=info.usable.to_metrics_dict(),
+                                  factor_cols=[...], forward_periods=5)
+
+        Metrics whose class needs explicit construction arguments (the
+        scalar-input utilities) are omitted — construct and add those by hand.
+        """
+        return {m.name: m.metric() for m in self if _default_constructible(m.metric)}
+
+
 @dataclass(frozen=True, slots=True)
 class PanelInspection:
     """Result of :func:`inspect_panel`.
@@ -203,7 +247,7 @@ class PanelInspection:
     warnings: list[Warning] = field(default_factory=list)
 
     @property
-    def usable(self) -> list[MetricApplicability]:
+    def usable(self) -> MetricApplicabilityGroup:
         """Metrics that are applicable AND carry no degraded warning.
 
         The production-safe set: every verdict here passed cell match
@@ -215,11 +259,17 @@ class PanelInspection:
         *excludes* degraded verdicts so it can be the single safe set
         a bulk discovery flow runs without re-filtering. The
         "usable but warned" verdicts live in :attr:`degraded`.
+
+        Returns a :class:`MetricApplicabilityGroup` (a ``list`` subclass);
+        ``.to_metrics_dict()`` normalises it straight into the
+        ``metrics=`` argument of :func:`factrix.evaluate`.
         """
-        return [m for m in self.metrics if m.usable and not m.warnings]
+        return MetricApplicabilityGroup(
+            m for m in self.metrics if m.usable and not m.warnings
+        )
 
     @property
-    def degraded(self) -> list[MetricApplicability]:
+    def degraded(self) -> MetricApplicabilityGroup:
         """Applicable metrics that run but with degraded inference.
 
         ``usable=True`` yet at least one ``warn_*``-tier
@@ -228,10 +278,12 @@ class PanelInspection:
         read the warnings before trusting the inference. Disjoint from
         :attr:`usable` and :attr:`unusable`.
         """
-        return [m for m in self.metrics if m.usable and m.warnings]
+        return MetricApplicabilityGroup(
+            m for m in self.metrics if m.usable and m.warnings
+        )
 
     @property
-    def unusable(self) -> list[MetricApplicability]:
+    def unusable(self) -> MetricApplicabilityGroup:
         """Metrics that cannot run on this panel.
 
         ``usable=False`` — blocked by cell mismatch or a ``min_*``
@@ -239,7 +291,7 @@ class PanelInspection:
         the concrete reasons. Disjoint from :attr:`usable` and
         :attr:`degraded`.
         """
-        return [m for m in self.metrics if not m.usable]
+        return MetricApplicabilityGroup(m for m in self.metrics if not m.usable)
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-friendly nested dict view.

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -635,8 +635,13 @@ types-only; runner wiring lands with the DAG executor.
     `usable: bool`, a `warnings: list[Warning]` for degraded
     inference (above HARD floor but below WARN floor), and
     `blockers: list[str]` for unusable reasons (cell mismatch or HARD
-    floor violation). Caller partitions via list comprehension —
-    `[m for m in info.metrics if m.usable]`.
+    floor violation). The `usable` / `degraded` / `unusable`
+    properties expose this as a mutually exclusive partition, each a
+    `MetricApplicabilityGroup` (a `list` subclass with `.names` and
+    `.to_metrics_dict()`). `info.usable.to_metrics_dict()` normalises a
+    tier into the `{label: instance}` dict `evaluate(metrics=...)`
+    expects — the canonical discovery → evaluate bridge (scalar-input
+    utilities that need required args are omitted).
   - `PanelInspection.warnings: list[Warning]` carries panel-level
     sample-shape diagnostics (`source=None`); per-metric degraded
     warnings live on each `MetricApplicability`.

--- a/tests/test_inspect_panel.py
+++ b/tests/test_inspect_panel.py
@@ -343,3 +343,44 @@ class TestCellMatchesSignature:
             )
             is True
         )
+
+
+class TestMetricApplicabilityGroup:
+    def _info(self):
+        return inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+
+    def test_partitions_are_groups_and_lists(self):
+        info = self._info()
+        for tier in (info.usable, info.degraded, info.unusable):
+            assert isinstance(tier, fx.MetricApplicabilityGroup)
+            assert isinstance(tier, list)  # every list operation still works
+
+    def test_names_property(self):
+        info = self._info()
+        assert info.usable.names == [m.name for m in info.usable]
+
+    def test_to_metrics_dict_shape_and_excludes_scalar_utilities(self):
+        from factrix.metrics._base import MetricBase
+
+        info = self._info()
+        md = info.usable.to_metrics_dict()
+        assert md, "fixture should have usable metrics"
+        assert all(isinstance(v, MetricBase) for v in md.values())
+        assert set(md) <= set(info.usable.names)
+        # breakeven_cost / net_spread need required scalar args -> omitted.
+        assert "breakeven_cost" not in md
+        assert "net_spread" not in md
+
+    def test_to_metrics_dict_feeds_evaluate(self):
+        # The discovery bridge: a usable metric round-trips into evaluate().
+        raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=80)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        md = inspect_panel(panel).usable.to_metrics_dict()
+        results = fx.evaluate(
+            panel,
+            metrics={"ic": md["ic"]},
+            factor_cols=["factor"],
+            forward_periods=5,
+            strict=False,
+        )
+        assert results[0].metrics["ic"].name == "ic"


### PR DESCRIPTION
## Summary

**PR 2 of 2 for #497.** PR1 (#513) made `evaluate` take `dict[str, Metric]`;
this adds the discovery → evaluate bridge so `inspect_panel` output
normalises straight into that argument:

```python
info = fx.inspect_panel(panel)
results = fx.evaluate(
    panel, metrics=info.usable.to_metrics_dict(),
    factor_cols=[...], forward_periods=5,
)
```

- `inspect_panel(...).usable` / `degraded` / `unusable` now return a
  **`MetricApplicabilityGroup`** — a `list` subclass (every list operation
  still works) with `.names` and `.to_metrics_dict()`.
- `to_metrics_dict()` maps `{name: metric()}` for each verdict whose class
  is default-constructible. Scalar-input utilities that require explicit
  args (`breakeven_cost` / `net_spread`) are omitted — they consume
  pre-aggregated scalars, not a panel, so they're not part of the
  zero-config discovery flow.
- `MetricApplicabilityGroup` is exported from the package.

## Non-breaking

The flat `PanelInspection.metrics` list and the partition semantics are
unchanged; only the partition properties' return type is enriched (a `list`
subclass), so existing `for m in info.usable` / set-comprehension callers
are unaffected.

## Note

`to_metrics_dict()` is a candidate generator, not a runnability guarantee —
cross-factor metrics (e.g. `greedy_forward_selection`) still need ≥2
`factor_cols` to run, exactly as before this PR (verified pre-existing on
`main`).

## Test plan

- `tests/test_inspect_panel.py::TestMetricApplicabilityGroup` (4 tests):
  partitions are group+list, `.names`, `to_metrics_dict()` shape +
  scalar-utility exclusion, and the round-trip into `evaluate`.
- Full suite green except the 4 pre-existing `tests/bench` failures
  (unrelated); doctests green; `ruff` / `ruff format` / `mypy` clean.

Closes #497