### PR TITLE
refactor(bench): migrate scenarios to new evaluate API (#465)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,10 +64,7 @@ jobs:
         run: uv sync --frozen --python ${{ matrix.python }} --all-extras
 
       - name: Run pytest
-        # tests/bench/ ignored — scenarios still call the retired
-        # AnalysisConfig API and assert setup_s populated. Re-enable
-        # after #465 migrates bench to the new evaluate signature.
-        run: uv run --python ${{ matrix.python }} pytest --ignore=tests/bench
+        run: uv run --python ${{ matrix.python }} pytest
 
   doctest:
     name: pytest --doctest-modules
@@ -124,35 +121,30 @@ jobs:
   #           echo "::endgroup::"
   #         done
 
-  # bench-tiny smoke disabled — bench/ scenarios still call the retired
-  # evaluate(panel, cfg, ...) / run_metrics signatures and emit JSONL
-  # status:"error" records that the harness swallows into exit 0,
-  # making the smoke step falsely green. Re-enable after #465 migrates
-  # scenarios + adds fail-on-error gating.
-  # bench-tiny:
-  #   name: bench-tiny smoke
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 5
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #
-  #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v7
-  #       with:
-  #         version: "0.8.x"
-  #         enable-cache: true
-  #
-  #     - name: Install dependencies
-  #       run: uv sync --frozen --python 3.12 --all-extras
-  #
-  #     - name: Run bench-tiny (harness smoke; perf not asserted)
-  #       env:
-  #         OMP_NUM_THREADS: "1"
-  #         OPENBLAS_NUM_THREADS: "1"
-  #         MKL_NUM_THREADS: "1"
-  #         VECLIB_MAXIMUM_THREADS: "1"
-  #         NUMEXPR_NUM_THREADS: "1"
-  #       run: uv run python -m bench --target tiny --output "$RUNNER_TEMP/bench-tiny"
+  bench-tiny:
+    name: bench-tiny smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --python 3.12 --all-extras
+
+      - name: Run bench-tiny (harness smoke; perf not asserted)
+        env:
+          OMP_NUM_THREADS: "1"
+          OPENBLAS_NUM_THREADS: "1"
+          MKL_NUM_THREADS: "1"
+          VECLIB_MAXIMUM_THREADS: "1"
+          NUMEXPR_NUM_THREADS: "1"
+        run: uv run python -m bench --target tiny --output "$RUNNER_TEMP/bench-tiny"
 
   build:
     name: wheel build + import smoke

--- a/bench/README.md
+++ b/bench/README.md
@@ -26,7 +26,7 @@ sub-issues. This README describes the current surface only.
   scale ↔ axis_cell mismatch.
 - `bench.metric_sets` — pinned `core` / `heavy` / `algo` / `event`
   bundles + `METRIC_SET_VERSION`, independent of
-  `factrix.run_metrics` defaults so a default-set tweak in factrix
+  `factrix.evaluate` defaults so a default-set tweak in factrix
   cannot silently shift baselines.
 - `bench.scenarios.*` — scenario implementations grouped by
   analysis-axis cell (see scenario reference below).
@@ -85,7 +85,7 @@ ad-hoc warm runs skip the subprocess overhead.
 
 | `scenario_id` | Cell | Compute |
 |---|---|---|
-| `S1` | Continuous × Individual | Single factor through `evaluate` + `run_metrics` + bootstrap CI on the IC series |
+| `S1` | Continuous × Individual | Single factor through `evaluate` + bootstrap CI on the IC series |
 | `S2` | Continuous × Individual | 50-factor screen with the `core` metric set per factor |
 | `S3` | Continuous × Individual | 200-factor screen with the `core` metric set per factor |
 | `S4` | Continuous × Individual | Greedy forward selection over a candidate factor pool |
@@ -262,7 +262,7 @@ and event-clustering structure of real markets are not reproduced.
   warm, before vs. after an optimisation, machine A vs. machine B).
 - Do **not** use them to predict production runtime on real
   factors, or to validate that a metric's statistical behaviour is
-  correct — that is what `tests/` and `factrix.run_metrics`
+  correct — that is what `tests/` and `factrix.evaluate`
   invariants are for.
 - `dataset_spec_version` is bumped any time the generator default
   parameters move (IC strength, correlation level, etc.); baselines

--- a/bench/__main__.py
+++ b/bench/__main__.py
@@ -20,6 +20,7 @@ subprocess overhead.
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from collections.abc import Callable
@@ -66,6 +67,19 @@ def _run_one(
     output = output_dir / f"{scenario_id}.jsonl"
     output.parent.mkdir(parents=True, exist_ok=True)
     fn(output, preset=preset, cache_state=cache_state, threads=threads)
+
+    # Fail-fast on scenario errors so CI smoke runs turn red
+    with open(output, encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                record = json.loads(line)
+                if record.get("status") == "error":
+                    print(
+                        f"Scenario {scenario_id} failed: {record.get('error_message')}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+
     return output
 
 

--- a/bench/metric_sets.py
+++ b/bench/metric_sets.py
@@ -1,9 +1,9 @@
-"""Pinned metric sets — independent of ``factrix.run_metrics`` defaults
+"""Pinned metric sets — independent of ``factrix.evaluate`` defaults
 so a default-set tweak in factrix cannot silently shift the baseline.
 
-Each ``MetricSet`` declares the names ``run_metrics`` should dispatch
-(``run_metrics_names``) and an optional ``custom`` callable for paths
-that don't live behind ``run_metrics`` (e.g. ``greedy_forward_selection``,
+Each ``MetricSet`` declares the names ``evaluate`` should dispatch
+(``metric_specs``) and an optional ``custom`` callable for paths
+that don't live behind ``evaluate`` (e.g. ``greedy_forward_selection``,
 direct ``bootstrap_mean_ci``). Scenarios pick a set + cell and the
 helper in ``bench.scenarios._helpers`` does the dispatch.
 """
@@ -14,6 +14,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from factrix import MetricSpec, spec_by_name
+
 # Bumped when a metric set's membership / parameterization changes in
 # a way that should refuse silent comparison against earlier baselines.
 METRIC_SET_VERSION = "1"
@@ -23,21 +25,23 @@ METRIC_SET_VERSION = "1"
 class MetricSet:
     """A pinned bundle of metric calls.
 
-    ``run_metrics_names`` is passed straight to
-    ``factrix.run_metrics(metrics=...)``. ``custom`` is run on the same
-    panel afterwards; its return value is discarded — the harness times
-    the call, not the result. Scenarios that want to time a non-
-    ``run_metrics`` path (algo / bootstrap primitives) declare it here.
+    ``metric_specs`` dictates the bundle dispatched through ``factrix.evaluate``.
+    ``custom`` is run on the same panel afterwards; its return value is
+    discarded — the harness times the call, not the result. Scenarios
+    that want to time a path without metrics (algo / bootstrap primitives)
+    declare it here.
     """
 
     name: str
-    run_metrics_names: tuple[str, ...]
+    metric_specs: tuple[MetricSpec, ...]
     custom: Callable[..., Any] | None = field(default=None, repr=False)
 
 
 CORE = MetricSet(
     name="core",
-    run_metrics_names=("ic", "quantile_spread", "monotonicity"),
+    metric_specs=tuple(
+        spec_by_name()[n] for n in ("ic", "quantile_spread", "monotonicity")
+    ),
 )
 
 HEAVY = MetricSet(
@@ -46,25 +50,25 @@ HEAVY = MetricSet(
     # automatically extends `heavy` — `heavy = core + bootstrap` is
     # the conceptual relationship, not two parallel literals.
     # Bootstrap supplement is layered at the scenario level (S1 /
-    # M-ic-boot) rather than via run_metrics, so it lives outside
+    # M-ic-boot) rather than via evaluate, so it lives outside
     # this tuple.
-    run_metrics_names=CORE.run_metrics_names,
+    metric_specs=CORE.metric_specs,
 )
 
 ALGO = MetricSet(
     name="algo",
-    run_metrics_names=(),
+    metric_specs=(),
 )
 
 EVENT = MetricSet(
     name="event",
-    # Only `corrado_rank_test` dispatches through ``run_metrics``;
+    # Only `corrado_rank` dispatches through ``evaluate``;
     # ``caar`` and ``mfe_mae_summary`` require pre-computed event-row
     # inputs and are called directly by the sparse scenario. The set
     # name is the JSONL label for the conceptual bundle; the
-    # ``run_metrics_names`` tuple reflects what ``run_metrics`` can
+    # ``metric_specs`` tuple reflects what ``evaluate`` can
     # actually take.
-    run_metrics_names=("corrado_rank_test",),
+    metric_specs=(spec_by_name()["corrado_rank"],),
 )
 
 

--- a/bench/scenarios/__init__.py
+++ b/bench/scenarios/__init__.py
@@ -1,7 +1,7 @@
 """Benchmark scenario modules, grouped by analysis-axis cell.
 
 - ``continuous`` — Continuous × Individual scenarios.
-- ``algo`` — scenarios that bypass ``run_metrics`` (greedy forward
+- ``algo`` — scenarios that bypass ``evaluate`` (greedy forward
   selection).
 - ``sparse`` — Sparse × Individual scenarios (event-study).
 - ``dummy`` — minimal end-to-end smoke proving wrapper → JSONL →

--- a/bench/scenarios/_helpers.py
+++ b/bench/scenarios/_helpers.py
@@ -210,13 +210,6 @@ def factor_columns(panel: pl.DataFrame) -> list[str]:
     return sorted(c for c in panel.columns if c.startswith("factor_"))
 
 
-def make_cfg() -> fx.AnalysisConfig:
-    """Canonical continuous × individual config used across scenarios."""
-    return fx.AnalysisConfig.individual_continuous(
-        forward_periods=DEFAULT_FORWARD_PERIODS
-    )
-
-
 def write_and_validate(output: Path, records: list[BenchRecord]) -> None:
     """Write records as JSONL and read them back through ``validate_file``.
 
@@ -294,7 +287,7 @@ def run_continuous_scenario(
     scenario_id: str,
     metric_set: MetricSet,
     scale: ContinuousScale,
-    compute: Callable[[pl.DataFrame, fx.AnalysisConfig], Any],
+    compute: Callable[[pl.DataFrame, tuple[fx.MetricSpec, ...]], Any],
     output: Path | None,
     warmup: bool = True,
     cache_state: CacheState = "warm",
@@ -303,8 +296,8 @@ def run_continuous_scenario(
 ) -> list[BenchRecord]:
     """Run a Continuous × Individual scenario.
 
-    ``compute`` receives the prepared panel and a default config; what
-    it does inside (``run_metrics(metrics=...)``, direct algo call,
+    ``compute`` receives the prepared panel and the resolved metric specs;
+    what it does inside (``evaluate(metrics=...)``, direct algo call,
     bootstrap primitives) is up to the scenario — the helper only
     knows about timing + JSONL + validation.
 
@@ -312,12 +305,12 @@ def run_continuous_scenario(
     """
     pre = preflight(threads=threads, seed=seed)
 
-    def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
-        return build_panel(scale, seed=seed), make_cfg()
+    def setup() -> tuple[pl.DataFrame, tuple[fx.MetricSpec, ...]]:
+        return build_panel(scale, seed=seed), metric_set.metric_specs
 
-    def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> Any:
-        panel, cfg = artifact
-        return compute(panel, cfg)
+    def compute_step(artifact: tuple[pl.DataFrame, tuple[fx.MetricSpec, ...]]) -> Any:
+        panel, specs = artifact
+        return compute(panel, specs)
 
     return run_scenario(
         scenario_id=scenario_id,
@@ -338,7 +331,7 @@ def run_sparse_scenario(
     scenario_id: str,
     metric_set: MetricSet,
     scale: SparseScale,
-    compute: Callable[[pl.DataFrame, fx.AnalysisConfig], Any],
+    compute: Callable[[pl.DataFrame, tuple[fx.MetricSpec, ...]], Any],
     output: Path | None,
     warmup: bool = True,
     cache_state: CacheState = "warm",
@@ -358,15 +351,13 @@ def run_sparse_scenario(
     n_events = count_events(build_event_panel(scale, seed=seed))
     scale_dict = scale.as_scale_field(n_events=n_events)
 
-    def setup() -> tuple[pl.DataFrame, fx.AnalysisConfig]:
+    def setup() -> tuple[pl.DataFrame, tuple[fx.MetricSpec, ...]]:
         panel = build_event_panel(scale, seed=seed)
-        return panel, fx.AnalysisConfig.individual_sparse(
-            forward_periods=DEFAULT_FORWARD_PERIODS
-        )
+        return panel, metric_set.metric_specs
 
-    def compute_step(artifact: tuple[pl.DataFrame, fx.AnalysisConfig]) -> Any:
-        panel, cfg = artifact
-        return compute(panel, cfg)
+    def compute_step(artifact: tuple[pl.DataFrame, tuple[fx.MetricSpec, ...]]) -> Any:
+        panel, specs = artifact
+        return compute(panel, specs)
 
     return run_scenario(
         scenario_id=scenario_id,

--- a/bench/scenarios/algo.py
+++ b/bench/scenarios/algo.py
@@ -1,6 +1,6 @@
 """Algo scenarios — ``greedy_forward_selection``.
 
-`greedy_forward_selection` does not live behind ``factrix.run_metrics``;
+`greedy_forward_selection` does not live behind ``factrix.evaluate``;
 it consumes a ``dict[str, pl.DataFrame]`` of per-factor spread series.
 The scenario therefore splits the work explicitly:
 

--- a/bench/scenarios/continuous.py
+++ b/bench/scenarios/continuous.py
@@ -25,6 +25,7 @@ from factrix.stats import bootstrap_mean_ci, bootstrap_mean_ci_batch
 from bench import metric_sets
 from bench.metric_sets import MetricSet
 from bench.scenarios._helpers import (
+    DEFAULT_FORWARD_PERIODS,
     factor_columns,
     resolve_scale,
     run_continuous_scenario,
@@ -56,7 +57,7 @@ def _bootstrap_ic_per_factor(
 ) -> int:
     # Batch the IC compute across factors (one polars query) and the
     # bootstrap (one shared block-index matrix). compute_ic is called
-    # directly (not via fx.run_metrics) because run_metrics' IC stage-1
+    # directly (not via fx.evaluate) because evaluate's IC stage-1
     # is shaped for the t-test consumers (ic / ic_newey_west / ic_ir),
     # not for downstream non-metric numpy work like bootstrap.
     ic_results = compute_ic(panel, factor_cols=factors)
@@ -66,7 +67,7 @@ def _bootstrap_ic_per_factor(
 
 
 # ---------------------------------------------------------------------------
-# S1 — single factor: evaluate + run_metrics(heavy)
+# S1 — single factor: evaluate(heavy)
 # ---------------------------------------------------------------------------
 
 
@@ -78,18 +79,21 @@ def s1_evaluate(
     cache_state: CacheState = "warm",
     threads: int = 1,
 ) -> list[BenchRecord]:
-    """S1: single factor through ``evaluate`` + ``run_metrics(heavy)``.
+    """S1: single factor through ``evaluate(heavy)``.
 
     Fixed scale: 1 factor; dates / assets follow the preset.
     """
     scale = resolve_scale(preset, n_factors=1)
     heavy = metric_sets.HEAVY
 
-    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+    def compute(panel: pl.DataFrame, specs: tuple[fx.MetricSpec, ...]) -> int:
         col = factor_columns(panel)[0]
-        fx.evaluate(panel, cfg, factor_cols=[col])
-        fx.run_metrics(
-            panel, cfg, factor_cols=[col], metrics=list(heavy.run_metrics_names)
+        metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}
+        fx.evaluate(
+            panel,
+            metrics=metric_instances,
+            factor_cols=[col],
+            forward_periods=DEFAULT_FORWARD_PERIODS,
         )
         ic_df = compute_ic(panel, factor_cols=[col])[col]
         bootstrap_mean_ci(ic_df["ic"].to_numpy(), n_bootstrap=BOOTSTRAP_N, seed=seed)
@@ -125,14 +129,15 @@ def _screen(
     scale = resolve_scale(preset, n_factors=n_factors)
     core = metric_sets.CORE
 
-    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
-        bundles = fx.run_metrics(
+    def compute(panel: pl.DataFrame, specs: tuple[fx.MetricSpec, ...]) -> int:
+        metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}
+        results = fx.evaluate(
             panel,
-            cfg,
+            metrics=metric_instances,
             factor_cols=factor_columns(panel),
-            metrics=list(core.run_metrics_names),
+            forward_periods=DEFAULT_FORWARD_PERIODS,
         )
-        return sum(len(b.metrics) for b in bundles.values())
+        return len(results)
 
     return run_continuous_scenario(
         scenario_id=scenario_id,
@@ -252,9 +257,15 @@ def _evaluate_batch(
 ) -> list[BenchRecord]:
     scale = resolve_scale(preset, n_factors=n_factors)
 
-    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
-        profiles = fx.evaluate(panel, cfg, factor_cols=factor_columns(panel))
-        return len(profiles)
+    def compute(panel: pl.DataFrame, specs: tuple[fx.MetricSpec, ...]) -> int:
+        metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}
+        results = fx.evaluate(
+            panel,
+            metrics=metric_instances,
+            factor_cols=factor_columns(panel),
+            forward_periods=DEFAULT_FORWARD_PERIODS,
+        )
+        return len(results)
 
     return run_continuous_scenario(
         scenario_id=scenario_id,
@@ -332,13 +343,17 @@ def _micro(
     # from "ran a single metric to attribute its cost". Stuffing both
     # under `core` would let an aggregator double-count M-ic + S2 as
     # combined core cost when M-ic is a strict subset of S2's work.
-    label = MetricSet(name=metric_name, run_metrics_names=(metric_name,))
+    label = MetricSet(name=metric_name, metric_specs=(fx.spec_by_name()[metric_name],))
 
-    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
-        bundles = fx.run_metrics(
-            panel, cfg, factor_cols=factor_columns(panel), metrics=[metric_name]
+    def compute(panel: pl.DataFrame, specs: tuple[fx.MetricSpec, ...]) -> int:
+        metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}
+        results = fx.evaluate(
+            panel,
+            metrics=metric_instances,
+            factor_cols=factor_columns(panel),
+            forward_periods=DEFAULT_FORWARD_PERIODS,
         )
-        return sum(len(b.metrics) for b in bundles.values())
+        return len(results)
 
     return run_continuous_scenario(
         scenario_id=scenario_id,
@@ -423,7 +438,7 @@ def m_ic_bootstrap(
     """Cost of the bootstrap path on a per-factor IC series.
 
     Unlike the other single-metric scenarios this one does **not** go
-    through ``run_metrics``; it times ``compute_ic`` +
+    through ``evaluate``; it times ``compute_ic`` +
     ``bootstrap_mean_ci`` directly so the bootstrap cost is
     attributable separately from the IC computation.
     """
@@ -433,10 +448,10 @@ def m_ic_bootstrap(
     # Single-metric attribution: label by what is actually being
     # timed (compute_ic + bootstrap_mean_ci), parallel to the other
     # micros. The `heavy` bundle is reserved for S1 which times the
-    # full evaluate + run_metrics + bootstrap path together.
-    label = MetricSet(name="ic_bootstrap", run_metrics_names=())
+    # full evaluate + bootstrap path together.
+    label = MetricSet(name="ic_bootstrap", metric_specs=())
 
-    def compute(panel: pl.DataFrame, _cfg: fx.AnalysisConfig) -> int:
+    def compute(panel: pl.DataFrame, _specs: tuple[fx.MetricSpec, ...]) -> int:
         return _bootstrap_ic_per_factor(panel, factor_columns(panel), seed=seed)
 
     return run_continuous_scenario(

--- a/bench/scenarios/dummy.py
+++ b/bench/scenarios/dummy.py
@@ -17,7 +17,7 @@ from bench.preflight import preflight
 from bench.scenarios._helpers import AXIS_CELL_CONT_IND, run_scenario
 from bench.schema import BenchRecord
 
-_DUMMY_SET = MetricSet(name="dummy", run_metrics_names=())
+_DUMMY_SET = MetricSet(name="dummy", metric_specs=())
 
 
 def run(

--- a/bench/scenarios/sparse.py
+++ b/bench/scenarios/sparse.py
@@ -3,7 +3,7 @@
 The sparse cell exercises a different factrix code path from the
 continuous one: ``corrado_rank_test`` is loop-heavy with a
 permutation-style bootstrap, ``compute_caar`` and ``compute_mfe_mae``
-are direct (not behind ``run_metrics``) and run on the same panel.
+are direct (not behind ``evaluate``) and run on the same panel.
 
 `compute_caar` / `compute_mfe_mae` consume the canonical event panel
 (``date, asset_id, factor, forward_return`` with sparse ``factor``)
@@ -23,6 +23,7 @@ from factrix.metrics.mfe_mae import compute_mfe_mae, mfe_mae_summary
 
 from bench.metric_sets import EVENT, MetricSet
 from bench.scenarios._helpers import (
+    DEFAULT_FORWARD_PERIODS,
     resolve_sparse_scale,
     run_sparse_scenario,
 )
@@ -35,9 +36,15 @@ _MFE_WINDOW = 10
 _MFE_ESTIMATION_WINDOW = 30
 
 
-def _run_event_bundle(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
+def _run_event_bundle(panel: pl.DataFrame, specs: tuple[fx.MetricSpec, ...]) -> int:
     """Run the three event-cell metrics on the panel."""
-    fx.run_metrics(panel, cfg, metrics=["corrado_rank_test"])
+    metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}
+    fx.evaluate(
+        panel,
+        metrics=metric_instances,
+        factor_cols=["factor"],
+        forward_periods=DEFAULT_FORWARD_PERIODS,
+    )
     caar(compute_caar(panel))
     mfe_mae_summary(
         compute_mfe_mae(
@@ -83,11 +90,17 @@ def m_corrado(
     continuous cell.
     """
     label = MetricSet(
-        name="corrado_rank_test", run_metrics_names=("corrado_rank_test",)
+        name="corrado_rank", metric_specs=(fx.spec_by_name()["corrado_rank"],)
     )
 
-    def compute(panel: pl.DataFrame, cfg: fx.AnalysisConfig) -> int:
-        fx.run_metrics(panel, cfg, metrics=["corrado_rank_test"])
+    def compute(panel: pl.DataFrame, specs: tuple[fx.MetricSpec, ...]) -> int:
+        metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}
+        fx.evaluate(
+            panel,
+            metrics=metric_instances,
+            factor_cols=["factor"],
+            forward_periods=DEFAULT_FORWARD_PERIODS,
+        )
         return 1
 
     return run_sparse_scenario(

--- a/bench/ux_targets.py
+++ b/bench/ux_targets.py
@@ -45,7 +45,7 @@ class UxTarget:
 UX_TARGETS: dict[str, UxTarget] = {
     "S1": UxTarget(
         wall_s_max=5.0,
-        description="Single factor evaluate + run_metrics — interactive notebook",
+        description="Single factor evaluate — interactive notebook",
     ),
     "S2": UxTarget(
         wall_s_max=30.0,

--- a/tests/bench/test_algo_scenarios.py
+++ b/tests/bench/test_algo_scenarios.py
@@ -18,6 +18,7 @@ def test_s4_runs_and_validates(tmp_path: Path):
     assert records[1].is_warmup is False
     assert all(r.scenario_id == "S4" for r in records)
     assert all(r.metric_set == "algo" for r in records)
+    assert all(r.status == "ok" for r in records)
 
 
 def test_s4_setup_compute_split(tmp_path: Path):

--- a/tests/bench/test_continuous_scenarios.py
+++ b/tests/bench/test_continuous_scenarios.py
@@ -29,6 +29,7 @@ def test_every_scenario_runs_and_validates(tmp_path: Path):
         assert records, sid
         assert all(r.scenario_id == sid for r in records)
         assert all(r.axis_cell == "continuous_individual_panel" for r in records)
+        assert all(r.status == "ok" for r in records)
 
 
 def test_setup_compute_split(tmp_path: Path):

--- a/tests/bench/test_metric_sets.py
+++ b/tests/bench/test_metric_sets.py
@@ -12,7 +12,7 @@ def test_version_pinned():
 
 
 def test_core_membership():
-    assert metric_sets.CORE.run_metrics_names == (
+    assert tuple(s.name for s in metric_sets.CORE.metric_specs) == (
         "ic",
         "quantile_spread",
         "monotonicity",
@@ -23,22 +23,22 @@ def test_heavy_extends_core():
     # `heavy` shares the core metric list; the bootstrap supplement
     # is layered on at the scenario level (see continuous.s1_evaluate
     # / m_ic_bootstrap) so the JSONL `metric_set` label stays clean.
-    assert metric_sets.HEAVY.run_metrics_names == metric_sets.CORE.run_metrics_names
+    assert metric_sets.HEAVY.metric_specs == metric_sets.CORE.metric_specs
 
 
 def test_event_set_lists_only_run_metrics_dispatchable():
     # `caar` and `mfe_mae_summary` are part of the event bundle
     # conceptually but require pre-computed event-row inputs;
-    # `run_metrics_names` must contain only metrics `run_metrics`
+    # `metric_specs` must contain only metrics `evaluate`
     # can dispatch directly.
-    assert metric_sets.EVENT.run_metrics_names == ("corrado_rank_test",)
+    assert tuple(s.name for s in metric_sets.EVENT.metric_specs) == ("corrado_rank",)
 
 
 def test_algo_is_run_metrics_empty():
     # `algo` (`greedy_forward_selection`) does not live behind
-    # run_metrics; the set is a label slot and the scenario calls the
+    # evaluate; the set is a label slot and the scenario calls the
     # function directly.
-    assert metric_sets.ALGO.run_metrics_names == ()
+    assert metric_sets.ALGO.metric_specs == ()
 
 
 def test_get_known_and_unknown():

--- a/tests/bench/test_sparse_scenarios.py
+++ b/tests/bench/test_sparse_scenarios.py
@@ -17,6 +17,7 @@ def test_every_sparse_scenario_runs_and_validates(tmp_path: Path):
         assert records, sid
         assert all(r.scenario_id == sid for r in records)
         assert all(r.axis_cell == "sparse_individual_panel" for r in records)
+        assert all(r.status == "ok" for r in records)
 
 
 def test_s5_uses_event_bundle_label(tmp_path: Path):
@@ -31,7 +32,7 @@ def test_m_corrado_labels_by_single_metric(tmp_path: Path):
     distinguish single-metric attribution from whole-bundle runs."""
     out = tmp_path / "M.jsonl"
     records = m_corrado(out, preset="tiny")
-    assert all(r.metric_set == "corrado_rank_test" for r in records)
+    assert all(r.metric_set == "corrado_rank" for r in records)
 
 
 def test_scale_records_realised_event_count(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Migrate all bench scenarios to the new `fx.evaluate` signature.
- Remove references to deprecated `AnalysisConfig` and `run_metrics`.
- Update `MetricSet` in `bench/metric_sets.py` to use `metric_specs`.
- Make `bench-tiny` CI step fail-fast on scenario errors and re-enable it.

## Test plan
- [x] Run `pytest tests/bench/` locally (all 78 tests passed).
- [x] Verify `python -m bench --target tiny` raises errors correctly on failure instead of silently exiting 0.

## Implementation Notes & Issue Scope Discrepancies
- **Metric type discrepancy**: The issue `#465` body states: `"改為直接傳 metrics: list[MetricSpec]"`, but the actual `fx.evaluate` signature requires `metrics: dict[str, MetricBase]` as keyword-only. The implementation correctly instantiates the specs via `metric_instances = {s.name: getattr(fx.metrics, s.name)() for s in specs}` and passes this dictionary to `evaluate`.
- **MetricSets schema**: `bench/metric_sets.py` uses `metric_specs: tuple[MetricSpec, ...]` instead of `list` to preserve its frozen dataclass/immutable semantic.

Closes #465
