### PR TITLE
refactor(api)!: retire evaluate primary param, return dict[str, EvaluationResult] (#549)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ results = fx.evaluate(
     factor_cols=["factor"],
     forward_periods=5,
 )
-[res] = results
+res = results["factor"]
 ic_res = res.metrics["ic"]
 
 print('ic_mean =', round(ic_res.value, 4))
@@ -135,7 +135,7 @@ results = fx.evaluate(
     factor_cols=["macro_factor"],
     forward_periods=5,
 )
-print(results[0].metrics["ts_beta"].value)
+print(results["macro_factor"].metrics["ts_beta"].value)
 ```
 
 ## Documentation

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -72,7 +72,7 @@ title: factrix.evaluate
     )
 
     # 3. Retrieve and inspect results
-    [res] = results
+    res = results["factor"]
     print(f"Factor: {res.factor}")
     print(f"Cell: {res.cell}")
     print(f"Plan: \n{res.plan}")

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -52,7 +52,7 @@ for h in horizons:
         factor_cols=["mom_12_1"],
         forward_periods=h,
     )
-    results.extend(res)
+    results.extend(res.values())
 
 table = pl.concat([r.to_frame() for r in results])  # long-form: horizon x metric
 ```
@@ -76,7 +76,7 @@ for h in horizons:
         factor_cols=["mom_12_1"],
         forward_periods=h,
     )
-    results.extend(res)
+    results.extend(res.values())
 
 fdr_res = fx.multi_factor.bhy(
     results,

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -110,7 +110,8 @@ class EvaluationResult:
     factor: str
     cell: tuple[FactorScope, FactorDensity, DataStructure]
     forward_periods: int
-    n_obs: int
+    n_periods: int
+    n_pairs: int
     n_assets: int
     metrics: MetricResultGroup
     plan: str

--- a/docs/examples/multi_factor_screening.md
+++ b/docs/examples/multi_factor_screening.md
@@ -67,11 +67,11 @@ for name, p in candidates.items():
         factor_cols=[name],
         forward_periods=5,
     )
-    results.extend(res)
+    results.extend(res.values())
 
-for res in results:
-    ic_res = res.metrics["ic"]
-    print(f"  {res.factor:12s} p_value={ic_res.p_value:.4g}")
+for er in results:
+    ic_res = er.metrics["ic"]
+    print(f"  {er.factor:12s} p_value={ic_res.p_value:.4g}")
 ```
 
 ## 3. Apply BHY

--- a/docs/examples/stock_factor_evaluation.md
+++ b/docs/examples/stock_factor_evaluation.md
@@ -53,7 +53,7 @@ results = fx.evaluate(
     forward_periods=5,
 )
 
-[res] = results
+res = results["factor"]
 ic_res = res.metrics["ic"]
 
 print(f"factor       = {res.factor}")
@@ -92,7 +92,8 @@ Illustrative output:
     "structure": "panel"
   },
   "forward_periods": 5,
-  "n_obs": 494,
+  "n_periods": 494,
+  "n_pairs": 49400,
   "n_assets": 100,
   "context": {},
   "metrics": {
@@ -112,12 +113,6 @@ Illustrative output:
         "tie_ratio": 0.0
       }
     }
-  },
-  "metrics_partition": {
-    "primary": [
-      "ic"
-    ],
-    "diagnostic": []
   },
   "warnings": [],
   "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=ic_df"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,7 +27,7 @@ results = fx.evaluate(
     forward_periods=5,
 )
 
-[res] = results
+res = results["factor"]
 ic_res = res.metrics["ic"]
 
 print('ic_mean =', round(ic_res.value, 4))
@@ -61,7 +61,8 @@ Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-fri
     "structure": "panel"
   },
   "forward_periods": 5,
-  "n_obs": 494,
+  "n_periods": 494,
+  "n_pairs": 49400,
   "n_assets": 100,
   "context": {},
   "metrics": {
@@ -81,10 +82,6 @@ Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-fri
         "tie_ratio": 0.0
       }
     }
-  },
-  "metrics_partition": {
-    "primary": ["ic"],
-    "diagnostic": []
   },
   "warnings": [],
   "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=ic_df"

--- a/docs/guides/large-scale-evaluation.md
+++ b/docs/guides/large-scale-evaluation.md
@@ -63,7 +63,7 @@ for i in range(0, len(factor_cols), chunk_size):
         strict=False,  # Keep inapplicable metrics as NaN with warnings instead of raising
     )
 
-    all_results.extend(chunk_results)
+    all_results.extend(chunk_results.values())
 
     # chunk_data is now free to be garbage collected
 ```

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -53,7 +53,7 @@ results = fx.evaluate(
     metrics={"ic": ic(), "ic_ir": ic_ir()},
     factor_cols=["factor"],
 )
-print(results[0].plan)
+print(results["factor"].plan)
 ```
 
 **Output:**

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -12,11 +12,12 @@ Each entry point in `factrix` returns a frozen result dataclass. This page walks
 ## `EvaluationResult` — single-factor `evaluate()` result
 
 ```python
-[result] = fx.evaluate(
+results = fx.evaluate(
     data,
     metrics={"ic": ic_newey_west()},
     factor_cols=["factor"],
 )
+result = results["factor"]
 ```
 
 An `EvaluationResult` represents the outcome of evaluating a single factor column over all specified metrics. Read the fields in the order below:
@@ -34,7 +35,8 @@ An `EvaluationResult` represents the outcome of evaluating a single factor colum
 
 | Field | Type | Notes |
 |---|---|---|
-| `n_obs` | `int` | Final-stage sample size for the primary metric after trimming. |
+| `n_periods` | `int` | Unique non-null dates in the factor column — the time-series depth. |
+| `n_pairs` | `int` | Non-null `(date, asset_id)` pairs — the effective cross-sectional coverage. |
 | `n_assets` | `int` | Unique assets in the panel (union across dates). |
 
 ### 3. Evaluated metrics (`result.metrics`)

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -82,8 +82,7 @@ results = fx.evaluate(
     forward_periods=5,
 )
 
-# results is a list[EvaluationResult]
-res = results[0]
+res = results["factor"]
 print(res.metrics["ic"].value)
 print(res.metrics["spread"].value)
 ```

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -384,8 +384,8 @@ panel = pl.from_pandas(zipline_out.reset_index())
 panel = compute_forward_return(panel, forward_periods=5)
 
 from factrix.metrics import ic
-results = fx.evaluate(panel, factor_cols=["factor"], metrics=[ic])
-primary_p = results[0].metrics["ic"].p_value
+results = fx.evaluate(panel, factor_cols=["factor"], metrics={"ic": ic()})
+primary_p = results["factor"].metrics["ic"].p_value
 ```
 
 factrix → Stage 2: surviving profiles after BHY feed a portfolio
@@ -400,10 +400,10 @@ from factrix.metrics import ic
 # from factor_cols so identities stay unique without manual surgery.
 results = []
 for name, p in panels.items():
-    res = fx.evaluate(p, factor_cols=[name], metrics=[ic])
-    results.extend(res)
+    res = fx.evaluate(p, factor_cols=[name], metrics={"ic": ic()})
+    results.extend(res.values())
 
-survivors = fx.multi_factor.bhy(results, q=0.05)
+survivors = fx.multi_factor.bhy(results, primary=["ic"], q=0.05)
 
 # survivors is a list[EvaluationResult]; pass the underlying factor
 # panels to skfolio / PyPortfolioOpt / riskfolio-lib as Stage 2 input

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -13,17 +13,18 @@ Single-factor::
     import factrix as fx
     from factrix.metrics import ic_newey_west
 
-    [result] = fx.evaluate(
+    results = fx.evaluate(
         panel, metrics={"ic": ic_newey_west()}, factor_cols=["factor"]
     )
-    print(result.metrics["ic"])
+    print(results["factor"].metrics["ic"])
 
 Batch + Benjamini-Hochberg-Yekutieli (BHY)::
 
     results = fx.evaluate(
         panel, metrics={"ic": ic_newey_west()}, factor_cols=candidate_cols
     )
-    survivors = fx.multi_factor.bhy(results, primary=[ic], q=0.05)
+    ic_results = {col: er.metrics["ic"] for col, er in results.items()}
+    survivors = fx.multi_factor.bhy(ic_results, primary=["ic"], q=0.05)
 
 LLM agent reference: ``llms-full.txt`` covers concepts, public API, and
 typical usage patterns in a single fetch. Two access paths::
@@ -100,9 +101,8 @@ def evaluate(
     metrics: "dict[str, MetricBase]",
     factor_cols: list[str],
     forward_periods: int | None = None,
-    primary: str | None = None,
     strict: bool = True,
-) -> list[EvaluationResult]:
+) -> "dict[str, EvaluationResult]":
     """Evaluate one or more factors against forward returns through the DAG executor.
 
     Closed-set DAG dispatch — every spec referenced by another spec's
@@ -114,17 +114,13 @@ def evaluate(
         data: Long-format data satisfying the four-column floor
             ``(date, asset_id, <factor_col>, forward_return)``. The
             three fixed-name columns ``(date, asset_id, forward_return)``
-            are validated eagerly; the factor-column name is dynamic
-            and supplied via ``factor_cols=``. ``forward_return`` must
-            already be attached via
-            :func:`factrix.preprocess.compute_forward_return`. ``price``
-            is **not** required at the baseline — it is an optional
-            column consumed by event-study metrics (caar /
-            event_around_return / mfe_mae_summary), which short-circuit
-            to NaN with a ``reason`` when ``price`` is absent.
+            are validated eagerly; ``forward_return`` must already be
+            attached via :func:`factrix.preprocess.compute_forward_return`.
+            ``price`` is optional — consumed by event-study metrics which
+            short-circuit to NaN when it is absent.
         metrics: ``dict[str, Metric]`` mapping a caller-chosen label to a
             metric **instance** from :mod:`factrix.metrics` (e.g.
-            ``{"ic_5d": ic(), "spread": quantile_spread(n_quantiles=5)}``).
+            ``{"ic_5d": ic(), "spread": quantile_spread(n_groups=5)}``).
             Results key by these labels. Passing the bare class (``ic``
             rather than ``ic()``), a ``str`` or a :class:`MetricSpec` is
             rejected with a targeted error. One metric class may run under
@@ -132,38 +128,34 @@ def evaluate(
             ``{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}`` — via
             by-value DAG dedup; shared upstream producers are computed
             once per distinct config.
-        factor_cols: Names of density columns on ``data``. List-only —
+        factor_cols: Names of factor columns on ``data``. List-only —
             single ``str`` is rejected. Non-empty, no duplicates, every
             name must exist on ``data``.
         forward_periods: Default forward-return horizon (rows of the data's
             time axis) for metrics left at their signature default. A
             per-instance value — ``ic(forward_periods=20)`` — always overrides
-            it. ``None`` (default) leaves every metric at its own
-            default. ``EvaluationResult.forward_periods`` reports the primary
-            metric's resolved horizon.
-        primary: Label of the primary metric — drives
-            ``EvaluationResult.n_obs`` and the primary / diagnostic
-            partition. ``None`` (default) uses the first ``metrics`` key
-            (insertion order). Must be a key of ``metrics``.
+            it. ``None`` (default) leaves every metric at its own default.
+            Stamped on every :class:`EvaluationResult` as
+            ``forward_periods``; per-metric resolved horizons are in
+            ``result.metrics[label].metadata["forward_periods"]``.
         strict: When ``True`` (default), raise if any metric is
             inapplicable to the data (apply-time short-circuit to NaN).
             When ``False``, keep those as NaN outputs with attached
             warnings. Config-time / construct-time failures always raise.
 
     Returns:
-        ``list[EvaluationResult]`` in ``factor_cols`` order. Always a
-        list — single factor calls return a one-element list. The
-        ``cell`` tuple stamped on each result derives from the primary
-        metric's cell and is informational only; ``DagExecutor`` does
-        not consult it for dispatch.
+        ``dict[str, EvaluationResult]`` keyed by factor column name, in
+        ``factor_cols`` insertion order. Each value carries the full
+        per-metric outputs, panel structural stats (``n_periods``,
+        ``n_pairs``), and warnings for that factor.
 
     Raises:
         UserInputError: ``metrics`` not a ``dict[str, Metric]`` of
-            instances; ``primary`` not a metrics label; ``factor_cols``
-            empty / single ``str`` / contains duplicates / references a
-            column not on ``data``; ``data`` missing a baseline column;
-            a metric ``requires`` a producer absent from the registry; under
-            ``strict=True``, a metric inapplicable to the data.
+            instances; ``factor_cols`` empty / single ``str`` / contains
+            duplicates / references a column not on ``data``; ``data``
+            missing a baseline column; a metric ``requires`` a producer
+            absent from the registry; under ``strict=True``, a metric
+            inapplicable to the data.
 
     Examples:
         Single-factor IC + IC information ratio (IR):
@@ -178,21 +170,17 @@ def evaluate(
         ...     factor_cols=["factor"],
         ...     forward_periods=5,
         ... )
-        >>> len(results)
-        1
-        >>> "ic" in results[0].metrics and "ic_ir" in results[0].metrics
+        >>> "ic" in results["factor"].metrics
+        True
+        >>> "ic_ir" in results["factor"].metrics
         True
     """
     _validate_metrics_arg(metrics)
-    primary_label = _resolve_primary(metrics, primary)
     cols = _validate_factor_cols_arg(factor_cols)
     data = _coerce_data(data)
     _validate_baseline_columns(data)
     _validate_factor_cols_on_data(data, cols)
 
-    # label -> spec, plus per-instance params with forward_periods resolved
-    # against the top-level default (an instance still at its signature default
-    # inherits ``forward_periods=``; an explicit per-instance value overrides).
     label_spec = {label: type(inst).spec() for label, inst in metrics.items()}
     label_params = {
         label: _resolve_instance_params(inst, forward_periods)
@@ -200,41 +188,25 @@ def evaluate(
     }
 
     nodes, label_to_node, node_kwargs = _build_nodes(label_spec, label_params)
-    primary_node = label_to_node[primary_label]
     node_to_label = {nid: label for label, nid in label_to_node.items()}
 
-    primary_spec = label_spec[primary_label]
-    _validate_primary_metric_applicable(primary_spec, data, strict)
+    _validate_all_metrics_applicable(label_spec, data, strict)
 
-    primary_cell = primary_spec.cell
-    scope = (
-        primary_cell.scope if primary_cell.scope is not None else FactorScope.INDIVIDUAL
-    )
-    density = (
-        primary_cell.density
-        if primary_cell.density is not None
-        else FactorDensity.DENSE
-    )
-    # Bundle-level forward_periods is the primary metric's resolved horizon.
-    fp = node_kwargs[primary_node].get(
-        "forward_periods", forward_periods if forward_periods is not None else 5
-    )
+    fp = forward_periods if forward_periods is not None else 5
 
-    executor = DagExecutor(nodes, primary_names=(primary_node,))
+    executor = DagExecutor(nodes)
     result_dict = executor.execute(
         data,
         cols,
-        scope=scope,
-        density=density,
+        scope=FactorScope.INDIVIDUAL,
+        density=FactorDensity.DENSE,
         forward_periods=fp,
         kwargs_by_metric=node_kwargs,
     )
-    return [
-        _relabel_result(
-            result_dict[c], label_to_node, node_to_label, primary_label, strict
-        )
+    return {
+        c: _relabel_result(result_dict[c], label_to_node, node_to_label, strict)
         for c in cols
-    ]
+    }
 
 
 _DOCS_METRICS = "api/evaluate#metrics"
@@ -334,22 +306,6 @@ def _validate_metrics_arg(metrics: object) -> None:
                 ),
                 docs_path=_DOCS_METRICS,
             )
-
-
-def _resolve_primary(metrics: "dict[str, MetricBase]", primary: str | None) -> str:
-    """Resolve the primary label — explicit ``primary`` or the first dict key."""
-    keys = list(metrics)
-    if primary is None:
-        return keys[0]
-    if primary not in metrics:
-        raise UserInputError(
-            func_name="evaluate",
-            field="primary",
-            value=primary,
-            expected=f"one of the metrics labels {keys!r}",
-            docs_path=_DOCS_METRICS,
-        )
-    return primary
 
 
 _NO_DEFAULT = object()
@@ -507,7 +463,6 @@ def _relabel_result(
     result: EvaluationResult,
     label_to_node: dict[str, str],
     node_to_label: dict[str, str],
-    primary_label: str,
     strict: bool,
 ) -> EvaluationResult:
     """Re-key a node-keyed executor result onto the user's labels."""
@@ -528,13 +483,11 @@ def _relabel_result(
         else w
         for w in result.warnings
     ]
-    group = MetricResultGroup(
-        applicable=list(label_to_node),
-        primary=[primary_label],
-        diagnostic=[label for label in label_to_node if label != primary_label],
-        outputs=label_outputs,
+    return dataclasses.replace(
+        result,
+        metrics=MetricResultGroup(outputs=label_outputs),
+        warnings=warnings,
     )
-    return dataclasses.replace(result, metrics=group, warnings=warnings)
 
 
 def _validate_factor_cols_arg(factor_cols: object) -> list[str]:
@@ -618,45 +571,39 @@ def _validate_baseline_columns(data: pl.DataFrame) -> None:
     )
 
 
-def _validate_primary_metric_applicable(
-    primary: MetricSpec, data: pl.DataFrame, strict: bool
+def _validate_all_metrics_applicable(
+    label_spec: "dict[str, MetricSpec]", data: pl.DataFrame, strict: bool
 ) -> None:
-    """Reject a primary metric whose ``cell.structure`` disagrees with the data.
+    """Reject any metric whose declared ``cell.structure`` disagrees with the data.
 
-    DataStructure is the cheap pre-flight gate: IC / FM / quantile_spread declare
-    ``cell.structure = DataStructure.PANEL`` and produce only NaN short-circuits on a
-    single-asset data; surfacing that as a UserInputError keeps the
-    diagnostic specific instead of letting the executor return a result
-    bundle whose every metric carries an ``UPSTREAM_UNAVAILABLE`` warning.
-    Cell-axis (scope / density) applicability requires data detection
-    and is left to ``fx.inspect_data`` for the explicit pre-flight path.
+    DataStructure is the cheap pre-flight gate: panel metrics (IC / FM /
+    quantile_spread) produce only NaN short-circuits on single-asset data;
+    surfacing that eagerly keeps the diagnostic specific.
 
-    Under ``strict=False`` this guard is skipped: a structure mismatch is an apply-time failure, so the metric is
-    allowed to flow through to a NaN output + warning rather than raise. The
-    ``strict=True`` default keeps the eager raise.
+    Under ``strict=False`` this guard is skipped and structure mismatches
+    flow through to NaN outputs + warnings.
     """
     if not strict:
         return
-    cell_structure = primary.cell.structure
-    if cell_structure is None:
-        return
     data_structure = _detect_structure(data)
-    if cell_structure is data_structure:
-        return
     n_assets = int(data["asset_id"].n_unique())
-    raise UserInputError(
-        func_name="evaluate",
-        field="metrics",
-        value=primary.name,
-        expected=(
-            f"primary metric {primary.name!r} declares "
-            f"cell.structure={cell_structure.value!r} but data has "
-            f"structure={data_structure.value!r} (n_assets={n_assets}); "
-            f"call fx.inspect_data(data) to see metrics applicable "
-            f"to this data shape"
-        ),
-        docs_path=_DOCS_METRICS,
-    )
+    for label, spec in label_spec.items():
+        cell_structure = spec.cell.structure
+        if cell_structure is None or cell_structure is data_structure:
+            continue
+        raise UserInputError(
+            func_name="evaluate",
+            field="metrics",
+            value=label,
+            expected=(
+                f"metric {label!r} declares "
+                f"cell.structure={cell_structure.value!r} but data has "
+                f"structure={data_structure.value!r} (n_assets={n_assets}); "
+                f"call fx.inspect_data(data) to see metrics applicable "
+                f"to this data shape"
+            ),
+            docs_path=_DOCS_METRICS,
+        )
 
 
 __version__ = "0.13.0"

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -111,10 +111,6 @@ class DagExecutor:
             spec.name)`` via the spec's declaring module. Tests pass an
             explicit resolver to use locally-defined callables without
             building a fake module tree.
-        primary_names: Names of specs whose :class:`MetricResult` is
-            the bundle's primary p-value driver. Empty by default —
-            the primary-vs-diagnostic classification is a cell-level
-            policy decision and lives outside this executor.
 
     Raises:
         CycleError: if ``requires`` introduces a cycle.
@@ -129,7 +125,6 @@ class DagExecutor:
         specs: Sequence[MetricSpec | _Node],
         *,
         fn_resolver: Callable[[str], Callable[..., Any]] | None = None,
-        primary_names: Sequence[str] = (),
     ) -> None:
         import logging
 
@@ -154,7 +149,6 @@ class DagExecutor:
         self._nodes: tuple[_Node, ...] = tuple(nodes)
         self._fn_resolver = fn_resolver or _default_fn_resolver
         self._fn_cache: dict[str, Callable[..., Any]] = {}
-        self._primary_ids = frozenset(primary_names)
         self._plan_steps: list[_PlanStep] = self._build_plan()
 
     def _fn(self, spec: MetricSpec) -> Callable[..., Any]:
@@ -209,6 +203,15 @@ class DagExecutor:
         cols = list(factor_cols)
         n_assets = data.select(pl.col("asset_id").n_unique()).item()
         structure = DataStructure.PANEL if n_assets > 1 else DataStructure.TIMESERIES
+
+        # per-factor panel structure stats (computed before dispatch)
+        factor_n_periods: dict[str, int] = {}
+        factor_n_pairs: dict[str, int] = {}
+        for c in cols:
+            mask = data[c].is_not_null()
+            factor_n_pairs[c] = int(mask.sum())
+            factor_n_periods[c] = int(data.filter(mask)["date"].n_unique())
+
         projections: dict[str, pl.DataFrame] = {}
 
         def project(c: str) -> pl.DataFrame:
@@ -269,7 +272,15 @@ class DagExecutor:
                     metric_outputs[(nid, c)] = out
 
         return self._assemble(
-            cols, scope, density, forward_periods, structure, n_assets, metric_outputs
+            cols,
+            scope,
+            density,
+            forward_periods,
+            structure,
+            n_assets,
+            factor_n_periods,
+            factor_n_pairs,
+            metric_outputs,
         )
 
     def _batch_handle(
@@ -340,14 +351,11 @@ class DagExecutor:
         forward_periods: int,
         structure: DataStructure,
         n_assets: int,
+        factor_n_periods: Mapping[str, int],
+        factor_n_pairs: Mapping[str, int],
         metric_outputs: Mapping[tuple[str, str], MetricResult],
     ) -> dict[str, EvaluationResult]:
         public_nodes = [n for n in self._nodes if n.spec.role is SpecRole.METRIC]
-        applicable = [n.node_id for n in public_nodes]
-        primary = [n.node_id for n in public_nodes if n.node_id in self._primary_ids]
-        diagnostic = [
-            n.node_id for n in public_nodes if n.node_id not in self._primary_ids
-        ]
         plan = self.plan
 
         results: dict[str, EvaluationResult] = {}
@@ -371,25 +379,18 @@ class DagExecutor:
                                 message=reason,
                             )
                         )
-                    # Lift the metric's typed advisory codes into per-source
-                    # Warning records so to_frame() / to_dict() surface them.
                     for code in out.warning_codes:
                         warnings.append(
                             Warning(code=WarningCode(code), source=label, message="")
                         )
-            n_obs = _resolve_n_obs(primary, c, metric_outputs)
             results[c] = EvaluationResult(
                 factor=c,
                 cell=(scope, density, structure),
                 forward_periods=forward_periods,
-                n_obs=n_obs,
+                n_periods=factor_n_periods[c],
+                n_pairs=factor_n_pairs[c],
                 n_assets=n_assets,
-                metrics=MetricResultGroup(
-                    applicable=applicable,
-                    primary=primary,
-                    diagnostic=diagnostic,
-                    outputs=outputs,
-                ),
+                metrics=MetricResultGroup(outputs=outputs),
                 plan=plan,
                 warnings=warnings,
             )
@@ -468,18 +469,6 @@ def _check_upstream_short_circuit(
                 },
             )
     return None
-
-
-def _resolve_n_obs(
-    primary: Sequence[str],
-    factor: str,
-    metric_outputs: Mapping[tuple[str, str], Any],
-) -> int:
-    for name in primary:
-        out = metric_outputs.get((name, factor))
-        if out is not None and isinstance(out, MetricResult) and out.n_obs is not None:
-            return out.n_obs
-    return 0
 
 
 def _topo_sort_nodes(nodes: Sequence[_Node]) -> list[_Node]:

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -36,8 +36,8 @@ class MetricResult:
             single integer count is not meaningful (e.g. multi-window
             CAAR series).
         stat: Test statistic (t, z, W, chi2, ...), when applicable.
-        metadata: Tool-specific context (``p_value``, ``stat_type``,
-            ``h0``, ``method`` are the standard keys).
+        metadata: Estimator-specific context beyond the top-level fields
+            (``stat_type``, ``h0``, ``method`` are the standard keys).
         warning_codes: Per-metric advisory :class:`WarningCode` values
             (as strings) the producer attached to *this* output.
             Empty tuple when the metric raised no advisory.

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -26,41 +26,23 @@ if TYPE_CHECKING:
 class MetricResult:
     """Single-metric result produced by a ``factrix.metrics.*`` primitive.
 
-    Moved here from :mod:`factrix._types` (renamed from ``MetricOutput``)
-    so every result dataclass lives in one module.
-
     Attributes:
         value: Raw metric value.
-        p_value: Two-sided p-value for the metric's hypothesis test, promoted
-            from ``metadata["p_value"]`` to a typed first-class field.
-            Serialisers (:meth:`EvaluationResult.to_frame` / ``to_dict``)
-            read this field; the raw ``metadata["p_value"]`` key is still
-            populated by producers for tool-specific context. ``None`` for
-            descriptive / diagnostic metrics that carry no formal test
-            (primary metrics are never ``None``).
-        n_obs: Sample size the primitive's estimator actually saw. Same
-            family name as ``FactorProfile.n_obs`` but a different scope:
-            per-metric single-stage count, vs. the final-stage test
-            denominator at the dispatched-cell level. ``None`` where a
+        p_value: Two-sided p-value for the metric's hypothesis test.
+            ``None`` for descriptive metrics that carry no formal test.
+        n_obs: Effective sample size the estimator actually used
+            (e.g. number of non-overlapping IC periods, number of
+            events, number of bootstrap windows). ``None`` where a
             single integer count is not meaningful (e.g. multi-window
             CAAR series).
         stat: Test statistic (t, z, W, chi2, ...), when applicable.
         metadata: Tool-specific context (``p_value``, ``stat_type``,
-            ``h0``, ``method`` are the standard keys). Read :attr:`p_value`
-            for the typed promoted view of ``p_value``.
+            ``h0``, ``method`` are the standard keys).
         warning_codes: Per-metric advisory :class:`WarningCode` values
-            (as strings) the producer attached to *this* output — e.g.
-            ``FEW_EVENTS`` / ``BORDERLINE_PORTFOLIO_PERIODS`` /
-            ``UNRELIABLE_SE_SHORT_PERIODS`` from the two-tier sample
-            guards. A typed first-class field (promoted from the legacy
-            ``metadata["warning_codes"]`` stash) so the DAG executor can
-            lift each into a :class:`Warning` record (``source ==`` the
-            metric's label) that surfaces on
-            :meth:`EvaluationResult.to_frame` / ``to_dict``. Empty tuple
-            when the metric raised no advisory.
+            (as strings) the producer attached to *this* output.
+            Empty tuple when the metric raised no advisory.
         name: Metric name stamped by the DAG executor at dispatch time.
-            Empty string for outputs constructed outside the registry
-            (free-standing primitive calls, tests).
+            Empty string for outputs constructed outside the registry.
     """
 
     value: float
@@ -87,27 +69,15 @@ class MetricResult:
 class Warning:
     """Flat per-evaluation diagnostic record.
 
-    Replaces the per-procedure ``frozenset[WarningCode]`` aggregation
-    on :class:`factrix.FactorProfile` with an explicit tuple of
-    ``(code, source, message)`` so callers can filter on the metric
-    that emitted the warning.
-
-    Source convention (uniform across every emission point):
-    a per-metric warning carries ``source == <metric name>`` (the
-    emitting :class:`MetricSpec`'s ``name``); a panel-level /
-    cross-metric warning carries ``source is None``. Callers filter on
-    this — ``w.source == name`` for one metric, ``w.source is None`` for
-    bundle diagnostics — so the two-state ``str | None`` is load-bearing,
-    not incidental.
+    Source convention: a per-metric warning carries
+    ``source == <metric label>``; a panel-level / cross-metric warning
+    carries ``source is None``.
 
     Attributes:
         code: The :class:`WarningCode` enum member.
-        source: Metric name that emitted the warning, or ``None`` for
-            bundle-level / cross-metric diagnostics (e.g. sample-guard
-            failures detected before dispatch).
-        message: Human-readable detail. Empty string when the code's
-            registered description in
-            :data:`factrix._codes._WARNING_DESCRIPTIONS` is sufficient.
+        source: Metric label that emitted the warning, or ``None`` for
+            bundle-level diagnostics.
+        message: Human-readable detail.
     """
 
     code: WarningCode
@@ -117,31 +87,17 @@ class Warning:
 
 @dataclass(frozen=True, slots=True)
 class MetricResultGroup:
-    """Group of metric outputs for one factor at one cell.
+    """Dict-like container of per-metric outputs for one factor.
 
-    Mirrors the ``MetricGroups`` shape that ``inspect_data``
-    exposes: three ``list[str]`` key partitions plus dict-like access to
-    the produced :class:`MetricResult` instances.
-
-    The key is the caller's label when produced by
-    :func:`factrix.evaluate` (the ``dict[str, Metric]`` key) — so
-    two labels may reuse one metric class — and the metric name when
-    produced elsewhere. Iteration / membership / ``keys`` / ``values`` /
-    ``items`` and the partition lists all use that same key.
+    The key is the caller-supplied label (from ``evaluate(metrics=...)``).
+    Supports ``[]``, ``in``, iteration, ``keys`` / ``values`` / ``items``,
+    and ``len``.
 
     Attributes:
-        applicable: Every key applicable to the dispatched cell
-            (superset of ``primary + diagnostic``).
-        primary: Keys whose ``MetricResult`` carries the bundle's primary
-            p-value (driver of downstream multi-factor FDR).
-        diagnostic: Keys whose output is descriptive / supplementary.
-        outputs: ``key -> MetricResult`` for every metric that produced a
-            value (including short-circuit outputs).
+        outputs: ``label -> MetricResult`` for every metric that produced
+            a value (including short-circuit NaN outputs).
     """
 
-    applicable: list[str]
-    primary: list[str]
-    diagnostic: list[str]
     outputs: Mapping[str, MetricResult] = field(default_factory=dict)
 
     def __getitem__(self, key: str) -> MetricResult:
@@ -168,53 +124,42 @@ class MetricResultGroup:
 
 @dataclass(frozen=True, slots=True)
 class EvaluationResult:
-    """Bundle-level result for one factor under one ``AnalysisConfig``.
-
-    Single return type for the unified DAG executor;
-    replaces :class:`factrix.FactorProfile` (inferential) and
-    :class:`factrix.MetricsBundle` (descriptive).
+    """Bundle-level result for one factor.
 
     Attributes:
         factor: Factor column name from the source panel.
-        cell: ``(scope, density, structure)`` tuple of the dispatched cell.
-            ``structure`` is ``DataStructure.PANEL`` or ``DataStructure.TIMESERIES``
-            resolved from the panel's asset count at dispatch.
-        forward_periods: Forward-return horizon (rows) the evaluation
-            ran under. Carried through from the source ``AnalysisConfig``
-            so multi-horizon callers can partition / mix-warn without
-            re-threading the config.
-        n_obs: Final-stage estimator sample size — the n the primary
-            metric saw after trimming. Matches the cell's primary
-            ``MetricResult.n_obs`` when one exists; bundle-level field
-            so consumers don't have to reach inside ``metrics``.
-        n_assets: Unique assets in the panel under the any-non-null
-            union (cell-invariant; ``1`` is legal for TIMESERIES).
-        metrics: :class:`MetricResultGroup` carrying the per-metric
-            outputs and the applicable / primary / diagnostic name
-            partitions.
+        cell: ``(scope, density, structure)`` tuple derived from the
+            panel structure at dispatch time. ``structure`` is
+            ``DataStructure.PANEL`` or ``DataStructure.TIMESERIES``
+            resolved from the panel's asset count; ``scope`` and
+            ``density`` default to INDIVIDUAL / DENSE.
+        forward_periods: Forward-return horizon passed to
+            :func:`factrix.evaluate`.
+        n_periods: Number of unique dates in the factor panel where
+            the factor column is non-null. A panel structural property —
+            independent of any individual metric's estimator.
+        n_pairs: Number of non-null ``(date, asset_id)`` pairs in the
+            factor panel. A panel structural property.
+        n_assets: Unique assets in the panel (cell-invariant;
+            ``1`` is legal for TIMESERIES).
+        metrics: :class:`MetricResultGroup` carrying per-metric outputs,
+            keyed by the caller-supplied label.
         context: Caller-supplied free-form labels (e.g.
-            ``{"region": "US"}``, ``{"family": "momentum"}``). Read by
+            ``{"region": "US"}``). Read by
             ``bhy(expand_over=...)`` / ``partial_conjunction`` /
-            ``bhy_hierarchical`` to partition or aggregate inputs;
-            empty dict means no labels attached.
+            ``bhy_hierarchical`` to partition or aggregate inputs.
         warnings: Flat list of :class:`Warning` records. Per-metric
-            entries carry ``source=metric_name``; cross-metric or
-            pre-dispatch entries carry ``source=None``.
-        plan: Multi-line execution plan emitted by the DAG executor —
-            numbered topological order of every spec the executor ran,
-            each line annotated with ``[batchable]`` / ``[per-factor]``,
-            the ``requires=`` upstream list, and any stage-1
-            share-hit marker. Required: callers constructing
-            :class:`EvaluationResult` outside the DAG (tests, manual
-            assembly) must supply an explicit string. There is no
-            default to avoid silent ``""`` placeholders that obscure
-            whether the DAG actually ran.
+            entries carry ``source=label``; cross-metric or pre-dispatch
+            entries carry ``source=None``.
+        plan: Multi-line DAG execution plan (topological order,
+            ``[batchable]`` / ``[per-factor]`` annotations).
     """
 
     factor: str
     cell: tuple[FactorScope, FactorDensity, DataStructure]
     forward_periods: int
-    n_obs: int
+    n_periods: int
+    n_pairs: int
     n_assets: int
     metrics: MetricResultGroup
     plan: str
@@ -230,21 +175,15 @@ class EvaluationResult:
         |---|---|---|
         | ``factor`` | str | :attr:`factor` |
         | ``n_assets`` | i64 | :attr:`n_assets` |
-        | ``metric_name`` | str | ``MetricResult.name`` (stamped at dispatch), falls back to mapping key |
-        | ``value`` | f64 \\| null | ``MetricResult.value`` (``NaN`` / ``Inf`` -> null) |
-        | ``p_value`` | f64 \\| null | ``MetricResult.p_value`` |
-        | ``stat`` | f64 \\| null | ``MetricResult.stat`` |
-        | ``n_obs`` | i64 \\| null | ``MetricResult.n_obs`` |
-        | ``warning_codes`` | list[str] | per-metric :class:`Warning` codes (``source == metric_name``); empty list when none |
-
-        Short-circuit rows surface as ``value=null`` / ``p_value=null``; the
-        explanatory message lives on the matching :class:`Warning`
-        record. Bundle-level warnings (``source is None``) do not
-        produce rows; read them from :attr:`warnings` directly.
+        | ``metric_name`` | str | ``MetricResult.name`` |
+        | ``value`` | f64 \| null | ``MetricResult.value`` |
+        | ``p_value`` | f64 \| null | ``MetricResult.p_value`` |
+        | ``stat`` | f64 \| null | ``MetricResult.stat`` |
+        | ``n_obs`` | i64 \| null | ``MetricResult.n_obs`` — estimator effective sample size |
+        | ``warning_codes`` | list[str] | per-metric warning codes |
 
         Designed for stacking across factors:
-        ``pl.concat([r.to_frame() for r in results])`` is the parquet
-        write path.
+        ``pl.concat([r.to_frame() for r in results.values()])``
         """
         by_metric: dict[str, list[str]] = {}
         for w in self.warnings:
@@ -266,16 +205,13 @@ class EvaluationResult:
 
         Layout (top-level keys, stable order):
 
-        - ``factor`` / ``cell`` / ``n_obs`` / ``n_assets``
-        - ``metrics``: dict ``metric_name -> MetricResult-as-dict``
-          (``value`` / ``p`` / ``stat`` / ``n_obs`` / ``metadata``)
-        - ``metrics_partition``: ``{"primary": [...], "diagnostic": [...]}``
-          listing metric names in each partition
-        - ``warnings``: list of ``{code, source, message}`` dicts
-        - ``plan``: the DAG execution plan string
+        - ``factor`` / ``cell`` / ``forward_periods`` / ``n_periods`` /
+          ``n_pairs`` / ``n_assets`` / ``context``
+        - ``metrics``: ``label -> {value, p_value, stat, n_obs, metadata}``
+        - ``warnings``: list of ``{code, source, message}``
+        - ``plan``
 
-        Float ``NaN`` / ``Inf`` are emitted as ``None`` so the dict
-        survives ``json.dumps`` without ``allow_nan``.
+        Float ``NaN`` / ``Inf`` are emitted as ``None``.
         """
         scope, density, structure = self.cell
         return {
@@ -286,16 +222,13 @@ class EvaluationResult:
                 "structure": structure.value,
             },
             "forward_periods": self.forward_periods,
-            "n_obs": self.n_obs,
+            "n_periods": self.n_periods,
+            "n_pairs": self.n_pairs,
             "n_assets": self.n_assets,
             "context": dict(self.context),
             "metrics": {
                 name: _metric_output_to_record(out)
                 for name, out in self.metrics.outputs.items()
-            },
-            "metrics_partition": {
-                "primary": list(self.metrics.primary),
-                "diagnostic": list(self.metrics.diagnostic),
             },
             "warnings": [
                 {
@@ -314,7 +247,8 @@ class EvaluationResult:
             ("factor", self.factor),
             ("cell", f"({scope.value}, {density.value}, {structure.value})"),
             ("forward_periods", self.forward_periods),
-            ("n_obs", self.n_obs),
+            ("n_periods", self.n_periods),
+            ("n_pairs", self.n_pairs),
             ("n_assets", self.n_assets),
             ("n_metrics", len(self.metrics)),
         ]
@@ -328,10 +262,8 @@ class EvaluationResult:
             for k, v in header_rows
         )
 
-        primary_names = set(self.metrics.primary)
         metric_rows = []
         for name, out in sorted(self.metrics.outputs.items()):
-            tag = "primary" if name in primary_names else "diagnostic"
             if isinstance(out, MetricResult):
                 val_repr = "null" if math.isnan(out.value) else f"{out.value:.4g}"
                 p_repr = f"{out.p_value:.4g}" if isinstance(out.p_value, float) else ""
@@ -340,12 +272,11 @@ class EvaluationResult:
                 p_repr = ""
             metric_rows.append(
                 f"<tr><td>{html.escape(name)}</td>"
-                f"<td>{tag}</td>"
                 f"<td style='text-align:right'>{val_repr}</td>"
                 f"<td style='text-align:right'>{p_repr}</td></tr>"
             )
         metric_table = (
-            "<table><thead><tr><th>metric</th><th>role</th><th>value</th>"
+            "<table><thead><tr><th>metric</th><th>value</th>"
             "<th>p</th></tr></thead>"
             f"<tbody>{''.join(metric_rows)}</tbody></table>"
         )

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -67,12 +67,13 @@ info = fx.inspect_data(data, factor_cols=["factor"])
 print("Detected structure:", info.detected.structure)
 
 # 3. Evaluate using the ic_newey_west metric
-[res] = fx.evaluate(
+results = fx.evaluate(
     data,
     metrics={"ic": ic_newey_west()},
     factor_cols=["factor"],
     forward_periods=5,
 )
+res = results["factor"]
 
 print("IC Value:", res.metrics["ic"].value)
 print("p-value:", res.metrics["ic"].p_value)
@@ -126,12 +127,13 @@ raw = fx.datasets.make_cs_panel(n_assets=1, n_dates=200, seed=2024)
 data = compute_forward_return(raw, forward_periods=5)
 
 # 2. Evaluate using timeseries beta metric
-[res] = fx.evaluate(
+results = fx.evaluate(
     data,
     metrics={"ts_beta": ts_beta()},
     factor_cols=["factor"],
     forward_periods=5,
 )
+res = results["factor"]
 
 print("Timeseries Beta:", res.metrics["ts_beta"].value)
 ```
@@ -149,9 +151,8 @@ def evaluate(
     metrics: dict[str, MetricBase],
     factor_cols: list[str],
     forward_periods: int | None = None,
-    primary: str | None = None,
     strict: bool = True,
-) -> list[EvaluationResult]:
+) -> dict[str, EvaluationResult]:
 ```
 
 `DataInput = pl.DataFrame | pl.LazyFrame`. factrix is polars-native on its primary entry points. `LazyFrame` is collected at the API boundary.
@@ -159,12 +160,11 @@ def evaluate(
 - `metrics` accepts a dictionary mapping labels to metric **instances** from `factrix.metrics` (e.g., `{"ic_5d": ic_newey_west(forward_periods=5)}`).
 - `factor_cols` accepts a list of column names on `data`.
 - `forward_periods` sets a default horizon (rows) for metrics that leave it at signature default.
-- `primary` names the primary metric label to drive `EvaluationResult` partitions.
 - `strict` (default `True`) raises an exception on inapplicable metrics; when `False`, inapplicable metrics return `NaN` with warnings.
 
 Under the hood, evaluation is scheduled and executed via `DagExecutor`, which topologically sorts specs and dependencies, raising a `CycleError` if circular dependencies are detected.
 
-Returns `list[EvaluationResult]` aligned to the order of `factor_cols`.
+Returns `dict[str, EvaluationResult]` keyed by factor column name, insertion order matches `factor_cols`.
 
 ---
 
@@ -343,8 +343,10 @@ Dataclass containing the evaluation outputs:
 - `factor`: Column name.
 - `cell`: `(scope, density, structure)` tuple.
 - `forward_periods`: Horizon used.
+- `n_periods`: Unique non-null dates in the factor column (panel time-series depth).
+- `n_pairs`: Non-null `(date, asset_id)` pairs (effective cross-sectional coverage).
 - `n_assets`: Unique asset count.
-- `metrics`: `MetricResultGroup` holding metric results.
+- `metrics`: `MetricResultGroup` holding metric results (dict-like, keyed by user label).
 - `plan`: Execution plan string.
 - `context`: Free-form context dictionary.
 - `warnings`: Attached `Warning` records.

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -178,8 +178,6 @@ def _short_circuit_output(
 
     metadata: dict[str, object] = {"reason": reason, **extra_metadata}
     p: float | None = None if descriptive else 1.0
-    if p is not None:
-        metadata["p_value"] = p
     return MetricResult(
         value=float("nan"),
         p_value=p,

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -175,7 +175,6 @@ def caar(
     metadata: dict = {
         "n_event_dates": n,
         "n_sampled": n_sampled,
-        "p_value": p,
         "stat_type": "t",
         "h0": "mu=0",
         "method": "non-overlapping t-test",
@@ -416,7 +415,6 @@ def bmp_test(
         z = z_bmp
 
     p = _p_value_from_z(z)
-    metadata["p_value"] = p
 
     return MetricResult(
         p_value=p,

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -208,7 +208,6 @@ def top_concentration(
     # WHY: one-sided test → p = P(T < t), not two-sided
     p = _p_value_from_t(t, n, alternative="less")
     metadata: dict = {
-        "p_value": p,
         "stat_type": "t",
         "h0": "ratio>=0.5",
         "method": "one-sided t-test on ratio",

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -147,7 +147,6 @@ def corrado_rank(
         metadata={
             "n_events": n_events,
             "n_total_obs": len(ranked),
-            "p_value": p,
             "stat_type": "z",
             "h0": "mu_rank=0",
             "method": "Corrado (1989) rank test",

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -196,7 +196,6 @@ def directional_hit_rate(
         n_obs=n,
         stat=float(s_n),
         metadata={
-            "p_value": p,
             "stat_type": "z",
             "h0": "independent_direction",
             "method": "Pesaran-Timmermann (1992)",

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -147,6 +147,5 @@ def event_around_return(
         metadata={
             "per_offset": per_offset,
             "interpretation": "value = mean |pre-event return|; high = potential leakage",
-            "p_value": 1.0,
         },
     )

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -129,7 +129,6 @@ def event_hit_rate(
         metadata={
             "n_events": n,
             "n_hits": hits,
-            "p_value": p,
             "stat_type": stat_type,
             "h0": "p=0.5",
             "method": _binomial_test_method_name(n),
@@ -232,7 +231,6 @@ def event_ic(
         stat=z,
         metadata={
             "n_events": n,
-            "p_value": p,
             "stat_type": "z",
             "h0": "rho=0",
             "method": "Spearman rank correlation (|density| vs signed_car)",
@@ -405,7 +403,6 @@ def event_skewness(
             "n_events": n,
             **(
                 {
-                    "p_value": p,
                     "stat_type": "z",
                     "h0": "skew=0",
                     "method": "D'Agostino skew test",

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -249,8 +249,8 @@ def fm_beta(
     )
     actual_lags = _resolve_nw_lags(n, newey_west_lags, forward_periods)
 
+    p_final = p
     metadata: dict = {
-        "p_value": p,
         "stat_type": "t",
         "h0": "mean(β)=0",
         "method": "Fama-MacBeth + Newey-West",
@@ -289,14 +289,14 @@ def fm_beta(
                     "shanken_c": c,
                     "shanken_factor_return_var": sigma2_f,
                     "shanken_factor_return_var_source": source,
-                    "p_value": p_shanken,
                     "method": ("Fama-MacBeth + Newey-West + Shanken (1992) EIV"),
                 }
             )
+            p_final = p_shanken
             t = t_shanken
 
     return MetricResult(
-        p_value=metadata.get("p_value"),
+        p_value=p_final,
         value=mean_beta,
         stat=t,
         metadata=metadata,
@@ -386,7 +386,6 @@ def _pooled_beta_driscoll_kraay(
                 "reason": "insufficient_periods",
                 "n_periods": n_periods,
                 "min_required": _MIN_DK_PERIODS,
-                "p_value": 1.0,
             },
         )
 
@@ -408,7 +407,6 @@ def _pooled_beta_driscoll_kraay(
         )
 
     metadata = {
-        "p_value": p,
         "stat_type": "t",
         "h0": "β=0",
         "method": f"Pooled OLS + Driscoll-Kraay (1998) SE ({cluster_col})",
@@ -627,7 +625,6 @@ def pooled_beta(
                     "reason": "insufficient_clusters",
                     "n_clusters": g_a,
                     "min_required": 3,
-                    "p_value": 1.0,
                 },
             )
         effective_meat = (g_a / (g_a - 1)) * meat_a
@@ -656,7 +653,6 @@ def pooled_beta(
                     "min_required": 3,
                     "n_clusters_a": g_a,
                     "n_clusters_b": g_b,
-                    "p_value": 1.0,
                 },
             )
         effective_meat = (
@@ -702,7 +698,6 @@ def pooled_beta(
     p = _p_value_from_t(t_stat, df_t)
 
     metadata = {
-        "p_value": p,
         "stat_type": "t",
         "h0": "β=0",
         "method": method_desc,

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -154,7 +154,6 @@ def hit_rate(
         metadata={
             "n_hits": hits,
             "n_total": n,
-            "p_value": p,
             "stat_type": stat_type,
             "h0": "p=0.5",
             "method": _binomial_test_method_name(n),

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -194,7 +194,6 @@ def ic(
         stat=t,
         metadata={
             "n_periods": n,
-            "p_value": p,
             "stat_type": "t",
             "h0": "mu=0",
             "method": "non-overlapping t-test",
@@ -284,7 +283,6 @@ def ic_newey_west(
         stat=t,
         metadata={
             "n_periods": n,
-            "p_value": p,
             "stat_type": "t",
             "h0": "mu=0",
             "method": "Newey-West HAC t-test on overlapping IC series",

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -210,7 +210,6 @@ def k_spread(
         metadata={
             "n_periods": n,
             "k": k,
-            "p_value": p,
             "stat_type": "t",
             "h0": "mu=0",
             "method": sig_method,

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -205,7 +205,6 @@ def monotonicity(
             value=avg_mono,
             stat=t,
             metadata={
-                "p_value": p,
                 "stat_type": "t",
                 "h0": "mu=0",
                 "mean_signed": mean_mono,

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -211,7 +211,6 @@ def _quantile_spread_from_series(
         stat=t,
         metadata={
             "n_periods": n,
-            "p_value": p,
             "stat_type": "t",
             "h0": "mu=0",
             "method": sig_method,
@@ -389,7 +388,6 @@ def quantile_spread_vw(
         stat=t,
         metadata={
             "n_periods": n,
-            "p_value": p,
             "stat_type": "t",
             "h0": "mu=0",
             "tie_ratio": tie_ratio,

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -236,7 +236,6 @@ def spanning_alpha(
         n_obs=n_obs,
         stat=ols.alpha_t,
         metadata={
-            "p_value": p,
             "stat_type": "t",
             "h0": "alpha=0",
             "method": "OLS spanning regression",

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -177,7 +177,6 @@ def ic_trend(
 
     p = _p_value_from_t(approx_t, n)
     metadata: dict = {
-        "p_value": p,
         "stat_type": "t",
         "h0": "slope=0",
         "method": "theil-sen CI approximation",

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -88,7 +88,7 @@ def ts_asymmetry(
     - ``value`` = method-A magnitude ``β_long + β_short`` (0 under
       perfect symmetry; positive = long side stronger)
     - ``stat``  = ``value`` / Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) SE
-    - ``metadata["p_value"]`` = method-A Wald p (two-sided)
+    - ``p_value`` = method-A Wald p (two-sided)
 
     Method B (Gate C passing) populates ``beta_pos`` / ``beta_neg`` /
     ``p_wald_slopes``; otherwise ``method_b_skipped`` carries the
@@ -259,7 +259,6 @@ def ts_asymmetry(
         value=asym_value,
         stat=asym_t,
         metadata={
-            "p_value": p_a,
             "stat_type": "wald (NW HAC)",
             "h0": "beta_long + beta_short = 0",
             "method": "method A: dummy regression on sign(factor)",

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -98,7 +98,6 @@ def compute_ts_beta_single_asset_fallback(ts_betas_df: pl.DataFrame) -> MetricRe
         stat=float(row["t_stat"]),
         metadata={
             "n_assets": 1,
-            "p_value": 1.0,
             "method": "single-asset TS regression (no cross-asset test)",
         },
     )
@@ -175,7 +174,6 @@ def ts_beta(ts_betas_df: pl.DataFrame) -> MetricResult:
         value=mean_b,
         stat=t,
         metadata={
-            "p_value": p,
             "stat_type": "t",
             "h0": "mean(β)=0",
             "method": "cross-sectional t-test on per-asset TS betas",

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -231,7 +231,6 @@ def ts_quantile_spread(
         value=spread_value,
         stat=spread_t,
         metadata={
-            "p_value": p_spread,
             "stat_type": "wald (NW HAC)",
             "h0": "beta_top = beta_bottom",
             "method": "OLS on bucket dummies + Newey-West HAC",

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -108,7 +108,7 @@ def compute_forward_return(
         >>> results = fx.evaluate(
         ...     panel, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
         ... )
-        >>> isinstance(results, list) and len(results) == 1
+        >>> isinstance(results, dict) and "factor" in results
         True
     """
     return (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,10 +47,10 @@ def make_result(
     extra_outputs: dict[str, MetricResult] | None = None,
     extra_primaries: tuple[str, ...] = (),
 ) -> EvaluationResult:
-    """Build an :class:`EvaluationResult` carrying the named primary metric.
+    """Build an :class:`EvaluationResult` for testing.
 
-    ``p=None`` simulates a metric output that emitted no p-value
-    (exercising the family resolver's missing-p path).
+    ``primary`` and ``extra_primaries`` name the metric labels included in
+    outputs. ``p=None`` simulates a metric with no p-value.
     """
     metadata: dict[str, Any] = {} if p is None else {"p_value": float(p)}
     primary_out = MetricResult(
@@ -59,20 +59,16 @@ def make_result(
     outputs = {primary: primary_out}
     if extra_outputs:
         outputs.update(extra_outputs)
-    primaries = [primary, *extra_primaries]
-    primary_names = primaries
+    # extra_primaries is retained for call-site compatibility but is a no-op:
+    # MetricResultGroup no longer carries a primary/diagnostic partition.
     return EvaluationResult(
         factor=factor,
         cell=(FactorScope.INDIVIDUAL, FactorDensity.DENSE, DataStructure.PANEL),
         forward_periods=forward_periods,
-        n_obs=100,
+        n_periods=100,
+        n_pairs=2500,
         n_assets=25,
-        metrics=MetricResultGroup(
-            applicable=primary_names,
-            primary=primary_names,
-            diagnostic=[],
-            outputs=outputs,
-        ),
+        metrics=MetricResultGroup(outputs=outputs),
         plan="1. test [per-factor]",
         context=context or {},
     )

--- a/tests/test_cross_type_invariants.py
+++ b/tests/test_cross_type_invariants.py
@@ -234,25 +234,17 @@ class TestResultMirrorsSpecAndApplicability:
     @pytest.fixture(scope="class")
     def evaluated(self, request: pytest.FixtureRequest):
         panel = request.getfixturevalue("panel")
-        [result] = fx.evaluate(
+        results = fx.evaluate(
             panel,
             metrics=_CORE_METRICS,
             factor_cols=["factor"],
             forward_periods=5,
-            primary="ic",
         )
-        return result
+        return results["factor"]
 
-    def test_group_partition_invariants(self, evaluated) -> None:
-        group = evaluated.metrics
-        applicable = set(group.applicable)
-        primary = set(group.primary)
-        diagnostic = set(group.diagnostic)
-        # primary + diagnostic exactly tile applicable, disjointly, and every
-        # applicable key produced exactly one output.
-        assert primary | diagnostic == applicable
-        assert primary.isdisjoint(diagnostic)
-        assert set(group.outputs) == applicable
+    def test_outputs_are_all_metric_labels(self, evaluated) -> None:
+        # All requested metric labels appear in outputs.
+        assert set(evaluated.metrics.outputs) == set(_CORE_METRICS)
 
     def test_result_keys_resolve_to_metric_specs(self, evaluated) -> None:
         # Result dict keys are a join key back into the spec table; each must
@@ -280,4 +272,4 @@ class TestResultMirrorsSpecAndApplicability:
         # flagged unusable by inspect_data for the same data.
         info = inspect_data(panel)
         runnable = set(info.usable.names) | set(info.degraded.names)
-        assert set(evaluated.metrics.applicable) <= runnable
+        assert set(evaluated.metrics.outputs) <= runnable

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -413,7 +413,7 @@ class TestEndToEndIcCell:
         }
         raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80)
         panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
-        ex = DagExecutor(specs, primary_names=["ic"])
+        ex = DagExecutor(specs)
         out = ex.execute(panel, ["factor"], **axes)
         r = out["factor"]
         assert isinstance(r, fx.EvaluationResult)

--- a/tests/test_data_input.py
+++ b/tests/test_data_input.py
@@ -54,7 +54,7 @@ def test_evaluate_accepts_lazyframe_end_to_end(data_pl: pl.DataFrame) -> None:
     lazy = fx.evaluate(
         data_pl.lazy(), metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
     )
-    assert eager[0].metrics["ic"].value == lazy[0].metrics["ic"].value
+    assert eager["factor"].metrics["ic"].value == lazy["factor"].metrics["ic"].value
 
 
 def test_evaluate_rejects_pandas_with_guidance(data_pl: pl.DataFrame) -> None:

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -150,13 +150,13 @@ class TestDispatch:
 
         raw = fx.datasets.make_cs_panel(n_assets=25, n_dates=120)
         panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
-        [er] = fx.evaluate(
+        results = fx.evaluate(
             panel,
             metrics={"da": directional_hit_rate()},
             factor_cols=["factor"],
             forward_periods=5,
         )
-        out = er.metrics["da"]
+        out = results["factor"].metrics["da"]
         assert out.name == "da"
         assert 0.0 <= out.value <= 1.0
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,4 +1,4 @@
-"""``fx.evaluate`` dict[str, Metric] API — labels, primary, strict, per-instance
+"""``fx.evaluate`` dict[str, Metric] API — labels, strict, per-instance
 forward_periods + by-value DAG dedup."""
 
 from __future__ import annotations
@@ -16,8 +16,6 @@ def _panel(n_assets: int = 20, n_dates: int = 80, *, with_price: bool = True):
     raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates)
     panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
     if not with_price and "price" in panel.columns:
-        # forward_return is already attached; dropping price now makes
-        # event-study metrics (caar) short-circuit at evaluate time.
         panel = panel.drop("price")
     return panel
 
@@ -30,30 +28,50 @@ def _eval(metrics, panel=None, **kw):
 
 
 class TestLabelKeying:
-    def test_results_key_by_user_label(self):
-        [er] = _eval({"my_ic": ic(), "my_ir": ic_ir()})
+    def test_results_key_by_factor_name(self):
+        results = _eval({"my_ic": ic(), "my_ir": ic_ir()})
+        assert "factor" in results
+        er = results["factor"]
         assert list(er.metrics.outputs) == ["my_ic", "my_ir"]
         assert er.metrics["my_ic"].name == "my_ic"
 
     def test_to_frame_uses_labels(self):
-        [er] = _eval({"my_ic": ic()})
-        assert er.to_frame()["metric_name"].to_list() == ["my_ic"]
+        results = _eval({"my_ic": ic()})
+        assert results["factor"].to_frame()["metric_name"].to_list() == ["my_ic"]
+
+    def test_returns_dict_keyed_by_factor(self):
+        panel = _panel()
+        panel = panel.with_columns((pl.col("factor") * -1).alias("factor_b"))
+        results = fx.evaluate(
+            panel,
+            metrics={"ic": ic()},
+            factor_cols=["factor", "factor_b"],
+            forward_periods=5,
+        )
+        assert set(results.keys()) == {"factor", "factor_b"}
+
+    def test_dict_insertion_order_matches_factor_cols(self):
+        panel = _panel()
+        panel = panel.with_columns((pl.col("factor") * -1).alias("factor_b"))
+        results = fx.evaluate(
+            panel,
+            metrics={"ic": ic()},
+            factor_cols=["factor", "factor_b"],
+            forward_periods=5,
+        )
+        assert list(results.keys()) == ["factor", "factor_b"]
 
 
-class TestPrimary:
-    def test_default_primary_is_first_key(self):
-        [er] = _eval({"a": ic(), "b": ic_ir()})
-        assert er.metrics.primary == ["a"]
-        assert er.metrics.diagnostic == ["b"]
+class TestPanelStats:
+    def test_n_periods_and_n_pairs_populated(self):
+        er = _eval({"ic": ic()})["factor"]
+        assert er.n_periods > 0
+        assert er.n_pairs > 0
+        assert er.n_pairs >= er.n_periods
 
-    def test_explicit_primary(self):
-        [er] = _eval({"a": ic(), "b": ic_ir()}, primary="b")
-        assert er.metrics.primary == ["b"]
-        assert er.metrics.diagnostic == ["a"]
-
-    def test_unknown_primary_raises(self):
-        with pytest.raises(UserInputError, match="one of the metrics labels"):
-            _eval({"a": ic()}, primary="zzz")
+    def test_no_n_obs_on_bundle(self):
+        er = _eval({"ic": ic()})["factor"]
+        assert not hasattr(er, "n_obs")
 
 
 class TestMetricsValidation:
@@ -78,42 +96,36 @@ class TestMetricsValidation:
 
 class TestByValueDedup:
     def test_same_config_alias_is_one_node_two_labels(self):
-        [er] = _eval({"a": ic_ir(), "b": ic_ir()})
+        er = _eval({"a": ic_ir(), "b": ic_ir()})["factor"]
         assert set(er.metrics.outputs) == {"a", "b"}
 
     def test_different_config_coexists(self):
-        # #494: one class under two labels with different config now runs both.
         from factrix.metrics import quantile_spread
 
-        [er] = _eval(
+        er = _eval(
             {"a": quantile_spread(n_groups=5), "b": quantile_spread(n_groups=10)}
-        )
+        )["factor"]
         assert set(er.metrics.outputs) == {"a", "b"}
 
     def test_per_instance_forward_periods_override(self):
-        # Distinct horizons coexist; each carries its own resolved fp.
-        [er] = fx.evaluate(
+        er = fx.evaluate(
             _panel(),
             metrics={"fp5": ic_newey_west(), "fp20": ic_newey_west(forward_periods=20)},
             factor_cols=["factor"],
-        )
+        )["factor"]
         assert er.metrics["fp5"].metadata["forward_periods"] == 5
         assert er.metrics["fp20"].metadata["forward_periods"] == 20
 
     def test_shared_producer_runs_once_across_configs(self):
-        # Both ic horizons require compute_ic, which is fp-independent — so the
-        # single batchable producer is computed once, not per config.
-        [er] = fx.evaluate(
+        er = fx.evaluate(
             _panel(),
             metrics={"fp5": ic_newey_west(), "fp20": ic_newey_west(forward_periods=20)},
             factor_cols=["factor"],
-        )
+        )["factor"]
         assert er.plan.count("compute_ic [batchable]") == 1
 
     def test_top_level_forward_periods_is_default_fallback(self):
-        # An instance left at its signature default inherits the top-level fp;
-        # an explicit per-instance value still wins.
-        [er] = fx.evaluate(
+        er = fx.evaluate(
             _panel(),
             metrics={
                 "dflt": ic_newey_west(),
@@ -121,15 +133,13 @@ class TestByValueDedup:
             },
             factor_cols=["factor"],
             forward_periods=20,
-        )
+        )["factor"]
         assert er.metrics["dflt"].metadata["forward_periods"] == 20
         assert er.metrics["expl"].metadata["forward_periods"] == 10
-        assert er.forward_periods == 20  # primary = first key ("dflt")
+        assert er.forward_periods == 20  # top-level fp stamped on bundle
 
 
 class TestStrict:
-    # A 12-date panel is below IC's period floor, so ``ic`` short-circuits to
-    # NaN with reason ``insufficient_ic_periods`` — an apply-time failure.
     def test_strict_true_raises_on_inapplicable(self):
         thin = _panel(n_dates=12)
         with pytest.raises(UserInputError, match="inapplicable"):
@@ -139,19 +149,17 @@ class TestStrict:
 
     def test_strict_false_keeps_nan(self):
         thin = _panel(n_dates=12)
-        [er] = fx.evaluate(
+        er = fx.evaluate(
             thin,
             metrics={"ic": ic()},
             factor_cols=["factor"],
             forward_periods=5,
             strict=False,
-        )
+        )["factor"]
         assert er.metrics["ic"].value != er.metrics["ic"].value  # NaN
 
 
 class TestStrictStructureSoftening:
-    # #494 / #497 carry-over: a PANEL primary on a single-asset TIMESERIES panel
-    # is a structure mismatch — an apply-time failure under #476 §4.
     def _single_asset_panel(self):
         panel = _panel(n_assets=20, n_dates=80)
         first = panel["asset_id"][0]
@@ -167,11 +175,11 @@ class TestStrictStructureSoftening:
             )
 
     def test_strict_false_softens_to_nan(self):
-        [er] = fx.evaluate(
+        er = fx.evaluate(
             self._single_asset_panel(),
             metrics={"ic": ic()},
             factor_cols=["factor"],
             forward_periods=5,
             strict=False,
-        )
+        )["factor"]
         assert math.isnan(er.metrics["ic"].value)

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -29,12 +29,7 @@ def _sample_group() -> MetricResultGroup:
         n_obs=100,
         name="ic_ir",
     )
-    return MetricResultGroup(
-        applicable=["ic", "ic_ir"],
-        primary=["ic"],
-        diagnostic=["ic_ir"],
-        outputs={"ic": ic_out, "ic_ir": ic_ir_out},
-    )
+    return MetricResultGroup(outputs={"ic": ic_out, "ic_ir": ic_ir_out})
 
 
 def _sample_result(
@@ -44,7 +39,8 @@ def _sample_result(
         factor="mom_12_1",
         cell=(FactorScope.INDIVIDUAL, FactorDensity.DENSE, DataStructure.PANEL),
         forward_periods=5,
-        n_obs=100,
+        n_periods=100,
+        n_pairs=2500,
         n_assets=25,
         metrics=group,
         plan=plan,
@@ -52,7 +48,7 @@ def _sample_result(
     )
 
 
-class TestMetricResult:
+class TestMetricResultGroup:
     def test_dict_like_access(self):
         g = _sample_group()
         assert "ic" in g
@@ -64,11 +60,11 @@ class TestMetricResult:
         assert {k for k, _ in g.items()} == {"ic", "ic_ir"}
         assert list(iter(g)) == ["ic", "ic_ir"]
 
-    def test_partition_lists_are_names(self):
+    def test_no_partition_fields(self):
         g = _sample_group()
-        assert g.primary == ["ic"]
-        assert g.diagnostic == ["ic_ir"]
-        assert g.applicable == ["ic", "ic_ir"]
+        assert not hasattr(g, "primary")
+        assert not hasattr(g, "diagnostic")
+        assert not hasattr(g, "applicable")
 
 
 class TestEvaluationResultToFrame:
@@ -91,11 +87,17 @@ class TestEvaluationResultToFrame:
         assert df.schema["warning_codes"] == pl.List(pl.Utf8)
         assert df.height == 2
 
+    def test_n_obs_carries_per_metric_sample_size(self):
+        ic_out = MetricResult(value=0.05, n_obs=114, name="ic")
+        spread_out = MetricResult(value=0.01, n_obs=23, name="spread")
+        g = MetricResultGroup(outputs={"ic": ic_out, "spread": spread_out})
+        df = _sample_result(g).to_frame()
+        assert df.filter(pl.col("metric_name") == "ic")["n_obs"][0] == 114
+        assert df.filter(pl.col("metric_name") == "spread")["n_obs"][0] == 23
+
     def test_short_circuit_row_is_null(self):
         bad = MetricResult(value=float("nan"), name="ic")
-        g = MetricResultGroup(
-            applicable=["ic"], primary=["ic"], diagnostic=[], outputs={"ic": bad}
-        )
+        g = MetricResultGroup(outputs={"ic": bad})
         df = _sample_result(g).to_frame()
         row = df.row(0, named=True)
         assert row["value"] is None
@@ -121,12 +123,7 @@ class TestEvaluationResultToFrame:
 
     def test_metric_name_from_name_field(self):
         out = MetricResult(value=0.01, name="fm_beta")
-        g = MetricResultGroup(
-            applicable=["fm_beta"],
-            primary=["fm_beta"],
-            diagnostic=[],
-            outputs={"fm_beta": out},
-        )
+        g = MetricResultGroup(outputs={"fm_beta": out})
         df = _sample_result(g).to_frame()
         assert df.row(0, named=True)["metric_name"] == "fm_beta"
 
@@ -146,10 +143,11 @@ class TestEvaluationResultToDict:
         assert back["cell"]["scope"] == "individual"
         assert back["cell"]["density"] == "dense"
         assert back["cell"]["structure"] == "panel"
-        assert back["n_obs"] == 100
+        assert back["n_periods"] == 100
+        assert back["n_pairs"] == 2500
+        assert "n_obs" not in back
+        assert "metrics_partition" not in back
         assert back["metrics"]["ic"]["p_value"] == 0.012
-        assert back["metrics_partition"]["primary"] == ["ic"]
-        assert back["metrics_partition"]["diagnostic"] == ["ic_ir"]
         assert back["warnings"][0]["code"] == WarningCode.SMALL_CROSS_SECTION_N.value
         assert back["plan"] == "1. ic [per-factor]"
 
@@ -161,9 +159,7 @@ class TestEvaluationResultToDict:
             metadata={"p_value": float("nan")},
             name="ic",
         )
-        g = MetricResultGroup(
-            applicable=["ic"], primary=["ic"], diagnostic=[], outputs={"ic": bad}
-        )
+        g = MetricResultGroup(outputs={"ic": bad})
         d = _sample_result(g).to_dict()
         assert d["metrics"]["ic"]["value"] is None
         assert d["metrics"]["ic"]["stat"] is None
@@ -173,13 +169,16 @@ class TestEvaluationResultToDict:
 
 class TestReprHtml:
     def test_group_renders(self):
-        # MetricResultGroup itself ships only dict-like access; HTML
-        # lives on the bundle. Smoke-test the bundle render.
         r = _sample_result(_sample_group())
         html_out = r._repr_html_()
         assert "EvaluationResult" in html_out
         assert "mom_12_1" in html_out
         assert "ic" in html_out
+
+    def test_no_role_column_in_html(self):
+        r = _sample_result(_sample_group())
+        assert "primary" not in r._repr_html_()
+        assert "diagnostic" not in r._repr_html_()
 
     def test_renders_warnings_when_present(self):
         warnings = [

--- a/tests/test_hit_rate.py
+++ b/tests/test_hit_rate.py
@@ -49,7 +49,7 @@ class TestComputeHitRate:
         result = hit_rate(series, forward_periods=1)
         assert result.metadata["method"] == "binomial exact test"
         # Exact p for 15/15 successes under H₀: p=0.5 is 2 * 0.5**15.
-        assert result.metadata["p_value"] == pytest.approx(2 * 0.5**15)
+        assert result.p_value == pytest.approx(2 * 0.5**15)
 
     def test_large_n_uses_normal_approximation(self):
         series = _make_series([0.01] * 100 + [-0.01] * 100)

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -396,7 +396,7 @@ class TestMetricApplicabilityGroup:
             strict=False,
         )
         for name in md:
-            assert name in results[0].metrics.outputs
+            assert name in results["factor"].metrics.outputs
 
 
 class TestCrossFactorConsistency:

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -223,11 +223,12 @@ class TestDispatch:
 
         raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=120)
         panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
-        [er] = fx.evaluate(
+        results = fx.evaluate(
             panel,
             metrics={"tks": k_spread(k=5)},
             factor_cols=["factor"],
             forward_periods=5,
         )
+        er = results["factor"]
         assert er.metrics["tks"].name == "tks"
         assert not math.isnan(er.metrics["tks"].value)

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -94,7 +94,7 @@ class TestDriscollKraayPath:
         res = pooled_beta(df, driscoll_kraay=True)
         assert res.stat is None
         assert res.metadata["reason"] == "insufficient_periods"
-        assert res.metadata["p_value"] == 1.0
+        assert res.p_value == 1.0
 
     def test_mutually_exclusive_with_two_way_cluster(self):
         df = _common_factor_panel(n_dates=40, n_assets=10, rho=0.2)

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -109,7 +109,7 @@ class TestQuantileSpread:
             assert "short_alpha" in result.metadata
             assert "long_stat" in result.metadata
             assert "short_stat" in result.metadata
-            assert "p_value" in result.metadata
+            assert result.p_value is not None
 
 
 class TestQuantileSpreadVW:

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -24,7 +24,7 @@ def test_readme_quickstart_runs_end_to_end() -> None:
     )
 
     assert len(results) == 1
-    p = results["factor"].metrics["ic"].metadata.get("p_value")
+    p = results["factor"].metrics["ic"].p_value
     assert isinstance(p, float)
     assert 0.0 <= p <= 1.0
 

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -24,7 +24,7 @@ def test_readme_quickstart_runs_end_to_end() -> None:
     )
 
     assert len(results) == 1
-    p = results[0].metrics["ic"].metadata.get("p_value")
+    p = results["factor"].metrics["ic"].metadata.get("p_value")
     assert isinstance(p, float)
     assert 0.0 <= p <= 1.0
 

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -277,12 +277,13 @@ class TestSpanningEvaluate:
         # Create a second factor column so we have multiple candidate factors
         panel = panel.with_columns((pl.col("factor") + pl.lit(0.01)).alias("factor2"))
 
-        [er1, er2] = fx.evaluate(
+        results = fx.evaluate(
             panel,
             metrics={"gfs": greedy_forward_selection(suppress_snooping_warning=True)},
             factor_cols=["factor", "factor2"],
             forward_periods=2,
         )
+        er1, er2 = results["factor"], results["factor2"]
 
         assert "gfs" in er1.metrics.outputs
         assert "gfs" in er2.metrics.outputs

--- a/tests/test_ts_asymmetry.py
+++ b/tests/test_ts_asymmetry.py
@@ -31,7 +31,7 @@ class TestSymmetricDgp:
         r = 0.05 * f + rng.standard_normal(T) * 0.5
         out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
         # H0: β_long + β_short = 0; under symmetric DGP we should not reject.
-        assert out.metadata["p_value"] > 0.05
+        assert out.p_value > 0.05
         # Method B should run (continuous f → both sides have variation).
         assert "p_wald_slopes" in out.metadata
         assert out.metadata["p_wald_slopes"] > 0.05
@@ -47,7 +47,7 @@ class TestAsymmetricDgp:
         r = 0.20 * np.maximum(f, 0) + rng.standard_normal(T) * 0.4
         out = ts_asymmetry(_series_panel(f, r), forward_periods=1)
         assert out.value > 0
-        assert out.metadata["p_value"] < 0.05
+        assert out.p_value < 0.05
         assert out.metadata["beta_long"] > out.metadata["beta_short"]
         # Slope test should also reject β_pos = β_neg.
         assert out.metadata["p_wald_slopes"] < 0.05

--- a/tests/test_ts_quantile.py
+++ b/tests/test_ts_quantile.py
@@ -33,7 +33,7 @@ class TestLinearDgp:
         r = 0.10 * f + rng.standard_normal(T) * 0.5
         out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
         assert out.value > 0
-        assert out.metadata["p_value"] < 0.05
+        assert out.p_value < 0.05
         assert out.metadata["spearman_rho"] > 0.5
 
     def test_top_bucket_mean_exceeds_bottom(self):
@@ -61,7 +61,7 @@ class TestNullDgp:
             f = rng.standard_normal(T)
             r = rng.standard_normal(T) * 0.5
             out = ts_quantile_spread(_series_panel(f, r), n_groups=5)
-            if out.metadata["p_value"] < 0.05:
+            if out.p_value < 0.05:
                 rejects += 1
         rate = rejects / n_trials
         # Wide-but-meaningful band: 0–13% covers binomial noise at n=100


### PR DESCRIPTION
## Summary

`evaluate()` API 有三個具體缺陷，此 PR 一次修正：

1. **回傳 `list` 靠 index 取因子** — `results[0]` 不知道對應哪個因子，改為 `dict[str, EvaluationResult]` 直接以欄位名稱為 key
2. **頂層 `n_obs` 在最常見情境下是假值** — IC 的樣本期數藏在 `metadata["n_periods"]`，`_resolve_n_obs` fallback 0，改為明確的 `n_periods`（unique dates）與 `n_pairs`（non-null (date, asset) pairs），與各 metric 自身的 `MetricResult.n_obs` 解耦
3. **`primary` 機制無實質作用** — `evaluate(primary=)` 不接 FDR 篩選，`MetricResultGroup.primary/diagnostic/applicable` 分區純粹是實作噪音；移除後由呼叫端自行決定哪些指標送進 `bhy` / `partial_conjunction`

變更範圍：`evaluate()` 簽名、`EvaluationResult` dataclass、`MetricResultGroup`、`DagExecutor`、全部受影響的 test 與 doc 範例（含 JSON schema sample 與 `llms-full.txt`）。

## Test plan

- [ ] `pytest` — 1423 passed, 4 skipped
- [ ] `pytest --doctest-modules` — 92 passed
- [ ] `ruff check` / `ruff format --check` / `mypy factrix` — clean
- [ ] Dict-keyed access: `results["factor"].metrics["ic"]` 正確
- [ ] `n_periods` / `n_pairs` 有值；bundle 層無 `n_obs` / `metrics_partition`
- [ ] `bhy` / `partial_conjunction` 接受 `list[EvaluationResult]`（介面不變）

Closes #549