### PR TITLE
docs: add Common × Sparse landing page and sync stale metric-doc framing

### DIFF
--- a/docs/api/metrics/common-continuous.md
+++ b/docs/api/metrics/common-continuous.md
@@ -8,19 +8,24 @@ sentiment). Aggregation is **time-series first**: per-asset ordinary least squar
 over all dates, then a cross-asset $t$ on the mean of the per-asset
 betas.
 
-| Metric | Role | Page |
-|---|---|---|
-| Cross-asset $t$ on per-asset $\beta_i$ (BJS aggregation) | Primary | [`ts_beta`](ts_beta.md) |
-| Spread between top- and bottom-bucket assets sorted by $\beta_i$ | Profile | [`ts_quantile`](ts_quantile.md) |
-| Sign-asymmetric slopes (positive vs negative regimes) | Profile | [`ts_asymmetry`](ts_asymmetry.md) |
+| Metric | Page |
+|---|---|
+| Cross-asset $t$ on per-asset $\beta_i$ (BJS aggregation) | [`ts_beta`](ts_beta.md) |
+| Spread between top- and bottom-bucket assets sorted by $\beta_i$ | [`ts_quantile`](ts_quantile.md) |
+| Sign-asymmetric slopes (positive vs negative regimes) | [`ts_asymmetry`](ts_asymmetry.md) |
+
+`ts_beta` carries the cross-asset significance test; `ts_quantile` and
+`ts_asymmetry` are descriptive profile diagnostics.
 
 At `N == 1` the cross-asset $t$ degenerates; factrix auto-routes to a
 TIMESERIES single-series test (null: $\beta = 0$, **not**
-$\mathbb{E}[\beta] = 0$). Same `StatCode.MEAN` identifier, different
-statistical meaning.
+$\mathbb{E}[\beta] = 0$). The statistic lands in the same
+`MetricResult.stat` field in both modes, but the null differs —
+`metadata["method"]` records which test ran.
 
-The `Common × Sparse` cell shares the time-series-first aggregation
-shape but with a `{0, R}` broadcast event dummy (`R` unrestricted;
-`{0, 1}` for a pure event flag is the simplest form) in place of the
-continuous regressor; metrics live under
-[Individual sparse](individual-sparse.md).
+The `Common × Sparse` cell swaps this continuous regressor for a
+`{0, R}` broadcast event dummy (`R` unrestricted; `{0, 1}` for a pure
+event flag is the simplest form). It does **not** reuse this
+time-series-first OLS-$\beta$ flow — a broadcast sparse dummy is
+evaluated through the event-time metrics under
+[Common sparse](common-sparse.md).

--- a/docs/api/metrics/common-sparse.md
+++ b/docs/api/metrics/common-sparse.md
@@ -1,0 +1,37 @@
+---
+title: Common sparse
+---
+
+Metrics for the `Common × Sparse` cell — a market-wide event dummy
+broadcast across `N` assets (e.g. an FOMC-announcement or macro-release
+flag that is identical for every asset on a given date). This cell
+combines two traits:
+
+1. **Sparse `{0, R}` signal shape**: the factor is zero on non-event
+   entries and any real value otherwise (`{0, 1}` for a pure event flag
+   is the simplest form), like [Individual sparse](individual-sparse.md).
+2. **Common scope**: the same value is broadcast to every asset on an
+   event date rather than varying cross-sectionally.
+
+Because the event-time column contract is identical to
+`Individual × Sparse`, this cell **reuses the same scope-agnostic sparse
+metrics** — there is no separate Common-sparse module set. The
+dispatcher selects them for any `SPARSE × PANEL` factor regardless of
+scope.
+
+| Metric | Page |
+|---|---|
+| Cumulative average abnormal return — $t$-test or BMP $z$-test | [`caar`](caar.md) |
+| Skewness / hit-rate / win-loss diagnostics on per-event returns | [`event_quality`](event_quality.md) |
+| MFE / MAE order-statistic excursion within an event window | [`mfe_mae`](mfe_mae.md) |
+| Event-window horizon decay | [`event_horizon`](event_horizon.md) |
+| Herfindahl-Hirschman index (HHI) on event dates | [`clustering`](clustering_hhi.md) |
+| Non-parametric Corrado rank test | [`corrado`](corrado_rank.md) |
+
+`caar` carries the abnormal-return significance test; the rest are
+descriptive event-profile diagnostics.
+
+Because every event shares the same date across assets, this cell is
+especially exposed to event-date clustering — prefer
+`caar.bmp_test(kolari_pynnonen_adjust=True)` over the vanilla $t$-test
+and read [`clustering`](clustering_hhi.md) first.

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -95,9 +95,9 @@ modules plus a fourth axis-agnostic group**:
 
 | Cell | Group on this nav | Notes |
 |---|---|---|
-| `Individual × Dense` | **Individual continuous** | Both `IC` and `FM` primary metrics live in this cell; ancillary metrics (`quantile`, `monotonicity`, `concentration`, `tradability`, `spanning`) are shared across both. |
+| `Individual × Dense` | **Individual continuous** | Both `IC` and `FM` inferential metrics live in this cell; ancillary metrics (`quantile`, `monotonicity`, `concentration`, `tradability`, `spanning`) are shared across both. |
 | `Individual × Sparse` | **Individual sparse** | Per-event tests on `(date, asset_id, factor)` with sparse `{0, R}` schema (zero on non-event entries; `R` is any real magnitude, `{0, 1}` is the simplest form). Domain shorthand: *event signal*. |
-| `Common × Sparse` | **Individual sparse** (shared metric modules) | Has its own dispatch procedure: per-asset OLS β on the broadcast dummy → cross-asset *t* — not the CAAR per-event flow used by `Individual × Sparse`. The two cells share the SPARSE column contract and the event-quality / clustering / corrado helper metrics, so factrix groups them on this nav. |
+| `Common × Sparse` | **Common sparse** | A market-wide event dummy broadcast across `N` assets, with the `{0, R}` sparse signal shape. Evaluated through the same scope-agnostic event-time metrics as Individual sparse (CAAR significance plus event diagnostics) — not the time-series-first OLS-β flow. |
 | `Common × Dense` | **Common continuous** | Single time series broadcast across assets (VIX, USD index, …). |
 
 **Series diagnostics** (`hit_rate`, `trend`, `oos_decay`) are axis-agnostic —

--- a/docs/api/metrics/individual-continuous.md
+++ b/docs/api/metrics/individual-continuous.md
@@ -6,19 +6,20 @@ Metrics for the `Individual × Continuous` cell — one continuous factor
 score per `(date, asset_id)`, evaluated cross-sectionally per date and
 aggregated over time.
 
-| Metric | Role | Page |
-|---|---|---|
-| Spearman rank correlation, the canonical signal-quality summary | Primary | [`ic`](ic.md) |
-| Per-date ordinary least squares (OLS) slope $\lambda$, Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) $t$ on its mean | Primary | [`fm_beta`](fm_beta.md) |
-| Long-short quintile spread (equal- and value-weighted) | Profile | [`quantile`](quantile.md) |
-| Quintile-return monotonicity rank test | Profile | [`monotonicity`](monotonicity.md) |
-| HHI-style top-bucket concentration | Profile | [`concentration`](concentration.md) |
-| Turnover, breakeven cost, net spread | Profile | [`tradability`](tradability.md) |
-| Spanning $\alpha$ vs an existing factor pool | Profile | [`spanning`](spanning.md) |
+| Metric | Page |
+|---|---|
+| Spearman rank correlation, the canonical signal-quality summary | [`ic`](ic.md) |
+| Per-date ordinary least squares (OLS) slope $\lambda$, Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) $t$ on its mean | [`fm_beta`](fm_beta.md) |
+| Long-short quintile spread (equal- and value-weighted) | [`quantile`](quantile.md) |
+| Quintile-return monotonicity rank test | [`monotonicity`](monotonicity.md) |
+| HHI-style top-bucket concentration | [`concentration`](concentration.md) |
+| Turnover, breakeven cost, net spread | [`tradability`](tradability.md) |
+| Spanning $\alpha$ vs an existing factor pool | [`spanning`](spanning.md) |
 
-`ic` and `fm_beta` are the two **inferential** entry points; the
-rest are **profile / risk** diagnostics that describe the same factor
-without contributing to the primary inference.
+`ic` and `fm_beta` are the two **inferential** entry points (each
+carries a $p$-value); the rest are **descriptive / risk** diagnostics
+that profile the same factor without contributing to the inferential
+test.
 
 For when each applies see
 [Reference § Metric applicability](../../reference/metric-applicability.md).

--- a/docs/api/metrics/individual-sparse.md
+++ b/docs/api/metrics/individual-sparse.md
@@ -10,19 +10,22 @@ or any magnitude). Common forms: `{0, 1}` for a pure event flag, or
 `{0, R}` for any real-valued magnitude; both flow through (see
 [`caar`](caar.md) for the input-form table).
 
-| Metric | Role | Page |
-|---|---|---|
-| Cumulative average abnormal return — $t$-test or BMP $z$-test | Primary | [`caar`](caar.md) |
-| Skewness / hit-rate / win-loss diagnostics on per-event returns | Profile | [`event_quality`](event_quality.md) |
-| MFE / MAE order-statistic excursion within an event window | Profile | [`mfe_mae`](mfe_mae.md) |
-| Event-window horizon decay | Profile | [`event_horizon`](event_horizon.md) |
-| Herfindahl-Hirschman index (HHI) on event dates — flags clustering that violates BMP/CAAR independence | Profile | [`clustering`](clustering_hhi.md) |
-| Non-parametric Corrado rank test — robust to non-Gaussian returns | Profile | [`corrado`](corrado_rank.md) |
+| Metric | Page |
+|---|---|
+| Cumulative average abnormal return — $t$-test or BMP $z$-test | [`caar`](caar.md) |
+| Skewness / hit-rate / win-loss diagnostics on per-event returns | [`event_quality`](event_quality.md) |
+| MFE / MAE order-statistic excursion within an event window | [`mfe_mae`](mfe_mae.md) |
+| Event-window horizon decay | [`event_horizon`](event_horizon.md) |
+| Herfindahl-Hirschman index (HHI) on event dates — flags clustering that violates BMP/CAAR independence | [`clustering`](clustering_hhi.md) |
+| Non-parametric Corrado rank test — robust to non-Gaussian returns | [`corrado`](corrado_rank.md) |
 
-The `Common × Sparse` cell shares this column contract but routes
-through a distinct procedure (`_CommonSparsePanelProcedure` — per-asset
-ordinary least squares (OLS) $\beta$ on the broadcast dummy → cross-asset $t$). Its metrics live
-under [Common continuous](common-continuous.md).
+`caar` carries the abnormal-return significance test; the rest are
+descriptive event-profile diagnostics.
+
+The `Common × Sparse` cell shares this same `{0, R}` column contract
+and scope-agnostic event-time metrics — the dispatcher selects them for
+any `SPARSE × PANEL` factor, broadcast or per-asset. The cross-cell
+landing page is [Common sparse](common-sparse.md).
 
 When events cluster on the same date (earnings season, macro release),
 prefer `caar.bmp_test(kolari_pynnonen_adjust=True)` over the vanilla

--- a/docs/api/metrics/series-tools.md
+++ b/docs/api/metrics/series-tools.md
@@ -7,10 +7,10 @@ Axis-agnostic metrics that operate on any `(date, value)` series produced by an 
 !!! warning "Not the same as `DataStructure.TIMESERIES`"
     `DataStructure.TIMESERIES` is the dispatch structure for `n_assets == 1` (set on `EvaluationResult.cell`); the metrics on this page run on a `(date, value)` series regardless of which structure produced it.
 
-| Metric | Role | Page |
-|---|---|---|
-| Out-of-sample decay across multiple splits | Robustness | [`oos`](oos_decay.md) |
-| Theil-Sen monotonic trend with augmented Dickey-Fuller (ADF) persistence flag | Diagnostic | [`trend`](trend.md) |
-| Sign-consistency / hit rate of the series | Diagnostic | [`hit_rate`](hit_rate.md) |
+| Metric | Page |
+|---|---|
+| Out-of-sample decay across multiple splits | [`oos`](oos_decay.md) |
+| Theil-Sen monotonic trend with augmented Dickey-Fuller (ADF) persistence flag | [`trend`](trend.md) |
+| Sign-consistency / hit rate of the series | [`hit_rate`](hit_rate.md) |
 
-Use these against the IC series from [`ic.compute_ic`](ic.md), the CAAR series from [`caar.compute_caar`](caar.md), or any externally constructed `(date, value)` DataFrame to layer decay, drift, and sign-stability checks on top of the cell's primary inferential test.
+All three are descriptive robustness diagnostics. Use them against the IC series from [`ic.compute_ic`](ic.md), the CAAR series from [`caar.compute_caar`](caar.md), or any externally constructed `(date, value)` DataFrame to layer decay, drift, and sign-stability checks on top of the cell's inferential test.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -152,8 +152,7 @@ on the single-asset series — scope-collapse no longer happens, and there is no
 sentinel routing both sparse scopes to a shared TIMESERIES procedure. At `N=1`
 the `INDIVIDUAL` / `COMMON` distinction is moot (one asset → no
 scope axis), but that falls out of the derived structure rather than an explicit
-routing token, and no `InfoCode` is attached (`InfoCode` is a reserved,
-currently-empty enum).
+routing token.
 
 ---
 
@@ -393,9 +392,10 @@ Failure modes:
 - `MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.BORDERLINE_CROSS_SECTION_N`.
 - `n_assets = 1` → degenerate cross-asset test → mode auto-routed to
   TIMESERIES single-series β test (null: β = 0, **not** E[β] = 0). The
-  `StatCode.MEAN` identifier is shared across the two modes, so the
-  same field on `EvaluationResult` carries different statistical meaning
-  depending on `profile.mode`; see §PANEL/TIMESERIES equivalence.
+  statistic lands in the same `MetricResult.stat` field across both
+  modes, so it carries different statistical meaning depending on
+  `profile.mode` (read `metadata["method"]` to tell them apart); see
+  §PANEL/TIMESERIES equivalence.
 
 ### `common_sparse` (PANEL) — time-series first
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -407,7 +407,7 @@ which folder they happen to live in. Four shapes carry the whole site:
 - **lookup** — pure table or reverse-index, scanned not read. Lives
   under `User guide` > `Reference tables`. Ordered by quant scan
   frequency, not alphabetically. (`Metrics applicability`, `Stat keys`,
-  `Warning / info / stat codes`.)
+  `Warning codes`.)
 - **migration** — deprecation notes, rename recipes, BREAKING upgrade
   paths. Belongs to the `Release notes` register. Linked from the
   CHANGELOG entry that retired the surface; not given its own nav slot
@@ -687,7 +687,7 @@ Conventions split by layer:
 
 Conversion rules when migrating from a bare citation: `&` and `and` in the visible text become hyphens; commas in 3+ author lists also become hyphens (`Black, Jensen & Scholes (1972)` → `[Black-Jensen-Scholes (1972)][black-jensen-scholes-1972]`); single-author citations stay single (`MacKinlay (1997)` → `[MacKinlay (1997)][mackinlay-1997]`). Year stays parenthesised.
 
-The rule applies uniformly to module-level docstrings and to public symbol (function / class / method) docstrings. It does **not** apply to Python `# comments` or to runtime string values (`StatCode` descriptions, `"method": "..."` dict literals, `refs=(...)` tuples on registry calls) — those render outside the mkdocs autorefs pipeline and the link would not resolve.
+The rule applies uniformly to module-level docstrings and to public symbol (function / class / method) docstrings. It does **not** apply to Python `# comments` or to runtime string values (`WarningCode` descriptions, `"method": "..."` dict literals, `refs=(...)` tuples on registry calls) — those render outside the mkdocs autorefs pipeline and the link would not resolve.
 
 #### `bibliography.md` as catalog, not single SSOT
 
@@ -752,8 +752,7 @@ PR (no CI gate):
 - Additions / removals to `factrix/__init__.py` `__all__`
 - Public API signature changes (factory, `evaluate`, `bhy`,
   `EvaluationResult`)
-- `WarningCode` / `InfoCode` / `StatCode` additions, renames, or
-  description rewrites
+- `WarningCode` additions, renames, or description rewrites
 - DataStructure dispatch rules or canonical data schema changes
 
 PR self-check: run all three code blocks, `uv run mkdocs build

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -95,7 +95,7 @@ The most common warnings include:
 - `EVENT_WINDOW_OVERLAP` — event windows overlap on the same asset.
 - `SERIAL_CORRELATION_DETECTED` — Ljung-Box $p$-value < 0.05 on residuals.
 
-For the full enum and the trigger conditions for each `WarningCode` and `StatCode`, see [Reference § Warning / info / stat codes](../reference/warning-codes.md).
+For the full enum and the trigger conditions for each `WarningCode`, see [Reference § Warning codes](../reference/warning-codes.md).
 
 For exception classes (`InsufficientSampleError`, `IncompatibleAxisError`, `UserInputError`, ...) and their catch patterns, see [Errors](../api/errors.md).
 

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -36,7 +36,7 @@ the sample axis that constrains it.
 
 ## Other metrics by family
 
-Primary metrics (`ic`, `fm_beta`, `caar`, `ts_beta`) are the SSOT.
+The inferential entry points (`ic`, `fm_beta`, `caar`, `ts_beta`) are the SSOT.
 The remaining
 metrics group by family below; the section heading carries the cell
 context, so each per-row schema reduces to *Metric / Sample axis /

--- a/docs/reference/ts-mode-conventions.md
+++ b/docs/reference/ts-mode-conventions.md
@@ -42,8 +42,8 @@ slope significance should be read with that caveat.
 Full derivation, threshold rationale, and interpolation accuracy live
 in
 [Statistical methods § Persistence diagnostics](statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors).
-The `EvaluationResult` StatCode → method mapping
-maps `FACTOR_ADF_P` to that section directly. The
+The `FACTOR_ADF_P` persistence diagnostic on `EvaluationResult`
+maps to that section directly. The
 `unit_root_suspected=True` flag is `ic_trend` metadata only — the
 TIMESERIES-mode cells expose the raw `FACTOR_ADF_P` *p*-value and
 leave the threshold call to the caller.

--- a/docs/reference/warning-codes.md
+++ b/docs/reference/warning-codes.md
@@ -1,28 +1,27 @@
 ---
-title: Warning, info, and stat codes
+title: Warning codes
 ---
 
-Structured enum payloads attached to every
-`EvaluationResult`. Use these as the SSOT
+Structured `WarningCode` payloads attached to every
+`EvaluationResult.warnings`. Use these as the SSOT
 when you need to filter, route, or trigger downstream behaviour from
 factrix output without parsing free-text strings.
-
-The three enums:
 
 - **`WarningCode`** — risk flags surfaced on `EvaluationResult.warnings`.
   Does **not** affect `MetricResult.p_value`;
   the user decides whether to pre-filter on warnings before
   multi-factor Benjamini-Hochberg-Yekutieli (BHY).
-- **`InfoCode`** — information-severity diagnose annotations. Reserved
-  enum; it currently defines no codes.
-- **`StatCode`** — canonical names for the scalar statistics that
-  populate `EvaluationResult.metrics`.
 
 Each member's trigger / meaning is sourced from
-`factrix._codes.<Code>.description` (single source of truth, also
+`factrix._codes.WarningCode.description` (single source of truth, also
 returned at runtime by `profile.diagnose()`). For the per-procedure
 breakdown of which codes a given pipeline can emit, see
 [Architecture § Procedure pipelines](../development/architecture.md#procedure-pipelines).
+
+The scalar statistics that populate `EvaluationResult.metrics` are not
+enum-keyed — each `MetricResult` exposes its statistic on
+`MetricResult.stat` with `stat_type` / `h0` / `method` in
+`MetricResult.metadata`; see [Stat keys by metric](stat-keys-by-metric.md).
 
 ## WarningCode
 
@@ -33,9 +32,3 @@ breakdown of which codes a given pipeline can emit, see
       show_root_heading: false
       show_source: false
       members: false
-
-## InfoCode
-
-`InfoCode` is a reserved enum and currently defines no codes. It is kept
-on the public surface so info-severity annotations can be added without a
-breaking import change.

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -343,8 +343,6 @@ Flat warning representation containing:
 - `source`: String representing the metric name (or `None` for bundle-level).
 - `message`: Warning description.
 
-`InfoCode` represents informational-only note enums re-exported at package root.
-
 ### `MetricResult`
 
 Dataclass for a single metric's output:
@@ -382,23 +380,6 @@ All exceptions inherit from `FactrixError`:
 | `few_events` | event dates < 29; t-stat power is thin. |
 | `borderline_portfolio_periods` | portfolio periods < 19; t_crit is inflated. |
 | `upstream_unavailable` | Downstream consumer skipped due to upstream short-circuit. |
-
----
-
-## StatCode reference
-
-| StatCode | Meaning |
-|---|---|
-| `MEAN` | Primary point estimate (IC mean, FM lambda, CAAR mean, etc.). |
-| `T_NW` | Newey-West HAC t-statistic. |
-| `P_NW` | Newey-West HAC p-value. |
-| `T_HH` / `P_HH` | Hansen-Hodrick HAC t-statistic and p-value. |
-| `J_GMM` / `P_GMM` | Hansen J statistic and over-identification p-value. |
-| `FACTOR_ADF_TAU` | ADF test statistic on factor input. |
-| `FACTOR_ADF_P` | ADF p-value on factor input. |
-| `RESID_LJUNG_BOX_Q` | Ljung-Box Q statistic on residuals. |
-| `RESID_LJUNG_BOX_P` | Ljung-Box p-value on residuals. |
-| `EVENT_HHI_VALUE` | Concentration HHI for events. |
 
 ---
 

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -15,6 +15,6 @@
 - [API — Multi-horizon](https://awwesomeman.github.io/factrix/api/multi-horizon/): multi-horizon evaluation recipes using evaluate per horizon + bhy(expand_over=)
 - [API — EvaluationResult](https://awwesomeman.github.io/factrix/api/evaluation-result/): unified result schema, to_dict() / to_frame()
 - [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() / bhy_hierarchical() / partial_conjunction() — FDR-corrected screening
-- [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode / InfoCode / StatCode enums
+- [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode enum
 - [Reference — metric applicability](https://awwesomeman.github.io/factrix/reference/metric-applicability/): which metrics apply to which axis combinations
 - [Full LLM reference](https://awwesomeman.github.io/factrix/llms-full.txt): single-fetch file covering concepts + API + usage patterns

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,7 +167,7 @@ nav:
           - Glossary: reference/glossary.md
           - Metrics applicability: reference/metric-applicability.md
           - Stat keys: reference/stat-keys-by-metric.md
-          - Warning / info / stat codes: reference/warning-codes.md
+          - Warning codes: reference/warning-codes.md
           - Metrics pipelines: reference/metric-pipelines.md
           - Bibliography: reference/bibliography.md
   - API reference:
@@ -213,6 +213,8 @@ nav:
               - mfe_mae: api/metrics/mfe_mae.md
               - clustering: api/metrics/clustering_hhi.md
               - corrado: api/metrics/corrado_rank.md
+          - Common sparse:
+              - Overview: api/metrics/common-sparse.md
           - Common continuous:
               - Overview: api/metrics/common-continuous.md
               - ts_beta: api/metrics/ts_beta.md


### PR DESCRIPTION
## Summary
- Add `docs/api/metrics/common-sparse.md`, resolving the navigation loop where `individual-sparse.md` and `common-continuous.md` pointed at each other. The page now routes to the event-time CAAR / event-quality metrics this cell actually dispatches — verified against `inspect_data` on a broadcast sparse factor; `ts_beta` is blocked on a density mismatch and is no longer presented as the cell's metric.
- Drop the obsolete Primary/Profile "Role" column from the cell landing pages and `index.md`. `SpecRole` carries no `PRIMARY`; the inferential-vs-descriptive distinction now lives in prose.
- Retire stale `StatCode` / `InfoCode` references (both enums were removed from the code) across the warning-codes reference page, `factrix/llms*.txt`, and the architecture / contributing / quickstart / ts-mode docs.

## Test plan
- [x] `ruff check .` / `ruff format --check .` / `mypy factrix` green
- [x] Docs validation suite (`test_docs_pages`, `test_docs_matrix`, `test_docs_terminology_ratchet`, `test_docs_llms`, `test_docs_stat_keys_by_metric`): 206 passed
- [x] `grep` confirms no residual `StatCode` / `InfoCode` in docs / llms (one `p_stat` reference in `architecture.md` is deferred — see follow-up issue)

Closes #268