### PR TITLE
refactor(metrics)!: converge sample-threshold enforcement (Closes #587)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -388,8 +388,7 @@ per-asset OLS R_i = α_i + β_i·F over all n_periods dates   (time-series step)
 Failure modes:
 
 - per-asset `n_periods < MIN_TS_OBS = 20` → asset dropped.
-- `n_assets < MIN_ASSETS = 10` → `WarningCode.SMALL_CROSS_SECTION_N` (still runs).
-- `MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.BORDERLINE_CROSS_SECTION_N`.
+- `n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.CROSS_SECTION_N` (still runs; severity scales with `n_assets`).
 - `n_assets = 1` → degenerate cross-asset test → mode auto-routed to
   TIMESERIES single-series β test (null: β = 0, **not** E[β] = 0). The
   statistic lands in the same `MetricResult.stat` field across both
@@ -416,8 +415,8 @@ per I6 (sparse regressors are not unit-root candidates).
 Failure modes:
 
 - per-asset `n_periods < MIN_TS_OBS = 20` → asset dropped.
-- `n_assets` two-tier guard same as `common_continuous` (`SMALL_CROSS_SECTION_N` /
-  `BORDERLINE_CROSS_SECTION_N`).
+- `n_assets` cross-section guard same as `common_continuous` (single
+  `CROSS_SECTION_N`; severity from `n_assets` metadata).
 - Two-tier event-count guard (`factrix/_stats/constants.py`):
   `n_events < MIN_BROADCAST_EVENTS_HARD = 5` raises `InsufficientSampleError`;
   `5 ≤ n_events < MIN_BROADCAST_EVENTS_WARN = 20` emits

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -17,7 +17,7 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 | Axis | Hard block | Soft warning | Clean |
 |---|---|---|---|
 | `n_periods` (T) | T < 20 → `InsufficientSampleError` | 20 ≤ T < 30 → `UNRELIABLE_SE_SHORT_PERIODS` | T ≥ 30 |
-| `n_assets` (N) | none | N < 10 → `SMALL_CROSS_SECTION_N`; 10 ≤ N < 30 → `BORDERLINE_CROSS_SECTION_N` | N ≥ 30 |
+| `n_assets` (N) | none | N < 30 → `CROSS_SECTION_N` (severity scales with N) | N ≥ 30 |
 
 `n_assets` is never hard-blocked because the cross-asset t-test on E[β] is mathematically well-defined for N ≥ 2 — only its statistical power degrades. A hard block would force users to choose between "can't run" and "don't know there's a problem"; the warning provides the result while surfacing the issue.
 
@@ -27,7 +27,7 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 |---|---|---|---|---|
 | `INDIVIDUAL` × `DENSE` (IC) | raises `UserInputError` or `IncompatibleAxisError` | all dates dropped (MIN_ASSETS_PER_DATE_IC=10) → NaN | normal PANEL | normal PANEL |
 | `INDIVIDUAL` × `DENSE` (FM) | raises `UserInputError` or `IncompatibleAxisError` | per-date guard; low df | normal PANEL | normal PANEL |
-| `COMMON` × `DENSE` | TIMESERIES single-series β | emits `SMALL_CROSS_SECTION_N` | emits `BORDERLINE_CROSS_SECTION_N` | normal PANEL |
+| `COMMON` × `DENSE` | TIMESERIES single-series β | emits `CROSS_SECTION_N` | emits `CROSS_SECTION_N` | normal PANEL |
 | `INDIVIDUAL` × `SPARSE` / `COMMON` × `SPARSE` | `_SCOPE_COLLAPSED` → TS dummy | normal PANEL CAAR | normal PANEL CAAR | normal PANEL CAAR |
 
 ## Sample-deficiency surfacing

--- a/docs/reference/_generated_warning_codes.md
+++ b/docs/reference/_generated_warning_codes.md
@@ -4,8 +4,7 @@
 | `event_window_overlap` | Adjacent events sit within forward_periods; AR windows overlap. |
 | `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
-| `small_cross_section_n` | PANEL cross-asset t-test with n_assets < MIN_ASSETS (10); df=n_assets-1 too low — t_crit at n_assets=3 ≈ 4.30 (+119% vs asymptotic 1.96). |
-| `borderline_cross_section_n` | PANEL cross-asset t-test with MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN (10..29); residual t_crit inflation 5–15% — read borderline p-values cautiously. |
+| `cross_section_n` | PANEL cross-asset t-test with n_assets < MIN_ASSETS_WARN (30); df=n_assets-1 inflates t_crit relative to the asymptotic 1.96 (≈4.30 at n_assets=3, +119%; 5–15% near 30). Severity scales with n_assets — read the n_assets metadata. |
 | `sparse_common_few_events` | (COMMON, SPARSE, PANEL) broadcast dummy has MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_WARN (5..19); per-asset β estimable but cross-event averaging too thin for asymptotic t. |
 | `sparse_magnitude_weighted` | Sparse factor column is mixed-sign and not a clean ±1 ternary; statistic is magnitude-weighted (Sefcik-Thompson) rather than textbook MacKinlay signed CAAR — apply .sign() before calling for sign-flip semantics. |
 | `few_events` | CAAR significance test with MIN_EVENTS_HARD ≤ n_event_dates < MIN_EVENTS_WARN (4..29); t-stat returned but Brown-Warner (1985) convention treats sub-30 events as power-thin for the asymptotic t-distribution — read borderline p-values cautiously. |

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -136,8 +136,7 @@ below.
 | `MIN_MONOTONICITY_PERIODS` | 5 | `T/h` | hard | `factrix/_types.py` | `monotonicity` |
 | `MIN_PERIODS_HARD` | 20 | `T` (TIMESERIES) | hard | `factrix/_stats/constants.py` | TIMESERIES procedures (`individual_continuous` / `common_continuous` at `N == 1`); raises `InsufficientSampleError` |
 | `MIN_PERIODS_WARN` | 30 | `T` (TIMESERIES) | warn | `factrix/_stats/constants.py` | same procedures; tags `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` |
-| `MIN_ASSETS` | 10 | `N` | warn | `factrix/_stats/constants.py` | PANEL `common_continuous`; tags `WarningCode.SMALL_CROSS_SECTION_N` |
-| `MIN_ASSETS_WARN` | 30 | `N` | warn | `factrix/_stats/constants.py` | same; tags `WarningCode.BORDERLINE_CROSS_SECTION_N` |
+| `MIN_ASSETS_WARN` | 30 | `N` | warn | `factrix/_stats/constants.py` | PANEL `common_continuous`; tags `WarningCode.CROSS_SECTION_N` (severity from `n_assets`) |
 | `MIN_BROADCAST_EVENTS_HARD` | 5 | `K` (broadcast dummy) | hard | `factrix/_stats/constants.py` | `(COMMON, SPARSE, None, PANEL)` procedure |
 | `MIN_BROADCAST_EVENTS_WARN` | 20 | `K` (broadcast dummy) | warn | `factrix/_stats/constants.py` | same; tags `WarningCode.SPARSE_COMMON_FEW_EVENTS` |
 | `MIN_FM_PERIODS_HARD` | 4 | `T` (λ series) | hard | `factrix/metrics/fm_beta.py` | `fm_beta`, `beta_sign_consistency` |
@@ -146,16 +145,13 @@ below.
 
 Naming caveats:
 
-- `MIN_ASSETS_PER_DATE_IC` (10) and `MIN_ASSETS` (10) are different
-  constants with the same value: the first gates **per-date** asset
-  count for IC; the second gates **panel-wide** `N` for the
-  cross-asset *t* on E[β]. The IC variant was renamed from
-  `MIN_IC_PERIODS` because the historical "PERIODS" suffix did not
-  match the per-date axis it actually checks.
-- `MIN_ASSETS = 10` deliberately omits the `_HARD` suffix — the `N`
+- `MIN_ASSETS_PER_DATE_IC` (10) gates the **per-date** asset count for
+  IC (dates below it are dropped); it is distinct from the panel-wide
+  `N` cross-asset guard, which lives solely on `MIN_ASSETS_WARN`.
+- `MIN_ASSETS_WARN = 30` is a single warn floor (no `_HARD`) — the `N`
   axis only **warns** (small `N` is well-defined statistics, just
-  weak), so the `_HARD` convention (which means "raise") would
-  mislead.
+  weak), so the `_HARD` convention (which means "raise") would mislead;
+  severity scales with `n_assets` rather than splitting into tiers.
 - `MIN_BROADCAST_EVENTS_*` is named after its procedure domain to
   avoid colliding with `MIN_EVENTS_*` in `_types.py` (CAAR statistic
   vs broadcast-dummy regression — different gates).

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -299,10 +299,9 @@ Both `quantile_spread` and `k_spread` switch the headline test to a
 block-bootstrap CI when `n_assets < MIN_ASSETS_WARN`. In that branch
 they additionally emit `p_value_t` (the parametric `t` p-value kept
 for reference), `bootstrap_block_length`, `bootstrap_n_resamples`,
-and `bootstrap_seed`. The switch is **not** silent: the cross-section
-tier code (`small_cross_section_n` / `borderline_cross_section_n`) is
-attached to `warning_codes`, so the method change surfaces as a
-`Warning` on the result.
+and `bootstrap_seed`. The switch is **not** silent: the single
+cross-section code (`cross_section_n`) is attached to `warning_codes`,
+so the method change surfaces as a `Warning` on the result.
 
 ### `concentration` (`factrix.metrics.concentration`)
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -22,11 +22,12 @@ class WarningCode(StrEnum):
     # persistent-regressor flag, §5.2 / §7.3). Not raised for SPARSE.
     PERSISTENT_REGRESSOR = "persistent_regressor"
     SERIAL_CORRELATION_DETECTED = "serial_correlation_detected"
-    # Two-tier cross-asset N guards for PANEL common_continuous. Mirrors
-    # the n_periods two-tier (UNRELIABLE_SE_SHORT_PERIODS) but the axis
-    # never raises — cross-asset t-test on E[β] is well-defined for N≥2.
-    SMALL_CROSS_SECTION_N = "small_cross_section_n"
-    BORDERLINE_CROSS_SECTION_N = "borderline_cross_section_n"
+    # Single cross-asset N guard for PANEL common_continuous: the cross-asset
+    # t-test on E[β] runs for any N≥2 (this axis never raises) but its t_crit
+    # inflates as N shrinks. One code flags the whole thin regime
+    # (n_assets < MIN_ASSETS_WARN); severity is read from the ``n_assets``
+    # metadata rather than split across separate tier members.
+    CROSS_SECTION_N = "cross_section_n"
     # Fired by the (COMMON, SPARSE, PANEL) procedure when the broadcast
     # dummy carries MIN_BROADCAST_EVENTS_HARD ≤ n_events <
     # MIN_BROADCAST_EVENTS_WARN. Per-asset β is identifiable but
@@ -91,12 +92,10 @@ _WARNING_DESCRIPTIONS.update(
         WarningCode.EVENT_WINDOW_OVERLAP: "Adjacent events sit within forward_periods; AR windows overlap.",
         WarningCode.PERSISTENT_REGRESSOR: "ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias.",
         WarningCode.SERIAL_CORRELATION_DETECTED: "Ljung-Box p < 0.05 on residuals; NW lag may be under-set.",
-        WarningCode.SMALL_CROSS_SECTION_N: "PANEL cross-asset t-test with n_assets < MIN_ASSETS (10); "
-        "df=n_assets-1 too low — t_crit at n_assets=3 ≈ 4.30 "
-        "(+119% vs asymptotic 1.96).",
-        WarningCode.BORDERLINE_CROSS_SECTION_N: "PANEL cross-asset t-test with MIN_ASSETS ≤ n_assets < "
-        "MIN_ASSETS_WARN (10..29); residual t_crit inflation "
-        "5–15% — read borderline p-values cautiously.",
+        WarningCode.CROSS_SECTION_N: "PANEL cross-asset t-test with n_assets < "
+        "MIN_ASSETS_WARN (30); df=n_assets-1 inflates t_crit relative to the "
+        "asymptotic 1.96 (≈4.30 at n_assets=3, +119%; 5–15% near 30). "
+        "Severity scales with n_assets — read the n_assets metadata.",
         WarningCode.SPARSE_COMMON_FEW_EVENTS: "(COMMON, SPARSE, PANEL) broadcast dummy has "
         "MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_WARN "
         "(5..19); per-asset β estimable but cross-event averaging too thin "
@@ -137,16 +136,15 @@ def cross_section_tier(n_assets: int) -> WarningCode | None:
     ``primary_p``'s ``dof = N - 1``. Callers (``suggest_config``,
     ``_compute_common_panel``) therefore pre-filter before calling.
 
-    Tiers are mutually exclusive — SMALL is strictly more severe than
-    BORDERLINE — so callers can membership-check the more severe code
-    without an else branch. Returns ``None`` at ``n_assets ≥
-    MIN_ASSETS_WARN`` (clean) or ``n_assets < 2`` (PANEL impossible
-    by upstream structure routing; defensive).
+    A single :attr:`WarningCode.CROSS_SECTION_N` flags the whole thin regime
+    (``2 ≤ n_assets < MIN_ASSETS_WARN``); how severe it is scales with
+    ``n_assets``, which callers carry in metadata rather than encoding into
+    separate tier members. Returns ``None`` at ``n_assets ≥ MIN_ASSETS_WARN``
+    (clean) or ``n_assets < 2`` (PANEL impossible by upstream structure
+    routing; defensive).
     """
-    from factrix._stats.constants import MIN_ASSETS, MIN_ASSETS_WARN
+    from factrix._stats.constants import MIN_ASSETS_WARN
 
-    if 2 <= n_assets < MIN_ASSETS:
-        return WarningCode.SMALL_CROSS_SECTION_N
-    if MIN_ASSETS <= n_assets < MIN_ASSETS_WARN:
-        return WarningCode.BORDERLINE_CROSS_SECTION_N
+    if 2 <= n_assets < MIN_ASSETS_WARN:
+        return WarningCode.CROSS_SECTION_N
     return None

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -602,9 +602,9 @@ def _evaluate_applicability(
             blockers.append(f"n_{av.axis}={av.n} < min_{av.axis}={av.floor}")
         elif av.tier is Tier.DEGRADED:
             # The assets axis gates DEGRADED on the spec's warn_assets, but the
-            # emitted warning is the inference-stage cross-section tier, keyed on
-            # the global MIN_ASSETS / MIN_ASSETS_WARN constants — so it can be
-            # None here even though the axis verdict is DEGRADED.
+            # emitted warning is the inference-stage CROSS_SECTION_N code, keyed
+            # on the global MIN_ASSETS_WARN constant — so it can be None here
+            # even though the axis verdict is DEGRADED.
             if av.axis == "assets":
                 code = cross_section_tier(properties.n_assets)
                 if code is not None:

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -15,19 +15,13 @@ MIN_PERIODS_HARD: int = 20
 # tagged with :attr:`factrix._codes.WarningCode.UNRELIABLE_SE_SHORT_PERIODS`.
 MIN_PERIODS_WARN: int = 30
 
-# ``n_assets < MIN_ASSETS`` → :attr:`factrix._codes.WarningCode.SMALL_CROSS_SECTION_N`
+# ``n_assets < MIN_ASSETS_WARN`` → :attr:`factrix._codes.WarningCode.CROSS_SECTION_N`
 # from PANEL ``common_continuous`` and from ``suggest_config``. The cross-asset
-# t-test on E[β] has df = n_assets - 1; below 10 the critical t inflates
-# severely (n_assets=3 → t_crit≈4.30 vs asymptotic 1.96). The axis intentionally
-# never raises — N=2..9 is well-defined statistics, only weak.
-# Naming deliberately omits ``_HARD``: the n_assets axis only warns, so reusing
-# the n_periods ``_HARD`` (which means "raise") would be misleading.
-MIN_ASSETS: int = 10
-
-# ``MIN_ASSETS <= n_assets < MIN_ASSETS_WARN`` →
-# :attr:`factrix._codes.WarningCode.BORDERLINE_CROSS_SECTION_N`. Mirrors
-# ``MIN_PERIODS_WARN`` semantically: residual t_crit inflation 5–15%
-# (n_assets=10 → +15%, n_assets=20 → +7%, n_assets=30 → +5%).
+# t-test on E[β] has df = n_assets - 1; as n_assets shrinks the critical t
+# inflates (n_assets=3 → t_crit≈4.30 vs asymptotic 1.96; ~+15% at 10, ~+5% at
+# 30). The axis intentionally never raises — N≥2 is well-defined statistics,
+# only weak — so a single warn floor (no ``_HARD``) flags the whole thin
+# regime; severity is read from the ``n_assets`` metadata, not encoded in tiers.
 MIN_ASSETS_WARN: int = 30
 
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -373,8 +373,7 @@ All exceptions inherit from `FactrixError`:
 | `event_window_overlap` | Adjacent events sit within `forward_periods`; AR windows overlap. |
 | `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
-| `small_cross_section_n` | PANEL cross-asset t-test with `n_assets < MIN_ASSETS (10)`; df too low. |
-| `borderline_cross_section_n` | PANEL cross-asset t-test with `MIN_ASSETS ≤ n_assets < MIN_ASSETS_WARN` (10..29); residual t_crit inflation. |
+| `cross_section_n` | PANEL cross-asset t-test with `n_assets < MIN_ASSETS_WARN` (30); df=n_assets-1 inflates t_crit; severity in the n_assets metadata. |
 | `sparse_common_few_events` | broadcast dummy has 5..19 events; too thin for asymptotic t. |
 | `sparse_magnitude_weighted` | Sparse factor column is mixed-sign and not a clean ±1 ternary; magnitude-weighted. |
 | `few_events` | event dates < 29; t-stat power is thin. |

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -81,10 +81,9 @@ def _spread_significance(
 
     The switch fires exactly when :func:`cross_section_tier` flags the
     cross-section (``n_assets < MIN_ASSETS_WARN``), so the returned
-    ``warning_codes`` carry that tier code (``SMALL_`` /
-    ``BORDERLINE_CROSS_SECTION_N``). This surfaces the method change as a
-    :class:`Warning` on the result rather than leaving it buried in
-    metadata — the same two-tier convention the sample guards use.
+    ``warning_codes`` carry the single ``CROSS_SECTION_N`` code. This
+    surfaces the method change as a :class:`Warning` on the result rather
+    than leaving it buried in metadata; severity is read from ``n_assets``.
     """
     n = len(spread)
     mean = float(np.mean(spread))

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -229,6 +229,31 @@ def _enforce_min_floor(
     return None
 
 
+def _warn_below_floor(
+    metric: Any,
+    n: int,
+    message: str,
+    code: WarningCode,
+    *,
+    axis: str = "periods",
+) -> str | None:
+    """Flag the degraded tier when ``n`` falls below the declared ``warn_<axis>``.
+
+    Warn-tier companion to :func:`_enforce_min_floor`: the sample clears the
+    ``min`` floor (a result is still returned) but sits below ``warn``, so the
+    metric runs with a documented bias. Reads ``warn_<axis>`` via an
+    ``Any``-typed ``metric`` (no per-call ``# type: ignore[attr-defined]``);
+    when the floor is breached it emits ``message`` as a ``UserWarning`` and
+    returns ``code.value`` for the caller to fold into the result's
+    ``warning_codes``. Returns ``None`` when the warn floor is clear or ungated.
+    """
+    warn = getattr(metric.sample_threshold, f"warn_{axis}")
+    if warn is not None and n < warn:
+        warnings.warn(message, UserWarning, stacklevel=3)
+        return code.value
+    return None
+
+
 def _pick_event_return_col(df: pl.DataFrame) -> str:
     """Return the preferred return column for event analysis.
 

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from typing import Any
 
 import numpy as np
 import polars as pl
@@ -185,6 +186,47 @@ def _short_circuit_output(
         stat=None,
         metadata=metadata,
     )
+
+
+def _enforce_min_floor(
+    metric: Any,
+    name: str,
+    n: int,
+    reason: str,
+    *,
+    axis: str = "periods",
+    descriptive: bool = False,
+    **extra: object,
+) -> MetricResult | None:
+    """Short-circuit when ``n`` falls below the metric's declared ``min_<axis>``.
+
+    Single owner for the "read declared floor → compare → short-circuit"
+    step that was hand-copied across the metric bodies. Each metric still
+    computes its own ``n`` (post-sampling / post-drop-nulls / post-aggregation
+    counts are metric-specific) and passes it in; this helper holds only the
+    comparison and the canonical :func:`_short_circuit_output` call.
+
+    ``metric`` is typed ``Any`` so the ``@metric``-decorator-attached
+    ``sample_threshold`` is reachable without a per-call
+    ``# type: ignore[attr-defined]`` (the decorator types each metric as its
+    wrapped function, which has no such attribute).
+
+    Returns the short-circuit ``MetricResult`` to propagate, or ``None`` when
+    the sample clears the floor (axis ungated → always ``None``). ``descriptive``
+    and any extra keyword metadata are forwarded to
+    :func:`_short_circuit_output`.
+    """
+    floor = getattr(metric.sample_threshold, f"min_{axis}")
+    if floor is not None and n < floor:
+        return _short_circuit_output(
+            name,
+            reason,
+            n_obs=n,
+            min_required=floor,
+            descriptive=descriptive,
+            **extra,
+        )
+    return None
 
 
 def _pick_event_return_col(df: pl.DataFrame) -> str:

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -14,8 +14,6 @@ Notes:
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import polars as pl
 
@@ -26,7 +24,7 @@ from factrix._axis import (
     FactorScope,
 )
 from factrix._codes import WarningCode
-from factrix._metric_index import cell
+from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
 from factrix._types import (
@@ -39,8 +37,10 @@ from factrix._types import (
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _compute_tie_ratio,
+    _enforce_min_floor,
     _sample_non_overlapping,
     _short_circuit_output,
+    _warn_below_floor,
 )
 
 __all__ = [
@@ -53,6 +53,10 @@ __all__ = [
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.CS_THEN_TS,
+    sample_threshold=SampleThreshold(
+        min_periods=MIN_PORTFOLIO_PERIODS_HARD,
+        warn_periods=MIN_PORTFOLIO_PERIODS_WARN,
+    ),
 )
 def top_concentration(
     df: pl.DataFrame,
@@ -163,27 +167,29 @@ def top_concentration(
     )
 
     n_periods_hhi = len(hhi_per_date)
-    if n_periods_hhi < MIN_PORTFOLIO_PERIODS_HARD:
-        return _short_circuit_output(
-            "top_concentration",
-            "insufficient_portfolio_periods",
-            n_obs=n_periods_hhi,
-            min_required=MIN_PORTFOLIO_PERIODS_HARD,
-            tie_ratio=tie_ratio,
-        )
+    sc = _enforce_min_floor(
+        top_concentration,
+        "top_concentration",
+        n_periods_hhi,
+        "insufficient_portfolio_periods",
+        tie_ratio=tie_ratio,
+    )
+    if sc is not None:
+        return sc
 
     warning_codes: list[str] = []
-    if n_periods_hhi < MIN_PORTFOLIO_PERIODS_WARN:
-        warning_codes.append(WarningCode.BORDERLINE_PORTFOLIO_PERIODS.value)
-        warnings.warn(
-            f"top_concentration: n_periods={n_periods_hhi} below "
-            f"MIN_PORTFOLIO_PERIODS_WARN={MIN_PORTFOLIO_PERIODS_WARN}; "
-            f"the one-sided t-test on the per-date diversification ratio is "
-            f"returned but df=n-1 inflates t_crit relative to the asymptotic "
-            f"cutoff. Read borderline p-values cautiously.",
-            UserWarning,
-            stacklevel=2,
-        )
+    warn_code = _warn_below_floor(
+        top_concentration,
+        n_periods_hhi,
+        f"top_concentration: n_periods={n_periods_hhi} below "
+        f"MIN_PORTFOLIO_PERIODS_WARN={MIN_PORTFOLIO_PERIODS_WARN}; "
+        f"the one-sided t-test on the per-date diversification ratio is "
+        f"returned but df=n-1 inflates t_crit relative to the asymptotic "
+        f"cutoff. Read borderline p-values cautiously.",
+        WarningCode.BORDERLINE_PORTFOLIO_PERIODS,
+    )
+    if warn_code is not None:
+        warning_codes.append(warn_code)
 
     eff_n_arr = hhi_per_date["eff_n"].to_numpy()
     n_top_arr = hhi_per_date["n_top"].to_numpy()

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -34,11 +34,15 @@ from factrix._axis import (
     FactorDensity,
     InputShape,
 )
-from factrix._metric_index import cell
+from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import MIN_IC_PERIODS
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
+from factrix.metrics._helpers import (
+    _enforce_min_floor,
+    _sample_non_overlapping,
+    _short_circuit_output,
+)
 
 __all__ = [
     "directional_hit_rate",
@@ -55,6 +59,7 @@ MIN_DIRECTIONAL_PERIODS: int = MIN_IC_PERIODS
     cell=cell(None, FactorDensity.DENSE, structure=None),
     aggregation=Aggregation.TS_ONLY,
     input_shape=InputShape.PANEL,
+    sample_threshold=SampleThreshold(min_periods=MIN_DIRECTIONAL_PERIODS),
 )
 def directional_hit_rate(
     df: pl.DataFrame,
@@ -148,13 +153,14 @@ def directional_hit_rate(
     )
 
     n = paired.height
-    if n < MIN_DIRECTIONAL_PERIODS:
-        return _short_circuit_output(
-            "directional_hit_rate",
-            "insufficient_directional_samples",
-            n_obs=n,
-            min_required=MIN_DIRECTIONAL_PERIODS,
-        )
+    sc = _enforce_min_floor(
+        directional_hit_rate,
+        "directional_hit_rate",
+        n,
+        "insufficient_directional_samples",
+    )
+    if sc is not None:
+        return sc
 
     x_up = paired["_x_sign"].to_numpy() > 0
     y_up = paired["_y_sign"].to_numpy() > 0

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -45,7 +45,7 @@ from factrix._stats import (
 )
 from factrix._types import DDOF, EPSILON, ShankenVarSource
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
 from factrix.metrics._metric_capabilities import per_date_series_rename
 from factrix.metrics._primitives import compute_fm_betas
 
@@ -213,16 +213,11 @@ def fm_beta(
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
 
-    min_periods = fm_beta.sample_threshold.min_periods  # type: ignore[attr-defined]
-    warn_periods = fm_beta.sample_threshold.warn_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "fm_beta",
-            "insufficient_fm_periods",
-            n_obs=n,
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(fm_beta, "fm_beta", n, "insufficient_fm_periods")
+    if sc is not None:
+        return sc
 
+    warn_periods = fm_beta.sample_threshold.warn_periods  # type: ignore[attr-defined]
     warning_codes: list[str] = []
     if warn_periods is not None and n < warn_periods:
         warning_codes.append(WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value)
@@ -566,14 +561,15 @@ def pooled_beta(
     x = df[factor_col].to_numpy().astype(np.float64)
     n_obs = len(y)
 
-    min_pairs = pooled_beta.sample_threshold.min_pairs  # type: ignore[attr-defined]
-    if min_pairs is not None and n_obs < min_pairs:
-        return _short_circuit_output(
-            "pooled_beta",
-            "insufficient_pooled_observations",
-            n_obs=n_obs,
-            min_required=min_pairs,
-        )
+    sc = _enforce_min_floor(
+        pooled_beta,
+        "pooled_beta",
+        n_obs,
+        "insufficient_pooled_observations",
+        axis="pairs",
+    )
+    if sc is not None:
+        return sc
 
     X = np.column_stack([np.ones(n_obs), x])
     try:
@@ -769,14 +765,11 @@ def beta_sign_consistency(
     """
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
-    min_periods = beta_sign_consistency.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "beta_sign_consistency",
-            "no_beta_observations",
-            n_obs=n,
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(
+        beta_sign_consistency, "beta_sign_consistency", n, "no_beta_observations"
+    )
+    if sc is not None:
+        return sc
 
     if expected_sign >= 0:
         consistent = float(np.mean(betas > 0))

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -45,7 +45,11 @@ from factrix._stats import (
 )
 from factrix._types import DDOF, EPSILON, ShankenVarSource
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
+from factrix.metrics._helpers import (
+    _enforce_min_floor,
+    _short_circuit_output,
+    _warn_below_floor,
+)
 from factrix.metrics._metric_capabilities import per_date_series_rename
 from factrix.metrics._primitives import compute_fm_betas
 
@@ -217,18 +221,18 @@ def fm_beta(
     if sc is not None:
         return sc
 
-    warn_periods = fm_beta.sample_threshold.warn_periods  # type: ignore[attr-defined]
     warning_codes: list[str] = []
-    if warn_periods is not None and n < warn_periods:
-        warning_codes.append(WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value)
-        warnings.warn(
-            f"fm_beta: n_periods={n} below MIN_FM_PERIODS_WARN="
-            f"{warn_periods}; NW HAC SE on a short β series is "
-            f"borderline (Fama-MacBeth convention is T≥30). t-stat is "
-            f"returned but read p-values cautiously.",
-            UserWarning,
-            stacklevel=2,
-        )
+    warn_code = _warn_below_floor(
+        fm_beta,
+        n,
+        f"fm_beta: n_periods={n} below MIN_FM_PERIODS_WARN="
+        f"{MIN_FM_PERIODS_WARN}; NW HAC SE on a short β series is "
+        f"borderline (Fama-MacBeth convention is T≥30). t-stat is "
+        f"returned but read p-values cautiously.",
+        WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+    )
+    if warn_code is not None:
+        warning_codes.append(warn_code)
 
     from factrix._stats import _resolve_nw_lags
 

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -43,6 +43,7 @@ from factrix._stats import (
     _newey_west_t_test,
     _p_value_from_t,
 )
+from factrix._stats.constants import MIN_PERIODS_WARN
 from factrix._types import DDOF, EPSILON, ShankenVarSource
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
@@ -357,7 +358,6 @@ def _pooled_beta_driscoll_kraay(
             "cross-sectional dependence across the panel; pick one SE method."
         )
 
-    from factrix._stats.constants import MIN_PERIODS_WARN
     from factrix._stats.hac import _driscoll_kraay_cov as _dk_cov
 
     period_ids = df[cluster_col].to_numpy()
@@ -423,7 +423,11 @@ def _pooled_beta_driscoll_kraay(
 @metric(
     cell=_FM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    sample_threshold=SampleThreshold(min_pairs=10),
+    sample_threshold=SampleThreshold(
+        min_pairs=10,
+        min_periods=_MIN_DK_PERIODS,
+        warn_periods=MIN_PERIODS_WARN,
+    ),
 )
 def pooled_beta(
     df: pl.DataFrame,

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -30,7 +30,10 @@ from factrix._stats import (
 )
 from factrix._types import MIN_IC_PERIODS
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _sample_non_overlapping, _short_circuit_output
+from factrix.metrics._helpers import (
+    _enforce_min_floor,
+    _sample_non_overlapping,
+)
 from factrix.metrics.ic import compute_ic
 
 __all__ = [
@@ -119,14 +122,9 @@ def hit_rate(
     vals = sampled[value_col].drop_nulls()
 
     n = len(vals)
-    min_periods = hit_rate.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "hit_rate",
-            "insufficient_hit_rate_samples",
-            n_obs=n,
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(hit_rate, "hit_rate", n, "insufficient_hit_rate_samples")
+    if sc is not None:
+        return sc
 
     hits = int((vals > 0).sum())
     rate = hits / n

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -36,6 +36,7 @@ from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     TIE_RATIO_WARN_THRESHOLD,
+    _enforce_min_floor,
     _short_circuit_output,
 )
 from factrix.metrics._metric_capabilities import per_date_series_rename
@@ -260,14 +261,9 @@ def ic_ir(
     median_tie = _warn_if_high_ic_tie_ratio(ic_df, "ic_ir")
     ic_vals = ic_df["ic"].drop_nulls()
     n = len(ic_vals)
-    min_periods = ic_ir.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "ic_ir",
-            "insufficient_ic_periods",
-            n_obs=n,
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(ic_ir, "ic_ir", n, "insufficient_ic_periods")
+    if sc is not None:
+        return sc
 
     mean_ic = float(ic_vals.mean())  # type: ignore[arg-type]
     std_ic = float(ic_vals.std())  # type: ignore[arg-type]

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -25,6 +25,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
 )
+from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
@@ -38,6 +39,7 @@ from factrix.metrics._helpers import (
     TIE_RATIO_WARN_THRESHOLD,
     _enforce_min_floor,
     _short_circuit_output,
+    _warn_below_floor,
 )
 from factrix.metrics._metric_capabilities import per_date_series_rename
 from factrix.metrics._primitives import compute_ic
@@ -277,8 +279,21 @@ def ic_ir(
 
     ratio = mean_ic / std_ic
 
+    warning_codes: list[str] = []
+    warn_code = _warn_below_floor(
+        ic_ir,
+        n,
+        f"ic_ir: n_periods={n} below MIN_PERIODS_WARN={MIN_PERIODS_WARN}; "
+        f"the IC information ratio on a short series is unstable. value is "
+        f"returned but read it cautiously.",
+        WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+    )
+    if warn_code is not None:
+        warning_codes.append(warn_code)
+
     return MetricResult(
         value=ratio,
+        warning_codes=tuple(warning_codes),
         metadata={
             "mean_ic": mean_ic,
             "std_ic": std_ic,

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -39,6 +39,7 @@ from factrix._results import MetricResult
 from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _enforce_min_floor,
     _sample_non_overlapping,
     _short_circuit_output,
     _spread_significance,
@@ -177,15 +178,11 @@ def k_spread(
 
     spread_vals = series["spread"].drop_nulls()
     n = len(spread_vals)
-    min_periods = k_spread.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "k_spread",
-            "insufficient_portfolio_periods",
-            n_obs=n,
-            min_required=min_periods,
-            k=k,
-        )
+    sc = _enforce_min_floor(
+        k_spread, "k_spread", n, "insufficient_portfolio_periods", k=k
+    )
+    if sc is not None:
+        return sc
 
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -36,8 +36,8 @@ from factrix._types import (
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups_batch,
+    _enforce_min_floor,
     _sample_non_overlapping,
-    _short_circuit_output,
     _warn_high_tie_ratio,
 )
 
@@ -160,7 +160,6 @@ def monotonicity(
     group_idx = np.arange(n_groups, dtype=np.float64)
     group_idx_centered = group_idx - group_idx.mean()
     group_idx_norm = float(np.sqrt(np.sum(group_idx_centered**2)))
-    min_periods = monotonicity.sample_threshold.min_periods  # type: ignore[attr-defined]
     results: dict[str, MetricResult] = {}
     for i, f in enumerate(cols):
         mat = all_means[:, i * n_groups : (i + 1) * n_groups]
@@ -180,16 +179,17 @@ def monotonicity(
                 )
             mono_arr = mono_arr[np.isfinite(mono_arr)]
 
-        if min_periods is not None and len(mono_arr) < min_periods:
-            results[f] = _short_circuit_output(
-                "monotonicity",
-                "insufficient_monotonicity_periods",
-                n_obs=len(mono_arr),
-                min_required=min_periods,
-                n_groups=n_groups,
-                tie_ratio=tie_ratios[f],
-                tie_policy=tie_policy,
-            )
+        sc = _enforce_min_floor(
+            monotonicity,
+            "monotonicity",
+            len(mono_arr),
+            "insufficient_monotonicity_periods",
+            n_groups=n_groups,
+            tie_ratio=tie_ratios[f],
+            tie_policy=tie_policy,
+        )
+        if sc is not None:
+            results[f] = sc
             continue
         avg_mono = float(np.mean(np.abs(mono_arr)))
         mean_mono = float(np.mean(mono_arr))

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -30,7 +30,7 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import EPSILON, MIN_OOS_PERIODS
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor
 from factrix.metrics.ic import compute_ic
 
 __all__ = [
@@ -123,19 +123,19 @@ def oos_decay(
     vals = sorted_series[value_col].drop_nulls()
     n = len(vals)
 
-    min_periods = oos_decay.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "oos_decay",
-            "insufficient_oos_periods",
-            n_obs=n,
-            descriptive=True,
-            min_required=min_periods,
-            sign_flipped=False,
-            status="VETOED",
-            is_ratio=is_ratio,
-            survival_threshold=survival_threshold,
-        )
+    sc = _enforce_min_floor(
+        oos_decay,
+        "oos_decay",
+        n,
+        "insufficient_oos_periods",
+        descriptive=True,
+        sign_flipped=False,
+        status="VETOED",
+        is_ratio=is_ratio,
+        survival_threshold=survival_threshold,
+    )
+    if sc is not None:
+        return sc
 
     split_idx = int(n * is_ratio)
     is_vals = vals[:split_idx]

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -36,6 +36,7 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
     _compute_tie_ratio,
+    _enforce_min_floor,
     _lag_within_asset,
     _sample_non_overlapping,
     _short_circuit_output,
@@ -165,16 +166,16 @@ def _quantile_spread_from_series(
     _warn_high_tie_ratio(tie_ratio, "quantile_spread", tie_policy)
     spread_vals = series["spread"].drop_nulls()
     n = len(spread_vals)
-    min_periods = quantile_spread.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "quantile_spread",
-            "insufficient_portfolio_periods",
-            n_obs=n,
-            min_required=min_periods,
-            tie_ratio=tie_ratio,
-            tie_policy=tie_policy,
-        )
+    sc = _enforce_min_floor(
+        quantile_spread,
+        "quantile_spread",
+        n,
+        "insufficient_portfolio_periods",
+        tie_ratio=tie_ratio,
+        tie_policy=tie_policy,
+    )
+    if sc is not None:
+        return sc
 
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))
@@ -359,16 +360,16 @@ def quantile_spread_vw(
 
     spread_vals = vw_series["spread_vw"].drop_nulls()
     n = len(spread_vals)
-    min_periods = quantile_spread_vw.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            "quantile_spread_vw",
-            "insufficient_portfolio_periods",
-            n_obs=n,
-            min_required=min_periods,
-            tie_ratio=tie_ratio,
-            tie_policy=tie_policy,
-        )
+    sc = _enforce_min_floor(
+        quantile_spread_vw,
+        "quantile_spread_vw",
+        n,
+        "insufficient_portfolio_periods",
+        tie_ratio=tie_ratio,
+        tie_policy=tie_policy,
+    )
+    if sc is not None:
+        return sc
 
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -40,7 +40,7 @@ from factrix._ols import ols_alpha as _ols_alpha
 from factrix._results import MetricResult
 from factrix._stats import _p_value_from_t
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
 from factrix.metrics.quantile import compute_spread_series
 
 __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
@@ -210,14 +210,14 @@ def spanning_alpha(
         base_arrays = {}
         base_matrix = np.empty((len(candidate_arr), 0))
 
-    min_periods = spanning_alpha.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and len(candidate_arr) < min_periods:
-        return _short_circuit_output(
-            "spanning_alpha",
-            "insufficient_spread_observations",
-            n_obs=len(candidate_arr),
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(
+        spanning_alpha,
+        "spanning_alpha",
+        len(candidate_arr),
+        "insufficient_spread_observations",
+    )
+    if sc is not None:
+        return sc
 
     ols = _ols_alpha(candidate_arr, base_matrix)
 

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -41,6 +41,7 @@ from factrix._types import DDOF, EPSILON
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
+    _enforce_min_floor,
     _sample_non_overlapping,
     _short_circuit_output,
 )
@@ -325,15 +326,15 @@ def notional_turnover(
         df = _sample_non_overlapping(df, forward_periods)
 
     dates = df["date"].unique().sort()
-    min_periods = notional_turnover.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and len(dates) < min_periods:
-        return _short_circuit_output(
-            "notional_turnover",
-            "insufficient_dates",
-            n_obs=len(dates),
-            min_required=min_periods,
-            forward_periods=forward_periods,
-        )
+    sc = _enforce_min_floor(
+        notional_turnover,
+        "notional_turnover",
+        len(dates),
+        "insufficient_dates",
+        forward_periods=forward_periods,
+    )
+    if sc is not None:
+        return sc
 
     top_g = n_groups - 1
     bot_g = 0

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -28,7 +28,7 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _adf, _p_value_from_t
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor
 from factrix.metrics.ic import compute_ic
 
 __all__ = [
@@ -142,14 +142,9 @@ def ic_trend(
     vals = vals[np.isfinite(vals)]
     n = len(vals)
 
-    min_periods = ic_trend.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n < min_periods:
-        return _short_circuit_output(
-            name,
-            "insufficient_trend_periods",
-            n_obs=n,
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(ic_trend, name, n, "insufficient_trend_periods")
+    if sc is not None:
+        return sc
 
     # WHY: index by sequence rather than date difference — non-overlapping
     # sampling can leave irregular gaps between dates.

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -56,6 +56,7 @@ from factrix._types import MIN_PORTFOLIO_PERIODS_HARD
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _aggregate_to_per_date,
+    _enforce_min_floor,
     _short_circuit_output,
 )
 
@@ -165,14 +166,11 @@ def ts_asymmetry(
     )
     n_periods = len(per_date)
 
-    min_periods = ts_asymmetry.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n_periods < min_periods:
-        return _short_circuit_output(
-            "ts_asymmetry",
-            "insufficient_portfolio_periods",
-            n_obs=n_periods,
-            min_required=min_periods,
-        )
+    sc = _enforce_min_floor(
+        ts_asymmetry, "ts_asymmetry", n_periods, "insufficient_portfolio_periods"
+    )
+    if sc is not None:
+        return sc
 
     f = per_date["_f"].to_numpy()
     r = per_date["_r"].to_numpy()

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -37,7 +37,7 @@ from factrix._stats import (
 )
 from factrix._types import DDOF
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor
 from factrix.metrics._primitives import compute_ts_betas
 
 __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
@@ -147,14 +147,9 @@ def ts_beta(ts_betas_df: pl.DataFrame) -> MetricResult:
     betas = ts_betas_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
 
-    min_assets = ts_beta.sample_threshold.min_assets  # type: ignore[attr-defined]
-    if min_assets is not None and n < min_assets:
-        return _short_circuit_output(
-            "ts_beta",
-            "insufficient_assets",
-            n_obs=n,
-            min_required=min_assets,
-        )
+    sc = _enforce_min_floor(ts_beta, "ts_beta", n, "insufficient_assets", axis="assets")
+    if sc is not None:
+        return sc
 
     mean_b = float(np.mean(betas))
     std_b = float(np.std(betas, ddof=DDOF))
@@ -230,14 +225,15 @@ def mean_r_squared(ts_betas_df: pl.DataFrame) -> MetricResult:
     r2_vals = ts_betas_df["r_squared"].drop_nulls().to_numpy()
     n = len(r2_vals)
 
-    min_assets = mean_r_squared.sample_threshold.min_assets  # type: ignore[attr-defined]
-    if min_assets is not None and n < min_assets:
-        return _short_circuit_output(
-            "mean_r_squared",
-            "no_asset_r_squared_observations",
-            n_obs=n,
-            min_required=min_assets,
-        )
+    sc = _enforce_min_floor(
+        mean_r_squared,
+        "mean_r_squared",
+        n,
+        "no_asset_r_squared_observations",
+        axis="assets",
+    )
+    if sc is not None:
+        return sc
 
     return MetricResult(
         value=float(np.mean(r2_vals)),
@@ -416,14 +412,15 @@ def ts_beta_sign_consistency(ts_betas_df: pl.DataFrame) -> MetricResult:
     """
     betas = ts_betas_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
-    min_assets = ts_beta_sign_consistency.sample_threshold.min_assets  # type: ignore[attr-defined]
-    if min_assets is not None and n < min_assets:
-        return _short_circuit_output(
-            "ts_beta_sign_consistency",
-            "insufficient_assets_for_sign_consistency",
-            n_obs=n,
-            min_required=min_assets,
-        )
+    sc = _enforce_min_floor(
+        ts_beta_sign_consistency,
+        "ts_beta_sign_consistency",
+        n,
+        "insufficient_assets_for_sign_consistency",
+        axis="assets",
+    )
+    if sc is not None:
+        return sc
 
     positive = float(np.mean(betas > 0))
     consistency = max(positive, 1.0 - positive)

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -42,6 +42,7 @@ from factrix._types import EPSILON, MIN_PORTFOLIO_PERIODS_HARD
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _aggregate_to_per_date,
+    _enforce_min_floor,
     _short_circuit_output,
 )
 
@@ -150,15 +151,15 @@ def ts_quantile_spread(
     )
     n_periods = len(per_date)
 
-    min_periods = ts_quantile_spread.sample_threshold.min_periods  # type: ignore[attr-defined]
-    if min_periods is not None and n_periods < min_periods:
-        return _short_circuit_output(
-            "ts_quantile_spread",
-            "insufficient_portfolio_periods",
-            n_obs=n_periods,
-            min_required=min_periods,
-            n_groups=n_groups,
-        )
+    sc = _enforce_min_floor(
+        ts_quantile_spread,
+        "ts_quantile_spread",
+        n_periods,
+        "insufficient_portfolio_periods",
+        n_groups=n_groups,
+    )
+    if sc is not None:
+        return sc
 
     n_distinct = int(per_date["_f"].n_unique())
     if n_distinct < n_groups * 2:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -189,3 +189,48 @@ class TestStrictStructureSoftening:
             strict=False,
         )["factor"]
         assert math.isnan(er.metrics["ic"].value)
+
+
+class TestEntryConsistency:
+    """A metric's sample gating must be identical whether it is called
+    directly or routed through ``evaluate()`` — the declare-once-enforce
+    contract. The shared helpers read the same declared floor on both paths.
+    ``ic_ir`` exercises all three tiers (short-circuit / warn / clean) off a
+    single periods floor, with ``evaluate`` computing the same upstream IC.
+    """
+
+    @staticmethod
+    def _ic_df(panel):
+        from factrix.metrics.ic import compute_ic
+
+        return compute_ic(panel)["factor"]
+
+    def _direct_and_via(self, panel):
+        direct = ic_ir(self._ic_df(panel))
+        via = _eval({"ir": ic_ir()}, panel, strict=False)["factor"].metrics["ir"]
+        return direct, via
+
+    def test_short_circuit_matches(self):
+        # ~15 IC rows < MIN_PERIODS_HARD=20: both entry points short-circuit
+        # to NaN on the same floor with the same reason.
+        direct, via = self._direct_and_via(_panel(n_assets=20, n_dates=20))
+        assert math.isnan(direct.value) and math.isnan(via.value)
+        assert direct.metadata["reason"] == via.metadata["reason"]
+        assert direct.metadata["reason"] == "insufficient_ic_periods"
+
+    def test_warn_code_matches(self):
+        # ~25 IC rows: clears the min floor (20) but below the warn floor
+        # (30) -> both paths attach the same degraded-tier code.
+        from factrix._codes import WarningCode
+
+        direct, via = self._direct_and_via(_panel(n_assets=20, n_dates=30))
+        assert not math.isnan(direct.value)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in direct.warning_codes
+        assert direct.warning_codes == via.warning_codes
+
+    def test_clean_tier_matches(self):
+        # ~75 IC rows >= warn floor: both paths return the same value, no code.
+        direct, via = self._direct_and_via(_panel(n_assets=20, n_dates=80))
+        assert not math.isnan(direct.value)
+        assert direct.value == via.value
+        assert direct.warning_codes == via.warning_codes == ()

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -105,9 +105,7 @@ class TestEvaluationResultToFrame:
 
     def test_warning_codes_filter_by_source(self):
         warnings = [
-            Warning(
-                code=WarningCode.SMALL_CROSS_SECTION_N, source="ic", message="thin"
-            ),
+            Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="thin"),
             Warning(
                 code=WarningCode.SERIAL_CORRELATION_DETECTED,
                 source=None,
@@ -118,7 +116,7 @@ class TestEvaluationResultToFrame:
         df = r.to_frame()
         ic_row = df.filter(pl.col("metric_name") == "ic").row(0, named=True)
         ic_ir_row = df.filter(pl.col("metric_name") == "ic_ir").row(0, named=True)
-        assert ic_row["warning_codes"] == [WarningCode.SMALL_CROSS_SECTION_N.value]
+        assert ic_row["warning_codes"] == [WarningCode.CROSS_SECTION_N.value]
         assert ic_ir_row["warning_codes"] == []
 
     def test_metric_name_from_name_field(self):
@@ -131,9 +129,7 @@ class TestEvaluationResultToFrame:
 class TestEvaluationResultToDict:
     def test_round_trips_through_json(self):
         warnings = [
-            Warning(
-                code=WarningCode.SMALL_CROSS_SECTION_N, source="ic", message="thin"
-            ),
+            Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="thin"),
         ]
         r = _sample_result(_sample_group(), warnings=warnings)
         d = r.to_dict()
@@ -148,7 +144,7 @@ class TestEvaluationResultToDict:
         assert "n_obs" not in back
         assert "metrics_partition" not in back
         assert back["metrics"]["ic"]["p_value"] == 0.012
-        assert back["warnings"][0]["code"] == WarningCode.SMALL_CROSS_SECTION_N.value
+        assert back["warnings"][0]["code"] == WarningCode.CROSS_SECTION_N.value
         assert back["plan"] == "1. ic [per-factor]"
 
     def test_nonfinite_floats_become_null(self):
@@ -182,12 +178,12 @@ class TestReprHtml:
 
     def test_renders_warnings_when_present(self):
         warnings = [
-            Warning(code=WarningCode.SMALL_CROSS_SECTION_N, source="ic", message="thin")
+            Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="thin")
         ]
         r = _sample_result(_sample_group(), warnings=warnings)
         html_out = r._repr_html_()
         assert "warnings" in html_out
-        assert WarningCode.SMALL_CROSS_SECTION_N.value in html_out
+        assert WarningCode.CROSS_SECTION_N.value in html_out
 
     def test_no_warnings_block_when_empty(self):
         r = _sample_result(_sample_group())

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -216,6 +216,35 @@ class TestICIR:
         result = ic_ir(df)
         assert math.isnan(result.value)
 
+    @staticmethod
+    def _ic_series(n: int) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)],
+                "ic": [0.05 + 0.01 * (i % 3) for i in range(n)],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_warn_below_warn_periods(self):
+        # 25 periods clears the HARD floor (MIN_PERIODS_HARD=20) but sits below
+        # the WARN floor (MIN_PERIODS_WARN=30): a value is returned with the
+        # degraded-tier warning attached.
+        from factrix._codes import WarningCode
+
+        with pytest.warns(UserWarning, match="below MIN_PERIODS_WARN"):
+            result = ic_ir(self._ic_series(25))
+        assert not math.isnan(result.value)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in result.warning_codes
+
+    def test_no_warn_at_or_above_warn_periods(self):
+        from factrix._codes import WarningCode
+
+        result = ic_ir(self._ic_series(40))
+        assert not math.isnan(result.value)
+        assert (
+            WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in result.warning_codes
+        )
+
 
 class TestICDispatch:
     """``ic()`` delegates its significance test to ``NonOverlappingSample``.

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -241,9 +241,7 @@ class TestICIR:
 
         result = ic_ir(self._ic_series(40))
         assert not math.isnan(result.value)
-        assert (
-            WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in result.warning_codes
-        )
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in result.warning_codes
 
 
 class TestICDispatch:

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -183,6 +183,43 @@ class TestSampleThresholdGate:
         assert ic.warnings == []
 
 
+class TestDeclaredPeriodsFloorsVisible:
+    """Metrics that gate on a periods floor must declare it on their spec so
+    ``inspect_data`` can pre-flight it — previously these enforced the floor in
+    the body while declaring an empty ``SampleThreshold()``, hiding it from the
+    pre-flight verdict.
+    """
+
+    def test_directional_hit_rate_declares_min_periods(self):
+        from factrix.metrics.directional_hit_rate import (
+            MIN_DIRECTIONAL_PERIODS,
+            directional_hit_rate,
+        )
+
+        st = directional_hit_rate.spec().sample_threshold
+        assert st.min_periods == MIN_DIRECTIONAL_PERIODS
+
+    def test_top_concentration_declares_periods_floors(self):
+        from factrix._types import (
+            MIN_PORTFOLIO_PERIODS_HARD,
+            MIN_PORTFOLIO_PERIODS_WARN,
+        )
+        from factrix.metrics.concentration import top_concentration
+
+        st = top_concentration.spec().sample_threshold
+        assert st.min_periods == MIN_PORTFOLIO_PERIODS_HARD
+        assert st.warn_periods == MIN_PORTFOLIO_PERIODS_WARN
+
+    def test_pooled_beta_declares_periods_floors_alongside_pairs(self):
+        from factrix._stats.constants import MIN_PERIODS_WARN
+        from factrix.metrics.fm_beta import _MIN_DK_PERIODS, pooled_beta
+
+        st = pooled_beta.spec().sample_threshold
+        assert st.min_pairs == 10
+        assert st.min_periods == _MIN_DK_PERIODS
+        assert st.warn_periods == MIN_PERIODS_WARN
+
+
 class TestTierPartition:
     def test_three_tiers_partition_metrics_disjointly(self):
         # n_dates=25 puts ic_ir between min and warn -> degraded.

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -82,7 +82,7 @@ class TestSmallNSignificanceSwitch:
         assert "p_value_t" in result.metadata  # parametric p retained for reference
         assert result.metadata["bootstrap_seed"] == 0
         # the method switch surfaces as a cross-section warning, not silently
-        assert "borderline_cross_section_n" in result.warning_codes
+        assert "cross_section_n" in result.warning_codes
         # reproducible run-to-run under the fixed seed
         again = k_spread(panel, forward_periods=1, k=5)
         assert result.p_value == again.p_value

--- a/tests/test_two_tier_guards.py
+++ b/tests/test_two_tier_guards.py
@@ -170,3 +170,29 @@ class TestTopConcentrationTwoTier:
             out = top_concentration(df, forward_periods=1, q_top=0.2)
         assert out.stat is not None
         assert out.warning_codes == ()
+
+
+class TestCrossSectionTierSingleCode:
+    """The cross-asset N guard is a single ``CROSS_SECTION_N`` across the whole
+    thin band (no SMALL/BORDERLINE split); severity is carried by ``n_assets``.
+    """
+
+    def test_flags_whole_thin_band_with_one_code(self):
+        from factrix._codes import cross_section_tier
+        from factrix._stats.constants import MIN_ASSETS_WARN
+
+        for n in (2, 3, 9, 10, MIN_ASSETS_WARN - 1):
+            assert cross_section_tier(n) is WarningCode.CROSS_SECTION_N
+
+    def test_clean_at_or_above_warn_floor(self):
+        from factrix._codes import cross_section_tier
+        from factrix._stats.constants import MIN_ASSETS_WARN
+
+        assert cross_section_tier(MIN_ASSETS_WARN) is None
+        assert cross_section_tier(MIN_ASSETS_WARN + 50) is None
+
+    def test_none_below_panel_minimum(self):
+        from factrix._codes import cross_section_tier
+
+        assert cross_section_tier(1) is None
+        assert cross_section_tier(0) is None

--- a/tests/test_warning.py
+++ b/tests/test_warning.py
@@ -7,10 +7,8 @@ from factrix import Warning, WarningCode
 
 def _sample_warnings() -> list[Warning]:
     return [
-        Warning(code=WarningCode.SMALL_CROSS_SECTION_N, source="ic", message="n=8"),
-        Warning(
-            code=WarningCode.BORDERLINE_CROSS_SECTION_N, source="fm_beta", message=""
-        ),
+        Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="n=8"),
+        Warning(code=WarningCode.CROSS_SECTION_N, source="fm_beta", message=""),
         Warning(
             code=WarningCode.SERIAL_CORRELATION_DETECTED, source=None, message="bundle"
         ),
@@ -18,7 +16,7 @@ def _sample_warnings() -> list[Warning]:
 
 
 def test_default_source_and_message():
-    w = Warning(code=WarningCode.SMALL_CROSS_SECTION_N)
+    w = Warning(code=WarningCode.CROSS_SECTION_N)
     assert w.source is None
     assert w.message == ""
 
@@ -27,7 +25,7 @@ def test_filter_by_source_metric_name():
     warnings = _sample_warnings()
     per_metric = [w for w in warnings if w.source == "ic"]
     assert len(per_metric) == 1
-    assert per_metric[0].code is WarningCode.SMALL_CROSS_SECTION_N
+    assert per_metric[0].code is WarningCode.CROSS_SECTION_N
 
 
 def test_filter_bundle_level_with_source_none():
@@ -46,7 +44,7 @@ def test_group_by_source():
 
 
 def test_frozen_dataclass_equality_and_hashable():
-    a = Warning(code=WarningCode.SMALL_CROSS_SECTION_N, source="ic", message="m")
-    b = Warning(code=WarningCode.SMALL_CROSS_SECTION_N, source="ic", message="m")
+    a = Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="m")
+    b = Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="m")
     assert a == b
     assert hash(a) == hash(b)


### PR DESCRIPTION
## Summary

Converge the scattered sample-threshold enforcement onto a single owner, close the declare-vs-enforce gaps, and merge the over-split cross-section warning into one code.

- **One enforcement helper.** The hand-copied "read declared floor → compare against the metric's own count → short-circuit" (18 bodies, each with a `# type: ignore[attr-defined]`) collapses into `_enforce_min_floor`; the warn-tier sibling `_warn_below_floor` removes the last such `type: ignore`. Each metric still computes its own `n` (post-sampling / post-drop-nulls / per-date counts are metric-specific) and passes it in.
- **Close the declare≠enforce gaps.** `ic_ir` declared `warn_periods` but never enforced it; `directional_hit_rate` / `top_concentration` / `pooled_beta` enforced a periods floor in-body while declaring an empty (or pairs-only) `SampleThreshold`, hiding it from `inspect_data`. All now declare on the spec and route through the helpers, so direct calls and `inspect_data` agree.
- **Merge the cross-section warning (breaking).** `SMALL_CROSS_SECTION_N` / `BORDERLINE_CROSS_SECTION_N` + the `MIN_ASSETS` (=10) constant collapse into a single `WarningCode.CROSS_SECTION_N` over the whole thin band (`2 ≤ n_assets < MIN_ASSETS_WARN`); severity is read from the `n_assets` metadata. `_codes` / `_inspect` / `_helpers`, the generated warning-code table, and the reference/guide docs follow.

The literal "generic wrapper measures every axis before/after `_impl`" goal was dropped on purpose: each metric's count is metric-specific, so a black-box wrapper would change short-circuit semantics. Convergence is "every metric calls the shared helper with its own count". The earlier-claimed HARD/strict bypass and EVENTS exclusion were already resolved by prior refactors (see #587 notes).

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy factrix` clean
- [x] full suite: 1266 passed, 4 skipped
- [x] new direct-call vs `evaluate()` consistency tests (`ic_ir`, all three tiers)
- [x] `ic_ir` warn-tier tests; merged `cross_section_tier` single-code tests; spec-declaration tests for the three gap-fixed metrics

## Notes

- `pooled_beta`'s periods floor is enforced in the Driscoll-Kraay primitive (not a `@metric`); its spec mirrors the floor via the same constants so the value stays single-sourced, but the comparison logic lives in two layers. Fully collapsing it would mean lifting the primitive's check into the metric body — left as a follow-up.

BREAKING CHANGE: `WarningCode.SMALL_CROSS_SECTION_N` and `BORDERLINE_CROSS_SECTION_N` are removed in favour of `CROSS_SECTION_N`; the `MIN_ASSETS` (=10) constant is removed (use `MIN_ASSETS_WARN`).

Closes #587