### PR TITLE
refactor(metrics)!: drop phantom test_method / se_method spec fields (#558)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -82,7 +82,7 @@ raises under `strict=True` or short-circuits to a NaN `MetricResult` under
 Each `factrix/metrics/*.py` module declares a module-level `__metric_specs__`
 tuple — **the** source of truth, resolved through `factrix._metric_index`:
 
-- `MetricSpec(name, cell, aggregation, test_method, se_method, ...)` — the typed
+- `MetricSpec(name, cell, aggregation, ...)` — the typed
   per-callable spec; `cell` is a `(scope, density, structure)` `Cell` with `None`
   = `*` wildcard on any axis.
 - `spec_by_name() -> dict[str, MetricSpec]` — name → spec lookup across every
@@ -581,8 +581,8 @@ control is needed across a batch.
 factrix/
 ├── __init__.py              # public surface + evaluate()
 ├── _axis.py                 # FactorScope / FactorDensity / DataStructure / Tier + spec-metadata
-│                            #   enums (Aggregation / TestMethod / SEMethod / SpecRole / InputShape / OutputShape)
-├── _codes.py                # WarningCode / InfoCode (reserved, no codes) / StatCode StrEnums
+│                            #   enums (Aggregation / SpecRole / InputShape / OutputShape)
+├── _codes.py                # WarningCode StrEnum
 ├── _errors.py               # flat hierarchy: FactrixError → {IncompatibleAxisError, InsufficientSampleError, UnknownEstimatorError, UserInputError}
 ├── _metric_index.py         # MetricSpec + __metric_specs__ SSOT (spec_by_name / list_metrics / public_specs / metric_spec)
 ├── _dag.py                  # DagExecutor — MetricSpec.requires / batchable dispatch (+ CycleError)

--- a/docs/guides/custom-metrics.md
+++ b/docs/guides/custom-metrics.md
@@ -30,7 +30,7 @@ Here is how to implement a custom Information Coefficient (IC) metric that accep
 ```python
 import polars as pl
 import factrix as fx
-from factrix._axis import Aggregation, TestMethod, SEMethod
+from factrix._axis import Aggregation
 from factrix._metric_index import cell, SampleThreshold
 from factrix import MetricResult
 from factrix.metrics import metric
@@ -46,8 +46,6 @@ _CUSTOM_CELL = cell(
 @metric(
     cell=_CUSTOM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     sample_threshold=SampleThreshold(min_periods=10),
 )
 def custom_trimmed_ic(
@@ -104,7 +102,7 @@ from factrix.metrics import register
 
 # `cell` and the spec enums are not yet on the public surface; import
 # from the internal modules until they are re-exported.
-from factrix._axis import Aggregation, TestMethod, SEMethod
+from factrix._axis import Aggregation
 from factrix._metric_index import cell
 
 # 1. Stamp the spec onto the callable
@@ -113,8 +111,6 @@ from factrix._metric_index import cell
         name="my_custom_stat",
         cell=cell(fx.FactorScope.INDIVIDUAL, fx.FactorDensity.DENSE),
         aggregation=Aggregation.CS_THEN_TS,
-        test_method=TestMethod.T,
-        se_method=SEMethod.HAC,
     )
 )
 def my_custom_stat(data: pl.DataFrame) -> MetricResult:

--- a/docs/reference/_generated_metric_matrix.md
+++ b/docs/reference/_generated_metric_matrix.md
@@ -1,25 +1,24 @@
-| Module | Cell scope | Aggregation order | Inference SE |
-|---|---|---|---|
-| [`metrics.caar`][factrix.metrics.caar] | `(*, SPARSE, PANEL)` | event_time | t (hac) |
-| [`metrics.clustering_hhi`][factrix.metrics.clustering_hhi] | `(*, SPARSE, PANEL)` | cs_snapshot | descriptive (none) |
-| [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (ols) |
-| [`metrics.corrado_rank`][factrix.metrics.corrado_rank] | `(*, SPARSE, PANEL)` | event_time | rank (built_in) |
-| [`metrics.directional_hit_rate`][factrix.metrics.directional_hit_rate] | `(*, DENSE, *)` | ts_only | t (built_in) |
-| [`metrics.event_horizon`][factrix.metrics.event_horizon] | `(*, SPARSE, PANEL)` | event_time | binomial (built_in) |
-| [`metrics.event_quality`][factrix.metrics.event_quality] | `(*, SPARSE, PANEL)` | event_time | rank (built_in) |
-| [`metrics.fm_beta`][factrix.metrics.fm_beta] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (hac) |
-| [`metrics.hit_rate`][factrix.metrics.hit_rate] | `(*, DENSE, TIMESERIES)` | ts_only | binomial (built_in) |
-| [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (ols) |
-| [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (hac) |
-| [`metrics.k_spread`][factrix.metrics.k_spread] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (ols) |
-| [`metrics.mfe_mae`][factrix.metrics.mfe_mae] | `(*, SPARSE, PANEL)` | event_time | descriptive (none) |
-| [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (ols) |
-| [`metrics.oos_decay`][factrix.metrics.oos_decay] | `(*, DENSE, TIMESERIES)` | ts_only | descriptive (none) |
-| [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | t (ols) |
-| [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | ts_only | t (hac) |
-| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts | descriptive (none) |
-| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, DENSE, PANEL)` | ts_only | descriptive (none) |
-| [`metrics.trend`][factrix.metrics.trend] | `(*, DENSE, TIMESERIES)` | ts_only | rank (built_in) |
-| [`metrics.ts_asymmetry`][factrix.metrics.ts_asymmetry] | `(COMMON, DENSE, PANEL)` | cs_then_ts | chi2 (hac) |
-| [`metrics.ts_beta`][factrix.metrics.ts_beta] | `(COMMON, DENSE, PANEL)` | ts_then_cs | t (ols) |
-| [`metrics.ts_quantile`][factrix.metrics.ts_quantile] | `(COMMON, DENSE, PANEL)` | cs_then_ts | chi2 (hac) |
+| Module | Cell scope | Aggregation order |
+|---|---|---|
+| [`metrics.caar`][factrix.metrics.caar] | `(*, SPARSE, PANEL)` | event_time |
+| [`metrics.clustering_hhi`][factrix.metrics.clustering_hhi] | `(*, SPARSE, PANEL)` | cs_snapshot |
+| [`metrics.concentration`][factrix.metrics.concentration] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.corrado_rank`][factrix.metrics.corrado_rank] | `(*, SPARSE, PANEL)` | event_time |
+| [`metrics.directional_hit_rate`][factrix.metrics.directional_hit_rate] | `(*, DENSE, *)` | ts_only |
+| [`metrics.event_horizon`][factrix.metrics.event_horizon] | `(*, SPARSE, PANEL)` | event_time |
+| [`metrics.event_quality`][factrix.metrics.event_quality] | `(*, SPARSE, PANEL)` | event_time |
+| [`metrics.fm_beta`][factrix.metrics.fm_beta] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.hit_rate`][factrix.metrics.hit_rate] | `(*, DENSE, TIMESERIES)` | ts_only |
+| [`metrics.ic`][factrix.metrics.ic] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.k_spread`][factrix.metrics.k_spread] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.mfe_mae`][factrix.metrics.mfe_mae] | `(*, SPARSE, PANEL)` | event_time |
+| [`metrics.monotonicity`][factrix.metrics.monotonicity] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.oos_decay`][factrix.metrics.oos_decay] | `(*, DENSE, TIMESERIES)` | ts_only |
+| [`metrics.quantile`][factrix.metrics.quantile] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.spanning`][factrix.metrics.spanning] | `factor-return-series consumer (post-PANEL pipeline)` | ts_only |
+| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.tradability`][factrix.metrics.tradability] | `(INDIVIDUAL, DENSE, PANEL)` | ts_only |
+| [`metrics.trend`][factrix.metrics.trend] | `(*, DENSE, TIMESERIES)` | ts_only |
+| [`metrics.ts_asymmetry`][factrix.metrics.ts_asymmetry] | `(COMMON, DENSE, PANEL)` | cs_then_ts |
+| [`metrics.ts_beta`][factrix.metrics.ts_beta] | `(COMMON, DENSE, PANEL)` | ts_then_cs |
+| [`metrics.ts_quantile`][factrix.metrics.ts_quantile] | `(COMMON, DENSE, PANEL)` | cs_then_ts |

--- a/factrix/_axis.py
+++ b/factrix/_axis.py
@@ -12,8 +12,8 @@ Two orthogonal user-facing axes describe an analysis cell:
 user-set: it is derived from ``N`` at evaluate-time and surfaced as the
 third position of ``EvaluationResult.cell`` for downstream pattern-match.
 
-Metric-spec structural enums (``Aggregation``, ``TestMethod``, ``SEMethod``,
-``SpecRole``, ``InputShape``, ``OutputShape``) live here alongside the axis
+Metric-spec structural enums (``Aggregation``, ``SpecRole``,
+``InputShape``, ``OutputShape``) live here alongside the axis
 enums so all enum definitions share one import path.
 """
 
@@ -80,59 +80,6 @@ class Aggregation(Enum):
 
     RETURN_SPANNING = "return_spanning"
     """Spanning regression on factor-return time series."""
-
-
-class TestMethod(Enum):
-    """Primary statistical test family.
-
-    Drives ``primary_eligible`` (``DESCRIPTIVE`` specs are excluded from
-    being the primary metric in ``evaluate()``).
-    """
-
-    __test__ = False
-
-    T = "t"
-    """t-test, including NW HAC-corrected variants."""
-
-    BINOMIAL = "binomial"
-    """Binomial proportion test."""
-
-    RANK = "rank"
-    """Nonparametric rank-based test (Corrado, Theil-Sen, etc.)."""
-
-    CHI2 = "chi2"
-    """Chi-square / Wald asymptotic test."""
-
-    DESCRIPTIVE = "descriptive"
-    """No formal H₀ — measurement / descriptive statistic only."""
-
-
-class SEMethod(Enum):
-    """Standard-error / variance-estimation family.
-
-    Intentionally coarse-grained — NW / HH / Driscoll-Kraay are all
-    ``HAC``; method details live in the spec's docstring. Coarseness
-    gives callers programmable filtering without coupling to literature
-    names that may expand.
-    """
-
-    HAC = "hac"
-    """Autocorrelation-robust (Newey-West / Hansen-Hodrick family)."""
-
-    CLUSTER = "cluster"
-    """Cluster-robust (reserved; no current spec uses this)."""
-
-    HETEROSKEDASTIC = "heteroskedastic"
-    """White-style HC / BMP standardization."""
-
-    OLS = "ols"
-    """Vanilla OLS standard error."""
-
-    BUILT_IN = "built_in"
-    """Test carries its own null distribution (rank / binomial); no external SE."""
-
-    NONE = "none"
-    """Descriptive — no inference, no SE."""
 
 
 class SpecRole(Enum):

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -24,8 +24,6 @@ access. Adding a new metric module just imports :class:`MetricSpec` and
             name="my_metric",
             cell=cell(FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         ),
     )
 """
@@ -47,9 +45,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
     Tier,
 )
 
@@ -250,8 +246,6 @@ class MetricSpec:
       the *concept family* (``ic`` / ``decay`` / ``quantile``), which is
       the declaring module's stem and is derived from file location
       (the ``file = family`` invariant), never stored on the spec.
-    - ``test_method``: primary statistical test family.
-    - ``se_method``: standard-error / variance-estimation family.
     - ``input_shape``: shape of data the callable directly receives
       (``PANEL`` / ``SERIES`` / ``SCALAR``).
     - ``output_shape``: shape of the returned value. ``METRIC`` specs
@@ -279,8 +273,6 @@ class MetricSpec:
     name: str
     cell: Cell
     aggregation: Aggregation
-    test_method: TestMethod
-    se_method: SEMethod
     input_shape: InputShape = InputShape.PANEL
     output_shape: OutputShape = OutputShape.SCALAR
     role: SpecRole = SpecRole.METRIC

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -9,9 +9,7 @@ from factrix._axis import (
     Aggregation,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import Cell, MetricSpec, SampleThreshold
 
@@ -78,8 +76,6 @@ class MetricBase(metaclass=MetricMeta):
 
     cell: ClassVar[Cell]
     aggregation: ClassVar[Aggregation]
-    test_method: ClassVar[TestMethod]
-    se_method: ClassVar[SEMethod]
     input_shape: ClassVar[InputShape]
     output_shape: ClassVar[OutputShape]
     role: ClassVar[SpecRole]
@@ -103,8 +99,6 @@ class MetricBase(metaclass=MetricMeta):
             name=cls.__name__,
             cell=cls.cell,
             aggregation=cls.aggregation,
-            test_method=cls.test_method,
-            se_method=cls.se_method,
             input_shape=cls.input_shape,
             output_shape=cls.output_shape,
             role=cls.role,

--- a/factrix/metrics/_decorators.py
+++ b/factrix/metrics/_decorators.py
@@ -9,9 +9,7 @@ from factrix._axis import (
     Aggregation,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import Cell, SampleThreshold
 from factrix.metrics._base import MetricBase
@@ -23,8 +21,6 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 def metric(
     cell: Cell,
     aggregation: Aggregation,
-    test_method: TestMethod,
-    se_method: SEMethod,
     *,
     input_shape: InputShape = InputShape.PANEL,
     output_shape: OutputShape = OutputShape.SCALAR,
@@ -78,8 +74,6 @@ def metric(
         cls_attrs = {
             "cell": cell,
             "aggregation": aggregation,
-            "test_method": test_method,
-            "se_method": se_method,
             "input_shape": input_shape,
             "output_shape": output_shape,
             "role": role,

--- a/factrix/metrics/_primitives/_caar.py
+++ b/factrix/metrics/_primitives/_caar.py
@@ -10,9 +10,7 @@ from factrix._axis import (
     FactorDensity,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
@@ -24,8 +22,6 @@ from factrix.metrics._helpers import _is_sparse_magnitude_weighted
         None, FactorDensity.SPARSE, DataStructure.PANEL, raw="(*, SPARSE, PANEL)"
     ),
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_event_returns.py
+++ b/factrix/metrics/_primitives/_event_returns.py
@@ -9,9 +9,7 @@ from factrix._axis import (
     FactorDensity,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix._types import EPSILON
@@ -23,8 +21,6 @@ from factrix.metrics._decorators import metric
         None, FactorDensity.SPARSE, DataStructure.PANEL, raw="(*, SPARSE, PANEL)"
     ),
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -11,9 +11,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
@@ -29,8 +27,6 @@ MIN_FM_CS_OBS: int = 3
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_group_returns.py
+++ b/factrix/metrics/_primitives/_group_returns.py
@@ -9,9 +9,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
@@ -26,8 +24,6 @@ from factrix.metrics._helpers import (
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -11,9 +11,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix._types import MIN_ASSETS_PER_DATE_IC
@@ -25,8 +23,6 @@ from factrix.metrics._decorators import metric
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -9,9 +9,7 @@ from factrix._axis import (
     FactorDensity,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix._types import EPSILON
@@ -43,8 +41,6 @@ def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
         None, FactorDensity.SPARSE, DataStructure.PANEL, raw="(*, SPARSE, PANEL)"
     ),
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -12,9 +12,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
@@ -30,8 +28,6 @@ from factrix.metrics._helpers import (
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/_primitives/_ts_betas.py
+++ b/factrix/metrics/_primitives/_ts_betas.py
@@ -11,9 +11,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix._types import EPSILON
@@ -27,8 +25,6 @@ MIN_TS_OBS: int = 20
 @metric(
     cell=cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.TS_THEN_CS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -31,8 +31,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
@@ -76,8 +74,6 @@ min_assets_per_group: int | None = None
 @metric(
     cell=_CAAR_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.SERIES,
     requires={"caar_df": compute_caar},
     sample_threshold=SampleThreshold(),
@@ -192,8 +188,6 @@ def caar(
 @metric(
     cell=_CAAR_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     sample_threshold=SampleThreshold(),
 )
 def bmp_test(

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -23,8 +23,6 @@ from factrix._axis import (
     Aggregation,
     DataStructure,
     FactorDensity,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -40,8 +38,6 @@ __all__ = [
 @metric(
     cell=cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.CS_SNAPSHOT,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     sample_threshold=SampleThreshold(),
 )
 def clustering_hhi(

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -24,8 +24,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._codes import WarningCode
 from factrix._metric_index import cell
@@ -55,8 +53,6 @@ __all__ = [
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
 )
 def top_concentration(
     df: pl.DataFrame,

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -14,8 +14,6 @@ from factrix._axis import (
     Aggregation,
     DataStructure,
     FactorDensity,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -32,8 +30,6 @@ __all__ = [
 @metric(
     cell=cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def corrado_rank(

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -33,8 +33,6 @@ from factrix._axis import (
     Aggregation,
     FactorDensity,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import cell
 from factrix._results import MetricResult
@@ -55,8 +53,6 @@ MIN_DIRECTIONAL_OBS: int = MIN_ASSETS_PER_DATE_IC
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=None),
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.T,
-    se_method=SEMethod.BUILT_IN,
     input_shape=InputShape.PANEL,
 )
 def directional_hit_rate(

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -24,8 +24,6 @@ from factrix._axis import (
     Aggregation,
     DataStructure,
     FactorDensity,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -43,8 +41,6 @@ _EH_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
 @metric(
     cell=_EH_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.BINOMIAL,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def event_around_return(

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -28,8 +28,6 @@ from factrix._axis import (
     Aggregation,
     DataStructure,
     FactorDensity,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -56,8 +54,6 @@ _EQ_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def event_hit_rate(
@@ -139,8 +135,6 @@ def event_hit_rate(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def event_ic(
@@ -241,8 +235,6 @@ def event_ic(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def profit_factor(
@@ -320,8 +312,6 @@ def profit_factor(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def event_skewness(
@@ -417,8 +407,6 @@ def event_skewness(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     sample_threshold=SampleThreshold(),
 )
 def signal_density(

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -35,8 +35,6 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
@@ -88,8 +86,6 @@ MIN_FM_PERIODS_WARN: int = 30
 @metric(
     cell=_FM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.SERIES,
     requires={"beta_df": compute_fm_betas},
     sample_threshold=SampleThreshold(
@@ -427,8 +423,6 @@ def _pooled_beta_driscoll_kraay(
 @metric(
     cell=_FM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     sample_threshold=SampleThreshold(min_pairs=10),
 )
 def pooled_beta(
@@ -723,8 +717,6 @@ def pooled_beta(
 @metric(
     cell=_FM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.SERIES,
     requires={"beta_df": compute_fm_betas},
     sample_threshold=SampleThreshold(min_periods=1),

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -20,8 +20,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -67,8 +65,6 @@ def per_date_series(series: pl.DataFrame) -> pl.DataFrame:
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=DataStructure.TIMESERIES),
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.BINOMIAL,
-    se_method=SEMethod.BUILT_IN,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     sample_threshold=SampleThreshold(min_periods=MIN_ASSETS_PER_DATE_IC),

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -24,8 +24,6 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -100,8 +98,6 @@ def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
 @metric(
     cell=_IC_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.SERIES,
     requires={"ic_df": compute_ic},
     sample_threshold=SampleThreshold(),
@@ -209,8 +205,6 @@ def ic(
 @metric(
     cell=_IC_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.SERIES,
     requires={"ic_df": compute_ic},
     sample_threshold=SampleThreshold(

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -33,8 +33,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -56,8 +54,6 @@ __all__ = [
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
 def k_spread(

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -25,8 +25,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -47,8 +45,6 @@ DEFAULT_MIN_ESTIMATION_SAMPLES: int = 20
 @metric(
     cell=_MFE_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.SERIES,
     requires={"mfe_mae_df": compute_mfe_mae},
     sample_threshold=SampleThreshold(),

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -25,8 +25,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -64,8 +62,6 @@ min_assets_per_group: int | None = 50
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     batchable=True,
     sample_threshold=SampleThreshold(min_periods=MIN_MONOTONICITY_PERIODS),
 )

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -25,8 +25,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -45,8 +43,6 @@ GateStatus = Literal["PASS", "VETOED"]
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=DataStructure.TIMESERIES),
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     sample_threshold=SampleThreshold(min_periods=MIN_OOS_PERIODS * 2),

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -24,8 +24,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -64,8 +62,6 @@ _Q_CELL = cell(
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     batchable=True,
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
@@ -232,8 +228,6 @@ def _quantile_spread_from_series(
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
 def quantile_spread_vw(

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -34,8 +34,6 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._ols import ols_alpha as _ols_alpha
@@ -137,8 +135,6 @@ def _align_spread_series(
 @metric(
     cell=_SPANNING_CELL,
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.SERIES,
     requires={"factor_spread": compute_spread_series},
     sample_threshold=SampleThreshold(min_periods=10),
@@ -255,8 +251,6 @@ def spanning_alpha(
 @metric(
     cell=_SPANNING_CELL,
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.T,
-    se_method=SEMethod.HAC,
     input_shape=InputShape.SERIES,
     batchable=True,
     requires={"factor_spreads": compute_spread_series},

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -34,8 +34,6 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -68,8 +66,6 @@ __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     sample_threshold=SampleThreshold(),
 )
 def turnover(
@@ -244,8 +240,6 @@ def turnover(
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     sample_threshold=SampleThreshold(min_periods=2),
 )
 def notional_turnover(
@@ -422,8 +416,6 @@ def notional_turnover(
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.SCALAR,
     requires={"gross_spread": quantile_spread, "turnover": notional_turnover},
     sample_threshold=SampleThreshold(),
@@ -515,8 +507,6 @@ def breakeven_cost(
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.DESCRIPTIVE,
-    se_method=SEMethod.NONE,
     input_shape=InputShape.SCALAR,
     requires={"gross_spread": quantile_spread, "turnover": notional_turnover},
     sample_threshold=SampleThreshold(),

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -23,8 +23,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     InputShape,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -41,8 +39,6 @@ __all__ = [
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=DataStructure.TIMESERIES),
     aggregation=Aggregation.TS_ONLY,
-    test_method=TestMethod.RANK,
-    se_method=SEMethod.BUILT_IN,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     sample_threshold=SampleThreshold(min_periods=10),

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -44,8 +44,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -69,8 +67,6 @@ __all__ = [
 @metric(
     cell=cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.CHI2,
-    se_method=SEMethod.HAC,
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
 def ts_asymmetry(

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -27,9 +27,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
     OutputShape,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -57,8 +55,6 @@ MIN_TS_OBS: int = 20
 @metric(
     cell=_TSB_CELL,
     aggregation=Aggregation.TS_THEN_CS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     role=SpecRole.PIPELINE,
 )
 def compute_ts_beta_single_asset_fallback(ts_betas_df: pl.DataFrame) -> MetricResult:
@@ -106,8 +102,6 @@ def compute_ts_beta_single_asset_fallback(ts_betas_df: pl.DataFrame) -> MetricRe
 @metric(
     cell=_TSB_CELL,
     aggregation=Aggregation.TS_THEN_CS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.SERIES,
     requires={"ts_betas_df": compute_ts_betas},
     sample_threshold=SampleThreshold(min_assets=3),
@@ -192,8 +186,6 @@ def ts_beta(ts_betas_df: pl.DataFrame) -> MetricResult:
 @metric(
     cell=_TSB_CELL,
     aggregation=Aggregation.TS_THEN_CS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.SERIES,
     requires={"ts_betas_df": compute_ts_betas},
     sample_threshold=SampleThreshold(min_assets=1),
@@ -268,8 +260,6 @@ def mean_r_squared(ts_betas_df: pl.DataFrame) -> MetricResult:
 @metric(
     cell=_TSB_CELL,
     aggregation=Aggregation.TS_THEN_CS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
@@ -379,8 +369,6 @@ def compute_rolling_mean_beta(
 @metric(
     cell=_TSB_CELL,
     aggregation=Aggregation.TS_THEN_CS,
-    test_method=TestMethod.T,
-    se_method=SEMethod.OLS,
     input_shape=InputShape.SERIES,
     requires={"ts_betas_df": compute_ts_betas},
     sample_threshold=SampleThreshold(min_assets=2),

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -30,8 +30,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -55,8 +53,6 @@ __all__ = [
 @metric(
     cell=cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.CS_THEN_TS,
-    test_method=TestMethod.CHI2,
-    se_method=SEMethod.HAC,
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
 def ts_quantile_spread(

--- a/scripts/mkdocs_hooks/gen_metric_matrix.py
+++ b/scripts/mkdocs_hooks/gen_metric_matrix.py
@@ -1,14 +1,14 @@
 """Build-time generator for the standalone-metrics matrix table.
 
 Renders a Markdown table to ``docs/reference/_generated_metric_matrix.md``
-from the typed ``__metric_specs__`` declarations exposed by
-:mod:`factrix._metric_index` (single source of truth, also consumed at
-runtime by ``factrix.list_metrics``).
+from the typed metric specs exposed by :mod:`factrix._metric_index`
+(single source of truth, also consumed at runtime by
+``factrix.list_metrics``).
 
-One table row per distinct ``(module, cell.raw, family, inference)``
-group — modules whose specs cover multiple cells (e.g. ``tradability``
-splitting its panel-aggregated and rank-autocorrelation metrics across
-two rows) surface as multiple rows.
+One table row per distinct ``(module, cell.raw, aggregation)`` group —
+modules whose specs cover multiple cells (e.g. ``tradability`` splitting
+its panel-aggregated and rank-autocorrelation metrics across two rows)
+surface as multiple rows.
 
 Usage (manual)::
 
@@ -30,62 +30,43 @@ from factrix._metric_index import MetricSpec, public_specs
 _REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 _OUT_FILE = _REPO_ROOT / "docs" / "reference" / "_generated_metric_matrix.md"
 
-_TABLE_HEADER = (
-    "| Module | Cell scope | Aggregation order | Inference SE |\n|---|---|---|---|\n"
-)
+_TABLE_HEADER = "| Module | Cell scope | Aggregation order |\n|---|---|---|\n"
 
 
 @dataclass(frozen=True, slots=True)
 class _GroupedRow:
-    """One docs-matrix row: a ``(module, cell, aggregation, test_method, se_method)`` group."""
+    """One docs-matrix row: a ``(module, cell, aggregation)`` group."""
 
     module: str
     cell_raw: str
     aggregation: str
-    test_method: str
-    se_method: str
 
 
 def _group_specs(specs: tuple[tuple[str, MetricSpec], ...]) -> list[_GroupedRow]:
-    """Collapse per-callable specs into per-(module, cell, aggregation, test_method, se_method) rows.
+    """Collapse per-callable specs into per-(module, cell, aggregation) rows.
 
     Stable on insertion order so the rendered table follows the
     spec-declaration order in each module.
     """
-    seen: dict[tuple[str, str, str, str, str], _GroupedRow] = {}
+    seen: dict[tuple[str, str, str], _GroupedRow] = {}
     for stem, spec in specs:
-        key = (
-            stem,
-            spec.cell.raw,
-            spec.aggregation.name,
-            spec.test_method.name,
-            spec.se_method.name,
-        )
+        key = (stem, spec.cell.raw, spec.aggregation.name)
         if key not in seen:
             seen[key] = _GroupedRow(
                 module=stem,
                 cell_raw=spec.cell.raw,
                 aggregation=spec.aggregation.value,
-                test_method=spec.test_method.value,
-                se_method=spec.se_method.value,
             )
     return list(seen.values())
 
 
 def _render_row(row: _GroupedRow) -> str:
     module_cell = f"[`metrics.{row.module}`][factrix.metrics.{row.module}]"
-    inference_str = (
-        f"{row.test_method} ({row.se_method})"
-        if row.se_method != "NONE"
-        else row.test_method
-    )
-    return (
-        f"| {module_cell} | `{row.cell_raw}` | {row.aggregation} | {inference_str} |\n"
-    )
+    return f"| {module_cell} | `{row.cell_raw}` | {row.aggregation} |\n"
 
 
 def generate() -> None:
-    """Generate ``_generated_metric_matrix.md`` from ``__metric_specs__``."""
+    """Generate ``_generated_metric_matrix.md`` from the metric specs."""
     rows = _group_specs(public_specs())
     lines = [_TABLE_HEADER, *(_render_row(r) for r in rows)]
     _OUT_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,6 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
-    TestMethod,
 )
 from factrix._metric_index import Cell, MetricSpec
 from factrix._results import EvaluationResult, MetricResult, MetricResultGroup
@@ -31,8 +29,6 @@ def make_spec(name: str) -> MetricSpec:
         name=name,
         cell=Cell(scope=None, density=None, structure=None, raw="*"),
         aggregation=Aggregation.CS_THEN_TS,
-        test_method=TestMethod.T,
-        se_method=SEMethod.HAC,
     )
 
 

--- a/tests/test_cross_type_invariants.py
+++ b/tests/test_cross_type_invariants.py
@@ -112,8 +112,6 @@ class TestSpecMirrorsClass:
         spec = cls.spec()
         assert spec.cell == cls.cell
         assert spec.aggregation == cls.aggregation
-        assert spec.test_method == cls.test_method
-        assert spec.se_method == cls.se_method
         assert spec.input_shape == cls.input_shape
         assert spec.output_shape == cls.output_shape
         assert spec.role == cls.role

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -11,9 +11,7 @@ from factrix._axis import (
     Aggregation,
     FactorDensity,
     FactorScope,
-    SEMethod,
     SpecRole,
-    TestMethod,
 )
 from factrix._codes import WarningCode
 from factrix._dag import CycleError, DagExecutor, _Node, _topo_sort
@@ -36,8 +34,6 @@ def _make_spec(
         name=name,
         cell=cell(None, None),
         aggregation=Aggregation.CS_THEN_TS,
-        test_method=TestMethod.T,
-        se_method=SEMethod.HAC,
         requires=requires or {},
         batchable=batchable,
         role=role,

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -225,13 +225,6 @@ class TestICDispatch:
     (to floating-point ULP — polars vs numpy variance reduction order).
     """
 
-    def test_se_method_declares_ols(self):
-        from factrix._axis import SEMethod
-
-        # The default path runs a non-overlapping OLS t-test, not HAC;
-        # the spec declaration must match the actual standard error.
-        assert ic.se_method is SEMethod.OLS
-
     def _ic_df(self):
         import factrix as fx
         from factrix.preprocess import compute_forward_return

--- a/tests/test_list_metrics.py
+++ b/tests/test_list_metrics.py
@@ -212,8 +212,6 @@ def test_public_spec_fields_are_serialisable() -> None:
             "family": stem,
             "cell": spec.cell.raw,
             "aggregation": spec.aggregation.value,
-            "test_method": spec.test_method.value,
-            "se_method": spec.se_method.value,
             "import_path": import_path_for(stem),
             "input_shape": spec.input_shape.value,
         }

--- a/tests/test_metric_base.py
+++ b/tests/test_metric_base.py
@@ -1,6 +1,6 @@
 import polars as pl
 import pytest
-from factrix._axis import Aggregation, OutputShape, SEMethod, SpecRole, TestMethod
+from factrix._axis import Aggregation, OutputShape, SpecRole
 from factrix._metric_index import Cell, spec_by_name
 from factrix.metrics import MetricBase, metric
 
@@ -15,8 +15,6 @@ def test_metric_base_dataclass_properties():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             output_shape=OutputShape.PANEL,
             role=SpecRole.PIPELINE,
         )
@@ -26,8 +24,6 @@ def test_metric_base_dataclass_properties():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             requires={"df_input": dummy_pipeline},
         )
         def dummy_metric(
@@ -67,8 +63,6 @@ def test_metric_spec_generation():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
         )
         def dummy_pipeline(df: pl.DataFrame, shift: int = 1) -> pl.DataFrame:
             return df.with_columns(pl.col("value") + shift)
@@ -76,8 +70,6 @@ def test_metric_spec_generation():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             requires={"df_input": dummy_pipeline},
         )
         def dummy_metric(
@@ -109,8 +101,6 @@ def test_metric_dual_interface():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
         )
         def dummy_pipeline(df: pl.DataFrame, shift: int = 1) -> pl.DataFrame:
             return df.with_columns(pl.col("value") + shift)
@@ -118,8 +108,6 @@ def test_metric_dual_interface():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             requires={"df_input": dummy_pipeline},
         )
         def dummy_metric(
@@ -162,8 +150,6 @@ def test_registry_integration():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             output_shape=OutputShape.PANEL,
             role=SpecRole.PIPELINE,
         )
@@ -173,8 +159,6 @@ def test_registry_integration():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             requires={"df_input": dummy_pipeline},
         )
         def dummy_metric(
@@ -208,8 +192,6 @@ def test_registry_validation_raises():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
         )
         def dummy_pipeline(df: pl.DataFrame, shift: int = 1) -> pl.DataFrame:
             return df.with_columns(pl.col("value") + shift)
@@ -217,8 +199,6 @@ def test_registry_validation_raises():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
             requires={"non_existent_param": dummy_pipeline},
         )
         def invalid_metric(df: pl.DataFrame):
@@ -249,8 +229,6 @@ def test_metric_parameter_ordering_and_reflection():
         @metric(
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
-            test_method=TestMethod.T,
-            se_method=SEMethod.BUILT_IN,
         )
         def ordered_metric(df: pl.DataFrame, a: int = 10, *, b: int) -> str:
             return f"a={a}, b={b}"

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -15,9 +15,7 @@ from factrix._axis import (
     DataStructure,
     FactorDensity,
     FactorScope,
-    SEMethod,
     SpecRole,
-    TestMethod,
     Tier,
 )
 from factrix._inspect import DataProperties
@@ -132,8 +130,6 @@ class TestDefaults:
             name="probe",
             cell=cell(FactorScope.INDIVIDUAL, FactorDensity.DENSE),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
         assert spec.requires == {}
 
@@ -142,8 +138,6 @@ class TestDefaults:
             name="probe",
             cell=cell(FactorScope.INDIVIDUAL, FactorDensity.DENSE),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
         assert spec.batchable is False
 
@@ -152,8 +146,6 @@ class TestDefaults:
             name="probe",
             cell=cell(FactorScope.INDIVIDUAL, FactorDensity.DENSE),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
         assert spec.role is SpecRole.METRIC
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -62,17 +62,13 @@ def test_metric_logger_exception(caplog):
         Aggregation,
         InputShape,
         OutputShape,
-        SEMethod,
         SpecRole,
-        TestMethod,
     )
     from factrix.metrics._base import MetricBase
 
     class dummy_metric(MetricBase):
         cell = fx.metrics.ic.cell
         aggregation = Aggregation.CS_THEN_TS
-        test_method = TestMethod.T
-        se_method = SEMethod.HAC
         input_shape = InputShape.SERIES
         output_shape = OutputShape.SCALAR
         role = SpecRole.METRIC

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import factrix as fx
 import polars as pl
 import pytest
-from factrix._axis import Aggregation, SEMethod, TestMethod
+from factrix._axis import Aggregation
 from factrix._metric_index import (
     _METRIC_REGISTRY,
     MetricSpec,
@@ -35,8 +35,6 @@ class TestMetricSpecDecorator:
             name="stamp_only",
             cell=cell(None, None),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
 
         @fx.metric_spec(spec)
@@ -50,8 +48,6 @@ class TestMetricSpecDecorator:
             name="no_auto_register",
             cell=cell(None, None),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
 
         @fx.metric_spec(spec)
@@ -68,8 +64,6 @@ class TestRegister:
             name="custom_ic_smoke",
             cell=cell(None, None),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
 
         @fx.metric_spec(spec)
@@ -89,8 +83,6 @@ class TestRegister:
             name="dag_resolves_me",
             cell=cell(None, None),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
 
         @fx.metric_spec(spec)
@@ -116,8 +108,6 @@ class TestRegister:
             name="dup_metric",
             cell=cell(None, None),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
 
         @fx.metric_spec(spec)
@@ -133,8 +123,6 @@ class TestRegister:
             name="ic",
             cell=cell(None, None),
             aggregation=Aggregation.CS_THEN_TS,
-            test_method=TestMethod.T,
-            se_method=SEMethod.HAC,
         )
 
         @fx.metric_spec(clash_spec)


### PR DESCRIPTION
## Summary

Removes the `test_method` / `se_method` descriptive fields from the metric-spec surface — the #558 B' cleanup. (This is the third commit from #573, which squash-merged before this was pushed; re-landed here onto current `main`.)

These were class-level `@metric` declarations flowing into `MetricSpec`, but no code branched on the values — the only readers were the serialized spec surface, the docs matrix generator, and round-trip test assertions. The `TestMethod` docstring referenced a `primary_eligible` mechanism that no longer exists. Investigation chose full removal over the originally-planned "derive from inference" (B'), because the non-`ic` metrics have no inference object to derive from and nothing consumes the values anyway.

Removed end to end:
- the `metric()` decorator params + `MetricBase` ClassVars
- the `MetricSpec` dataclass fields + the `spec()` projection
- the `TestMethod` / `SEMethod` enums (`factrix._axis`)
- all 30 `@metric` call sites (94 keyword lines) and the matching test constructions / assertions
- the "Inference SE" column from the metric-matrix doc generator (`gen_metric_matrix.py` was a real consumer — the matrix is now 3 columns)

The runtime `MetricResult.metadata["se_method"]` annotation on `pooled_beta` (value `"driscoll_kraay"`) is unrelated and retained.

## Breaking changes
- `MetricSpec` no longer carries `test_method` / `se_method`.
- `factrix._axis.TestMethod` / `SEMethod` are removed.
- `@metric` no longer accepts `test_method=` / `se_method=`; custom metrics must drop these arguments.

## Deferred to #558 epic wrap-up
- CHANGELOG entry for the removal

## Test plan
- `ruff check` / `ruff format --check` / `mypy factrix` — all green
- `pytest -q` — 1271 passed, 4 skipped
- metric-matrix doc regenerated (3 columns)

Refs #558