### PR TITLE
doc(caar): decouple description from implementation details

### DIFF
--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -26,10 +26,10 @@ title: factrix.metrics.caar
 
     ---
 
-    Build the per-event-date weighted abnormal return series from a
-    long-format panel before any inferential test. Pre-step for `caar`
-    and (where the magnitude-weighted form is wanted) for downstream
-    slicing.
+    The per-event-date weighted abnormal return series from a
+    long-format panel. Consumed by `caar` for the significance test, and
+    (where the magnitude-weighted form is wanted) available for
+    per-slice summaries.
 
 -   __Mean-CAAR significance, non-overlapping__
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -456,7 +456,7 @@ Reached whenever a sparse factor evaluates at N=1 — the sparse metrics' cells
 apply at TIMESERIES, so the DAG executor runs them directly on the single-asset
 series (no scope-collapse step; at N=1 the two scopes are statistically
 equivalent). The series is the **full period grid** with
-zero-padding on non-event periods (distinct from the PANEL CAAR pipeline,
+zero-padding on non-event periods (distinct from the PANEL CAAR computation,
 which works on the event-date-only series). Factor magnitudes are
 preserved (no `.sign()` coercion at this layer).
 

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -6,10 +6,10 @@ Tests $H_0$: event abnormal return = 0, using two complementary methods:
     bmp_test     — BMP standardized AR test (robust to event-induced variance)
 
 Notes:
-    **Pipeline.** Per-event-date weighted abnormal return
-    (per-event-date step) then non-overlapping cross-event sample;
-    $t$-test on CAAR, or BMP standardized AR $z$-test for event-induced
-    variance.
+    `caar` and `bmp_test` are complementary inferential tests on the
+    per-event-date abnormal-return series. `caar` is the parametric
+    cross-event $t$-test; `bmp_test` is the standardized-AR $z$-test that
+    is robust to event-induced variance.
 
 References:
     - [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics


### PR DESCRIPTION
Closes #143

## What

CAAR documentation referenced a "canonical event pipeline" framing that no longer maps to the v0.14.0 unified architecture. This makes the CAAR description simple, descriptive, and decoupled from implementation-flow details.

- **`factrix/metrics/caar.py`** — module-level `Notes:` no longer describes a sequential `**Pipeline.**`; it now describes `caar` and `bmp_test` as complementary inferential tests on the per-event-date abnormal-return series.
- **`docs/api/metrics/caar.md`** — the `compute_caar` "Use cases" card no longer frames the function as a "pre-step … before any inferential test"; it describes what the series is and what consumes it.
- **`docs/development/architecture.md`** — "PANEL CAAR pipeline" → "PANEL CAAR computation".

## Checks

- `ruff check` / `ruff format --check` / `mypy` clean on `caar.py`
- `pytest -k caar` → 55 passed (incl. docs-matrix / docs-pages tests)