### PR TITLE
refactor(api)!: lift warning_codes to typed MetricResult field + Warning records (#516)

### DIFF
--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -335,6 +335,12 @@ class DagExecutor:
                             message=reason,
                         )
                     )
+                # Lift the metric's typed advisory codes into per-source
+                # Warning records so to_frame() / to_dict() surface them (#516).
+                for code in out.warning_codes:
+                    warnings.append(
+                        Warning(code=WarningCode(code), source=label, message="")
+                    )
             n_obs = _resolve_n_obs(primary, c, metric_outputs)
             results[c] = EvaluationResult(
                 factor=c,

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -49,6 +49,16 @@ class MetricResult:
         metadata: Tool-specific context (``p_value``, ``stat_type``,
             ``h0``, ``method`` are the standard keys). Read :attr:`p`
             for the typed promoted view of ``p_value``.
+        warning_codes: Per-metric advisory :class:`WarningCode` values
+            (as strings) the producer attached to *this* output — e.g.
+            ``FEW_EVENTS`` / ``BORDERLINE_PORTFOLIO_PERIODS`` /
+            ``UNRELIABLE_SE_SHORT_PERIODS`` from the two-tier sample
+            guards. A typed first-class field (promoted from the legacy
+            ``metadata["warning_codes"]`` stash) so the DAG executor can
+            lift each into a :class:`Warning` record (``source ==`` the
+            metric's label) that surfaces on
+            :meth:`EvaluationResult.to_frame` / ``to_dict``. Empty tuple
+            when the metric raised no advisory.
         name: Metric name stamped by the DAG executor at dispatch time.
             Empty string for outputs constructed outside the registry
             (free-standing primitive calls, tests).
@@ -59,6 +69,7 @@ class MetricResult:
     n_obs: int | None = None
     stat: float | None = None
     metadata: dict[str, object] = field(default_factory=dict)
+    warning_codes: tuple[str, ...] = ()
     name: str = ""
 
     def __repr__(self) -> str:

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -175,14 +175,13 @@ def caar(
         "h0": "mu=0",
         "method": "non-overlapping t-test",
     }
-    if warning_codes:
-        metadata["warning_codes"] = warning_codes
 
     return MetricResult(
         p=p,
         value=mean_caar,
         stat=t,
         metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -217,11 +217,10 @@ def top_concentration(
         "tie_ratio": tie_ratio,
         "weight_by": weight_by,
     }
-    if warning_codes:
-        metadata["warning_codes"] = warning_codes
     return MetricResult(
         p=p,
         value=mean_eff_n,
         stat=t,
         metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -251,8 +251,6 @@ def fm_beta(
         "forward_periods": forward_periods,
         "is_estimated_factor": is_estimated_factor,
     }
-    if warning_codes:
-        metadata["warning_codes"] = warning_codes
 
     if is_estimated_factor:
         sigma2_f = (
@@ -294,6 +292,7 @@ def fm_beta(
         value=mean_beta,
         stat=t,
         metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -15,6 +15,7 @@ from factrix._axis import (
     SpecRole,
     TestMethod,
 )
+from factrix._codes import WarningCode
 from factrix._dag import CycleError, DagExecutor, _Node, _topo_sort
 from factrix._metric_index import MetricSpec, cell, spec_by_name
 from factrix._results import MetricResult
@@ -236,6 +237,34 @@ class TestByValueNodes:
         assert out["x"].metrics["per_factor"].value == 5.0
         assert out["x"].metrics["per_factor#1"].value == 9.0
         assert sorted(calls) == [5, 9]
+
+
+class TestWarningCodeLift:
+    def test_typed_warning_codes_lift_to_warning_records(self):
+        # #516: a metric's typed MetricResult.warning_codes is lifted into
+        # per-source Warning records and surfaces on to_frame().
+        def flagged(panel):
+            return MetricResult(
+                value=1.0, warning_codes=(WarningCode.FEW_EVENTS.value,)
+            )
+
+        spec = _make_spec("flagged")
+        axes = {
+            "scope": FactorScope.INDIVIDUAL,
+            "density": FactorDensity.DENSE,
+            "forward_periods": 1,
+        }
+        panel = _build_panel(factor_cols=("x",))
+        ex = DagExecutor([spec], fn_resolver={"flagged": flagged}.__getitem__)
+        er = ex.execute(panel, ["x"], **axes)["x"]
+
+        assert (WarningCode.FEW_EVENTS, "flagged") in [
+            (w.code, w.source) for w in er.warnings
+        ]
+        row = (
+            er.to_frame().filter(pl.col("metric_name") == "flagged").row(0, named=True)
+        )
+        assert row["warning_codes"] == [WarningCode.FEW_EVENTS.value]
 
 
 class TestShortCircuitPropagation:

--- a/tests/test_two_tier_guards.py
+++ b/tests/test_two_tier_guards.py
@@ -5,8 +5,9 @@ must implement three tiers:
 
 1. ``n < HARD`` → short-circuit (NaN ``MetricResult``).
 2. ``HARD ≤ n < WARN`` → return stat AND emit ``UserWarning`` AND
-   surface the relevant ``WarningCode.value`` in ``metadata["warning_codes"]``.
-3. ``n ≥ WARN`` → silent: stat returned, no warning, no warning_codes.
+   surface the relevant ``WarningCode.value`` in the typed
+   ``MetricResult.warning_codes`` field (#516).
+3. ``n ≥ WARN`` → silent: stat returned, no warning, empty ``warning_codes``.
 """
 
 from __future__ import annotations
@@ -94,10 +95,7 @@ class TestFamaMacbethTwoTier:
         with pytest.warns(UserWarning, match="MIN_FM_PERIODS_WARN"):
             out = fm_beta(df)
         assert out.stat is not None
-        assert (
-            WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value
-            in out.metadata["warning_codes"]
-        )
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in out.warning_codes
 
     def test_at_or_above_warn_is_silent(self) -> None:
         df = _beta_df(MIN_FM_PERIODS_WARN + 5)
@@ -105,7 +103,7 @@ class TestFamaMacbethTwoTier:
             warnings.simplefilter("error", UserWarning)
             out = fm_beta(df)
         assert out.stat is not None
-        assert "warning_codes" not in out.metadata
+        assert out.warning_codes == ()
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +129,7 @@ class TestCaarTwoTier:
         with pytest.warns(UserWarning, match="MIN_EVENTS_WARN"):
             out = caar(df, forward_periods=1)
         assert out.stat is not None
-        assert WarningCode.FEW_EVENTS.value in out.metadata["warning_codes"]
+        assert WarningCode.FEW_EVENTS.value in out.warning_codes
 
     def test_at_or_above_warn_is_silent(self) -> None:
         df = _caar_df(MIN_EVENTS_WARN + 5)
@@ -139,7 +137,7 @@ class TestCaarTwoTier:
             warnings.simplefilter("error", UserWarning)
             out = caar(df, forward_periods=1)
         assert out.stat is not None
-        assert "warning_codes" not in out.metadata
+        assert out.warning_codes == ()
 
 
 # ---------------------------------------------------------------------------
@@ -163,10 +161,7 @@ class TestTopConcentrationTwoTier:
         with pytest.warns(UserWarning, match="MIN_PORTFOLIO_PERIODS_WARN"):
             out = top_concentration(df, forward_periods=1, q_top=0.2)
         assert out.stat is not None
-        assert (
-            WarningCode.BORDERLINE_PORTFOLIO_PERIODS.value
-            in out.metadata["warning_codes"]
-        )
+        assert WarningCode.BORDERLINE_PORTFOLIO_PERIODS.value in out.warning_codes
 
     def test_at_or_above_warn_is_silent(self) -> None:
         df = _concentration_panel(MIN_PORTFOLIO_PERIODS_WARN + 5)
@@ -174,4 +169,4 @@ class TestTopConcentrationTwoTier:
             warnings.simplefilter("error", UserWarning)
             out = top_concentration(df, forward_periods=1, q_top=0.2)
         assert out.stat is not None
-        assert "warning_codes" not in out.metadata
+        assert out.warning_codes == ()


### PR DESCRIPTION
## What

Promotes per-metric advisory codes from the loose `metadata["warning_codes"]` stash to a typed first-class field, and wires them through to the bundle's serialised surface.

- **Typed field** — `MetricResult.warning_codes: tuple[str, ...] = ()`.
- **Metrics** — `top_concentration` / `caar` / `fm_beta` populate `warning_codes` directly (codes `BORDERLINE_PORTFOLIO_PERIODS` / `FEW_EVENTS` / `UNRELIABLE_SE_SHORT_PERIODS`); the `metadata["warning_codes"]` stash is removed.
- **Executor** — `DagExecutor._assemble` lifts each output's `warning_codes` into per-source `Warning(code=…, source=<label>)` records.
- **Result** — `EvaluationResult.to_frame()` / `to_dict()` now surface these codes. The `to_frame()` `warning_codes` column was **always empty** for these three metrics before (it derives only from `Warning` records where `source == metric_name`); this closes that gap.

## Why

Split out of #499; tentatively routed to #493 but that PR landed only the `__call_batch__` protocol and never touched result-assembly, leaving it orphaned. Kept out of #494 to keep that PR focused.

## Breaking changes (for #501 migration)

- Codes no longer appear under `MetricResult.metadata["warning_codes"]`; read the typed `MetricResult.warning_codes` field, or the lifted `Warning` records on the bundle.

## Tests

- `test_two_tier_guards.py`: the borderline/silent tiers now assert the typed `warning_codes` field (the mechanism this PR changes).
- `test_dag.py`: new end-to-end lift test — a metric's typed `warning_codes` becomes a `Warning(source=label)` record and surfaces on `to_frame()`.
- Full suite green excluding `tests/bench/` (4 failures there pre-exist on main, unrelated). `ruff check` + `ruff format --check` + `mypy factrix` clean.

## Deferred

Reference-doc prose mentioning `metadata["warning_codes"]` (`docs/reference/stat-keys-by-metric.md`, `docs/reference/metric-applicability.md`) is left for the final docs batch (#501).

Closes #516
Refs #499 #493 #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)