### PR TITLE
refactor(errors): flatten exception hierarchy and add logging conventions (#446)

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -10,14 +10,17 @@ How to read factrix errors and which exception class to catch.
 import factrix as fx
 
 try:
-    profile = fx.evaluate(panel, cfg)
+    results = fx.evaluate(data, metrics={"ic": ic()}, factor_cols=["factor"])
 except fx.UserInputError as exc:
     # User typed the wrong thing — typo, unknown name, wrong column.
     # The message carries a fuzzy suggestion + a docs link.
     print(exc)
-except fx.ConfigError as exc:
-    # AnalysisConfig validation / dispatch failure.
-    # exc.suggested_fix may carry a nearest-legal AnalysisConfig.
+except fx.IncompatibleAxisError as exc:
+    # Axis miswire.
+    ...
+except fx.InsufficientSampleError as exc:
+    # n_periods or other axis is below the required hard floor.
+    # exc.actual_periods and exc.required_periods carry details.
     ...
 except fx.FactrixError as exc:
     # Catch-all for anything else factrix raises.
@@ -31,21 +34,18 @@ All factrix-raised exceptions inherit from `FactrixError`, so a single
 
 ```
 FactrixError                       # base
-├── ConfigError                    # AnalysisConfig validation / dispatch
-│   ├── MissingConfigError         # evaluate(panel) called without a config
-│   ├── IncompatibleAxisError      # (scope, signal, metric) is not a legal cell
-│   ├── ModeAxisError              # legal cell, no procedure at runtime mode
-│   └── InsufficientSampleError    # T below MIN_PERIODS_HARD on a TIMESERIES procedure
-└── UserInputError                 # named-set typo / type mismatch
+├── IncompatibleAxisError          # (scope, density, metric) is not a legal cell
+├── InsufficientSampleError        # T below MIN_PERIODS_HARD on a TIMESERIES procedure
+├── UnknownEstimatorError          # lookup miss in get_estimator
+└── UserInputError                 # named-set typo / type mismatch / dataset schema error
 ```
 
 | Exception | When you see it | What it carries |
 |---|---|---|
-| `MissingConfigError` | `evaluate(panel)` called without an `AnalysisConfig` | — |
-| `IncompatibleAxisError` | `(scope, signal, metric)` is not a legal cell | optional `.suggested_fix` |
-| `ModeAxisError` | Legal cell has no procedure at the runtime `PanelMode` | typically `.suggested_fix: AnalysisConfig` |
+| `IncompatibleAxisError` | `(scope, density, metric)` is not a legal cell | — |
 | `InsufficientSampleError` | `T` below the procedure floor | `.actual_periods`, `.required_periods` |
-| `UserInputError` | Unknown metric / `p_stat` / context key, column not in panel, wrong type | structured `.field`, `.value`, `.candidates`, `.suggestions`, `.expected`, `.docs_url` |
+| `UnknownEstimatorError` | `get_estimator(name)` lookup miss | — |
+| `UserInputError` | Unknown metric / estimator / `primary` label, column not in data, wrong type | structured `.field`, `.value`, `.candidates`, `.suggestions`, `.expected`, `.docs_url` |
 
 ---
 
@@ -62,14 +62,12 @@ Use the table to skim; jump to the linked page for the why.
 | `Both 'factor' and 'X' present` | Wide panel still has stale `"factor"` column alongside the renamed one | `panel.drop("factor")` before calling. |
 | `forward_return column missing` | Forgot the preprocess step | `compute_forward_return(raw, forward_periods=h)` before `evaluate`. See [Panel schema § Preprocess pipeline](panel-schema.md#preprocess-pipeline). |
 
-### Config failures (`ConfigError` family)
+### Structural and sample failures
 
 | Exception / message | Trigger | Fix |
 |---|---|---|
-| `MissingConfigError: evaluate(panel) needs AnalysisConfig` | `evaluate(panel)` called with no `cfg` | Pass an explicit `AnalysisConfig` (one of the four factory methods on `AnalysisConfig`). |
-| `IncompatibleAxisError: (scope, signal, metric) is not a legal cell` | Combination like `(INDIVIDUAL, SPARSE, IC)` that the dispatch table never registers | Use one of the four factories (`individual_continuous`, `individual_sparse`, `common_continuous`, `common_sparse`) — illegal combos are unreachable via factories. See [Concepts](../getting-started/concepts.md). |
-| `ModeAxisError: no procedure at runtime PanelMode=TIMESERIES` | Legal cell, but `N = panel["asset_id"].n_unique()` triggers a PanelMode the cell does not implement (typical case: `individual_continuous` at `N=1`) | Read `.suggested_fix` — it carries the nearest-legal `AnalysisConfig` for the actual `PanelMode`. See [Quickstart § N = 1](../getting-started/quickstart.md). |
-| `InsufficientSampleError: T below required` | `n_periods` below the procedure's `MIN_PERIODS_HARD` floor | Read `.actual_periods` and `.required_periods`. The fix is either more data, or — if the procedure is not the right one for short series — switching to a TIMESERIES-friendly cell. `evaluate()` raises; standalone metric callables (e.g. [`quantile_spread`](metrics/quantile.md#factrix.metrics.quantile.quantile_spread)) and `run_metrics()` surface the same condition differently — see [Panel vs timeseries § Sample-deficiency surfacing by entry point](../guides/panel-timeseries.md#sample-deficiency-surfacing-by-entry-point). |
+| `IncompatibleAxisError: (scope, density, metric) is not a legal cell` | Combination like `(INDIVIDUAL, SPARSE, IC)` that the dispatch table never registers | Use compatible axes. Check [`list_metrics`](list-metrics.md) or [`inspect_data`](../guides/reading-results.md) to find applicable metrics. |
+| `InsufficientSampleError: T below required` | `n_periods` below the procedure's hard floor | Read `.actual_periods` and `.required_periods`. The fix is either more data, or switching to a TIMESERIES-friendly metric. See [Panel vs timeseries](../guides/panel-timeseries.md). |
 
 ### User-input failures (`UserInputError`)
 
@@ -182,12 +180,7 @@ Autodoc anchors for cross-references of the form
       show_root_toc_entry: false
       heading_level: 4
 
-### Config failures
-
-::: factrix.ConfigError
-    options:
-      show_root_toc_entry: false
-      heading_level: 4
+### Structural and sample failures
 
 ::: factrix.IncompatibleAxisError
     options:

--- a/docs/api/panel-schema.md
+++ b/docs/api/panel-schema.md
@@ -98,7 +98,6 @@ Schema-related failures and their fix paths:
 |---|---|---|
 | `factor_col 'X' not in panel columns` | Typo / wrong column name | Check `panel.columns`; pass the actual name to `factor_col=`. |
 | `Both 'factor' and 'X' present` | Wide panel still has stale `"factor"` column | `panel.drop("factor")` before calling. |
-| `MissingConfigError: evaluate(panel) needs AnalysisConfig` | Called `evaluate(panel)` with no `cfg` | — |
 | `forward_return column missing` | Forgot the preprocess step | `panel = compute_forward_return(raw, forward_periods=h)` before `evaluate`. |
 
 Full error taxonomy and recovery patterns: [Errors](errors.md).

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -61,7 +61,7 @@ Plus introspection / error / enum re-exports:
 
 - `fx.FactorScope`, `fx.FactorDensity` — user-facing axes
 - `fx.WarningCode`, `fx.InfoCode`, `fx.StatCode` — structured result codes
-- `fx.FactrixError`, `fx.ConfigError`, `fx.IncompatibleAxisError`, `fx.InsufficientSampleError`, `fx.UserInputError` — exception hierarchy (see § Error UX contract)
+- `fx.FactrixError`, `fx.IncompatibleAxisError`, `fx.InsufficientSampleError`, `fx.UserInputError` — exception hierarchy (see § Error UX contract)
 
 `__version__` is sourced from `pyproject.toml` (Commitizen-managed).
 
@@ -164,10 +164,8 @@ in `stats: Mapping[StatCode, float]` keyed by enum, not by string.
 Both modes produce real `primary_p` values — neither is degraded.
 
 `(INDIVIDUAL, DENSE, *) × N=1` is mathematically undefined (no
-cross-sectional dispersion → IC and per-date ordinary least squares (OLS) undefined). `_evaluate`
-raises `ModeAxisError` with `suggested_fix=AnalysisConfig.common_continuous(...)`
-drawn from `_FALLBACK_MAP` in `factrix/_analysis_config.py`. Explicit
-user-correctable, never silent rewrite.
+cross-sectional dispersion → IC and per-date ordinary least squares (OLS) undefined). Evaluate
+raises `IncompatibleAxisError`. Explicit user-correctable, never silent rewrite.
 
 `(*, SPARSE, *) × N=1` is well-defined but the `INDIVIDUAL` / `COMMON`
 distinction collapses (one asset → no scope axis). Both user-facing factory
@@ -224,17 +222,15 @@ all functions.
 
 ```
 FactrixError                       # base — all factrix-raised errors
-├── ConfigError                    # AnalysisConfig validation / dispatch
-│   ├── MissingConfigError
-│   ├── IncompatibleAxisError
-│   ├── ModeAxisError              # carries .suggested_fix
-│   └── InsufficientSampleError    # carries .actual_periods / .required_periods
+├── IncompatibleAxisError
+├── InsufficientSampleError    # carries .actual_periods / .required_periods
+├── UnknownEstimatorError
 └── UserInputError                 # named-set typo / type mismatch
 ```
 
 `UserInputError` is the marker for "user typed the wrong thing"
 (unknown metric / `p_stat` / `expand_over` key, column not in panel,
-wrong type). Catch it separately from `ConfigError` (axis miswire) and
+wrong type). Catch it separately from `IncompatibleAxisError` (axis miswire) and
 `InsufficientSampleError` (data limitation) when those branches need
 different recovery.
 
@@ -597,7 +593,7 @@ factrix/
 ├── __init__.py              # public surface
 ├── _axis.py                 # FactorScope / FactorDensity / Metric / DataStructure StrEnums
 ├── _codes.py                # WarningCode / InfoCode / StatCode StrEnums
-├── _errors.py               # FactrixError → ConfigError → {IncompatibleAxisError, ModeAxisError, InsufficientSampleError}
+├── _errors.py               # FactrixError → {IncompatibleAxisError, InsufficientSampleError, UnknownEstimatorError, UserInputError}
 ├── _analysis_config.py      # AnalysisConfig + 4 factories + _FALLBACK_MAP
 ├── _registry.py             # _DispatchKey, _RegistryEntry, _SCOPE_COLLAPSED, register()
 ├── _procedures.py           # 7 FactorProcedure classes; bootstrap-registered at import

--- a/docs/examples/stock_factor_evaluation.md
+++ b/docs/examples/stock_factor_evaluation.md
@@ -14,7 +14,7 @@ This recipe uses `AnalysisConfig.individual_continuous(metric=Metric.IC)`
 
 Procedure: per-date Spearman ρ between factor and forward return,
 aggregated to a Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) t-statistic on `E[IC]`. PANEL mode
-(`N ≥ 2`); `N = 1` raises `ModeAxisError`
+(`N ≥ 2`); `N = 1` raises `IncompatibleAxisError`
 since there is no cross-section to rank within.
 
 Literature: [Grinold (1989)](../reference/bibliography.md);
@@ -152,6 +152,5 @@ specifically:
 
 - `N < 30` emits `BORDERLINE_CROSS_SECTION_N` /
   `SMALL_CROSS_SECTION_N`.
-- `N = 1` raises `ModeAxisError` with
-  `suggested_fix=common_continuous(...)` — the factor would no
+- `N = 1` raises `IncompatibleAxisError` — the factor would no
   longer be cross-sectional.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -51,9 +51,9 @@ factory. For task-oriented help on **picking** the right factory (information co
 when to add standalone metrics), see [Choosing a metric](../guides/choosing-metric.md).
 
 !!! note "N = 1 (single asset / series)"
-    `PanelMode` auto-switches to `TIMESERIES`. The `common_continuous` and
-    `*_sparse` factories work as-is. `individual_continuous` at N=1 raises
-    `ModeAxisError` with `suggested_fix=common_continuous(...)`.
+    `DataStructure` auto-switches to `TIMESERIES`. The `common_continuous` and
+    `*_sparse` metric families work as-is. `individual_continuous` at N=1 raises
+    `IncompatibleAxisError` — use a `common_*` or `*_sparse` metric instead.
 
 ---
 
@@ -89,9 +89,8 @@ The most common warnings:
 For the full enum and the trigger conditions for each `WarningCode`,
 `InfoCode`, and `StatCode`, see
 [Reference § Warning / info / stat codes](../reference/warning-codes.md).
-For exception classes (`InsufficientSampleError`, `ModeAxisError`,
-`UserInputError`, `ConfigError`, `MissingConfigError`, ...), their TL;DR
-catch pattern, and recovery via `suggested_fix`, see
+For exception classes (`InsufficientSampleError`, `IncompatibleAxisError`,
+`UserInputError`, ...) and their catch patterns, see
 [Errors](../api/errors.md).
 
 `warnings` does **not** affect `primary_p` —

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,87 @@
+# Observability
+
+This guide covers the observability features in `factrix` that help you debug execution flow, trace metric applicability, and understand the internal evaluation steps.
+
+---
+
+## 1. Logger Structure
+
+`factrix` uses structured logger namespaces categorized by their layer of responsibility. You can configure individual logger levels or attach handlers depending on what you want to trace.
+
+### Logger Namespaces
+
+All logger namespaces are prefixed with `factrix.` (for example, `factrix` + `.dag`):
+
+| Logger Name (prefixed with `factrix.`) | Level | Purpose / Description |
+| :--- | :--- | :--- |
+| `evaluation` | `INFO` / `WARNING` | **Orchestration & Decision Layer**: Logs orchestration-level events (e.g. Benjamini-Hochberg-Yekutieli (BHY) adjustments) and raises warning diagnostics when data characteristics might degrade metric performance. |
+| `metrics` | `DEBUG` / `WARNING` | **Per-Metric Correction Layer**: Logs internal execution steps (e.g. non-overlapping sampling intervals, Newey-West lag resolution) and warns when a correction produces degenerate/fractional samples. |
+| `dag` | `DEBUG` | **DAG Execution Layer**: Logs the topological order of DAG nodes, batched execution hits, and short-circuit propagation when upstream prerequisites fail. |
+| `metric.<name>` | `INFO` | **Individual Metric Call Layer**: Logs individual metric failures (e.g. short-circuits due to lack of periods, or raised exceptions) under the specific metric's lowercase registry name (e.g. `metric.ic`). |
+
+### Example Configuration
+
+To enable verbose debugging of the DAG executor and metric calls in a notebook or script:
+
+```python
+import logging
+
+# Configure root logger
+logging.basicConfig(level=logging.INFO)
+
+# Enable detailed DAG executor tracing
+logging.getLogger("factrix" + ".dag").setLevel(logging.DEBUG)
+```
+
+---
+
+## 2. DAG Execution Plan (`EvaluationResult.plan`)
+
+When you run `fx.evaluate()`, the toolkit resolves the required metrics and their dependencies through a Directed Acyclic Graph (DAG) executor.
+
+Every `EvaluationResult` exposes the topological execution plan via the `plan` property. This plan lists the steps of execution, showing:
+* Step number
+* Node ID (spec name and optional configuration key)
+* Mode of execution (`[batchable]` vs `[per-factor]`)
+* Upstream requirements (`requires=...`)
+
+### Example Plan Output
+
+```python
+results = fx.evaluate(
+    data,
+    metrics={"ic": ic(), "ic_ir": ic_ir()},
+    factor_cols=["factor"],
+)
+print(results[0].plan)
+```
+
+**Output:**
+```text
+1. compute_ic [batchable]
+2. ic [per-factor] requires=ic_df
+3. ic_ir [per-factor] requires=ic_df
+```
+
+This output lets you verify that shared upstream producers (like `compute_ic`) are computed exactly once across all factors before downstream consumers run.
+
+---
+
+## 3. Rich Notebook Formatting (`_repr_html_`)
+
+For interactive analysis in Jupyter notebooks, `factrix` implements native HTML representations (`_repr_html_`) on key return types. When you print these objects as the final statement in a cell, they render as formatted tables.
+
+### `DataInspection`
+
+Calling `fx.inspect_data(data)` returns a `DataInspection` object. In a notebook, it displays:
+* **Detected Properties**: Axis classifications (`scope`, `density`, `structure`) alongside sample numerics (`n_assets`, `n_periods`, `n_pairs`, `sparse_ratio`).
+* **Axis Reasoning**: Text rationales explaining *why* a particular classification was selected.
+* **Metrics Verdict Table**: A detailed list of all registered public metrics, showing their eligibility (`usable` vs `unusable`), cell-match requirements, blockers, and warnings.
+* **Data-Level Warnings**: Diagnostic warnings (e.g., NW HAC SE unreliable due to short periods).
+
+### `EvaluationResult`
+
+`EvaluationResult` objects also render as styled tables detailing:
+* Target factor name and resolved cell type.
+* Resolved `forward_periods` and observations (`n_obs`, `n_assets`).
+* **Metrics Table**: Evaluated metric values, test statistics, p-values, and warnings.

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -6,7 +6,7 @@ title: Panel vs timeseries
     What `PanelMode.PANEL` vs `PanelMode.TIMESERIES` mean, when each is dispatched, and the sample-guard contract for each.
     For the conventions table (column names, alignment), see [Timeseries-mode conventions](../reference/ts-mode-conventions.md).
     For the `mode=` parameter on `evaluate()`, see [`evaluate`](../api/evaluate.md).
-    For sample-guard error surfacing (`InsufficientSampleError`, `ModeAxisError`), see [Errors](../api/errors.md).
+    For sample-guard error surfacing (`InsufficientSampleError`, `IncompatibleAxisError`), see [Errors](../api/errors.md).
 
 ## Sample guards
 
@@ -25,8 +25,8 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 
 | Factory | N=1 | N=2..9 | N=10..29 | N≥30 |
 |---|---|---|---|---|
-| `individual_continuous(IC)` | raises `ModeAxisError` | all dates dropped (MIN_ASSETS_PER_DATE_IC=10) → NaN | normal PANEL | normal PANEL |
-| `individual_continuous(FM)` | raises `ModeAxisError` | per-date guard; low df | normal PANEL | normal PANEL |
+| `individual_continuous(IC)` | raises `IncompatibleAxisError` | all dates dropped (MIN_ASSETS_PER_DATE_IC=10) → NaN | normal PANEL | normal PANEL |
+| `individual_continuous(FM)` | raises `IncompatibleAxisError` | per-date guard; low df | normal PANEL | normal PANEL |
 | `common_continuous` | TIMESERIES single-series β | emits `SMALL_CROSS_SECTION_N` | emits `BORDERLINE_CROSS_SECTION_N` | normal PANEL |
 | `individual_sparse` / `common_sparse` | `_SCOPE_COLLAPSED` → TS dummy; `SCOPE_AXIS_COLLAPSED` info | normal PANEL CAAR | normal PANEL CAAR | normal PANEL CAAR |
 

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -152,7 +152,7 @@ Three responsibilities sit upstream of `compute_forward_return`:
 |---|---|---|
 | NaN in `factor` | Not auto-imputed; flows through to the procedure, where it depresses `n_obs` and may trip sample-size guards. | Drop or impute before `compute_forward_return`. |
 | NaN in `price` | `compute_forward_return` produces NaN `forward_return` for the row and then drops it from the output. Tail rows where `t + 1 + N` runs off the end of the series are dropped by the same filter. | If a daily NaN reflects a true gap (suspended trading, holiday), the drop is correct. If imputable (forward-fill from previous close), impute before calling. |
-| Single-asset panel (N = 1) | `PanelMode` auto-switches to `TIMESERIES`. `individual_continuous` at N = 1 raises [`ModeAxisError`](../api/errors.md) with `suggested_fix=common_continuous(...)`. | Either pass N ≥ 1 explicitly or use the `*_sparse` / `common_*` factories. |
+| Single-asset panel (N = 1) | `DataStructure` auto-switches to `TIMESERIES`. `individual_continuous` at N = 1 raises [`IncompatibleAxisError`](../api/errors.md). | Use a `*_sparse` or `common_*` metric instead. |
 | T < `MIN_PERIODS_HARD` (= 20) periods | Raises [`InsufficientSampleError`](../api/errors.md); procedures never silently produce a result on under-sample data. | Extend the window or accept the procedure's refusal. |
 
 ## 6. Sparse and event signals

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -134,6 +134,6 @@ sample-restriction vs hypothesis-dimension splits.
 
 - [`Survivors`](../api/multi-factor.md) — full symbol reference.
 - [Quickstart § profile.diagnose() and warnings](../getting-started/quickstart.md#profilediagnose-and-warnings) — runnable end-to-end example.
-- [Errors](../api/errors.md) — exception classes for the failure modes the result trio does not cover (`InsufficientSampleError`, `ModeAxisError`, ...).
+- [Errors](../api/errors.md) — exception classes for the failure modes the result trio does not cover (`InsufficientSampleError`, `IncompatibleAxisError`, ...).
 - [Architecture § Invariants](../development/architecture.md#invariants) — `primary_p` semantic contract (items 5 and 6).
 - [Batch screening with BHY](batch-screening.md) — `Survivors` lifecycle end-to-end.

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -230,7 +230,7 @@ returns a meaningful-looking result. Three deterministic outcomes:
   `diagnose()` records the degradation.
 
 Structural errors (wrong cell, missing column, `N == 1` on a cell that
-requires `PANEL` PanelMode) raise `ValueError` / [`ConfigError`][factrix.ConfigError] rather than
+requires `PANEL` DataStructure) raise `ValueError` / [`FactrixError`][factrix.FactrixError] rather than
 falling back.
 
 ## Event-study contracts

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -58,7 +58,6 @@ from factrix._compare import compare
 from factrix._dag import CycleError, DagExecutor, _Node
 from factrix._data_input import DataInput, _coerce_data
 from factrix._errors import (
-    ConfigError,
     FactrixError,
     IncompatibleAxisError,
     InsufficientSampleError,
@@ -672,7 +671,6 @@ __all__ = [
     "StatCode",
     "WarningCode",
     # Errors
-    "ConfigError",
     "FactrixError",
     "IncompatibleAxisError",
     "InsufficientSampleError",

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -131,6 +131,9 @@ class DagExecutor:
         fn_resolver: Callable[[str], Callable[..., Any]] | None = None,
         primary_names: Sequence[str] = (),
     ) -> None:
+        import logging
+
+        self._logger = logging.getLogger("factrix.dag")
         # Back-compat: a plain spec is wrapped one node per spec with
         # ``node_id == spec.name`` and requires resolved by producer name;
         # pre-built ``_Node`` items (the by-value path) pass straight through.
@@ -200,6 +203,8 @@ class DagExecutor:
         least one downstream consumer needs it; raw-data consumers
         skip projection).
         """
+        self._logger.debug("Executing DAG with topological plan:\n%s", self.plan)
+
         kwargs_by_metric = kwargs_by_metric or {}
         cols = list(factor_cols)
         n_assets = data.select(pl.col("asset_id").n_unique()).item()
@@ -226,12 +231,31 @@ class DagExecutor:
             for c in cols:
                 skip = _check_upstream_short_circuit(node, c, producer_outputs)
                 if skip is not None:
+                    self._logger.debug(
+                        "Short-circuit propagation: skipping node %s for factor %s because upstream %s failed (%s)",
+                        nid,
+                        c,
+                        skip.metadata.get("upstream"),
+                        skip.metadata.get("upstream_reason"),
+                    )
                     producer_outputs[(nid, c)] = skip
                     metric_outputs[(nid, c)] = dataclasses.replace(skip, name=nid)
                 else:
                     live.append(c)
             if not live:
+                self._logger.debug("Node %s skipped entirely (no live factors)", nid)
                 continue
+
+            if node.spec.batchable:
+                self._logger.debug(
+                    "Batched hit: executing batchable node %s across factors %r",
+                    nid,
+                    live,
+                )
+            else:
+                self._logger.debug(
+                    "Executing node %s individually for factors %r", nid, live
+                )
 
             upstream = self._gather_upstream_batch(node, live, producer_outputs)
             result = handle(data, live, project=project, upstream=upstream)
@@ -273,6 +297,7 @@ class DagExecutor:
             upstream: dict[str, dict[str, Any]],
         ) -> dict[str, Any]:
             return _dispatch_batch(
+                name=spec.name,
                 call_one=lambda *a, **k: bare(*a, **{**kw, **k}),
                 run_batch=lambda: bare(
                     data, factor_cols=list(factor_cols), **upstream, **kw

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -1,16 +1,15 @@
-"""v0.5 exception hierarchy (§4.5).
+"""Flat exception hierarchy rooted at :class:`FactrixError`.
 
-Three concrete ``ConfigError`` subclasses cover every config-validation
-or evaluate-time failure structure; ``suggested_fix`` carries the nearest
-legal :class:`factrix._analysis_config.AnalysisConfig` (when one exists)
-so the user — or a calling AI agent — can recover programmatically.
+:class:`IncompatibleAxisError`, :class:`InsufficientSampleError`,
+:class:`UnknownEstimatorError`, and :class:`UserInputError` each inherit
+directly from :class:`FactrixError`; callers can branch on subclass without
+parsing message strings.
 """
 
 from __future__ import annotations
 
 import difflib
 from collections.abc import Iterable
-from typing import Any
 
 _DOCS_BASE = "https://awwesomeman.github.io/factrix/"
 _VALUE_REPR_CAP = 120
@@ -102,25 +101,7 @@ class UserInputError(FactrixError, ValueError):
         return "\n".join(lines)
 
 
-class ConfigError(FactrixError):
-    """Base for cell / dispatch validation errors.
-
-    ``suggested_fix`` carries any caller-actionable recovery payload
-    (e.g. nearest-legal cell); stays ``None`` when the failure is a
-    data limitation rather than a cell miswire.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        suggested_fix: Any | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.suggested_fix = suggested_fix
-
-
-class UnknownEstimatorError(ConfigError, ValueError):
+class UnknownEstimatorError(FactrixError, ValueError):
     """``get_estimator(name)`` lookup miss (#163).
 
     Inherits ``ValueError`` so ``pytest.raises(ValueError)`` and the
@@ -130,7 +111,7 @@ class UnknownEstimatorError(ConfigError, ValueError):
     """
 
 
-class IncompatibleAxisError(ConfigError):
+class IncompatibleAxisError(FactrixError):
     """``(scope, density, metric)`` tuple is not a legal analysis cell.
 
     Covers e.g. ``density=SPARSE`` paired with ``metric=IC``, or
@@ -138,12 +119,11 @@ class IncompatibleAxisError(ConfigError):
     """
 
 
-class InsufficientSampleError(ConfigError):
+class InsufficientSampleError(FactrixError):
     """``T < MIN_PERIODS_HARD`` for a TIMESERIES procedure.
 
     Below the floor, Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) SE is too biased for ``primary_p`` to be
-    trustworthy. Raised at evaluate-time. ``suggested_fix`` is ``None``
-    — this is a data limitation, not a cell miswire. ``actual_periods``
+    trustworthy. Raised at evaluate-time. ``actual_periods``
     and ``required_periods`` carry the numbers so callers can recover or
     aggregate programmatically (review fix UX-3).
     """
@@ -154,8 +134,7 @@ class InsufficientSampleError(ConfigError):
         *,
         actual_periods: int,
         required_periods: int,
-        suggested_fix: Any | None = None,
     ) -> None:
-        super().__init__(message, suggested_fix=suggested_fix)
+        super().__init__(message)
         self.actual_periods = actual_periods
         self.required_periods = required_periods

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -501,16 +501,13 @@ All factrix exceptions inherit from `FactrixError`, so agents can write
 
 ```
 FactrixError                       # base — all factrix-raised errors
-├── ConfigError                    # AnalysisConfig validation / dispatch
-│   ├── MissingConfigError         # evaluate(panel) called without a config
-│   ├── IncompatibleAxisError      # (scope, density, metric) is not a legal cell
-│   ├── ModeAxisError              # legal cell, no procedure at runtime structure;
-│   │                              # carries .suggested_fix: AnalysisConfig | None
-│   └── InsufficientSampleError    # T < MIN_PERIODS_HARD on a TIMESERIES procedure;
+├── IncompatibleAxisError          # (scope, density, metric) is not a legal cell
+├── InsufficientSampleError        # T < MIN_PERIODS_HARD on a TIMESERIES procedure;
 │                                  # carries .actual_periods / .required_periods
+├── UnknownEstimatorError          # lookup miss in get_estimator
 └── UserInputError                 # user-supplied input does not match expected
                                    # names or types (typo in named-set kwarg,
-                                   # column not in panel, wrong type)
+                                   # column not in data, wrong type)
 ```
 
 `UserInputError` is keyword-constructed and renders its own canonical
@@ -522,19 +519,15 @@ compatibility.
 
 Recovery payloads — what each subclass carries beyond `.args[0]`:
 
-| Exception                | `.suggested_fix` | Extra fields                              |
-|--------------------------|:----------------:|-------------------------------------------|
-| `ConfigError` (base)     | optional         | —                                         |
-| `MissingConfigError`     | always `None`    | (pass an explicit `AnalysisConfig` factory call)  |
-| `IncompatibleAxisError`  | optional         | —                                         |
-| `ModeAxisError`          | typically set    | —                                         |
-| `InsufficientSampleError`| optional         | `.actual_periods: int`, `.required_periods: int` |
+| Exception                | Extra fields                              |
+|--------------------------|-------------------------------------------|
+| `IncompatibleAxisError`  | —                                         |
+| `InsufficientSampleError`| `.actual_periods: int`, `.required_periods: int` |
+| `UnknownEstimatorError`  | —                                         |
 
 Agents can branch on these payloads without parsing message strings; the
 canonical pattern is `except fx.FactrixError as exc:` followed by
-`isinstance(exc, …)` dispatch on the subclass. `MissingConfigError` is the
-only subclass with `.suggested_fix` always `None` — the recovery path is
-to pass an explicit `AnalysisConfig` to `evaluate`.
+`isinstance(exc, …)` dispatch on the subclass.
 
 ---
 

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import logging
 from collections.abc import Callable, Sequence
 from typing import Any, ClassVar
 
@@ -12,6 +14,16 @@ from factrix._axis import (
     TestMethod,
 )
 from factrix._metric_index import Cell, MetricSpec, SampleThreshold
+
+
+def _log_exception_once(
+    logger: logging.Logger, msg: str, *args: Any, exc: BaseException
+) -> None:
+    """Log *exc* at INFO level the first time it surfaces; no-op if already logged."""
+    if not getattr(exc, "_logged", False):
+        logger.info(msg, *args, exc_info=True)
+        with contextlib.suppress(AttributeError):
+            exc._logged = True  # type: ignore[attr-defined]
 
 
 class MetricMeta(type):
@@ -78,6 +90,11 @@ class MetricBase(metaclass=MetricMeta):
     _impl: ClassVar[Callable]
     _first_param_name: ClassVar[str | None]
     _param_names: ClassVar[tuple[str, ...]]
+    _logger: ClassVar[logging.Logger]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._logger = logging.getLogger(f"factrix.metric.{cls.__name__}")
 
     @classmethod
     def spec(cls) -> MetricSpec:
@@ -102,8 +119,18 @@ class MetricBase(metaclass=MetricMeta):
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Evaluate the metric on a single input (one factor's view / upstream)."""
-        # Accessed via __class__ to avoid binding ``_impl`` as a method.
-        return self.__class__._impl(*args, **{**self._params(), **kwargs})
+        try:
+            # Accessed via __class__ to avoid binding ``_impl`` as a method.
+            return self.__class__._impl(*args, **{**self._params(), **kwargs})
+        except Exception as e:
+            _log_exception_once(
+                self._logger,
+                "Metric %s failed with exception: %s",
+                self.__class__.__name__,
+                str(e),
+                exc=e,
+            )
+            raise
 
     def __call_batch__(
         self,
@@ -123,6 +150,7 @@ class MetricBase(metaclass=MetricMeta):
         (thin view) — are unified in :func:`_dispatch_batch`.
         """
         return _dispatch_batch(
+            name=self.__class__.__name__,
             call_one=self,
             run_batch=lambda: self.__class__._impl(
                 panel,
@@ -139,6 +167,7 @@ class MetricBase(metaclass=MetricMeta):
 
 def _dispatch_batch(
     *,
+    name: str | None = None,
     call_one: Callable[..., Any],
     run_batch: Callable[[], dict[str, Any]],
     batchable: bool,
@@ -153,15 +182,37 @@ def _dispatch_batch(
     Shared by :meth:`MetricBase.__call_batch__` and the DAG executor's
     bare-callable (``fn_resolver``) path.
     """
+    logger = logging.getLogger(f"factrix.metric.{name}") if name else None
+
     if batchable:
-        return run_batch()
+        try:
+            return run_batch()
+        except Exception as e:
+            if logger:
+                _log_exception_once(
+                    logger, "Metric %s failed with exception: %s", name, str(e), exc=e
+                )
+            raise
+
     out: dict[str, Any] = {}
     for c in factor_cols:
-        if requires:
-            # Metric consumes upstream data via kwargs, replacing the raw panel
-            c_kwargs = {k: upstream[k][c] for k in requires}
-            out[c] = call_one(**c_kwargs)
-        else:
-            # Metric consumes the raw thin view
-            out[c] = call_one(project(c))
+        try:
+            if requires:
+                # Metric consumes upstream data via kwargs, replacing the raw panel
+                c_kwargs = {k: upstream[k][c] for k in requires}
+                out[c] = call_one(**c_kwargs)
+            else:
+                # Metric consumes the raw thin view
+                out[c] = call_one(project(c))
+        except Exception as e:
+            if logger:
+                _log_exception_once(
+                    logger,
+                    "Metric %s failed for factor %s with exception: %s",
+                    name,
+                    c,
+                    str(e),
+                    exc=e,
+                )
+            raise
     return out

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -105,6 +105,17 @@ def _short_circuit_output(
     Use this instead of hand-rolling ``MetricResult(value=float("nan"),
     p_value=1.0, stat=None, metadata={"reason": ..., "p_value": 1.0, ...})``.
     """
+    import logging
+
+    logger = logging.getLogger(f"factrix.metric.{name}")
+    logger.info(
+        "Metric %s short-circuited: %s (n_obs=%s, extra=%s)",
+        name,
+        reason,
+        n_obs,
+        extra_metadata,
+    )
+
     metadata: dict[str, object] = {"reason": reason, **extra_metadata}
     p: float | None = None if descriptive else 1.0
     if p is not None:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
           - Information coefficient vs Fama-MacBeth: guides/choosing-metric.md
           - Panel vs timeseries: guides/panel-timeseries.md
           - Reading results: guides/reading-results.md
+          - Observability: guides/observability.md
           - Batch screening with Benjamini-Hochberg-Yekutieli: guides/batch-screening.md
           - Slice analysis: guides/slice-analysis.md
           - Standalone metrics: guides/standalone-metrics.md

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -13,6 +13,29 @@ def test_subclasses_factrix_error_and_value_error() -> None:
     assert issubclass(UserInputError, ValueError)
 
 
+def test_other_error_subclasses_inheritance() -> None:
+    import factrix
+    import factrix._errors
+    from factrix._errors import (
+        IncompatibleAxisError,
+        InsufficientSampleError,
+        UnknownEstimatorError,
+    )
+
+    assert issubclass(UnknownEstimatorError, FactrixError)
+    assert issubclass(UnknownEstimatorError, ValueError)
+
+    assert issubclass(IncompatibleAxisError, FactrixError)
+    assert not issubclass(IncompatibleAxisError, ValueError)
+
+    assert issubclass(InsufficientSampleError, FactrixError)
+    assert not issubclass(InsufficientSampleError, ValueError)
+
+    # Verify ConfigError is completely removed
+    assert not hasattr(factrix, "ConfigError")
+    assert not hasattr(factrix._errors, "ConfigError")
+
+
 def test_caught_by_generic_value_error() -> None:
     with pytest.raises(ValueError):
         raise UserInputError(

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,102 @@
+import logging
+from typing import ClassVar
+
+import factrix as fx
+import pytest
+from factrix.metrics import ic
+
+
+def test_dag_logger_plan_and_execution(caplog):
+    # Set the level of the factrix.dag logger to DEBUG
+    logging.getLogger("factrix.dag").setLevel(logging.DEBUG)
+
+    raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80, seed=0)
+    data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    with caplog.at_level(logging.DEBUG, logger="factrix.dag"):
+        fx.evaluate(
+            data,
+            metrics={"ic": ic()},
+            factor_cols=["factor"],
+            forward_periods=5,
+        )
+
+    # Check that topological plan was logged
+    assert any(
+        "Executing DAG with topological plan" in record.message
+        for record in caplog.records
+    )
+    # Check that batched or individual execution was logged
+    assert any(
+        "Executing node ic" in record.message or "Batched hit" in record.message
+        for record in caplog.records
+    )
+
+
+def test_metric_logger_short_circuit(caplog):
+    # Set level to INFO
+    logging.getLogger("factrix.metric.ic").setLevel(logging.INFO)
+
+    # Create too thin dataset to force short-circuit (less than MIN_ASSETS_PER_DATE_IC * 5 = 150 dates)
+    raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=10, seed=0)
+    data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    with caplog.at_level(logging.INFO, logger="factrix.metric.ic"):
+        # evaluate will raise UserInputError in strict=True; use strict=False to verify short circuit
+        fx.evaluate(
+            data,
+            metrics={"ic": ic()},
+            factor_cols=["factor"],
+            forward_periods=5,
+            strict=False,
+        )
+
+    assert any(
+        "Metric ic short-circuited" in record.message for record in caplog.records
+    )
+
+
+def test_metric_logger_exception(caplog):
+    # Let's define a metric class that raises an error
+    from factrix._axis import (
+        Aggregation,
+        InputShape,
+        OutputShape,
+        SEMethod,
+        SpecRole,
+        TestMethod,
+    )
+    from factrix.metrics._base import MetricBase
+
+    class dummy_metric(MetricBase):
+        cell = fx.metrics.ic.cell
+        aggregation = Aggregation.CS_THEN_TS
+        test_method = TestMethod.T
+        se_method = SEMethod.HAC
+        input_shape = InputShape.SERIES
+        output_shape = OutputShape.SCALAR
+        role = SpecRole.METRIC
+        requires: ClassVar[dict] = {}
+        batchable = False
+        sample_threshold = fx.metrics.ic.sample_threshold
+
+        _first_param_name = "series"
+        _param_names = ()
+
+        @classmethod
+        def _impl(cls, series):
+            raise RuntimeError("forced dummy failure")
+
+    # Set logger to INFO
+    logging.getLogger("factrix.metric.dummy_metric").setLevel(logging.INFO)
+
+    with (
+        caplog.at_level(logging.INFO, logger="factrix.metric.dummy_metric"),
+        pytest.raises(RuntimeError, match="forced dummy failure"),
+    ):
+        dummy_metric()([1, 2, 3])
+
+    assert any(
+        "Metric dummy_metric failed with exception" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- Retire the intermediate `ConfigError` class and transition `UnknownEstimatorError`, `IncompatibleAxisError`, and `InsufficientSampleError` to inherit directly from `FactrixError`.
- Implement `logging.getLogger("factrix.dag")` at the `DEBUG` level inside `DagExecutor` to log topological plan step execution, batched hits, and short-circuit propagation.
- Implement `logging.getLogger("factrix.metric.<name>")` at the `INFO` level inside per-metric callables (specifically in `__call__`, `_dispatch_batch`, and `_short_circuit_output`) to log metric failure diagnostics and exceptions.
- Add `docs/guides/observability.md` to document the loggers, `EvaluationResult.plan`, and rich HTML representations, and clean up all documentation pages to match the flat error hierarchy.

## Test plan
- [x] Run `uv run pytest tests/test_errors.py` and `tests/test_observability.py` to verify error inheritance and logging outputs.
- [x] Run `uv run pytest` to ensure all 1120 tests pass.
- [x] Run `uv run mypy factrix` to ensure type checks pass.

Closes #446
