### PR TITLE
feat(metrics): directional_hit_rate (Pesaran-Timmermann test) (#535)

### DIFF
--- a/docs/api/metrics/directional_hit_rate.md
+++ b/docs/api/metrics/directional_hit_rate.md
@@ -1,0 +1,110 @@
+---
+title: factrix.metrics.directional_hit_rate
+---
+
+::: factrix.metrics.directional_hit_rate
+    options:
+      show_root_members_full_path: true
+      members:
+        - directional_hit_rate
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Small-N robust sibling of `hit_rate`__
+
+    ---
+
+    `directional_hit_rate` is the `(*, DENSE, *)` directional counterpart
+    of `hit_rate`. Where `hit_rate` runs a naive binomial against
+    $p = 0.5$ on a single `(date, value)` series, this metric consumes
+    the raw panel `(date, asset_id, factor, forward_return)` and tests
+    whether `sign(factor)` predicts `sign(forward_return)`. The headline
+    `value` is itself a hit rate — the fraction of correctly-signed
+    calls.
+
+-   __Pesaran-Timmermann conditions on the marginals__
+
+    ---
+
+    The Pesaran-Timmermann (1992) statistic compares the realised hit
+    rate to the rate *expected under directional independence*, derived
+    from the marginal up/down frequencies of both the prediction and the
+    realisation. A factor that is simply long a persistently-rising
+    market is therefore not credited with skill — the correct framing for
+    small, sign-imbalanced samples (the `N < 30` allocation regime).
+
+-   __One-sided, non-overlap sampled__
+
+    ---
+
+    The test is one-sided: a large positive $S_n$ signals genuine
+    directional skill, so a sign-inverted predictor scores poorly (flip
+    its sign before testing). Observations are sub-sampled at stride
+    `forward_periods` so overlapping forward-return windows do not
+    inflate the statistic; degenerate samples (one-signed predictions or
+    realisations) short-circuit to `NaN`.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                                  | Function               |
+|-----------------------------------------------------------------------|------------------------|
+| Sign-significance of a `(date, value)` series vs $p = 0.5$            | `hit_rate`             |
+| Directional skill of a factor in small, sign-imbalanced samples      | `directional_hit_rate` |
+
+## Worked example — directional skill on a panel
+
+!!! example "factor → directional_hit_rate"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.directional_hit_rate import directional_hit_rate
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(
+        n_assets=25, n_dates=120, ic_target=0.06, seed=2024,
+    )
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    out = directional_hit_rate(panel, forward_periods=5)
+    print(out.value, out.stat, out.metadata["p_value"], out.metadata["method"])
+    # 0.57  2.74  0.0031  Pesaran-Timmermann (1992)   (approximate)
+    ```
+
+## See also
+
+<div class="grid cards" markdown>
+
+-   __`hit_rate`__
+
+    ---
+
+    The series-diagnostic sibling: binomial significance of a single
+    `(date, value)` series against $p = 0.5$.
+
+    [api/metrics/hit_rate →](hit_rate.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guard that gates it
+    (`MIN_ASSETS_PER_DATE_IC` floor on the non-overlapping pooled signs).
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+-   __Statistical methods__
+
+    ---
+
+    Non-overlap stride discipline and the Hansen-Hodrick autocorrelation
+    floor that motivates it.
+
+    [reference/statistical-methods →](../../reference/statistical-methods.md)
+
+</div>

--- a/docs/reference/_generated_metric_name_index.md
+++ b/docs/reference/_generated_metric_name_index.md
@@ -6,6 +6,7 @@
 | `caar` | [`factrix.metrics.caar`][factrix.metrics.caar] | [`caar`](../api/metrics/caar.md#factrix.metrics.caar.caar) |
 | `clustering_hhi` | [`factrix.metrics.clustering_hhi`][factrix.metrics.clustering_hhi] | [`clustering_hhi`](../api/metrics/clustering_hhi.md#factrix.metrics.clustering_hhi.clustering_hhi) |
 | `corrado_rank` | [`factrix.metrics.corrado_rank`][factrix.metrics.corrado_rank] | [`corrado_rank`](../api/metrics/corrado_rank.md#factrix.metrics.corrado_rank.corrado_rank) |
+| `directional_hit_rate` | [`factrix.metrics.directional_hit_rate`][factrix.metrics.directional_hit_rate] | [`directional_hit_rate`](../api/metrics/directional_hit_rate.md#factrix.metrics.directional_hit_rate.directional_hit_rate) |
 | `event_around_return` | [`factrix.metrics.event_horizon`][factrix.metrics.event_horizon] | [`event_around_return`](../api/metrics/event_horizon.md#factrix.metrics.event_horizon.event_around_return) |
 | `event_hit_rate` | [`factrix.metrics.event_quality`][factrix.metrics.event_quality] | [`event_hit_rate`](../api/metrics/event_quality.md#factrix.metrics.event_quality.event_hit_rate) |
 | `event_ic` | [`factrix.metrics.event_quality`][factrix.metrics.event_quality] | [`event_ic`](../api/metrics/event_quality.md#factrix.metrics.event_quality.event_ic) |

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -111,6 +111,7 @@ Min sample*. `MIN_*` constants resolve to values in the
 | Metric | Sample axis | Min sample |
 |---|---|---|
 | [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | series length | `T ≥ MIN_ASSETS_PER_DATE_IC` |
+| [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | pooled `(date, asset)` signs | non-overlapping obs `≥ MIN_ASSETS_PER_DATE_IC` |
 | [`ic_trend`][factrix.metrics.trend.ic_trend] | `T` | `T ≥ 10` (literal floor) |
 | [`oos_decay`][factrix.metrics.oos_decay.oos_decay] | `T` | `T ≥ 2 × MIN_OOS_PERIODS` |
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -51,6 +51,7 @@ contrasts, not a sidecar to a primary value.
 | [`bmp_test`][factrix.metrics.caar.bmp_test] | BMP cross-sectional `z` on SAR | `p_value` | mean(SAR) |
 | [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] | nonparametric rank `z` | `p_value` | mean(U × sign(factor)) |
 | [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | binomial test (or normal `z`) | `p_value` | hit rate ∈ [0, 1] |
+| [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | Pesaran-Timmermann `z` (one-sided) | `p_value` | directional hit rate ∈ [0, 1] |
 | [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | binomial test (or normal `z`) | `p_value` | hit rate ∈ [0, 1] |
 | [`event_ic`][factrix.metrics.event_quality.event_ic] | Fisher-transformed Spearman `z` | `p_value` | Spearman ρ |
 | [`event_skewness`][factrix.metrics.event_quality.event_skewness] | D'Agostino skew `z` (N ≥ 20) | `p_value` (conditional) | Fisher skewness |
@@ -177,6 +178,20 @@ runs, the normal `z` when the approximation branch runs;
 - *primary*: `p_value` — binomial / normal-approximation test on
   non-overlapping wins (stride `forward_periods`).
 - *descriptive*: `n_hits`, `n_total`.
+
+### `directional_hit_rate` (`factrix.metrics.directional_hit_rate`)
+
+#### `directional_hit_rate`
+
+Small-N robust sibling of `hit_rate`. `MetricResult.value` is the
+directional hit rate (sign-agreement fraction); `stat` is the
+Pesaran-Timmermann `z` statistic (`stat_type="z"`), tested one-sided.
+
+- *primary*: `p_value` — one-sided Pesaran-Timmermann test conditioning
+  on the marginal up/down frequencies of prediction and realisation.
+- *descriptive*: `p_correct` (realised hit rate), `p_expected`
+  (hit rate under directional independence), `p_up_pred` (fraction of
+  positive predictions), `p_up_real` (fraction of positive realisations).
 
 ### `event_quality` (`factrix.metrics.event_quality`)
 

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -44,6 +44,7 @@ from factrix.metrics.caar import (
 from factrix.metrics.clustering_hhi import clustering_hhi
 from factrix.metrics.concentration import top_concentration
 from factrix.metrics.corrado_rank import corrado_rank
+from factrix.metrics.directional_hit_rate import directional_hit_rate
 from factrix.metrics.event_horizon import (
     event_around_return,
 )
@@ -99,6 +100,7 @@ __all__ = [
     "clustering_hhi",
     "compute_rolling_mean_beta",
     "corrado_rank",
+    "directional_hit_rate",
     "event_around_return",
     "event_hit_rate",
     "event_ic",

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -1,0 +1,209 @@
+"""Directional hit rate — small-N robust sibling of ``hit_rate``.
+
+Notes:
+    **Pipeline.** Pool sign agreement between predicted (``factor``) and
+    realised (``forward_return``) direction over a non-overlapping
+    subsample; Pesaran-Timmermann (1992) market-timing test against
+    ``H₀: predicted and realised direction are independent``.
+
+    **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
+
+    The small-N robust counterpart of
+    :func:`~factrix.metrics.hit_rate.hit_rate` (and a directional sibling
+    of :func:`~factrix.metrics.event_quality.event_hit_rate`). ``hit_rate``
+    runs a naive two-sided binomial against ``p = 0.5`` on a single
+    pre-aggregated per-date series, implicitly assuming each call is an
+    independent Bernoulli draw with a fixed 0.5 success rate. The
+    Pesaran-Timmermann test instead conditions on the *marginal* up/down
+    frequencies of both the prediction and the realisation, so a factor
+    that is simply long a persistently-rising market is not credited with
+    skill. This makes it the appropriate directional test for small,
+    sign-imbalanced samples (the N < 30 allocation regime). The headline
+    ``value`` is itself a hit rate — the fraction of correctly-signed
+    calls — hence the shared ``hit_rate`` name.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+from scipy import stats as sp_stats
+
+from factrix._axis import (
+    Aggregation,
+    FactorDensity,
+    InputShape,
+    SEMethod,
+    TestMethod,
+)
+from factrix._metric_index import cell
+from factrix._results import MetricResult
+from factrix._types import MIN_ASSETS_PER_DATE_IC
+from factrix.metrics._decorators import metric
+from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
+
+__all__ = [
+    "directional_hit_rate",
+]
+
+# Minimum non-overlapping sign observations below which the PT normal
+# approximation is unreliable. Reuses the IC per-date floor — both gate a
+# pooled-sign statistic on the same "≥10 independent draws" rule of thumb.
+MIN_DIRECTIONAL_OBS: int = MIN_ASSETS_PER_DATE_IC
+
+
+@metric(
+    cell=cell(None, FactorDensity.DENSE, structure=None),
+    aggregation=Aggregation.TS_ONLY,
+    test_method=TestMethod.T,
+    se_method=SEMethod.BUILT_IN,
+    input_shape=InputShape.PANEL,
+)
+def directional_hit_rate(
+    df: pl.DataFrame,
+    forward_periods: int = 5,
+    factor_col: str = "factor",
+    return_col: str = "forward_return",
+) -> MetricResult:
+    r"""Directional hit rate via the Pesaran-Timmermann (1992) test.
+
+    Proportion of observations whose predicted direction
+    ``sign(factor)`` matches the realised direction
+    ``sign(forward_return)``, tested for predictive ability against the
+    PT independence null.
+
+    Args:
+        df: Panel with ``date, asset_id``, ``factor_col`` and
+            ``return_col``. Pooled across all ``(date, asset)``
+            observations on the non-overlapping subsample.
+        forward_periods: Sampling stride for non-overlapping dates;
+            match the forward-return horizon so overlapping windows do
+            not inflate the test.
+        factor_col: Prediction column (default ``"factor"``).
+        return_col: Realisation column (default ``"forward_return"``).
+
+    Returns:
+        MetricResult with value = directional hit rate ``P̂`` (0.0-1.0),
+        ``stat`` = PT statistic ``S_n``, one-sided p-value.
+
+    Notes:
+        On the non-overlapping subsample, drop observations where either
+        sign is zero (direction undefined), leaving $n$ pooled pairs.
+        With $\hat P_x = \Pr(\text{factor} > 0)$,
+        $\hat P_y = \Pr(\text{return} > 0)$ and the realised hit rate
+        $\hat P = \frac1n \sum_t \mathbb{1}[\operatorname{sign}(x_t) =
+        \operatorname{sign}(y_t)]$, the rate expected under independence is
+
+        $$P_* = \hat P_x \hat P_y + (1 - \hat P_x)(1 - \hat P_y).$$
+
+        The Pesaran-Timmermann statistic
+
+        $$S_n = \frac{\hat P - P_*}{\sqrt{\widehat{\operatorname{var}}(\hat P)
+        - \widehat{\operatorname{var}}(P_*)}}$$
+
+        is asymptotically $N(0, 1)$ under $H_0$, with
+        $\widehat{\operatorname{var}}(\hat P) = P_*(1 - P_*)/n$ and
+        $\widehat{\operatorname{var}}(P_*) = \frac1n (2\hat P_y - 1)^2
+        \hat P_x (1 - \hat P_x) + \frac1n (2\hat P_x - 1)^2 \hat P_y
+        (1 - \hat P_y) + \frac{4}{n^2} \hat P_x \hat P_y (1 - \hat P_x)
+        (1 - \hat P_y)$.
+
+        The test is **one-sided**: a large positive $S_n$ signals genuine
+        directional skill, so $p = \Pr(Z > S_n)$. A factor expected to be
+        *negatively* related to forward returns scores poorly here — flip
+        its sign before testing. Degenerate samples (all predictions or
+        all realisations one-signed, or a non-positive variance estimate)
+        short-circuit: $P_*$ is then 1 and the statistic is undefined.
+
+    References:
+        Pesaran, M. H., & Timmermann, A. (1992). A simple nonparametric
+        test of predictive performance. *Journal of Business & Economic
+        Statistics*, 10(4), 461-465.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> from factrix.metrics.directional_hit_rate import directional_hit_rate
+        >>> panel = compute_forward_return(
+        ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
+        ...     forward_periods=5,
+        ... )
+        >>> result = directional_hit_rate(panel, forward_periods=5)
+        >>> result.name == ""
+        True
+    """
+    if return_col not in df.columns:
+        return _short_circuit_output(
+            "directional_hit_rate",
+            "no_return_column",
+            missing_column=return_col,
+        )
+
+    sampled = _sample_non_overlapping(df, forward_periods)
+    paired = sampled.select(
+        pl.col(factor_col).sign().alias("_x_sign"),
+        pl.col(return_col).sign().alias("_y_sign"),
+    ).filter(
+        pl.col("_x_sign").is_not_null()
+        & pl.col("_y_sign").is_not_null()
+        & (pl.col("_x_sign") != 0)
+        & (pl.col("_y_sign") != 0)
+    )
+
+    n = paired.height
+    if n < MIN_DIRECTIONAL_OBS:
+        return _short_circuit_output(
+            "directional_hit_rate",
+            "insufficient_directional_samples",
+            n_obs=n,
+            min_required=MIN_DIRECTIONAL_OBS,
+        )
+
+    x_up = paired["_x_sign"].to_numpy() > 0
+    y_up = paired["_y_sign"].to_numpy() > 0
+
+    p_correct = float(np.mean(x_up == y_up))
+    p_x = float(np.mean(x_up))
+    p_y = float(np.mean(y_up))
+    p_star = p_x * p_y + (1.0 - p_x) * (1.0 - p_y)
+
+    var_p_hat = p_star * (1.0 - p_star) / n
+    var_p_star = (
+        (2.0 * p_y - 1.0) ** 2 * p_x * (1.0 - p_x) / n
+        + (2.0 * p_x - 1.0) ** 2 * p_y * (1.0 - p_y) / n
+        + 4.0 * p_x * p_y * (1.0 - p_x) * (1.0 - p_y) / n**2
+    )
+    var_s = var_p_hat - var_p_star
+
+    # Degenerate: one-signed predictions or realisations collapse P* to 1
+    # and drive var_s to (numerically) zero or below — S_n is undefined.
+    if var_s <= 0.0:
+        return _short_circuit_output(
+            "directional_hit_rate",
+            "degenerate_directional_variance",
+            n_obs=n,
+            p_correct=p_correct,
+            p_up_pred=p_x,
+            p_up_real=p_y,
+        )
+
+    s_n = (p_correct - p_star) / np.sqrt(var_s)
+    p = float(sp_stats.norm.sf(s_n))
+
+    return MetricResult(
+        value=p_correct,
+        p_value=p,
+        n_obs=n,
+        stat=float(s_n),
+        metadata={
+            "p_value": p,
+            "stat_type": "z",
+            "h0": "independent_direction",
+            "method": "Pesaran-Timmermann (1992)",
+            "p_correct": p_correct,
+            "p_expected": p_star,
+            "p_up_pred": p_x,
+            "p_up_real": p_y,
+            "n_obs": n,
+        },
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,6 +220,7 @@ nav:
           - Series diagnostics:
               - Overview: api/metrics/series-tools.md
               - hit_rate: api/metrics/hit_rate.md
+              - directional_hit_rate: api/metrics/directional_hit_rate.md
               - trend: api/metrics/trend.md
               - oos: api/metrics/oos.md
       - Supporting modules:

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -1,0 +1,172 @@
+"""Tests for factrix.metrics.directional_hit_rate (Pesaran-Timmermann)."""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.metrics.directional_hit_rate import (
+    MIN_DIRECTIONAL_OBS,
+    directional_hit_rate,
+)
+from factrix.metrics.hit_rate import hit_rate
+
+
+def _ts_panel(x: np.ndarray, y: np.ndarray) -> pl.DataFrame:
+    """Single-asset panel from prediction ``x`` and realisation ``y``."""
+    n = len(x)
+    dates = [date(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame(
+        {"date": dates, "asset_id": ["A"] * n, "factor": x, "forward_return": y}
+    )
+
+
+def _pt_reference(x: np.ndarray, y: np.ndarray) -> tuple[float, float]:
+    """Independent re-derivation of (P̂, S_n) for cross-checking."""
+    xs, ys = x > 0, y > 0
+    n = len(x)
+    p_correct = float(np.mean(xs == ys))
+    p_x, p_y = float(np.mean(xs)), float(np.mean(ys))
+    p_star = p_x * p_y + (1 - p_x) * (1 - p_y)
+    var_p_hat = p_star * (1 - p_star) / n
+    var_p_star = (
+        (2 * p_y - 1) ** 2 * p_x * (1 - p_x) / n
+        + (2 * p_x - 1) ** 2 * p_y * (1 - p_y) / n
+        + 4 * p_x * p_y * (1 - p_x) * (1 - p_y) / n**2
+    )
+    return p_correct, (p_correct - p_star) / math.sqrt(var_p_hat - var_p_star)
+
+
+class TestStatisticCorrectness:
+    def test_matches_independent_reference(self):
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=200)
+        y = 0.5 * x + rng.normal(size=200)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+
+        ref_value, ref_stat = _pt_reference(x, y)
+        assert result.value == pytest.approx(ref_value)
+        assert result.stat == pytest.approx(ref_stat)
+        assert result.metadata["method"] == "Pesaran-Timmermann (1992)"
+        assert result.metadata["stat_type"] == "z"
+
+    def test_positive_predictor_is_significant(self):
+        rng = np.random.default_rng(1)
+        x = rng.normal(size=300)
+        y = x + 0.3 * rng.normal(size=300)  # strong sign agreement
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert result.value > 0.5
+        assert result.stat > 0
+        assert result.p_value < 0.01
+
+    def test_independent_factor_not_significant(self):
+        rng = np.random.default_rng(2)
+        x = rng.normal(size=400)
+        y = rng.normal(size=400)  # no relation
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert result.p_value > 0.05
+
+    def test_negative_predictor_scores_poorly_one_sided(self):
+        # PT directional accuracy is one-sided: a sign-inverted predictor has
+        # poor directional accuracy (S_n < 0), so the one-sided p stays high.
+        rng = np.random.default_rng(3)
+        x = rng.normal(size=300)
+        y = -x + 0.3 * rng.normal(size=300)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert result.value < 0.5
+        assert result.stat < 0
+        assert result.p_value > 0.95
+
+
+class TestDivergenceFromHitRate:
+    def test_discounts_persistent_market_drift(self):
+        # Market is up ~85% of periods; the factor is sign-independent of it.
+        # A naive hit-rate vs 0.5 on the sign-agreement series reads as
+        # "skill" purely from the shared upward drift; PT conditions on the
+        # marginal up-frequencies and correctly finds no directional skill.
+        rng = np.random.default_rng(4)
+        n = 400
+        y = np.where(rng.random(n) < 0.85, 1.0, -1.0) * (rng.random(n) + 0.1)
+        x = np.where(rng.random(n) < 0.85, 1.0, -1.0) * (rng.random(n) + 0.1)
+
+        pt = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+
+        agree = pl.DataFrame(
+            {
+                "date": [date(2020, 1, 1) + timedelta(days=i) for i in range(n)],
+                "value": (np.sign(x) == np.sign(y)).astype(float),
+            }
+        )
+        naive = hit_rate(agree, forward_periods=1)
+
+        # Naive binomial sees a high hit rate and calls it significant;
+        # PT, conditioning on the imbalanced marginals, does not.
+        assert naive.value > 0.5
+        assert naive.p_value < 0.05
+        assert pt.p_value > 0.10
+
+
+class TestShortCircuits:
+    def test_insufficient_samples(self):
+        rng = np.random.default_rng(5)
+        n = MIN_DIRECTIONAL_OBS - 1
+        x = rng.normal(size=n)
+        y = rng.normal(size=n)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_directional_samples"
+
+    def test_degenerate_one_signed_predictor(self):
+        rng = np.random.default_rng(6)
+        x = np.abs(rng.normal(size=100)) + 0.1  # all positive
+        y = rng.normal(size=100)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "degenerate_directional_variance"
+
+    def test_missing_return_column(self):
+        rng = np.random.default_rng(7)
+        x = rng.normal(size=50)
+        df = _ts_panel(x, x).drop("forward_return")
+        result = directional_hit_rate(df, forward_periods=1)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "no_return_column"
+
+    def test_zero_signs_are_dropped(self):
+        # Exact-zero predictions have undefined direction and must not count.
+        x = np.array([0.0] * 30 + [1.0] * 30 + [-1.0] * 30)
+        y = np.array([1.0] * 30 + [1.0] * 30 + [-1.0] * 30)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert result.n_obs == 60  # the 30 zero-factor rows dropped
+        assert result.value == pytest.approx(1.0)
+
+
+class TestDispatch:
+    def test_runs_on_panel(self):
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=25, n_dates=120)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        [er] = fx.evaluate(
+            panel,
+            metrics={"da": directional_hit_rate()},
+            factor_cols=["factor"],
+            forward_periods=5,
+        )
+        out = er.metrics["da"]
+        assert out.name == "da"
+        assert 0.0 <= out.value <= 1.0
+
+    def test_runs_on_single_asset_timeseries(self):
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=4, n_dates=160)
+        first = raw["asset_id"].unique()[0]
+        ts = fx.preprocess.compute_forward_return(
+            raw.filter(pl.col("asset_id") == first), forward_periods=5
+        )
+        result = directional_hit_rate(ts, forward_periods=5)
+        assert math.isnan(result.value) or 0.0 <= result.value <= 1.0


### PR DESCRIPTION
## Summary
- Add `directional_hit_rate` — the small-N robust sibling of `hit_rate`. Tests whether `sign(factor)` predicts `sign(forward_return)` via the Pesaran-Timmermann (1992) directional test, conditioning on the marginal up/down frequencies of both series so a factor merely long a rising market is not credited with skill.
- `@metric` cell `(*, DENSE, *)`, panel input; pools per-`(date, asset)` signs on a non-overlapping subsample (stride `forward_periods`), one-sided p. One-signed predictions/realisations and thin samples short-circuit to `NaN`.
- Named per the existing `hit_rate` / `event_hit_rate` family so the kinship is discoverable; the PT method lives in the docstring and `metadata["method"]` rather than the callable name (consistent with the #460 concept-naming philosophy).

## Test plan
- [x] `tests/test_directional_hit_rate.py` (11 passed): PT statistic matches an independent re-derivation; positive/negative/independent predictors; **divergence from naive `hit_rate`** under a persistently-rising market; three short-circuits; zero-sign drop; panel + single-asset dispatch.
- [x] docs drift-guards green (`test_docs_matrix` / `test_list_metrics` / `test_docs_stat_keys_by_metric`); name-index regenerated, stat-keys + applicability + api page + nav updated.
- [x] `ruff check` · `ruff format --check` · `mypy factrix` · full suite (1379 passed, 0 failed).

## Notes
- CHANGELOG `### Added` and the wholesale `llms-full.txt` regen are intentionally left to the #532 docs sweep (llms-full.txt has no per-metric catalog section to slot into; CHANGELOG carries an unrelated pre-existing terminology edit in the tree).
- `scripts/mkdocs_hooks/gen_metric_matrix.py` is broken on main (references the retired `spec.agg_order`) — pre-existing, no test depends on it, out of scope here.

Closes #535