### PR TITLE
perf(fm): vectorize + batch compute_fm_betas via closed-form slope (#551)

### DIFF
--- a/docs/api/metrics/fm_beta.md
+++ b/docs/api/metrics/fm_beta.md
@@ -80,7 +80,7 @@ title: factrix.metrics.fm_beta
     )
     panel = compute_forward_return(raw, forward_periods=5)
 
-    beta_df = compute_fm_betas(panel)
+    beta_df = compute_fm_betas(panel)["factor"]
     print(beta_df.head())
     # ┌────────────┬───────────┐
     # │ date       ┆ beta      │

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -182,7 +182,11 @@ primitives that procedures wrap:
 - `MIN_EVENTS_HARD = 4`, `MIN_EVENTS_WARN = 30` — two-tier sparse-cell
   event-count floor. `n < HARD` short-circuits the CAAR / event-quality
   primitives; `HARD ≤ n < WARN` emits `WarningCode.FEW_EVENTS`.
-- `compute_fm_betas` carries an inline `if len(y) < 3: continue` guard, no per-date min above 3.
+- `MIN_FM_CS_OBS = 3` — `compute_fm_betas` emits a date only with ≥ 3 complete
+  `(factor, return)` pairs and non-zero cross-sectional variance; the closed-form
+  slope `Cov_t(x, y) / Var_t(x)` is computed batched across factors (one
+  `group_by("date").agg`), so degenerate (zero-variance) dates are dropped rather
+  than assigned an arbitrary least-norm slope.
 
 ### Inflation cost at low `n_assets`
 

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+from collections.abc import Sequence
+
 import polars as pl
 
 from factrix._axis import (
@@ -17,6 +18,11 @@ from factrix._axis import (
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
 
+# Minimum complete (factor, return) pairs per date to estimate a slope.
+# Two parameters (intercept + slope) leave one residual degree of freedom
+# at three observations.
+MIN_FM_CS_OBS: int = 3
+
 
 @metric(
     cell=cell(
@@ -28,39 +34,78 @@ from factrix.metrics._decorators import metric
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
+    batchable=True,
 )
 def compute_fm_betas(
     df: pl.DataFrame,
-    *,
-    factor_col: str = "factor",
+    factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
-) -> pl.DataFrame:
-    r"""Per-date cross-sectional ordinary least squares (OLS): $R_i = \alpha + \beta \cdot \text{Signal}_i + \varepsilon$."""
-    dates = df["date"].unique().sort()
-    rows: list[dict] = []
+) -> dict[str, pl.DataFrame]:
+    r"""Per-date cross-sectional ordinary least squares (OLS) slope.
 
-    for dt in dates:
-        chunk = df.filter(pl.col("date") == dt)
-        y = chunk[return_col].to_numpy().astype(np.float64)
-        x = chunk[factor_col].to_numpy().astype(np.float64)
+    Fits $R_i = \alpha + \beta \cdot \text{Signal}_i + \varepsilon$ per date
+    and returns the time series of slopes $\beta_t$. The single-regressor
+    OLS slope has the closed form
 
-        if len(y) < 3:
-            continue
+    $$\beta_t = \frac{\operatorname{Cov}_t(x, y)}{\operatorname{Var}_t(x)},$$
 
-        x_with_const = np.column_stack([np.ones(len(x)), x])
-        try:
-            beta, _, _, _ = np.linalg.lstsq(x_with_const, y, rcond=None)
-        except np.linalg.LinAlgError:
-            continue
+    so the whole panel is scored in one polars query (one
+    ``group_by("date").agg(...)`` + one ``collect``) across all factors,
+    with no per-date Python loop — the N=1 case is just the general path
+    specialised.
 
-        rows.append({"date": dt, "beta": float(beta[1])})
+    Args:
+        df: Panel with ``date``, ``asset_id``, every name in
+            ``factor_cols``, and ``return_col``.
+        factor_cols: Factor column names to score. All factors run in a
+            single query regardless of N.
+        return_col: Forward-return column shared across factors.
 
-    if not rows:
-        return pl.DataFrame(
-            {
-                "date": pl.Series([], dtype=pl.Datetime("ms")),
-                "beta": pl.Series([], dtype=pl.Float64),
-            }
+    Returns:
+        Dict mapping each factor name to a DataFrame with columns
+        ``date, beta`` sorted by date. A date is emitted only when it has
+        at least ``MIN_FM_CS_OBS`` complete ``(factor, return)`` pairs and
+        a non-degenerate cross-sectional spread; dates with zero factor
+        variance (no identifiable slope) are dropped.
+    """
+    cols = list(factor_cols)
+    if not cols:
+        raise ValueError("factor_cols must be non-empty")
+
+    agg_exprs: list[pl.Expr] = []
+    for f in cols:
+        # Restrict every moment to the pairwise-complete (factor, return) set
+        # so the slope numerator and denominator share one sample — polars'
+        # ``cov`` already pairwise-drops, but ``var`` would otherwise keep
+        # factor-present / return-null rows and bias the ratio.
+        both = pl.col(f).is_not_null() & pl.col(return_col).is_not_null()
+        xf = pl.col(f).filter(both)
+        yf = pl.col(return_col).filter(both)
+        var_f = xf.var()
+        agg_exprs.append(both.sum().alias(f"_cnt__{f}"))
+        # ``var_f > 0`` (not an absolute epsilon) is the scale-free degeneracy
+        # test: variance is exactly 0 only when the date has no cross-sectional
+        # spread, which is the single case with no identifiable slope. A small
+        # but real spread is a legitimate (if noisy) estimate and is kept.
+        agg_exprs.append(
+            pl.when(var_f > 0)
+            .then(pl.cov(xf, yf) / var_f)
+            .otherwise(None)
+            .alias(f"_beta__{f}")
         )
 
-    return pl.DataFrame(rows)
+    wide = df.lazy().group_by("date").agg(agg_exprs).sort("date").collect()
+
+    return {
+        f: (
+            wide.select(
+                pl.col("date"),
+                pl.col(f"_cnt__{f}").alias("_cnt"),
+                pl.col(f"_beta__{f}").alias("beta"),
+            )
+            .filter(pl.col("_cnt") >= MIN_FM_CS_OBS)
+            .drop_nulls("beta")
+            .select("date", "beta")
+        )
+        for f in cols
+    }

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -1,7 +1,7 @@
 r"""Fama-MacBeth regression — FM-canonical metric for the
 ``Individual × Continuous`` cell.
 
-``compute_fm_betas``: per-date cross-sectional ordinary least squares (OLS) → (date, beta) DataFrame.
+``compute_fm_betas``: per-date cross-sectional ordinary least squares (OLS) → ``{factor: (date, beta) DataFrame}``.
 ``fm_beta``: Newey-West t-test on the beta series.
 ``pooled_beta``: pooled OLS with clustered SE by date.
 ``beta_sign_consistency``: fraction of periods with correct beta sign.
@@ -209,7 +209,7 @@ def fm_beta(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> beta_df = compute_fm_betas(panel)
+        >>> beta_df = compute_fm_betas(panel)["factor"]
         >>> result = fm_beta(beta_df, forward_periods=5)
         >>> result.name == ""
         True
@@ -769,7 +769,7 @@ def beta_sign_consistency(
         ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> beta_df = compute_fm_betas(panel)
+        >>> beta_df = compute_fm_betas(panel)["factor"]
         >>> result = beta_sign_consistency(beta_df, expected_sign=1)
         >>> result.name == ""
         True

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -1,0 +1,179 @@
+"""Tests for ``compute_fm_betas`` — vectorized per-date cross-sectional OLS slope.
+
+Mirrors ``test_ic.py``: single-factor behaviour (schema, closed-form value,
+small-date / zero-variance drops) plus the multi-factor batch contract (each
+batch element equals the corresponding list-of-one call).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.metrics.fm_beta import compute_fm_betas
+
+
+def _lstsq_betas(df: pl.DataFrame, factor_col: str = "factor") -> dict:
+    """Reference per-date slope via the pre-vectorization lstsq path."""
+    out = {}
+    for dt in df["date"].unique().sort():
+        chunk = df.filter(pl.col("date") == dt)
+        y = chunk["forward_return"].to_numpy().astype(np.float64)
+        x = chunk[factor_col].to_numpy().astype(np.float64)
+        if len(y) < 3:
+            continue
+        beta, _, _, _ = np.linalg.lstsq(
+            np.column_stack([np.ones(len(x)), x]), y, rcond=None
+        )
+        out[dt] = float(beta[1])
+    return out
+
+
+class TestComputeFMBetas:
+    def test_returns_dict_keyed_by_factor(self, tiny_panel):
+        result = compute_fm_betas(tiny_panel)
+        assert isinstance(result, dict)
+        assert set(result) == {"factor"}
+
+    def test_output_schema(self, noisy_panel):
+        df = compute_fm_betas(noisy_panel)["factor"]
+        assert df.columns == ["date", "beta"]
+        assert df["date"].is_sorted()
+
+    def test_closed_form_value(self, tiny_panel):
+        # forward_return = 0.01 * factor exactly → per-date slope == 0.01.
+        df = compute_fm_betas(tiny_panel)["factor"]
+        assert df.height == 3
+        assert df["beta"].to_numpy() == pytest.approx(0.01, abs=1e-12)
+
+    def test_matches_lstsq_reference(self, noisy_panel):
+        df = compute_fm_betas(noisy_panel)["factor"]
+        ref = _lstsq_betas(noisy_panel)
+        got = dict(zip(df["date"].to_list(), df["beta"].to_list(), strict=True))
+        assert got.keys() == ref.keys()
+        for dt, beta in got.items():
+            assert beta == pytest.approx(ref[dt], abs=1e-12)
+
+    def test_drops_dates_below_min_obs(self):
+        # date d0 has 2 assets (below MIN_FM_CS_OBS=3), d1 has 4.
+        rows = [
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": "A",
+                "factor": 1.0,
+                "forward_return": 0.1,
+            },
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": "B",
+                "factor": 2.0,
+                "forward_return": 0.2,
+            },
+        ] + [
+            {
+                "date": datetime(2024, 1, 2),
+                "asset_id": a,
+                "factor": f,
+                "forward_return": 0.05 * f,
+            }
+            for a, f in zip("ABCD", (1.0, 2.0, 3.0, 4.0), strict=True)
+        ]
+        df = compute_fm_betas(pl.DataFrame(rows))["factor"]
+        assert df["date"].to_list() == [datetime(2024, 1, 2)]
+
+    def test_drops_zero_variance_dates(self):
+        # date d0: factor constant → no identifiable slope, dropped.
+        # date d1: ordinary spread → kept.
+        rows = [
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": a,
+                "factor": 5.0,
+                "forward_return": r,
+            }
+            for a, r in zip("ABC", (0.1, 0.2, 0.3), strict=True)
+        ] + [
+            {
+                "date": datetime(2024, 1, 2),
+                "asset_id": a,
+                "factor": f,
+                "forward_return": 0.05 * f,
+            }
+            for a, f in zip("ABC", (1.0, 2.0, 3.0), strict=True)
+        ]
+        df = compute_fm_betas(pl.DataFrame(rows))["factor"]
+        assert df["date"].to_list() == [datetime(2024, 1, 2)]
+        assert df["beta"].is_finite().all()
+
+    def test_null_return_uses_pairwise_complete_slope(self):
+        # One asset has a null return: cov drops the pair, and var(factor)
+        # must drop it too so the slope is the OLS fit on complete pairs
+        # (forward_return = 0.1 * factor over the 3 complete rows → 0.1),
+        # not a numerator/denominator-mismatched value.
+        rows = [
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": "A",
+                "factor": 1.0,
+                "forward_return": 0.1,
+            },
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": "B",
+                "factor": 2.0,
+                "forward_return": 0.2,
+            },
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": "C",
+                "factor": 3.0,
+                "forward_return": 0.3,
+            },
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": "D",
+                "factor": 4.0,
+                "forward_return": None,
+            },
+        ]
+        df = compute_fm_betas(pl.DataFrame(rows))["factor"]
+        assert df["beta"].to_numpy() == pytest.approx(0.1, abs=1e-12)
+
+    def test_tiny_scale_variance_is_not_dropped(self):
+        # Variance of a 1e-5-scale factor is ~1e-10; a fixed absolute epsilon
+        # would wrongly discard this legitimately dispersed date. The slope is
+        # scale-free: forward_return = 1e4 * factor.
+        rows = [
+            {
+                "date": datetime(2024, 1, 1),
+                "asset_id": a,
+                "factor": f,
+                "forward_return": 1e4 * f,
+            }
+            for a, f in zip("ABC", (1e-5, 2e-5, 3e-5), strict=True)
+        ]
+        df = compute_fm_betas(pl.DataFrame(rows))["factor"]
+        assert df.height == 1
+        assert df["beta"][0] == pytest.approx(1e4, rel=1e-9)
+
+
+class TestComputeFMBetasBatch:
+    """Multi-factor path — each batch element equals the list-of-one call."""
+
+    def test_multi_factor_matches_list_of_one(self, noisy_panel):
+        rng = np.random.default_rng(7)
+        panel = noisy_panel.with_columns(
+            (pl.col("factor") * 1.5).alias("f1"),
+            pl.Series("f2", rng.standard_normal(noisy_panel.height)),
+        )
+        cols = ["f1", "f2"]
+        batch = compute_fm_betas(panel, factor_cols=cols)
+        for col in cols:
+            single = compute_fm_betas(panel, factor_cols=[col])[col]
+            assert batch[col].equals(single), col
+
+    def test_empty_factor_list_rejected(self, tiny_panel):
+        with pytest.raises(ValueError, match="factor_cols must be non-empty"):
+            compute_fm_betas(tiny_panel, factor_cols=[])

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -185,12 +185,17 @@ class TestVisibility:
 class TestBatchable:
     def test_known_batchable_specs(self) -> None:
         specs = spec_by_name()
-        for name in ("compute_ic", "quantile_spread", "monotonicity"):
+        for name in (
+            "compute_ic",
+            "compute_fm_betas",
+            "quantile_spread",
+            "monotonicity",
+        ):
             assert specs[name].batchable is True, name
 
     def test_non_batchable_specs(self) -> None:
         specs = spec_by_name()
-        for name in ("top_concentration", "turnover", "compute_fm_betas"):
+        for name in ("top_concentration", "turnover"):
             assert specs[name].batchable is False, name
 
 


### PR DESCRIPTION
Closes #551 (T1 of the #545 scale-out epic).

## What

Replaces the per-date Python loop in `compute_fm_betas`
(`filter(date == dt)` + `np.linalg.lstsq` per date, called **once per
factor** because the spec was `batchable=False`) with the single-regressor
OLS closed form

```
beta_t = Cov_t(x, y) / Var_t(x)
```

computed **batched across all factors** in one `group_by("date").agg` +
`collect`. The spec is now `batchable=True` and the signature switches to
`factor_cols` / `dict[str, DataFrame]` return, mirroring `compute_ic` — so
the DAG dispatches it once per batch instead of once per factor.

This removes both costs the issue flagged at 100–1000+ factor scale:
the per-iteration `filter(==dt)` full-table scan (O(n_dates × N_rows)) and
the per-factor repetition of the whole loop.

## Correctness

- **Parity:** matches the prior `lstsq` slope to ~1e-12 on real panels
  (the cov/var ddof cancels in the ratio); batch == list-of-one exactly.
- **Pairwise-complete moments:** every per-date moment is taken over the
  complete `(factor, return)` set, so `cov` and `var` share one sample —
  a row with a present factor but null return no longer biases the
  denominator (the self-consistency `pl.corr` gives `compute_ic` for free).
- **Scale-free degeneracy test:** uses `var_t > 0` rather than an absolute
  epsilon. Zero cross-sectional spread (no identifiable slope) is dropped;
  a small-but-real spread is kept — a fixed epsilon would silently discard
  legitimately tiny-scale factors. A date is emitted only with
  `>= MIN_FM_CS_OBS` (3) complete pairs.

The zero-variance drop is a deliberate, rare improvement over the old
path, which handed such dates an arbitrary `lstsq` least-norm slope.

## Tests / docs

- New `tests/test_fm_betas.py`: closed-form value, lstsq parity, min-obs
  and zero-variance drops, pairwise-complete null handling, tiny-scale
  variance, batch equivalence.
- `compute_fm_betas` moved to the batchable group in `test_metric_index.py`.
- `fm_beta` doctests + `docs/api/metrics/fm_beta.md` updated for the dict
  return; `docs/development/architecture.md` documents `MIN_FM_CS_OBS` and
  the scale-free guard.

## Verification

`ruff check` · `ruff format --check` · `mypy factrix` all clean;
full suite **1433 passed, 4 skipped**; doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)