### PR TITLE
chore(estimators): drop unused lowercase HAC aliases (#567)

### DIFF
--- a/docs/api/estimators.md
+++ b/docs/api/estimators.md
@@ -8,18 +8,6 @@ title: factrix.estimators
 
 ---
 
-## `newey_west`
-
-::: factrix.estimators.newey_west
-
----
-
-## `hansen_hodrick`
-
-::: factrix.estimators.hansen_hodrick
-
----
-
 ## `driscoll_kraay`
 
 ::: factrix.estimators.driscoll_kraay

--- a/factrix/estimators/__init__.py
+++ b/factrix/estimators/__init__.py
@@ -3,16 +3,16 @@
 Boundary with :mod:`factrix.stats`:
 
 - :mod:`factrix.stats` exposes the PascalCase :class:`Estimator` protocol
-  family (``NeweyWest`` / ``HansenHodrick`` / ``BlockBootstrap``) used
-  by the metric parameters and the slice-test estimator-dispatch path.
+  family (``DriscollKraay`` / ``BlockBootstrap``) used by the slice-test
+  estimator-dispatch path.
 - :mod:`factrix.estimators` exposes lowercase function aliases over the
   same underlying computations, callable directly from inside a metric
-  implementation without instantiating an ``Estimator`` first.
+  implementation without instantiating an ``Estimator`` first
+  (``driscoll_kraay`` → ``fm_beta``; ``block_bootstrap`` → ``_helpers``).
 
 The two namespaces are not in tension — :mod:`factrix.stats` exposes the
 class-based ``Estimator`` surface, and the lowercase callables here are the
-forward-compatible internal-consumption surface for metric callables
-and, in the future, runtime per-metric estimator override.
+forward-compatible internal-consumption surface for metric callables.
 """
 
 from __future__ import annotations
@@ -21,36 +21,6 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     import numpy as np
-
-    from factrix.stats._estimator import InferenceResult
-
-
-def newey_west(series: np.ndarray, *, forward_periods: int) -> InferenceResult:
-    """Newey-West HAC SE on a series mean → t-statistic → two-sided p-value.
-
-    Lowercase callable alias over :class:`factrix.stats.NeweyWest`.
-    Bartlett kernel, NW1994 auto-bandwidth, Hansen-Hodrick overlap
-    floor. ``forward_periods`` sets the overlap horizon used by the
-    floor.
-    """
-    from factrix.stats.newey_west import NeweyWest
-
-    return NeweyWest().compute(series, forward_periods=forward_periods)
-
-
-def hansen_hodrick(series: np.ndarray, *, forward_periods: int) -> InferenceResult:
-    """Hansen-Hodrick (1980) rectangular-kernel HAC SE on a series mean.
-
-    Lowercase callable alias over :class:`factrix.stats.HansenHodrick`.
-    Rectangular kernel matched to MA(h-1) overlap structure from
-    h-period forward returns; no PSD guarantee — variance is clamped
-    at zero and the result carries
-    ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE`` when the raw estimate
-    is negative.
-    """
-    from factrix.stats.hansen_hodrick import HansenHodrick
-
-    return HansenHodrick().compute(series, forward_periods=forward_periods)
 
 
 def driscoll_kraay(
@@ -145,6 +115,4 @@ def block_bootstrap(
 __all__ = [
     "block_bootstrap",
     "driscoll_kraay",
-    "hansen_hodrick",
-    "newey_west",
 ]

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -5,23 +5,7 @@ from __future__ import annotations
 import factrix as fx
 import numpy as np
 import pytest
-from factrix.stats import BlockBootstrap, HansenHodrick, NeweyWest
-
-
-class TestNeweyWestCallable:
-    def test_matches_class_compute(self) -> None:
-        series = np.random.default_rng(0).standard_normal(60)
-        out_class = NeweyWest().compute(series, forward_periods=5)
-        out_func = fx.estimators.newey_west(series, forward_periods=5)
-        assert out_class == out_func
-
-
-class TestHansenHodrickCallable:
-    def test_matches_class_compute(self) -> None:
-        series = np.random.default_rng(1).standard_normal(60)
-        out_class = HansenHodrick().compute(series, forward_periods=5)
-        out_func = fx.estimators.hansen_hodrick(series, forward_periods=5)
-        assert out_class == out_func
+from factrix.stats import BlockBootstrap
 
 
 class TestBlockBootstrapCallable:
@@ -66,8 +50,6 @@ class TestNamespaceExports:
 
     def test_namespace_exports_callables(self) -> None:
         for name in (
-            "newey_west",
-            "hansen_hodrick",
             "block_bootstrap",
             "driscoll_kraay",
         ):
@@ -77,13 +59,3 @@ class TestNamespaceExports:
         # Driscoll-Kraay is the cross-section-robust HAC SE
         # option behind pooled_beta(driscoll_kraay=True).
         assert callable(fx.estimators.driscoll_kraay)
-
-
-@pytest.mark.parametrize("forward_periods", [1, 5, 21])
-class TestEstimatorForwardPeriodsParametrize:
-    def test_newey_west_returns_finite_for_iid_normal(self, forward_periods):
-        rng = np.random.default_rng(2024)
-        series = rng.standard_normal(120)
-        out = fx.estimators.newey_west(series, forward_periods=forward_periods)
-        assert np.isfinite(out.p_value)
-        assert 0.0 <= out.p_value <= 1.0


### PR DESCRIPTION
## Summary
- Remove the unused lowercase `factrix.estimators.newey_west` / `hansen_hodrick` callable aliases — zero production consumers; metric paths call the `factrix._stats` kernels directly.
- Keep the live aliases `driscoll_kraay` (→ `fm_beta`) and `block_bootstrap` (→ `_helpers`) untouched.
- Mechanical doc fix only: drop the now-dangling mkdocstrings autodoc blocks in `docs/api/estimators.md`. Prose/CHANGELOG batched to the epic wrap-up per #558 policy.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean
- [x] `pytest tests/` — 1304 passed, 4 skipped
- [x] Surviving consumers regress green (`driscoll_kraay` / `block_bootstrap`)

Closes #567
Refs #558
