### PR TITLE
refactor(api)!: rename panel to data for consistency (#527)

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -79,7 +79,7 @@ triggers and fix paths:
 
 | Message hint | Trigger | Fix |
 |---|---|---|
-| `unknown metric='...'` | Typo or metric not applicable to the cell | `inspect_panel(panel).usable` enumerates the metrics applicable to a panel; `exc.suggestions` carries the top-3 fuzzy candidates. See [`list_metrics`](list-metrics.md) for the full catalog. |
+| `unknown metric='...'` | Typo or metric not applicable to the cell | `inspect_data(panel).usable` enumerates the metrics applicable to a panel; `exc.suggestions` carries the top-3 fuzzy candidates. See [`list_metrics`](list-metrics.md) for the full catalog. |
 | `unknown estimator='...'` | Typo or estimator not applicable to the cell | `list_estimators(scope, signal)` enumerates the applicable set. See [`list_estimators`](list-estimators.md). |
 | `unknown expand_over='...'` | Context key not present on every profile in the family | All profiles in the family must carry the key in `.context`; check that the caller is populating it consistently at `evaluate` time. See [Cross-function reference § `expand_over`](decision-tree.md#expand_over-is-not-one-concept) for the three different `expand_over` semantics across functions. |
 | `expand_over=[...] requires every profile to carry key 'X'` | One or more profiles missing the key | Confirm the upstream `evaluate` call records the key in `context=...`. |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -82,7 +82,7 @@ Click any node to jump to its API page. Nodes are grouped into category subgraph
 | Slice exploration (single axis) | `by_slice(metric, df, label="...")` → `SliceResult` |
 | Slice statistical test | `slice_pairwise_test(metric, df, label="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
 | Metric catalog discovery | `list_metrics()` → family-grouped `dict` of specs |
-| Per-panel applicability | `inspect_panel(panel)` → `.usable` / `.degraded` / `.unusable` |
+| Per-panel applicability | `inspect_data(panel)` → `.usable` / `.degraded` / `.unusable` |
 | Multi-factor screening with false discovery rate (FDR) | `[evaluate(panel, cfg_i) for cfg_i in cfgs]` → `multi_factor.bhy(profiles)` |
 | Cross-factor leaderboard | `compare(profiles)` / `compare(survivors)` → `pl.DataFrame` |
 
@@ -101,7 +101,7 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 | [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction p-values (Benjamini-Heller 2008) → BHY. | "Factor X passes in ≥ k of m contexts." |
 | [`bhy_hierarchical`](bhy-hierarchical.md) | Screening (FDR) | Hierarchical FDR (Yekutieli 2008) — outer BHY on group representatives, inner BHY within passing groups. | Factor families / nested-context structure. |
 | [`compare`](compare.md) | Descriptive view | Cross-factor leaderboard — stacks evaluation / `Survivors` artifacts into a `pl.DataFrame` (no recompute). | Ranking N candidate factors. |
-| [`list_metrics`](list-metrics.md) | Introspection | Family-grouped catalog of standalone `factrix.metrics.*` callables (no-arg). | Browsing the metric catalog; pair with `inspect_panel` for per-panel applicability. |
+| [`list_metrics`](list-metrics.md) | Introspection | Family-grouped catalog of standalone `factrix.metrics.*` callables (no-arg). | Browsing the metric catalog; pair with `inspect_data` for per-panel applicability. |
 | [`list_estimators`](list-estimators.md) | Introspection | Estimators applicable to a cell — inference-side twin of `list_metrics`. | Picking `estimator=` for screening functions. |
 | [`Metrics`](metrics/index.md) | Catalogue | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly. |
 | [`stats`](stats.md) | Catalogue | Estimator catalogue (`NeweyWest` / `HansenHodrick` / `WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`), StatCode pairs, FDR / bootstrap utilities. | Picking an inference method to pass through `estimator=`. |

--- a/docs/api/list-metrics.md
+++ b/docs/api/list-metrics.md
@@ -26,22 +26,22 @@ callables up from `factrix.metrics` and pass them to
 from factrix.metrics import ic, fm_beta, breakeven_cost
 ```
 
-## Per-cell applicability → `inspect_panel`
+## Per-cell applicability → `inspect_data`
 
 The former `list_metrics(scope, density)` cell filter — together with
 its `format="json"` and `with_import` knobs — is **retired** (#498). To
 learn which metrics actually run on a given panel, and which are
 degraded or blocked by sample floors, inspect a real panel with
-`inspect_panel`:
+`inspect_data`:
 
 ```python
-info = fx.inspect_panel(panel)
+info = fx.inspect_data(panel)
 [m.name for m in info.usable]     # production-safe metrics for this panel
 [m.name for m in info.degraded]   # run, but inference degraded
 [m.name for m in info.unusable]   # blocked (cell mismatch / sample floor)
 ```
 
-`inspect_panel` subsumes the old cell filter with a structure-aware,
+`inspect_data` subsumes the old cell filter with a structure-aware,
 sample-floor-aware verdict: each `MetricApplicability` carries the
 metric `name`, its callable class, and any `blockers` / `warnings`.
 Unlike the static cell filter, it accounts for the actual panel shape

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -146,6 +146,6 @@ For the subset applicable to a *specific panel* — accounting for its
 actual shape — inspect the panel and read the verdict partitions:
 
 ```python
-info = fx.inspect_panel(panel)
+info = fx.inspect_data(panel)
 [m.name for m in info.usable]   # production-safe metrics for this panel
 ```

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -5,7 +5,7 @@ plus an evaluate-time-derived ``DataStructure`` define the analysis
 cell. Resolve metric specs via ``spec_by_name()`` (or register custom ones
 with ``metric_spec`` + ``factrix.metrics.register``), dispatch through the
 DAG executor via ``evaluate()``, inspect a panel's applicable metrics via
-``inspect_panel()``, and aggregate across factors with ``multi_factor.bhy``
+``inspect_data()``, and aggregate across factors with ``multi_factor.bhy``
 for FDR-corrected screening.
 
 Single-factor::
@@ -56,6 +56,7 @@ from factrix._axis import (  # noqa: F401  DataStructure re-exported for namespa
 from factrix._codes import InfoCode, StatCode, WarningCode
 from factrix._compare import compare
 from factrix._dag import CycleError, DagExecutor, _Node
+from factrix._data_input import DataInput, _coerce_data
 from factrix._errors import (
     ConfigError,
     FactrixError,
@@ -65,12 +66,12 @@ from factrix._errors import (
     UserInputError,
 )
 from factrix._inspect import (
+    DataInspection,
+    DataProperties,
     MetricApplicability,
     MetricApplicabilityGroup,
-    PanelInspection,
-    PanelProperties,
     _detect_structure,
-    inspect_panel,
+    inspect_data,
 )
 from factrix._metric_index import (
     MetricSpec,
@@ -79,7 +80,6 @@ from factrix._metric_index import (
     metric_spec,
     spec_by_name,
 )
-from factrix._panel_input import PanelInput, _coerce_panel
 from factrix._results import (
     EvaluationResult,
     MetricResult,
@@ -96,7 +96,7 @@ from factrix.stats import list_estimators
 
 
 def evaluate(
-    panel: PanelInput,
+    data: DataInput,
     *,
     metrics: "dict[str, MetricBase]",
     factor_cols: list[str],
@@ -112,7 +112,7 @@ def evaluate(
     ``compute_ic`` etc.), and per-factor consumers run once per factor.
 
     Args:
-        panel: Long-format panel satisfying the four-column floor
+        data: Long-format data satisfying the four-column floor
             ``(date, asset_id, <factor_col>, forward_return)``. The
             three fixed-name columns ``(date, asset_id, forward_return)``
             are validated eagerly; the factor-column name is dynamic
@@ -127,16 +127,16 @@ def evaluate(
             metric **instance** from :mod:`factrix.metrics` (e.g.
             ``{"ic_5d": ic(), "spread": quantile_spread(n_quantiles=5)}``).
             Results key by these labels. Passing the bare class (``ic``
-            rather than ``ic()``), a ``str``, or a :class:`MetricSpec` is
+            rather than ``ic()``), a ``str`` or a :class:`MetricSpec` is
             rejected with a targeted error. One metric class may run under
             several labels with **different** config — e.g.
             ``{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}`` — via
             by-value DAG dedup (#494); shared upstream producers are computed
             once per distinct config.
-        factor_cols: Names of density columns on ``panel``. List-only —
+        factor_cols: Names of density columns on ``data``. List-only —
             single ``str`` is rejected. Non-empty, no duplicates, every
-            name must exist on ``panel``.
-        forward_periods: Default forward-return horizon (rows of the panel's
+            name must exist on ``data``.
+        forward_periods: Default forward-return horizon (rows of the data's
             time axis) for metrics left at their signature default. A
             per-instance value — ``ic(forward_periods=20)`` — always overrides
             it (#494). ``None`` (default) leaves every metric at its own
@@ -147,7 +147,7 @@ def evaluate(
             partition. ``None`` (default) uses the first ``metrics`` key
             (insertion order). Must be a key of ``metrics``.
         strict: When ``True`` (default), raise if any metric is
-            inapplicable to the panel (apply-time short-circuit to NaN).
+            inapplicable to the data (apply-time short-circuit to NaN).
             When ``False``, keep those as NaN outputs with attached
             warnings. Config-time / construct-time failures always raise.
 
@@ -162,9 +162,9 @@ def evaluate(
         UserInputError: ``metrics`` not a ``dict[str, Metric]`` of
             instances; ``primary`` not a metrics label; ``factor_cols``
             empty / single ``str`` / contains duplicates / references a
-            column not on ``panel``; ``panel`` missing a baseline column;
+            column not on ``data``; ``data`` missing a baseline column;
             a metric ``requires`` a producer absent from the registry; under
-            ``strict=True``, a metric inapplicable to the panel.
+            ``strict=True``, a metric inapplicable to the data.
 
     Examples:
         Single-factor IC + IC information ratio (IR):
@@ -172,9 +172,9 @@ def evaluate(
         >>> import factrix as fx
         >>> from factrix.metrics import ic, ic_ir
         >>> raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80)
-        >>> panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        >>> data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
         >>> results = fx.evaluate(
-        ...     panel,
+        ...     data,
         ...     metrics={"ic": ic(), "ic_ir": ic_ir()},
         ...     factor_cols=["factor"],
         ...     forward_periods=5,
@@ -187,9 +187,9 @@ def evaluate(
     _validate_metrics_arg(metrics)
     primary_label = _resolve_primary(metrics, primary)
     cols = _validate_factor_cols_arg(factor_cols)
-    panel = _coerce_panel(panel)
-    _validate_baseline_columns(panel)
-    _validate_factor_cols_on_panel(panel, cols)
+    data = _coerce_data(data)
+    _validate_baseline_columns(data)
+    _validate_factor_cols_on_data(data, cols)
 
     # label -> spec, plus per-instance params with forward_periods resolved
     # against the top-level default (an instance still at its signature default
@@ -205,7 +205,7 @@ def evaluate(
     node_to_label = {nid: label for label, nid in label_to_node.items()}
 
     primary_spec = label_spec[primary_label]
-    _validate_primary_metric_applicable(primary_spec, panel, strict)
+    _validate_primary_metric_applicable(primary_spec, data, strict)
 
     primary_cell = primary_spec.cell
     scope = (
@@ -223,7 +223,7 @@ def evaluate(
 
     executor = DagExecutor(nodes, primary_names=(primary_node,))
     result_dict = executor.execute(
-        panel,
+        data,
         cols,
         scope=scope,
         density=density,
@@ -240,7 +240,7 @@ def evaluate(
 
 _DOCS_METRICS = "api/evaluate#metrics"
 _DOCS_FACTOR_COLS = "api/evaluate#factor_cols"
-_DOCS_PANEL = "api/evaluate#panel"
+_DOCS_DATA = "api/evaluate#data"
 
 
 def _is_metrics_overview(metrics: object) -> bool:
@@ -272,7 +272,7 @@ def _validate_metrics_arg(metrics: object) -> None:
                 "a dict[str, Metric] of metric instances. fx.list_metrics() "
                 "returns an overview catalog (family -> specs), not runnable "
                 "metrics; construct the ones you want, e.g. {'ic': ic()}, or "
-                "pre-filter with factrix.inspect_panel(panel).usable"
+                "pre-filter with factrix.inspect_data(data).usable"
             ),
             docs_path=_DOCS_METRICS,
         )
@@ -498,7 +498,7 @@ def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
             expected=(
                 f"all metrics applicable to the panel. Inapplicable — {detail}. "
                 f"Pass strict=False to keep them as NaN with warnings, or "
-                f"pre-filter with [m.name for m in factrix.inspect_panel(panel).usable]."
+                f"pre-filter with [m.name for m in factrix.inspect_data(data).usable]."
             ),
             docs_path=_DOCS_METRICS,
         )
@@ -574,16 +574,16 @@ def _validate_factor_cols_arg(factor_cols: object) -> list[str]:
     return list(factor_cols)
 
 
-def _validate_factor_cols_on_panel(panel: pl.DataFrame, cols: list[str]) -> None:
-    missing = [c for c in cols if c not in panel.columns]
+def _validate_factor_cols_on_data(data: pl.DataFrame, cols: list[str]) -> None:
+    missing = [c for c in cols if c not in data.columns]
     if missing:
         raise UserInputError(
             func_name="evaluate",
             field="factor_cols",
             value=missing,
             expected=(
-                f"every name in factor_cols to exist on panel; "
-                f"got columns {list(panel.columns)!r}"
+                f"every name in factor_cols to exist on data; "
+                f"got columns {list(data.columns)!r}"
             ),
             docs_path=_DOCS_FACTOR_COLS,
         )
@@ -592,42 +592,42 @@ def _validate_factor_cols_on_panel(panel: pl.DataFrame, cols: list[str]) -> None
 _BASELINE_COLUMNS: tuple[str, ...] = ("date", "asset_id", "forward_return")
 
 
-def _validate_baseline_columns(panel: pl.DataFrame) -> None:
-    missing = [c for c in _BASELINE_COLUMNS if c not in panel.columns]
+def _validate_baseline_columns(data: pl.DataFrame) -> None:
+    missing = [c for c in _BASELINE_COLUMNS if c not in data.columns]
     if not missing:
         return
     if "forward_return" in missing:
         hint = (
             ". Attach forward_return:\n"
-            "    panel = factrix.preprocess.compute_forward_return("
-            "panel, forward_periods=<N>)"
+            "    data = factrix.preprocess.compute_forward_return("
+            "data, forward_periods=<N>)"
         )
     else:
         hint = ""
     raise UserInputError(
         func_name="evaluate",
-        field="panel",
-        value=list(panel.columns),
+        field="data",
+        value=list(data.columns),
         expected=(
-            f"panel must include baseline columns {list(_BASELINE_COLUMNS)!r}; "
+            f"data must include baseline columns {list(_BASELINE_COLUMNS)!r}; "
             f"missing {missing!r}{hint}"
         ),
-        docs_path=_DOCS_PANEL,
+        docs_path=_DOCS_DATA,
     )
 
 
 def _validate_primary_metric_applicable(
-    primary: MetricSpec, panel: pl.DataFrame, strict: bool
+    primary: MetricSpec, data: pl.DataFrame, strict: bool
 ) -> None:
-    """Reject a primary metric whose ``cell.structure`` disagrees with the panel.
+    """Reject a primary metric whose ``cell.structure`` disagrees with the data.
 
     DataStructure is the cheap pre-flight gate: IC / FM / quantile_spread declare
     ``cell.structure = DataStructure.PANEL`` and produce only NaN short-circuits on a
-    single-asset panel; surfacing that as a UserInputError keeps the
+    single-asset data; surfacing that as a UserInputError keeps the
     diagnostic specific instead of letting the executor return a result
     bundle whose every metric carries an ``UPSTREAM_UNAVAILABLE`` warning.
-    Cell-axis (scope / density) applicability requires panel detection
-    and is left to ``fx.inspect_panel`` for the explicit pre-flight path.
+    Cell-axis (scope / density) applicability requires data detection
+    and is left to ``fx.inspect_data`` for the explicit pre-flight path.
 
     Under ``strict=False`` this guard is skipped (#494 / #497 carry-over): per
     #476 §4 a structure mismatch is an apply-time failure, so the metric is
@@ -639,20 +639,20 @@ def _validate_primary_metric_applicable(
     cell_structure = primary.cell.structure
     if cell_structure is None:
         return
-    panel_structure = _detect_structure(panel)
-    if cell_structure is panel_structure:
+    data_structure = _detect_structure(data)
+    if cell_structure is data_structure:
         return
-    n_assets = int(panel["asset_id"].n_unique())
+    n_assets = int(data["asset_id"].n_unique())
     raise UserInputError(
         func_name="evaluate",
         field="metrics",
         value=primary.name,
         expected=(
             f"primary metric {primary.name!r} declares "
-            f"cell.structure={cell_structure.value!r} but panel has "
-            f"structure={panel_structure.value!r} (n_assets={n_assets}); "
-            f"call fx.inspect_panel(panel) to see metrics applicable "
-            f"to this panel shape"
+            f"cell.structure={cell_structure.value!r} but data has "
+            f"structure={data_structure.value!r} (n_assets={n_assets}); "
+            f"call fx.inspect_data(data) to see metrics applicable "
+            f"to this data shape"
         ),
         docs_path=_DOCS_METRICS,
     )
@@ -684,17 +684,17 @@ __all__ = [
     "EvaluationResult",
     "MetricResult",
     "MetricResultGroup",
-    "PanelInput",
+    "DataInput",
     "Warning",
     "compare",
     "evaluate",
     # Introspection
     "MetricApplicability",
     "MetricApplicabilityGroup",
-    "PanelInspection",
-    "PanelProperties",
+    "DataInspection",
+    "DataProperties",
     "SampleThreshold",
-    "inspect_panel",
+    "inspect_data",
     "list_estimators",
     "list_metrics",
     # Slicing dispatcher + cross-slice inference functions

--- a/factrix/_axis.py
+++ b/factrix/_axis.py
@@ -179,7 +179,7 @@ class Tier(StrEnum):
     """Usability tier for a metric on a given panel shape axis.
 
     Reflects the sample-floor verdict only (cell-match is evaluated
-    separately by ``inspect_panel``):
+    separately by ``inspect_data``):
 
     CLEAN: at or above the ``warn`` floor — fully usable, no warning.
     DEGRADED: between the ``min`` and ``warn`` floors — usable but inference

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -42,15 +42,15 @@ from factrix._results import (
 )
 
 
-def _project_factor(panel: pl.DataFrame, col: str) -> pl.DataFrame:
-    """Project ``panel`` to the canonical 4-column per-factor view.
+def _project_factor(data: pl.DataFrame, col: str) -> pl.DataFrame:
+    """Project ``data`` to the canonical 4-column per-factor view.
 
-    Non-batch primitives expect a panel whose factor column is literally
+    Non-batch primitives expect data whose factor column is literally
     named ``"factor"``; this projection renames ``col`` and drops any
     sibling columns so primitives see an identical schema regardless of
     the caller's ``factor_cols`` choice.
     """
-    return panel.select(
+    return data.select(
         pl.col("date"),
         pl.col("asset_id"),
         pl.col("forward_return"),
@@ -182,7 +182,7 @@ class DagExecutor:
 
     def execute(
         self,
-        panel: pl.DataFrame,
+        data: pl.DataFrame,
         factor_cols: Sequence[str],
         *,
         scope: FactorScope,
@@ -197,19 +197,19 @@ class DagExecutor:
         ``factor_cols=`` and the per-factor entries of its returned
         dict are unpacked into the cache. When false, the producer is
         called once per factor on a thin projection (only when at
-        least one downstream consumer needs it; raw-panel consumers
+        least one downstream consumer needs it; raw-data consumers
         skip projection).
         """
         kwargs_by_metric = kwargs_by_metric or {}
         cols = list(factor_cols)
-        n_assets = panel.select(pl.col("asset_id").n_unique()).item()
+        n_assets = data.select(pl.col("asset_id").n_unique()).item()
         structure = DataStructure.PANEL if n_assets > 1 else DataStructure.TIMESERIES
         projections: dict[str, pl.DataFrame] = {}
 
         def project(c: str) -> pl.DataFrame:
             view = projections.get(c)
             if view is None:
-                view = _project_factor(panel, c)
+                view = _project_factor(data, c)
                 projections[c] = view
             return view
 
@@ -234,7 +234,7 @@ class DagExecutor:
                 continue
 
             upstream = self._gather_upstream_batch(node, live, producer_outputs)
-            result = handle(panel, live, project=project, upstream=upstream)
+            result = handle(data, live, project=project, upstream=upstream)
             _validate_batch_result(node, live, result)
             for c in live:
                 out = result[c]
@@ -266,7 +266,7 @@ class DagExecutor:
         bare: Callable[..., Any] = fn
 
         def handle(
-            panel: pl.DataFrame,
+            data: pl.DataFrame,
             factor_cols: Sequence[str],
             *,
             project: Callable[[str], pl.DataFrame],
@@ -275,7 +275,7 @@ class DagExecutor:
             return _dispatch_batch(
                 call_one=lambda *a, **k: bare(*a, **{**kw, **k}),
                 run_batch=lambda: bare(
-                    panel, factor_cols=list(factor_cols), **upstream, **kw
+                    data, factor_cols=list(factor_cols), **upstream, **kw
                 ),
                 batchable=spec.batchable,
                 requires=tuple(spec.requires),

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import polars as pl
 
-type PanelInput = pl.DataFrame | pl.LazyFrame
+type DataInput = pl.DataFrame | pl.LazyFrame
 
 
 def _is_pandas_dataframe(obj: object) -> bool:
@@ -32,23 +32,23 @@ def _is_pandas_dataframe(obj: object) -> bool:
     return type(obj).__module__.split(".", 1)[0] == "pandas"
 
 
-def _coerce_panel(panel: PanelInput) -> pl.DataFrame:
-    """Coerce ``PanelInput`` to eager ``pl.DataFrame``.
+def _coerce_data(data: DataInput) -> pl.DataFrame:
+    """Coerce ``DataInput`` to eager ``pl.DataFrame``.
 
     ``pl.LazyFrame`` is collected immediately. ``pd.DataFrame`` is
     rejected with a ``TypeError`` that points to the documented
     conversion paths.
     """
-    if isinstance(panel, pl.DataFrame):
-        return panel
-    if isinstance(panel, pl.LazyFrame):
-        return panel.collect()
-    if _is_pandas_dataframe(panel):
+    if isinstance(data, pl.DataFrame):
+        return data
+    if isinstance(data, pl.LazyFrame):
+        return data.collect()
+    if _is_pandas_dataframe(data):
         raise TypeError(
-            "panel must be pl.DataFrame or pl.LazyFrame; got pandas DataFrame. "
+            "data must be pl.DataFrame or pl.LazyFrame; got pandas DataFrame. "
             "factrix is polars-native — convert with `pl.from_pandas(df)`, "
             "or use `factrix.adapt(df, ...)` if column renaming is needed."
         )
     raise TypeError(
-        f"panel must be pl.DataFrame or pl.LazyFrame; got {type(panel).__name__}."
+        f"data must be pl.DataFrame or pl.LazyFrame; got {type(data).__name__}."
     )

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -1,22 +1,22 @@
-"""``fx.inspect_panel`` — typed panel introspection with per-metric verdict (#443).
+"""``fx.inspect_data`` — typed data introspection with per-metric verdict (#443).
 
 Two-stage applicability model:
 
 1. **Cell match** — ``(scope, density, structure)`` axes on
-   :class:`MetricSpec.cell` must agree with the inspected panel's
-   :class:`PanelProperties`. DataStructure is integral to the match — a metric
+   :class:`MetricSpec.cell` must agree with the inspected data's
+   :class:`DataProperties`. DataStructure is integral to the match — a metric
    whose cell declares ``structure=DataStructure.PANEL`` (e.g. IC, which has no
-   cross-section in TIMESERIES) is unusable when the panel is
+   cross-section in TIMESERIES) is unusable when the data is
    single-asset, not just "degraded".
 2. **Sample floor** — :class:`MetricSpec.sample_floor` declares the
-   panel-shape thresholds below which the metric short-circuits
+   data-shape thresholds below which the metric short-circuits
    (``min_*``) or runs with a documented bias warning (``warn_*``).
-   :func:`inspect_panel` evaluates these against
-   :class:`PanelProperties`.
+   :func:`inspect_data` evaluates these against
+   :class:`DataProperties`.
 
 Each public spec receives one :class:`MetricApplicability` verdict
 exposing ``usable`` / ``warnings`` / ``blockers``. The flat
-``list[MetricApplicability]`` on :class:`PanelInspection.metrics` is
+``list[MetricApplicability]`` on :class:`DataInspection.metrics` is
 the single source of truth; the ``usable`` / ``degraded`` /
 ``unusable`` properties expose it as a mutually exclusive partition.
 """
@@ -41,11 +41,11 @@ if TYPE_CHECKING:
 _SPARSITY_THRESHOLD: float = 0.5
 
 
-def _detect_structure(panel: Any) -> DataStructure:
-    """Return ``TIMESERIES`` if the panel has a single asset, else ``PANEL``."""
+def _detect_structure(data: Any) -> DataStructure:
+    """Return ``TIMESERIES`` if the data has a single asset, else ``PANEL``."""
     return (
         DataStructure.TIMESERIES
-        if panel["asset_id"].n_unique() <= 1
+        if data["asset_id"].n_unique() <= 1
         else DataStructure.PANEL
     )
 
@@ -98,13 +98,13 @@ def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
 
 
 @dataclass(frozen=True, slots=True)
-class PanelProperties:
-    """Inspected panel properties driving cell dispatch.
+class DataProperties:
+    """Inspected data properties driving cell dispatch.
 
     Carries the dispatch axes (``scope`` / ``density`` / ``structure``
     as typed enums), the human-readable rationale for each axis decision
     (``scope_reason`` / ``density_reason`` / ``structure_reason``), and
-    the panel-shape numerics the user typically wants next to them
+    the data-shape numerics the user typically wants next to them
     (``n_assets`` / ``n_periods`` / ``n_pairs`` / ``sparse_ratio``).
     Named ``Properties`` rather than ``Axes`` because the numeric fields
     are not axes — they are observations supporting the axis decisions.
@@ -118,17 +118,17 @@ class PanelProperties:
         density: Detected :class:`FactorDensity`.
         density_reason: Human-readable rationale for ``density``.
         structure: Detected :class:`DataStructure` — ``TIMESERIES`` iff
-            ``n_assets == 1`` (single-asset panel), ``PANEL`` otherwise.
+            ``n_assets == 1`` (single-asset data), ``PANEL`` otherwise.
         structure_reason: Human-readable rationale for ``structure``.
         n_assets: Unique ``asset_id`` count under any-non-null union.
         n_periods: Unique ``date`` count under any-non-null union.
         n_pairs: Non-null ``(date, asset_id)`` factor observation
             count — the upper bound on usable sample size for any
             pair-counting metric (IC, rank-IC, FM cross-section).
-            Equals ``panel.height`` for a dense panel; smaller when
+            Equals ``data.height`` for a dense panel; smaller when
             the factor column has nulls.
         sparse_ratio: Zero-ratio in the ``factor`` column (denominator
-            is non-null cell count). ``math.nan`` for an empty panel.
+            is non-null cell count). ``math.nan`` for an empty data.
     """
 
     scope: FactorScope
@@ -145,7 +145,7 @@ class PanelProperties:
 
 @dataclass(frozen=True, slots=True)
 class MetricApplicability:
-    """Per-metric pre-flight verdict against one panel's properties.
+    """Per-metric pre-flight verdict against one data's properties.
 
     Attributes:
         metric: The :class:`~factrix.metrics._base.MetricBase` subclass
@@ -182,7 +182,7 @@ def _default_constructible(metric: Any) -> bool:
 
     Scalar-input utilities (e.g. ``breakeven_cost`` / ``net_spread``) declare
     required parameters (``turnover`` / ``forward_periods`` …) and consume
-    pre-aggregated scalars rather than a panel, so they are not part of the
+    pre-aggregated scalars rather than a data, so they are not part of the
     zero-config discovery -> :func:`factrix.evaluate` flow.
     """
     return all(
@@ -195,7 +195,7 @@ class MetricApplicabilityGroup(list["MetricApplicability"]):
     """A tier partition of :class:`MetricApplicability` verdicts.
 
     A ``list`` subclass — every list operation works — with discovery
-    helpers layered on. Returned by :attr:`PanelInspection.usable` /
+    helpers layered on. Returned by :attr:`DataInspection.usable` /
     ``degraded`` / ``unusable``.
     """
 
@@ -220,8 +220,8 @@ class MetricApplicabilityGroup(list["MetricApplicability"]):
         feed its default-constructed instances straight to
         :func:`factrix.evaluate`::
 
-            info = fx.inspect_panel(panel)
-            results = fx.evaluate(panel, metrics=info.usable.to_metrics_dict(),
+            info = fx.inspect_data(data)
+            results = fx.evaluate(data, metrics=info.usable.to_metrics_dict(),
                                   factor_cols=[...], forward_periods=5)
 
         Metrics whose class needs explicit construction arguments (the
@@ -231,27 +231,27 @@ class MetricApplicabilityGroup(list["MetricApplicability"]):
 
 
 @dataclass(frozen=True, slots=True)
-class PanelInspection:
-    """Result of :func:`inspect_panel`.
+class DataInspection:
+    """Result of :func:`inspect_data`.
 
     Pure data — no execution methods.
 
     Attributes:
-        detected: :class:`PanelProperties` with typed enum axes, the
+        detected: :class:`DataProperties` with typed enum axes, the
             per-axis rationale strings, and shape numerics.
         metrics: Flat ``list[MetricApplicability]`` — one verdict
             per ``visibility=PUBLIC`` spec the inspector considered.
             Single source of truth; the :attr:`usable` /
             :attr:`degraded` / :attr:`unusable` properties expose it
             as a mutually exclusive partition.
-        warnings: Panel-level sample-shape diagnostics (NW HAC SE
+        warnings: Data-level sample-shape diagnostics (NW HAC SE
             unreliable, cross-asset df low). ``source=None`` on
-            every entry because these are panel-level, not
+            every entry because these are data-level, not
             per-metric. Per-metric degraded warnings live inside
             each :class:`MetricApplicability`.
     """
 
-    detected: PanelProperties
+    detected: DataProperties
     metrics: list[MetricApplicability]
     warnings: list[Warning] = field(default_factory=list)
 
@@ -293,7 +293,7 @@ class PanelInspection:
 
     @property
     def unusable(self) -> MetricApplicabilityGroup:
-        """Metrics that cannot run on this panel.
+        """Metrics that cannot run on this data.
 
         ``usable=False`` — blocked by cell mismatch or a ``min_*``
         floor violation; :attr:`MetricApplicability.blockers` carries
@@ -314,8 +314,8 @@ class PanelInspection:
         - ``reasoning``: ``{scope, density, structure}``.
         - ``metrics``: list of per-spec dicts
           ``{name, cell, usable, warnings, blockers}`` — same row
-          shape suits ``pl.from_dicts`` for cross-panel audit.
-        - ``warnings``: panel-level ``[{code, source, message}, ...]``.
+          shape suits ``pl.from_dicts`` for cross-data audit.
+        - ``warnings``: data-level ``[{code, source, message}, ...]``.
 
         Mirrors :meth:`factrix.EvaluationResult.to_dict` shape — single
         ``to_dict`` convention across the public result-type group so
@@ -421,7 +421,7 @@ class PanelInspection:
                 for w in self.warnings
             )
             warnings_block = (
-                "<details open><summary>panel-level warnings "
+                "<details open><summary>data-level warnings "
                 f"({len(self.warnings)})</summary>"
                 "<table><thead><tr><th>code</th><th>message</th>"
                 "</tr></thead>"
@@ -429,8 +429,8 @@ class PanelInspection:
             )
 
         return (
-            "<div class='factrix-panel-inspection'>"
-            "<table><caption>PanelInspection — detected</caption>"
+            "<div class='factrix-data-inspection'>"
+            "<table><caption>DataInspection — detected</caption>"
             f"<tbody>{header_html}</tbody></table>"
             "<table><caption>reasoning</caption>"
             f"<tbody>{reasoning_rows}</tbody></table>"
@@ -439,14 +439,14 @@ class PanelInspection:
         )
 
 
-def inspect_panel(panel: Any) -> PanelInspection:
-    """Inspect a panel and return typed dispatch-axis + per-metric verdict.
+def inspect_data(data: Any) -> DataInspection:
+    """Inspect data and return typed dispatch-axis + per-metric verdict.
 
     Pre-flight introspection: typed detection plus, for every
-    ``visibility=PUBLIC`` :class:`MetricSpec` in the registry, a
+    ``role=SpecRole.METRIC`` :class:`MetricSpec` in the registry, a
     :class:`MetricApplicability` verdict combining (a) cell-match
     against the detected ``(scope, density, structure)`` and (b) the
-    spec's optional :class:`SampleThreshold` against the panel's
+    spec's optional :class:`SampleThreshold` against the data's
     ``n_periods`` / ``n_assets``.
 
     Sample-floor checks against ``n_events`` (factor-column-dependent)
@@ -454,32 +454,32 @@ def inspect_panel(panel: Any) -> PanelInspection:
     own short-circuit path.
 
     Args:
-        panel: Long-format panel with the canonical columns
+        data: Long-format factor data with the canonical columns
             ``date`` / ``asset_id`` / ``factor``.
 
     Returns:
-        :class:`PanelInspection`.
+        :class:`DataInspection`.
 
     Examples:
         >>> import factrix as fx
         >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
-        >>> info = fx.inspect_panel(raw)
+        >>> info = fx.inspect_data(raw)
         >>> all(m.spec.cell.matches(info.detected.scope, info.detected.density, info.detected.structure) for m in info.usable)
         True
     """
-    density, density_reason, sparse_ratio = _detect_density(panel)
-    scope, scope_reason = _detect_scope(panel)
-    structure = _detect_structure(panel)
-    n_assets = int(panel["asset_id"].n_unique())
-    n_periods = int(panel["date"].n_unique())
-    n_pairs = int(panel.drop_nulls("factor").height)
+    density, density_reason, sparse_ratio = _detect_density(data)
+    scope, scope_reason = _detect_scope(data)
+    structure = _detect_structure(data)
+    n_assets = int(data["asset_id"].n_unique())
+    n_periods = int(data["date"].n_unique())
+    n_pairs = int(data.drop_nulls("factor").height)
 
     structure_reason = (
         f"n_assets={n_assets} → "
-        f"{'TIMESERIES (single-asset panel)' if structure is DataStructure.TIMESERIES else 'PANEL'}"
+        f"{'TIMESERIES (single-asset data)' if structure is DataStructure.TIMESERIES else 'PANEL'}"
     )
 
-    properties = PanelProperties(
+    properties = DataProperties(
         scope=scope,
         scope_reason=scope_reason,
         density=density,
@@ -492,18 +492,18 @@ def inspect_panel(panel: Any) -> PanelInspection:
         sparse_ratio=sparse_ratio,
     )
 
-    panel_warnings = _panel_level_warnings(properties)
+    data_warnings = _data_level_warnings(properties)
     metrics = [_evaluate_applicability(spec, properties) for _, spec in public_specs()]
 
-    return PanelInspection(
+    return DataInspection(
         detected=properties,
         metrics=metrics,
-        warnings=panel_warnings,
+        warnings=data_warnings,
     )
 
 
 def _evaluate_applicability(
-    spec: MetricSpec, properties: PanelProperties
+    spec: MetricSpec, properties: DataProperties
 ) -> MetricApplicability:
     from factrix.metrics._registry import REGISTRY
 
@@ -554,10 +554,10 @@ def _evaluate_applicability(
     )
 
 
-def _panel_level_warnings(properties: PanelProperties) -> list[Warning]:
+def _data_level_warnings(properties: DataProperties) -> list[Warning]:
     """Sample-shape warnings the user can act on before running anything.
 
-    Panel-level (``source=None``) — not attributable to any single
+    Data-level (``source=None``) — not attributable to any single
     metric. Per-metric degraded warnings live on each
     :class:`MetricApplicability`.
     """

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -54,7 +54,7 @@ from factrix._axis import (
 )
 
 if TYPE_CHECKING:
-    from factrix._inspect import PanelProperties
+    from factrix._inspect import DataProperties
     from factrix.metrics._base import MetricBase
 
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -160,9 +160,9 @@ class SampleThreshold:
 
     Declares the sample-size floors below which a metric is
     statistically unusable (``min_*``) or runs with a documented
-    bias warning (``warn_*``). :func:`factrix.inspect_panel`
+    bias warning (``warn_*``). :func:`factrix.inspect_data`
     evaluates these against the inspected panel's
-    :class:`PanelProperties` and partitions specs into
+    :class:`DataProperties` and partitions specs into
     ``usable`` / ``unusable``.
 
     The same constants are read by the metric's own short-circuit
@@ -197,11 +197,11 @@ class SampleThreshold:
         """Return ``(min_<axis>, warn_<axis>)`` for one shape axis."""
         return getattr(self, f"min_{axis}"), getattr(self, f"warn_{axis}")
 
-    def iter_verdicts(self, properties: PanelProperties) -> Iterator[AxisVerdict]:
+    def iter_verdicts(self, properties: DataProperties) -> Iterator[AxisVerdict]:
         """Yield the per-axis verdict for each shape axis, in ``_AXES`` order.
 
         Single source of truth for the tier decision: ``per_axis_verdict``,
-        ``verdict`` and ``factrix.inspect_panel``'s blocker/warning assembly
+        ``verdict`` and ``factrix.inspect_data``'s blocker/warning assembly
         all consume this so the floor → tier mapping lives in exactly one
         place. Each yielded record also carries the actual ``n`` and the
         ``floor``/``warn`` bounds the decision was made against, so callers
@@ -218,11 +218,11 @@ class SampleThreshold:
                 tier = Tier.CLEAN
             yield AxisVerdict(axis=axis, n=n, floor=floor, warn=warn, tier=tier)
 
-    def per_axis_verdict(self, properties: PanelProperties) -> dict[str, Tier]:
+    def per_axis_verdict(self, properties: DataProperties) -> dict[str, Tier]:
         """Return the usability tier for each shape axis (periods, assets, pairs)."""
         return {v.axis: v.tier for v in self.iter_verdicts(properties)}
 
-    def verdict(self, properties: PanelProperties) -> Tier:
+    def verdict(self, properties: DataProperties) -> Tier:
         """Return the worst usability tier across all shape axes."""
         worst = Tier.CLEAN
         for v in self.iter_verdicts(properties):
@@ -272,7 +272,7 @@ class MetricSpec:
     - ``sample_threshold``: :class:`SampleThreshold` declaring the
       panel-shape thresholds below which the metric is statistically
       unusable / degraded. Defaults to ``SampleThreshold()`` (all
-      ``None`` — no pre-flight gate); :func:`inspect_panel` applies
+      ``None`` — no pre-flight gate); :func:`inspect_data` applies
       the cell-match check and any declared thresholds.
     """
 
@@ -653,9 +653,9 @@ def list_metrics() -> dict[str, list[MetricSpec]]:
 
     For per-cell applicability — which metrics actually run on a given
     panel, and which are degraded or blocked — inspect a real panel with
-    :func:`factrix.inspect_panel` and read its ``usable`` / ``degraded``
+    :func:`factrix.inspect_data` and read its ``usable`` / ``degraded``
     / ``unusable`` partitions. (The former ``list_metrics(scope, density)``
-    cell filter is retired; ``inspect_panel`` subsumes it with a
+    cell filter is retired; ``inspect_data`` subsumes it with a
     structure-aware, sample-floor-aware verdict.)
 
     Source of truth is the registered ``@metric`` classes in each

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -120,7 +120,7 @@ class Warning:
 class MetricResultGroup:
     """Group of metric outputs for one factor at one cell.
 
-    Mirrors the ``MetricGroups`` shape that #443 ``inspect_panel``
+    Mirrors the ``MetricGroups`` shape that #443 ``inspect_data``
     exposes: three ``list[str]`` key partitions plus dict-like access to
     the produced :class:`MetricResult` instances.
 

--- a/factrix/adapt.py
+++ b/factrix/adapt.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import polars.selectors as cs
 
-from factrix._panel_input import _is_pandas_dataframe
+from factrix._data_input import _is_pandas_dataframe
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -97,7 +97,7 @@ cross-section to compute IC across).
 # signature pending v0.14.0 docs rewrite
 ```
 
-`PanelInput = pl.DataFrame | pl.LazyFrame`. factrix is polars-native
+`DataInput = pl.DataFrame | pl.LazyFrame`. factrix is polars-native
 on its primary entry points; pandas users go through `factrix.adapt`
 (which also renames columns) or `pl.from_pandas` first. `LazyFrame`
 is collected at the API boundary (no projection / predicate pushdown
@@ -423,7 +423,7 @@ factrix.list_metrics() -> dict[str, list[MetricSpec]]
     # A reference catalog, not runnable — pass concrete factrix.metrics
     # callables to evaluate(). For per-panel applicability (which metrics
     # run / are degraded / are blocked on an actual panel) use
-    # inspect_panel(panel).usable / .degraded / .unusable. The former
+    # inspect_data(panel).usable / .degraded / .unusable. The former
     # list_metrics(scope, density) cell filter + format/with_import knobs
     # are retired (#498).
 
@@ -576,7 +576,7 @@ types-only; runner wiring lands with the DAG executor.
   - `_repr_html_()` → Jupyter rich render with primary / diagnostic
     role column and a collapsible warnings block.
 - **`MetricResultGroup`** — mirrors the `MetricGroups` shape from
-  `inspect_panel` (#443). Three `list[str]` (metric name) partitions
+  `inspect_data` (#443). Three `list[str]` (metric name) partitions
   (`applicable` / `primary` / `diagnostic`) plus dict-like access to
   the produced `MetricResult` instances (`__getitem__` / `keys` /
   `values` / `items` / `__iter__` all key by metric name).
@@ -615,10 +615,10 @@ types-only; runner wiring lands with the DAG executor.
   producer returned a short-circuit `MetricResult`. The downstream
   `MetricResult` carries `metadata["upstream"]` and
   `metadata["upstream_reason"]` for root-cause recovery.
-- **`fx.inspect_panel(panel) -> PanelInspection`** — typed
+- **`fx.inspect_data(panel) -> DataInspection`** — typed
   pre-flight introspection that combines axis detection with a
   per-metric usability verdict.
-  - `PanelInspection.detected: PanelProperties` carries the typed
+  - `DataInspection.detected: DataProperties` carries the typed
     enums (`scope` / `density` / `structure`), the per-axis rationale
     strings folded in alongside each enum (`scope_reason` /
     `density_reason` / `structure_reason`), plus shape numerics
@@ -627,7 +627,7 @@ types-only; runner wiring lands with the DAG executor.
     — the upper bound on sample size for pair-counting metrics.
     (The standalone `PanelReasoning` type is retired; `to_dict()`
     still emits a top-level `reasoning` block for serialization.)
-  - `PanelInspection.metrics: list[MetricApplicability]` — one
+  - `DataInspection.metrics: list[MetricApplicability]` — one
     verdict per `visibility=PUBLIC` spec. Each carries `metric:
     type[MetricBase]` (the callable class) and `name: str`
     (`metric.__name__` == `spec.name`, the registry key) so callers
@@ -642,7 +642,7 @@ types-only; runner wiring lands with the DAG executor.
     tier into the `{label: instance}` dict `evaluate(metrics=...)`
     expects — the canonical discovery → evaluate bridge (scalar-input
     utilities that need required args are omitted).
-  - `PanelInspection.warnings: list[Warning]` carries panel-level
+  - `DataInspection.warnings: list[Warning]` carries data-level
     sample-shape diagnostics (`source=None`); per-metric degraded
     warnings live on each `MetricApplicability`.
   - Two-stage applicability: (1) `Cell.matches(scope, density, structure)`
@@ -651,16 +651,16 @@ types-only; runner wiring lands with the DAG executor.
     `MetricSpec.sample_floor: SampleThreshold | None` — declarative
     `min_periods` / `warn_periods` / `min_assets` / `warn_assets` /
     `min_pairs` / `warn_pairs` gates evaluated against
-    `PanelProperties`. Specs without `sample_floor` only get the
+    `DataProperties`. Specs without `sample_floor` only get the
     cell-match check.
 - **`Tier`** — StrEnum representing usability tiers returned by `SampleThreshold.verdict` / `per_axis_verdict`:
   - `CLEAN` — metric is fully usable with zero warnings.
   - `DEGRADED` — metric is usable but with degraded inference warnings (between HARD and WARN floors).
   - `UNUSABLE` — metric is unusable (below HARD floor). Cell mismatch is a
-    separate `inspect_panel` blocker and does not flow through `Tier`.
+    separate `inspect_data` blocker and does not flow through `Tier`.
 - **`Cell.matches(scope, density, structure=None)`** — gains optional
   `structure` argument. Existing `list_metrics` callers stay backward
-  compatible (default `None` skips the structure axis); `inspect_panel`
+  compatible (default `None` skips the structure axis); `inspect_data`
   passes the detected structure.
 - **`MetricSpec.sample_floor: SampleThreshold | None`** — new optional
   field carrying per-metric pre-flight thresholds. Currently

--- a/tests/test_data_input.py
+++ b/tests/test_data_input.py
@@ -1,4 +1,4 @@
-"""Tests for `_coerce_panel`, the strict polars-native API gateway.
+"""Tests for `_coerce_data`, the strict polars-native API gateway.
 
 `fx.evaluate` and `fx.run_metrics` accept `pl.DataFrame` (passes
 through) and `pl.LazyFrame` (collected at the boundary). `pd.DataFrame`
@@ -12,54 +12,54 @@ from __future__ import annotations
 import factrix as fx
 import polars as pl
 import pytest
-from factrix._panel_input import _coerce_panel
+from factrix._data_input import _coerce_data
 from factrix.preprocess import compute_forward_return
 
 
 @pytest.fixture(scope="module")
-def panel_pl() -> pl.DataFrame:
+def data_pl() -> pl.DataFrame:
     raw = fx.datasets.make_cs_panel(n_assets=50, n_dates=120, seed=7)
     return compute_forward_return(raw, forward_periods=5)
 
 
-def test_coerce_polars_dataframe_passthrough(panel_pl: pl.DataFrame) -> None:
-    out = _coerce_panel(panel_pl)
-    assert out is panel_pl
+def test_coerce_polars_dataframe_passthrough(data_pl: pl.DataFrame) -> None:
+    out = _coerce_data(data_pl)
+    assert out is data_pl
 
 
-def test_coerce_lazyframe_collects(panel_pl: pl.DataFrame) -> None:
-    out = _coerce_panel(panel_pl.lazy())
+def test_coerce_lazyframe_collects(data_pl: pl.DataFrame) -> None:
+    out = _coerce_data(data_pl.lazy())
     assert isinstance(out, pl.DataFrame)
-    assert out.equals(panel_pl)
+    assert out.equals(data_pl)
 
 
 def test_coerce_pandas_dataframe_is_rejected_with_guidance() -> None:
     pd = pytest.importorskip("pandas")
     pdf = pd.DataFrame({"a": [1, 2]})
     with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):
-        _coerce_panel(pdf)
+        _coerce_data(pdf)
 
 
 def test_coerce_unsupported_type_raises() -> None:
     with pytest.raises(TypeError, match=r"pl\.DataFrame or pl\.LazyFrame"):
-        _coerce_panel([{"date": 1}])
+        _coerce_data([{"date": 1}])
 
 
-def test_evaluate_accepts_lazyframe_end_to_end(panel_pl: pl.DataFrame) -> None:
+def test_evaluate_accepts_lazyframe_end_to_end(data_pl: pl.DataFrame) -> None:
     from factrix.metrics import ic
 
     eager = fx.evaluate(
-        panel_pl, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
+        data_pl, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
     )
     lazy = fx.evaluate(
-        panel_pl.lazy(), metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
+        data_pl.lazy(), metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
     )
     assert eager[0].metrics["ic"].value == lazy[0].metrics["ic"].value
 
 
-def test_evaluate_rejects_pandas_with_guidance(panel_pl: pl.DataFrame) -> None:
+def test_evaluate_rejects_pandas_with_guidance(data_pl: pl.DataFrame) -> None:
     pytest.importorskip("pandas")
-    pdf = panel_pl.to_pandas()
+    pdf = data_pl.to_pandas()
     from factrix.metrics import ic
 
     with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -1,4 +1,4 @@
-"""``fx.inspect_panel`` — typed PanelInspection + per-metric verdict (#443)."""
+"""``fx.inspect_data`` — typed DataInspection + per-metric verdict (#443)."""
 
 from __future__ import annotations
 
@@ -7,35 +7,35 @@ import math
 import factrix as fx
 import polars as pl
 from factrix._inspect import (
+    DataInspection,
+    DataProperties,
     MetricApplicability,
-    PanelInspection,
-    PanelProperties,
-    inspect_panel,
+    inspect_data,
 )
 
 
-def _single_asset_panel(n_dates: int = 80) -> pl.DataFrame:
+def _single_asset_data(n_dates: int = 80) -> pl.DataFrame:
     raw = fx.datasets.make_cs_panel(n_assets=4, n_dates=n_dates)
     first = raw["asset_id"].unique()[0]
     return raw.filter(pl.col("asset_id") == first)
 
 
-def _common_continuous_panel(n_assets: int = 20, n_dates: int = 80) -> pl.DataFrame:
+def _common_continuous_data(n_assets: int = 20, n_dates: int = 80) -> pl.DataFrame:
     raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates)
     one_per_date = raw.group_by("date").agg(pl.col("factor").first())
     return raw.drop("factor").join(one_per_date, on="date")
 
 
-def _by_name(info: PanelInspection, name: str) -> MetricApplicability:
+def _by_name(info: DataInspection, name: str) -> MetricApplicability:
     for m in info.metrics:
         if m.spec.name == name:
             return m
     raise KeyError(name)
 
 
-class TestPanelPropertiesDetection:
+class TestDataPropertiesDetection:
     def test_individual_continuous_cs_panel(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         assert info.detected.scope is fx.FactorScope.INDIVIDUAL
         assert info.detected.density is fx.FactorDensity.DENSE
         assert info.detected.structure is fx.DataStructure.PANEL
@@ -45,19 +45,19 @@ class TestPanelPropertiesDetection:
         assert 0.0 <= info.detected.sparse_ratio < 0.5
 
     def test_n1_routes_to_timeseries(self):
-        info = inspect_panel(_single_asset_panel(n_dates=80))
+        info = inspect_data(_single_asset_data(n_dates=80))
         assert info.detected.structure is fx.DataStructure.TIMESERIES
         assert info.detected.n_assets == 1
         assert "TIMESERIES" in info.detected.structure_reason
 
     def test_common_continuous_detection(self):
-        info = inspect_panel(_common_continuous_panel())
+        info = inspect_data(_common_continuous_data())
         assert info.detected.scope is fx.FactorScope.COMMON
         assert info.detected.density is fx.FactorDensity.DENSE
 
     def test_empty_panel_sparse_ratio_is_nan(self):
         empty = fx.datasets.make_cs_panel(n_assets=4, n_dates=10).head(0)
-        info = inspect_panel(empty)
+        info = inspect_data(empty)
         assert math.isnan(info.detected.sparse_ratio)
         assert info.detected.n_pairs == 0
 
@@ -69,14 +69,14 @@ class TestPanelPropertiesDetection:
             .otherwise(pl.col("factor"))
             .alias("factor")
         )
-        info = inspect_panel(with_nulls)
+        info = inspect_data(with_nulls)
         assert info.detected.n_pairs == with_nulls.drop_nulls("factor").height
         assert info.detected.n_pairs < raw.height
 
 
-class TestPanelReasoning:
+class TestDataReasoning:
     def test_three_axis_fields_populated(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         assert "INDIVIDUAL" in info.detected.scope_reason
         assert "DENSE" in info.detected.density_reason
         assert "PANEL" in info.detected.structure_reason
@@ -84,20 +84,20 @@ class TestPanelReasoning:
 
 class TestCellMatchGate:
     def test_panel_mode_metric_unusable_under_timeseries(self):
-        # IC's cell declares structure=PANEL; single-asset panel must reject it.
-        info = inspect_panel(_single_asset_panel(n_dates=80))
+        # IC's cell declares structure=PANEL; single-asset data must reject it.
+        info = inspect_data(_single_asset_data(n_dates=80))
         ic = _by_name(info, "ic")
         assert ic.usable is False
         assert any("cell mismatch" in b for b in ic.blockers)
 
     def test_sparse_metric_unusable_under_continuous(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         caar = _by_name(info, "caar")
         assert caar.usable is False
         assert any("cell mismatch" in b for b in caar.blockers)
 
     def test_only_public_specs_appear(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         names = {m.spec.name for m in info.metrics}
         assert "compute_ic" not in names  # visibility=INTERNAL
         assert "ic" in names
@@ -108,7 +108,7 @@ class TestMetricApplicabilityIdentity:
         from factrix.metrics._base import MetricBase
         from factrix.metrics._registry import REGISTRY
 
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         for m in info.metrics:
             assert issubclass(m.metric, MetricBase)
             # name is the registry key and agrees with both the class and spec
@@ -117,7 +117,7 @@ class TestMetricApplicabilityIdentity:
             assert REGISTRY[m.name] is m.metric
 
     def test_name_lets_caller_key_without_spec(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         ic = _by_name(info, "ic")
         assert ic.name == "ic"
         assert ic.metric is _by_name(info, "ic").metric
@@ -125,20 +125,20 @@ class TestMetricApplicabilityIdentity:
 
 class TestSampleThresholdGate:
     def test_below_min_periods_is_unusable(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
         nw = _by_name(info, "ic_newey_west")
         assert nw.usable is False
         assert any("min_periods" in b for b in nw.blockers)
 
     def test_between_min_and_warn_is_usable_with_warning(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
         nw = _by_name(info, "ic_newey_west")
         assert nw.usable is True
         codes = [w.code.value for w in nw.warnings]
         assert "unreliable_se_short_periods" in codes
 
     def test_above_warn_floor_is_clean(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
         nw = _by_name(info, "ic_newey_west")
         assert nw.usable is True
         assert nw.warnings == []
@@ -146,7 +146,7 @@ class TestSampleThresholdGate:
     def test_below_min_pairs_is_unusable(self):
         from factrix._metric_index import SampleThreshold
 
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
         floor = SampleThreshold(min_pairs=info.detected.n_pairs + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_newey_west")
         from dataclasses import replace
@@ -165,7 +165,7 @@ class TestSampleThresholdGate:
         from factrix._inspect import _evaluate_applicability
         from factrix._metric_index import SampleThreshold
 
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
         n = info.detected.n_pairs
         floor = SampleThreshold(min_pairs=n - 1, warn_pairs=n + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_newey_west")
@@ -176,7 +176,7 @@ class TestSampleThresholdGate:
         assert any("n_pairs" in w.message for w in verdict.warnings)
 
     def test_metric_without_sample_floor_only_cell_checked(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
         ic = _by_name(info, "ic")
         # ic has no sample_floor declared (only cell match); cell matches, so usable
         assert ic.usable is True
@@ -186,7 +186,7 @@ class TestSampleThresholdGate:
 class TestTierPartition:
     def test_three_tiers_partition_metrics_disjointly(self):
         # n_dates=25 puts ic_newey_west between min and warn -> degraded.
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
         usable = {m.spec.name for m in info.usable}
         degraded = {m.spec.name for m in info.degraded}
         unusable = {m.spec.name for m in info.unusable}
@@ -201,50 +201,50 @@ class TestTierPartition:
         assert usable | degraded | unusable == {m.spec.name for m in info.metrics}
 
     def test_usable_excludes_degraded(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
         nw = _by_name(info, "ic_newey_west")
         assert nw.usable is True and nw.warnings  # the degraded case
         assert nw not in info.usable
         assert nw in info.degraded
 
     def test_usable_is_clean_only(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
         assert all(m.usable and not m.warnings for m in info.usable)
 
     def test_degraded_is_usable_with_warnings(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
         assert all(m.usable and m.warnings for m in info.degraded)
 
     def test_unusable_is_not_usable(self):
-        info = inspect_panel(_single_asset_panel(n_dates=80))
+        info = inspect_data(_single_asset_data(n_dates=80))
         assert all(not m.usable for m in info.unusable)
-        # ic (cell=PANEL) is unusable on a single-asset panel.
+        # ic (cell=PANEL) is unusable on a single-asset data.
         assert "ic" in {m.spec.name for m in info.unusable}
 
 
-class TestPanelLevelWarnings:
-    def test_thin_panel_short_n_periods_emits_panel_warning(self):
-        info = inspect_panel(_single_asset_panel(n_dates=25))
+class TestDataLevelWarnings:
+    def test_thin_data_short_n_periods_emits_data_warning(self):
+        info = inspect_data(_single_asset_data(n_dates=25))
         codes = [w.code.value for w in info.warnings]
         assert "unreliable_se_short_periods" in codes
         assert all(w.source is None for w in info.warnings)
 
     def test_thin_cross_section_emits_tier(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))
         codes = [w.code.value for w in info.warnings]
         assert any("cross_section" in c for c in codes)
 
 
 class TestWarningSourceConvention:
     """Guard the `Warning.source` convention across every emission point:
-    per-metric warnings carry `source == <metric name>`; panel-level
+    per-metric warnings carry `source == <metric name>`; data-level
     warnings carry `source is None`. See #499.
     """
 
     def test_per_metric_warnings_carry_their_metric_name(self):
         # n_periods=25 puts NW-SE metrics in the degraded tier, n_assets=5
         # trips the cross-section tier — both per-metric warning paths fire.
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=25))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=5, n_dates=25))
         emitted = 0
         for m in info.metrics:
             for w in m.warnings:
@@ -252,9 +252,9 @@ class TestWarningSourceConvention:
                 emitted += 1
         assert emitted > 0  # the fixture actually exercises the per-metric path
 
-    def test_panel_level_warnings_carry_no_source(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=25))
-        assert info.warnings  # fixture produces panel-level diagnostics
+    def test_data_level_warnings_carry_no_source(self):
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=5, n_dates=25))
+        assert info.warnings  # fixture produces data-level diagnostics
         assert all(w.source is None for w in info.warnings)
 
 
@@ -262,7 +262,7 @@ class TestToDict:
     def test_round_trips_through_json(self):
         import json
 
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
         d = info.to_dict()
         back = json.loads(json.dumps(d))
         assert back["detected"]["scope"] == "individual"
@@ -276,30 +276,30 @@ class TestToDict:
 
     def test_nan_sparse_ratio_becomes_null(self):
         empty = fx.datasets.make_cs_panel(n_assets=4, n_dates=10).head(0)
-        d = inspect_panel(empty).to_dict()
+        d = inspect_data(empty).to_dict()
         assert d["detected"]["sparse_ratio"] is None
         assert d["detected"]["n_pairs"] == 0
 
-    def test_panel_level_warnings_serialised(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))
+    def test_data_level_warnings_serialised(self):
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))
         d = info.to_dict()
         assert any(w["source"] is None for w in d["warnings"])
 
 
 class TestReprHtml:
     def test_smoke(self):
-        info = inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
         out = info._repr_html_()
-        assert "PanelInspection" in out
+        assert "DataInspection" in out
         assert "usable" in out
 
 
 class TestPublicSurface:
     def test_dataclass_types_exported(self):
-        assert fx.PanelInspection is PanelInspection
-        assert fx.PanelProperties is PanelProperties
+        assert fx.DataInspection is DataInspection
+        assert fx.DataProperties is DataProperties
         assert fx.MetricApplicability is MetricApplicability
-        assert fx.inspect_panel is inspect_panel
+        assert fx.inspect_data is inspect_data
         assert fx.SampleThreshold is not None
 
 
@@ -347,7 +347,7 @@ class TestCellMatchesSignature:
 
 class TestMetricApplicabilityGroup:
     def _info(self):
-        return inspect_panel(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
+        return inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
 
     def test_partitions_are_groups_and_lists(self):
         info = self._info()
@@ -387,7 +387,7 @@ class TestMetricApplicabilityGroup:
         # The discovery bridge: a usable metric round-trips into evaluate().
         raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=80)
         panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
-        md = inspect_panel(panel).usable.to_metrics_dict()
+        md = inspect_data(panel).usable.to_metrics_dict()
         results = fx.evaluate(
             panel,
             metrics={"ic": md["ic"]},

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -32,7 +32,7 @@ def _names_for_cell(scope: FactorScope, density: FactorDensity) -> set[str]:
     The cell filter ``list_metrics(scope, density)`` exposed was retired
     (#498); the underlying mechanism — ``spec.cell.matches`` over
     ``public_specs()`` — is what drives both this drift guard and
-    ``inspect_panel``'s per-metric verdict.
+    ``inspect_data``'s per-metric verdict.
     """
     return {
         spec.name for _, spec in public_specs() if spec.cell.matches(scope, density)

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -20,7 +20,7 @@ from factrix._axis import (
     TestMethod,
     Tier,
 )
-from factrix._inspect import PanelProperties
+from factrix._inspect import DataProperties
 from factrix._metric_index import (
     MetricSpec,
     SampleThreshold,
@@ -60,7 +60,7 @@ class TestSampleThresholdHelpers:
             warn_pairs=50,
         )
 
-        props_clean = PanelProperties(
+        props_clean = DataProperties(
             scope=FactorScope.INDIVIDUAL,
             scope_reason="",
             density=FactorDensity.DENSE,
@@ -79,7 +79,7 @@ class TestSampleThresholdHelpers:
         }
         assert st.verdict(props_clean) is Tier.CLEAN
 
-        props_degraded = PanelProperties(
+        props_degraded = DataProperties(
             scope=FactorScope.INDIVIDUAL,
             scope_reason="",
             density=FactorDensity.DENSE,
@@ -98,7 +98,7 @@ class TestSampleThresholdHelpers:
         }
         assert st.verdict(props_degraded) is Tier.DEGRADED
 
-        props_unusable = PanelProperties(
+        props_unusable = DataProperties(
             scope=FactorScope.INDIVIDUAL,
             scope_reason="",
             density=FactorDensity.DENSE,


### PR DESCRIPTION
## Summary
- Renamed the core API entrypoints and properties from "panel" to "data" (e.g., `inspect_panel` -> `inspect_data`, `PanelInspection` -> `DataInspection`, `PanelProperties` -> `DataProperties`) to align with the `DataStructure` design and resolve TIMESERIES contradiction.
- Refactored `evaluate` signature to accept `data: DataInput` instead of `panel: PanelInput`.
- Renamed internal files and updated testing suite files/helpers to be consistent.
- Updated all document references including docs site pages and `llms-full.txt`.

## Test plan
- [x] Run `uv run pytest` to ensure all 1109 test cases (including docs reference validation tests) pass successfully.

Closes #527
