### PR TITLE
feat(api)!: per-instance forward_periods + by-value DAG dedup (#494)

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -55,7 +55,7 @@ from factrix._axis import (  # noqa: F401  DataStructure re-exported for namespa
 )
 from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._compare import compare
-from factrix._dag import CycleError, DagExecutor
+from factrix._dag import CycleError, DagExecutor, _Node
 from factrix._errors import (
     ConfigError,
     FactrixError,
@@ -128,18 +128,20 @@ def evaluate(
             ``{"ic_5d": ic(), "spread": quantile_spread(n_quantiles=5)}``).
             Results key by these labels. Passing the bare class (``ic``
             rather than ``ic()``), a ``str``, or a :class:`MetricSpec` is
-            rejected with a targeted error. Two labels may reuse one
-            metric class only with identical config (per-instance config
-            divergence — e.g. differing ``forward_periods`` — needs the
-            by-value DAG dedup in #494 and is rejected for now).
+            rejected with a targeted error. One metric class may run under
+            several labels with **different** config — e.g.
+            ``{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}`` — via
+            by-value DAG dedup (#494); shared upstream producers are computed
+            once per distinct config.
         factor_cols: Names of density columns on ``panel``. List-only —
             single ``str`` is rejected. Non-empty, no duplicates, every
             name must exist on ``panel``.
-        forward_periods: Forward-return horizon in rows of the panel's
-            time axis. ``None`` raises when any metric consumes the
-            forward return; pass an explicit value otherwise. (Per-instance
-            ``forward_periods`` override lands in #494; for now this is the
-            single horizon applied to every fwd-return metric.)
+        forward_periods: Default forward-return horizon (rows of the panel's
+            time axis) for metrics left at their signature default. A
+            per-instance value — ``ic(forward_periods=20)`` — always overrides
+            it (#494). ``None`` (default) leaves every metric at its own
+            default. ``EvaluationResult.forward_periods`` reports the primary
+            metric's resolved horizon.
         primary: Label of the primary metric — drives
             ``EvaluationResult.n_obs`` and the primary / diagnostic
             partition. ``None`` (default) uses the first ``metrics`` key
@@ -161,7 +163,7 @@ def evaluate(
             instances; ``primary`` not a metrics label; ``factor_cols``
             empty / single ``str`` / contains duplicates / references a
             column not on ``panel``; ``panel`` missing a baseline column;
-            ``forward_periods=None`` but a metric consumes it; under
+            a metric ``requires`` a producer absent from the registry; under
             ``strict=True``, a metric inapplicable to the panel.
 
     Examples:
@@ -189,22 +191,21 @@ def evaluate(
     _validate_baseline_columns(panel)
     _validate_factor_cols_on_panel(panel, cols)
 
-    # label -> (spec, configured params), derived from the metric instances.
+    # label -> spec, plus per-instance params with forward_periods resolved
+    # against the top-level default (an instance still at its signature default
+    # inherits ``forward_periods=``; an explicit per-instance value overrides).
     label_spec = {label: type(inst).spec() for label, inst in metrics.items()}
-    label_params = {label: inst._params() for label, inst in metrics.items()}
-    _guard_duplicate_classes(label_spec, label_params)
+    label_params = {
+        label: _resolve_instance_params(inst, forward_periods)
+        for label, inst in metrics.items()
+    }
 
-    # Distinct specs (by name) for the executor; first occurrence wins.
-    distinct: dict[str, MetricSpec] = {}
-    name_to_label: dict[str, str] = {}
-    for label, spec in label_spec.items():
-        distinct.setdefault(spec.name, spec)
-        name_to_label.setdefault(spec.name, label)
+    nodes, label_to_node, node_kwargs = _build_nodes(label_spec, label_params)
+    primary_node = label_to_node[primary_label]
+    node_to_label = {nid: label for label, nid in label_to_node.items()}
 
-    closure_specs = _close_requires(list(distinct.values()))
-    _validate_forward_periods_when_required(closure_specs, forward_periods)
     primary_spec = label_spec[primary_label]
-    _validate_primary_metric_applicable(primary_spec, panel)
+    _validate_primary_metric_applicable(primary_spec, panel, strict)
 
     primary_cell = primary_spec.cell
     scope = (
@@ -215,31 +216,23 @@ def evaluate(
         if primary_cell.density is not None
         else FactorDensity.DENSE
     )
-    fp = forward_periods if forward_periods is not None else 5
+    # Bundle-level forward_periods is the primary metric's resolved horizon.
+    fp = node_kwargs[primary_node].get(
+        "forward_periods", forward_periods if forward_periods is not None else 5
+    )
 
-    # Per-instance params drive the executor; forward_periods stays top-level
-    # (per-instance forward_periods override lands in #494).
-    kwargs_by_metric: dict[str, dict[str, Any]] = {
-        spec.name: {
-            k: v for k, v in label_params[label].items() if k != "forward_periods"
-        }
-        for label, spec in label_spec.items()
-    }
-    for name, kw in _build_kwargs_by_metric(closure_specs, forward_periods).items():
-        kwargs_by_metric.setdefault(name, {}).update(kw)
-
-    executor = DagExecutor(closure_specs, primary_names=(primary_spec.name,))
+    executor = DagExecutor(nodes, primary_names=(primary_node,))
     result_dict = executor.execute(
         panel,
         cols,
         scope=scope,
         density=density,
         forward_periods=fp,
-        kwargs_by_metric=kwargs_by_metric,
+        kwargs_by_metric=node_kwargs,
     )
     return [
         _relabel_result(
-            result_dict[c], label_spec, name_to_label, primary_label, strict
+            result_dict[c], label_to_node, node_to_label, primary_label, strict
         )
         for c in cols
     ]
@@ -248,7 +241,6 @@ def evaluate(
 _DOCS_METRICS = "api/evaluate#metrics"
 _DOCS_FACTOR_COLS = "api/evaluate#factor_cols"
 _DOCS_PANEL = "api/evaluate#panel"
-_DOCS_FORWARD_PERIODS = "api/evaluate#forward_periods"
 
 
 def _is_metrics_overview(metrics: object) -> bool:
@@ -346,38 +338,126 @@ def _resolve_primary(metrics: "dict[str, MetricBase]", primary: str | None) -> s
     return primary
 
 
-def _guard_duplicate_classes(
+_NO_DEFAULT = object()
+
+
+def _forward_periods_default(cls: "type[MetricBase]") -> object:
+    """The ``forward_periods`` signature default declared by a metric class.
+
+    Read from the wrapped ``_impl`` so the evaluate-level ``forward_periods``
+    fallback can tell an instance still at its default apart from an explicit
+    per-instance override. Returns a unique sentinel when the metric has no
+    ``forward_periods`` parameter.
+    """
+    try:
+        param = inspect.signature(cls._impl).parameters.get("forward_periods")
+    except (TypeError, ValueError):
+        return _NO_DEFAULT
+    if param is None or param.default is inspect.Parameter.empty:
+        return _NO_DEFAULT
+    return param.default
+
+
+def _resolve_instance_params(
+    inst: "MetricBase", top_forward_periods: int | None
+) -> dict[str, Any]:
+    """Per-instance params with ``forward_periods`` resolved against the fallback.
+
+    Per-instance override is the rule: an instance's configured
+    ``forward_periods`` always wins. The top-level ``evaluate(forward_periods=)``
+    is a *default fallback* — it fills only instances still sitting at the
+    metric's signature default (and only when the caller passed one). Passing
+    the default value explicitly is indistinguishable from not passing it and
+    is therefore also treated as "use the fallback".
+    """
+    params = dict(inst._params())
+    if top_forward_periods is None or "forward_periods" not in params:
+        return params
+    default = _forward_periods_default(type(inst))
+    if params["forward_periods"] == default:
+        params["forward_periods"] = top_forward_periods
+    return params
+
+
+def _build_nodes(
     label_spec: "dict[str, MetricSpec]",
     label_params: dict[str, dict[str, Any]],
-) -> None:
-    """Reject one metric class under several labels with differing config.
+) -> tuple[list[_Node], dict[str, str], dict[str, dict[str, Any]]]:
+    """Build the by-value execution node graph for the DAG executor.
 
-    The same class under two labels with identical config is a harmless alias;
-    with *different* config (e.g. ``ic()`` vs ``ic(forward_periods=20)``) the
-    name-keyed executor cannot tell them apart — by-value DAG dedup lands in
-    #494. Surface it as a precise config-time error rather than silently
-    dropping one config.
+    Dedups user metrics into **consumer nodes** keyed by ``(name, config)`` —
+    so one class under two labels with *identical* config is a single node
+    (harmless alias) while *different* config is two nodes (#494's headline
+    capability). Then closes ``requires``: each consumer pulls a **producer
+    node** whose config inherits only the consumer's ``forward_periods`` (the
+    sole consumer param any ``requires``-pulled producer accepts), reusing one
+    producer node across consumers that share that inherited config.
+
+    Returns ``(nodes, label -> node_id, node_id -> kwargs)``.
     """
-    by_name: dict[str, list[str]] = {}
-    for label, spec in label_spec.items():
-        by_name.setdefault(spec.name, []).append(label)
-    for name, labels in by_name.items():
-        if len(labels) < 2:
+    by_name = spec_by_name()
+    node_by_key: dict[tuple[str, frozenset], str] = {}
+    node_kwargs: dict[str, dict[str, Any]] = {}
+    node_spec: dict[str, MetricSpec] = {}
+    name_counts: dict[str, int] = {}
+    creation_order: list[str] = []
+
+    def intern(spec: MetricSpec, params: dict[str, Any]) -> str:
+        key = (spec.name, frozenset(params.items()))
+        nid = node_by_key.get(key)
+        if nid is None:
+            i = name_counts.get(spec.name, 0)
+            nid = spec.name if i == 0 else f"{spec.name}#{i}"
+            name_counts[spec.name] = i + 1
+            node_by_key[key] = nid
+            node_kwargs[nid] = dict(params)
+            node_spec[nid] = spec
+            creation_order.append(nid)
+        return nid
+
+    label_to_node = {
+        label: intern(spec, label_params[label]) for label, spec in label_spec.items()
+    }
+
+    requires_nodes: dict[str, tuple[tuple[str, str], ...]] = {}
+    queue = list(creation_order)
+    while queue:
+        nid = queue.pop(0)
+        if nid in requires_nodes:
             continue
-        first = label_params[labels[0]]
-        if any(label_params[other] != first for other in labels[1:]):
-            raise UserInputError(
-                func_name="evaluate",
-                field="metrics",
-                value=f"{name!r} under labels {labels!r}",
-                expected=(
-                    f"distinct metric classes — labels {labels!r} all use "
-                    f"{name!r} with different config. Running one metric under "
-                    f"multiple configs needs by-value DAG dedup (lands in #494); "
-                    f"for now give them a single config or a single label."
-                ),
-                docs_path=_DOCS_METRICS,
-            )
+        spec = node_spec[nid]
+        consumer_params = node_kwargs[nid]
+        edges: list[tuple[str, str]] = []
+        for param_key, producer in spec.requires.items():
+            pname = producer.__name__
+            if pname not in by_name:
+                raise UserInputError(
+                    func_name="evaluate",
+                    field="metrics",
+                    value=pname,
+                    expected=(
+                        f"{spec.name!r} requires producer {pname!r} but no "
+                        f"MetricSpec for it exists in the registry"
+                    ),
+                    docs_path=_DOCS_METRICS,
+                )
+            accepted = set(getattr(producer, "_param_names", ()))
+            inherited = {
+                k: consumer_params[k]
+                for k in ("forward_periods",)
+                if k in consumer_params and k in accepted
+            }
+            pid = intern(by_name[pname], inherited)
+            edges.append((param_key, pid))
+            if pid not in requires_nodes:
+                queue.append(pid)
+        requires_nodes[nid] = tuple(edges)
+
+    nodes = [
+        _Node(spec=node_spec[nid], node_id=nid, requires_nodes=requires_nodes[nid])
+        for nid in creation_order
+    ]
+    return nodes, label_to_node, node_kwargs
 
 
 def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
@@ -411,30 +491,30 @@ def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
 
 def _relabel_result(
     result: EvaluationResult,
-    label_spec: "dict[str, MetricSpec]",
-    name_to_label: dict[str, str],
+    label_to_node: dict[str, str],
+    node_to_label: dict[str, str],
     primary_label: str,
     strict: bool,
 ) -> EvaluationResult:
-    """Re-key a name-keyed executor result onto the user's labels."""
-    name_outputs = result.metrics.outputs
+    """Re-key a node-keyed executor result onto the user's labels."""
+    node_outputs = result.metrics.outputs
     label_outputs: dict[str, MetricResult] = {}
-    for label, spec in label_spec.items():
-        out = name_outputs.get(spec.name)
+    for label, nid in label_to_node.items():
+        out = node_outputs.get(nid)
         if out is not None:
             label_outputs[label] = dataclasses.replace(out, name=label)
     if strict:
         _enforce_strict(label_outputs)
     warnings = [
-        dataclasses.replace(w, source=name_to_label[w.source])
-        if w.source is not None and w.source in name_to_label
+        dataclasses.replace(w, source=node_to_label[w.source])
+        if w.source is not None and w.source in node_to_label
         else w
         for w in result.warnings
     ]
     group = MetricResultGroup(
-        applicable=list(label_spec),
+        applicable=list(label_to_node),
         primary=[primary_label],
-        diagnostic=[label for label in label_spec if label != primary_label],
+        diagnostic=[label for label in label_to_node if label != primary_label],
         outputs=label_outputs,
     )
     return dataclasses.replace(result, metrics=group, warnings=warnings)
@@ -521,83 +601,8 @@ def _validate_baseline_columns(panel: pl.DataFrame) -> None:
     )
 
 
-def _close_requires(metrics: list[MetricSpec]) -> list[MetricSpec]:
-    by_name = spec_by_name()
-    closed: dict[str, MetricSpec] = {m.name: m for m in metrics}
-    stack: list[MetricSpec] = list(metrics)
-    while stack:
-        s = stack.pop()
-        for producer in s.requires.values():
-            pname = producer.__name__
-            if pname in closed:
-                continue
-            if pname not in by_name:
-                raise UserInputError(
-                    func_name="evaluate",
-                    field="metrics",
-                    value=pname,
-                    expected=(
-                        f"{s.name!r} requires producer {pname!r} but no "
-                        f"MetricSpec for it exists in the registry"
-                    ),
-                    docs_path=_DOCS_METRICS,
-                )
-            producer_spec = by_name[pname]
-            closed[pname] = producer_spec
-            stack.append(producer_spec)
-    return list(closed.values())
-
-
-def _resolve_callable(name: str):
-    from factrix._dag import _registry_callable_table
-
-    return _registry_callable_table().get(name)
-
-
-def _signature_has_forward_periods(name: str) -> bool:
-    fn = _resolve_callable(name)
-    if fn is None or not callable(fn):
-        return False
-    try:
-        sig = inspect.signature(fn)
-    except (TypeError, ValueError):
-        return False
-    return "forward_periods" in sig.parameters
-
-
-def _validate_forward_periods_when_required(
-    closure_specs: list[MetricSpec], forward_periods: int | None
-) -> None:
-    if forward_periods is not None:
-        return
-    needing = [s.name for s in closure_specs if _signature_has_forward_periods(s.name)]
-    if needing:
-        raise UserInputError(
-            func_name="evaluate",
-            field="forward_periods",
-            value=None,
-            expected=(
-                f"int — required by metric(s) {needing!r} that consume the "
-                f"forward-return horizon"
-            ),
-            docs_path=_DOCS_FORWARD_PERIODS,
-        )
-
-
-def _build_kwargs_by_metric(
-    closure_specs: list[MetricSpec], forward_periods: int | None
-) -> dict[str, dict[str, Any]]:
-    if forward_periods is None:
-        return {}
-    return {
-        s.name: {"forward_periods": forward_periods}
-        for s in closure_specs
-        if _signature_has_forward_periods(s.name)
-    }
-
-
 def _validate_primary_metric_applicable(
-    primary: MetricSpec, panel: pl.DataFrame
+    primary: MetricSpec, panel: pl.DataFrame, strict: bool
 ) -> None:
     """Reject a primary metric whose ``cell.structure`` disagrees with the panel.
 
@@ -608,7 +613,14 @@ def _validate_primary_metric_applicable(
     bundle whose every metric carries an ``UPSTREAM_UNAVAILABLE`` warning.
     Cell-axis (scope / density) applicability requires panel detection
     and is left to ``fx.inspect_panel`` for the explicit pre-flight path.
+
+    Under ``strict=False`` this guard is skipped (#494 / #497 carry-over): per
+    #476 §4 a structure mismatch is an apply-time failure, so the metric is
+    allowed to flow through to a NaN output + warning rather than raise. The
+    ``strict=True`` default keeps the eager raise.
     """
+    if not strict:
+        return
     cell_structure = primary.cell.structure
     if cell_structure is None:
         return

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -62,10 +62,37 @@ class CycleError(ValueError):
     """Raised when ``MetricSpec.requires`` declares a dependency cycle."""
 
 
+@dataclasses.dataclass(frozen=True)
+class _Node:
+    """A configured execution node — a ``MetricSpec`` at one ``forward_periods`` /
+    param configuration.
+
+    By-value dedup (#494) keys the executor on ``node_id`` rather than
+    ``spec.name`` so the same metric class can run at several configs in one
+    call (``{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}``). ``node_id``
+    is ``spec.name`` for the sole config of a name and ``f"{spec.name}#{i}"``
+    for additional configs; the per-node kwargs live in ``execute``'s
+    ``kwargs_by_metric`` keyed by ``node_id``.
+
+    Attributes:
+        spec: The underlying :class:`MetricSpec` (drives callable resolution
+            by ``spec.name`` and the batchable / role / requires shape).
+        node_id: Stable identity within one executor run.
+        requires_nodes: ``(consumer_param, producer_node_id)`` pairs — the
+            resolved upstream producer **node** for each ``requires`` key,
+            so a consumer at one config reads exactly the producer node
+            built for that config.
+    """
+
+    spec: MetricSpec
+    node_id: str
+    requires_nodes: tuple[tuple[str, str], ...]
+
+
 class _PlanStep(NamedTuple):
     """One topologically-ordered step in an execution plan."""
 
-    spec: MetricSpec
+    node: _Node
     role: str
     requires: tuple[str, ...]
 
@@ -99,15 +126,32 @@ class DagExecutor:
 
     def __init__(
         self,
-        specs: Sequence[MetricSpec],
+        specs: Sequence[MetricSpec | _Node],
         *,
         fn_resolver: Callable[[str], Callable[..., Any]] | None = None,
         primary_names: Sequence[str] = (),
     ) -> None:
-        self._specs: tuple[MetricSpec, ...] = tuple(specs)
+        # Back-compat: a plain spec is wrapped one node per spec with
+        # ``node_id == spec.name`` and requires resolved by producer name;
+        # pre-built ``_Node`` items (the by-value path) pass straight through.
+        nodes: list[_Node] = []
+        for item in specs:
+            if isinstance(item, _Node):
+                nodes.append(item)
+            else:
+                nodes.append(
+                    _Node(
+                        spec=item,
+                        node_id=item.name,
+                        requires_nodes=tuple(
+                            (k, p.__name__) for k, p in item.requires.items()
+                        ),
+                    )
+                )
+        self._nodes: tuple[_Node, ...] = tuple(nodes)
         self._fn_resolver = fn_resolver or _default_fn_resolver
         self._fn_cache: dict[str, Callable[..., Any]] = {}
-        self._primary_names = frozenset(primary_names)
+        self._primary_ids = frozenset(primary_names)
         self._plan_steps: list[_PlanStep] = self._build_plan()
 
     def _fn(self, spec: MetricSpec) -> Callable[..., Any]:
@@ -118,11 +162,11 @@ class DagExecutor:
     def _build_plan(self) -> list[_PlanStep]:
         return [
             _PlanStep(
-                spec=spec,
-                role="batchable" if spec.batchable else "per-factor",
-                requires=tuple(p.__name__ for p in spec.requires.values()),
+                node=node,
+                role="batchable" if node.spec.batchable else "per-factor",
+                requires=tuple(pid for _, pid in node.requires_nodes),
             )
-            for spec in _topo_sort(self._specs)
+            for node in _topo_sort_nodes(self._nodes)
         ]
 
     @property
@@ -130,7 +174,7 @@ class DagExecutor:
         """Multi-line numbered execution plan."""
         lines: list[str] = []
         for idx, step in enumerate(self._plan_steps, start=1):
-            parts = [f"{idx}. {step.spec.name} [{step.role}]"]
+            parts = [f"{idx}. {step.node.node_id} [{step.role}]"]
             if step.requires:
                 parts.append(f"requires={','.join(step.requires)}")
             lines.append(" ".join(parts))
@@ -172,34 +216,31 @@ class DagExecutor:
         producer_outputs: dict[tuple[str, str], Any] = {}
         metric_outputs: dict[tuple[str, str], MetricResult] = {}
 
-        for spec in (step.spec for step in self._plan_steps):
-            handle = self._batch_handle(spec, kwargs_by_metric.get(spec.name, {}))
+        for node in (step.node for step in self._plan_steps):
+            nid = node.node_id
+            handle = self._batch_handle(node.spec, kwargs_by_metric.get(nid, {}))
 
             # Split factors by upstream short-circuit: dead factors get the
             # propagated skip output and never reach the metric.
             live: list[str] = []
             for c in cols:
-                skip = _check_upstream_short_circuit(spec, c, producer_outputs)
+                skip = _check_upstream_short_circuit(node, c, producer_outputs)
                 if skip is not None:
-                    producer_outputs[(spec.name, c)] = skip
-                    metric_outputs[(spec.name, c)] = dataclasses.replace(
-                        skip, name=spec.name
-                    )
+                    producer_outputs[(nid, c)] = skip
+                    metric_outputs[(nid, c)] = dataclasses.replace(skip, name=nid)
                 else:
                     live.append(c)
             if not live:
                 continue
 
-            upstream = self._gather_upstream_batch(spec, live, producer_outputs)
+            upstream = self._gather_upstream_batch(node, live, producer_outputs)
             result = handle(panel, live, project=project, upstream=upstream)
-            _validate_batch_result(spec, live, result)
+            _validate_batch_result(node, live, result)
             for c in live:
                 out = result[c]
-                producer_outputs[(spec.name, c)] = out
+                producer_outputs[(nid, c)] = out
                 if isinstance(out, MetricResult):
-                    metric_outputs[(spec.name, c)] = dataclasses.replace(
-                        out, name=spec.name
-                    )
+                    metric_outputs[(nid, c)] = dataclasses.replace(out, name=nid)
 
         return self._assemble(
             cols, scope, density, forward_periods, structure, n_assets, metric_outputs
@@ -247,14 +288,13 @@ class DagExecutor:
 
     def _gather_upstream_batch(
         self,
-        spec: MetricSpec,
+        node: _Node,
         cols: Sequence[str],
         producer_outputs: Mapping[tuple[str, str], Any],
     ) -> dict[str, Any]:
         out: dict[str, Any] = {}
-        for key, producer in spec.requires.items():
-            pname = producer.__name__
-            out[key] = {c: producer_outputs[(pname, c)] for c in cols}
+        for key, producer_id in node.requires_nodes:
+            out[key] = {c: producer_outputs[(producer_id, c)] for c in cols}
         return out
 
     def _assemble(
@@ -267,22 +307,24 @@ class DagExecutor:
         n_assets: int,
         metric_outputs: Mapping[tuple[str, str], MetricResult],
     ) -> dict[str, EvaluationResult]:
-        public_specs = [s for s in self._specs if s.role is SpecRole.METRIC]
-        applicable = [s.name for s in public_specs]
-        primary = [s.name for s in public_specs if s.name in self._primary_names]
-        diagnostic = [s.name for s in public_specs if s.name not in self._primary_names]
+        public_nodes = [n for n in self._nodes if n.spec.role is SpecRole.METRIC]
+        applicable = [n.node_id for n in public_nodes]
+        primary = [n.node_id for n in public_nodes if n.node_id in self._primary_ids]
+        diagnostic = [
+            n.node_id for n in public_nodes if n.node_id not in self._primary_ids
+        ]
         plan = self.plan
 
         results: dict[str, EvaluationResult] = {}
         for c in cols:
             outputs: dict[str, MetricResult] = {}
             warnings: list[Warning] = []
-            for spec in public_specs:
-                key = (spec.name, c)
+            for node in public_nodes:
+                label = node.node_id
+                key = (label, c)
                 if key not in metric_outputs:
                     continue
                 out = metric_outputs[key]
-                label = spec.name
                 outputs[label] = out
                 reason = out.metadata.get("reason")
                 if isinstance(reason, str) and math.isnan(out.value):
@@ -349,7 +391,7 @@ def _registry_callable_table() -> dict[str, Callable[..., Any]]:
 
 
 def _validate_batch_result(
-    spec: MetricSpec, factor_cols: Sequence[str], result: Any
+    node: _Node, factor_cols: Sequence[str], result: Any
 ) -> None:
     """Check a batch dispatch returned a ``{factor: output}`` mapping.
 
@@ -358,27 +400,27 @@ def _validate_batch_result(
     """
     if not isinstance(result, Mapping):
         raise TypeError(
-            f"{spec.name}: batchable=True spec must return a "
+            f"{node.node_id}: batchable=True spec must return a "
             f"Mapping[factor, output]; got {type(result).__name__}."
         )
     for c in factor_cols:
         if c not in result:
-            raise KeyError(f"{spec.name}: batchable result missing factor {c!r}")
+            raise KeyError(f"{node.node_id}: batchable result missing factor {c!r}")
 
 
 def _check_upstream_short_circuit(
-    spec: MetricSpec,
+    node: _Node,
     factor: str,
     producer_outputs: Mapping[tuple[str, str], Any],
 ) -> MetricResult | None:
-    for key, producer in spec.requires.items():
-        upstream = producer_outputs.get((producer.__name__, factor))
+    for key, producer_id in node.requires_nodes:
+        upstream = producer_outputs.get((producer_id, factor))
         if isinstance(upstream, MetricResult) and math.isnan(upstream.value):
             return MetricResult(
                 value=float("nan"),
                 metadata={
                     "reason": "upstream_unavailable",
-                    "upstream": producer.__name__,
+                    "upstream": producer_id,
                     "upstream_reason": upstream.metadata.get("reason", "unknown"),
                     "consumer_param": key,
                 },
@@ -396,6 +438,46 @@ def _resolve_n_obs(
         if out is not None and out.n_obs is not None:
             return out.n_obs
     return 0
+
+
+def _topo_sort_nodes(nodes: Sequence[_Node]) -> list[_Node]:
+    """Kahn topo-order configured nodes by ``node_id`` / ``requires_nodes``.
+
+    The by-value sibling of :func:`_topo_sort` (which orders bare specs by
+    name). Raises :class:`CycleError` on a cycle and ``ValueError`` when a
+    referenced producer node is absent — the caller must close the node graph
+    before constructing the executor.
+    """
+    by_id = {n.node_id: n for n in nodes}
+    indegree: dict[str, int] = {n.node_id: 0 for n in nodes}
+    deps: dict[str, list[str]] = {n.node_id: [] for n in nodes}
+    for n in nodes:
+        for _, producer_id in n.requires_nodes:
+            if producer_id not in by_id:
+                raise ValueError(
+                    f"DagExecutor: {n.node_id!r} requires node {producer_id!r} "
+                    f"but that producer node is absent. The caller must close "
+                    f"the requires-graph before constructing the executor."
+                )
+            deps[producer_id].append(n.node_id)
+            indegree[n.node_id] += 1
+
+    ready = [n for n in nodes if indegree[n.node_id] == 0]
+    ordered: list[_Node] = []
+    cursor = 0
+    while cursor < len(ready):
+        node = ready[cursor]
+        cursor += 1
+        ordered.append(node)
+        for downstream_id in deps[node.node_id]:
+            indegree[downstream_id] -= 1
+            if indegree[downstream_id] == 0:
+                ready.append(by_id[downstream_id])
+
+    if len(ordered) != len(nodes):
+        remaining = [n.node_id for n in nodes if n not in ordered]
+        raise CycleError(f"DagExecutor: cycle detected among nodes {sorted(remaining)}")
+    return ordered
 
 
 def _topo_sort(specs: Sequence[MetricSpec]) -> list[MetricSpec]:

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -15,7 +15,7 @@ from factrix._axis import (
     SpecRole,
     TestMethod,
 )
-from factrix._dag import CycleError, DagExecutor, _topo_sort
+from factrix._dag import CycleError, DagExecutor, _Node, _topo_sort
 from factrix._metric_index import MetricSpec, cell, spec_by_name
 from factrix._results import MetricResult
 
@@ -203,6 +203,39 @@ class TestStage1Share:
         assert producer_calls["n"] == 1
         assert out["x"].metrics["consumer_a"].value == 43.0
         assert out["x"].metrics["consumer_b"].value == 44.0
+
+
+class TestByValueNodes:
+    def test_two_configs_one_spec_run_as_distinct_nodes(self):
+        # #494: the same callable under two node_ids (different config) runs
+        # twice and each result keys by its node_id.
+        calls = []
+
+        def per_factor(panel, n=0):
+            calls.append(n)
+            return MetricResult(value=float(n))
+
+        spec = _make_spec("per_factor")
+        nodes = [
+            _Node(spec=spec, node_id="per_factor", requires_nodes=()),
+            _Node(spec=spec, node_id="per_factor#1", requires_nodes=()),
+        ]
+        axes = {
+            "scope": FactorScope.INDIVIDUAL,
+            "density": FactorDensity.DENSE,
+            "forward_periods": 1,
+        }
+        panel = _build_panel(factor_cols=("x",))
+        ex = DagExecutor(nodes, fn_resolver={"per_factor": per_factor}.__getitem__)
+        out = ex.execute(
+            panel,
+            ["x"],
+            kwargs_by_metric={"per_factor": {"n": 5}, "per_factor#1": {"n": 9}},
+            **axes,
+        )
+        assert out["x"].metrics["per_factor"].value == 5.0
+        assert out["x"].metrics["per_factor#1"].value == 9.0
+        assert sorted(calls) == [5, 9]
 
 
 class TestShortCircuitPropagation:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,11 +1,15 @@
-"""``fx.evaluate`` dict[str, Metric] API — labels, primary, strict (#497)."""
+"""``fx.evaluate`` dict[str, Metric] API — labels, primary, strict, per-instance
+forward_periods + by-value DAG dedup (#497 / #494)."""
 
 from __future__ import annotations
 
+import math
+
 import factrix as fx
+import polars as pl
 import pytest
 from factrix._errors import UserInputError
-from factrix.metrics import ic, ic_ir
+from factrix.metrics import ic, ic_ir, ic_newey_west
 
 
 def _panel(n_assets: int = 20, n_dates: int = 80, *, with_price: bool = True):
@@ -72,16 +76,55 @@ class TestMetricsValidation:
             _eval(fx.list_metrics())
 
 
-class TestDuplicateClassGuard:
-    def test_same_config_alias_is_allowed(self):
+class TestByValueDedup:
+    def test_same_config_alias_is_one_node_two_labels(self):
         [er] = _eval({"a": ic_ir(), "b": ic_ir()})
         assert set(er.metrics.outputs) == {"a", "b"}
 
-    def test_different_config_via_params_raises(self):
+    def test_different_config_coexists(self):
+        # #494: one class under two labels with different config now runs both.
         from factrix.metrics import quantile_spread
 
-        with pytest.raises(UserInputError, match="different config"):
-            _eval({"a": quantile_spread(n_groups=5), "b": quantile_spread(n_groups=10)})
+        [er] = _eval(
+            {"a": quantile_spread(n_groups=5), "b": quantile_spread(n_groups=10)}
+        )
+        assert set(er.metrics.outputs) == {"a", "b"}
+
+    def test_per_instance_forward_periods_override(self):
+        # Distinct horizons coexist; each carries its own resolved fp.
+        [er] = fx.evaluate(
+            _panel(),
+            metrics={"fp5": ic_newey_west(), "fp20": ic_newey_west(forward_periods=20)},
+            factor_cols=["factor"],
+        )
+        assert er.metrics["fp5"].metadata["forward_periods"] == 5
+        assert er.metrics["fp20"].metadata["forward_periods"] == 20
+
+    def test_shared_producer_runs_once_across_configs(self):
+        # Both ic horizons require compute_ic, which is fp-independent — so the
+        # single batchable producer is computed once, not per config.
+        [er] = fx.evaluate(
+            _panel(),
+            metrics={"fp5": ic_newey_west(), "fp20": ic_newey_west(forward_periods=20)},
+            factor_cols=["factor"],
+        )
+        assert er.plan.count("compute_ic [batchable]") == 1
+
+    def test_top_level_forward_periods_is_default_fallback(self):
+        # An instance left at its signature default inherits the top-level fp;
+        # an explicit per-instance value still wins.
+        [er] = fx.evaluate(
+            _panel(),
+            metrics={
+                "dflt": ic_newey_west(),
+                "expl": ic_newey_west(forward_periods=10),
+            },
+            factor_cols=["factor"],
+            forward_periods=20,
+        )
+        assert er.metrics["dflt"].metadata["forward_periods"] == 20
+        assert er.metrics["expl"].metadata["forward_periods"] == 10
+        assert er.forward_periods == 20  # primary = first key ("dflt")
 
 
 class TestStrict:
@@ -104,3 +147,31 @@ class TestStrict:
             strict=False,
         )
         assert er.metrics["ic"].value != er.metrics["ic"].value  # NaN
+
+
+class TestStrictStructureSoftening:
+    # #494 / #497 carry-over: a PANEL primary on a single-asset TIMESERIES panel
+    # is a structure mismatch — an apply-time failure under #476 §4.
+    def _single_asset_panel(self):
+        panel = _panel(n_assets=20, n_dates=80)
+        first = panel["asset_id"][0]
+        return panel.filter(pl.col("asset_id") == first)
+
+    def test_strict_true_raises_on_structure_mismatch(self):
+        with pytest.raises(UserInputError, match="structure"):
+            fx.evaluate(
+                self._single_asset_panel(),
+                metrics={"ic": ic()},
+                factor_cols=["factor"],
+                forward_periods=5,
+            )
+
+    def test_strict_false_softens_to_nan(self):
+        [er] = fx.evaluate(
+            self._single_asset_panel(),
+            metrics={"ic": ic()},
+            factor_cols=["factor"],
+            forward_periods=5,
+            strict=False,
+        )
+        assert math.isnan(er.metrics["ic"].value)


### PR DESCRIPTION
## What

Makes `forward_periods` **per-instance** and re-keys the DAG executor **by value** so one metric class can run at several configs in a single `evaluate` call.

- **per-instance fp override** — each metric instance carries its own `forward_periods`; top-level `evaluate(forward_periods=)` is now a *default fallback* that fills only instances still at their signature default (detected via `inspect.signature(cls._impl)`). An explicit per-instance value always wins.
- **by-value DAG dedup** — executor keys on a configured `node_id` (new `_Node` + `_build_nodes`) instead of `spec.name`. `{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}` now coexist; shared fp-independent producers (`compute_ic`) run once per distinct config. Producer config inheritance is derived from `cls._param_names` — no signature probing.
- **helper removal** — drops `_build_kwargs_by_metric` / `_validate_forward_periods_when_required` / `_signature_has_forward_periods`, plus the now-unused `_close_requires` / `_resolve_callable` and the `_guard_duplicate_classes` rejection.
- **strict softening (#497 carry-over)** — `strict=False` softens the primary-metric structure guard to NaN + warning instead of raising (per #476 §4); `strict=True` (default) unchanged.

`DagExecutor` keeps a back-compat path: a plain `Sequence[MetricSpec]` is wrapped one node-per-spec (`node_id == spec.name`), so existing executor tests run unchanged.

## Breaking changes (for #501 migration)

- `DagExecutor` is keyed on configured nodes, not `spec.name`.
- `evaluate` no longer rejects one class under two labels with different config — it runs both.
- `EvaluationResult.forward_periods` reports the **primary** metric's resolved horizon.

## Tests

- `test_evaluate.py`: inverted the old "different config raises" into a coexistence test; added per-instance fp override, shared-producer-once, top-level fallback, and strict-structure-softening cases.
- `test_dag.py`: added a multi-config `_Node` execution test; existing 13 cases unchanged.
- Full suite green excluding `tests/bench/` (4 failures there are **pre-existing on main**, unrelated). `ruff` + `mypy` clean.

## Out of scope

- warning-lifting orphan → **#516** (separate issue).

Closes #494
Refs #497 #476 #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)