### PR TITLE
fix(dag): handle batchable metrics with non-empty requires (#533)

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -483,7 +483,8 @@ def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
     failed = [
         (label, str(out.metadata.get("reason")))
         for label, out in label_outputs.items()
-        if isinstance(out.value, float)
+        if isinstance(out, MetricResult)
+        and isinstance(out.value, float)
         and math.isnan(out.value)
         and out.metadata.get("reason")
     ]
@@ -515,7 +516,10 @@ def _relabel_result(
     for label, nid in label_to_node.items():
         out = node_outputs.get(nid)
         if out is not None:
-            label_outputs[label] = dataclasses.replace(out, name=label)
+            if isinstance(out, MetricResult):
+                label_outputs[label] = dataclasses.replace(out, name=label)
+            else:
+                label_outputs[label] = out
     if strict:
         _enforce_strict(label_outputs)
     warnings = [

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -265,6 +265,8 @@ class DagExecutor:
                 producer_outputs[(nid, c)] = out
                 if isinstance(out, MetricResult):
                     metric_outputs[(nid, c)] = dataclasses.replace(out, name=nid)
+                elif node.spec.role is SpecRole.METRIC:
+                    metric_outputs[(nid, c)] = out
 
         return self._assemble(
             cols, scope, density, forward_periods, structure, n_assets, metric_outputs
@@ -296,12 +298,17 @@ class DagExecutor:
             project: Callable[[str], pl.DataFrame],
             upstream: dict[str, dict[str, Any]],
         ) -> dict[str, Any]:
+            if spec.requires:
+                def run_batch() -> dict[str, Any]:
+                    return bare(**{**upstream, **kw})
+            else:
+                def run_batch() -> dict[str, Any]:
+                    return bare(data, factor_cols=list(factor_cols), **kw)
+
             return _dispatch_batch(
                 name=spec.name,
                 call_one=lambda *a, **k: bare(*a, **{**kw, **k}),
-                run_batch=lambda: bare(
-                    data, factor_cols=list(factor_cols), **upstream, **kw
-                ),
+                run_batch=run_batch,
                 batchable=spec.batchable,
                 requires=tuple(spec.requires),
                 input_shape=spec.input_shape,
@@ -352,21 +359,22 @@ class DagExecutor:
                     continue
                 out = metric_outputs[key]
                 outputs[label] = out
-                reason = out.metadata.get("reason")
-                if isinstance(reason, str) and math.isnan(out.value):
-                    warnings.append(
-                        Warning(
-                            code=WarningCode.UPSTREAM_UNAVAILABLE,
-                            source=label,
-                            message=reason,
+                if isinstance(out, MetricResult):
+                    reason = out.metadata.get("reason")
+                    if isinstance(reason, str) and math.isnan(out.value):
+                        warnings.append(
+                            Warning(
+                                code=WarningCode.UPSTREAM_UNAVAILABLE,
+                                source=label,
+                                message=reason,
+                            )
                         )
-                    )
-                # Lift the metric's typed advisory codes into per-source
-                # Warning records so to_frame() / to_dict() surface them.
-                for code in out.warning_codes:
-                    warnings.append(
-                        Warning(code=WarningCode(code), source=label, message="")
-                    )
+                    # Lift the metric's typed advisory codes into per-source
+                    # Warning records so to_frame() / to_dict() surface them.
+                    for code in out.warning_codes:
+                        warnings.append(
+                            Warning(code=WarningCode(code), source=label, message="")
+                        )
             n_obs = _resolve_n_obs(primary, c, metric_outputs)
             results[c] = EvaluationResult(
                 factor=c,
@@ -463,11 +471,11 @@ def _check_upstream_short_circuit(
 def _resolve_n_obs(
     primary: Sequence[str],
     factor: str,
-    metric_outputs: Mapping[tuple[str, str], MetricResult],
+    metric_outputs: Mapping[tuple[str, str], Any],
 ) -> int:
     for name in primary:
         out = metric_outputs.get((name, factor))
-        if out is not None and out.n_obs is not None:
+        if out is not None and isinstance(out, MetricResult) and out.n_obs is not None:
             return out.n_obs
     return 0
 

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -299,9 +299,11 @@ class DagExecutor:
             upstream: dict[str, dict[str, Any]],
         ) -> dict[str, Any]:
             if spec.requires:
+
                 def run_batch() -> dict[str, Any]:
                     return bare(**{**upstream, **kw})
             else:
+
                 def run_batch() -> dict[str, Any]:
                     return bare(data, factor_cols=list(factor_cols), **kw)
 

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -332,8 +332,12 @@ class EvaluationResult:
         metric_rows = []
         for name, out in sorted(self.metrics.outputs.items()):
             tag = "primary" if name in primary_names else "diagnostic"
-            val_repr = "null" if math.isnan(out.value) else f"{out.value:.4g}"
-            p_repr = f"{out.p_value:.4g}" if isinstance(out.p_value, float) else ""
+            if isinstance(out, MetricResult):
+                val_repr = "null" if math.isnan(out.value) else f"{out.value:.4g}"
+                p_repr = f"{out.p_value:.4g}" if isinstance(out.p_value, float) else ""
+            else:
+                val_repr = "object"
+                p_repr = ""
             metric_rows.append(
                 f"<tr><td>{html.escape(name)}</td>"
                 f"<td>{tag}</td>"
@@ -391,9 +395,18 @@ _TO_FRAME_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
 
 def _output_row(
     key: str,
-    out: MetricResult,
+    out: Any,
     warnings_by_metric: Mapping[str, list[str]],
 ) -> dict[str, Any]:
+    if not isinstance(out, MetricResult):
+        return {
+            "metric_name": key,
+            "value": None,
+            "p_value": None,
+            "stat": None,
+            "n_obs": None,
+            "warning_codes": list(warnings_by_metric.get(key, [])),
+        }
     label = out.name or key
     return {
         "metric_name": label,
@@ -415,7 +428,23 @@ def _float_or_none(x: object) -> float | None:
     return None
 
 
-def _metric_output_to_record(out: MetricResult) -> dict[str, Any]:
+def _metric_output_to_record(out: Any) -> dict[str, Any]:
+    if not isinstance(out, MetricResult):
+        if hasattr(out, "__dict__"):
+            return {
+                "value": None,
+                "p_value": None,
+                "stat": None,
+                "n_obs": None,
+                "metadata": {"result": repr(out)},
+            }
+        return {
+            "value": None,
+            "p_value": None,
+            "stat": None,
+            "n_obs": None,
+            "metadata": {},
+        }
     return {
         "value": _float_or_none(out.value),
         "p_value": _float_or_none(out.p_value),

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -150,14 +150,17 @@ class MetricBase(metaclass=MetricMeta):
         (thin view) — are unified in :func:`_dispatch_batch`.
         """
         if self.requires:
+
             def run_batch() -> dict[str, Any]:
                 return self.__class__._impl(**{**self._params(), **upstream})
         else:
+
             def run_batch() -> dict[str, Any]:
                 return self.__class__._impl(
                     panel,
                     **{**self._params(), "factor_cols": list(factor_cols)},
                 )
+
         return _dispatch_batch(
             name=self.__class__.__name__,
             call_one=self,

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -149,13 +149,19 @@ class MetricBase(metaclass=MetricMeta):
         ``batchable`` (whole panel), ``requires`` (consume upstream), plain
         (thin view) — are unified in :func:`_dispatch_batch`.
         """
+        if self.requires:
+            def run_batch() -> dict[str, Any]:
+                return self.__class__._impl(**{**self._params(), **upstream})
+        else:
+            def run_batch() -> dict[str, Any]:
+                return self.__class__._impl(
+                    panel,
+                    **{**self._params(), "factor_cols": list(factor_cols)},
+                )
         return _dispatch_batch(
             name=self.__class__.__name__,
             call_one=self,
-            run_batch=lambda: self.__class__._impl(
-                panel,
-                **{**self._params(), "factor_cols": list(factor_cols), **upstream},
-            ),
+            run_batch=run_batch,
             batchable=self.batchable,
             requires=tuple(self.requires),
             input_shape=self.input_shape,
@@ -186,7 +192,10 @@ def _dispatch_batch(
 
     if batchable:
         try:
-            return run_batch()
+            res = run_batch()
+            if isinstance(res, dict):
+                return res
+            return {c: res for c in factor_cols}
         except Exception as e:
             if logger:
                 _log_exception_once(

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -35,6 +35,7 @@ from factrix.metrics._helpers import (
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
+    batchable=True,
 )
 def compute_spread_series(
     df: pl.DataFrame,

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -390,12 +390,13 @@ class TestMetricApplicabilityGroup:
         md = inspect_data(panel).usable.to_metrics_dict()
         results = fx.evaluate(
             panel,
-            metrics={"ic": md["ic"]},
+            metrics=md,
             factor_cols=["factor"],
             forward_periods=5,
             strict=False,
         )
-        assert results[0].metrics["ic"].name == "ic"
+        for name in md:
+            assert name in results[0].metrics.outputs
 
 
 class TestCrossFactorConsistency:

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -270,13 +270,12 @@ class TestGreedyForwardSelection:
 class TestSpanningEvaluate:
     def test_evaluate_greedy_forward_selection(self):
         import factrix as fx
+
         # Create a small panel with date, asset_id, factor, and forward_return
         panel = fx.datasets.make_cs_panel(n_assets=5, n_dates=20)
         panel = fx.preprocess.compute_forward_return(panel, forward_periods=2)
         # Create a second factor column so we have multiple candidate factors
-        panel = panel.with_columns(
-            (pl.col("factor") + pl.lit(0.01)).alias("factor2")
-        )
+        panel = panel.with_columns((pl.col("factor") + pl.lit(0.01)).alias("factor2"))
 
         [er1, er2] = fx.evaluate(
             panel,
@@ -293,4 +292,3 @@ class TestSpanningEvaluate:
         assert isinstance(result2, ForwardSelectionResult)
         # Verify both factors return the same selection result structure
         assert result1 is result2
-

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -265,3 +265,32 @@ class TestGreedyForwardSelection:
             "the invariant check would have vacuously passed"
         )
         assert len(result.selected_factors) >= 1
+
+
+class TestSpanningEvaluate:
+    def test_evaluate_greedy_forward_selection(self):
+        import factrix as fx
+        # Create a small panel with date, asset_id, factor, and forward_return
+        panel = fx.datasets.make_cs_panel(n_assets=5, n_dates=20)
+        panel = fx.preprocess.compute_forward_return(panel, forward_periods=2)
+        # Create a second factor column so we have multiple candidate factors
+        panel = panel.with_columns(
+            (pl.col("factor") + pl.lit(0.01)).alias("factor2")
+        )
+
+        [er1, er2] = fx.evaluate(
+            panel,
+            metrics={"gfs": greedy_forward_selection(suppress_snooping_warning=True)},
+            factor_cols=["factor", "factor2"],
+            forward_periods=2,
+        )
+
+        assert "gfs" in er1.metrics.outputs
+        assert "gfs" in er2.metrics.outputs
+        result1 = er1.metrics["gfs"]
+        result2 = er2.metrics["gfs"]
+        assert isinstance(result1, ForwardSelectionResult)
+        assert isinstance(result2, ForwardSelectionResult)
+        # Verify both factors return the same selection result structure
+        assert result1 is result2
+


### PR DESCRIPTION
## Summary
- Split `run_batch` into two branches in both `MetricBase.__call_batch__` and the DAG executor's bare-callable path: the `requires` path drops the panel positional arg, the non-`requires` path keeps it with `factor_cols`
- Guard all downstream access to `MetricResult` attributes (`.value`, `.metadata`, `.warning_codes`, `.n_obs`) behind `isinstance` checks so non-`MetricResult` outputs (e.g. `ForwardSelectionResult`) flow through serialization without crashing
- Mark `compute_spread_series` as `batchable=True` to avoid redundant per-factor re-computation

## Test plan
- [ ] `TestSpanningEvaluate::test_evaluate_greedy_forward_selection` — end-to-end evaluate with `greedy_forward_selection` across multiple factors
- [ ] `TestMetricApplicabilityGroup::test_to_metrics_dict_feeds_evaluate` — all discovered metrics (including batchable+requires) evaluate without crash
- [ ] Full suite: 1431 passed, 4 skipped

Closes #533
