### PR TITLE
feat(metrics): declare dynamic sample thresholds via a hook

### DIFF
--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -82,6 +82,16 @@ class MetricBase(metaclass=MetricMeta):
     requires: ClassVar[dict[str, Any]]
     batchable: ClassVar[bool]
     sample_threshold: ClassVar[SampleThreshold]
+    # Optional dynamic-threshold hook. When a metric's floor is a function of
+    # its own parameters (e.g. ``ic``'s floor scales with ``forward_periods``),
+    # the static ``sample_threshold`` cannot express it. Such a metric supplies
+    # ``sample_threshold_for`` instead — it reads the configured params off the
+    # instance and returns a concrete :class:`SampleThreshold`. ``spec()``
+    # resolves it against a default-constructed instance so ``inspect_data``
+    # sees a real floor; ``None`` means the static ``sample_threshold`` holds.
+    sample_threshold_for: ClassVar[Callable[[MetricBase], SampleThreshold] | None] = (
+        None
+    )
 
     _impl: ClassVar[Callable]
     _first_param_name: ClassVar[str | None]
@@ -94,7 +104,20 @@ class MetricBase(metaclass=MetricMeta):
 
     @classmethod
     def spec(cls) -> MetricSpec:
-        """Dynamically build and return the MetricSpec for this metric."""
+        """Dynamically build and return the MetricSpec for this metric.
+
+        When the metric declares a dynamic ``sample_threshold_for`` hook, the
+        floor is resolved here against a default-constructed instance (its
+        params take their declared defaults) so the spec carries a concrete
+        :class:`SampleThreshold` for ``inspect_data`` rather than the empty
+        static placeholder. Static metrics keep ``cls.sample_threshold``.
+        """
+        threshold = cls.sample_threshold
+        hook = cls.sample_threshold_for
+        if hook is not None:
+            # Call the unbound hook with a default-built instance as ``self``;
+            # its configured param fields take their declared defaults.
+            threshold = hook(cls())
         return MetricSpec(
             name=cls.__name__,
             cell=cls.cell,
@@ -104,7 +127,7 @@ class MetricBase(metaclass=MetricMeta):
             role=cls.role,
             requires=cls.requires,
             batchable=cls.batchable,
-            sample_threshold=cls.sample_threshold,
+            sample_threshold=threshold,
         )
 
     def _params(self) -> dict[str, Any]:

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -111,6 +111,12 @@ class MetricBase(metaclass=MetricMeta):
         params take their declared defaults) so the spec carries a concrete
         :class:`SampleThreshold` for ``inspect_data`` rather than the empty
         static placeholder. Static metrics keep ``cls.sample_threshold``.
+
+        A metric declaring the hook must therefore be default-constructible —
+        every param other than the input frame needs a default. The resolved
+        floor reflects those defaults; ``inspect_data`` pre-flights the
+        default-config floor, while run-time enforcement uses the body's actual
+        params (the two share one computation, e.g. ``min_input_periods``).
         """
         threshold = cls.sample_threshold
         hook = cls.sample_threshold_for

--- a/factrix/metrics/_decorators.py
+++ b/factrix/metrics/_decorators.py
@@ -28,6 +28,7 @@ def metric(
     requires: dict[str, Any] | None = None,
     batchable: bool = False,
     sample_threshold: SampleThreshold | None = None,
+    sample_threshold_for: Callable[[Any], SampleThreshold] | None = None,
 ) -> Callable[[_F], _F]:
     """Decorator to define a Metric class from a function definition.
 
@@ -80,6 +81,10 @@ def metric(
             "requires": requires or {},
             "batchable": batchable,
             "sample_threshold": sample_threshold or SampleThreshold(),
+            # Plain function (not staticmethod) so it binds ``self`` — the hook
+            # reads the instance's configured param fields. ``None`` falls back
+            # to the inherited static ``sample_threshold``.
+            "sample_threshold_for": sample_threshold_for,
             "_impl": fn,
             "_first_param_name": first_param_name,
             "_param_names": tuple(f[0] for f in fields),

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -225,6 +225,12 @@ def _enforce_min_floor(
     the sample clears the floor (axis ungated → always ``None``). ``descriptive``
     and any extra keyword metadata are forwarded to
     :func:`_short_circuit_output`.
+
+    Reads the metric's *static* ``sample_threshold`` only; it does not resolve a
+    dynamic ``sample_threshold_for`` hook (it holds the metric class, not a
+    configured instance, so it cannot know the run-time params the dynamic floor
+    depends on). A metric whose floor is dynamic enforces it in its own body —
+    delegating to the same source the hook reads — rather than through here.
     """
     floor = getattr(metric.sample_threshold, f"min_{axis}")
     if floor is not None and n < floor:
@@ -256,6 +262,10 @@ def _warn_below_floor(
     when the floor is breached it emits ``message`` as a ``UserWarning`` and
     returns ``code.value`` for the caller to fold into the result's
     ``warning_codes``. Returns ``None`` when the warn floor is clear or ungated.
+
+    Like :func:`_enforce_min_floor`, reads the static ``sample_threshold`` only;
+    a dynamic ``sample_threshold_for`` hook is not resolved here, so dynamic-floor
+    metrics warn in-body.
     """
     warn = getattr(metric.sample_threshold, f"warn_{axis}")
     if warn is not None and n < warn:

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import math
 import warnings as _warnings
+from typing import Any
 
 import polars as pl
 
@@ -99,12 +100,23 @@ def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
     return med
 
 
+def _ic_sample_threshold(self: Any) -> SampleThreshold:
+    """Dynamic periods floor for ``ic``: the inference method's minimum input
+    length, which scales with ``forward_periods`` (non-overlapping stride) or
+    is a fixed HAC bound. Delegates to the same ``min_input_periods`` the
+    in-body short-circuit reads, so the pre-flight and run-time floors agree.
+    """
+    return SampleThreshold(
+        min_periods=self.inference.min_input_periods(self.forward_periods)
+    )
+
+
 @metric(
     cell=_IC_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     input_shape=InputShape.SERIES,
     requires={"ic_df": compute_ic},
-    sample_threshold=SampleThreshold(),
+    sample_threshold_for=_ic_sample_threshold,
 )
 def ic(
     ic_df: pl.DataFrame,
@@ -113,7 +125,9 @@ def ic(
 ) -> MetricResult:
     r"""Information coefficient (IC) mean significance: is mean IC significantly different from zero?
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on the forward_periods parameter.
+    The periods floor is dynamic — the minimum input length scales with the
+    forward_periods parameter and the inference method — so it is declared via
+    the sample_threshold_for hook rather than a static sample_threshold.
 
     Args:
         ic_df: Output of ``compute_ic()``.

--- a/tests/test_cross_type_invariants.py
+++ b/tests/test_cross_type_invariants.py
@@ -117,7 +117,13 @@ class TestSpecMirrorsClass:
         assert spec.role == cls.role
         assert spec.requires == cls.requires
         assert spec.batchable == cls.batchable
-        assert spec.sample_threshold == cls.sample_threshold
+        if cls.sample_threshold_for is None:
+            assert spec.sample_threshold == cls.sample_threshold
+        else:
+            # Dynamic floor: spec() resolves the hook against a default-built
+            # instance, so the spec carries a concrete threshold rather than
+            # the empty static placeholder.
+            assert spec.sample_threshold == cls().sample_threshold_for()
 
     @pytest.mark.parametrize("cls", _REGISTRY_CLASSES, ids=_REGISTRY_IDS)
     def test_metric_role_implies_scalar_output(self, cls: type[MetricBase]) -> None:

--- a/tests/test_dynamic_sample_threshold.py
+++ b/tests/test_dynamic_sample_threshold.py
@@ -1,0 +1,56 @@
+"""Dynamic sample-threshold hook.
+
+A metric whose floor is a function of its own parameters (e.g. ``ic``'s periods
+floor scales with ``forward_periods``) cannot express it as a static
+``SampleThreshold``. It declares ``sample_threshold_for`` instead; ``spec()``
+resolves the hook against a default-constructed instance so the spec carries a
+concrete floor and ``inspect_data`` can pre-flight it — previously these metrics
+declared an empty ``SampleThreshold()`` and hid the floor in the body.
+"""
+
+from __future__ import annotations
+
+import factrix as fx
+from factrix._inspect import DataInspection, inspect_data
+from factrix._types import MIN_IC_PERIODS
+from factrix.metrics._registry import REGISTRY
+from factrix.metrics.ic import ic
+
+
+def _by_name(info: DataInspection, name: str):
+    for m in info.metrics:
+        if m.spec.name == name:
+            return m
+    raise KeyError(name)
+
+
+class TestHookResolution:
+    def test_spec_resolves_dynamic_floor_from_default_params(self):
+        # ic default forward_periods=5, non-overlapping → MIN_IC_PERIODS * 5.
+        st = ic.spec().sample_threshold
+        assert st.min_periods == MIN_IC_PERIODS * 5
+
+    def test_hook_reflects_configured_params(self):
+        # The hook reads params off the instance, so a non-default
+        # forward_periods scales the floor.
+        inst = REGISTRY["ic"](forward_periods=10)
+        assert inst.sample_threshold_for().min_periods == MIN_IC_PERIODS * 10
+
+    def test_static_metric_keeps_empty_spec_threshold(self):
+        # A hookless metric resolves to its static (here empty) threshold.
+        assert REGISTRY["turnover"].sample_threshold_for is None
+        st = REGISTRY["turnover"].spec().sample_threshold
+        assert st.min_periods is None
+
+
+class TestInspectDataPreflight:
+    def test_dynamic_floor_gates_short_panel(self):
+        # forward_periods=5 default needs MIN_IC_PERIODS*5 = 50 input periods;
+        # 30 dates is short, so inspect_data now flags ic unusable — the floor
+        # that used to be invisible at pre-flight.
+        short = fx.datasets.make_cs_panel(n_assets=40, n_dates=30, seed=0)
+        assert _by_name(inspect_data(short), "ic").usable is False
+
+    def test_dynamic_floor_passes_long_panel(self):
+        long_panel = fx.datasets.make_cs_panel(n_assets=40, n_dates=120, seed=0)
+        assert _by_name(inspect_data(long_panel), "ic").usable is True

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -177,10 +177,10 @@ class TestSampleThresholdGate:
 
     def test_metric_without_sample_threshold_only_cell_checked(self):
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=15))
-        ic = _by_name(info, "ic")
-        # ic has empty sample_threshold declared (only cell match); cell matches, so usable
-        assert ic.usable is True
-        assert ic.warnings == []
+        turnover = _by_name(info, "turnover")
+        # turnover declares no sample_threshold (cell match only); cell matches, so usable
+        assert turnover.usable is True
+        assert turnover.warnings == []
 
 
 class TestDeclaredPeriodsFloorsVisible:


### PR DESCRIPTION
## Summary

- Metrics whose floor is a function of their params (e.g. `ic`'s periods floor scales with `forward_periods`) could only declare an empty `SampleThreshold()` and hand-write the floor in the body — so `inspect_data` (which reads `SampleThreshold.iter_verdicts`) couldn't pre-flight exactly the metrics that most need warning.
- New optional `sample_threshold_for(self) -> SampleThreshold` hook on `@metric`: it reads the configured params off the spec instance (the decorator already stores them as dataclass fields) and returns a concrete `SampleThreshold`. No `DataProperties` arg — every current dynamic floor is a function of params, not data.
- `MetricBase.spec()` resolves the hook against a default-built instance and fills `MetricSpec.sample_threshold`, so `inspect_data` pre-flights the dynamic floor **with zero change to its own logic**.
- `ic` migrated: its hook delegates to `inference.min_input_periods` — the same source the in-body short-circuit reads — so pre-flight and run-time floors share one computation (no parallel mechanism, no drift). The body's `raw_min` short-circuit is unchanged.

**Scope (confirmed during implementation):** this PR is the mechanism + `ic` only. The event-count metrics (`caar` / `mfe_mae` / `corrado_rank` / `event_quality`) gate on an **events axis** that `SampleThreshold._AXES = (periods, assets, pairs)` does not yet carry, so they can't be expressed as a `SampleThreshold` today — deferred to a follow-up gated on the events axis (per #585). `tradability`/`turnover` only validate `forward_periods >= 1` (no param-scaled short-circuit), so they're out of scope. Descriptive/structural empties (`clustering_hhi`, `spanning`, `event_horizon`) stay empty.

## Test plan

- [x] `tests/test_dynamic_sample_threshold.py` (new): hook resolves the floor from default params (`MIN_IC_PERIODS*5`), reflects non-default `forward_periods`, hookless metrics keep their static threshold; `inspect_data` flags `ic` unusable on a 30-date panel and usable on 120 dates.
- [x] `test_cross_type_invariants::test_spec_projects_classvars` updated — the spec-mirrors-class invariant now has a dynamic-hook branch.
- [x] `test_inspect_data::test_metric_without_sample_threshold_only_cell_checked` repointed from `ic` (now has a declared floor) to `turnover`.
- [x] Full suite: 1306 passed, 4 skipped.
- [x] `ruff check`, `ruff format --check`, `mypy factrix` all clean.

Closes #588
