### PR TITLE
feat(metrics): pre-flight event-axis sample floors (#597)

### DIFF
--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -131,6 +131,15 @@ class DataProperties:
             pair-counting metric (IC, rank-IC, FM cross-section).
             Equals ``data.height`` for a dense panel; smaller when
             the factor column has nulls.
+        n_events: Non-zero ``factor`` observation count — the event
+            sample size for event-driven metrics (CAAR, MFE/MAE,
+            corrado-rank, event-quality). Non-null AND non-zero cells,
+            matching those metrics' ``factor != 0`` event filter. For a
+            dense continuous factor this is ~``n_pairs`` (the event
+            axis only gates SPARSE-cell metrics). ``caar`` counts event
+            *dates* rather than rows, so its pre-flight reads this as a
+            loose upper bound; its in-body short-circuit on event dates
+            stays authoritative.
         sparse_ratio: Zero-ratio in the ``factor`` column (denominator
             is non-null cell count). ``math.nan`` for an empty data.
     """
@@ -144,6 +153,7 @@ class DataProperties:
     n_assets: int
     n_periods: int
     n_pairs: int
+    n_events: int
     sparse_ratio: float
 
 
@@ -451,11 +461,12 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     :class:`MetricApplicability` verdict combining (a) cell-match
     against the detected ``(scope, density, structure)`` and (b) the
     spec's optional :class:`SampleThreshold` against the data's
-    ``n_periods`` / ``n_assets``.
+    ``n_periods`` / ``n_assets`` / ``n_pairs`` / ``n_events``.
 
-    Sample-floor checks against ``n_events`` (factor-column-dependent)
-    are out of scope — those surface at evaluate time on the metric's
-    own short-circuit path.
+    The ``n_events`` floor is pre-flighted against the non-zero factor
+    count for event-driven metrics; a metric with a dynamic event floor
+    (``caar``) is pre-flighted at its default config, and its in-body
+    short-circuit on the actual run-time params stays authoritative.
 
     Args:
         data: Long-format factor data with the canonical columns.
@@ -509,6 +520,9 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     n_assets = int(data["asset_id"].n_unique())
     n_periods = int(data["date"].n_unique())
     n_pairs = int(data.drop_nulls(first_col).height)
+    # Event sample: non-zero factor cells (nulls compare false, so excluded),
+    # matching the ``factor != 0`` filter the event-driven metrics apply.
+    n_events = int(data.filter(pl.col(first_col) != 0).height)
 
     structure_reason = (
         f"n_assets={n_assets} → "
@@ -525,6 +539,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
         n_assets=n_assets,
         n_periods=n_periods,
         n_pairs=n_pairs,
+        n_events=n_events,
         sparse_ratio=sparse_ratio,
     )
 
@@ -611,6 +626,16 @@ def _evaluate_applicability(
                     warnings.append(
                         Warning(code=code, source=spec.name, message=code.description)
                     )
+            elif av.axis == "events":
+                # Event-thin degraded tier maps to the event-specific code,
+                # not the periods-flavored UNRELIABLE_SE_SHORT_PERIODS.
+                warnings.append(
+                    Warning(
+                        code=WarningCode.FEW_EVENTS,
+                        source=spec.name,
+                        message=f"n_{av.axis}={av.n} < warn_{av.axis}={av.warn}: inference degraded",
+                    )
+                )
             else:
                 warnings.append(
                     Warning(

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -177,8 +177,10 @@ class SampleThreshold:
     warn_assets: int | None = None
     min_pairs: int | None = None
     warn_pairs: int | None = None
+    min_events: int | None = None
+    warn_events: int | None = None
 
-    _AXES: ClassVar[tuple[str, ...]] = ("periods", "assets", "pairs")
+    _AXES: ClassVar[tuple[str, ...]] = ("periods", "assets", "pairs", "events")
 
     def __post_init__(self) -> None:
         for axis in self._AXES:
@@ -214,7 +216,7 @@ class SampleThreshold:
             yield AxisVerdict(axis=axis, n=n, floor=floor, warn=warn, tier=tier)
 
     def per_axis_verdict(self, properties: DataProperties) -> dict[str, Tier]:
-        """Return the usability tier for each shape axis (periods, assets, pairs)."""
+        """Return the usability tier for each shape axis (periods, assets, pairs, events)."""
         return {v.axis: v.tier for v in self.iter_verdicts(properties)}
 
     def verdict(self, properties: DataProperties) -> Tier:

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -22,6 +22,7 @@ References:
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 import numpy as np
 import polars as pl
@@ -49,6 +50,7 @@ from factrix._types import (
 )
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _enforce_min_floor,
     _sample_non_overlapping,
     _scaled_min_periods,
     _short_circuit_output,
@@ -71,12 +73,24 @@ _CAAR_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
 min_assets_per_group: int | None = None
 
 
+def _caar_sample_threshold(self: Any) -> SampleThreshold:
+    """Dynamic event floor for ``caar``: the raw event-date count scales with
+    ``forward_periods`` because the t-test runs on a non-overlap subsample
+    (stride ``forward_periods``). Delegates to the same ``_scaled_min_periods``
+    the in-body short-circuit reads, so pre-flight and run-time floors agree.
+    """
+    return SampleThreshold(
+        min_events=_scaled_min_periods(MIN_EVENTS_HARD, self.forward_periods),
+        warn_events=_scaled_min_periods(MIN_EVENTS_WARN, self.forward_periods),
+    )
+
+
 @metric(
     cell=_CAAR_CELL,
     aggregation=Aggregation.EVENT_TIME,
     input_shape=InputShape.SERIES,
     requires={"caar_df": compute_caar},
-    sample_threshold=SampleThreshold(),
+    sample_threshold_for=_caar_sample_threshold,
 )
 def caar(
     caar_df: pl.DataFrame,
@@ -85,7 +99,11 @@ def caar(
 ) -> MetricResult:
     r"""CAAR significance: is mean CAAR significantly different from zero?
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on the forward_periods parameter and are factor-context-dependent.
+    The event floor is dynamic — the minimum event-date count scales with the
+    forward_periods parameter (non-overlapping stride) — so it is declared via
+    the sample_threshold_for hook rather than a static sample_threshold. Pre-flight
+    counts non-zero factor rows as a loose upper bound; this in-body short-circuit
+    on event dates stays authoritative.
 
     Args:
         caar_df: Output of ``compute_caar()`` with columns ``date, caar``.
@@ -188,7 +206,7 @@ def caar(
 @metric(
     cell=_CAAR_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def bmp_test(
     df: pl.DataFrame,
@@ -202,7 +220,7 @@ def bmp_test(
 ) -> MetricResult:
     r"""Boehmer-Musumeci-Poulsen Standardized Abnormal Return test.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on the estimation_window parameter and are factor-context-dependent.
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the standardized-AR z-test on the count of events with a usable estimation-window volatility.
 
     Standardizes each event's abnormal return by the asset's pre-event
     residual volatility, making the test robust to event-induced variance
@@ -360,13 +378,11 @@ def bmp_test(
     )
 
     n_valid = len(valid)
-    if n_valid < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "bmp_test",
-            "insufficient_estimation_window",
-            n_obs=n_valid,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        bmp_test, "bmp_test", n_valid, "insufficient_estimation_window", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     valid = valid.with_columns(
         (pl.col("_signed_ar") / pl.col("_est_vol")).alias("_sar")

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -28,7 +28,7 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor
 
 __all__ = [
     "clustering_hhi",
@@ -38,7 +38,7 @@ __all__ = [
 @metric(
     cell=cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.CS_SNAPSHOT,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def clustering_hhi(
     df: pl.DataFrame,
@@ -48,7 +48,7 @@ def clustering_hhi(
 ) -> MetricResult:
     r"""Event clustering Herfindahl index on event dates.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because it is a descriptive diagnostic on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates this descriptive diagnostic on the count of non-zero (event) observations.
 
     Computes $\mathrm{HHI} = \sum_d s_d^2$ where
     $s_d = (\text{events on date } d) / (\text{total events})$. Herfindahl-Hirschman index (HHI)
@@ -91,13 +91,11 @@ def clustering_hhi(
     events = df.filter(pl.col(factor_col) != 0)
     n_events = len(events)
 
-    if n_events < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "clustering_hhi",
-            "insufficient_events",
-            n_obs=n_events,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        clustering_hhi, "clustering_hhi", n_events, "insufficient_events", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     # Count events per date
     per_date = events.group_by("date").agg(pl.len().alias("count"))

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -20,7 +20,7 @@ from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_z
 from factrix._types import EPSILON, MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
 
 __all__ = [
     "corrado_rank",
@@ -30,7 +30,7 @@ __all__ = [
 @metric(
     cell=cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.EVENT_TIME,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def corrado_rank(
     df: pl.DataFrame,
@@ -40,7 +40,7 @@ def corrado_rank(
 ) -> MetricResult:
     r"""Corrado nonparametric rank test for event abnormal returns.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the rank test on the count of non-zero (event) observations.
 
     A non-parametric alternative to the CAAR t-test. Robust to extreme
     returns, non-normal distributions, and cross-asset
@@ -112,13 +112,11 @@ def corrado_rank(
     events = ranked.filter(pl.col(factor_col) != 0)
     n_events = len(events)
 
-    if n_events < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "corrado_rank",
-            "insufficient_events",
-            n_obs=n_events,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        corrado_rank, "corrado_rank", n_events, "insufficient_events", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     u_event = events["_rank_u"].to_numpy() * np.sign(events[factor_col].to_numpy())
 

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -38,7 +38,11 @@ from factrix._stats import (
 )
 from factrix._types import EPSILON, MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output, _signed_car
+from factrix.metrics._helpers import (
+    _enforce_min_floor,
+    _short_circuit_output,
+    _signed_car,
+)
 
 __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
     "event_hit_rate",
@@ -54,7 +58,7 @@ _EQ_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def event_hit_rate(
     df: pl.DataFrame,
@@ -64,7 +68,7 @@ def event_hit_rate(
 ) -> MetricResult:
     r"""Fraction of events with return in expected direction.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the hit-rate binomial test on the count of non-zero (event) observations.
 
     Args:
         df: Panel with event density and forward return.
@@ -97,13 +101,11 @@ def event_hit_rate(
     events = df.filter(pl.col(factor_col) != 0)
 
     n = len(events)
-    if n < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "event_hit_rate",
-            "insufficient_events",
-            n_obs=n,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        event_hit_rate, "event_hit_rate", n, "insufficient_events", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     signed = _signed_car(events, factor_col, return_col)
     hits = int(np.sum(signed > 0))
@@ -135,7 +137,7 @@ def event_hit_rate(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def event_ic(
     df: pl.DataFrame,
@@ -145,7 +147,7 @@ def event_ic(
 ) -> MetricResult:
     r"""Spearman correlation between factor value and realised forward return.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the rank correlation on the count of non-zero (event) observations.
 
     Spearman correlation between ``|factor|`` and ``signed_car``
     (``return × sign(factor)``), computed only on event rows.
@@ -191,13 +193,11 @@ def event_ic(
     events = df.filter(pl.col(factor_col) != 0)
     n = len(events)
 
-    if n < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "event_ic",
-            "insufficient_events",
-            n_obs=n,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        event_ic, "event_ic", n, "insufficient_events", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     abs_signal = np.abs(events[factor_col].to_numpy())
 
@@ -235,7 +235,7 @@ def event_ic(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def profit_factor(
     df: pl.DataFrame,
@@ -245,7 +245,7 @@ def profit_factor(
 ) -> MetricResult:
     r"""Profit factor = sum(gains) / sum(|losses|) across events.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the ratio on the count of non-zero (event) observations.
 
     Per-event aggregate — no strategy assumptions. A profit factor > 1
     means gross gains exceed gross losses across all events.
@@ -282,13 +282,11 @@ def profit_factor(
     events = df.filter(pl.col(factor_col) != 0)
     n = len(events)
 
-    if n < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "profit_factor",
-            "insufficient_events",
-            n_obs=n,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        profit_factor, "profit_factor", n, "insufficient_events", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     signed = _signed_car(events, factor_col, return_col)
 
@@ -312,7 +310,7 @@ def profit_factor(
 @metric(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def event_skewness(
     df: pl.DataFrame,
@@ -322,7 +320,7 @@ def event_skewness(
 ) -> MetricResult:
     r"""Skewness of signed event return distribution.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the descriptive skewness on the count of non-zero (event) observations.
 
     Positive skew = occasional large gains, frequent small losses
     (desirable for event strategies). Uses scipy's Fisher skewness
@@ -365,13 +363,11 @@ def event_skewness(
     events = df.filter(pl.col(factor_col) != 0)
     n = len(events)
 
-    if n < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "event_skewness",
-            "insufficient_events",
-            n_obs=n,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        event_skewness, "event_skewness", n, "insufficient_events", axis="events"
+    )
+    if sc is not None:
+        return sc
 
     signed = _signed_car(events, factor_col, return_col)
 

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -30,7 +30,7 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import EPSILON, MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _short_circuit_output
+from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
 from factrix.metrics._primitives import compute_mfe_mae
 
 __all__ = [
@@ -45,12 +45,12 @@ _MFE_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
     aggregation=Aggregation.EVENT_TIME,
     input_shape=InputShape.SERIES,
     requires={"mfe_mae_df": compute_mfe_mae},
-    sample_threshold=SampleThreshold(),
+    sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def mfe_mae_summary(mfe_mae_df: pl.DataFrame) -> MetricResult:
     """Aggregate MFE/MAE statistics.
 
-    No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because the minimum required periods depend dynamically on event occurrence count (which is factor-context-dependent).
+    The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the summary on the per-event MFE/MAE count. Pre-flight reads the raw non-zero factor count as a loose upper bound.
 
     Reports MFE/MAE ratio as the primary value — higher is better
     (favorable excursion exceeds adverse excursion).
@@ -103,14 +103,17 @@ def mfe_mae_summary(mfe_mae_df: pl.DataFrame) -> MetricResult:
     mae = mfe_mae_df["mae"].drop_nulls().drop_nans()
 
     n_events = min(len(mfe), len(mae))
-    if n_events < MIN_EVENTS_HARD:
-        return _short_circuit_output(
-            "mfe_mae_summary",
-            "insufficient_events",
-            mfe_mae_ratio=float("nan"),
-            n_events=n_events,
-            min_required=MIN_EVENTS_HARD,
-        )
+    sc = _enforce_min_floor(
+        mfe_mae_summary,
+        "mfe_mae_summary",
+        n_events,
+        "insufficient_events",
+        axis="events",
+        mfe_mae_ratio=float("nan"),
+        n_events=n_events,
+    )
+    if sc is not None:
+        return sc
 
     mfe_p50 = float(mfe.quantile(0.50))  # type: ignore[arg-type]
     mae_p75 = float(mae.quantile(0.75))  # type: ignore[arg-type]

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -220,6 +220,92 @@ class TestDeclaredPeriodsFloorsVisible:
         assert st.warn_periods == MIN_PERIODS_WARN
 
 
+class TestDeclaredEventFloorsVisible:
+    """Event-driven metrics must declare their event floor on the spec so
+    ``inspect_data`` can pre-flight it — previously these enforced the floor in
+    the body while declaring an empty ``SampleThreshold()``, hiding it from the
+    pre-flight verdict.
+    """
+
+    def test_static_event_metrics_declare_min_events(self):
+        from factrix._types import MIN_EVENTS_HARD
+        from factrix.metrics.caar import bmp_test
+        from factrix.metrics.clustering_hhi import clustering_hhi
+        from factrix.metrics.corrado_rank import corrado_rank
+        from factrix.metrics.event_quality import (
+            event_hit_rate,
+            event_ic,
+            event_skewness,
+            profit_factor,
+        )
+        from factrix.metrics.mfe_mae import mfe_mae_summary
+
+        for m in (
+            corrado_rank,
+            clustering_hhi,
+            mfe_mae_summary,
+            bmp_test,
+            event_hit_rate,
+            event_ic,
+            profit_factor,
+            event_skewness,
+        ):
+            assert m.spec().sample_threshold.min_events == MIN_EVENTS_HARD
+
+    def test_caar_declares_scaled_event_floor(self):
+        from factrix._types import MIN_EVENTS_HARD, MIN_EVENTS_WARN
+        from factrix.metrics._helpers import _scaled_min_periods
+        from factrix.metrics.caar import caar
+
+        # Hook resolves against the default config (forward_periods=5).
+        st = caar.spec().sample_threshold
+        assert st.min_events == _scaled_min_periods(MIN_EVENTS_HARD, 5)
+        assert st.warn_events == _scaled_min_periods(MIN_EVENTS_WARN, 5)
+
+
+class TestEventAxisPreflight:
+    def _event_panel(self):
+        return fx.datasets.make_event_panel(n_assets=50, n_dates=400, seed=0)
+
+    def test_n_events_counts_nonzero_factor_rows(self):
+        import polars as pl
+
+        panel = self._event_panel()
+        info = inspect_data(panel)
+        assert info.detected.n_events == panel.filter(pl.col("factor") != 0).height
+
+    def test_below_min_events_is_unusable(self):
+        from dataclasses import replace
+
+        from factrix._inspect import _evaluate_applicability
+        from factrix._metric_index import SampleThreshold
+
+        info = inspect_data(self._event_panel())
+        floor = SampleThreshold(min_events=info.detected.n_events + 1)
+        spec = next(m.spec for m in info.metrics if m.spec.name == "corrado_rank")
+        verdict = _evaluate_applicability(
+            replace(spec, sample_threshold=floor), info.detected
+        )
+        assert verdict.usable is False
+        assert any("min_events" in b for b in verdict.blockers)
+
+    def test_between_min_and_warn_events_emits_few_events(self):
+        from dataclasses import replace
+
+        from factrix._inspect import _evaluate_applicability
+        from factrix._metric_index import SampleThreshold
+
+        info = inspect_data(self._event_panel())
+        n = info.detected.n_events
+        floor = SampleThreshold(min_events=n - 1, warn_events=n + 1)
+        spec = next(m.spec for m in info.metrics if m.spec.name == "corrado_rank")
+        verdict = _evaluate_applicability(
+            replace(spec, sample_threshold=floor), info.detected
+        )
+        assert verdict.usable is True
+        assert "few_events" in [w.code.value for w in verdict.warnings]
+
+
 class TestTierPartition:
     def test_three_tiers_partition_metrics_disjointly(self):
         # n_dates=25 puts ic_ir between min and warn -> degraded.

--- a/tests/test_metric_index.py
+++ b/tests/test_metric_index.py
@@ -68,12 +68,14 @@ class TestSampleThresholdHelpers:
             n_periods=30,
             n_assets=15,
             n_pairs=50,
+            n_events=50,
             sparse_ratio=0.0,
         )
         assert st.per_axis_verdict(props_clean) == {
             "periods": Tier.CLEAN,
             "assets": Tier.CLEAN,
             "pairs": Tier.CLEAN,
+            "events": Tier.CLEAN,
         }
         assert st.verdict(props_clean) is Tier.CLEAN
 
@@ -87,12 +89,14 @@ class TestSampleThresholdHelpers:
             n_periods=20,
             n_assets=15,
             n_pairs=50,
+            n_events=50,
             sparse_ratio=0.0,
         )
         assert st.per_axis_verdict(props_degraded) == {
             "periods": Tier.DEGRADED,
             "assets": Tier.CLEAN,
             "pairs": Tier.CLEAN,
+            "events": Tier.CLEAN,
         }
         assert st.verdict(props_degraded) is Tier.DEGRADED
 
@@ -106,12 +110,14 @@ class TestSampleThresholdHelpers:
             n_periods=20,
             n_assets=4,
             n_pairs=50,
+            n_events=50,
             sparse_ratio=0.0,
         )
         assert st.per_axis_verdict(props_unusable) == {
             "periods": Tier.DEGRADED,
             "assets": Tier.UNUSABLE,
             "pairs": Tier.CLEAN,
+            "events": Tier.CLEAN,
         }
         assert st.verdict(props_unusable) is Tier.UNUSABLE
 
@@ -120,8 +126,31 @@ class TestSampleThresholdHelpers:
             "periods": Tier.CLEAN,
             "assets": Tier.CLEAN,
             "pairs": Tier.CLEAN,
+            "events": Tier.CLEAN,
         }
         assert st_empty.verdict(props_unusable) is Tier.CLEAN
+
+    def test_events_axis_tiers(self) -> None:
+        st = SampleThreshold(min_events=4, warn_events=30)
+
+        def _props(n_events: int) -> DataProperties:
+            return DataProperties(
+                scope=FactorScope.INDIVIDUAL,
+                scope_reason="",
+                density=FactorDensity.SPARSE,
+                density_reason="",
+                structure=DataStructure.PANEL,
+                structure_reason="",
+                n_periods=100,
+                n_assets=50,
+                n_pairs=100,
+                n_events=n_events,
+                sparse_ratio=0.9,
+            )
+
+        assert st.per_axis_verdict(_props(3))["events"] is Tier.UNUSABLE
+        assert st.per_axis_verdict(_props(10))["events"] is Tier.DEGRADED
+        assert st.per_axis_verdict(_props(50))["events"] is Tier.CLEAN
 
 
 class TestDefaults:


### PR DESCRIPTION
## Summary
- Add an events axis to `SampleThreshold` (`min_events` / `warn_events`) and expose `n_events` (non-zero factor observations) on `DataProperties`, so `inspect_data` can pre-flight the event-count floors that the event-driven metrics previously enforced only in-body behind an empty `SampleThreshold()`.
- Static-floor metrics (`corrado_rank`, `clustering_hhi`, `mfe_mae_summary`, `bmp_test`, `event_hit_rate`, `event_ic`, `profit_factor`, `event_skewness`) declare `SampleThreshold(min_events=MIN_EVENTS_HARD)` and reuse `_enforce_min_floor(axis="events")` — declared floor and body short-circuit single-sourced on the same constant, no parallel mechanism.
- `caar`'s floor scales with `forward_periods`, so it uses the dynamic `sample_threshold_for` hook delegating to the same `_scaled_min_periods` the body reads; its pre-flight reads `n_events` as a loose upper bound while the in-body short-circuit on event dates stays authoritative.
- Events DEGRADED tier maps to the event-specific `FEW_EVENTS` code, not the periods-flavored `UNRELIABLE_SE_SHORT_PERIODS`.

## Design notes
- Only `caar` is genuinely dynamic, so it is the only metric using the hook; the rest gate on a constant and use the existing static-threshold + helper path (matches `ic_ir` / `hit_rate` / `ts_beta`). This keeps the migration consistent with the `#588` hook contract (hook is for dynamic floors).
- Single `events` axis = non-zero factor observations; no separate `event_dates` axis for the one metric (`caar`) that counts dates — the granularity gap is absorbed by the documented loose-upper-bound pre-flight.
- `signal_density` keeps its in-body `>= 2` degeneracy guard (a different floor than the statistical `MIN_EVENTS_HARD`), like other degeneracy guards (e.g. corrado's `std_u < EPSILON`).

## Test plan
- [x] `pytest` — 1312 passed, 4 skipped (+6 new event-axis pre-flight / tier tests)
- [x] `ruff check` / `ruff format --check` / `mypy factrix` — clean

Closes #597