### PR TITLE
refactor(metrics): name sample-size thresholds by dimension (Closes #585)

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -132,7 +132,7 @@ def cross_section_tier(n_assets: int) -> WarningCode | None:
     actually entering the cross-asset test, not the panel-union
     ``n_assets`` surface field. For ``(COMMON, *, None,
     PANEL)`` cells the two differ: ``compute_ts_betas`` drops assets
-    with fewer than ``MIN_TS_OBS`` non-null observations, so the union
+    with fewer than ``MIN_TS_PERIODS`` non-null observations, so the union
     can be materially larger than the post-filter count that drives
     ``primary_p``'s ``dof = N - 1``. Callers (``suggest_config``,
     ``_compute_common_panel``) therefore pre-filter before calling.

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -34,7 +34,7 @@ MIN_ASSETS_WARN: int = 30
 # Broadcast-dummy event count for the ``(COMMON, SPARSE, None, PANEL)``
 # procedure. Per-asset OLS β on a sparse {-1, 0, +1} dummy is driven
 # entirely by the event observations — total ``n_periods`` is already
-# checked (``MIN_TS_OBS = 20`` per asset in ``compute_ts_betas``), but
+# checked (``MIN_TS_PERIODS = 20`` per asset in ``compute_ts_betas``), but
 # with ``n_events = 1`` a β is still fit from a single point with no
 # diagnostic. These thresholds guard the event-count axis specifically.
 # Naming is procedure-domain-specific to avoid colliding with the
@@ -47,7 +47,7 @@ MIN_BROADCAST_EVENTS_HARD: int = 5
 
 # ``MIN_BROADCAST_EVENTS_HARD <= n_events < MIN_BROADCAST_EVENTS_WARN`` →
 # :attr:`factrix._codes.WarningCode.SPARSE_COMMON_FEW_EVENTS`. Aligns with
-# the ``MIN_TS_OBS = 20`` philosophy: slope is estimable but cross-event
+# the ``MIN_TS_PERIODS = 20`` philosophy: slope is estimable but cross-event
 # averaging is too thin for the asymptotic t-distribution to be trusted.
 MIN_BROADCAST_EVENTS_WARN: int = 20
 

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -31,11 +31,28 @@ MAD_CONSISTENCY_CONSTANT: float = 1.4826
 # ---------------------------------------------------------------------------
 # Minimum sample thresholds (used by metrics primitives)
 # ---------------------------------------------------------------------------
+#
+# Naming grammar: ``MIN_<DOMAIN>_<DIMENSION>[_<TIER>]``. The DIMENSION
+# token is mandatory and names the axis the threshold guards:
+#   ``ASSETS``  — cross-sectional asset count (N per date)
+#   ``PERIODS`` — time-series length (T, number of dates / draws)
+#   ``EVENTS``  — event-date count
+# A constant for one axis must never be reused as a threshold on another
+# (e.g. an ``_ASSETS`` floor must not gate a series length); introduce a
+# separate ``_PERIODS`` constant even when the calibrated value coincides.
 
-# Per-date minimum asset count below which ``compute_ic`` drops the date.
-# Renamed from MIN_IC_PERIODS — the "PERIODS" suffix was misleading;
-# the value has always been checked against per-date asset counts.
+# Per-date minimum asset count below which ``compute_ic`` drops the date
+# (cross-sectional axis). Spearman ρ needs ≥ this many names per date for
+# its asymptotic distribution to hold.
 MIN_ASSETS_PER_DATE_IC: int = 10
+
+# Minimum IC time-series length (periods axis) for a reliable mean / sign
+# test on the per-date IC series: the post-stride sample in ``ic()``, the
+# series-length floor in ``hit_rate`` / ``directional_hit_rate``, and the
+# raw-period base in the non-overlapping inference floor all key off this
+# "≥10 independent draws" rule. Distinct axis from
+# ``MIN_ASSETS_PER_DATE_IC`` despite the shared value — do not collapse.
+MIN_IC_PERIODS: int = 10
 
 # Two-tier event-count guard for CAAR / Brown-Warner-family tests.
 # ``n < MIN_EVENTS_HARD`` short-circuits to NaN MetricResult (math floor —

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from factrix._codes import WarningCode
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
-from factrix._types import MIN_ASSETS_PER_DATE_IC
+from factrix._types import MIN_IC_PERIODS
 from factrix.inference._base import InferenceResult
 
 if TYPE_CHECKING:
@@ -60,9 +60,9 @@ class NonOverlapping:
     summary: ClassVar[str] = "non-overlapping t-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
 
-    def hard_floor(self, forward_periods: int) -> int:
-        """Raw-period floor: need ``base · h`` rows to land ``base`` after striding."""
-        return MIN_ASSETS_PER_DATE_IC * max(forward_periods, 1)
+    def min_input_periods(self, forward_periods: int) -> int:
+        """Minimum input series length (periods): need ``base · h`` rows to land ``base`` after striding."""
+        return MIN_IC_PERIODS * max(forward_periods, 1)
 
     def compute(
         self, df: pl.DataFrame, *, value_col: str, forward_periods: int
@@ -110,8 +110,8 @@ class NeweyWest:
     summary: ClassVar[str] = "Newey-West HAC t-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
 
-    def hard_floor(self, forward_periods: int) -> int:
-        """Raw-period floor below which the HAC t-test cannot run."""
+    def min_input_periods(self, forward_periods: int) -> int:
+        """Minimum input series length (periods) below which the HAC t-test cannot run."""
         return MIN_PERIODS_HARD
 
     def compute(
@@ -155,8 +155,8 @@ class HansenHodrick:
     summary: ClassVar[str] = "Hansen-Hodrick HAC t-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
 
-    def hard_floor(self, forward_periods: int) -> int:
-        """Raw-period floor below which the HAC t-test cannot run."""
+    def min_input_periods(self, forward_periods: int) -> int:
+        """Minimum input series length (periods) below which the HAC t-test cannot run."""
         return MIN_PERIODS_HARD
 
     def compute(

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -222,7 +222,7 @@ def _sample_non_overlapping(
     alternative (keeps all obs but corrects SE).
 
     Logs a WARNING at ``factrix.metrics`` when the sampled series
-    has < 1.5 × MIN_ASSETS_PER_DATE_IC rows — downstream t-tests may be frail
+    has < 1.5 × MIN_IC_PERIODS rows — downstream t-tests may be frail
     even if they don't short-circuit.
 
     Args:
@@ -235,7 +235,7 @@ def _sample_non_overlapping(
         other columns untouched.
     """
     from factrix._logging import get_metrics_logger
-    from factrix._types import MIN_ASSETS_PER_DATE_IC
+    from factrix._types import MIN_IC_PERIODS
 
     sampled_dates = df["date"].unique().sort().gather_every(forward_periods)
     result = df.filter(pl.col("date").is_in(sampled_dates.implode()))
@@ -250,10 +250,10 @@ def _sample_non_overlapping(
     # WARNING: post-sampling series shorter than 1.5x the usual minimum is
     # a red flag — downstream t-tests either short-circuit or operate on
     # a frail sample that silently caller-doesn't-notice.
-    min_safe = int(MIN_ASSETS_PER_DATE_IC * 1.5)
+    min_safe = int(MIN_IC_PERIODS * 1.5)
     if 0 < n_after < min_safe:
         logger.warning(
-            "non_overlap_sample shrunk to n=%d (< %d = MIN_ASSETS_PER_DATE_IC*1.5); "
+            "non_overlap_sample shrunk to n=%d (< %d = MIN_IC_PERIODS*1.5); "
             "downstream significance tests may be unreliable. "
             "forward_periods=%d",
             n_after,

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -19,7 +19,7 @@ from factrix.metrics._decorators import metric
 # Minimum complete (factor, return) pairs per date to estimate a slope.
 # Two parameters (intercept + slope) leave one residual degree of freedom
 # at three observations.
-MIN_FM_CS_OBS: int = 3
+MIN_FM_ASSETS: int = 3
 
 
 @metric(
@@ -60,7 +60,7 @@ def compute_fm_betas(
     Returns:
         Dict mapping each factor name to a DataFrame with columns
         ``date, beta`` sorted by date. A date is emitted only when it has
-        at least ``MIN_FM_CS_OBS`` complete ``(factor, return)`` pairs and
+        at least ``MIN_FM_ASSETS`` complete ``(factor, return)`` pairs and
         a non-degenerate cross-sectional spread; dates with zero factor
         variance (no identifiable slope) are dropped.
     """
@@ -99,7 +99,7 @@ def compute_fm_betas(
                 pl.col(f"_cnt__{f}").alias("_cnt"),
                 pl.col(f"_beta__{f}").alias("beta"),
             )
-            .filter(pl.col("_cnt") >= MIN_FM_CS_OBS)
+            .filter(pl.col("_cnt") >= MIN_FM_ASSETS)
             .drop_nulls("beta")
             .select("date", "beta")
         )

--- a/factrix/metrics/_primitives/_ts_betas.py
+++ b/factrix/metrics/_primitives/_ts_betas.py
@@ -19,7 +19,7 @@ from factrix.metrics._decorators import metric
 
 # Minimum complete (factor, return) observations per asset to fit a
 # time-series slope. Mirrors the historical per-asset floor.
-MIN_TS_OBS: int = 20
+MIN_TS_PERIODS: int = 20
 
 
 @metric(
@@ -65,7 +65,7 @@ def compute_ts_betas(
         Dict mapping each factor name to a DataFrame with columns
         ``asset_id, beta, alpha, t_stat, r_squared, n_obs`` sorted by
         ``asset_id``. An asset is emitted only with at least
-        ``MIN_TS_OBS`` complete pairs and non-zero factor time-variation
+        ``MIN_TS_PERIODS`` complete pairs and non-zero factor time-variation
         (zero-variance assets have no identifiable slope and are dropped).
     """
     cols = list(factor_cols)
@@ -93,7 +93,7 @@ def _ts_betas_one(df: pl.DataFrame, factor_col: str, return_col: str) -> pl.Data
             pl.col(return_col).var().alias("_var_y"),
             pl.cov(factor_col, return_col).alias("_cov"),
         )
-        .filter(pl.col("n_obs") >= MIN_TS_OBS)
+        .filter(pl.col("n_obs") >= MIN_TS_PERIODS)
     )
 
     n = pl.col("n_obs")

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -36,7 +36,7 @@ from factrix._axis import (
 )
 from factrix._metric_index import cell
 from factrix._results import MetricResult
-from factrix._types import MIN_ASSETS_PER_DATE_IC
+from factrix._types import MIN_IC_PERIODS
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
 
@@ -45,9 +45,10 @@ __all__ = [
 ]
 
 # Minimum non-overlapping sign observations below which the PT normal
-# approximation is unreliable. Reuses the IC per-date floor — both gate a
-# pooled-sign statistic on the same "≥10 independent draws" rule of thumb.
-MIN_DIRECTIONAL_OBS: int = MIN_ASSETS_PER_DATE_IC
+# approximation is unreliable. Shares the IC series-length floor — both
+# gate a pooled-sign statistic on the same "≥10 independent draws" rule
+# of thumb (periods axis, not the per-date asset count).
+MIN_DIRECTIONAL_OBS: int = MIN_IC_PERIODS
 
 
 @metric(

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -48,7 +48,7 @@ __all__ = [
 # approximation is unreliable. Shares the IC series-length floor — both
 # gate a pooled-sign statistic on the same "≥10 independent draws" rule
 # of thumb (periods axis, not the per-date asset count).
-MIN_DIRECTIONAL_OBS: int = MIN_IC_PERIODS
+MIN_DIRECTIONAL_PERIODS: int = MIN_IC_PERIODS
 
 
 @metric(
@@ -148,12 +148,12 @@ def directional_hit_rate(
     )
 
     n = paired.height
-    if n < MIN_DIRECTIONAL_OBS:
+    if n < MIN_DIRECTIONAL_PERIODS:
         return _short_circuit_output(
             "directional_hit_rate",
             "insufficient_directional_samples",
             n_obs=n,
-            min_required=MIN_DIRECTIONAL_OBS,
+            min_required=MIN_DIRECTIONAL_PERIODS,
         )
 
     x_up = paired["_x_sign"].to_numpy() > 0

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -28,7 +28,7 @@ from factrix._stats import (
     _binomial_test_method_name,
     _binomial_two_sided_p,
 )
-from factrix._types import MIN_ASSETS_PER_DATE_IC
+from factrix._types import MIN_IC_PERIODS
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
 from factrix.metrics.ic import compute_ic
@@ -67,7 +67,7 @@ def per_date_series(series: pl.DataFrame) -> pl.DataFrame:
     aggregation=Aggregation.TS_ONLY,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
-    sample_threshold=SampleThreshold(min_periods=MIN_ASSETS_PER_DATE_IC),
+    sample_threshold=SampleThreshold(min_periods=MIN_IC_PERIODS),
 )
 def hit_rate(
     series: pl.DataFrame,

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -30,7 +30,7 @@ from factrix._results import MetricResult
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 from factrix._types import (
     EPSILON,
-    MIN_ASSETS_PER_DATE_IC,
+    MIN_IC_PERIODS,
 )
 from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
@@ -162,7 +162,7 @@ def ic(
     # its stride / lag math.
     ic_vals = ic_df["ic"].drop_nulls()
     n = len(ic_vals)
-    raw_min = inference.hard_floor(forward_periods)
+    raw_min = inference.min_input_periods(forward_periods)
     if n < raw_min:
         return _short_circuit_output(
             "ic",
@@ -177,12 +177,12 @@ def ic(
     # Stride-based methods report a post-sampling count; guard on the
     # effective sample so a coarse stride cannot silently test ~nothing.
     n_sampled = result.metadata.get("n_obs_sampled")
-    if n_sampled is not None and n_sampled < MIN_ASSETS_PER_DATE_IC:
+    if n_sampled is not None and n_sampled < MIN_IC_PERIODS:
         return _short_circuit_output(
             "ic",
             "insufficient_sampled_ic_periods",
             n_obs=int(n_sampled),
-            min_required=MIN_ASSETS_PER_DATE_IC,
+            min_required=MIN_IC_PERIODS,
             forward_periods=forward_periods,
         )
 

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -39,8 +39,6 @@ __all__ = [
 
 _MFE_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
 
-DEFAULT_MIN_ESTIMATION_SAMPLES: int = 20
-
 
 @metric(
     cell=_MFE_CELL,

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -49,8 +49,6 @@ __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
 
 _TSB_CELL = cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructure.PANEL)
 
-MIN_TS_OBS: int = 20
-
 
 @metric(
     cell=_TSB_CELL,

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -101,8 +101,10 @@ class TestNonOverlapping:
         )
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in result.warnings
 
-    def test_hard_floor_scales_with_stride(self) -> None:
-        assert NON_OVERLAPPING.hard_floor(5) == 5 * NON_OVERLAPPING.hard_floor(1)
+    def test_min_input_periods_scales_with_stride(self) -> None:
+        assert NON_OVERLAPPING.min_input_periods(
+            5
+        ) == 5 * NON_OVERLAPPING.min_input_periods(1)
 
 
 class TestNeweyWest:

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -9,7 +9,7 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix.metrics.directional_hit_rate import (
-    MIN_DIRECTIONAL_OBS,
+    MIN_DIRECTIONAL_PERIODS,
     directional_hit_rate,
 )
 from factrix.metrics.hit_rate import hit_rate
@@ -112,7 +112,7 @@ class TestDivergenceFromHitRate:
 class TestShortCircuits:
     def test_insufficient_samples(self):
         rng = np.random.default_rng(5)
-        n = MIN_DIRECTIONAL_OBS - 1
+        n = MIN_DIRECTIONAL_PERIODS - 1
         x = rng.normal(size=n)
         y = rng.normal(size=n)
         result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -57,7 +57,7 @@ class TestComputeFMBetas:
             assert beta == pytest.approx(ref[dt], abs=1e-12)
 
     def test_drops_dates_below_min_obs(self):
-        # date d0 has 2 assets (below MIN_FM_CS_OBS=3), d1 has 4.
+        # date d0 has 2 assets (below MIN_FM_ASSETS=3), d1 has 4.
         rows = [
             {
                 "date": datetime(2024, 1, 1),

--- a/tests/test_hit_rate.py
+++ b/tests/test_hit_rate.py
@@ -36,7 +36,7 @@ class TestComputeHitRate:
         assert abs(result.stat) < 0.5
 
     def test_insufficient_data(self):
-        series = _make_series([0.01] * 5)  # < MIN_ASSETS_PER_DATE_IC=10
+        series = _make_series([0.01] * 5)  # < MIN_IC_PERIODS=10
         result = hit_rate(series, forward_periods=1)
         assert math.isnan(result.value)
         assert result.p_value is None or result.p_value >= 0.10

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -37,7 +37,7 @@ def test_metric_logger_short_circuit(caplog):
     # Set level to INFO
     logging.getLogger("factrix.metric.ic").setLevel(logging.INFO)
 
-    # Create too thin dataset to force short-circuit (less than MIN_ASSETS_PER_DATE_IC * 5 = 150 dates)
+    # Create too thin dataset to force short-circuit (less than MIN_IC_PERIODS * 5 = 150 dates)
     raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=10, seed=0)
     data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
 

--- a/tests/test_ts_betas.py
+++ b/tests/test_ts_betas.py
@@ -13,7 +13,7 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix._types import EPSILON
-from factrix.metrics._primitives._ts_betas import MIN_TS_OBS, compute_ts_betas
+from factrix.metrics._primitives._ts_betas import MIN_TS_PERIODS, compute_ts_betas
 
 _OUT_COLS = ["asset_id", "beta", "alpha", "t_stat", "r_squared", "n_obs"]
 
@@ -50,7 +50,7 @@ def _lstsq_reference(
         y = c[rc].drop_nulls().to_numpy().astype(np.float64)
         x = c[fc].drop_nulls().to_numpy().astype(np.float64)
         n = min(len(y), len(x))
-        if n < MIN_TS_OBS:
+        if n < MIN_TS_PERIODS:
             continue
         y, x = y[:n], x[:n]
         X = np.column_stack([np.ones(n), x])
@@ -102,11 +102,11 @@ class TestComputeTSBetas:
         assert (j["n_obs"] == j["n_obs_g"]).all()
 
     def test_drops_assets_below_min_obs(self):
-        # GOOD has MIN_TS_OBS rows; SHORT has fewer → dropped.
-        panel = _common_factor_panel(1, MIN_TS_OBS, seed=3).with_columns(
+        # GOOD has MIN_TS_PERIODS rows; SHORT has fewer → dropped.
+        panel = _common_factor_panel(1, MIN_TS_PERIODS, seed=3).with_columns(
             pl.lit("GOOD").alias("asset_id")
         )
-        short = panel.head(MIN_TS_OBS - 1).with_columns(
+        short = panel.head(MIN_TS_PERIODS - 1).with_columns(
             pl.lit("SHORT").alias("asset_id")
         )
         df = compute_ts_betas(pl.concat([panel, short]))["factor"]


### PR DESCRIPTION
## Why

Sample-size threshold constants didn't consistently say *which axis* they
guard, and a few borrowed one axis's constant for another. Readers (and
agents) couldn't tell from a name which dimension a floor gated, making
edits error-prone. Per epic #586, this sub-issue is **naming / dimension
legibility only — zero behavior change**.

## What

Adopt the grammar `MIN_<DOMAIN>_<DIMENSION>[_<TIER>]` where the DIMENSION
token (`PERIODS` / `ASSETS` / `EVENTS`) is mandatory and names the axis,
documented in `_types.py`.

- **Eliminate cross-axis borrowing** — introduce a dedicated periods-axis
  `MIN_IC_PERIODS`; the five series-length uses (ic sampled-stride guard,
  `hit_rate` / `directional_hit_rate` series floors, the non-overlapping
  inference floor, `_sample_non_overlapping` warning) now key off it.
  `MIN_ASSETS_PER_DATE_IC` again gates only the per-date asset count.
- **Dimension-legible method name** — `Inference.hard_floor` →
  `min_input_periods`.
- **Retire opaque `_obs` suffixes**:
  - `MIN_DIRECTIONAL_OBS` → `MIN_DIRECTIONAL_PERIODS`
  - `MIN_TS_OBS` → `MIN_TS_PERIODS`
  - `MIN_FM_CS_OBS` → `MIN_FM_ASSETS`
- **Drop dead duplicates** — `MIN_TS_OBS` in `ts_beta.py` and the unused
  `DEFAULT_MIN_ESTIMATION_SAMPLES` in `mfe_mae.py` (live ones live in the
  respective primitives).

## Verification

- `ruff check`, `ruff format --check`, `mypy factrix` all clean.
- Full suite: 1255 passed, 4 skipped. Pure rename; values unchanged.

Closes #585