### PR TITLE
refactor(api): decouple result side from MetricSpec (#521)

### DIFF
--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -16,16 +16,15 @@ from typing import Any
 import polars as pl
 
 from factrix._errors import UserInputError
-from factrix._metric_index import MetricSpec
-from factrix._multi_factor import _require_non_empty_results, _validate_spec_list
+from factrix._multi_factor import _require_non_empty_results, _validate_metric_list
 from factrix._results import EvaluationResult, _float_or_none
 
 
 def compare(
     results: list[EvaluationResult],
     *,
-    metrics: list[MetricSpec],
-    sort_by: MetricSpec | None = None,
+    metrics: list[str],
+    sort_by: str | None = None,
     descending: bool = True,
 ) -> pl.DataFrame:
     """Render a wide leaderboard ``pl.DataFrame`` for multiple metrics.
@@ -37,19 +36,19 @@ def compare(
     Args:
         results: Non-empty list of :class:`EvaluationResult`. Each must
             carry every spec in ``metrics``.
-        metrics: ``list[MetricSpec]`` — list-only canonical form
-            (element type strictly :class:`MetricSpec`). Single-metric
+        metrics: ``list[str]`` — list-only canonical form
+            (element type strictly :class:`str`). Single-metric
             callers still pass a one-element list; mirrors the
             ``primary`` contract on ``fx.multi_factor.bhy`` so the
             whole multi-factor API surface uses one shape.
-        sort_by: Optional :class:`MetricSpec` (must be in ``metrics``)
+        sort_by: Optional :class:`str` (must be in ``metrics``)
             naming the sort key. ``None`` keeps input order and omits
             the ``rank`` column.
         descending: Sort direction applied to ``sort_by``. Default
             ``True`` (higher-is-better, the common case for ``ic`` /
             ``alpha`` / information ratio). Pass ``descending=False``
             for lower-is-better metrics such as ``turnover`` or any
-            cost / drag metric. :class:`MetricSpec` deliberately does
+            cost / drag metric. :class:`str` deliberately does
             not carry a ``higher_is_better`` flag — encoding sort
             direction in the type system bakes in a default that
             silently mis-ranks when wrong. No-op when ``sort_by`` is
@@ -63,7 +62,7 @@ def compare(
 
     Raises:
         UserInputError: Empty ``results``; ``metrics`` not a non-empty
-            ``list[MetricSpec]``; any metric absent from any result's
+            ``list[str]``; any metric absent from any result's
             outputs; ``sort_by`` not present in ``metrics``.
 
     Examples:
@@ -82,15 +81,15 @@ def compare(
         ...     results, metrics=[turnover], sort_by=turnover, descending=False
         ... )
     """
-    metric_list = _validate_spec_list(metrics, func_name="compare", field="metrics")
+    metric_list = _validate_metric_list(metrics, func_name="compare", field="metrics")
     _require_non_empty_results(results, func_name="compare")
-    if sort_by is not None and sort_by.name not in {m.name for m in metric_list}:
+    if sort_by is not None and sort_by not in {m for m in metric_list}:
         raise UserInputError(
             func_name="compare",
             field="sort_by",
-            value=sort_by.name,
-            expected="MetricSpec that appears in `metrics`",
-            candidates=[m.name for m in metric_list],
+            value=sort_by,
+            expected="str that appears in `metrics`",
+            candidates=[m for m in metric_list],
             docs_path="api/compare#sort_by",
         )
 
@@ -104,26 +103,26 @@ def compare(
         for k in context_keys:
             row[k] = r.context.get(k)
         for spec in metric_list:
-            if spec.name not in r.metrics.outputs:
+            if spec not in r.metrics.outputs:
                 raise UserInputError(
                     func_name="compare",
                     field="metrics",
-                    value=spec.name,
+                    value=spec,
                     expected=(
-                        f"every result to carry metric {spec.name!r}; "
+                        f"every result to carry metric {spec!r}; "
                         f"missing on factor={r.factor!r}"
                     ),
                     candidates=sorted(r.metrics.outputs),
                     docs_path="api/compare#metrics",
                 )
-            out = r.metrics.outputs[spec.name]
-            row[spec.name] = _float_or_none(out.value)
-            row[f"{spec.name}_p"] = _float_or_none(out.p)
+            out = r.metrics.outputs[spec]
+            row[spec] = _float_or_none(out.value)
+            row[f"{spec}_p"] = _float_or_none(out.p)
         rows.append(row)
 
     df = pl.DataFrame(rows)
     if sort_by is not None:
-        df = df.sort(sort_by.name, descending=descending, nulls_last=True)
+        df = df.sort(sort_by, descending=descending, nulls_last=True)
         df = df.with_columns(
             pl.int_range(1, df.height + 1, dtype=pl.Int64).alias("rank")
         )

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -11,8 +11,8 @@ anti-shopping defense: the hypothesis identity is
 from ``forward_periods`` (the lone non-context built-in slicing axis)
 or from ``EvaluationResult.context``. The estimator-override hook is
 gone — the new ``fx.estimators`` namespace bakes the inference choice
-into each MetricSpec name (e.g. ``ic_newey_west``), so callers pick
-the estimator by passing the corresponding ``primary`` MetricSpec.
+into each str name (e.g. ``ic_newey_west``), so callers pick
+the estimator by passing the corresponding ``primary`` label.
 """
 
 from __future__ import annotations
@@ -23,7 +23,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from factrix._errors import UserInputError
-from factrix._metric_index import MetricSpec
 
 if TYPE_CHECKING:
     from factrix._results import EvaluationResult
@@ -116,7 +115,7 @@ def _attach_p_values(
     partition: Sequence[_FamilyEntry],
     *,
     func_name: str,
-    primary: MetricSpec,
+    primary: str,
 ) -> list[_FamilyEntry]:
     """Resolve per-primary p-value for each partition entry."""
     return [
@@ -134,7 +133,7 @@ def _resolve_family(
     results: Sequence[EvaluationResult],
     *,
     func_name: str,
-    primary: MetricSpec,
+    primary: str,
     expand_over: Sequence[str] = (),
 ) -> list[_FamilyEntry]:
     """Single-primary convenience wrapper around ``_partition`` +
@@ -182,19 +181,19 @@ def _expand_over_values(
 def _resolve_p_value(
     result: EvaluationResult,
     *,
-    primary: MetricSpec,
+    primary: str,
     func_name: str,
 ) -> float:
     try:
-        out = result.metrics.outputs[primary.name]
+        out = result.metrics.outputs[primary]
     except KeyError:
         raise UserInputError(
             func_name=func_name,
             field="primary",
-            value=primary.name,
+            value=primary,
             expected=(
                 f"every result to carry the primary metric "
-                f"{primary.name!r}; missing on factor={result.factor!r}"
+                f"{primary!r}; missing on factor={result.factor!r}"
             ),
             candidates=sorted(result.metrics.outputs),
             docs_path=f"api/{func_name}#primary",
@@ -205,11 +204,11 @@ def _resolve_p_value(
         raise UserInputError(
             func_name=func_name,
             field="primary",
-            value=primary.name,
+            value=primary,
             expected=(
                 f"a p-value (`.p`) populated on every result; "
                 f"factor={result.factor!r} has no p-value for "
-                f"metric {primary.name!r}"
+                f"metric {primary!r}"
             ),
             docs_path=f"api/{func_name}#primary",
         )
@@ -219,10 +218,10 @@ def _resolve_p_value(
         raise UserInputError(
             func_name=func_name,
             field="primary",
-            value=primary.name,
+            value=primary,
             expected=(
                 f"finite p-value on every result; factor={result.factor!r} "
-                f"has NaN p for metric {primary.name!r} — drop the result "
+                f"has NaN p for metric {primary!r} — drop the result "
                 "or pick a different primary"
             ),
             docs_path=f"api/{func_name}#primary",

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -2,9 +2,9 @@
 / ``bhy_hierarchical``).
 
 All three accept ``list[EvaluationResult]`` and a list of primary
-:class:`~factrix._metric_index.MetricSpec` records; each function runs
+:class:`~factrix._metric_index.metric label` records; each function runs
 one independent screen per primary and returns a
-``dict[primary_name, *Result]`` keyed by ``MetricSpec.name`` (single
+``dict[primary_name, *Result]`` keyed by ``label`` (single
 primary still returns a dict — no isinstance dispatch on the caller
 side).
 
@@ -27,7 +27,6 @@ import numpy as np
 
 from factrix._errors import UserInputError
 from factrix._family import _attach_p_values, _partition, _resolve_family
-from factrix._metric_index import MetricSpec
 from factrix.stats.multiple_testing import (
     bhy_adjusted_p,
     partial_conjunction_p,
@@ -39,13 +38,13 @@ if TYPE_CHECKING:
 
 
 _NOT_METRICSPEC_EXPECTED = (
-    "MetricSpec instance (str / Callable not accepted — pick the spec from "
+    "metric label instance (str / Callable not accepted — pick the spec from "
     "fx.metrics.spec_by_name() or the metric module's __metric_specs__ tuple)"
 )
 
 
-def _validate_spec_list(value: Any, *, func_name: str, field: str) -> list[MetricSpec]:
-    """Shared validator: ``list[MetricSpec]`` canonical form.
+def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str]:
+    """Shared validator: ``list[str]`` canonical form.
 
     Used by ``bhy.primary`` / ``compare.metrics`` so both surfaces give
     identical error messages for the same misuse.
@@ -56,7 +55,7 @@ def _validate_spec_list(value: Any, *, func_name: str, field: str) -> list[Metri
             func_name=func_name,
             field=field,
             value=type(value).__name__,
-            expected=(f"list[MetricSpec] (always a list, even for a single {field})"),
+            expected=(f"list[str] (always a list, even for a single {field})"),
             docs_path=anchor,
         )
     if not value:
@@ -64,16 +63,16 @@ def _validate_spec_list(value: Any, *, func_name: str, field: str) -> list[Metri
             func_name=func_name,
             field=field,
             value=value,
-            expected="non-empty list[MetricSpec]",
+            expected="non-empty list[str]",
             docs_path=anchor,
         )
     for i, spec in enumerate(value):
-        if not isinstance(spec, MetricSpec):
+        if not isinstance(spec, str):
             raise UserInputError(
                 func_name=func_name,
                 field=f"{field}[{i}]",
                 value=type(spec).__name__,
-                expected=_NOT_METRICSPEC_EXPECTED,
+                expected="str metric label (e.g. 'ic_newey_west')",
                 docs_path=anchor,
             )
     return list(value)
@@ -139,7 +138,7 @@ class _FdrResultBase:
     Subclasses append their own fields and supply ``_header`` / ``_rows``.
 
     Common attributes:
-        primary_name: ``MetricSpec.name`` of the primary driving the screen;
+        primary_name: ``label`` of the primary driving the screen;
             also the key under which the record is returned.
         survivors: Surviving :class:`EvaluationResult` records.
         adj_p: BHY-adjusted p-value aligned with ``survivors``.
@@ -323,7 +322,7 @@ def _lookup_expand(result: EvaluationResult, key: str) -> Any:
 def bhy(
     results: list[EvaluationResult],
     *,
-    primary: list[MetricSpec],
+    primary: list[str],
     expand_over: tuple[str, ...] = (),
     q: float = 0.05,
 ) -> dict[str, BhyResult]:
@@ -339,9 +338,9 @@ def bhy(
     Args:
         results: :class:`EvaluationResult` records. The full input is
             one family unless ``expand_over`` further partitions it.
-        primary: ``list[MetricSpec]`` — element type strictly
-            :class:`MetricSpec`. One independent BHY screen runs per
-            primary; the return dict is keyed by ``MetricSpec.name``.
+        primary: ``list[str]`` — element type strictly
+            :class:`metric label`. One independent BHY screen runs per
+            primary; the return dict is keyed by ``label``.
             Single-primary callers still receive a one-key dict (no
             isinstance branching downstream).
         expand_over: Tuple of keys whose distinct value tuples split
@@ -351,10 +350,10 @@ def bhy(
         q: Nominal FDR target. Default ``0.05``.
 
     Returns:
-        ``dict[str, BhyResult]`` keyed by ``MetricSpec.name``.
+        ``dict[str, BhyResult]`` keyed by ``label``.
 
     Raises:
-        UserInputError: ``primary`` not a non-empty ``list[MetricSpec]``;
+        UserInputError: ``primary`` not a non-empty ``list[str]``;
             duplicate ``(factor, *expand_over_values)`` identifier;
             ``expand_over`` key missing from a result's context or
             naming ``'factor'``; primary metric absent from a result's
@@ -366,7 +365,7 @@ def bhy(
             per-rank threshold). Or most ``expand_over`` buckets are
             singletons (BHY on n=1 provides no FDR correction).
     """
-    primary_list = _validate_spec_list(primary, func_name="bhy", field="primary")
+    primary_list = _validate_metric_list(primary, func_name="bhy", field="primary")
     _require_non_empty_results(results, func_name="bhy")
     expand_over_tuple = tuple(expand_over)
 
@@ -400,8 +399,8 @@ def bhy(
             adj_p_all[ix] = bhy_adjusted_p(p_array)
 
         survivor_idxs = np.flatnonzero(adj_p_all <= q)
-        out[spec.name] = BhyResult(
-            primary_name=spec.name,
+        out[spec] = BhyResult(
+            primary_name=spec,
             survivors=[entries[i].result for i in survivor_idxs],
             adj_p=adj_p_all[survivor_idxs],
             q=q,
@@ -414,7 +413,7 @@ def bhy(
 def partial_conjunction(
     results: list[EvaluationResult],
     *,
-    primary: list[MetricSpec],
+    primary: list[str],
     min_pass: int,
     expand_over: tuple[str, ...],
     n_conditions: int | None = None,
@@ -439,8 +438,8 @@ def partial_conjunction(
             identity come from ``expand_over``; multiple results
             sharing the hypothesis identifier (``factor``) must differ
             on at least one ``expand_over`` key.
-        primary: ``list[MetricSpec]`` — one PC screen runs per primary;
-            return dict keyed by ``MetricSpec.name``.
+        primary: ``list[str]`` — one PC screen runs per primary;
+            return dict keyed by ``label``.
         min_pass: ``k`` in "k of m". Must be ``>= 2``.
         expand_over: Non-empty tuple of context keys (or
             ``"forward_periods"``) defining the condition axis.
@@ -451,7 +450,7 @@ def partial_conjunction(
 
     Returns:
         ``dict[str, PartialConjunctionResult]`` keyed by
-        ``MetricSpec.name``.
+        ``label``.
 
     Raises:
         UserInputError: ``min_pass < 2``; ``expand_over`` empty;
@@ -459,7 +458,7 @@ def partial_conjunction(
             identity with fewer than ``min_pass`` conditions; any
             ``_resolve_family`` invariant failure.
     """
-    primary_list = _validate_spec_list(
+    primary_list = _validate_metric_list(
         primary, func_name="partial_conjunction", field="primary"
     )
     _require_non_empty_results(results, func_name="partial_conjunction")
@@ -515,7 +514,7 @@ def partial_conjunction(
 
     out: dict[str, PartialConjunctionResult] = {}
     for spec in primary_list:
-        out[spec.name] = _partial_conjunction_one(
+        out[spec] = _partial_conjunction_one(
             results,
             primary=spec,
             min_pass=min_pass,
@@ -529,7 +528,7 @@ def partial_conjunction(
 def _partial_conjunction_one(
     results: Sequence[EvaluationResult],
     *,
-    primary: MetricSpec,
+    primary: str,
     min_pass: int,
     expand_over: tuple[str, ...],
     n_conditions: int | None,
@@ -613,7 +612,7 @@ def _partial_conjunction_one(
     survivor_idx = np.flatnonzero(adj_p_all <= q)
     surviving_factors = [identifiers_ordered[i] for i in survivor_idx]
     return PartialConjunctionResult(
-        primary_name=primary.name,
+        primary_name=primary,
         survivors=[rep_results[i] for i in survivor_idx],
         adj_p=adj_p_all[survivor_idx],
         pc_p=pc_p_arr[survivor_idx],
@@ -628,7 +627,7 @@ def _partial_conjunction_one(
 def bhy_hierarchical(
     results: list[EvaluationResult],
     *,
-    primary: list[MetricSpec],
+    primary: list[str],
     group: str,
     q: float = 0.05,
 ) -> dict[str, HierarchicalBhyResult]:
@@ -645,13 +644,13 @@ def bhy_hierarchical(
             to one group via ``result.context[group]`` (or via
             ``result.forward_periods`` if ``group == "forward_periods"``).
             Within a group, ``factor`` must be unique.
-        primary: ``list[MetricSpec]`` — one hierarchical screen per
-            primary; return dict keyed by ``MetricSpec.name``.
+        primary: ``list[str]`` — one hierarchical screen per
+            primary; return dict keyed by ``label``.
         group: Single key naming the group axis.
         q: Nominal FDR target shared by both layers.
 
     Returns:
-        ``dict[str, HierarchicalBhyResult]`` keyed by ``MetricSpec.name``.
+        ``dict[str, HierarchicalBhyResult]`` keyed by ``label``.
 
     Raises:
         UserInputError: ``group == 'factor'`` (it is the identifier);
@@ -665,21 +664,21 @@ def bhy_hierarchical(
             result — inner BHY on n=1 is a raw cutoff and the outer
             Simes representative equals that single p-value.
     """
-    primary_list = _validate_spec_list(
+    primary_list = _validate_metric_list(
         primary, func_name="bhy_hierarchical", field="primary"
     )
     _require_non_empty_results(results, func_name="bhy_hierarchical")
 
     out: dict[str, HierarchicalBhyResult] = {}
     for spec in primary_list:
-        out[spec.name] = _bhy_hierarchical_one(results, primary=spec, group=group, q=q)
+        out[spec] = _bhy_hierarchical_one(results, primary=spec, group=group, q=q)
     return out
 
 
 def _bhy_hierarchical_one(
     results: Sequence[EvaluationResult],
     *,
-    primary: MetricSpec,
+    primary: str,
     group: str,
     q: float,
 ) -> HierarchicalBhyResult:
@@ -757,7 +756,7 @@ def _bhy_hierarchical_one(
 
     survivor_idxs = np.flatnonzero(adj_p_all <= q)
     return HierarchicalBhyResult(
-        primary_name=primary.name,
+        primary_name=primary,
         survivors=[entries[i].result for i in survivor_idxs],
         adj_p=adj_p_all[survivor_idxs],
         q=q,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,12 +40,12 @@ def make_result(
     *,
     factor: str,
     p: float | None,
-    primary: MetricSpec,
+    primary: str,
     value: float = 0.05,
     forward_periods: int = 5,
     context: dict[str, Any] | None = None,
     extra_outputs: dict[str, MetricResult] | None = None,
-    extra_primaries: tuple[MetricSpec, ...] = (),
+    extra_primaries: tuple[str, ...] = (),
 ) -> EvaluationResult:
     """Build an :class:`EvaluationResult` carrying the named primary metric.
 
@@ -54,13 +54,13 @@ def make_result(
     """
     metadata: dict[str, Any] = {} if p is None else {"p_value": float(p)}
     primary_out = MetricResult(
-        value=value, p=p, n_obs=100, name=primary.name, metadata=metadata
+        value=value, p=p, n_obs=100, name=primary, metadata=metadata
     )
-    outputs = {primary.name: primary_out}
+    outputs = {primary: primary_out}
     if extra_outputs:
         outputs.update(extra_outputs)
     primaries = [primary, *extra_primaries]
-    primary_names = [s.name for s in primaries]
+    primary_names = primaries
     return EvaluationResult(
         factor=factor,
         cell=(FactorScope.INDIVIDUAL, FactorDensity.DENSE, DataStructure.PANEL),

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -14,28 +14,28 @@ from .conftest import make_result, make_spec
 
 
 def test_returns_dict_keyed_by_primary_name_even_for_single_primary():
-    ic = make_spec("ic")
-    results = [make_result(factor=f"f{i}", p=0.001, primary=ic) for i in range(5)]
-    out = bhy(results, primary=[ic], q=0.05)
+    make_spec("ic")
+    results = [make_result(factor=f"f{i}", p=0.001, primary="ic") for i in range(5)]
+    out = bhy(results, primary=["ic"], q=0.05)
     assert isinstance(out, dict)
     assert set(out) == {"ic"}
     assert isinstance(out["ic"], BhyResult)
 
 
 def test_multi_primary_runs_independent_screens():
-    ic = make_spec("ic")
+    make_spec("ic")
     ir = make_spec("ic_ir")
     results = [
         make_result(
             factor=f"f{i}",
             p=0.0001,
-            primary=ic,
+            primary="ic",
             extra_outputs={
                 "ic_ir": MetricResult(
                     value=0.4,
                     p=0.5,
                     n_obs=100,
-                    name=ir.name,
+                    name="ic_ir",
                     metadata={"p_value": 0.5},
                 )
             },
@@ -43,35 +43,35 @@ def test_multi_primary_runs_independent_screens():
         )
         for i in range(4)
     ]
-    out = bhy(results, primary=[ic, ir], q=0.05)
+    out = bhy(results, primary=["ic", "ic_ir"], q=0.05)
     assert set(out) == {"ic", "ic_ir"}
     assert len(out["ic"]) == 4
     assert len(out["ic_ir"]) == 0
 
 
 def test_empty_input_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     with pytest.raises(UserInputError, match="non-empty list\\[EvaluationResult\\]"):
-        bhy([], primary=[ic], q=0.05)
+        bhy([], primary=["ic"], q=0.05)
 
 
 def test_no_surviving_results_returns_empty_record():
-    ic = make_spec("ic")
-    results = [make_result(factor=f"f{i}", p=0.9, primary=ic) for i in range(5)]
-    out = bhy(results, primary=[ic], q=0.05)
+    make_spec("ic")
+    results = [make_result(factor=f"f{i}", p=0.9, primary="ic") for i in range(5)]
+    out = bhy(results, primary=["ic"], q=0.05)
     assert len(out["ic"]) == 0
 
 
 def test_expand_over_forward_periods_partitions_by_horizon():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor=f"f{i}", p=0.001, primary=ic, forward_periods=1)
+        make_result(factor=f"f{i}", p=0.001, primary="ic", forward_periods=1)
         for i in range(3)
     ] + [
-        make_result(factor=f"f{i}", p=0.9, primary=ic, forward_periods=5)
+        make_result(factor=f"f{i}", p=0.9, primary="ic", forward_periods=5)
         for i in range(3)
     ]
-    out = bhy(results, primary=[ic], expand_over=("forward_periods",), q=0.05)
+    out = bhy(results, primary=["ic"], expand_over=("forward_periods",), q=0.05)
     assert out["ic"].expand_over == ("forward_periods",)
     assert set(out["ic"].n_tests) == {(1,), (5,)}
     survivor_factors = {r.factor for r in out["ic"].survivors}
@@ -79,42 +79,42 @@ def test_expand_over_forward_periods_partitions_by_horizon():
 
 
 def test_expand_over_context_key():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor=f"f{i}", p=0.001, primary=ic, context={"region": "US"})
+        make_result(factor=f"f{i}", p=0.001, primary="ic", context={"region": "US"})
         for i in range(3)
     ] + [
-        make_result(factor=f"f{i}", p=0.9, primary=ic, context={"region": "EU"})
+        make_result(factor=f"f{i}", p=0.9, primary="ic", context={"region": "EU"})
         for i in range(3)
     ]
-    out = bhy(results, primary=[ic], expand_over=("region",), q=0.05)
+    out = bhy(results, primary=["ic"], expand_over=("region",), q=0.05)
     assert set(out["ic"].n_tests) == {("US",), ("EU",)}
 
 
 def test_mixed_horizons_without_expand_over_warns():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="f1", p=0.01, primary=ic, forward_periods=1),
-        make_result(factor="f2", p=0.01, primary=ic, forward_periods=5),
+        make_result(factor="f1", p=0.01, primary="ic", forward_periods=1),
+        make_result(factor="f2", p=0.01, primary="ic", forward_periods=5),
     ]
     with pytest.warns(RuntimeWarning, match="mixes forward_periods"):
-        bhy(results, primary=[ic], q=0.5)
+        bhy(results, primary=["ic"], q=0.5)
 
 
 def test_singleton_buckets_warn():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="f1", p=0.001, primary=ic, context={"region": "US"}),
-        make_result(factor="f2", p=0.001, primary=ic, context={"region": "EU"}),
+        make_result(factor="f1", p=0.001, primary="ic", context={"region": "US"}),
+        make_result(factor="f2", p=0.001, primary="ic", context={"region": "EU"}),
     ]
     with pytest.warns(RuntimeWarning, match="single result"):
-        bhy(results, primary=[ic], expand_over=("region",), q=0.5)
+        bhy(results, primary=["ic"], expand_over=("region",), q=0.5)
 
 
 def test_primary_must_be_list():
-    ic = make_spec("ic")
+    make_spec("ic")
     with pytest.raises(UserInputError, match="always a list"):
-        bhy([make_result(factor="f", p=0.01, primary=ic)], primary=ic)  # type: ignore[arg-type]
+        bhy([make_result(factor="f", p=0.01, primary="ic")], primary="ic")  # type: ignore[arg-type]
 
 
 def test_primary_must_be_non_empty():
@@ -122,61 +122,61 @@ def test_primary_must_be_non_empty():
         bhy([], primary=[])
 
 
-def test_primary_element_must_be_metricspec():
-    with pytest.raises(UserInputError, match="MetricSpec instance"):
-        bhy([], primary=["ic"])  # type: ignore[list-item]
+def test_primary_element_must_be_str():
+    with pytest.raises(UserInputError, match="str metric label"):
+        bhy([], primary=[123])  # type: ignore[list-item]
 
 
 def test_duplicate_factor_without_expand_over_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="f1", p=0.01, primary=ic),
-        make_result(factor="f1", p=0.02, primary=ic),
+        make_result(factor="f1", p=0.01, primary="ic"),
+        make_result(factor="f1", p=0.02, primary="ic"),
     ]
     with pytest.raises(UserInputError, match="unique"):
-        bhy(results, primary=[ic])
+        bhy(results, primary=["ic"])
 
 
 def test_missing_primary_metric_raises():
-    ic = make_spec("ic")
-    other = make_spec("alpha")
-    results = [make_result(factor="f1", p=0.01, primary=ic)]
-    with pytest.raises(UserInputError, match="alpha"):
-        bhy(results, primary=[other])
+    make_spec("ic")
+    make_spec("alpha")
+    results = [make_result(factor="f1", p=0.01, primary="ic")]
+    with pytest.raises(UserInputError, match="other"):
+        bhy(results, primary=["other"])
 
 
 def test_nan_p_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="f1", p=float("nan"), primary=ic),
+        make_result(factor="f1", p=float("nan"), primary="ic"),
     ]
     with pytest.raises(UserInputError, match="NaN"):
-        bhy(results, primary=[ic])
+        bhy(results, primary=["ic"])
 
 
 def test_factor_as_expand_over_key_raises():
-    ic = make_spec("ic")
-    results = [make_result(factor="f1", p=0.01, primary=ic)]
+    make_spec("ic")
+    results = [make_result(factor="f1", p=0.01, primary="ic")]
     with pytest.raises(UserInputError, match="hypothesis identifier"):
-        bhy(results, primary=[ic], expand_over=("factor",))
+        bhy(results, primary=["ic"], expand_over=("factor",))
 
 
 def test_missing_context_key_raises():
-    ic = make_spec("ic")
-    results = [make_result(factor="f1", p=0.01, primary=ic, context={"region": "US"})]
+    make_spec("ic")
+    results = [make_result(factor="f1", p=0.01, primary="ic", context={"region": "US"})]
     with pytest.raises(UserInputError, match="universe"):
-        bhy(results, primary=[ic], expand_over=("universe",))
+        bhy(results, primary=["ic"], expand_over=("universe",))
 
 
 def test_adj_p_monotonic_within_bucket():
-    ic = make_spec("ic")
+    make_spec("ic")
     p_values = [0.001, 0.01, 0.02, 0.5, 0.9]
     results = [
-        make_result(factor=f"f{i}", p=p, primary=ic) for i, p in enumerate(p_values)
+        make_result(factor=f"f{i}", p=p, primary="ic") for i, p in enumerate(p_values)
     ]
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        out = bhy(results, primary=[ic], q=1.0)
+        out = bhy(results, primary=["ic"], q=1.0)
     assert len(out["ic"]) == len(p_values)
     by_factor = dict(
         zip((r.factor for r in out["ic"].survivors), out["ic"].adj_p, strict=True)
@@ -186,9 +186,9 @@ def test_adj_p_monotonic_within_bucket():
 
 
 def test_bhy_result_repr_and_html():
-    ic = make_spec("ic")
-    results = [make_result(factor=f"f{i}", p=0.001, primary=ic) for i in range(3)]
-    out = bhy(results, primary=[ic], q=0.5)["ic"]
+    make_spec("ic")
+    results = [make_result(factor=f"f{i}", p=0.001, primary="ic") for i in range(3)]
+    out = bhy(results, primary=["ic"], q=0.5)["ic"]
     text = repr(out)
     assert "BhyResult" in text
     assert "f0" in text

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -19,74 +19,74 @@ def _grouped(p_by_factor: dict[str, float], group_value: str, primary):
 
 
 def test_returns_dict_per_primary():
-    ic = make_spec("ic")
-    results = _grouped({"mom_1": 0.001, "mom_2": 0.5}, "momentum", ic) + _grouped(
-        {"val_1": 0.001, "val_2": 0.5}, "value", ic
+    make_spec("ic")
+    results = _grouped({"mom_1": 0.001, "mom_2": 0.5}, "momentum", "ic") + _grouped(
+        {"val_1": 0.001, "val_2": 0.5}, "value", "ic"
     )
-    out = bhy_hierarchical(results, primary=[ic], group="family", q=0.05)
+    out = bhy_hierarchical(results, primary=["ic"], group="family", q=0.05)
     assert isinstance(out, dict)
     assert set(out) == {"ic"}
     assert isinstance(out["ic"], HierarchicalBhyResult)
 
 
 def test_n_tests_covers_all_input_groups():
-    ic = make_spec("ic")
-    results = _grouped({"a": 0.5, "b": 0.5}, "g1", ic) + _grouped(
-        {"c": 0.5, "d": 0.5}, "g2", ic
+    make_spec("ic")
+    results = _grouped({"a": 0.5, "b": 0.5}, "g1", "ic") + _grouped(
+        {"c": 0.5, "d": 0.5}, "g2", "ic"
     )
-    out = bhy_hierarchical(results, primary=[ic], group="family", q=0.05)
+    out = bhy_hierarchical(results, primary=["ic"], group="family", q=0.05)
     assert set(out["ic"].n_tests) == {("g1",), ("g2",)}
 
 
 def test_single_group_raises():
-    ic = make_spec("ic")
-    results = _grouped({"a": 0.001, "b": 0.001}, "only", ic)
+    make_spec("ic")
+    results = _grouped({"a": 0.001, "b": 0.001}, "only", "ic")
     with pytest.raises(UserInputError, match="at least 2"):
-        bhy_hierarchical(results, primary=[ic], group="family")
+        bhy_hierarchical(results, primary=["ic"], group="family")
 
 
 def test_every_result_own_group_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor=f"f{i}", p=0.01, primary=ic, context={"family": f"g{i}"})
+        make_result(factor=f"f{i}", p=0.01, primary="ic", context={"family": f"g{i}"})
         for i in range(3)
     ]
     with pytest.raises(UserInputError, match="every result is its own group"):
-        bhy_hierarchical(results, primary=[ic], group="family")
+        bhy_hierarchical(results, primary=["ic"], group="family")
 
 
 def test_singleton_group_warns():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = (
-        _grouped({"a": 0.5}, "g1", ic)
-        + _grouped({"b": 0.5}, "g2", ic)
-        + _grouped({"c": 0.5, "d": 0.5}, "g3", ic)
+        _grouped({"a": 0.5}, "g1", "ic")
+        + _grouped({"b": 0.5}, "g2", "ic")
+        + _grouped({"c": 0.5, "d": 0.5}, "g3", "ic")
     )
     with pytest.warns(RuntimeWarning, match="single result"):
-        bhy_hierarchical(results, primary=[ic], group="family", q=0.5)
+        bhy_hierarchical(results, primary=["ic"], group="family", q=0.5)
 
 
 def test_strong_group_survives_dead_group_does_not():
-    ic = make_spec("ic")
-    results = _grouped({"hit_1": 1e-6, "hit_2": 1e-6}, "live", ic) + _grouped(
-        {"d1": 0.95, "d2": 0.95}, "dead", ic
+    make_spec("ic")
+    results = _grouped({"hit_1": 1e-6, "hit_2": 1e-6}, "live", "ic") + _grouped(
+        {"d1": 0.95, "d2": 0.95}, "dead", "ic"
     )
-    out = bhy_hierarchical(results, primary=[ic], group="family", q=0.05)
+    out = bhy_hierarchical(results, primary=["ic"], group="family", q=0.05)
     surviving = {r.factor for r in out["ic"].survivors}
     assert surviving == {"hit_1", "hit_2"}
 
 
 def test_empty_input_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     with pytest.raises(UserInputError, match="non-empty list\\[EvaluationResult\\]"):
-        bhy_hierarchical([], primary=[ic], group="family", q=0.05)
+        bhy_hierarchical([], primary=["ic"], group="family", q=0.05)
 
 
-def test_primary_must_be_list_of_metricspec():
-    ic = make_spec("ic")
+def test_primary_must_be_list_of_str():
+    make_spec("ic")
     with pytest.raises(UserInputError, match="always a list"):
         bhy_hierarchical(
-            [make_result(factor="f", p=0.01, primary=ic)],
-            primary=ic,  # type: ignore[arg-type]
+            [make_result(factor="f", p=0.01, primary="ic")],
+            primary="ic",  # type: ignore[arg-type]
             group="family",
         )

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -14,14 +14,14 @@ def _with_extra(factor: str, ic, sharpe, ic_value: float, sharpe_value: float):
     return make_result(
         factor=factor,
         p=0.1,
-        primary=ic,
+        primary="ic",
         value=ic_value,
         extra_outputs={
             "sharpe": MetricResult(
                 value=sharpe_value,
                 p=0.2,
                 n_obs=100,
-                name=sharpe.name,
+                name="sharpe",
                 metadata={"p_value": 0.2},
             )
         },
@@ -36,7 +36,7 @@ def test_multi_metric_wide_layout():
         _with_extra("a", ic, sharpe, ic_value=0.05, sharpe_value=1.2),
         _with_extra("b", ic, sharpe, ic_value=0.02, sharpe_value=0.8),
     ]
-    df = compare(results, metrics=[ic, sharpe])
+    df = compare(results, metrics=["ic", "sharpe"])
     assert df.columns == [
         "factor",
         "forward_periods",
@@ -51,48 +51,48 @@ def test_multi_metric_wide_layout():
 
 
 def test_sort_by_descending_true_adds_rank():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="lo", p=0.5, primary=ic, value=0.01),
-        make_result(factor="hi", p=0.01, primary=ic, value=0.10),
-        make_result(factor="mid", p=0.1, primary=ic, value=0.05),
+        make_result(factor="lo", p=0.5, primary="ic", value=0.01),
+        make_result(factor="hi", p=0.01, primary="ic", value=0.10),
+        make_result(factor="mid", p=0.1, primary="ic", value=0.05),
     ]
-    df = compare(results, metrics=[ic], sort_by=ic, descending=True)
+    df = compare(results, metrics=["ic"], sort_by="ic", descending=True)
     assert df["factor"].to_list() == ["hi", "mid", "lo"]
     assert df["rank"].to_list() == [1, 2, 3]
 
 
 def test_sort_by_descending_false_ranks_low_first():
-    turnover = make_spec("turnover")
+    make_spec("turnover")
     results = [
-        make_result(factor="high_to", p=0.5, primary=turnover, value=0.80),
-        make_result(factor="low_to", p=0.5, primary=turnover, value=0.10),
-        make_result(factor="mid_to", p=0.5, primary=turnover, value=0.45),
+        make_result(factor="high_to", p=0.5, primary="turnover", value=0.80),
+        make_result(factor="low_to", p=0.5, primary="turnover", value=0.10),
+        make_result(factor="mid_to", p=0.5, primary="turnover", value=0.45),
     ]
-    df = compare(results, metrics=[turnover], sort_by=turnover, descending=False)
+    df = compare(results, metrics=["turnover"], sort_by="turnover", descending=False)
     assert df["factor"].to_list() == ["low_to", "mid_to", "high_to"]
     assert df["rank"].to_list() == [1, 2, 3]
 
 
 def test_no_sort_keeps_input_order_omits_rank():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="c", p=0.1, primary=ic, value=0.01),
-        make_result(factor="a", p=0.1, primary=ic, value=0.10),
-        make_result(factor="b", p=0.1, primary=ic, value=0.05),
+        make_result(factor="c", p=0.1, primary="ic", value=0.01),
+        make_result(factor="a", p=0.1, primary="ic", value=0.10),
+        make_result(factor="b", p=0.1, primary="ic", value=0.05),
     ]
-    df = compare(results, metrics=[ic])
+    df = compare(results, metrics=["ic"])
     assert df["factor"].to_list() == ["c", "a", "b"]
     assert "rank" not in df.columns
 
 
 def test_context_keys_propagate_with_null_fill():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="a", p=0.1, primary=ic, context={"region": "US"}),
-        make_result(factor="b", p=0.1, primary=ic, context={"sector": "tech"}),
+        make_result(factor="a", p=0.1, primary="ic", context={"region": "US"}),
+        make_result(factor="b", p=0.1, primary="ic", context={"sector": "tech"}),
     ]
-    df = compare(results, metrics=[ic])
+    df = compare(results, metrics=["ic"])
     assert set(df.columns) >= {"region", "sector"}
     a_row = df.filter(df["factor"] == "a").to_dicts()[0]
     b_row = df.filter(df["factor"] == "b").to_dicts()[0]
@@ -101,53 +101,49 @@ def test_context_keys_propagate_with_null_fill():
 
 
 def test_p_column_populated_when_metadata_present():
-    ic = make_spec("ic")
-    results = [make_result(factor="f1", p=0.042, primary=ic, value=0.05)]
-    df = compare(results, metrics=[ic])
+    make_spec("ic")
+    results = [make_result(factor="f1", p=0.042, primary="ic", value=0.05)]
+    df = compare(results, metrics=["ic"])
     assert df["ic_p"].to_list() == [pytest.approx(0.042)]
 
 
 def test_empty_results_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     with pytest.raises(UserInputError, match="non-empty list\\[EvaluationResult\\]"):
-        compare([], metrics=[ic])
+        compare([], metrics=["ic"])
 
 
 def test_metrics_must_be_list():
     ic = make_spec("ic")
     with pytest.raises(UserInputError, match="always a list"):
         compare(
-            [make_result(factor="f", p=0.01, primary=ic)],
+            [make_result(factor="f", p=0.01, primary="ic")],
             metrics=ic,  # type: ignore[arg-type]
         )
 
 
 def test_metrics_must_be_non_empty():
-    ic = make_spec("ic")
-    with pytest.raises(UserInputError, match="non-empty list\\[MetricSpec\\]"):
-        compare([make_result(factor="f", p=0.01, primary=ic)], metrics=[])
+    make_spec("ic")
+    with pytest.raises(UserInputError, match="non-empty list\\[str\\]"):
+        compare([make_result(factor="f", p=0.01, primary="ic")], metrics=[])
 
 
-def test_metrics_element_must_be_metricspec():
-    ic = make_spec("ic")
-    with pytest.raises(UserInputError, match="MetricSpec instance"):
-        compare(
-            [make_result(factor="f", p=0.01, primary=ic)],
-            metrics=["ic"],  # type: ignore[list-item]
-        )
+def test_metrics_element_must_be_str():
+    with pytest.raises(UserInputError, match="str metric label"):
+        compare([make_result(factor="f", p=0.01, primary="ic")], metrics=[123])  # type: ignore[list-item]
 
 
 def test_missing_metric_raises():
-    ic = make_spec("ic")
-    other = make_spec("alpha")
-    results = [make_result(factor="f", p=0.01, primary=ic)]
-    with pytest.raises(UserInputError, match="alpha"):
-        compare(results, metrics=[other])
+    make_spec("ic")
+    make_spec("alpha")
+    results = [make_result(factor="f", p=0.01, primary="ic")]
+    with pytest.raises(UserInputError, match="other"):
+        compare(results, metrics=["other"])
 
 
 def test_sort_by_not_in_metrics_raises():
-    ic = make_spec("ic")
-    sharpe = make_spec("sharpe")
-    results = [make_result(factor="f", p=0.01, primary=ic)]
+    make_spec("ic")
+    make_spec("sharpe")
+    results = [make_result(factor="f", p=0.01, primary="ic")]
     with pytest.raises(UserInputError, match="unknown sort_by"):
-        compare(results, metrics=[ic], sort_by=sharpe)
+        compare(results, metrics=["ic"], sort_by="sharpe")

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -17,12 +17,12 @@ def _replicate(factor: str, ps: list[float], primary, regions=("US", "EU", "JP")
 
 
 def test_returns_dict_per_primary():
-    ic = make_spec("ic")
-    results = _replicate("alpha_1", [0.001, 0.001, 0.001], ic) + _replicate(
-        "alpha_2", [0.5, 0.5, 0.5], ic
+    make_spec("ic")
+    results = _replicate("alpha_1", [0.001, 0.001, 0.001], "ic") + _replicate(
+        "alpha_2", [0.5, 0.5, 0.5], "ic"
     )
     out = partial_conjunction(
-        results, primary=[ic], min_pass=2, expand_over=("region",), q=0.05
+        results, primary=["ic"], min_pass=2, expand_over=("region",), q=0.05
     )
     assert isinstance(out, dict)
     assert set(out) == {"ic"}
@@ -30,39 +30,43 @@ def test_returns_dict_per_primary():
 
 
 def test_pc_min_pass_one_raises():
-    ic = make_spec("ic")
-    results = _replicate("alpha_1", [0.01, 0.01], ic, regions=("US", "EU"))
+    make_spec("ic")
+    results = _replicate("alpha_1", [0.01, 0.01], "ic", regions=("US", "EU"))
     with pytest.raises(UserInputError, match="union semantics"):
-        partial_conjunction(results, primary=[ic], min_pass=1, expand_over=("region",))
+        partial_conjunction(
+            results, primary=["ic"], min_pass=1, expand_over=("region",)
+        )
 
 
 def test_pc_min_pass_below_two_raises():
-    ic = make_spec("ic")
-    results = _replicate("alpha_1", [0.01, 0.01], ic, regions=("US", "EU"))
+    make_spec("ic")
+    results = _replicate("alpha_1", [0.01, 0.01], "ic", regions=("US", "EU"))
     with pytest.raises(UserInputError, match=">= 2"):
-        partial_conjunction(results, primary=[ic], min_pass=0, expand_over=("region",))
+        partial_conjunction(
+            results, primary=["ic"], min_pass=0, expand_over=("region",)
+        )
 
 
 def test_pc_empty_expand_over_raises():
-    ic = make_spec("ic")
-    results = _replicate("alpha_1", [0.01], ic, regions=("US",))
+    make_spec("ic")
+    results = _replicate("alpha_1", [0.01], "ic", regions=("US",))
     with pytest.raises(UserInputError, match="non-empty"):
-        partial_conjunction(results, primary=[ic], min_pass=2, expand_over=())
+        partial_conjunction(results, primary=["ic"], min_pass=2, expand_over=())
 
 
 def test_pc_empty_results_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     with pytest.raises(UserInputError, match="non-empty list\\[EvaluationResult\\]"):
-        partial_conjunction([], primary=[ic], min_pass=2, expand_over=("region",))
+        partial_conjunction([], primary=["ic"], min_pass=2, expand_over=("region",))
 
 
 def test_pc_n_conditions_strict_mismatch_raises():
-    ic = make_spec("ic")
-    results = _replicate("alpha_1", [0.01, 0.01], ic, regions=("US", "EU"))
+    make_spec("ic")
+    results = _replicate("alpha_1", [0.01, 0.01], "ic", regions=("US", "EU"))
     with pytest.raises(UserInputError, match="condition"):
         partial_conjunction(
             results,
-            primary=[ic],
+            primary=["ic"],
             min_pass=2,
             expand_over=("region",),
             n_conditions=3,
@@ -70,29 +74,33 @@ def test_pc_n_conditions_strict_mismatch_raises():
 
 
 def test_pc_insufficient_conditions_raises():
-    ic = make_spec("ic")
-    results = _replicate("alpha_1", [0.01], ic, regions=("US",))
+    make_spec("ic")
+    results = _replicate("alpha_1", [0.01], "ic", regions=("US",))
     with pytest.raises(UserInputError, match="condition"):
-        partial_conjunction(results, primary=[ic], min_pass=2, expand_over=("region",))
+        partial_conjunction(
+            results, primary=["ic"], min_pass=2, expand_over=("region",)
+        )
 
 
 def test_pc_duplicate_condition_raises():
-    ic = make_spec("ic")
+    make_spec("ic")
     results = [
-        make_result(factor="alpha_1", p=0.01, primary=ic, context={"region": "US"}),
-        make_result(factor="alpha_1", p=0.02, primary=ic, context={"region": "US"}),
+        make_result(factor="alpha_1", p=0.01, primary="ic", context={"region": "US"}),
+        make_result(factor="alpha_1", p=0.02, primary="ic", context={"region": "US"}),
     ]
     with pytest.raises(UserInputError, match="unique"):
-        partial_conjunction(results, primary=[ic], min_pass=2, expand_over=("region",))
+        partial_conjunction(
+            results, primary=["ic"], min_pass=2, expand_over=("region",)
+        )
 
 
 def test_pc_strong_signal_survives():
-    ic = make_spec("ic")
-    results = _replicate("strong", [0.0001, 0.0001, 0.0001], ic) + _replicate(
-        "weak", [0.4, 0.4, 0.4], ic
+    make_spec("ic")
+    results = _replicate("strong", [0.0001, 0.0001, 0.0001], "ic") + _replicate(
+        "weak", [0.4, 0.4, 0.4], "ic"
     )
     out = partial_conjunction(
-        results, primary=[ic], min_pass=2, expand_over=("region",), q=0.05
+        results, primary=["ic"], min_pass=2, expand_over=("region",), q=0.05
     )
     factors = {r.factor for r in out["ic"].survivors}
     assert "strong" in factors
@@ -100,11 +108,11 @@ def test_pc_strong_signal_survives():
 
 
 def test_pc_heterogeneous_m_warns_in_lenient_mode():
-    ic = make_spec("ic")
-    results = _replicate("a", [0.01, 0.01], ic, regions=("US", "EU")) + _replicate(
-        "b", [0.01, 0.01, 0.01], ic, regions=("US", "EU", "JP")
+    make_spec("ic")
+    results = _replicate("a", [0.01, 0.01], "ic", regions=("US", "EU")) + _replicate(
+        "b", [0.01, 0.01, 0.01], "ic", regions=("US", "EU", "JP")
     )
     with pytest.warns(RuntimeWarning, match="heterogeneous condition"):
         partial_conjunction(
-            results, primary=[ic], min_pass=2, expand_over=("region",), q=0.5
+            results, primary=["ic"], min_pass=2, expand_over=("region",), q=0.5
         )


### PR DESCRIPTION
## Summary
- Replaced `MetricSpec` object dependencies with string metric names across result-side FDR tools (`bhy`, `compare`, `partial_conjunction`, `bhy_hierarchical`).
- Fixed tests to supply string literals, ensuring result containers are strictly decoupled from metric definitions post-computation.

## Test plan
- [x] `uv run pytest tests` pass (excluding intentionally broken bench tests)
- [x] `uv run ruff check .` pass

Closes #521