### PR TITLE
refactor(metrics): route ic() significance test through NonOverlappingSample

### DIFF
--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -30,9 +30,7 @@ from factrix._axis import (
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import (
-    _calc_t_stat,
     _newey_west_t_test,
-    _p_value_from_t,
 )
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 from factrix._types import (
@@ -42,7 +40,6 @@ from factrix._types import (
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     TIE_RATIO_WARN_THRESHOLD,
-    _sample_non_overlapping,
     _scaled_min_periods,
     _short_circuit_output,
 )
@@ -108,7 +105,7 @@ def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
     cell=_IC_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
+    se_method=SEMethod.OLS,
     input_shape=InputShape.SERIES,
     requires={"ic_df": compute_ic},
     sample_threshold=SampleThreshold(),
@@ -162,7 +159,10 @@ def ic(
         True
     """
     median_tie = _warn_if_high_ic_tie_ratio(ic_df, "ic")
-    ic_vals = ic_df["ic"].drop_nulls()
+    # Date-order the series before striding so the non-overlapping
+    # subsample is time-coherent regardless of caller row order; mean /
+    # count below are order-invariant over the same non-null set.
+    ic_vals = ic_df.sort("date")["ic"].drop_nulls()
     n = len(ic_vals)
     raw_min = _scaled_min_periods(MIN_ASSETS_PER_DATE_IC, forward_periods)
     if n < raw_min:
@@ -174,9 +174,13 @@ def ic(
             forward_periods=forward_periods,
         )
 
+    from factrix.stats.non_overlapping import NonOverlappingSample
+
     mean_ic = float(ic_vals.mean())  # type: ignore[arg-type]
-    sampled = _sample_non_overlapping(ic_df, forward_periods)["ic"].drop_nulls()
-    n_sampled = len(sampled)
+    result = NonOverlappingSample().compute(
+        ic_vals.to_numpy(), forward_periods=forward_periods
+    )
+    n_sampled = int(result.metadata["n_obs_sampled"])
     if n_sampled < MIN_ASSETS_PER_DATE_IC:
         return _short_circuit_output(
             "ic",
@@ -185,13 +189,11 @@ def ic(
             min_required=MIN_ASSETS_PER_DATE_IC,
             forward_periods=forward_periods,
         )
-    t = _calc_t_stat(float(sampled.mean()), float(sampled.std()), n_sampled)  # type: ignore[arg-type]
-    p = _p_value_from_t(t, n_sampled)
 
     return MetricResult(
-        p_value=p,
+        p_value=result.p_value,
         value=mean_ic,
-        stat=t,
+        stat=result.stat,
         metadata={
             "n_periods": n,
             "stat_type": "t",

--- a/factrix/stats/_estimator.py
+++ b/factrix/stats/_estimator.py
@@ -94,6 +94,14 @@ class InferenceResult:
     ``{"nw_lags": k}``; Hansen-Hodrick (HH) emits ``{"kernel": "rectangular",
     "variance_clamped": bool}``).
 
+    ``stat_name`` / ``p_name`` are ``None`` for a metric-internal
+    inference unit that is not (yet) a discoverable ``Estimator`` and
+    therefore claims no ``profile.stats`` key — its ``stat`` / ``p_value``
+    feed a ``MetricResult`` directly rather than being keyed into
+    ``FactorProfile.stats``. The ``StatCode``-emitting promotion is gated
+    behind the structured-shape redesign the ``StatCode`` enum note
+    requires before the codebook grows further.
+
     Moment-condition estimators have a parallel return shape
     (``GMMResult`` carrying ``j_stat`` / ``df`` / ``overid_p``); they
     live on the separate ``MomentEstimator`` sub-protocol below rather
@@ -102,8 +110,8 @@ class InferenceResult:
 
     stat: float
     p_value: float
-    stat_name: StatCode
-    p_name: StatCode
+    stat_name: StatCode | None
+    p_name: StatCode | None
     metadata: Mapping[str, Any]
     warnings: frozenset[WarningCode]
 

--- a/factrix/stats/non_overlapping.py
+++ b/factrix/stats/non_overlapping.py
@@ -1,0 +1,108 @@
+"""``NonOverlappingSample`` — OLS t-test on a non-overlapping stride subsample of a series.
+
+A metric-internal inference unit, not a registered ``Estimator``: it
+emits no ``StatCode`` and does not enter ``_ESTIMATOR_REGISTRY`` /
+``list_estimators`` / the ``profile.stats`` dispatch path. ``ic()``
+delegates its default-path significance test here so the math lives in
+one named, independently-testable place instead of being inlined in the
+metric body.
+
+Promotion to a first-class ``Estimator`` (with a ``(stat, p)`` StatCode
+pair and ``emits_for`` dispatch) is gated behind the structured-shape
+redesign the ``StatCode`` enum note requires before the codebook grows
+further — see ``factrix._codes.StatCode``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from factrix._codes import WarningCode
+from factrix._stats.constants import MIN_PERIODS_WARN
+from factrix.stats._estimator import InferenceResult
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class NonOverlappingSample:
+    """Non-overlapping stride subsample inference: OLS t-test on every ``forward_periods``-th observation.
+
+    Sub-samples the series at a stride equal to ``forward_periods`` to
+    break the MA(h-1) autocorrelation that overlapping h-period forward
+    returns induce ([Hansen-Hodrick 1980][hansen-hodrick-1980]), then
+    runs a textbook OLS t-test on the surviving observations. The most
+    conservative overlap-aware path — it discards h-1 of every h
+    observations rather than correcting the SE; ``NeweyWest`` is the
+    less-lossy HAC alternative on the full series.
+    """
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+    @property
+    def description(self) -> str:
+        return (
+            "OLS t-test on non-overlapping stride subsamples (stride = forward_periods) "
+            "→ t → two-sided p-value."
+        )
+
+    @property
+    def min_periods(self) -> int:
+        """Soft floor on the *sampled* count below which the SE is frail.
+
+        Surfaced via ``warnings`` rather than silently degrading; the
+        hard short-circuit (sample too short to test at all) is the
+        caller's responsibility.
+        """
+        return MIN_PERIODS_WARN
+
+    def compute(
+        self,
+        series: np.ndarray,
+        *,
+        forward_periods: int,
+    ) -> InferenceResult:
+        """Run the non-overlapping OLS t-test on ``series``.
+
+        Args:
+            series: 1-D test-target series (e.g. the per-date IC series),
+                already null-dropped and ordered by the caller. The unit
+                strides it at ``forward_periods``; it does not re-sort or
+                re-clean.
+            forward_periods: Sub-sampling stride (the overlap horizon of
+                the underlying forward returns).
+
+        Returns:
+            ``InferenceResult`` with ``stat`` / ``p_value`` and
+            ``stat_name`` / ``p_name`` set to ``None`` (no profile
+            StatCode claimed). ``metadata`` carries ``stride`` and the
+            pre / post-sampling counts.
+        """
+        from factrix._stats import _p_value_from_t, _t_stat_from_array
+
+        sampled = series[::forward_periods]
+        n_sampled = len(sampled)
+
+        t_stat = _t_stat_from_array(sampled)
+        p_value = _p_value_from_t(t_stat, n_sampled)
+
+        warnings: frozenset[WarningCode] = frozenset()
+        if 0 < n_sampled < self.min_periods:
+            warnings = frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS})
+
+        return InferenceResult(
+            stat=t_stat,
+            p_value=p_value,
+            stat_name=None,
+            p_name=None,
+            metadata={
+                "stride": forward_periods,
+                "n_obs_original": len(series),
+                "n_obs_sampled": n_sampled,
+            },
+            warnings=warnings,
+        )

--- a/tests/stats/test_non_overlapping.py
+++ b/tests/stats/test_non_overlapping.py
@@ -1,0 +1,52 @@
+"""``NonOverlappingSample`` — stride subsample OLS t-test inference unit."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._codes import WarningCode
+from factrix._stats import _p_value_from_t, _t_stat_from_array
+from factrix.stats._estimator import InferenceResult
+from factrix.stats.non_overlapping import NonOverlappingSample
+
+
+class TestNonOverlappingSample:
+    def test_strides_at_forward_periods(self):
+        series = np.arange(20.0)
+        result = NonOverlappingSample().compute(series, forward_periods=5)
+        # series[::5] -> [0, 5, 10, 15]
+        assert result.metadata["stride"] == 5
+        assert result.metadata["n_obs_original"] == 20
+        assert result.metadata["n_obs_sampled"] == 4
+
+    def test_matches_primitive_t_and_p(self):
+        rng = np.random.default_rng(0)
+        series = rng.standard_normal(120) + 0.1
+        result = NonOverlappingSample().compute(series, forward_periods=5)
+        sampled = series[::5]
+        expected_t = _t_stat_from_array(sampled)
+        expected_p = _p_value_from_t(expected_t, len(sampled))
+        assert result.stat == expected_t
+        assert result.p_value == expected_p
+
+    def test_claims_no_statcode(self):
+        """Metric-internal unit: emits no profile StatCode pair."""
+        result = NonOverlappingSample().compute(np.arange(60.0), forward_periods=1)
+        assert isinstance(result, InferenceResult)
+        assert result.stat_name is None
+        assert result.p_name is None
+
+    def test_short_sample_warns(self):
+        # forward_periods=1 keeps all obs; 10 < MIN_PERIODS_WARN (30) -> warn
+        result = NonOverlappingSample().compute(np.arange(10.0), forward_periods=1)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in result.warnings
+
+    def test_ample_sample_no_warning(self):
+        result = NonOverlappingSample().compute(np.arange(60.0), forward_periods=1)
+        assert result.warnings == frozenset()
+
+    @pytest.mark.parametrize("attr", ["name", "description", "min_periods"])
+    def test_identity_surface(self, attr):
+        est = NonOverlappingSample()
+        assert getattr(est, attr) is not None
+        assert est.name == "NonOverlappingSample"

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -213,3 +213,45 @@ class TestICIR:
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = ic_ir(df)
         assert math.isnan(result.value)
+
+
+class TestICDispatch:
+    """``ic()`` delegates its significance test to ``NonOverlappingSample``.
+
+    These pin the result so the dispatch refactor stays numerically
+    equivalent to the previously-inlined non-overlapping OLS t-test
+    (to floating-point ULP — polars vs numpy variance reduction order).
+    """
+
+    def test_se_method_declares_ols(self):
+        from factrix._axis import SEMethod
+
+        # The default path runs a non-overlapping OLS t-test, not HAC;
+        # the spec declaration must match the actual standard error.
+        assert ic.se_method is SEMethod.OLS
+
+    def _ic_df(self):
+        import factrix as fx
+        from factrix.preprocess import compute_forward_return
+
+        panel = compute_forward_return(
+            fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0),
+            forward_periods=5,
+        )
+        return compute_ic(panel)["factor"]
+
+    @pytest.mark.parametrize(
+        ("forward_periods", "value", "stat", "p_value"),
+        [
+            (1, 0.049163258267725024, 5.404723194889399, 2.1264376169332541e-07),
+            (5, 0.049163258267725024, 4.136962357146272, 0.00021830177834358518),
+        ],
+    )
+    def test_regression_pins_dispatch_output(
+        self, forward_periods, value, stat, p_value
+    ):
+        result = ic(self._ic_df(), forward_periods=forward_periods)
+        assert result.value == pytest.approx(value, rel=1e-12)
+        assert result.stat == pytest.approx(stat, rel=1e-12)
+        assert result.p_value == pytest.approx(p_value, rel=1e-12)
+        assert result.metadata["method"] == "non-overlapping t-test"


### PR DESCRIPTION
## Summary
- Route `ic()`'s default non-overlapping OLS t-test through a named `NonOverlappingSample` inference object (new `factrix/stats/non_overlapping.py`), removing the inlined `_sample_non_overlapping` + `_calc_t_stat` and establishing the metric → inference consumption seam.
- Correct `ic()`'s spec `se_method` from `HAC` to `OLS` — the declaration contradicted the non-overlapping OLS test it actually runs.
- Relax `InferenceResult.stat_name` / `p_name` to `StatCode | None` so a metric-internal unit can reuse the shape without minting a new StatCode; the over-budget enum is left untouched per its structured-shape-redesign note.

Scope A of #558's `ic()` slice: default path only, numerically preserved to floating-point ULP (polars vs numpy variance reduction order). `ic_newey_west` merge + NW bandwidth unification are deferred (see the #558 decision note).

## Test plan
- [x] `tests/test_ic.py` regression pins `ic()` output (fp=1/5) and asserts `se_method == OLS`
- [x] `tests/stats/test_non_overlapping.py` covers the new inference object (stride, primitive parity, no StatCode, short-sample warning)
- [x] full suite: 1354 passed, 4 skipped
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean

Closes #563
