### PR TITLE
feat(metrics): k_spread fixed-K long-short spread + small-N bootstrap (#536)

### DIFF
--- a/docs/api/metrics/k_spread.md
+++ b/docs/api/metrics/k_spread.md
@@ -1,0 +1,104 @@
+---
+title: factrix.metrics.k_spread
+---
+
+::: factrix.metrics.k_spread
+    options:
+      show_root_members_full_path: true
+      members:
+        - k_spread
+
+<hr>
+
+## Use cases
+
+<div class="grid cards" markdown>
+
+-   __Small-N sibling of `quantile_spread`__
+
+    ---
+
+    `k_spread` is the fixed-**count** long-short spread: per non-overlapping
+    date it longs the `k` highest-factor names and shorts the `k` lowest,
+    then tests the spread across time. Quintile bucketing (`quantile_spread`,
+    `n_groups=5`) degrades when `N < 30` — each bucket holds only a few names
+    and the breakpoints are unstable. Fixing the count `k` keeps each leg's
+    composition stable regardless of `N`. Both name the selection convention,
+    not a leg: `quantile_spread` (fraction) ↔ `k_spread` (count).
+
+-   __Cross-sectional dispersion reported alongside__
+
+    ---
+
+    `metadata["cross_sectional_dispersion"]` carries the mean per-date
+    cross-sectional standard deviation of returns, so the headline spread can
+    be read relative to the typical spread of returns that period rather than
+    in isolation.
+
+-   __Cross-section-aware significance__
+
+    ---
+
+    The headline test follows the shared small-cross-section policy
+    (`_spread_significance`): with `n_assets < MIN_ASSETS_WARN` the per-date
+    spread is heavy-tailed (few names per leg), so the non-overlapping `t` is
+    replaced by a block-bootstrap CI; `metadata["method"]` records which ran.
+    Dates with fewer than `2·k` names are dropped; if none qualify the metric
+    short-circuits with `max_assets_per_date`.
+
+</div>
+
+## Choosing a function
+
+| Goal                                                            | Function          |
+|----------------------------------------------------------------|-------------------|
+| Long-short spread by extreme **quantiles** (large universe)    | `quantile_spread` |
+| Long-short spread by fixed **count** per leg (small universe)  | `k_spread`        |
+
+## Worked example — fixed-K spread on a small universe
+
+!!! example "k_spread on N=20"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics.k_spread import k_spread
+    from factrix.preprocess import compute_forward_return
+
+    raw   = fx.datasets.make_cs_panel(n_assets=20, n_dates=180, seed=2024)
+    panel = compute_forward_return(raw, forward_periods=5)
+
+    out = k_spread(panel, forward_periods=5, k=3)
+    print(out.value, out.metadata["method"], out.metadata["cross_sectional_dispersion"])
+    # 0.0018  block-bootstrap CI  0.041   (approximate)
+    ```
+
+## See also
+
+<div class="grid cards" markdown>
+
+-   __`quantile_spread`__
+
+    ---
+
+    The fraction-based sibling: long-short spread by extreme quantiles, the
+    idiomatic choice for large cross-sections.
+
+    [api/metrics/quantile →](quantile.md)
+
+-   __`top_concentration`__
+
+    ---
+
+    Long-leg diversification (HHI effective bets) on the top bucket.
+
+    [api/metrics/concentration →](concentration.md)
+
+-   __Metric applicability reference__
+
+    ---
+
+    When this metric applies and the sample-size guards that gate it.
+
+    [reference/metric-applicability →](../../reference/metric-applicability.md)
+
+</div>

--- a/docs/reference/_generated_metric_name_index.md
+++ b/docs/reference/_generated_metric_name_index.md
@@ -18,6 +18,7 @@
 | `ic_ir` | [`factrix.metrics.ic`][factrix.metrics.ic] | [`ic_ir`](../api/metrics/ic.md#factrix.metrics.ic.ic_ir) |
 | `ic_newey_west` | [`factrix.metrics.ic`][factrix.metrics.ic] | [`ic_newey_west`](../api/metrics/ic.md#factrix.metrics.ic.ic_newey_west) |
 | `ic_trend` | [`factrix.metrics.trend`][factrix.metrics.trend] | [`ic_trend`](../api/metrics/trend.md#factrix.metrics.trend.ic_trend) |
+| `k_spread` | [`factrix.metrics.k_spread`][factrix.metrics.k_spread] | [`k_spread`](../api/metrics/k_spread.md#factrix.metrics.k_spread.k_spread) |
 | `mean_r_squared` | [`factrix.metrics.ts_beta`][factrix.metrics.ts_beta] | [`mean_r_squared`](../api/metrics/ts_beta.md#factrix.metrics.ts_beta.mean_r_squared) |
 | `mfe_mae_summary` | [`factrix.metrics.mfe_mae`][factrix.metrics.mfe_mae] | [`mfe_mae_summary`](../api/metrics/mfe_mae.md#factrix.metrics.mfe_mae.mfe_mae_summary) |
 | `monotonicity` | [`factrix.metrics.monotonicity`][factrix.metrics.monotonicity] | [`monotonicity`](../api/metrics/monotonicity.md#factrix.metrics.monotonicity.monotonicity) |

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -63,6 +63,7 @@ Min sample*. `MIN_*` constants resolve to values in the
 |---|---|---|
 | [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; per-date `N ≥ n_groups` |
 | [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | `T/h` | as `quantile_spread` |
+| [`k_spread`][factrix.metrics.k_spread.k_spread] | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; per-date `N ≥ 2·k` |
 | [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | `T/h` | per-date `N ≥ n_groups`; series `≥ MIN_MONOTONICITY_PERIODS` |
 | [`top_concentration`][factrix.metrics.concentration.top_concentration] | `T/h` | `T/h ≥ MIN_PORTFOLIO_PERIODS_HARD`; warn if `T/h < MIN_PORTFOLIO_PERIODS_WARN` |
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -59,7 +59,8 @@ contrasts, not a sidecar to a primary value.
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | none — descriptive | — | mean bars per event |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | none — descriptive | — | mean leakage score |
 | [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | cross-asset `t` on signed Spearman | `p_value` | mean \|Spearman\| |
-| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | NW HAC `t` on top-bottom spread | `p_value` | mean(spread) |
+| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | NW HAC `t` on top-bottom spread (block-bootstrap CI when small cross-section) | `p_value` | mean(spread) |
+| [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (block-bootstrap CI when small cross-section) | `p_value` | mean(spread) |
 | [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
 | [`top_concentration`][factrix.metrics.concentration.top_concentration] | one-sided `t` on diversity ratio | `p_value` | mean(eff_n / n_top) |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | none — descriptive | — | event-date Herfindahl-Hirschman index (HHI) |
@@ -265,18 +266,43 @@ consistency are read separately.
 #### `quantile_spread`
 
 - *primary*: `p_value` — non-overlapping `t`-test on the
-  (top − bottom) spread series.
+  (top − bottom) spread series. Small cross-sections
+  (`n_assets < MIN_ASSETS_WARN`) switch to a block-bootstrap CI; see
+  the shared small-N keys below.
 - *secondary-test*: `long_alpha`, `long_stat`, `long_p_value` —
   long-leg attribution (mean excess and `t` / p-value).
 - *secondary-test*: `short_alpha`, `short_stat`, `short_p_value`,
   `short_significance` — short-leg attribution.
-- *descriptive*: `n_periods`, `tie_ratio`, `tie_policy`.
+- *descriptive*: `n_periods`, `tie_ratio`, `tie_policy`, `method`.
 
 #### `quantile_spread_vw`
 
 Value-weighted variant. Same metadata shape as `quantile_spread`
 plus a `weights_lagged` flag indicating whether the weighting input
 was lagged before the join (descriptive).
+
+### `k_spread` (`factrix.metrics.k_spread`)
+
+#### `k_spread`
+
+Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
+`quantile_spread`.
+
+- *primary*: `p_value` — non-overlapping `t`-test on the spread
+  series, or a block-bootstrap CI in the small-cross-section regime
+  (`method` records which).
+- *descriptive*: `k` (names per leg), `cross_sectional_dispersion`
+  (mean per-date cross-sectional return std), `top_return`,
+  `bottom_return`, `n_periods`, `method`. The `k`-too-large
+  short-circuit reports `max_assets_per_date`.
+
+#### Shared small-N significance keys
+
+Both `quantile_spread` and `k_spread` switch the headline test to a
+block-bootstrap CI when `n_assets < MIN_ASSETS_WARN`. In that branch
+they additionally emit `p_value_t` (the parametric `t` p-value kept
+for reference), `bootstrap_block_length`, `bootstrap_n_resamples`,
+and `bootstrap_seed`.
 
 ### `concentration` (`factrix.metrics.concentration`)
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -302,7 +302,10 @@ Both `quantile_spread` and `k_spread` switch the headline test to a
 block-bootstrap CI when `n_assets < MIN_ASSETS_WARN`. In that branch
 they additionally emit `p_value_t` (the parametric `t` p-value kept
 for reference), `bootstrap_block_length`, `bootstrap_n_resamples`,
-and `bootstrap_seed`.
+and `bootstrap_seed`. The switch is **not** silent: the cross-section
+tier code (`small_cross_section_n` / `borderline_cross_section_n`) is
+attached to `warning_codes`, so the method change surfaces as a
+`Warning` on the result.
 
 ### `concentration` (`factrix.metrics.concentration`)
 

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -66,6 +66,7 @@ from factrix.metrics.ic import (
     ic_ir,
     ic_newey_west,
 )
+from factrix.metrics.k_spread import k_spread
 from factrix.metrics.mfe_mae import (
     mfe_mae_summary,
 )
@@ -112,6 +113,7 @@ __all__ = [
     "ic_ir",
     "ic_newey_west",
     "ic_trend",
+    "k_spread",
     "mean_r_squared",
     "mfe_mae_summary",
     "monotonicity",

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -38,13 +38,63 @@ import numpy as np
 import polars as pl
 
 from factrix._results import MetricResult
-from factrix._types import EPSILON
+from factrix._stats import _calc_t_stat, _p_value_from_t
+from factrix._stats.constants import MIN_ASSETS_WARN
+from factrix._types import DDOF, EPSILON
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
 # tie_policy="ordinal". 0.3 is the empirical cutoff for "crowded" factors
 # (bucketed signals, industry/size dummies routinely sit at ~0.5 — below
 # 0.3 the sorting-artifact noise from ordinal tie-breaking is negligible).
 TIE_RATIO_WARN_THRESHOLD = 0.3
+
+# Fixed bootstrap seed for the small-cross-section significance path.
+# A spread metric's headline p must be reproducible run-to-run, so the
+# block-bootstrap branch draws from a fixed seed rather than system
+# entropy; the resolved seed is echoed into metadata for the record.
+_SPREAD_BOOTSTRAP_SEED = 0
+
+
+def _spread_significance(
+    spread: np.ndarray,
+    n_assets: int,
+    *,
+    rng_seed: int = _SPREAD_BOOTSTRAP_SEED,
+) -> tuple[float, float, str, dict[str, object]]:
+    """Headline significance for a per-date long-short spread series.
+
+    Returns ``(stat, p_value, method, extra_metadata)``.
+
+    Small cross-sections (``n_assets < MIN_ASSETS_WARN``) switch the
+    headline test from the non-overlapping ``t`` to a block-bootstrap
+    CI: with few names per leg the per-date spread is heavy-tailed, so
+    the ``t``-test's normality assumption is unreliable while the
+    block bootstrap (Politis-Romano stationary scheme) is
+    distribution-free and preserves any residual serial dependence.
+    Larger cross-sections keep the cheaper ``t``-test. ``stat`` is the
+    ``t`` statistic in both branches as a descriptive standardised
+    effect size; in the bootstrap branch ``p_value`` comes from the
+    resampling (``extra_metadata["p_value_t"]`` keeps the parametric ``p``
+    for reference). The chosen path is named in the returned ``method``.
+    """
+    n = len(spread)
+    mean = float(np.mean(spread))
+    std = float(np.std(spread, ddof=DDOF))
+    t = _calc_t_stat(mean, std, n)
+
+    if n_assets >= MIN_ASSETS_WARN:
+        return t, _p_value_from_t(t, n), "non-overlapping t-test", {}
+
+    from factrix.estimators import block_bootstrap
+
+    p_boot, boot_meta = block_bootstrap(spread, rng_seed=rng_seed)
+    extra: dict[str, object] = {
+        "p_value_t": _p_value_from_t(t, n),
+        "bootstrap_block_length": boot_meta["block_length"],
+        "bootstrap_n_resamples": boot_meta["n_resamples"],
+        "bootstrap_seed": boot_meta["rng_seed"],
+    }
+    return t, float(p_boot), "block-bootstrap CI", extra
 
 
 def _aggregate_to_per_date(

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -37,6 +37,7 @@ import warnings
 import numpy as np
 import polars as pl
 
+from factrix._codes import WarningCode, cross_section_tier
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
 from factrix._stats.constants import MIN_ASSETS_WARN
@@ -60,10 +61,10 @@ def _spread_significance(
     n_assets: int,
     *,
     rng_seed: int = _SPREAD_BOOTSTRAP_SEED,
-) -> tuple[float, float, str, dict[str, object]]:
+) -> tuple[float, float, str, dict[str, object], tuple[str, ...]]:
     """Headline significance for a per-date long-short spread series.
 
-    Returns ``(stat, p_value, method, extra_metadata)``.
+    Returns ``(stat, p_value, method, extra_metadata, warning_codes)``.
 
     Small cross-sections (``n_assets < MIN_ASSETS_WARN``) switch the
     headline test from the non-overlapping ``t`` to a block-bootstrap
@@ -76,6 +77,13 @@ def _spread_significance(
     effect size; in the bootstrap branch ``p_value`` comes from the
     resampling (``extra_metadata["p_value_t"]`` keeps the parametric ``p``
     for reference). The chosen path is named in the returned ``method``.
+
+    The switch fires exactly when :func:`cross_section_tier` flags the
+    cross-section (``n_assets < MIN_ASSETS_WARN``), so the returned
+    ``warning_codes`` carry that tier code (``SMALL_`` /
+    ``BORDERLINE_CROSS_SECTION_N``). This surfaces the method change as a
+    :class:`Warning` on the result rather than leaving it buried in
+    metadata — the same two-tier convention the sample guards use.
     """
     n = len(spread)
     mean = float(np.mean(spread))
@@ -83,7 +91,7 @@ def _spread_significance(
     t = _calc_t_stat(mean, std, n)
 
     if n_assets >= MIN_ASSETS_WARN:
-        return t, _p_value_from_t(t, n), "non-overlapping t-test", {}
+        return t, _p_value_from_t(t, n), "non-overlapping t-test", {}, ()
 
     from factrix.estimators import block_bootstrap
 
@@ -94,7 +102,9 @@ def _spread_significance(
         "bootstrap_n_resamples": boot_meta["n_resamples"],
         "bootstrap_seed": boot_meta["rng_seed"],
     }
-    return t, float(p_boot), "block-bootstrap CI", extra
+    tier: WarningCode | None = cross_section_tier(n_assets)
+    codes = (tier.value,) if tier is not None else ()
+    return t, float(p_boot), "block-bootstrap CI", extra, codes
 
 
 def _aggregate_to_per_date(

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -137,7 +137,15 @@ def k_spread(
         )
 
     sampled = _sample_non_overlapping(df, forward_periods)
-    ranked = sampled.with_columns(
+    # Drop rows with no factor or no realised return BEFORE ranking: ``rank``
+    # skips nulls but ``pl.len`` would still count them, so ``_n_date`` would
+    # overcount and the bottom-leg cutoff (``_rank > _n_date - k``) would point
+    # past the last real rank — silently shrinking or emptying the short leg.
+    # forward_return is null on the last ``forward_periods`` rows per asset.
+    clean = sampled.filter(
+        pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
+    )
+    ranked = clean.with_columns(
         pl.col(factor_col)
         .rank(method="ordinal", descending=True)
         .over("date")
@@ -146,7 +154,7 @@ def k_spread(
     ).filter(pl.col("_n_date") >= 2 * k)
 
     if ranked.height == 0:
-        per_date_counts = sampled.group_by("date").len()["len"].to_numpy()
+        per_date_counts = clean.group_by("date").len()["len"].to_numpy()
         max_per_date = int(np.max(per_date_counts)) if per_date_counts.size else 0
         return _short_circuit_output(
             "k_spread",
@@ -185,7 +193,7 @@ def k_spread(
 
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))
-    n_assets = sampled["asset_id"].n_unique()
+    n_assets = clean["asset_id"].n_unique()
     t, p, sig_method, sig_extra = _spread_significance(arr, n_assets, rng_seed=rng_seed)
 
     mean_dispersion = float(np.mean(series["xs_dispersion"].drop_nulls().to_numpy()))

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -194,7 +194,9 @@ def k_spread(
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))
     n_assets = clean["asset_id"].n_unique()
-    t, p, sig_method, sig_extra = _spread_significance(arr, n_assets, rng_seed=rng_seed)
+    t, p, sig_method, sig_extra, sig_codes = _spread_significance(
+        arr, n_assets, rng_seed=rng_seed
+    )
 
     mean_dispersion = float(np.mean(series["xs_dispersion"].drop_nulls().to_numpy()))
     mean_top = float(np.mean(series["top_return"].drop_nulls().to_numpy()))
@@ -217,4 +219,5 @@ def k_spread(
             "bottom_return": mean_bottom,
             **sig_extra,
         },
+        warning_codes=sig_codes,
     )

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -1,0 +1,212 @@
+"""Fixed-K Top-K vs Bottom-K long-short spread for small cross-sections.
+
+Notes:
+    **Pipeline.** Per non-overlapping date, select the top ``k`` and
+    bottom ``k`` names by factor rank, take the mean-return difference
+    (cross-section step), then test the per-date spread series across
+    time. Small cross-sections switch the headline test to a
+    block-bootstrap CI.
+
+    **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
+
+    **Output.** Mean spread, with the per-date cross-sectional return
+    dispersion reported alongside.
+
+    The small-N counterpart of
+    :func:`~factrix.metrics.quantile.quantile_spread`. Quantile bucketing
+    (``n_groups=5`` ⇒ quintiles) degrades when ``N < 30``: each bucket
+    holds only a handful of names, so the spread is dominated by
+    individual assets and the quintile breakpoints are unstable. Fixing
+    the **count** ``k`` per leg keeps each leg's composition stable
+    regardless of ``N``, and the metric reports the contemporaneous
+    cross-sectional dispersion so the spread can be read relative to the
+    typical spread of returns that period.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from factrix._axis import (
+    Aggregation,
+    DataStructure,
+    FactorDensity,
+    FactorScope,
+    SEMethod,
+    TestMethod,
+)
+from factrix._metric_index import SampleThreshold, cell
+from factrix._results import MetricResult
+from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
+from factrix.metrics._decorators import metric
+from factrix.metrics._helpers import (
+    _sample_non_overlapping,
+    _short_circuit_output,
+    _spread_significance,
+)
+
+__all__ = [
+    "k_spread",
+]
+
+
+@metric(
+    cell=cell(
+        FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
+    ),
+    aggregation=Aggregation.CS_THEN_TS,
+    test_method=TestMethod.T,
+    se_method=SEMethod.OLS,
+    sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
+)
+def k_spread(
+    df: pl.DataFrame,
+    forward_periods: int = 5,
+    k: int = 5,
+    factor_col: str = "factor",
+    return_col: str = "forward_return",
+    rng_seed: int = 0,
+) -> MetricResult:
+    r"""Fixed-K Top-K vs Bottom-K long-short spread.
+
+    Per non-overlapping date, the long leg is the mean forward return of
+    the ``k`` highest-factor names and the short leg the mean of the
+    ``k`` lowest; the spread is their difference. The mean spread is
+    tested across time.
+
+    Args:
+        df: Panel with ``date, asset_id``, ``factor_col`` and
+            ``return_col``.
+        forward_periods: Sampling stride for non-overlapping dates;
+            match the forward-return horizon.
+        k: Number of names per leg (fixed count, not a quantile
+            fraction). A date needs at least ``2 * k`` names to form
+            disjoint legs — dates with fewer are dropped.
+        factor_col: Ranking column (default ``"factor"``).
+        return_col: Realised-return column (default ``"forward_return"``).
+        rng_seed: Seed for the small-N block-bootstrap branch
+            (reproducible by default).
+
+    Returns:
+        MetricResult with value = mean spread, ``stat`` = ``t`` on the
+        spread series, p-value from the cross-section-aware significance
+        path. ``metadata["cross_sectional_dispersion"]`` carries the
+        mean per-date cross-sectional standard deviation of returns.
+
+    Notes:
+        Per qualifying date $t$ (universe size $N_t \geq 2k$), with
+        $\mathrm{top}_k$ / $\mathrm{bot}_k$ the names ranked $1..k$ /
+        $N_t-k+1..N_t$ by factor:
+
+        $$\text{spread}_t = \frac1k \sum_{i \in \mathrm{top}_k} r_{i,t}
+        - \frac1k \sum_{i \in \mathrm{bot}_k} r_{i,t}.$$
+
+        ``value = mean_t spread_t``. The headline test follows the shared
+        small-cross-section policy: with ``n_assets < MIN_ASSETS_WARN``
+        the per-date spread is heavy-tailed (few names per leg), so the
+        ``t``-test is replaced by a block-bootstrap CI; otherwise the
+        non-overlapping ``t`` applies. ``metadata["method"]`` records
+        which ran. The contemporaneous cross-sectional dispersion
+        $\mathrm{std}_i(r_{i,t})$ is averaged over dates and reported so
+        the spread can be judged against the period's return spread.
+
+    References:
+        [Hansen-Hodrick 1980][hansen-hodrick-1980]: overlapping-return
+        autocorrelation, motivating the non-overlap stride.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import compute_forward_return
+        >>> from factrix.metrics.k_spread import k_spread
+        >>> panel = compute_forward_return(
+        ...     fx.datasets.make_cs_panel(n_assets=20, n_dates=180, seed=0),
+        ...     forward_periods=5,
+        ... )
+        >>> result = k_spread(panel, forward_periods=5, k=3)
+        >>> result.name == ""
+        True
+    """
+    if k < 1:
+        raise ValueError(f"k must be >= 1; got {k}")
+    if return_col not in df.columns:
+        return _short_circuit_output(
+            "k_spread",
+            "no_return_column",
+            missing_column=return_col,
+        )
+
+    sampled = _sample_non_overlapping(df, forward_periods)
+    ranked = sampled.with_columns(
+        pl.col(factor_col)
+        .rank(method="ordinal", descending=True)
+        .over("date")
+        .alias("_rank"),
+        pl.len().over("date").alias("_n_date"),
+    ).filter(pl.col("_n_date") >= 2 * k)
+
+    if ranked.height == 0:
+        per_date_counts = sampled.group_by("date").len()["len"].to_numpy()
+        max_per_date = int(np.max(per_date_counts)) if per_date_counts.size else 0
+        return _short_circuit_output(
+            "k_spread",
+            "insufficient_assets_for_k_legs",
+            n_obs=0,
+            k=k,
+            min_required=2 * k,
+            max_assets_per_date=max_per_date,
+        )
+
+    series = (
+        ranked.group_by("date")
+        .agg(
+            pl.col(return_col).filter(pl.col("_rank") <= k).mean().alias("top_return"),
+            pl.col(return_col)
+            .filter(pl.col("_rank") > pl.col("_n_date") - k)
+            .mean()
+            .alias("bottom_return"),
+            pl.col(return_col).std(ddof=DDOF).alias("xs_dispersion"),
+        )
+        .with_columns((pl.col("top_return") - pl.col("bottom_return")).alias("spread"))
+        .sort("date")
+    )
+
+    spread_vals = series["spread"].drop_nulls()
+    n = len(spread_vals)
+    min_periods = k_spread.sample_threshold.min_periods  # type: ignore[attr-defined]
+    if min_periods is not None and n < min_periods:
+        return _short_circuit_output(
+            "k_spread",
+            "insufficient_portfolio_periods",
+            n_obs=n,
+            min_required=min_periods,
+            k=k,
+        )
+
+    arr = spread_vals.to_numpy()
+    mean_spread = float(np.mean(arr))
+    n_assets = sampled["asset_id"].n_unique()
+    t, p, sig_method, sig_extra = _spread_significance(arr, n_assets, rng_seed=rng_seed)
+
+    mean_dispersion = float(np.mean(series["xs_dispersion"].drop_nulls().to_numpy()))
+    mean_top = float(np.mean(series["top_return"].drop_nulls().to_numpy()))
+    mean_bottom = float(np.mean(series["bottom_return"].drop_nulls().to_numpy()))
+
+    return MetricResult(
+        value=mean_spread,
+        p_value=p,
+        n_obs=n,
+        stat=t,
+        metadata={
+            "n_periods": n,
+            "k": k,
+            "p_value": p,
+            "stat_type": "t",
+            "h0": "mu=0",
+            "method": sig_method,
+            "cross_sectional_dispersion": mean_dispersion,
+            "top_return": mean_top,
+            "bottom_return": mean_bottom,
+            **sig_extra,
+        },
+    )

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -186,7 +186,7 @@ def _quantile_spread_from_series(
     # from the non-overlapping t to a block-bootstrap CI (shared policy with
     # k_spread); larger cross-sections keep the t-test.
     n_assets = sampled["asset_id"].n_unique()
-    t, p, sig_method, sig_extra = _spread_significance(arr, n_assets)
+    t, p, sig_method, sig_extra, sig_codes = _spread_significance(arr, n_assets)
 
     # Long/short decomposition (spread = long_alpha + short_alpha)
     long_excess = (series["top_return"] - series["universe_return"]).drop_nulls()
@@ -226,6 +226,7 @@ def _quantile_spread_from_series(
             "tie_policy": tie_policy,
             **sig_extra,
         },
+        warning_codes=sig_codes,
     )
 
 

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -41,6 +41,7 @@ from factrix.metrics._helpers import (
     _lag_within_asset,
     _sample_non_overlapping,
     _short_circuit_output,
+    _spread_significance,
     _warn_high_tie_ratio,
 )
 from factrix.metrics._primitives import (
@@ -181,10 +182,11 @@ def _quantile_spread_from_series(
 
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))
-    std_spread = float(np.std(arr, ddof=DDOF))
-    t = _calc_t_stat(mean_spread, std_spread, n)
-
-    p = _p_value_from_t(t, n)
+    # Headline test: small cross-sections (n_assets < MIN_ASSETS_WARN) switch
+    # from the non-overlapping t to a block-bootstrap CI (shared policy with
+    # k_spread); larger cross-sections keep the t-test.
+    n_assets = sampled["asset_id"].n_unique()
+    t, p, sig_method, sig_extra = _spread_significance(arr, n_assets)
 
     # Long/short decomposition (spread = long_alpha + short_alpha)
     long_excess = (series["top_return"] - series["universe_return"]).drop_nulls()
@@ -212,7 +214,7 @@ def _quantile_spread_from_series(
             "p_value": p,
             "stat_type": "t",
             "h0": "mu=0",
-            "method": "non-overlapping t-test",
+            "method": sig_method,
             "long_alpha": mean_long,
             "short_alpha": mean_short,
             "long_stat": t_long,
@@ -222,6 +224,7 @@ def _quantile_spread_from_series(
             "short_significance": _significance_marker(p_short),
             "tie_ratio": tie_ratio,
             "tie_policy": tie_policy,
+            **sig_extra,
         },
     )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,7 @@ nav:
               - ic: api/metrics/ic.md
               - fama_macbeth: api/metrics/fama_macbeth.md
               - quantile: api/metrics/quantile.md
+              - k_spread: api/metrics/k_spread.md
               - monotonicity: api/metrics/monotonicity.md
               - concentration: api/metrics/concentration.md
               - tradability: api/metrics/tradability.md

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -163,6 +163,27 @@ class TestUnderfilledDatesDropped:
         result = k_spread(df, forward_periods=1, k=2)
         assert result.n_obs == 3  # only the three 6-asset dates
 
+    def test_null_factor_rows_excluded_from_leg_count(self):
+        # Null factor/return rows must not inflate the per-date count: a date
+        # with 5 valid names (≥ 2k=4) still qualifies, and ranks stay
+        # contiguous so the bottom leg is not silently emptied.
+        rows = []
+        for d in range(4):
+            day = date(2021, 1, 1) + timedelta(days=d)
+            for a in range(8):
+                f = None if (d == 1 and a in (0, 1, 2)) else float(a)
+                rows.append(
+                    {
+                        "date": day,
+                        "asset_id": f"A{a}",
+                        "factor": f,
+                        "forward_return": 0.01 * a + 0.001 * d,
+                    }
+                )
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = k_spread(df, forward_periods=1, k=2)
+        assert result.n_obs == 4  # all four dates qualify (date 1 has 5 valid)
+
 
 class TestQuantileSpreadSharesPolicy:
     """The small-N bootstrap switch is shared with quantile_spread."""

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -1,0 +1,203 @@
+"""Tests for factrix.metrics.k_spread (fixed-K long-short spread)."""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.metrics.k_spread import k_spread
+from factrix.metrics.quantile import quantile_spread
+
+
+def _panel_from_matrix(factor: np.ndarray, returns: np.ndarray) -> pl.DataFrame:
+    """Panel from a fixed per-asset ``factor`` and a ``[n_dates, n_assets]`` returns."""
+    n_dates, n_assets = returns.shape
+    rows = []
+    for d in range(n_dates):
+        day = date(2021, 1, 1) + timedelta(days=d)
+        for a in range(n_assets):
+            rows.append(
+                {
+                    "date": day,
+                    "asset_id": f"A{a}",
+                    "factor": float(factor[a]),
+                    "forward_return": float(returns[d, a]),
+                }
+            )
+    return pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+def _expected_spread(factor: np.ndarray, returns: np.ndarray, k: int) -> float:
+    top_idx = np.argsort(factor)[-k:]
+    bot_idx = np.argsort(factor)[:k]
+    per_date = returns[:, top_idx].mean(axis=1) - returns[:, bot_idx].mean(axis=1)
+    return float(per_date.mean())
+
+
+class TestSpreadComputation:
+    def test_fixed_k_selection_matches_reference(self):
+        rng = np.random.default_rng(0)
+        factor = np.arange(8, dtype=float)  # distinct → unambiguous ranks
+        returns = rng.normal(0.0, 0.02, size=(6, 8))
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=2)
+
+        assert result.value == pytest.approx(_expected_spread(factor, returns, k=2))
+        assert result.metadata["k"] == 2
+        assert result.n_obs == 6
+
+    def test_reports_cross_sectional_dispersion(self):
+        rng = np.random.default_rng(1)
+        factor = np.arange(10, dtype=float)
+        returns = rng.normal(0.0, 0.03, size=(8, 10))
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=3)
+
+        expected_disp = float(np.mean(returns.std(axis=1, ddof=1)))
+        assert result.metadata["cross_sectional_dispersion"] == pytest.approx(
+            expected_disp
+        )
+        assert "top_return" in result.metadata
+        assert "bottom_return" in result.metadata
+
+
+class TestSmallNSignificanceSwitch:
+    def test_large_cross_section_uses_t_test(self):
+        rng = np.random.default_rng(2)
+        factor = np.arange(40, dtype=float)
+        returns = rng.normal(0.001, 0.02, size=(30, 40))
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=5)
+        assert result.metadata["method"] == "non-overlapping t-test"
+        assert "p_value_t" not in result.metadata
+
+    def test_small_cross_section_uses_block_bootstrap(self):
+        rng = np.random.default_rng(3)
+        factor = np.arange(20, dtype=float)
+        returns = rng.normal(0.001, 0.02, size=(40, 20))
+        panel = _panel_from_matrix(factor, returns)
+        result = k_spread(panel, forward_periods=1, k=5)
+
+        assert result.metadata["method"] == "block-bootstrap CI"
+        assert "p_value_t" in result.metadata  # parametric p retained for reference
+        assert result.metadata["bootstrap_seed"] == 0
+        # reproducible run-to-run under the fixed seed
+        again = k_spread(panel, forward_periods=1, k=5)
+        assert result.p_value == again.p_value
+
+
+class TestShortCircuits:
+    def test_k_too_large_for_universe(self):
+        rng = np.random.default_rng(4)
+        factor = np.arange(8, dtype=float)
+        returns = rng.normal(0.0, 0.02, size=(10, 8))
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=5)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_assets_for_k_legs"
+        assert result.metadata["max_assets_per_date"] == 8
+
+    def test_insufficient_periods(self):
+        rng = np.random.default_rng(5)
+        factor = np.arange(8, dtype=float)
+        returns = rng.normal(0.0, 0.02, size=(2, 8))  # 2 dates < MIN_PORTFOLIO_PERIODS
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=2)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_portfolio_periods"
+
+    def test_missing_return_column(self):
+        factor = np.arange(8, dtype=float)
+        returns = np.zeros((5, 8))
+        df = _panel_from_matrix(factor, returns).drop("forward_return")
+        result = k_spread(df, forward_periods=1, k=2)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "no_return_column"
+
+    def test_invalid_k_raises(self):
+        factor = np.arange(8, dtype=float)
+        returns = np.zeros((5, 8))
+        with pytest.raises(ValueError, match="k must be"):
+            k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=0)
+
+
+class TestUnderfilledDatesDropped:
+    def test_dates_with_fewer_than_2k_assets_excluded(self):
+        # Date 0 has 6 assets (≥ 2k=4 → kept); date 1 has 3 (< 4 → dropped).
+        rows = []
+        for a in range(6):
+            rows.append(
+                {
+                    "date": date(2021, 1, 1),
+                    "asset_id": f"A{a}",
+                    "factor": float(a),
+                    "forward_return": 0.01 * a,
+                }
+            )
+        for a in range(3):
+            rows.append(
+                {
+                    "date": date(2021, 1, 2),
+                    "asset_id": f"A{a}",
+                    "factor": float(a),
+                    "forward_return": 0.5,
+                }
+            )
+        for a in range(6):  # third qualifying date so n_periods ≥ 3
+            rows.append(
+                {
+                    "date": date(2021, 1, 3),
+                    "asset_id": f"A{a}",
+                    "factor": float(a),
+                    "forward_return": 0.02 * a,
+                }
+            )
+        for a in range(6):
+            rows.append(
+                {
+                    "date": date(2021, 1, 4),
+                    "asset_id": f"A{a}",
+                    "factor": float(a),
+                    "forward_return": 0.03 * a,
+                }
+            )
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = k_spread(df, forward_periods=1, k=2)
+        assert result.n_obs == 3  # only the three 6-asset dates
+
+
+class TestQuantileSpreadSharesPolicy:
+    """The small-N bootstrap switch is shared with quantile_spread."""
+
+    def test_quantile_spread_switches_on_small_cross_section(self):
+        rng = np.random.default_rng(6)
+        factor = np.arange(20, dtype=float)
+        returns = rng.normal(0.001, 0.02, size=(40, 20))
+        out = quantile_spread(
+            _panel_from_matrix(factor, returns), forward_periods=1, n_groups=5
+        )["factor"]
+        assert out.metadata["method"] == "block-bootstrap CI"
+        assert "p_value_t" in out.metadata
+
+    def test_quantile_spread_keeps_t_test_on_large_cross_section(self):
+        rng = np.random.default_rng(7)
+        factor = np.arange(40, dtype=float)
+        returns = rng.normal(0.001, 0.02, size=(30, 40))
+        out = quantile_spread(
+            _panel_from_matrix(factor, returns), forward_periods=1, n_groups=5
+        )["factor"]
+        assert out.metadata["method"] == "non-overlapping t-test"
+
+
+class TestDispatch:
+    def test_runs_via_evaluate(self):
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=120)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        [er] = fx.evaluate(
+            panel,
+            metrics={"tks": k_spread(k=5)},
+            factor_cols=["factor"],
+            forward_periods=5,
+        )
+        assert er.metrics["tks"].name == "tks"
+        assert not math.isnan(er.metrics["tks"].value)

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -81,9 +81,18 @@ class TestSmallNSignificanceSwitch:
         assert result.metadata["method"] == "block-bootstrap CI"
         assert "p_value_t" in result.metadata  # parametric p retained for reference
         assert result.metadata["bootstrap_seed"] == 0
+        # the method switch surfaces as a cross-section warning, not silently
+        assert "borderline_cross_section_n" in result.warning_codes
         # reproducible run-to-run under the fixed seed
         again = k_spread(panel, forward_periods=1, k=5)
         assert result.p_value == again.p_value
+
+    def test_large_cross_section_emits_no_switch_warning(self):
+        rng = np.random.default_rng(8)
+        factor = np.arange(40, dtype=float)
+        returns = rng.normal(0.001, 0.02, size=(30, 40))
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=5)
+        assert result.warning_codes == ()
 
 
 class TestShortCircuits:


### PR DESCRIPTION
## Summary
- Add `k_spread` — the fixed-**count** (top-K minus bottom-K) long-short spread, the small-N sibling of `quantile_spread`. Quintile bucketing degrades at `N<30` (few names per bucket, unstable breakpoints); fixing the count `k` per leg keeps each leg stable regardless of `N`.
- Reports the per-date **cross-sectional return dispersion** alongside the spread (`metadata["cross_sectional_dispersion"]`) so the spread is read in context, not in isolation.
- Adds a shared `_spread_significance` policy: when `n_assets < MIN_ASSETS_WARN` the heavy-tailed per-date spread switches from the non-overlapping `t` to a **block-bootstrap CI** (fixed seed → reproducible); `metadata["method"]` records which ran and the parametric `p` is kept as `p_value_t`. Applied to **both** `k_spread` and `quantile_spread` (the latter's public signature unchanged).
- Naming follows the `<selection>_spread` scheme (`quantile_spread` = fraction ↔ `k_spread` = count); the selection convention is encoded and neither prefix names a single leg.

## Test plan
- [x] `tests/test_k_spread.py` (12 passed): fixed-K selection vs an independent reference; cross-sectional dispersion; large-N `t` vs small-N bootstrap (+ determinism); `k`-too-large / insufficient-periods / missing-column short-circuits; under-filled dates dropped; the shared small-N switch verified on `quantile_spread` too; evaluate dispatch.
- [x] existing `quantile_spread` tests still green (key-presence preserved); docs drift-guards green (matrix / list_metrics / stat-keys / api pages); name-index regenerated, stat-keys + applicability + api page + nav updated.
- [x] `ruff check` · `ruff format --check` · `mypy factrix` · full suite (1400 passed, 0 failed).

## Notes
- `quantile_spread`'s headline `p` now comes from the block bootstrap in the `N<30` regime (behavior change, signature unchanged) — surfaced via `metadata["method"]`/`p_value_t`.
- CHANGELOG `### Added` and the wholesale `llms-full.txt` regen are left to the #532 docs sweep, consistent with #535/#500.

Closes #536