### PR TITLE
feat(metrics): surface silent asset-axis sample drops

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -76,14 +76,21 @@ class WarningCode(StrEnum):
     CROSS_FACTOR_DENSITY_MISMATCH = "cross_factor_density_mismatch"
     CROSS_FACTOR_SCOPE_MISMATCH = "cross_factor_scope_mismatch"
 
-    # Fired by a metric whose upstream PANEL→SERIES primitive silently dropped
-    # a large share of dates at its cross-sectional filter (e.g. compute_ic
-    # dropping dates with n_assets below the per-date floor). A single
-    # aggregate flag per metric replaces per-date noise; the exact
-    # drop-stat schema (n_periods_in / n_periods_out / dropped_periods /
-    # drop_rate / drop_reason) rides in the MetricResult.metadata. Fires only
-    # when drop_rate exceeds DROP_RATE_WARN_THRESHOLD.
+    # Per-axis silent-drop flags. A metric whose upstream primitive silently
+    # dropped a large share of its sample at a filter raises the code for the
+    # dropped axis: PERIOD_DROPS for the time axis (e.g. compute_ic dropping
+    # dates with n_assets below the per-date floor), ASSET_DROPS for the
+    # cross-section (e.g. compute_ts_betas dropping assets with insufficient
+    # history or zero factor variance). The code is dimension-specific by
+    # design — a reader resolves the dropped axis from the code alone, not by
+    # digging into metadata (the dimension-naming grammar shared with
+    # SampleThreshold and the n_<axis> sample-size constants). A single
+    # aggregate flag per metric replaces per-row noise; the exact drop-stat
+    # schema (n_<axis>_in / n_<axis>_out / dropped_<axis> / drop_rate /
+    # drop_reason) rides in MetricResult.metadata. Fires only when drop_rate
+    # exceeds DROP_RATE_WARN_THRESHOLD.
     EXCESSIVE_PERIOD_DROPS = "excessive_period_drops"
+    EXCESSIVE_ASSET_DROPS = "excessive_asset_drops"
 
     @property
     def description(self) -> str:
@@ -134,6 +141,12 @@ _WARNING_DESCRIPTIONS.update(
         "metric was computed on a shortened sample. Exact counts are in "
         "MetricResult.metadata (n_periods_in / n_periods_out / dropped_periods / "
         "drop_rate / drop_reason).",
+        WarningCode.EXCESSIVE_ASSET_DROPS: "An upstream primitive dropped more than "
+        "DROP_RATE_WARN_THRESHOLD of assets at its per-asset filter (e.g. "
+        "compute_ts_betas dropping assets with insufficient history or zero "
+        "factor variance); the cross-asset aggregate was computed on a shortened "
+        "sample. Exact counts are in MetricResult.metadata (n_assets_in / "
+        "n_assets_out / dropped_assets / drop_rate / drop_reason).",
     }
 )
 

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -505,37 +505,59 @@ def _warn_high_tie_ratio(
     )
 
 
-# Canonical drop-stat schema keys. Both PANEL→SERIES drop sites and the
-# consumers that surface them share these exact five names — no per-metric
-# ad-hoc keys. The ``_periods`` token aligns with the sample-dimension naming
-# grammar (n_periods / min_periods).
-DROP_STAT_KEYS: tuple[str, ...] = (
-    "n_periods_in",
-    "n_periods_out",
-    "dropped_periods",
-    "drop_rate",
-    "drop_reason",
-)
+# Per-axis WarningCode for the silent-drop flag. A drop along the time axis
+# raises EXCESSIVE_PERIOD_DROPS, one along the cross-section EXCESSIVE_ASSET_DROPS;
+# the code is dimension-specific so a reader resolves the dropped axis from the
+# code alone (the naming grammar shared with SampleThreshold / n_<axis>).
+_DROP_CODE_BY_AXIS: dict[str, WarningCode] = {
+    "periods": WarningCode.EXCESSIVE_PERIOD_DROPS,
+    "assets": WarningCode.EXCESSIVE_ASSET_DROPS,
+}
+
+
+def _drop_stat_keys(axis: str = "periods") -> tuple[str, ...]:
+    """Canonical drop-stat schema keys for one sample ``axis``.
+
+    Both the drop site and the consumer that surfaces it share these exact five
+    names — no per-metric ad-hoc keys. The three count keys carry the ``axis``
+    token (``n_periods_*`` / ``n_assets_*`` / ``dropped_<axis>``) to align with
+    the sample-dimension naming grammar (``n_<axis>`` / ``min_<axis>``); the rate
+    and reason are dimension-neutral.
+    """
+    return (
+        f"n_{axis}_in",
+        f"n_{axis}_out",
+        f"dropped_{axis}",
+        "drop_rate",
+        "drop_reason",
+    )
+
+
+# Periods-axis schema keys — the common case, derived from the axis-generic
+# source of truth above so the two never drift.
+DROP_STAT_KEYS: tuple[str, ...] = _drop_stat_keys("periods")
 
 
 def _make_drop_stats(
     *,
-    n_periods_in: int,
-    n_periods_out: int,
+    axis: str = "periods",
+    n_in: int,
+    n_out: int,
     drop_reason: str,
 ) -> dict[str, Any]:
-    """Build the canonical five-key drop-stat dict from in/out period counts.
+    """Build the canonical five-key drop-stat dict from in/out counts on ``axis``.
 
-    Single source of truth for the schema, shared by the PANEL→SERIES carrier
+    Single source of truth for the schema, shared by the carrier
     (:func:`_attach_drop_stats`) and the SERIES→SCALAR consumer null-drop
-    (:func:`_surface_null_drop`). ``drop_rate`` is 0.0 when nothing entered.
+    (:func:`_surface_null_drop`). The three count keys carry the ``axis`` token
+    (see :func:`_drop_stat_keys`). ``drop_rate`` is 0.0 when nothing entered.
     """
-    dropped = n_periods_in - n_periods_out
-    drop_rate = dropped / n_periods_in if n_periods_in > 0 else 0.0
+    dropped = n_in - n_out
+    drop_rate = dropped / n_in if n_in > 0 else 0.0
     return {
-        "n_periods_in": n_periods_in,
-        "n_periods_out": n_periods_out,
-        "dropped_periods": dropped,
+        f"n_{axis}_in": n_in,
+        f"n_{axis}_out": n_out,
+        f"dropped_{axis}": dropped,
         "drop_rate": drop_rate,
         "drop_reason": drop_reason,
     }
@@ -544,13 +566,14 @@ def _make_drop_stats(
 def _attach_drop_stats(
     frame: pl.DataFrame,
     *,
-    n_periods_in: int,
+    axis: str = "periods",
+    n_in: int,
     drop_reason: str,
 ) -> pl.DataFrame:
     """Attach the canonical drop-stat struct to a post-filter per-factor frame.
 
-    The producing primitive holds the pre-filter date count (``n_periods_in``)
-    and the predicate (``drop_reason``); ``n_periods_out`` is the surviving row
+    The producing primitive holds the pre-filter count on ``axis`` (``n_in``)
+    and the predicate (``drop_reason``); ``n_<axis>_out`` is the surviving row
     count (``frame.height``). The five stats are broadcast as a single
     ``_drop_stats`` struct column so the diagnostic rides the existing
     ``dict[str, pl.DataFrame]`` contract (cf. the per-date ``tie_ratio`` column).
@@ -559,17 +582,18 @@ def _attach_drop_stats(
     consumer short-circuits first.
     """
     stats = _make_drop_stats(
-        n_periods_in=n_periods_in,
-        n_periods_out=frame.height,
+        axis=axis,
+        n_in=n_in,
+        n_out=frame.height,
         drop_reason=drop_reason,
     )
     return frame.with_columns(
         pl.struct(
-            n_periods_in=pl.lit(stats["n_periods_in"], dtype=pl.Int64),
-            n_periods_out=pl.lit(stats["n_periods_out"], dtype=pl.Int64),
-            dropped_periods=pl.lit(stats["dropped_periods"], dtype=pl.Int64),
-            drop_rate=pl.lit(stats["drop_rate"], dtype=pl.Float64),
-            drop_reason=pl.lit(stats["drop_reason"], dtype=pl.String),
+            pl.lit(stats[f"n_{axis}_in"], dtype=pl.Int64).alias(f"n_{axis}_in"),
+            pl.lit(stats[f"n_{axis}_out"], dtype=pl.Int64).alias(f"n_{axis}_out"),
+            pl.lit(stats[f"dropped_{axis}"], dtype=pl.Int64).alias(f"dropped_{axis}"),
+            pl.lit(stats["drop_rate"], dtype=pl.Float64).alias("drop_rate"),
+            pl.lit(stats["drop_reason"], dtype=pl.String).alias("drop_reason"),
         ).alias(_DROP_STATS_COL)
     )
 
@@ -586,28 +610,32 @@ def _read_drop_stats(frame: pl.DataFrame) -> dict[str, Any] | None:
     return frame[_DROP_STATS_COL][0]
 
 
-def _warn_if_high_drop_rate(stats: dict[str, Any], metric_name: str) -> str | None:
+def _warn_if_high_drop_rate(
+    stats: dict[str, Any], metric_name: str, *, axis: str = "periods"
+) -> str | None:
     """Emit one aggregate ``UserWarning`` when the drop rate clears the floor.
 
-    Returns :attr:`WarningCode.EXCESSIVE_PERIOD_DROPS` (as a string) for the
-    caller to append to ``warning_codes`` so the DAG's result-assembly boundary
-    also records a structured ``Warning`` — the dual-channel pattern shared with
-    ``_warn_below_floor``. Returns ``None`` (no warning) when ``drop_rate`` is at
-    or below :data:`DROP_RATE_WARN_THRESHOLD`. Uses ``warnings.warn`` so the
-    advisory surfaces in notebooks; the default filter dedupes sweep loops.
+    Returns the axis-specific drop ``WarningCode`` (as a string — see
+    :data:`_DROP_CODE_BY_AXIS`) for the caller to append to ``warning_codes`` so
+    the DAG's result-assembly boundary also records a structured ``Warning`` —
+    the dual-channel pattern shared with ``_warn_below_floor``. Reads the three
+    count keys via the ``axis`` token (``n_<axis>_in`` etc.); the message names
+    the axis. Returns ``None`` (no warning) when ``drop_rate`` is at or below
+    :data:`DROP_RATE_WARN_THRESHOLD`. Uses ``warnings.warn`` so the advisory
+    surfaces in notebooks; the default filter dedupes sweep loops.
     """
     drop_rate = float(stats["drop_rate"])
     if drop_rate <= DROP_RATE_WARN_THRESHOLD:
         return None
     warnings.warn(
-        f"{metric_name}: {drop_rate:.0%} of periods dropped "
-        f"({stats['dropped_periods']}/{stats['n_periods_in']}) — "
+        f"{metric_name}: {drop_rate:.0%} of {axis} dropped "
+        f"({stats[f'dropped_{axis}']}/{stats[f'n_{axis}_in']}) — "
         f"{stats['drop_reason']}. The metric was computed on the surviving "
-        f"{stats['n_periods_out']} periods; read it against that shortened sample.",
+        f"{stats[f'n_{axis}_out']} {axis}; read it against that shortened sample.",
         UserWarning,
         stacklevel=3,
     )
-    return WarningCode.EXCESSIVE_PERIOD_DROPS.value
+    return _DROP_CODE_BY_AXIS[axis].value
 
 
 def _surface_drop_stats(
@@ -615,23 +643,27 @@ def _surface_drop_stats(
     metric_name: str,
     metadata: dict[str, Any],
     warning_codes: list[str],
+    *,
+    axis: str = "periods",
 ) -> None:
     """Copy an upstream primitive's drop-stat schema into a consumer's result.
 
-    Single call-site shared by every PANEL→SERIES consumer: reads the five
-    drop-stat keys off *frame*, merges them into *metadata*, and (when the
-    drop rate clears :data:`DROP_RATE_WARN_THRESHOLD`) emits one aggregate
-    ``UserWarning`` and appends :attr:`WarningCode.EXCESSIVE_PERIOD_DROPS` to
-    *warning_codes*. No-op when *frame* carries no drop stats (hand-built
-    series) or has no surviving rows. Call only on the success path — a
-    consumer that short-circuits first defers to its own short-circuit reason,
-    so the drop warning never double-fires.
+    Single call-site shared by every carrier consumer: reads the five drop-stat
+    keys off *frame*, merges them into *metadata*, and (when the drop rate clears
+    :data:`DROP_RATE_WARN_THRESHOLD`) emits one aggregate ``UserWarning`` and
+    appends the axis-specific drop ``WarningCode`` to *warning_codes*. The
+    consumer passes the *axis* its upstream primitive dropped along (``"periods"``
+    for ``compute_ic`` / ``compute_fm_betas``, ``"assets"`` for
+    ``compute_ts_betas``). No-op when *frame* carries no drop stats (hand-built
+    series) or has no surviving rows. Call only on the success path — a consumer
+    that short-circuits first defers to its own short-circuit reason, so the drop
+    warning never double-fires.
     """
     stats = _read_drop_stats(frame)
     if stats is None:
         return
     metadata.update(stats)
-    code = _warn_if_high_drop_rate(stats, metric_name)
+    code = _warn_if_high_drop_rate(stats, metric_name, axis=axis)
     if code is not None:
         warning_codes.append(code)
 
@@ -655,14 +687,20 @@ def _surface_null_drop(
     the five keys into *metadata* and, when ``drop_rate`` clears the threshold,
     emits one aggregate ``UserWarning`` and appends the code to *warning_codes*.
     Call only on the success path so a short-circuit defers to its own reason.
+
+    Scoped to the period axis: every current SERIES→SCALAR null-drop site is
+    time-indexed. The carrier path (:func:`_surface_drop_stats`) already carries
+    an ``axis`` for the cross-section; a future EVENT-axis null-drop would
+    generalise this signature then.
     """
     stats = _make_drop_stats(
-        n_periods_in=n_periods_in,
-        n_periods_out=n_periods_out,
+        axis="periods",
+        n_in=n_periods_in,
+        n_out=n_periods_out,
         drop_reason=drop_reason,
     )
     metadata.update(stats)
-    code = _warn_if_high_drop_rate(stats, metric_name)
+    code = _warn_if_high_drop_rate(stats, metric_name, axis="periods")
     if code is not None:
         warning_codes.append(code)
 

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -113,7 +113,7 @@ def compute_fm_betas(
             .filter(pl.col("_cnt") >= MIN_FM_ASSETS)
             .drop_nulls("beta")
             .select("date", "beta"),
-            n_periods_in=n_periods_in,
+            n_in=n_periods_in,
             drop_reason=drop_reason,
         )
         for f in cols

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -89,7 +89,7 @@ def compute_ic(
                 pl.col(f"_ic__{f}").alias("ic"),
                 pl.col(f"_tie__{f}").alias("tie_ratio"),
             ),
-            n_periods_in=n_periods_in,
+            n_in=n_periods_in,
             drop_reason=drop_reason,
         )
         for f in cols

--- a/factrix/metrics/_primitives/_ts_betas.py
+++ b/factrix/metrics/_primitives/_ts_betas.py
@@ -16,10 +16,22 @@ from factrix._axis import (
 from factrix._metric_index import cell
 from factrix._types import EPSILON
 from factrix.metrics._decorators import metric
+from factrix.metrics._helpers import _attach_drop_stats
 
 # Minimum complete (factor, return) observations per asset to fit a
 # time-series slope. Mirrors the historical per-asset floor.
 MIN_TS_PERIODS: int = 20
+
+# One carrier label covering the three silent asset-axis reductions in
+# ``_ts_betas_one``: assets with no complete (factor, return) pairs vanish at
+# the valid-mask group-by; assets with fewer than MIN_TS_PERIODS complete pairs
+# are filtered; assets with zero factor time-variation yield a null slope that
+# is dropped. The cross-asset consumers aggregate over the survivors, so the
+# drop rate is measured against the raw universe.
+_TS_BETA_DROP_REASON = (
+    f"per-asset history below MIN_TS_PERIODS ({MIN_TS_PERIODS}), zero factor "
+    f"variation, or no complete (factor, return) pairs"
+)
 
 
 @metric(
@@ -64,9 +76,12 @@ def compute_ts_betas(
     Returns:
         Dict mapping each factor name to a DataFrame with columns
         ``asset_id, beta, alpha, t_stat, r_squared, n_obs`` sorted by
-        ``asset_id``. An asset is emitted only with at least
-        ``MIN_TS_PERIODS`` complete pairs and non-zero factor time-variation
-        (zero-variance assets have no identifiable slope and are dropped).
+        ``asset_id``, plus a broadcast ``_drop_stats`` carrier column on the
+        assets axis (see :func:`_attach_drop_stats`) so cross-asset consumers
+        can surface how much of the universe was silently dropped. An asset is
+        emitted only with at least ``MIN_TS_PERIODS`` complete pairs and
+        non-zero factor time-variation (zero-variance assets have no
+        identifiable slope and are dropped).
     """
     cols = list(factor_cols)
     if not cols:
@@ -76,6 +91,12 @@ def compute_ts_betas(
 
 
 def _ts_betas_one(df: pl.DataFrame, factor_col: str, return_col: str) -> pl.DataFrame:
+    # In-line asset count vs the raw universe, captured before the valid-mask
+    # filter so the carried drop rate reflects the silent reduction the
+    # cross-asset consumers see — including assets dropped for having no
+    # complete (factor, return) pairs at all.
+    n_assets_in = df["asset_id"].n_unique()
+
     # Restrict every moment to the pairwise-complete (factor, return) set so
     # cov and var share one sample (polars cov pairwise-drops; bare var would
     # not), matching a per-asset OLS on the complete observations.
@@ -114,7 +135,7 @@ def _ts_betas_one(df: pl.DataFrame, factor_col: str, return_col: str) -> pl.Data
     dof = n - 2
     se_beta = (ss_res / dof / s_xx).sqrt()
 
-    return (
+    result = (
         moments.with_columns(beta.alias("beta"))
         .with_columns(
             (pl.col("_ybar") - pl.col("beta") * pl.col("_xbar")).alias("alpha"),
@@ -138,4 +159,10 @@ def _ts_betas_one(df: pl.DataFrame, factor_col: str, return_col: str) -> pl.Data
         )
         .sort("asset_id")
         .collect()
+    )
+    return _attach_drop_stats(
+        result,
+        axis="assets",
+        n_in=n_assets_in,
+        drop_reason=_TS_BETA_DROP_REASON,
     )

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -37,7 +37,7 @@ from factrix._stats import (
 )
 from factrix._types import DDOF
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _enforce_min_floor
+from factrix.metrics._helpers import _enforce_min_floor, _surface_drop_stats
 from factrix.metrics._primitives import compute_ts_betas
 
 __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
@@ -156,18 +156,22 @@ def ts_beta(ts_betas_df: pl.DataFrame) -> MetricResult:
     t = _calc_t_stat(mean_b, std_b, n)
     p = _p_value_from_t(t, n)
 
+    metadata: dict[str, object] = {
+        "stat_type": "t",
+        "h0": "mean(β)=0",
+        "method": "cross-sectional t-test on per-asset TS betas",
+        "n_assets": n,
+        "beta_std": std_b,
+        "median_beta": float(np.median(betas)),
+    }
+    warning_codes: list[str] = []
+    _surface_drop_stats(ts_betas_df, "ts_beta", metadata, warning_codes, axis="assets")
     return MetricResult(
         p_value=p,
         value=mean_b,
         stat=t,
-        metadata={
-            "stat_type": "t",
-            "h0": "mean(β)=0",
-            "method": "cross-sectional t-test on per-asset TS betas",
-            "n_assets": n,
-            "beta_std": std_b,
-            "median_beta": float(np.median(betas)),
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 
@@ -235,14 +239,20 @@ def mean_r_squared(ts_betas_df: pl.DataFrame) -> MetricResult:
     if sc is not None:
         return sc
 
+    metadata: dict[str, object] = {
+        "n_assets": n,
+        "median_r_squared": float(np.median(r2_vals)),
+        "min_r_squared": float(np.min(r2_vals)),
+        "max_r_squared": float(np.max(r2_vals)),
+    }
+    warning_codes: list[str] = []
+    _surface_drop_stats(
+        ts_betas_df, "mean_r_squared", metadata, warning_codes, axis="assets"
+    )
     return MetricResult(
         value=float(np.mean(r2_vals)),
-        metadata={
-            "n_assets": n,
-            "median_r_squared": float(np.median(r2_vals)),
-            "min_r_squared": float(np.min(r2_vals)),
-            "max_r_squared": float(np.max(r2_vals)),
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 
@@ -425,10 +435,16 @@ def ts_beta_sign_consistency(ts_betas_df: pl.DataFrame) -> MetricResult:
     positive = float(np.mean(betas > 0))
     consistency = max(positive, 1.0 - positive)
 
+    metadata: dict[str, object] = {
+        "n_assets": n,
+        "fraction_positive": positive,
+    }
+    warning_codes: list[str] = []
+    _surface_drop_stats(
+        ts_betas_df, "ts_beta_sign_consistency", metadata, warning_codes, axis="assets"
+    )
     return MetricResult(
         value=consistency,
-        metadata={
-            "n_assets": n,
-            "fraction_positive": positive,
-        },
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )

--- a/tests/test_drop_rate_warning_assets.py
+++ b/tests/test_drop_rate_warning_assets.py
@@ -1,0 +1,157 @@
+"""Aggregate drop-rate warning — assets axis (``compute_ts_betas``).
+
+``compute_ts_betas`` silently drops assets at its per-asset filter (insufficient
+history, zero factor variation, or no complete pairs). It records the canonical
+drop-stat schema on the assets axis (``n_assets_*`` / ``dropped_assets``); its
+three cross-asset consumers (``ts_beta`` / ``mean_r_squared`` /
+``ts_beta_sign_consistency``) copy the schema into ``MetricResult.metadata`` and
+emit one aggregate ``UserWarning`` (plus a ``WarningCode.EXCESSIVE_ASSET_DROPS``)
+when ``drop_rate`` clears the threshold. This is the assets-axis sibling of the
+periods-axis path in ``test_drop_rate_warning.py``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._codes import WarningCode
+from factrix.metrics._helpers import (
+    DROP_RATE_WARN_THRESHOLD,
+    _drop_stat_keys,
+    _read_drop_stats,
+)
+from factrix.metrics.ts_beta import (
+    compute_ts_betas,
+    mean_r_squared,
+    ts_beta,
+    ts_beta_sign_consistency,
+)
+
+_ASSET_KEYS = _drop_stat_keys("assets")
+_CONSUMERS = (ts_beta, mean_r_squared, ts_beta_sign_consistency)
+
+
+def _sparse_factor_panel(
+    *, n_assets: int = 40, survivors: int = 6, n_dates: int = 50, seed: int = 0
+) -> pl.DataFrame:
+    """Panel where only ``survivors`` assets carry a time-varying factor.
+
+    The remaining assets get a constant-zero factor → zero time-variation → null
+    slope → dropped by ``compute_ts_betas``. ``survivors`` clears the consumers'
+    ``min_assets`` floors while the drop rate (``1 - survivors/n_assets``) sits
+    well above ``DROP_RATE_WARN_THRESHOLD``.
+    """
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates, seed=seed)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=1)
+    keep = panel["asset_id"].unique().sort().gather(range(survivors))
+    return panel.with_columns(
+        pl.when(pl.col("asset_id").is_in(keep.implode()))
+        .then(pl.col("factor"))
+        .otherwise(0.0)
+        .alias("factor")
+    )
+
+
+def _full_panel(
+    *, n_assets: int = 40, n_dates: int = 50, seed: int = 0
+) -> pl.DataFrame:
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates, seed=seed)
+    return fx.preprocess.compute_forward_return(raw, forward_periods=1)
+
+
+class TestSchema:
+    def test_keys_are_canonical(self):
+        assert _ASSET_KEYS == (
+            "n_assets_in",
+            "n_assets_out",
+            "dropped_assets",
+            "drop_rate",
+            "drop_reason",
+        )
+
+    def test_compute_ts_betas_attaches_drop_stats(self):
+        stats = _read_drop_stats(compute_ts_betas(_sparse_factor_panel())["factor"])
+        assert stats is not None
+        assert set(stats) == set(_ASSET_KEYS)
+        # 40 assets in, 6 survive → 34 dropped for zero factor variation.
+        assert stats["n_assets_in"] == 40
+        assert stats["n_assets_out"] == 6
+        assert stats["dropped_assets"] == 34
+        assert stats["drop_rate"] == pytest.approx(34 / 40)
+        assert "MIN_TS_PERIODS" in stats["drop_reason"]
+
+    def test_full_panel_reports_zero_drop(self):
+        stats = _read_drop_stats(compute_ts_betas(_full_panel())["factor"])
+        assert stats is not None
+        assert stats["dropped_assets"] == 0
+        assert stats["drop_rate"] == 0.0
+
+    def test_hand_built_frame_has_no_stats(self):
+        bare = compute_ts_betas(_full_panel())["factor"].select("asset_id", "beta")
+        assert _read_drop_stats(bare) is None
+
+
+class TestConsumerWarning:
+    @pytest.mark.parametrize("metric_fn", _CONSUMERS)
+    def test_high_drop_rate_warns_and_codes(self, metric_fn):
+        betas_df = compute_ts_betas(_sparse_factor_panel())["factor"]
+        with pytest.warns(UserWarning, match="of assets dropped"):
+            result = metric_fn(betas_df)
+        assert WarningCode.EXCESSIVE_ASSET_DROPS.value in result.warning_codes
+        assert result.metadata["drop_rate"] > DROP_RATE_WARN_THRESHOLD
+        # Full five-key assets schema lands in metadata for inspection.
+        assert set(_ASSET_KEYS) <= set(result.metadata)
+
+    @pytest.mark.parametrize("metric_fn", _CONSUMERS)
+    def test_low_drop_rate_no_warn_but_keys_present(self, metric_fn):
+        betas_df = compute_ts_betas(_full_panel())["factor"]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = metric_fn(betas_df)
+        assert WarningCode.EXCESSIVE_ASSET_DROPS.value not in result.warning_codes
+        assert result.metadata["drop_rate"] == 0.0
+        assert set(_ASSET_KEYS) <= set(result.metadata)
+
+    def test_full_drop_defers_to_short_circuit(self):
+        # Every asset's factor is zeroed → all slopes null → empty betas frame →
+        # the consumer short-circuits and must NOT emit a drop-rate warning.
+        panel = _sparse_factor_panel(survivors=0)
+        betas_df = compute_ts_betas(panel)["factor"]
+        assert betas_df.height == 0
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = ts_beta(betas_df)
+        assert result.value != result.value  # NaN short-circuit
+        assert "reason" in result.metadata
+        assert WarningCode.EXCESSIVE_ASSET_DROPS.value not in result.warning_codes
+
+
+class TestEvaluateBoundary:
+    def test_evaluate_records_drop_warning(self):
+        panel = _sparse_factor_panel()
+        with pytest.warns(UserWarning, match="of assets dropped"):
+            results = fx.evaluate(
+                panel, metrics={"m": ts_beta()}, factor_cols=["factor"]
+            )
+        er = results["factor"]
+        codes = [w.code for w in er.warnings]
+        assert WarningCode.EXCESSIVE_ASSET_DROPS in codes
+        drop_warn = next(
+            w for w in er.warnings if w.code == WarningCode.EXCESSIVE_ASSET_DROPS
+        )
+        assert drop_warn.source == "m"
+
+    def test_direct_and_evaluate_metadata_parity(self):
+        panel = _sparse_factor_panel()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            direct = ts_beta(compute_ts_betas(panel)["factor"])
+            results = fx.evaluate(
+                panel, metrics={"m": ts_beta()}, factor_cols=["factor"]
+            )
+        via_eval = results["factor"].metrics["m"]
+        for key in _ASSET_KEYS:
+            assert direct.metadata[key] == via_eval.metadata[key]

--- a/tests/test_ts_betas.py
+++ b/tests/test_ts_betas.py
@@ -85,7 +85,8 @@ class TestComputeTSBetas:
 
     def test_output_schema(self):
         df = compute_ts_betas(_common_factor_panel(6, 50, seed=1))["factor"]
-        assert df.columns == _OUT_COLS
+        # Analysis columns, plus the broadcast assets-axis drop-stat carrier.
+        assert df.columns == [*_OUT_COLS, "_drop_stats"]
         assert df["asset_id"].is_sorted()
         assert df.schema["n_obs"] == pl.Int64
 


### PR DESCRIPTION
## Summary

- `compute_ts_betas` silently drops assets (insufficient history, zero factor variation, no complete pairs); its three cross-asset consumers now surface how much of the universe was lost, the assets-axis sibling of the existing period-axis drop-rate warning.
- Drop-stat helpers in `_helpers.py` are generalized from hardcoded `n_periods_*` to an `axis` token (`n_<axis>_in` / `dropped_<axis>`). Period callers default to `axis="periods"` → keys, message, and `WarningCode` are unchanged (regression-tested as non-breaking).
- New dimension-specific `WarningCode.EXCESSIVE_ASSET_DROPS` for the cross-section; the time axis keeps `EXCESSIVE_PERIOD_DROPS`. `_warn_if_high_drop_rate` selects the code by `axis`, so a reader resolves the dropped axis from the code alone.
- `compute_ts_betas` attaches the schema on the assets axis with `n_assets_in` measured against the **raw** universe (before the valid-pair filter); the three consumers (`ts_beta` / `mean_r_squared` / `ts_beta_sign_consistency`) merge it into `metadata` and emit one aggregate warning past `DROP_RATE_WARN_THRESHOLD`. A full drop defers to each metric's own short-circuit (no double-warn).

**Scope deviation from the issue:** `_surface_null_drop` (the SERIES→SCALAR null-drop path) is kept period-only rather than gaining an `axis` parameter. The ts_betas path uses the carrier path, not null-drop, and the EVENT axis is deferred — adding `axis` there now would be speculative and churn six callers for no current use.

Per the epic's doc-deferral convention, the `n_<axis>_*` keys are not yet added to `docs/reference/stat-keys-by-metric.md` (the period keys from the sibling work aren't either); doc prose is batched to the epic wrap-up.

## Test plan

- [x] `tests/test_drop_rate_warning_assets.py` (new, 13 cases): schema values, all three consumers warn + carry `EXCESSIVE_ASSET_DROPS`, low-drop no-warn-but-keys, full-drop short-circuit defer, `evaluate()` boundary + direct-call parity.
- [x] `tests/test_drop_rate_warning.py` / `_phase2.py` green — period-axis keys/message/code unchanged.
- [x] Full suite: 1301 passed, 4 skipped.
- [x] `ruff check`, `ruff format --check`, `mypy factrix` all clean.

Closes #594
