### PR TITLE
feat(preprocess): publicize remaining preprocess helpers

### DIFF
--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -2,8 +2,34 @@
 title: factrix.preprocess
 ---
 
-Helpers for attaching `forward_return` to a raw panel. The output
-panel — `(date, asset_id, factor, forward_return)` — is the canonical
-input to [`evaluate`](evaluate.md).
+Helpers for shaping a raw panel before [`evaluate`](evaluate.md). The
+canonical entry point, `compute_forward_return`, attaches a
+`forward_return` column to a raw `(date, asset_id, price)` panel — the
+output `(date, asset_id, factor, forward_return)` panel is the canonical
+input to `evaluate`.
+
+The surrounding helpers cover the rest of the documented preprocessing
+pipeline and are independently usable on a canonical panel: return
+cleaning (`winsorize_forward_return`, `compute_abnormal_return`), factor
+normalization (`mad_winsorize`, `cross_sectional_zscore`), and
+orthogonalization against base factors (`orthogonalize_factor`).
+
+## Forward return
 
 ::: factrix.preprocess.compute_forward_return
+
+::: factrix.preprocess.winsorize_forward_return
+
+::: factrix.preprocess.compute_abnormal_return
+
+## Factor normalization
+
+::: factrix.preprocess.mad_winsorize
+
+::: factrix.preprocess.cross_sectional_zscore
+
+## Orthogonalization
+
+::: factrix.preprocess.orthogonalize_factor
+
+::: factrix.preprocess.OrthogonalizeResult

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -182,17 +182,6 @@ dispatch routes sparse signals to event-study procedures (`caar`,
 `ts_beta` on dummies). See [Concepts](../getting-started/concepts.md)
 for the contract.
 
-## Helpers not yet public
-
-`factrix.preprocess` currently re-exports only `compute_forward_return`.
-Submodule code under `factrix/preprocess/` carries normalization
-(`mad_winsorize`, `cross_sectional_zscore`), forward-return cleaning
-(`winsorize_forward_return`, `compute_abnormal_return`), and
-orthogonalization (`orthogonalize_factor`); publicization is tracked
-under [#323](https://github.com/awwesomeman/factrix/issues/323). Until
-then, treat the submodule paths as internal — they may be renamed or
-re-shaped before they land in `__all__`.
-
 ## See also
 
 - [Panel schema](../api/panel-schema.md) — column-level four-column contract and dtype rules.

--- a/factrix/preprocess/__init__.py
+++ b/factrix/preprocess/__init__.py
@@ -1,11 +1,34 @@
-"""Preprocessing helpers for attaching ``forward_return`` to a raw panel.
+"""Preprocessing helpers for shaping a raw panel before :func:`factrix.evaluate`.
 
-The public entry point is :func:`compute_forward_return`: given a raw
+The canonical entry point is :func:`compute_forward_return`: given a raw
 ``(date, asset_id, price)`` panel, it returns the same panel with a
 ``forward_return`` column attached, which is the canonical input to
 :func:`factrix.evaluate`.
+
+The surrounding helpers cover the rest of the documented preprocessing
+pipeline and are independently usable on a canonical panel:
+
+- :func:`winsorize_forward_return` — per-date percentile clip of returns.
+- :func:`compute_abnormal_return` — cross-sectional de-meaning of returns.
+- :func:`mad_winsorize` — per-date MAD-based factor outlier clipping.
+- :func:`cross_sectional_zscore` — MAD-robust factor standardization.
+- :func:`orthogonalize_factor` — residualize a factor against base factors.
 """
 
-from factrix.preprocess.returns import compute_forward_return
+from factrix.preprocess.normalize import cross_sectional_zscore, mad_winsorize
+from factrix.preprocess.orthogonalize import OrthogonalizeResult, orthogonalize_factor
+from factrix.preprocess.returns import (
+    compute_abnormal_return,
+    compute_forward_return,
+    winsorize_forward_return,
+)
 
-__all__ = ["compute_forward_return"]
+__all__ = [
+    "OrthogonalizeResult",
+    "compute_abnormal_return",
+    "compute_forward_return",
+    "cross_sectional_zscore",
+    "mad_winsorize",
+    "orthogonalize_factor",
+    "winsorize_forward_return",
+]

--- a/factrix/preprocess/normalize.py
+++ b/factrix/preprocess/normalize.py
@@ -39,6 +39,16 @@ def mad_winsorize(
 
     Returns:
         DataFrame with ``factor_col`` clipped in-place.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import mad_winsorize
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> clipped = mad_winsorize(raw, n_mad=3.0)
+        >>> clipped.columns == raw.columns
+        True
+        >>> clipped.height == raw.height
+        True
     """
     if n_mad <= 0:
         return df
@@ -63,6 +73,14 @@ def cross_sectional_zscore(
 
     Returns:
         DataFrame with ``factor_zscore`` column appended.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import cross_sectional_zscore
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> standardized = cross_sectional_zscore(raw)
+        >>> "factor_zscore" in standardized.columns
+        True
     """
     median_expr, mad_expr = _mad_expressions(factor_col)
 

--- a/factrix/preprocess/orthogonalize.py
+++ b/factrix/preprocess/orthogonalize.py
@@ -53,11 +53,30 @@ def orthogonalize_factor(
             If None, uses all columns except ``date`` and ``asset_id``.
 
     Returns:
-        OrthogonalizeResult with:
-        - ``df``: factor_df with ``factor_col`` replaced by residual,
-          ``factor_pre_ortho`` preserving original value.
-        - ``mean_betas``: average beta per base factor across dates.
-        - ``mean_r_squared``: average R² across dates.
+        OrthogonalizeResult with: ``df`` (factor_df with ``factor_col``
+        replaced by the residual and ``factor_pre_ortho`` preserving the
+        original value), ``mean_betas`` (average beta per base factor
+        across dates), and ``mean_r_squared`` (average R² across dates).
+
+    Examples:
+        >>> import factrix as fx
+        >>> import polars as pl
+        >>> from factrix.preprocess import (
+        ...     cross_sectional_zscore,
+        ...     orthogonalize_factor,
+        ... )
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> factor_df = cross_sectional_zscore(raw).select(
+        ...     "date", "asset_id", pl.col("factor_zscore").alias("factor")
+        ... )
+        >>> base = raw.with_columns(
+        ...     pl.col("price").rank().over("date").alias("size")
+        ... ).select("date", "asset_id", "size")
+        >>> result = orthogonalize_factor(factor_df, base, base_cols=["size"])
+        >>> "factor_pre_ortho" in result.df.columns
+        True
+        >>> isinstance(result.mean_r_squared, float)
+        True
     """
     if base_cols is None:
         base_cols = [c for c in base_factors.columns if c not in ("date", "asset_id")]

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -141,6 +141,20 @@ def winsorize_forward_return(
 
     Returns:
         DataFrame with ``forward_return`` clipped in-place.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import (
+        ...     compute_forward_return,
+        ...     winsorize_forward_return,
+        ... )
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> clipped = winsorize_forward_return(panel, lower=0.01, upper=0.99)
+        >>> clipped.height == panel.height
+        True
+        >>> clipped["forward_return"].max() <= panel["forward_return"].max()
+        True
     """
     if lower <= 0.0 and upper >= 1.0:
         return df
@@ -160,6 +174,18 @@ def compute_abnormal_return(df: pl.DataFrame) -> pl.DataFrame:
 
     Returns:
         DataFrame with ``abnormal_return`` column appended.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.preprocess import (
+        ...     compute_abnormal_return,
+        ...     compute_forward_return,
+        ... )
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> panel = compute_forward_return(raw, forward_periods=5)
+        >>> adjusted = compute_abnormal_return(panel)
+        >>> "abnormal_return" in adjusted.columns
+        True
     """
     return df.with_columns(
         (pl.col("forward_return") - pl.col("forward_return").mean().over("date")).alias(


### PR DESCRIPTION
## Summary

Resolves the publicize/keep-private decision deferred for the five
`factrix/preprocess/` helpers: **all five are publicized**. They already
formed the documented Step 1–6 pipeline and were referenced from the
data-prep guide, while only `compute_forward_return` was exported.

- Added to `factrix.preprocess.__all__`: `winsorize_forward_return`,
  `compute_abnormal_return`, `mad_winsorize`, `cross_sectional_zscore`,
  `orthogonalize_factor`, plus the `OrthogonalizeResult` return type
  (mirrors `multi_factor.__all__`, which exports `BhyResult` alongside
  its functions).
- Each helper gained an `Examples:` block following the existing doctest
  convention (`>>>`, call-shape assertions, self-contained `fx.datasets`
  setup, Examples last).
- `docs/api/preprocess.md` renders each helper under grouped sections;
  module prose broadened beyond forward-return attachment.
- Removed the now-false "Helpers not yet public" section from the
  data-prep guide (it also carried an issue link).
- Reworded `orthogonalize_factor`'s `Returns:` block to one line so
  `mkdocs build --strict` no longer warns on the list continuation now
  that the symbol is rendered.

## Test plan

- [x] `pytest --doctest-modules factrix/preprocess/` — 6 passed.
- [x] `pytest` full suite — 1317 passed, 4 skipped.
- [x] `mkdocs build --strict` — no new warnings (only the pre-existing
  `api/estimators.md` nav warning, unchanged from main).
- [x] `ruff check` / `ruff format --check` / `mypy factrix` — clean.

Closes #323
