### PR TITLE
refactor(metrics): rename sample-size identifiers to the axis-token grammar

### DIFF
--- a/docs/api/metrics/directional_hit_rate.md
+++ b/docs/api/metrics/directional_hit_rate.md
@@ -94,7 +94,7 @@ title: factrix.metrics.directional_hit_rate
     ---
 
     When this metric applies and the sample-size guard that gates it
-    (`MIN_ASSETS_PER_DATE_IC` floor on the non-overlapping pooled signs).
+    (`MIN_IC_ASSETS` floor on the non-overlapping pooled signs).
 
     [reference/metric-applicability →](../../reference/metric-applicability.md)
 

--- a/docs/api/metrics/hit_rate.md
+++ b/docs/api/metrics/hit_rate.md
@@ -121,7 +121,7 @@ title: factrix.metrics.hit_rate
     ---
 
     When this metric applies and the sample-size guards that gate it
-    (`MIN_ASSETS_PER_DATE_IC` floor on the sampled series).
+    (`MIN_IC_ASSETS` floor on the sampled series).
 
     [reference/metric-applicability →](../../reference/metric-applicability.md)
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -212,10 +212,9 @@ Four layers, one grammar:
   constant even when the calibrated value coincides with an `_ASSETS` one.
 - **Warning codes** (`factrix/_codes.py`) carry the same axis token so the
   degraded axis is legible from the code alone:
-  `UNRELIABLE_SE_SHORT_PERIODS`, `FEW_EVENTS`, `BORDERLINE_PORTFOLIO_PERIODS`,
-  `SPARSE_COMMON_FEW_EVENTS`, and the axis-specific drop pair
-  `EXCESSIVE_PERIOD_DROPS` / `EXCESSIVE_ASSET_DROPS`. (`CROSS_SECTION_N`
-  predates this rule and still uses the neutral `_N`.)
+  `UNRELIABLE_SE_SHORT_PERIODS`, `FEW_EVENTS`, `FEW_ASSETS`,
+  `BORDERLINE_PORTFOLIO_PERIODS`, `SPARSE_COMMON_FEW_EVENTS`, and the
+  axis-specific drop pair `EXCESSIVE_PERIOD_DROPS` / `EXCESSIVE_ASSET_DROPS`.
 
 Silent-drop diagnostics emit a fixed per-axis metadata schema
 (`factrix/metrics/_helpers.py`): `n_<axis>_in`, `n_<axis>_out`,
@@ -238,7 +237,7 @@ axis token, the rate keys are axis-neutral.
 `factrix/_types.py` and the metric primitives keep the older per-metric thresholds used
 internally by the primitives that procedures wrap:
 
-- `MIN_ASSETS_PER_DATE_IC = 10` — `compute_ic` drops dates with fewer than 10 assets;
+- `MIN_IC_ASSETS = 10` — `compute_ic` drops dates with fewer than 10 assets;
   at `n_assets` < 10 the IC procedure short-circuits to NaN because every date is dropped.
 - `MIN_EVENTS_HARD = 4`, `MIN_EVENTS_WARN = 30` — two-tier sparse-cell
   event-count floor. `n < HARD` short-circuits the CAAR / event-quality
@@ -386,7 +385,7 @@ per-date Spearman across n_assets         (cross-section step)
 
 Failure modes:
 
-- `n_assets` < 10 → `MIN_ASSETS_PER_DATE_IC` drops every date → output is NaN.
+- `n_assets` < 10 → `MIN_IC_ASSETS` drops every date → output is NaN.
 
 ### `individual_continuous(FM)` — cross-section first
 
@@ -451,7 +450,7 @@ per-asset OLS R_i = α_i + β_i·F over all n_periods dates   (time-series step)
 Failure modes:
 
 - per-asset `n_periods < MIN_TS_OBS = 20` → asset dropped.
-- `n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.CROSS_SECTION_N` (still runs; severity scales with `n_assets`).
+- `n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.FEW_ASSETS` (still runs; severity scales with `n_assets`).
 - `n_assets = 1` → degenerate cross-asset test → mode auto-routed to
   TIMESERIES single-series β test (null: β = 0, **not** E[β] = 0). The
   statistic lands in the same `MetricResult.stat` field across both
@@ -479,7 +478,7 @@ Failure modes:
 
 - per-asset `n_periods < MIN_TS_OBS = 20` → asset dropped.
 - `n_assets` cross-section guard same as `common_continuous` (single
-  `CROSS_SECTION_N`; severity from `n_assets` metadata).
+  `FEW_ASSETS`; severity from `n_assets` metadata).
 - Two-tier event-count guard (`factrix/_stats/constants.py`):
   `n_events < MIN_BROADCAST_EVENTS_HARD = 5` raises `InsufficientSampleError`;
   `5 ≤ n_events < MIN_BROADCAST_EVENTS_WARN = 20` emits
@@ -660,7 +659,7 @@ factrix/
 ├── adapt.py                 # column-name adapter → factrix canonical names
 ├── _logging.py              # shared loggers
 ├── _ols.py                  # shared OLS helpers (spanning metrics + orthogonalize preprocess)
-├── _types.py                # shared constants: EPSILON, DDOF, MIN_ASSETS_PER_DATE_IC,
+├── _types.py                # shared constants: EPSILON, DDOF, MIN_IC_ASSETS,
 │                            #   MIN_EVENTS_HARD/WARN, MIN_OOS_PERIODS, MIN_PORTFOLIO_PERIODS_HARD/WARN, ...
 ├── _stats/                  # numerics: hac, bootstrap, unit_root, wald, gmm, ols, diagnostics, constants
 ├── stats/                   # public estimator surface (newey_west, hansen_hodrick, driscoll_kraay, gmm, ...)

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -17,7 +17,7 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 | Axis | Hard block | Soft warning | Clean |
 |---|---|---|---|
 | `n_periods` (T) | T < 20 → `InsufficientSampleError` | 20 ≤ T < 30 → `UNRELIABLE_SE_SHORT_PERIODS` | T ≥ 30 |
-| `n_assets` (N) | none | N < 30 → `CROSS_SECTION_N` (severity scales with N) | N ≥ 30 |
+| `n_assets` (N) | none | N < 30 → `FEW_ASSETS` (severity scales with N) | N ≥ 30 |
 
 `n_assets` is never hard-blocked because the cross-asset t-test on E[β] is mathematically well-defined for N ≥ 2 — only its statistical power degrades. A hard block would force users to choose between "can't run" and "don't know there's a problem"; the warning provides the result while surfacing the issue.
 
@@ -25,9 +25,9 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 
 | Density / Scope | N=1 | N=2..9 | N=10..29 | N≥30 |
 |---|---|---|---|---|
-| `INDIVIDUAL` × `DENSE` (IC) | raises `UserInputError` or `IncompatibleAxisError` | all dates dropped (MIN_ASSETS_PER_DATE_IC=10) → NaN | normal PANEL | normal PANEL |
+| `INDIVIDUAL` × `DENSE` (IC) | raises `UserInputError` or `IncompatibleAxisError` | all dates dropped (MIN_IC_ASSETS=10) → NaN | normal PANEL | normal PANEL |
 | `INDIVIDUAL` × `DENSE` (FM) | raises `UserInputError` or `IncompatibleAxisError` | per-date guard; low df | normal PANEL | normal PANEL |
-| `COMMON` × `DENSE` | TIMESERIES single-series β | emits `CROSS_SECTION_N` | emits `CROSS_SECTION_N` | normal PANEL |
+| `COMMON` × `DENSE` | TIMESERIES single-series β | emits `FEW_ASSETS` | emits `FEW_ASSETS` | normal PANEL |
 | `INDIVIDUAL` × `SPARSE` / `COMMON` × `SPARSE` | `_SCOPE_COLLAPSED` → TS dummy | normal PANEL CAAR | normal PANEL CAAR | normal PANEL CAAR |
 
 ## Sample-deficiency surfacing

--- a/docs/reference/_generated_warning_codes.md
+++ b/docs/reference/_generated_warning_codes.md
@@ -4,7 +4,7 @@
 | `event_window_overlap` | Adjacent events sit within forward_periods; AR windows overlap. |
 | `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
-| `cross_section_n` | PANEL cross-asset t-test with n_assets < MIN_ASSETS_WARN (30); df=n_assets-1 inflates t_crit relative to the asymptotic 1.96 (≈4.30 at n_assets=3, +119%; 5–15% near 30). Severity scales with n_assets — read the n_assets metadata. |
+| `few_assets` | PANEL cross-asset t-test with n_assets < MIN_ASSETS_WARN (30); df=n_assets-1 inflates t_crit relative to the asymptotic 1.96 (≈4.30 at n_assets=3, +119%; 5–15% near 30). Severity scales with n_assets — read the n_assets metadata. |
 | `sparse_common_few_events` | (COMMON, SPARSE, PANEL) broadcast dummy has MIN_BROADCAST_EVENTS_HARD ≤ n_events < MIN_BROADCAST_EVENTS_WARN (5..19); per-asset β estimable but cross-event averaging too thin for asymptotic t. |
 | `sparse_magnitude_weighted` | Sparse factor column is mixed-sign and not a clean ±1 ternary; statistic is magnitude-weighted (Sefcik-Thompson) rather than textbook MacKinlay signed CAAR — apply .sign() before calling for sign-flip semantics. |
 | `few_events` | CAAR significance test with MIN_EVENTS_HARD ≤ n_event_periods < MIN_EVENTS_WARN (4..29). caar is an equal-weight calendar-time portfolio across event periods, so this counts the number of periods with an event, not events; a sub-30 series is power-thin for the asymptotic t-distribution — read borderline p-values cautiously. |

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -47,7 +47,7 @@ Min sample*. `MIN_*` constants resolve to values in the
 
 | Metric | Sample axis | Min sample |
 |---|---|---|
-| [`ic_ir`][factrix.metrics.ic.ic_ir] | `T` | `T ≥ MIN_ASSETS_PER_DATE_IC` |
+| [`ic_ir`][factrix.metrics.ic.ic_ir] | `T` | `T ≥ MIN_IC_ASSETS` |
 
 ### FM family — Cell: Individual × Continuous
 
@@ -110,8 +110,8 @@ Min sample*. `MIN_*` constants resolve to values in the
 
 | Metric | Sample axis | Min sample |
 |---|---|---|
-| [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | series length | `T ≥ MIN_ASSETS_PER_DATE_IC` |
-| [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | pooled `(date, asset)` signs | non-overlapping obs `≥ MIN_ASSETS_PER_DATE_IC` |
+| [`hit_rate`][factrix.metrics.hit_rate.hit_rate] | series length | `T ≥ MIN_IC_ASSETS` |
+| [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | pooled `(date, asset)` signs | non-overlapping obs `≥ MIN_IC_ASSETS` |
 | [`ic_trend`][factrix.metrics.trend.ic_trend] | `T` | `T ≥ 10` (literal floor) |
 | [`oos_decay`][factrix.metrics.oos_decay.oos_decay] | `T` | `T ≥ 2 × MIN_OOS_PERIODS` |
 
@@ -127,7 +127,7 @@ below.
 
 | Constant | Value | Axis | Tier | Source module | Used by |
 |---|---|---|---|---|---|
-| `MIN_ASSETS_PER_DATE_IC` | 10 | per-date `N` | hard | `factrix/_types.py` | `compute_ic` (drops dates with `N < 10`) → consumed by `ic`, `ic_ir`, `hit_rate` |
+| `MIN_IC_ASSETS` | 10 | per-date `N` | hard | `factrix/_types.py` | `compute_ic` (drops dates with `N < 10`) → consumed by `ic`, `ic_ir`, `hit_rate` |
 | `MIN_EVENTS_HARD` | 4 | `K` (event count) | hard | `factrix/_types.py` | `caar`, `bmp_test`, `event_hit_rate`, `event_ic`, `profit_factor`, `event_skewness`, `event_around_return`, `mfe_mae_summary`, `clustering_hhi`, `corrado_rank` |
 | `MIN_EVENTS_WARN` | 30 | `K` | warn | `factrix/_types.py` | `caar` only (Brown-Warner literature floor; descriptive event-quality metrics use HARD only) |
 | `MIN_OOS_PERIODS` | 5 | `T` (per split) | hard | `factrix/_types.py` | `oos_decay` (effective floor `T ≥ 2 × MIN_OOS_PERIODS = 10`) |
@@ -136,7 +136,7 @@ below.
 | `MIN_MONOTONICITY_PERIODS` | 5 | `T/h` | hard | `factrix/_types.py` | `monotonicity` |
 | `MIN_PERIODS_HARD` | 20 | `T` (TIMESERIES) | hard | `factrix/_stats/constants.py` | TIMESERIES procedures (`individual_continuous` / `common_continuous` at `N == 1`); raises `InsufficientSampleError` |
 | `MIN_PERIODS_WARN` | 30 | `T` (TIMESERIES) | warn | `factrix/_stats/constants.py` | same procedures; tags `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` |
-| `MIN_ASSETS_WARN` | 30 | `N` | warn | `factrix/_stats/constants.py` | PANEL `common_continuous`; tags `WarningCode.CROSS_SECTION_N` (severity from `n_assets`) |
+| `MIN_ASSETS_WARN` | 30 | `N` | warn | `factrix/_stats/constants.py` | PANEL `common_continuous`; tags `WarningCode.FEW_ASSETS` (severity from `n_assets`) |
 | `MIN_BROADCAST_EVENTS_HARD` | 5 | `K` (broadcast dummy) | hard | `factrix/_stats/constants.py` | `(COMMON, SPARSE, None, PANEL)` procedure |
 | `MIN_BROADCAST_EVENTS_WARN` | 20 | `K` (broadcast dummy) | warn | `factrix/_stats/constants.py` | same; tags `WarningCode.SPARSE_COMMON_FEW_EVENTS` |
 | `MIN_FM_PERIODS_HARD` | 4 | `T` (λ series) | hard | `factrix/metrics/fm_beta.py` | `fm_beta`, `beta_sign_consistency` |
@@ -145,7 +145,7 @@ below.
 
 Naming caveats:
 
-- `MIN_ASSETS_PER_DATE_IC` (10) gates the **per-date** asset count for
+- `MIN_IC_ASSETS` (10) gates the **per-date** asset count for
   IC (dates below it are dropped); it is distinct from the panel-wide
   `N` cross-asset guard, which lives solely on `MIN_ASSETS_WARN`.
 - `MIN_ASSETS_WARN = 30` is a single warn floor (no `_HARD`) — the `N`

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -302,7 +302,7 @@ block-bootstrap CI when `n_assets < MIN_ASSETS_WARN`. In that branch
 they additionally emit `p_value_t` (the parametric `t` p-value kept
 for reference), `bootstrap_block_length`, `bootstrap_n_resamples`,
 and `bootstrap_seed`. The switch is **not** silent: the single
-cross-section code (`cross_section_n`) is attached to `warning_codes`,
+cross-section code (`few_assets`) is attached to `warning_codes`,
 so the method change surfaces as a `Warning` on the result.
 
 ### `concentration` (`factrix.metrics.concentration`)

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -27,7 +27,7 @@ class WarningCode(StrEnum):
     # inflates as N shrinks. One code flags the whole thin regime
     # (n_assets < MIN_ASSETS_WARN); severity is read from the ``n_assets``
     # metadata rather than split across separate tier members.
-    CROSS_SECTION_N = "cross_section_n"
+    FEW_ASSETS = "few_assets"
     # Fired by the (COMMON, SPARSE, PANEL) procedure when the broadcast
     # dummy carries MIN_BROADCAST_EVENTS_HARD ≤ n_events <
     # MIN_BROADCAST_EVENTS_WARN. Per-asset β is identifiable but
@@ -108,7 +108,7 @@ _WARNING_DESCRIPTIONS.update(
         WarningCode.EVENT_WINDOW_OVERLAP: "Adjacent events sit within forward_periods; AR windows overlap.",
         WarningCode.PERSISTENT_REGRESSOR: "ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias.",
         WarningCode.SERIAL_CORRELATION_DETECTED: "Ljung-Box p < 0.05 on residuals; NW lag may be under-set.",
-        WarningCode.CROSS_SECTION_N: "PANEL cross-asset t-test with n_assets < "
+        WarningCode.FEW_ASSETS: "PANEL cross-asset t-test with n_assets < "
         "MIN_ASSETS_WARN (30); df=n_assets-1 inflates t_crit relative to the "
         "asymptotic 1.96 (≈4.30 at n_assets=3, +119%; 5–15% near 30). "
         "Severity scales with n_assets — read the n_assets metadata.",
@@ -165,7 +165,7 @@ def cross_section_tier(n_assets: int) -> WarningCode | None:
     ``primary_p``'s ``dof = N - 1``. Callers (``suggest_config``,
     ``_compute_common_panel``) therefore pre-filter before calling.
 
-    A single :attr:`WarningCode.CROSS_SECTION_N` flags the whole thin regime
+    A single :attr:`WarningCode.FEW_ASSETS` flags the whole thin regime
     (``2 ≤ n_assets < MIN_ASSETS_WARN``); how severe it is scales with
     ``n_assets``, which callers carry in metadata rather than encoding into
     separate tier members. Returns ``None`` at ``n_assets ≥ MIN_ASSETS_WARN``
@@ -175,5 +175,5 @@ def cross_section_tier(n_assets: int) -> WarningCode | None:
     from factrix._stats.constants import MIN_ASSETS_WARN
 
     if 2 <= n_assets < MIN_ASSETS_WARN:
-        return WarningCode.CROSS_SECTION_N
+        return WarningCode.FEW_ASSETS
     return None

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -617,7 +617,7 @@ def _evaluate_applicability(
             blockers.append(f"n_{av.axis}={av.n} < min_{av.axis}={av.floor}")
         elif av.tier is Tier.DEGRADED:
             # The assets axis gates DEGRADED on the spec's warn_assets, but the
-            # emitted warning is the inference-stage CROSS_SECTION_N code, keyed
+            # emitted warning is the inference-stage FEW_ASSETS code, keyed
             # on the global MIN_ASSETS_WARN constant — so it can be None here
             # even though the axis verdict is DEGRADED.
             if av.axis == "assets":

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -15,7 +15,7 @@ MIN_PERIODS_HARD: int = 20
 # tagged with :attr:`factrix._codes.WarningCode.UNRELIABLE_SE_SHORT_PERIODS`.
 MIN_PERIODS_WARN: int = 30
 
-# ``n_assets < MIN_ASSETS_WARN`` → :attr:`factrix._codes.WarningCode.CROSS_SECTION_N`
+# ``n_assets < MIN_ASSETS_WARN`` → :attr:`factrix._codes.WarningCode.FEW_ASSETS`
 # from PANEL ``common_continuous`` and from ``suggest_config``. The cross-asset
 # t-test on E[β] has df = n_assets - 1; as n_assets shrinks the critical t
 # inflates (n_assets=3 → t_crit≈4.30 vs asymptotic 1.96; ~+15% at 10, ~+5% at

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -44,14 +44,14 @@ MAD_CONSISTENCY_CONSTANT: float = 1.4826
 # Per-date minimum asset count below which ``compute_ic`` drops the date
 # (cross-sectional axis). Spearman ρ needs ≥ this many names per date for
 # its asymptotic distribution to hold.
-MIN_ASSETS_PER_DATE_IC: int = 10
+MIN_IC_ASSETS: int = 10
 
 # Minimum IC time-series length (periods axis) for a reliable mean / sign
 # test on the per-date IC series: the post-stride sample in ``ic()``, the
 # series-length floor in ``hit_rate`` / ``directional_hit_rate``, and the
 # raw-period base in the non-overlapping inference floor all key off this
 # "≥10 independent draws" rule. Distinct axis from
-# ``MIN_ASSETS_PER_DATE_IC`` despite the shared value — do not collapse.
+# ``MIN_IC_ASSETS`` despite the shared value — do not collapse.
 MIN_IC_PERIODS: int = 10
 
 # Two-tier event-count guard for CAAR / Brown-Warner-family tests.

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -373,7 +373,7 @@ All exceptions inherit from `FactrixError`:
 | `event_window_overlap` | Adjacent events sit within `forward_periods`; AR windows overlap. |
 | `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
-| `cross_section_n` | PANEL cross-asset t-test with `n_assets < MIN_ASSETS_WARN` (30); df=n_assets-1 inflates t_crit; severity in the n_assets metadata. |
+| `few_assets` | PANEL cross-asset t-test with `n_assets < MIN_ASSETS_WARN` (30); df=n_assets-1 inflates t_crit; severity in the n_assets metadata. |
 | `sparse_common_few_events` | broadcast dummy has 5..19 events; too thin for asymptotic t. |
 | `sparse_magnitude_weighted` | Sparse factor column is mixed-sign and not a clean ±1 ternary; magnitude-weighted. |
 | `few_events` | event dates < 29; t-stat power is thin. |

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -92,7 +92,7 @@ def _spread_significance(
 
     The switch fires exactly when :func:`cross_section_tier` flags the
     cross-section (``n_assets < MIN_ASSETS_WARN``), so the returned
-    ``warning_codes`` carry the single ``CROSS_SECTION_N`` code. This
+    ``warning_codes`` carry the single ``FEW_ASSETS`` code. This
     surfaces the method change as a :class:`Warning` on the result rather
     than leaving it buried in metadata; severity is read from ``n_assets``.
     """

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -14,7 +14,7 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._metric_index import cell
-from factrix._types import MIN_ASSETS_PER_DATE_IC
+from factrix._types import MIN_IC_ASSETS
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import _attach_drop_stats
 
@@ -50,7 +50,7 @@ def compute_ic(
         Dict mapping each factor name to a DataFrame with columns
         ``date, ic, tie_ratio`` sorted by date, plus an internal
         ``_drop_stats`` diagnostic struct column. Dates with fewer than
-        ``MIN_ASSETS_PER_DATE_IC`` assets are dropped; ``_drop_stats``
+        ``MIN_IC_ASSETS`` assets are dropped; ``_drop_stats``
         records how many were dropped (the aggregate drop-rate schema).
         ``tie_ratio`` is the per-date factor tie density
         $1 - n_{\mathrm{unique}} / n$ in $[0, 1]$.
@@ -79,8 +79,8 @@ def compute_ic(
         df.lazy().with_columns(rank_exprs).group_by("date").agg(agg_exprs).sort("date")
     ).collect()
     n_periods_in = grouped.height
-    wide = grouped.filter(pl.col("n") >= MIN_ASSETS_PER_DATE_IC)
-    drop_reason = f"n_assets below MIN_ASSETS_PER_DATE_IC ({MIN_ASSETS_PER_DATE_IC})"
+    wide = grouped.filter(pl.col("n") >= MIN_IC_ASSETS)
+    drop_reason = f"n_assets below MIN_IC_ASSETS ({MIN_IC_ASSETS})"
 
     return {
         f: _attach_drop_stats(

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -15,7 +15,7 @@ from factrix._metric_index import cell
 from factrix._types import EPSILON
 from factrix.metrics._decorators import metric
 
-DEFAULT_MIN_ESTIMATION_SAMPLES: int = 20
+DEFAULT_MIN_ESTIMATION_PERIODS: int = 20
 
 
 def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
@@ -50,7 +50,7 @@ def compute_mfe_mae(
     *,
     window: int = 20,
     estimation_window: int = 60,
-    min_estimation_samples: int = DEFAULT_MIN_ESTIMATION_SAMPLES,
+    min_estimation_periods: int = DEFAULT_MIN_ESTIMATION_PERIODS,
     factor_col: str = "factor",
     price_col: str = "price",
 ) -> pl.DataFrame:
@@ -60,10 +60,10 @@ def compute_mfe_mae(
     subsequent bars to find the peak gain (MFE) and peak loss (MAE)
     relative to event entry price, adjusted for density direction.
     """
-    if min_estimation_samples < 2:
+    if min_estimation_periods < 2:
         raise ValueError(
-            f"min_estimation_samples must be >= 2 (std needs ddof=1 "
-            f"and at least 2 observations), got {min_estimation_samples}"
+            f"min_estimation_periods must be >= 2 (std needs ddof=1 "
+            f"and at least 2 observations), got {min_estimation_periods}"
         )
 
     date_dtype = df.schema["date"]
@@ -116,10 +116,10 @@ def compute_mfe_mae(
         est_start = max(0, idx - estimation_window)
         est_prices = prices[est_start:idx]
         est_sigma = float("nan")
-        if len(est_prices) > min_estimation_samples:
+        if len(est_prices) > min_estimation_periods:
             prior = est_prices[:-1]
             safe = prior > EPSILON
-            if safe.sum() >= min_estimation_samples:
+            if safe.sum() >= min_estimation_periods:
                 daily_rets = (est_prices[1:][safe] / prior[safe]) - 1.0
                 if len(daily_rets) >= 2:
                     est_sigma = float(np.std(daily_rets, ddof=1))

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -62,7 +62,7 @@ _IC_CELL = cell(
 # downscale `n_groups`. The min-cross-section-per-date constraint
 # (Spearman ρ asymptotic distribution requires ≥ 30 obs per date,
 # Hollander-Wolfe-Chicken §8.6) lives in the procedure as
-# `MIN_ASSETS_PER_DATE_IC` short-circuit, parallel to (not exposed
+# `MIN_IC_ASSETS` short-circuit, parallel to (not exposed
 # via) this attribute.
 min_assets_per_group: int | None = None
 per_date_series = per_date_series_rename("ic")

--- a/tests/test_drop_rate_warning.py
+++ b/tests/test_drop_rate_warning.py
@@ -29,7 +29,7 @@ def _thinned_panel(
 ) -> pl.DataFrame:
     """Panel where every other date is thinned to ``thin`` assets.
 
-    ``thin`` < ``MIN_ASSETS_PER_DATE_IC`` (10), so the thinned dates are dropped
+    ``thin`` < ``MIN_IC_ASSETS`` (10), so the thinned dates are dropped
     by ``compute_ic`` — yielding a ~50% period drop with enough survivors to
     clear the consumers' own sample floors.
     """
@@ -68,7 +68,7 @@ class TestSchema:
             stats["n_periods_out"] == stats["n_periods_in"] - stats["dropped_periods"]
         )
         assert stats["drop_rate"] == pytest.approx(0.5, abs=0.02)
-        assert "MIN_ASSETS_PER_DATE_IC" in stats["drop_reason"]
+        assert "MIN_IC_ASSETS" in stats["drop_reason"]
 
     def test_compute_fm_betas_attaches_drop_stats(self):
         # Thin below MIN_FM_ASSETS (3): thinned dates carry a single asset.

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -105,7 +105,7 @@ class TestEvaluationResultToFrame:
 
     def test_warning_codes_filter_by_source(self):
         warnings = [
-            Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="thin"),
+            Warning(code=WarningCode.FEW_ASSETS, source="ic", message="thin"),
             Warning(
                 code=WarningCode.SERIAL_CORRELATION_DETECTED,
                 source=None,
@@ -116,7 +116,7 @@ class TestEvaluationResultToFrame:
         df = r.to_frame()
         ic_row = df.filter(pl.col("metric_name") == "ic").row(0, named=True)
         ic_ir_row = df.filter(pl.col("metric_name") == "ic_ir").row(0, named=True)
-        assert ic_row["warning_codes"] == [WarningCode.CROSS_SECTION_N.value]
+        assert ic_row["warning_codes"] == [WarningCode.FEW_ASSETS.value]
         assert ic_ir_row["warning_codes"] == []
 
     def test_metric_name_from_name_field(self):
@@ -129,7 +129,7 @@ class TestEvaluationResultToFrame:
 class TestEvaluationResultToDict:
     def test_round_trips_through_json(self):
         warnings = [
-            Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="thin"),
+            Warning(code=WarningCode.FEW_ASSETS, source="ic", message="thin"),
         ]
         r = _sample_result(_sample_group(), warnings=warnings)
         d = r.to_dict()
@@ -144,7 +144,7 @@ class TestEvaluationResultToDict:
         assert "n_obs" not in back
         assert "metrics_partition" not in back
         assert back["metrics"]["ic"]["p_value"] == 0.012
-        assert back["warnings"][0]["code"] == WarningCode.CROSS_SECTION_N.value
+        assert back["warnings"][0]["code"] == WarningCode.FEW_ASSETS.value
         assert back["plan"] == "1. ic [per-factor]"
 
     def test_nonfinite_floats_become_null(self):
@@ -177,13 +177,11 @@ class TestReprHtml:
         assert "diagnostic" not in r._repr_html_()
 
     def test_renders_warnings_when_present(self):
-        warnings = [
-            Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="thin")
-        ]
+        warnings = [Warning(code=WarningCode.FEW_ASSETS, source="ic", message="thin")]
         r = _sample_result(_sample_group(), warnings=warnings)
         html_out = r._repr_html_()
         assert "warnings" in html_out
-        assert WarningCode.CROSS_SECTION_N.value in html_out
+        assert WarningCode.FEW_ASSETS.value in html_out
 
     def test_no_warnings_block_when_empty(self):
         r = _sample_result(_sample_group())

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -26,8 +26,8 @@ class TestComputeIC:
             assert ic_val == pytest.approx(-1.0)
 
     def test_drops_small_dates(self):
-        """Dates with < MIN_ASSETS_PER_DATE_IC assets should be excluded."""
-        # 3 assets < MIN_ASSETS_PER_DATE_IC=10
+        """Dates with < MIN_IC_ASSETS assets should be excluded."""
+        # 3 assets < MIN_IC_ASSETS=10
         dates = [datetime(2024, 1, 1)]
         rows = [
             {

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -362,7 +362,7 @@ class TestDataLevelWarnings:
     def test_thin_cross_section_emits_tier(self):
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))
         codes = [w.code.value for w in info.warnings]
-        assert any("cross_section" in c for c in codes)
+        assert "few_assets" in codes
 
 
 class TestWarningSourceConvention:

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -82,7 +82,7 @@ class TestSmallNSignificanceSwitch:
         assert "p_value_t" in result.metadata  # parametric p retained for reference
         assert result.metadata["bootstrap_seed"] == 0
         # the method switch surfaces as a cross-section warning, not silently
-        assert "cross_section_n" in result.warning_codes
+        assert "few_assets" in result.warning_codes
         # reproducible run-to-run under the fixed seed
         again = k_spread(panel, forward_periods=1, k=5)
         assert result.p_value == again.p_value

--- a/tests/test_mfe_mae.py
+++ b/tests/test_mfe_mae.py
@@ -150,7 +150,7 @@ class TestComputeMfeMae:
         assert result.is_empty()
         assert result.schema["date"] == pl.Datetime("us")
 
-    def test_min_estimation_samples_lower_admits_more_z_scores(
+    def test_min_estimation_periods_lower_admits_more_z_scores(
         self,
         event_data,
     ):
@@ -162,13 +162,13 @@ class TestComputeMfeMae:
             event_data,
             window=10,
             estimation_window=30,
-            min_estimation_samples=20,
+            min_estimation_periods=20,
         )
         loose = compute_mfe_mae(
             event_data,
             window=10,
             estimation_window=30,
-            min_estimation_samples=5,
+            min_estimation_periods=5,
         )
         strict_finite = strict["est_sigma"].is_finite().sum()
         loose_finite = loose["est_sigma"].is_finite().sum()
@@ -178,9 +178,9 @@ class TestComputeMfeMae:
             "fits the loose threshold but not the strict one."
         )
 
-    def test_min_estimation_samples_below_two_raises(self, event_data):
-        with pytest.raises(ValueError, match="min_estimation_samples"):
-            compute_mfe_mae(event_data, window=10, min_estimation_samples=1)
+    def test_min_estimation_periods_below_two_raises(self, event_data):
+        with pytest.raises(ValueError, match="min_estimation_periods"):
+            compute_mfe_mae(event_data, window=10, min_estimation_periods=1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_two_tier_guards.py
+++ b/tests/test_two_tier_guards.py
@@ -173,7 +173,7 @@ class TestTopConcentrationTwoTier:
 
 
 class TestCrossSectionTierSingleCode:
-    """The cross-asset N guard is a single ``CROSS_SECTION_N`` across the whole
+    """The cross-asset N guard is a single ``FEW_ASSETS`` across the whole
     thin band (no SMALL/BORDERLINE split); severity is carried by ``n_assets``.
     """
 
@@ -182,7 +182,7 @@ class TestCrossSectionTierSingleCode:
         from factrix._stats.constants import MIN_ASSETS_WARN
 
         for n in (2, 3, 9, 10, MIN_ASSETS_WARN - 1):
-            assert cross_section_tier(n) is WarningCode.CROSS_SECTION_N
+            assert cross_section_tier(n) is WarningCode.FEW_ASSETS
 
     def test_clean_at_or_above_warn_floor(self):
         from factrix._codes import cross_section_tier

--- a/tests/test_warning.py
+++ b/tests/test_warning.py
@@ -7,8 +7,8 @@ from factrix import Warning, WarningCode
 
 def _sample_warnings() -> list[Warning]:
     return [
-        Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="n=8"),
-        Warning(code=WarningCode.CROSS_SECTION_N, source="fm_beta", message=""),
+        Warning(code=WarningCode.FEW_ASSETS, source="ic", message="n=8"),
+        Warning(code=WarningCode.FEW_ASSETS, source="fm_beta", message=""),
         Warning(
             code=WarningCode.SERIAL_CORRELATION_DETECTED, source=None, message="bundle"
         ),
@@ -16,7 +16,7 @@ def _sample_warnings() -> list[Warning]:
 
 
 def test_default_source_and_message():
-    w = Warning(code=WarningCode.CROSS_SECTION_N)
+    w = Warning(code=WarningCode.FEW_ASSETS)
     assert w.source is None
     assert w.message == ""
 
@@ -25,7 +25,7 @@ def test_filter_by_source_metric_name():
     warnings = _sample_warnings()
     per_metric = [w for w in warnings if w.source == "ic"]
     assert len(per_metric) == 1
-    assert per_metric[0].code is WarningCode.CROSS_SECTION_N
+    assert per_metric[0].code is WarningCode.FEW_ASSETS
 
 
 def test_filter_bundle_level_with_source_none():
@@ -44,7 +44,7 @@ def test_group_by_source():
 
 
 def test_frozen_dataclass_equality_and_hashable():
-    a = Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="m")
-    b = Warning(code=WarningCode.CROSS_SECTION_N, source="ic", message="m")
+    a = Warning(code=WarningCode.FEW_ASSETS, source="ic", message="m")
+    b = Warning(code=WarningCode.FEW_ASSETS, source="ic", message="m")
     assert a == b
     assert hash(a) == hash(b)


### PR DESCRIPTION
## Summary
- Rename `WarningCode.CROSS_SECTION_N` → `FEW_ASSETS` (value `"cross_section_n"` → `"few_assets"`), parallel to `FEW_EVENTS`; the cross-asset thinness it flags is an `n_assets`-axis condition.
- Rename `compute_mfe_mae` kwarg `min_estimation_samples` → `min_estimation_periods` and its default `DEFAULT_MIN_ESTIMATION_SAMPLES` → `DEFAULT_MIN_ESTIMATION_PERIODS` (estimation window is counted in periods, not a neutral "samples").
- Rename internal `MIN_ASSETS_PER_DATE_IC` → `MIN_IC_ASSETS` (DOMAIN-prefix form, matching `MIN_FM_ASSETS`).
- Regenerated `_generated_warning_codes.md` + llms reference; synced live docs naming the old identifiers. Archived plans under `docs/plans/archive/` left as historical snapshots.

## Breaking changes (pre-1.0, no compat aliases)
- Serialized warning code `"cross_section_n"` → `"few_assets"` (affects anyone matching the string in `warning_codes` / JSON / HTML output).
- Public `compute_mfe_mae(..., min_estimation_samples=...)` → `min_estimation_periods=...`.

CHANGELOG entry deferred to the #612 epic wrap-up per the epic doc-batching convention.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean.
- [x] Full suite: 1331 passed, 4 skipped.
- [x] No stale `cross_section_n` / `CROSS_SECTION_N` / `MIN_ASSETS_PER_DATE_IC` / `min_estimation_samples` outside archived plans.

Closes #614