### PR TITLE
feat(metrics): surface SERIES→SCALAR null-drop with the drop-rate schema

### DIFF
--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -518,6 +518,29 @@ DROP_STAT_KEYS: tuple[str, ...] = (
 )
 
 
+def _make_drop_stats(
+    *,
+    n_periods_in: int,
+    n_periods_out: int,
+    drop_reason: str,
+) -> dict[str, Any]:
+    """Build the canonical five-key drop-stat dict from in/out period counts.
+
+    Single source of truth for the schema, shared by the PANEL→SERIES carrier
+    (:func:`_attach_drop_stats`) and the SERIES→SCALAR consumer null-drop
+    (:func:`_surface_null_drop`). ``drop_rate`` is 0.0 when nothing entered.
+    """
+    dropped = n_periods_in - n_periods_out
+    drop_rate = dropped / n_periods_in if n_periods_in > 0 else 0.0
+    return {
+        "n_periods_in": n_periods_in,
+        "n_periods_out": n_periods_out,
+        "dropped_periods": dropped,
+        "drop_rate": drop_rate,
+        "drop_reason": drop_reason,
+    }
+
+
 def _attach_drop_stats(
     frame: pl.DataFrame,
     *,
@@ -535,17 +558,20 @@ def _attach_drop_stats(
     (0-row) frame carries an empty column and is never read because the
     consumer short-circuits first.
     """
-    n_periods_out = frame.height
-    dropped = n_periods_in - n_periods_out
-    drop_rate = dropped / n_periods_in if n_periods_in > 0 else 0.0
-    stats = pl.struct(
-        n_periods_in=pl.lit(n_periods_in, dtype=pl.Int64),
-        n_periods_out=pl.lit(n_periods_out, dtype=pl.Int64),
-        dropped_periods=pl.lit(dropped, dtype=pl.Int64),
-        drop_rate=pl.lit(drop_rate, dtype=pl.Float64),
-        drop_reason=pl.lit(drop_reason, dtype=pl.String),
-    ).alias(_DROP_STATS_COL)
-    return frame.with_columns(stats)
+    stats = _make_drop_stats(
+        n_periods_in=n_periods_in,
+        n_periods_out=frame.height,
+        drop_reason=drop_reason,
+    )
+    return frame.with_columns(
+        pl.struct(
+            n_periods_in=pl.lit(stats["n_periods_in"], dtype=pl.Int64),
+            n_periods_out=pl.lit(stats["n_periods_out"], dtype=pl.Int64),
+            dropped_periods=pl.lit(stats["dropped_periods"], dtype=pl.Int64),
+            drop_rate=pl.lit(stats["drop_rate"], dtype=pl.Float64),
+            drop_reason=pl.lit(stats["drop_reason"], dtype=pl.String),
+        ).alias(_DROP_STATS_COL)
+    )
 
 
 def _read_drop_stats(frame: pl.DataFrame) -> dict[str, Any] | None:
@@ -604,6 +630,37 @@ def _surface_drop_stats(
     stats = _read_drop_stats(frame)
     if stats is None:
         return
+    metadata.update(stats)
+    code = _warn_if_high_drop_rate(stats, metric_name)
+    if code is not None:
+        warning_codes.append(code)
+
+
+def _surface_null_drop(
+    *,
+    n_periods_in: int,
+    n_periods_out: int,
+    drop_reason: str,
+    metric_name: str,
+    metadata: dict[str, Any],
+    warning_codes: list[str],
+) -> None:
+    """Record a SERIES→SCALAR consumer's own null-drop with the shared schema.
+
+    The Phase-2 counterpart to :func:`_surface_drop_stats`: where a PANEL→SERIES
+    primitive records the drop on a carrier column, a time-indexed (period-axis)
+    consumer that collapses its value series to a scalar via ``drop_nulls`` knows
+    both counts locally — ``n_periods_in`` is the series length entering the
+    drop, ``n_periods_out`` the count of finite observations that survive. Merges
+    the five keys into *metadata* and, when ``drop_rate`` clears the threshold,
+    emits one aggregate ``UserWarning`` and appends the code to *warning_codes*.
+    Call only on the success path so a short-circuit defers to its own reason.
+    """
+    stats = _make_drop_stats(
+        n_periods_in=n_periods_in,
+        n_periods_out=n_periods_out,
+        drop_reason=drop_reason,
+    )
     metadata.update(stats)
     code = _warn_if_high_drop_rate(stats, metric_name)
     if code is not None:

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -33,6 +33,7 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
     _sample_non_overlapping,
+    _surface_null_drop,
 )
 from factrix.metrics.ic import compute_ic
 
@@ -141,15 +142,26 @@ def hit_rate(
         stat = float((rate - 0.5) * np.sqrt(n) / 0.5)
         stat_type = "z"
 
+    metadata: dict[str, object] = {
+        "n_hits": hits,
+        "n_total": n,
+        "stat_type": stat_type,
+        "h0": "p=0.5",
+        "method": _binomial_test_method_name(n),
+    }
+    warning_codes: list[str] = []
+    _surface_null_drop(
+        n_periods_in=len(sampled),
+        n_periods_out=n,
+        drop_reason="null value observations in the series",
+        metric_name="hit_rate",
+        metadata=metadata,
+        warning_codes=warning_codes,
+    )
     return MetricResult(
         p_value=p,
         value=rate,
         stat=stat,
-        metadata={
-            "n_hits": hits,
-            "n_total": n,
-            "stat_type": stat_type,
-            "h0": "p=0.5",
-            "method": _binomial_test_method_name(n),
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -43,6 +43,7 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _short_circuit_output,
     _spread_significance,
+    _surface_null_drop,
 )
 
 __all__ = [
@@ -195,21 +196,31 @@ def k_spread(
     mean_top = float(np.mean(series["top_return"].drop_nulls().to_numpy()))
     mean_bottom = float(np.mean(series["bottom_return"].drop_nulls().to_numpy()))
 
+    metadata: dict[str, object] = {
+        "n_periods": n,
+        "k": k,
+        "stat_type": "t",
+        "h0": "mu=0",
+        "method": sig_method,
+        "cross_sectional_dispersion": mean_dispersion,
+        "top_return": mean_top,
+        "bottom_return": mean_bottom,
+        **sig_extra,
+    }
+    warning_codes = list(sig_codes)
+    _surface_null_drop(
+        n_periods_in=series.height,
+        n_periods_out=n,
+        drop_reason="null spread observations in the series",
+        metric_name="k_spread",
+        metadata=metadata,
+        warning_codes=warning_codes,
+    )
     return MetricResult(
         value=mean_spread,
         p_value=p,
         n_obs=n,
         stat=t,
-        metadata={
-            "n_periods": n,
-            "k": k,
-            "stat_type": "t",
-            "h0": "mu=0",
-            "method": sig_method,
-            "cross_sectional_dispersion": mean_dispersion,
-            "top_return": mean_top,
-            "bottom_return": mean_bottom,
-            **sig_extra,
-        },
-        warning_codes=sig_codes,
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -30,7 +30,7 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import EPSILON, MIN_OOS_PERIODS
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _enforce_min_floor
+from factrix.metrics._helpers import _enforce_min_floor, _surface_null_drop
 from factrix.metrics.ic import compute_ic
 
 __all__ = [
@@ -156,15 +156,26 @@ def oos_decay(
     else:
         status = "VETOED"
 
+    metadata: dict[str, object] = {
+        "sign_flipped": sign_flipped,
+        "status": status,
+        "is_ratio": is_ratio,
+        "mean_is": mean_is,
+        "mean_oos": mean_oos,
+        "survival_threshold": survival_threshold,
+    }
+    warning_codes: list[str] = []
+    _surface_null_drop(
+        n_periods_in=sorted_series.height,
+        n_periods_out=n,
+        drop_reason="null value observations in the series",
+        metric_name="oos_decay",
+        metadata=metadata,
+        warning_codes=warning_codes,
+    )
     return MetricResult(
         value=survival,
         stat=None,
-        metadata={
-            "sign_flipped": sign_flipped,
-            "status": status,
-            "is_ratio": is_ratio,
-            "mean_is": mean_is,
-            "mean_oos": mean_oos,
-            "survival_threshold": survival_threshold,
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -41,6 +41,7 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _short_circuit_output,
     _spread_significance,
+    _surface_null_drop,
     _warn_high_tie_ratio,
 )
 from factrix.metrics._primitives import (
@@ -202,27 +203,37 @@ def _quantile_spread_from_series(
     t_short = _calc_t_stat(mean_short, std_short, len(short_arr))
     p_short = _p_value_from_t(t_short, len(short_arr))
 
+    metadata: dict[str, object] = {
+        "n_periods": n,
+        "stat_type": "t",
+        "h0": "mu=0",
+        "method": sig_method,
+        "long_alpha": mean_long,
+        "short_alpha": mean_short,
+        "long_stat": t_long,
+        "long_p_value": p_long,
+        "short_stat": t_short,
+        "short_p_value": p_short,
+        "short_significance": _significance_marker(p_short),
+        "tie_ratio": tie_ratio,
+        "tie_policy": tie_policy,
+        **sig_extra,
+    }
+    warning_codes = list(sig_codes)
+    _surface_null_drop(
+        n_periods_in=series.height,
+        n_periods_out=n,
+        drop_reason="null spread observations in the series",
+        metric_name="quantile_spread",
+        metadata=metadata,
+        warning_codes=warning_codes,
+    )
     return MetricResult(
         p_value=p,
         value=mean_spread,
         stat=t,
-        metadata={
-            "n_periods": n,
-            "stat_type": "t",
-            "h0": "mu=0",
-            "method": sig_method,
-            "long_alpha": mean_long,
-            "short_alpha": mean_short,
-            "long_stat": t_long,
-            "long_p_value": p_long,
-            "short_stat": t_short,
-            "short_p_value": p_short,
-            "short_significance": _significance_marker(p_short),
-            "tie_ratio": tie_ratio,
-            "tie_policy": tie_policy,
-            **sig_extra,
-        },
-        warning_codes=sig_codes,
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 
@@ -377,16 +388,27 @@ def quantile_spread_vw(
     t = _calc_t_stat(mean_spread, std_spread, n)
 
     p = _p_value_from_t(t, n)
+    metadata: dict[str, object] = {
+        "n_periods": n,
+        "stat_type": "t",
+        "h0": "mu=0",
+        "tie_ratio": tie_ratio,
+        "tie_policy": tie_policy,
+        "weights_lagged": lag_weights,
+    }
+    warning_codes: list[str] = []
+    _surface_null_drop(
+        n_periods_in=vw_series.height,
+        n_periods_out=n,
+        drop_reason="null spread observations in the series",
+        metric_name="quantile_spread_vw",
+        metadata=metadata,
+        warning_codes=warning_codes,
+    )
     return MetricResult(
         p_value=p,
         value=mean_spread,
         stat=t,
-        metadata={
-            "n_periods": n,
-            "stat_type": "t",
-            "h0": "mu=0",
-            "tie_ratio": tie_ratio,
-            "tie_policy": tie_policy,
-            "weights_lagged": lag_weights,
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -28,7 +28,7 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _adf, _p_value_from_t
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _enforce_min_floor
+from factrix.metrics._helpers import _enforce_min_floor, _surface_null_drop
 from factrix.metrics.ic import compute_ic
 
 __all__ = [
@@ -182,9 +182,19 @@ def ic_trend(
         metadata["adf_stat"] = adf_stat
         metadata["adf_p"] = adf_p
         metadata["unit_root_suspected"] = adf_p > adf_threshold
+    warning_codes: list[str] = []
+    _surface_null_drop(
+        n_periods_in=series.height,
+        n_periods_out=n,
+        drop_reason="null or non-finite value observations in the series",
+        metric_name=name,
+        metadata=metadata,
+        warning_codes=warning_codes,
+    )
     return MetricResult(
         p_value=p,
         value=slope,
         stat=approx_t,
         metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/tests/test_drop_rate_warning_phase2.py
+++ b/tests/test_drop_rate_warning_phase2.py
@@ -1,0 +1,160 @@
+"""Aggregate drop-rate warning — Phase 2 (SERIES→SCALAR null-drops).
+
+Period-axis SERIES→SCALAR consumers drop null / non-finite observations from
+their value series before collapsing to a scalar, shrinking the effective
+sample. Each now records the same canonical five-key schema (via
+``_surface_null_drop``) into ``MetricResult.metadata`` and emits one aggregate
+``UserWarning`` + ``WarningCode.EXCESSIVE_PERIOD_DROPS`` when the null-drop rate
+clears ``DROP_RATE_WARN_THRESHOLD``.
+
+Scope: the period-axis null-droppers — ``hit_rate``, ``oos_decay``,
+``ic_trend`` (IC series) and ``quantile_spread`` / ``quantile_spread_vw`` /
+``k_spread`` (spread series). Asset-axis (``ts_beta``) and event-axis
+(``caar`` / ``mfe_mae``) consumers are out of the ``n_periods_*`` schema.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import warnings
+
+import factrix as fx
+import numpy as np
+import polars as pl
+import pytest
+from factrix._codes import WarningCode
+from factrix.metrics._helpers import DROP_RATE_WARN_THRESHOLD, DROP_STAT_KEYS
+from factrix.metrics.hit_rate import hit_rate
+from factrix.metrics.k_spread import k_spread
+from factrix.metrics.oos_decay import oos_decay
+from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
+from factrix.metrics.trend import ic_trend
+
+EXCESSIVE = WarningCode.EXCESSIVE_PERIOD_DROPS.value
+
+
+def _ic_series(*, n: int = 150, null_every: int | None = 3, seed: int = 0):
+    """A ``(date, value)`` IC-like series; every ``null_every``-th value null."""
+    rng = np.random.default_rng(seed)
+    base = dt.date(2020, 1, 1)
+    rows = []
+    for d in range(n):
+        v: float | None = float(rng.normal())
+        if null_every is not None and d % null_every == 0:
+            v = None
+        rows.append({"date": base + dt.timedelta(days=d), "value": v})
+    return pl.DataFrame(rows)
+
+
+def _spread_panel(*, n_dates: int = 200, thin: int = 3, full: int = 50, seed: int = 0):
+    """Panel where even dates carry ``thin`` assets (< n_groups → null spread)."""
+    rng = np.random.default_rng(seed)
+    base = dt.date(2020, 1, 1)
+    rows = []
+    for d in range(n_dates):
+        n = thin if d % 2 == 0 else full
+        for a in range(n):
+            rows.append(
+                {
+                    "date": base + dt.timedelta(days=d),
+                    "asset_id": f"A{a:03d}",
+                    "factor": float(rng.normal()),
+                    "forward_return": float(rng.normal()),
+                    "market_cap": float(abs(rng.normal()) + 1.0),
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+class TestICSeriesTools:
+    @pytest.mark.parametrize(
+        ("fn", "name"),
+        [(hit_rate, "hit_rate"), (oos_decay, "oos_decay"), (ic_trend, "ic_trend")],
+    )
+    def test_high_null_drop_warns(self, fn, name):
+        series = _ic_series(null_every=3)  # ~1/3 null
+        with pytest.warns(UserWarning, match="of periods dropped"):
+            result = fn(series) if name != "hit_rate" else fn(series, forward_periods=1)
+        assert EXCESSIVE in result.warning_codes
+        assert result.metadata["drop_rate"] > DROP_RATE_WARN_THRESHOLD
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+
+    @pytest.mark.parametrize(
+        ("fn", "name"),
+        [(hit_rate, "hit_rate"), (oos_decay, "oos_decay"), (ic_trend, "ic_trend")],
+    )
+    def test_no_null_drop_no_warn_but_keys_present(self, fn, name):
+        series = _ic_series(null_every=None)  # no nulls
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = fn(series) if name != "hit_rate" else fn(series, forward_periods=1)
+        assert EXCESSIVE not in result.warning_codes
+        assert result.metadata["drop_rate"] == 0.0
+        assert result.metadata["dropped_periods"] == 0
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+
+    def test_short_circuit_defers_no_drop_warn(self):
+        # Mostly-null series → too few survivors → short-circuit; no drop warn.
+        rng = np.random.default_rng(0)
+        base = dt.date(2020, 1, 1)
+        rows = [
+            {
+                "date": base + dt.timedelta(days=d),
+                "value": None if d >= 4 else float(rng.normal()),
+            }
+            for d in range(150)
+        ]
+        series = pl.DataFrame(rows)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = oos_decay(series)
+        assert "reason" in result.metadata
+        assert EXCESSIVE not in result.warning_codes
+        assert "drop_rate" not in result.metadata
+
+
+class TestSpreadTools:
+    def test_quantile_spread_surfaces_null_drop(self):
+        with pytest.warns(UserWarning, match="of periods dropped"):
+            result = quantile_spread(_spread_panel(), forward_periods=1)["factor"]
+        assert EXCESSIVE in result.warning_codes
+        assert result.metadata["drop_rate"] == pytest.approx(0.5, abs=0.02)
+        assert "spread" in result.metadata["drop_reason"]
+
+    def test_quantile_spread_vw_records_schema(self):
+        # vw bucketing fills top/bottom even on thin dates here, so no null
+        # spread to drop — the five-key schema is still recorded on success.
+        result = quantile_spread_vw(_spread_panel(), forward_periods=1)
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+        assert (
+            result.metadata["drop_reason"] == "null spread observations in the series"
+        )
+        assert result.metadata["drop_rate"] >= 0.0
+
+    def test_k_spread_records_schema(self):
+        # k_spread's top-k/bottom-k yields a spread even on thin dates, so the
+        # drop rate is low here — the schema is still recorded. Single-factor
+        # path returns a MetricResult directly.
+        result = k_spread(_spread_panel(), forward_periods=1)
+        assert set(DROP_STAT_KEYS) <= set(result.metadata)
+        assert result.metadata["drop_rate"] >= 0.0
+
+
+class TestEvaluateBoundary:
+    def test_evaluate_records_drop_warning(self):
+        panel = _spread_panel()
+        with pytest.warns(UserWarning, match="of periods dropped"):
+            results = fx.evaluate(
+                panel,
+                metrics={"qs": quantile_spread()},
+                factor_cols=["factor"],
+                forward_periods=1,
+                strict=False,
+            )
+        er = results["factor"]
+        codes = [w.code for w in er.warnings]
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS in codes
+        drop_warn = next(
+            w for w in er.warnings if w.code == WarningCode.EXCESSIVE_PERIOD_DROPS
+        )
+        assert drop_warn.source == "qs"


### PR DESCRIPTION
## 背景

`#586`（收斂樣本驗證）的 #557 第二階段。Phase 1（PR #592，已併入）揭露 PANEL→SERIES primitive 在 `.filter(...)` 的丟棄；本階段補上**下一層的 consumer null-drop**：period 軸的 SERIES→SCALAR metric 在把 value 序列塌縮成純量前會丟掉 null / 非有限觀測值，靜默縮小有效樣本。

> #557 已於 Phase 1 PR 被 `Closes #557` 自動關閉；本 PR 補完其 DoD 的 Phase 2 條目。

## 變更

- 抽出共用的五-key builder `_make_drop_stats`（與 Phase 1 載體共用），新增 `_surface_null_drop`：以 in/out 期數計算 schema、併入 `metadata`，並在 `drop_rate` 越過門檻時發單一聚合 `UserWarning` + `WarningCode.EXCESSIVE_PERIOD_DROPS`。
- 接入的 period 軸 consumer：
  - **IC 序列**：`hit_rate`、`oos_decay`、`ic_trend`
  - **spread 序列**：`quantile_spread`、`quantile_spread_vw`、`k_spread`
- 一律只在 success path 呼叫，short-circuit 時沿用既有 `reason`、不重複警告。

## 範圍決策

`n_periods_*` schema 僅適用**時間（period）軸**丟棄（issue 明示「both drop sites drop along the time axis」），故以下排除：

- `ts_beta` 家族 → **asset 軸**（per-asset beta）。
- `caar` / `mfe_mae` → **event 軸**。
- `tradability` → `drop_nulls` 為 lag 邊界（每個 asset 首個 sampled date），非資料品質丟棄。
- `spanning` → 多因子 greedy 選擇，candidate 對齊隨分支而異，無單一乾淨的 per-date null-drop。
- `ic` / `ic_ir` / `fm_beta` → 已帶 Phase 1 keys（上游 filter 為主要丟棄）；其殘餘 null-drop 會與相同 keys 衝突。

## 驗證

- `pytest tests/`：1288 passed / 4 skipped。
- `ruff check` / `ruff format --check` / `mypy factrix` 全綠。
- 新增 `tests/test_drop_rate_warning_phase2.py`（11 tests）：六個 consumer 的 schema 記錄、高 null-drop 警告 + code、無丟棄不警告但 keys 仍在、short-circuit defer、`evaluate()` 邊界（`quantile_spread` 透過 `er.warnings` 揭露 `EXCESSIVE_PERIOD_DROPS`）。

> CHANGELOG / 敘述性文件依慣例留待 epic 收尾批次處理。

Refs #557