### PR TITLE
feat(inspect): warn on cross-factor density/scope mismatch (#457)

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -78,6 +78,10 @@ class WarningCode(StrEnum):
     # is recoverable without re-walking the dependency graph.
     UPSTREAM_UNAVAILABLE = "upstream_unavailable"
 
+    # Fired by inspect_data when factor columns carry inconsistent axes.
+    CROSS_FACTOR_DENSITY_MISMATCH = "cross_factor_density_mismatch"
+    CROSS_FACTOR_SCOPE_MISMATCH = "cross_factor_scope_mismatch"
+
     @property
     def description(self) -> str:
         return _WARNING_DESCRIPTIONS[self]
@@ -125,6 +129,8 @@ _WARNING_DESCRIPTIONS.update(
         WarningCode.UPSTREAM_UNAVAILABLE: "DAG-executor consumer skipped because an upstream "
         "producer short-circuited. The downstream MetricResult carries "
         "metadata['upstream'] / ['upstream_reason'] for the original cause.",
+        WarningCode.CROSS_FACTOR_DENSITY_MISMATCH: "Factor columns carry inconsistent FactorDensity (dense and sparse mixed).",
+        WarningCode.CROSS_FACTOR_SCOPE_MISMATCH: "Factor columns carry inconsistent FactorScope (individual and common mixed).",
     }
 )
 

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import html
 import math
+from collections.abc import Sequence
 from dataclasses import MISSING, dataclass, field, fields
 from typing import TYPE_CHECKING, Any
 
@@ -39,6 +40,9 @@ if TYPE_CHECKING:
     from factrix.metrics._base import MetricBase
 
 _SPARSITY_THRESHOLD: float = 0.5
+_INSPECT_RESERVED: frozenset[str] = frozenset(
+    {"date", "asset_id", "forward_return", "price"}
+)
 
 
 def _detect_structure(data: Any) -> DataStructure:
@@ -439,7 +443,7 @@ class DataInspection:
         )
 
 
-def inspect_data(data: Any) -> DataInspection:
+def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataInspection:
     """Inspect data and return typed dispatch-axis + per-metric verdict.
 
     Pre-flight introspection: typed detection plus, for every
@@ -454,8 +458,12 @@ def inspect_data(data: Any) -> DataInspection:
     own short-circuit path.
 
     Args:
-        data: Long-format factor data with the canonical columns
-            ``date`` / ``asset_id`` / ``factor``.
+        data: Long-format factor data with the canonical columns.
+            The baseline columns ``date`` / ``asset_id`` /
+            ``forward_return`` / ``price`` are reserved and not treated as factors.
+        factor_cols: Optional list of factor columns to check. When
+            ``None`` (default), auto-detects all columns except the
+            reserved columns as factor candidates.
 
     Returns:
         :class:`DataInspection`.
@@ -467,12 +475,40 @@ def inspect_data(data: Any) -> DataInspection:
         >>> all(m.spec.cell.matches(info.detected.scope, info.detected.density, info.detected.structure) for m in info.usable)
         True
     """
-    density, density_reason, sparse_ratio = _detect_density(data)
-    scope, scope_reason = _detect_scope(data)
+    if isinstance(factor_cols, str):
+        raise TypeError(
+            f"factor_cols must be a list of column names, not a str; "
+            f"did you mean factor_cols=[{factor_cols!r}]?"
+        )
+    if factor_cols is None:
+        cols = [c for c in data.columns if c not in _INSPECT_RESERVED]
+    else:
+        cols = list(factor_cols)
+    if not cols:
+        raise ValueError(
+            "No factor columns found. Pass factor_cols= explicitly or ensure "
+            "data has columns beyond the reserved set "
+            f"({sorted(_INSPECT_RESERVED)})."
+        )
+
+    first_col = cols[0]
+
+    # Project raw data to "factor" column name to reuse standard detectors
+    def _detect_col_density(col: str) -> tuple[FactorDensity, str, float]:
+        temp = data.select("date", "asset_id", pl.col(col).alias("factor"))
+        return _detect_density(temp)
+
+    def _detect_col_scope(col: str) -> tuple[FactorScope, str]:
+        temp = data.select("date", "asset_id", pl.col(col).alias("factor"))
+        return _detect_scope(temp)
+
+    # First factor column drives the returned properties (deterministic first-detected)
+    density, density_reason, sparse_ratio = _detect_col_density(first_col)
+    scope, scope_reason = _detect_col_scope(first_col)
     structure = _detect_structure(data)
     n_assets = int(data["asset_id"].n_unique())
     n_periods = int(data["date"].n_unique())
-    n_pairs = int(data.drop_nulls("factor").height)
+    n_pairs = int(data.drop_nulls(first_col).height)
 
     structure_reason = (
         f"n_assets={n_assets} → "
@@ -493,6 +529,46 @@ def inspect_data(data: Any) -> DataInspection:
     )
 
     data_warnings = _data_level_warnings(properties)
+
+    # Cross-factor consistency checks
+    if len(cols) > 1:
+        densities = [density] + [_detect_col_density(c)[0] for c in cols[1:]]
+        scopes = [scope] + [_detect_col_scope(c)[0] for c in cols[1:]]
+
+        if len(set(densities)) > 1:
+            detail = ", ".join(
+                f"'{c}': {d.value}" for c, d in zip(cols, densities, strict=True)
+            )
+            data_warnings.append(
+                Warning(
+                    code=WarningCode.CROSS_FACTOR_DENSITY_MISMATCH,
+                    source=None,
+                    message=(
+                        f"Factor columns carry inconsistent FactorDensity: {{{detail}}}. "
+                        f"Metric applicability is based on '{first_col}'; call "
+                        f"inspect_data(data, factor_cols=[<col>]) for a verdict "
+                        f"specific to that column."
+                    ),
+                )
+            )
+
+        if len(set(scopes)) > 1:
+            detail = ", ".join(
+                f"'{c}': {s.value}" for c, s in zip(cols, scopes, strict=True)
+            )
+            data_warnings.append(
+                Warning(
+                    code=WarningCode.CROSS_FACTOR_SCOPE_MISMATCH,
+                    source=None,
+                    message=(
+                        f"Factor columns carry inconsistent FactorScope: {{{detail}}}. "
+                        f"Metric applicability is based on '{first_col}'; call "
+                        f"inspect_data(data, factor_cols=[<col>]) for a verdict "
+                        f"specific to that column."
+                    ),
+                )
+            )
+
     metrics = [_evaluate_applicability(spec, properties) for _, spec in public_specs()]
 
     return DataInspection(

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -615,14 +615,18 @@ types-only; runner wiring lands with the DAG executor.
   producer returned a short-circuit `MetricResult`. The downstream
   `MetricResult` carries `metadata["upstream"]` and
   `metadata["upstream_reason"]` for root-cause recovery.
-- **`fx.inspect_data(panel) -> DataInspection`** — typed
+- **`fx.inspect_data(data, factor_cols=None) -> DataInspection`** — typed
   pre-flight introspection that combines axis detection with a
   per-metric usability verdict.
+  - Accepts `data` (e.g. DataFrame) and optional `factor_cols` (defaults to
+    `None` which auto-detects all columns except reserved `date`, `asset_id`,
+    `forward_return`, and `price` columns).
   - `DataInspection.detected: DataProperties` carries the typed
     enums (`scope` / `density` / `structure`), the per-axis rationale
     strings folded in alongside each enum (`scope_reason` /
     `density_reason` / `structure_reason`), plus shape numerics
-    (`n_assets` / `n_periods` / `n_pairs` / `sparse_ratio`).
+    (`n_assets` / `n_periods` / `n_pairs` / `sparse_ratio`) resolved against
+    the first factor column.
     `n_pairs` counts non-null `(date, asset_id)` factor observations
     — the upper bound on sample size for pair-counting metrics.
     (The standalone `PanelReasoning` type is retired; `to_dict()`
@@ -643,8 +647,12 @@ types-only; runner wiring lands with the DAG executor.
     expects — the canonical discovery → evaluate bridge (scalar-input
     utilities that need required args are omitted).
   - `DataInspection.warnings: list[Warning]` carries data-level
-    sample-shape diagnostics (`source=None`); per-metric degraded
-    warnings live on each `MetricApplicability`.
+    sample-shape diagnostics (`source=None`) and cross-factor consistency checks
+    (`CROSS_FACTOR_DENSITY_MISMATCH` / `CROSS_FACTOR_SCOPE_MISMATCH`); when
+    either fires, the warning message notes that metric applicability is based
+    on the first factor column and suggests calling `inspect_data(data,
+    factor_cols=[<col>])` for a per-column verdict.
+    Per-metric degraded warnings live on each `MetricApplicability`.
   - Two-stage applicability: (1) `Cell.matches(scope, density, structure)`
     — structure is integral so e.g. `IC` (cell declares `structure=PANEL`) is
     unusable on a single-asset panel, not just degraded. (2)

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -396,3 +396,112 @@ class TestMetricApplicabilityGroup:
             strict=False,
         )
         assert results[0].metrics["ic"].name == "ic"
+
+
+class TestCrossFactorConsistency:
+    def test_single_factor_no_warning(self):
+        # Only 1 factor column, should have no cross-factor mismatch warnings
+        data = fx.datasets.make_cs_panel(n_assets=10, n_dates=30)
+        info = inspect_data(data)
+        mismatch_codes = {
+            w.code.value for w in info.warnings if "cross_factor" in str(w.code.value)
+        }
+        assert mismatch_codes == set()
+
+    def test_multi_factor_consistent_no_warning(self):
+        # Two factor columns, both individual dense
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=1)
+        raw2 = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=2)
+        # Merge them
+        data = raw.join(
+            raw2.select("date", "asset_id", pl.col("factor").alias("factor2")),
+            on=["date", "asset_id"],
+        )
+        info = inspect_data(data, factor_cols=["factor", "factor2"])
+        mismatch_codes = {
+            w.code.value for w in info.warnings if "cross_factor" in str(w.code.value)
+        }
+        assert mismatch_codes == set()
+
+    def test_multi_factor_inconsistent_warnings(self):
+        # factor: individual dense
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=1)
+
+        # factor2: common dense (scope mismatch)
+        one_per_date = raw.group_by("date").agg(pl.col("factor").first())
+        common = (
+            raw.drop("factor")
+            .join(one_per_date, on="date")
+            .select("date", "asset_id", pl.col("factor").alias("factor2"))
+        )
+
+        # factor3: individual sparse (density mismatch)
+        sparse_factor = raw.with_columns(
+            pl.when(pl.int_range(0, raw.height) % 3 == 0)
+            .then(pl.col("factor"))
+            .otherwise(0.0)
+            .alias("factor3")
+        )
+
+        # Merge them
+        data = raw.join(common, on=["date", "asset_id"]).join(
+            sparse_factor.select("date", "asset_id", "factor3"), on=["date", "asset_id"]
+        )
+
+        # Test full mismatch
+        info = inspect_data(data, factor_cols=["factor", "factor2", "factor3"])
+        mismatch_codes = {
+            w.code.value for w in info.warnings if "cross_factor" in str(w.code.value)
+        }
+        assert "cross_factor_density_mismatch" in mismatch_codes
+        assert "cross_factor_scope_mismatch" in mismatch_codes
+
+        # Verify message contents carry inconsistent details
+        density_warning = next(
+            w for w in info.warnings if w.code.value == "cross_factor_density_mismatch"
+        )
+        assert "'factor': dense" in density_warning.message
+        assert "'factor3': sparse" in density_warning.message
+
+        scope_warning = next(
+            w for w in info.warnings if w.code.value == "cross_factor_scope_mismatch"
+        )
+        assert "'factor': individual" in scope_warning.message
+        assert "'factor2': common" in scope_warning.message
+
+    def test_factor_cols_restricts_scope(self):
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=1)
+        # factor2: common dense
+        one_per_date = raw.group_by("date").agg(pl.col("factor").first())
+        common = (
+            raw.drop("factor")
+            .join(one_per_date, on="date")
+            .select("date", "asset_id", pl.col("factor").alias("factor2"))
+        )
+        # factor3: individual dense (consistent with factor)
+        raw3 = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=3)
+
+        data = raw.join(common, on=["date", "asset_id"]).join(
+            raw3.select("date", "asset_id", pl.col("factor").alias("factor3")),
+            on=["date", "asset_id"],
+        )
+
+        # If we only inspect ["factor", "factor3"], there should be no mismatch warning
+        info = inspect_data(data, factor_cols=["factor", "factor3"])
+        mismatch_codes = {
+            w.code.value for w in info.warnings if "cross_factor" in str(w.code.value)
+        }
+        assert mismatch_codes == set()
+
+    def test_auto_detect_excludes_reserved_columns(self):
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=1)
+        data = raw.with_columns(pl.lit(1.0).alias("forward_return")).with_columns(
+            pl.col("factor").alias("factor2")
+        )
+
+        # If factor_cols is None, it should auto-detect: ['factor', 'factor2'] (no mismatch)
+        info = inspect_data(data)
+        mismatch_codes = {
+            w.code.value for w in info.warnings if "cross_factor" in str(w.code.value)
+        }
+        assert mismatch_codes == set()


### PR DESCRIPTION
## Summary

- Add `CROSS_FACTOR_DENSITY_MISMATCH` / `CROSS_FACTOR_SCOPE_MISMATCH` warnings to `inspect_data` when factor columns carry inconsistent axes
- Accept optional `factor_cols: list[str]` parameter; auto-detects all non-reserved columns when omitted
- Mismatch warning messages now include a guidance note that metric applicability is based on the first factor column and direct users to call `inspect_data(data, factor_cols=[<col>])` for a per-column verdict

**Post-review fixes (review findings #1–#5):**
- **#1/#2** Guard against `factor_cols=[]` (raises `ValueError`) and `factor_cols="str"` (raises `TypeError` with corrective hint)
- **#3** Extract `_INSPECT_RESERVED: frozenset[str]` as a module-level constant, replacing the anonymous inline set
- **#4** Mismatch warning messages now surface the first-column anchor and guide users to per-column inspection
- **#5** Cross-factor loop now seeds from already-computed `density`/`scope` and iterates `cols[1:]`, eliminating the redundant first-column detection pass

## Test plan

- [ ] `pytest tests/test_inspect_data.py` — 45 tests pass
- [ ] `ruff check` / `mypy factrix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)