### PR TITLE
feat(metrics): surface ic's thin-sample inference warning (#582)

### DIFF
--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -119,6 +119,15 @@ the advantage of exact rather than asymptotic-Gaussian inference at
 the cost of a factor of `h` in effective sample size; users with long
 panels often prefer NW.
 
+When the non-overlapping effective sample (`n / forward_periods`) is
+thin, `ic` surfaces `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` on the
+returned result — the post-stride series is too short for a reliable
+`t`. Switching to `ic(inference=fx.inference.NEWEY_WEST)` keeps every
+observation and recovers test power in that regime. The guidance is
+one-directional: a thin non-overlapping sample is a reason to move to
+NW, but an ample sample is **not** a reason to move back — both methods
+are valid there and `ic` never changes the method for you.
+
 ### NW vs HH-1980 vs Hodrick-1992 — when to use which
 
 The three procedures all target overlap-induced SE distortion but at

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -160,6 +160,20 @@ def ic(
         returns carry MA(K-1) autocorrelation — the motivation for the
         non-overlap stride used here.
 
+    Method selection:
+        The default ``NON_OVERLAPPING`` path tests on roughly
+        ``n / forward_periods`` effective observations; when that
+        post-stride sample is thin it emits
+        ``WarningCode.UNRELIABLE_SE_SHORT_PERIODS`` (now surfaced on the
+        returned result's ``warning_codes``). ``NEWEY_WEST`` keeps every
+        observation and absorbs the overlap-induced autocorrelation in the
+        HAC standard error, so on a thin series it retains more test power.
+        The guidance is one-directional: prefer ``NEWEY_WEST`` when the
+        non-overlapping effective sample is too thin; there is no symmetric
+        reason to switch back to non-overlapping once the sample is ample.
+        ``ic`` never changes ``inference`` for you — the choice stays
+        explicit.
+
     Examples:
         Chain from :func:`compute_ic` output:
 
@@ -215,6 +229,12 @@ def ic(
     }
     warning_codes: list[str] = []
     _surface_drop_stats(ic_df, "ic", metadata, warning_codes)
+    # Surface the inference method's own soft-floor signals (e.g. a thin
+    # post-stride sample tripping UNRELIABLE_SE_SHORT_PERIODS); de-dup so a
+    # code already raised by the drop-stats pass is not repeated.
+    for code in result.warnings:
+        if code.value not in warning_codes:
+            warning_codes.append(code.value)
     return MetricResult(
         p_value=result.p_value,
         value=mean_ic,

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -246,6 +246,54 @@ class TestICIR:
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in result.warning_codes
 
 
+class TestICInferenceWarningPropagation:
+    """``ic()`` must surface the inference method's own thin-sample warning
+    (``UNRELIABLE_SE_SHORT_PERIODS``) on the returned result — previously the
+    ``InferenceResult.warnings`` were consumed for the stat but never folded
+    into ``MetricResult.warning_codes``.
+    """
+
+    @staticmethod
+    def _ic_series(n: int) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)],
+                "ic": [0.05 + 0.01 * (i % 3) for i in range(n)],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_thin_non_overlap_surfaces_warning(self):
+        from factrix._codes import WarningCode
+
+        # forward_periods=1 => n_sampled == n == 25: clears MIN_IC_PERIODS (10)
+        # so no short-circuit, but below MIN_PERIODS_WARN (30) so the
+        # non-overlapping inference flags UNRELIABLE_SE_SHORT_PERIODS.
+        result = ic(self._ic_series(25), forward_periods=1)
+        assert not math.isnan(result.value)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in result.warning_codes
+
+    def test_ample_sample_no_warning(self):
+        from factrix._codes import WarningCode
+
+        result = ic(self._ic_series(40), forward_periods=1)
+        assert not math.isnan(result.value)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in result.warning_codes
+
+    def test_boundary_at_warn_floor(self):
+        from factrix._codes import WarningCode
+
+        # n_sampled == MIN_PERIODS_WARN (30) is the first clean count (strict <).
+        clean = ic(self._ic_series(30), forward_periods=1)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in clean.warning_codes
+        # One observation below the floor still warns.
+        warned = ic(self._ic_series(29), forward_periods=1)
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in warned.warning_codes
+
+    def test_surfaced_codes_are_deduplicated(self):
+        result = ic(self._ic_series(25), forward_periods=1)
+        assert len(result.warning_codes) == len(set(result.warning_codes))
+
+
 class TestICDispatch:
     """``ic()`` delegates its significance test to ``NonOverlappingSample``.
 


### PR DESCRIPTION
## Summary
- `ic()` consumed `InferenceResult.stat` / `p_value` but dropped `result.warnings`, so the non-overlapping path's `UNRELIABLE_SE_SHORT_PERIODS` (raised when the post-stride sample `n / forward_periods` is thin) never reached the returned `MetricResult`. Fold `result.warnings` into `warning_codes`, de-duplicated against codes already raised by the drop-stats pass.
- Add one-directional method-selection guidance to the `ic` docstring and `docs/reference/statistical-methods.md`: a thin non-overlapping effective sample is a reason to switch to `NEWEY_WEST` (keeps every observation); an ample sample is not a reason to switch back.

## Scope guardrails (per the issue's settled solution)
- **No new `WarningCode`** — reuses the existing `UNRELIABLE_SE_SHORT_PERIODS`, which was already produced by the inference layer and only lacked propagation.
- **No silent method switch** — `ic()` never changes `inference` based on sample size; the guidance is documentation only.
- Propagation gap was specific to `ic()`; `ic_ir` already surfaces its own warning via `_warn_below_floor`.

## Test plan
- [x] `pytest` — 1316 passed, 4 skipped (+4 new tests: thin sample surfaces the code, ample sample does not, the `n_sampled == MIN_PERIODS_WARN` boundary, and code de-duplication)
- [x] `ruff check` / `ruff format --check` / `mypy factrix` — clean

Closes #582