### PR TITLE
feat(metrics): emit aggregate drop-rate warning for silently dropped periods

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -76,6 +76,15 @@ class WarningCode(StrEnum):
     CROSS_FACTOR_DENSITY_MISMATCH = "cross_factor_density_mismatch"
     CROSS_FACTOR_SCOPE_MISMATCH = "cross_factor_scope_mismatch"
 
+    # Fired by a metric whose upstream PANEL→SERIES primitive silently dropped
+    # a large share of dates at its cross-sectional filter (e.g. compute_ic
+    # dropping dates with n_assets below the per-date floor). A single
+    # aggregate flag per metric replaces per-date noise; the exact
+    # drop-stat schema (n_periods_in / n_periods_out / dropped_periods /
+    # drop_rate / drop_reason) rides in the MetricResult.metadata. Fires only
+    # when drop_rate exceeds DROP_RATE_WARN_THRESHOLD.
+    EXCESSIVE_PERIOD_DROPS = "excessive_period_drops"
+
     @property
     def description(self) -> str:
         return _WARNING_DESCRIPTIONS[self]
@@ -120,6 +129,11 @@ _WARNING_DESCRIPTIONS.update(
         "metadata['upstream'] / ['upstream_reason'] for the original cause.",
         WarningCode.CROSS_FACTOR_DENSITY_MISMATCH: "Factor columns carry inconsistent FactorDensity (dense and sparse mixed).",
         WarningCode.CROSS_FACTOR_SCOPE_MISMATCH: "Factor columns carry inconsistent FactorScope (individual and common mixed).",
+        WarningCode.EXCESSIVE_PERIOD_DROPS: "An upstream PANEL→SERIES primitive dropped more than "
+        "DROP_RATE_WARN_THRESHOLD of dates at its cross-sectional filter; the "
+        "metric was computed on a shortened sample. Exact counts are in "
+        "MetricResult.metadata (n_periods_in / n_periods_out / dropped_periods / "
+        "drop_rate / drop_reason).",
     }
 )
 

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -50,6 +50,17 @@ from factrix._types import DDOF, EPSILON
 # 0.3 the sorting-artifact noise from ordinal tie-breaking is negligible).
 TIE_RATIO_WARN_THRESHOLD = 0.3
 
+# Aggregate share of dates a PANEL→SERIES primitive may silently drop at its
+# cross-sectional filter before a metric flags it. Named after the existing
+# ``TIE_RATIO_WARN_THRESHOLD`` rate-threshold convention. 0.05 is a soft floor:
+# routine end-of-sample thinning sits well below it, while the 20-year-panel /
+# 90%-dropped pathology the warning targets is far above.
+DROP_RATE_WARN_THRESHOLD = 0.05
+
+# Internal diagnostic column a PANEL→SERIES primitive attaches to each per-factor
+# frame, carrying the canonical drop-stat struct from its ``.filter(...)`` step.
+_DROP_STATS_COL = "_drop_stats"
+
 # Fixed bootstrap seed for the small-cross-section significance path.
 # A spread metric's headline p must be reproducible run-to-run, so the
 # block-bootstrap branch draws from a fixed seed rather than system
@@ -492,6 +503,111 @@ def _warn_high_tie_ratio(
         UserWarning,
         stacklevel=3,
     )
+
+
+# Canonical drop-stat schema keys. Both PANEL→SERIES drop sites and the
+# consumers that surface them share these exact five names — no per-metric
+# ad-hoc keys. The ``_periods`` token aligns with the sample-dimension naming
+# grammar (n_periods / min_periods).
+DROP_STAT_KEYS: tuple[str, ...] = (
+    "n_periods_in",
+    "n_periods_out",
+    "dropped_periods",
+    "drop_rate",
+    "drop_reason",
+)
+
+
+def _attach_drop_stats(
+    frame: pl.DataFrame,
+    *,
+    n_periods_in: int,
+    drop_reason: str,
+) -> pl.DataFrame:
+    """Attach the canonical drop-stat struct to a post-filter per-factor frame.
+
+    The producing primitive holds the pre-filter date count (``n_periods_in``)
+    and the predicate (``drop_reason``); ``n_periods_out`` is the surviving row
+    count (``frame.height``). The five stats are broadcast as a single
+    ``_drop_stats`` struct column so the diagnostic rides the existing
+    ``dict[str, pl.DataFrame]`` contract (cf. the per-date ``tie_ratio`` column).
+    A consumer reads row 0 via :func:`_read_drop_stats`; a fully-dropped
+    (0-row) frame carries an empty column and is never read because the
+    consumer short-circuits first.
+    """
+    n_periods_out = frame.height
+    dropped = n_periods_in - n_periods_out
+    drop_rate = dropped / n_periods_in if n_periods_in > 0 else 0.0
+    stats = pl.struct(
+        n_periods_in=pl.lit(n_periods_in, dtype=pl.Int64),
+        n_periods_out=pl.lit(n_periods_out, dtype=pl.Int64),
+        dropped_periods=pl.lit(dropped, dtype=pl.Int64),
+        drop_rate=pl.lit(drop_rate, dtype=pl.Float64),
+        drop_reason=pl.lit(drop_reason, dtype=pl.String),
+    ).alias(_DROP_STATS_COL)
+    return frame.with_columns(stats)
+
+
+def _read_drop_stats(frame: pl.DataFrame) -> dict[str, Any] | None:
+    """Return the five drop-stat values from row 0, or ``None`` if unavailable.
+
+    ``None`` when the primitive attached no ``_drop_stats`` column (e.g. a
+    hand-built series) or the frame has no surviving rows. Consumers merge the
+    returned dict straight into ``MetricResult.metadata``.
+    """
+    if _DROP_STATS_COL not in frame.columns or frame.is_empty():
+        return None
+    return frame[_DROP_STATS_COL][0]
+
+
+def _warn_if_high_drop_rate(stats: dict[str, Any], metric_name: str) -> str | None:
+    """Emit one aggregate ``UserWarning`` when the drop rate clears the floor.
+
+    Returns :attr:`WarningCode.EXCESSIVE_PERIOD_DROPS` (as a string) for the
+    caller to append to ``warning_codes`` so the DAG's result-assembly boundary
+    also records a structured ``Warning`` — the dual-channel pattern shared with
+    ``_warn_below_floor``. Returns ``None`` (no warning) when ``drop_rate`` is at
+    or below :data:`DROP_RATE_WARN_THRESHOLD`. Uses ``warnings.warn`` so the
+    advisory surfaces in notebooks; the default filter dedupes sweep loops.
+    """
+    drop_rate = float(stats["drop_rate"])
+    if drop_rate <= DROP_RATE_WARN_THRESHOLD:
+        return None
+    warnings.warn(
+        f"{metric_name}: {drop_rate:.0%} of periods dropped "
+        f"({stats['dropped_periods']}/{stats['n_periods_in']}) — "
+        f"{stats['drop_reason']}. The metric was computed on the surviving "
+        f"{stats['n_periods_out']} periods; read it against that shortened sample.",
+        UserWarning,
+        stacklevel=3,
+    )
+    return WarningCode.EXCESSIVE_PERIOD_DROPS.value
+
+
+def _surface_drop_stats(
+    frame: pl.DataFrame,
+    metric_name: str,
+    metadata: dict[str, Any],
+    warning_codes: list[str],
+) -> None:
+    """Copy an upstream primitive's drop-stat schema into a consumer's result.
+
+    Single call-site shared by every PANEL→SERIES consumer: reads the five
+    drop-stat keys off *frame*, merges them into *metadata*, and (when the
+    drop rate clears :data:`DROP_RATE_WARN_THRESHOLD`) emits one aggregate
+    ``UserWarning`` and appends :attr:`WarningCode.EXCESSIVE_PERIOD_DROPS` to
+    *warning_codes*. No-op when *frame* carries no drop stats (hand-built
+    series) or has no surviving rows. Call only on the success path — a
+    consumer that short-circuits first defers to its own short-circuit reason,
+    so the drop warning never double-fires.
+    """
+    stats = _read_drop_stats(frame)
+    if stats is None:
+        return
+    metadata.update(stats)
+    code = _warn_if_high_drop_rate(stats, metric_name)
+    if code is not None:
+        warning_codes.append(code)
 
 
 def _is_sparse_magnitude_weighted(

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -15,6 +15,7 @@ from factrix._axis import (
 )
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
+from factrix.metrics._helpers import _attach_drop_stats
 
 # Minimum complete (factor, return) pairs per date to estimate a slope.
 # Two parameters (intercept + slope) leave one residual degree of freedom
@@ -59,10 +60,12 @@ def compute_fm_betas(
 
     Returns:
         Dict mapping each factor name to a DataFrame with columns
-        ``date, beta`` sorted by date. A date is emitted only when it has
+        ``date, beta`` sorted by date, plus an internal ``_drop_stats``
+        diagnostic struct column. A date is emitted only when it has
         at least ``MIN_FM_ASSETS`` complete ``(factor, return)`` pairs and
         a non-degenerate cross-sectional spread; dates with zero factor
-        variance (no identifiable slope) are dropped.
+        variance (no identifiable slope) are dropped. ``_drop_stats``
+        records the per-factor aggregate drop count.
     """
     cols = list(factor_cols)
     if not cols:
@@ -91,9 +94,17 @@ def compute_fm_betas(
         )
 
     wide = df.lazy().group_by("date").agg(agg_exprs).sort("date").collect()
+    # ``wide`` holds every date before the per-factor thinness / degeneracy
+    # filter; its height is the shared pre-drop date count. ``n_periods_out``
+    # differs per factor (each factor has its own ``_cnt`` and null betas).
+    n_periods_in = wide.height
+    drop_reason = (
+        f"n_assets below MIN_FM_ASSETS ({MIN_FM_ASSETS}) or "
+        f"degenerate cross-sectional variance"
+    )
 
     return {
-        f: (
+        f: _attach_drop_stats(
             wide.select(
                 pl.col("date"),
                 pl.col(f"_cnt__{f}").alias("_cnt"),
@@ -101,7 +112,9 @@ def compute_fm_betas(
             )
             .filter(pl.col("_cnt") >= MIN_FM_ASSETS)
             .drop_nulls("beta")
-            .select("date", "beta")
+            .select("date", "beta"),
+            n_periods_in=n_periods_in,
+            drop_reason=drop_reason,
         )
         for f in cols
     }

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -16,6 +16,7 @@ from factrix._axis import (
 from factrix._metric_index import cell
 from factrix._types import MIN_ASSETS_PER_DATE_IC
 from factrix.metrics._decorators import metric
+from factrix.metrics._helpers import _attach_drop_stats
 
 
 @metric(
@@ -47,9 +48,11 @@ def compute_ic(
 
     Returns:
         Dict mapping each factor name to a DataFrame with columns
-        ``date, ic, tie_ratio`` sorted by date. Dates with fewer than
-        ``MIN_ASSETS_PER_DATE_IC`` assets are dropped. ``tie_ratio`` is
-        the per-date factor tie density
+        ``date, ic, tie_ratio`` sorted by date, plus an internal
+        ``_drop_stats`` diagnostic struct column. Dates with fewer than
+        ``MIN_ASSETS_PER_DATE_IC`` assets are dropped; ``_drop_stats``
+        records how many were dropped (the aggregate drop-rate schema).
+        ``tie_ratio`` is the per-date factor tie density
         $1 - n_{\mathrm{unique}} / n$ in $[0, 1]$.
     """
     cols = list(factor_cols)
@@ -68,21 +71,26 @@ def compute_ic(
         agg_exprs.append(pl.corr(f"_rank__{f}", "_rank_return").alias(f"_ic__{f}"))
         agg_exprs.append((1.0 - pl.col(f).n_unique() / pl.len()).alias(f"_tie__{f}"))
 
-    wide = (
-        df.lazy()
-        .with_columns(rank_exprs)
-        .group_by("date")
-        .agg(agg_exprs)
-        .filter(pl.col("n") >= MIN_ASSETS_PER_DATE_IC)
-        .sort("date")
-        .collect()
-    )
+    # Collect the per-date frame *before* the cross-section filter so the
+    # pre-drop date count is observable; the filter is shared across factors
+    # (``n`` is per-date, not per-factor), so the drop stats are identical
+    # for every factor.
+    grouped = (
+        df.lazy().with_columns(rank_exprs).group_by("date").agg(agg_exprs).sort("date")
+    ).collect()
+    n_periods_in = grouped.height
+    wide = grouped.filter(pl.col("n") >= MIN_ASSETS_PER_DATE_IC)
+    drop_reason = f"n_assets below MIN_ASSETS_PER_DATE_IC ({MIN_ASSETS_PER_DATE_IC})"
 
     return {
-        f: wide.select(
-            pl.col("date"),
-            pl.col(f"_ic__{f}").alias("ic"),
-            pl.col(f"_tie__{f}").alias("tie_ratio"),
+        f: _attach_drop_stats(
+            wide.select(
+                pl.col("date"),
+                pl.col(f"_ic__{f}").alias("ic"),
+                pl.col(f"_tie__{f}").alias("tie_ratio"),
+            ),
+            n_periods_in=n_periods_in,
+            drop_reason=drop_reason,
         )
         for f in cols
     }

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -49,6 +49,7 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
     _short_circuit_output,
+    _surface_drop_stats,
     _warn_below_floor,
 )
 from factrix.metrics._metric_capabilities import per_date_series_rename
@@ -291,6 +292,7 @@ def fm_beta(
             p_final = p_shanken
             t = t_shanken
 
+    _surface_drop_stats(beta_df, "fm_beta", metadata, warning_codes)
     return MetricResult(
         p_value=p_final,
         value=mean_beta,
@@ -784,10 +786,14 @@ def beta_sign_consistency(
     else:
         consistent = float(np.mean(betas < 0))
 
+    metadata: dict[str, object] = {
+        "expected_sign": expected_sign,
+        "n_periods": n,
+    }
+    warning_codes: list[str] = []
+    _surface_drop_stats(beta_df, "beta_sign_consistency", metadata, warning_codes)
     return MetricResult(
         value=consistent,
-        metadata={
-            "expected_sign": expected_sign,
-            "n_periods": n,
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -39,6 +39,7 @@ from factrix.metrics._helpers import (
     TIE_RATIO_WARN_THRESHOLD,
     _enforce_min_floor,
     _short_circuit_output,
+    _surface_drop_stats,
     _warn_below_floor,
 )
 from factrix.metrics._metric_capabilities import per_date_series_rename
@@ -190,18 +191,22 @@ def ic(
         )
 
     mean_ic = float(ic_vals.mean())  # type: ignore[arg-type]
+    metadata: dict[str, object] = {
+        "n_periods": n,
+        "forward_periods": forward_periods,
+        "stat_type": "t",
+        "h0": "mu=0",
+        "method": inference.summary,
+        "tie_ratio": median_tie,
+    }
+    warning_codes: list[str] = []
+    _surface_drop_stats(ic_df, "ic", metadata, warning_codes)
     return MetricResult(
         p_value=result.p_value,
         value=mean_ic,
         stat=result.stat,
-        metadata={
-            "n_periods": n,
-            "forward_periods": forward_periods,
-            "stat_type": "t",
-            "h0": "mu=0",
-            "method": inference.summary,
-            "tie_ratio": median_tie,
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 
@@ -291,13 +296,15 @@ def ic_ir(
     if warn_code is not None:
         warning_codes.append(warn_code)
 
+    metadata: dict[str, object] = {
+        "mean_ic": mean_ic,
+        "std_ic": std_ic,
+        "n_periods": n,
+        "tie_ratio": median_tie,
+    }
+    _surface_drop_stats(ic_df, "ic_ir", metadata, warning_codes)
     return MetricResult(
         value=ratio,
         warning_codes=tuple(warning_codes),
-        metadata={
-            "mean_ic": mean_ic,
-            "std_ic": std_ic,
-            "n_periods": n,
-            "tie_ratio": median_tie,
-        },
+        metadata=metadata,
     )

--- a/tests/test_drop_rate_warning.py
+++ b/tests/test_drop_rate_warning.py
@@ -1,0 +1,162 @@
+"""Aggregate drop-rate warning — Phase 1 (PANEL→SERIES).
+
+PANEL→SERIES primitives (``compute_ic``, ``compute_fm_betas``) silently drop
+dates whose cross-section is too thin. Each records a canonical five-key
+drop-stat schema at its ``.filter(...)`` step; each consumer copies the schema
+into ``MetricResult.metadata`` and emits one aggregate ``UserWarning`` (plus a
+``WarningCode.EXCESSIVE_PERIOD_DROPS``) when ``drop_rate`` clears the threshold.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._codes import WarningCode
+from factrix.metrics._helpers import (
+    DROP_RATE_WARN_THRESHOLD,
+    DROP_STAT_KEYS,
+    _read_drop_stats,
+)
+from factrix.metrics._primitives import compute_fm_betas
+from factrix.metrics.ic import compute_ic, ic, ic_ir
+
+
+def _thinned_panel(
+    *, n_dates: int = 300, full: int = 40, thin: int = 4, seed: int = 0
+) -> pl.DataFrame:
+    """Panel where every other date is thinned to ``thin`` assets.
+
+    ``thin`` < ``MIN_ASSETS_PER_DATE_IC`` (10), so the thinned dates are dropped
+    by ``compute_ic`` — yielding a ~50% period drop with enough survivors to
+    clear the consumers' own sample floors.
+    """
+    raw = fx.datasets.make_cs_panel(n_assets=full, n_dates=n_dates, seed=seed)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    dates = panel["date"].unique().sort()
+    thin_dates = dates.gather(range(0, len(dates), 2))
+    keep_assets = panel["asset_id"].unique().sort().gather(range(thin))
+    return panel.filter(
+        ~pl.col("date").is_in(thin_dates.implode())
+        | pl.col("asset_id").is_in(keep_assets.implode())
+    )
+
+
+def _full_panel(*, n_dates: int = 300, n_assets: int = 40, seed: int = 0):
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates, seed=seed)
+    return fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+
+class TestSchema:
+    def test_keys_are_canonical(self):
+        assert DROP_STAT_KEYS == (
+            "n_periods_in",
+            "n_periods_out",
+            "dropped_periods",
+            "drop_rate",
+            "drop_reason",
+        )
+
+    def test_compute_ic_attaches_drop_stats(self):
+        stats = _read_drop_stats(compute_ic(_thinned_panel())["factor"])
+        assert stats is not None
+        assert set(stats) == set(DROP_STAT_KEYS)
+        # Half the dates are thinned below the IC per-date floor.
+        assert (
+            stats["n_periods_out"] == stats["n_periods_in"] - stats["dropped_periods"]
+        )
+        assert stats["drop_rate"] == pytest.approx(0.5, abs=0.02)
+        assert "MIN_ASSETS_PER_DATE_IC" in stats["drop_reason"]
+
+    def test_compute_fm_betas_attaches_drop_stats(self):
+        # Thin below MIN_FM_ASSETS (3): thinned dates carry a single asset.
+        stats = _read_drop_stats(compute_fm_betas(_thinned_panel(thin=1))["factor"])
+        assert stats is not None
+        assert set(stats) == set(DROP_STAT_KEYS)
+        assert stats["drop_rate"] > DROP_RATE_WARN_THRESHOLD
+        assert "MIN_FM_ASSETS" in stats["drop_reason"]
+
+    def test_full_panel_reports_zero_drop(self):
+        stats = _read_drop_stats(compute_ic(_full_panel())["factor"])
+        assert stats is not None
+        assert stats["dropped_periods"] == 0
+        assert stats["drop_rate"] == 0.0
+
+    def test_hand_built_series_has_no_stats(self):
+        # A series without the primitive's diagnostic column reads as None.
+        bare = compute_ic(_full_panel())["factor"].select("date", "ic")
+        assert _read_drop_stats(bare) is None
+
+
+class TestConsumerWarning:
+    def test_high_drop_rate_warns_and_codes(self):
+        ic_df = compute_ic(_thinned_panel())["factor"]
+        with pytest.warns(UserWarning, match="of periods dropped"):
+            result = ic(ic_df, forward_periods=5)
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS.value in result.warning_codes
+        assert result.metadata["drop_rate"] > DROP_RATE_WARN_THRESHOLD
+        # Full five-key schema lands in metadata for programmatic inspection.
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+
+    def test_low_drop_rate_no_warn_but_keys_present(self):
+        ic_df = compute_ic(_full_panel())["factor"]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = ic(ic_df, forward_periods=5)
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS.value not in result.warning_codes
+        # Schema is still recorded even when below threshold.
+        assert result.metadata["drop_rate"] == 0.0
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+
+    def test_ic_ir_surfaces_drop_stats(self):
+        ic_df = compute_ic(_thinned_panel())["factor"]
+        with pytest.warns(UserWarning, match="ic_ir: .* of periods dropped"):
+            result = ic_ir(ic_df)
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS.value in result.warning_codes
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+
+    def test_full_drop_defers_to_short_circuit(self):
+        # Every date below the IC floor → empty IC series → consumer
+        # short-circuits and must NOT emit a drop-rate warning (no double-warn).
+        raw = fx.datasets.make_cs_panel(n_assets=4, n_dates=300, seed=0)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        ic_df = compute_ic(panel)["factor"]
+        assert ic_df.height == 0
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = ic(ic_df, forward_periods=5)
+        # Short-circuit output: NaN value, its own reason, no drop code.
+        assert result.value != result.value  # NaN
+        assert "reason" in result.metadata
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS.value not in result.warning_codes
+
+
+class TestEvaluateBoundary:
+    def test_evaluate_records_drop_warning(self):
+        panel = _thinned_panel()
+        with pytest.warns(UserWarning, match="of periods dropped"):
+            results = fx.evaluate(
+                panel, metrics={"m": ic()}, factor_cols=["factor"], forward_periods=5
+            )
+        er = results["factor"]
+        codes = [w.code for w in er.warnings]
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS in codes
+        # The structured Warning is sourced to the metric label.
+        drop_warn = next(
+            w for w in er.warnings if w.code == WarningCode.EXCESSIVE_PERIOD_DROPS
+        )
+        assert drop_warn.source == "m"
+
+    def test_direct_and_evaluate_metadata_parity(self):
+        panel = _thinned_panel()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            direct = ic(compute_ic(panel)["factor"], forward_periods=5)
+            results = fx.evaluate(
+                panel, metrics={"m": ic()}, factor_cols=["factor"], forward_periods=5
+            )
+        via_eval = results["factor"].metrics["m"]
+        for key in DROP_STAT_KEYS:
+            assert direct.metadata[key] == via_eval.metadata[key]

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -39,7 +39,9 @@ class TestComputeFMBetas:
 
     def test_output_schema(self, noisy_panel):
         df = compute_fm_betas(noisy_panel)["factor"]
-        assert df.columns == ["date", "beta"]
+        # ``_drop_stats`` is an internal diagnostic struct column appended by
+        # the primitive; the public series columns are ``date, beta``.
+        assert df.columns == ["date", "beta", "_drop_stats"]
         assert df["date"].is_sorted()
 
     def test_closed_form_value(self, tiny_panel):

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -44,7 +44,9 @@ class TestComputeIC:
 
     def test_output_schema(self, noisy_panel):
         result = compute_ic(noisy_panel)["factor"]
-        assert result.columns == ["date", "ic", "tie_ratio"]
+        # ``_drop_stats`` is an internal diagnostic struct column appended by
+        # the primitive; the public series columns are ``date, ic, tie_ratio``.
+        assert result.columns == ["date", "ic", "tie_ratio", "_drop_stats"]
         assert result["date"].dtype == pl.Datetime("ms")
 
     def test_tie_ratio_zero_on_unique_factor(self, noisy_panel):


### PR DESCRIPTION
## 背景

`#586`（收斂樣本驗證）子議題，隱性順序 `#585 → #587 → {#557, #588}`。#585 / #587 已併入 `main`，本 PR 為 #557 的 **Phase 1（PANEL→SERIES）**。

PANEL→SERIES primitive（`compute_ic`、`compute_fm_betas`）在 `.filter(...)` 階段會靜默丟棄橫斷面過薄的 date。長面板若大半 date 被丟，使用者可能在不知情下以極短樣本得出誤導結論。逐 date 警告會洗版，故改為當聚合丟棄率越過門檻時，每個 metric 發單一聚合警告,並把精確統計寫進 `MetricResult.metadata`。

## 變更

- **一致 schema（單一事實來源）**：五個固定 key `n_periods_in / n_periods_out / dropped_periods / drop_rate / drop_reason`（`DROP_STAT_KEYS`）。
- **載體**：primitive 在每個 per-factor frame 附上內部 `_drop_stats` struct 廣播欄，保留 `dict[str, pl.DataFrame]` 契約，公開呼叫端零改動。
- **shared helper**（`_helpers.py`）：`DROP_RATE_WARN_THRESHOLD = 0.05`（比照 `TIE_RATIO_WARN_THRESHOLD`）、`_attach_drop_stats`、`_read_drop_stats`、`_warn_if_high_drop_rate`、以及供 consumer 單行呼叫的 `_surface_drop_stats`。
- **`WarningCode.EXCESSIVE_PERIOD_DROPS`** + 對應 description。
- **consumer**（`ic` / `ic_ir` / `fm_beta` / `beta_sign_consistency`）：把 schema 併入 `metadata`；當 `drop_rate > 0.05` 時發單一 `UserWarning` 並掛上 code（雙通道，比照 `ic_ir`），由結果組裝邊界（`_dag._assemble`）轉成結構化 `Warning`。

## 範圍決策

- **不含 `compute_ts_betas`**：它丟的是 asset 軸，非 period 軸。
- **不含 `hit_rate` / `oos_decay` / `trend`**：issue 明確將其列為 **Phase 2**（SERIES→SCALAR consumer null-drop），且其輸入管線會剝掉診斷欄。
- **無雙重警告**：完全短路（空序列 / 100% 丟棄）的輸出沿用既有 short-circuit `reason`，不再發 drop 警告。

## 驗證

- `pytest tests/`：1277 passed / 4 skipped。
- `ruff check` / `ruff format --check` / `mypy factrix` 全綠；觸及模組的 doctest 通過。
- 新增 `tests/test_drop_rate_warning.py`（11 tests）：schema 附掛、高/低丟棄率、`ic_ir`、完全短路 defer、`evaluate()` 邊界、direct vs evaluate metadata 一致性。

> CHANGELOG / 敘述性文件依慣例留待 epic 收尾批次處理，本 PR 僅含程式碼與最小機械式 docstring 更新。

Closes #557