### PR TITLE
docs: drop dangling references to removed refactor_api.md

### DIFF
--- a/factrix/_axis.py
+++ b/factrix/_axis.py
@@ -1,4 +1,4 @@
-"""v0.5 analysis-axis enums (§4.1 of refactor_api.md).
+"""Analysis-axis enums.
 
 Two orthogonal user-facing axes describe an analysis cell:
 

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -1,7 +1,7 @@
 """TIMESERIES sample-size thresholds and Newey-West Bartlett bandwidth.
 
-Centralised per refactor_api.md §5.2 (A3): no literal ``20`` / ``30`` /
-``floor(4 * (T/100)**(2/9))`` may appear elsewhere in factrix.
+Single source of truth for the sample-size floors: no literal ``20`` /
+``30`` / ``floor(4 * (T/100)**(2/9))`` may appear elsewhere in factrix.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`refactor_api.md` was removed from the repo, but two module docstrings
still cited it as a source for design decisions, leaving dangling
references:

- `factrix/_stats/constants.py` — reworded the centralization rule to
  stand on its own ("single source of truth … no literal may appear
  elsewhere") without citing the deleted plan doc.
- `factrix/_axis.py` — dropped the `§4.1 of refactor_api.md` citation
  (and the stale `v0.5` version tag) from the module docstring.

Docstring-only; no behavior change.

## Test plan

- [x] `grep -rn refactor_api factrix/ tests/` — no remaining references (archive excluded).
- [x] `ruff check` / `ruff format --check` / `mypy` on touched files — clean.
- [x] Imports of both modules resolve.
