### PR TITLE
refactor(stats): scope groups out of the sample-axis system

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -179,6 +179,15 @@ identifiers must use an axis token, with two deliberate registers/exceptions:
   axis-agnostic `n_obs` on purpose: at those layers the caller's axis is
   unknown and any single token would mislabel a pooled or estimator-specific
   count. Per-metric metadata keys still use an axis token.
+- **`groups` is not a sample axis.** The quantile-bucket count `n_groups`
+  (quantile spread, monotonicity) is a *partition parameter the caller
+  chooses*, not an observed sample dimension: below its target it is
+  silently downscaled to fit the cross-section (`_downscale_n_groups` in
+  `factrix/_stats/slice_policy.py`), never blocked or warned like a thin
+  `n_periods`. So it carries no `SampleThreshold` tier and stays out of
+  `_AXES` (which is the four genuine sample axes above). Its per-bucket
+  floor is `min_assets_per_group` — an `assets`-axis quantity scoped per
+  bucket, already within the grammar, not a fifth axis.
 
 | Axis token | Dimension |
 |------------|-----------|

--- a/factrix/_stats/slice_policy.py
+++ b/factrix/_stats/slice_policy.py
@@ -13,8 +13,8 @@ Two private helpers consumed by the slice-test functions
   geometry properly.
 - ``_downscale_n_groups`` — for slice tests on metrics that bucket
   cross-section assets (quantile spread, monotonicity), shrinks
-  ``n_groups`` so each bucket retains at least ``min_per_group``
-  assets. The per-metric ``min_per_group`` floor lives on the metric
+  ``n_groups`` so each bucket retains at least ``min_assets_per_group``
+  assets. The per-metric ``min_assets_per_group`` floor lives on the metric
   module itself; the slice-test function resolves it per
   slice and feeds it here.
 """
@@ -79,32 +79,34 @@ def _downscale_n_groups(
     base_n_groups: int,
     n_assets: int,
     *,
-    min_per_group: int | None,
+    min_assets_per_group: int | None,
 ) -> int:
-    """Cap ``n_groups`` so each bucket retains ``≥ min_per_group`` assets.
+    """Cap ``n_groups`` so each bucket retains ``≥ min_assets_per_group`` assets.
 
     Args:
         base_n_groups: Caller's requested bucket count.
         n_assets: Number of distinct assets in the slice.
-        min_per_group: Minimum assets per bucket required for the metric
+        min_assets_per_group: Minimum assets per bucket required for the metric
             to be statistically meaningful (e.g. IC quintile spread:
             30; monotonicity rho: 50). ``None`` skips the downscale —
             for metrics that don't bucket cross-section (Fama-MacBeth,
             CAAR), pass ``None`` and ``base_n_groups`` returns unchanged.
 
     Returns:
-        ``min(base_n_groups, max(2, n_assets // min_per_group))`` when
-        ``min_per_group`` is set; ``base_n_groups`` otherwise. The lower
+        ``min(base_n_groups, max(2, n_assets // min_assets_per_group))`` when
+        ``min_assets_per_group`` is set; ``base_n_groups`` otherwise. The lower
         floor of 2 prevents a 1-bucket "spread" (degenerate) on very
         small slices — the slice test should ideally be skipped at
         that point but the helper does not raise.
 
     Raises:
-        ValueError: ``min_per_group < 1``.
+        ValueError: ``min_assets_per_group < 1``.
     """
-    if min_per_group is None:
+    if min_assets_per_group is None:
         return base_n_groups
-    if min_per_group < 1:
-        raise ValueError(f"min_per_group must be >= 1; got {min_per_group!r}.")
-    capacity = max(2, n_assets // min_per_group)
+    if min_assets_per_group < 1:
+        raise ValueError(
+            f"min_assets_per_group must be >= 1; got {min_assets_per_group!r}."
+        )
+    capacity = max(2, n_assets // min_assets_per_group)
     return min(base_n_groups, capacity)

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -52,7 +52,7 @@ __all__ = [
 # in Asset Returns" recommend ≥ 50 assets per bucket so the per-date
 # bucket means converge to their cross-sectional expectation; below
 # this floor individual-asset noise dominates the rank statistic.
-# `_downscale_n_groups(base, n_assets, min_per_group=50)` caps
+# `_downscale_n_groups(base, n_assets, min_assets_per_group=50)` caps
 # `n_groups` accordingly inside the slice-test function.
 min_assets_per_group: int | None = 50
 

--- a/tests/stats/test_slice_policy.py
+++ b/tests/stats/test_slice_policy.py
@@ -85,24 +85,24 @@ class TestDetectStrictSubsets:
 
 class TestDownscaleNGroups:
     def test_none_passes_through(self):
-        # min_per_group=None → metric doesn't bucket; return base.
-        assert _downscale_n_groups(5, n_assets=20, min_per_group=None) == 5
+        # min_assets_per_group=None → metric doesn't bucket; return base.
+        assert _downscale_n_groups(5, n_assets=20, min_assets_per_group=None) == 5
 
     def test_capacity_caps_groups(self):
-        # n_assets=60, min_per_group=30 → capacity=2; min(5, 2) = 2.
-        assert _downscale_n_groups(5, n_assets=60, min_per_group=30) == 2
+        # n_assets=60, min_assets_per_group=30 → capacity=2; min(5, 2) = 2.
+        assert _downscale_n_groups(5, n_assets=60, min_assets_per_group=30) == 2
 
     def test_capacity_above_base_returns_base(self):
         # n_assets=300, min=30 → capacity=10; base=5 → returns 5.
-        assert _downscale_n_groups(5, n_assets=300, min_per_group=30) == 5
+        assert _downscale_n_groups(5, n_assets=300, min_assets_per_group=30) == 5
 
     def test_floor_at_2_when_assets_below_min(self):
         # n_assets=15, min=30 → 15//30 = 0; floored to 2.
-        assert _downscale_n_groups(5, n_assets=15, min_per_group=30) == 2
+        assert _downscale_n_groups(5, n_assets=15, min_assets_per_group=30) == 2
 
     def test_zero_assets_floored_at_2(self):
-        assert _downscale_n_groups(5, n_assets=0, min_per_group=30) == 2
+        assert _downscale_n_groups(5, n_assets=0, min_assets_per_group=30) == 2
 
     def test_invalid_min_raises(self):
-        with pytest.raises(ValueError, match="min_per_group must be >= 1"):
-            _downscale_n_groups(5, n_assets=100, min_per_group=0)
+        with pytest.raises(ValueError, match="min_assets_per_group must be >= 1"):
+            _downscale_n_groups(5, n_assets=100, min_assets_per_group=0)


### PR DESCRIPTION
## Decision
`groups` does **not** join `SampleThreshold._AXES`. The four sample axes stay `(periods, assets, pairs, events)`.

**Rationale.** `n_groups` (quantile-bucket count for quantile spread / monotonicity) is a *caller-chosen partition parameter*, not an observed sample dimension. Below its target it is silently downscaled to fit the cross-section (`_downscale_n_groups`), never blocked or warned the way a thin `n_periods` is — so it has no `block / warn / clean` tier and does not fit the `iter_verdicts` model. Its per-bucket floor `min_assets_per_group` is an `assets`-axis quantity scoped per bucket, already inside the grammar; it is not a fifth axis.

## Summary
- Document the `groups` boundary in the architecture.md Sample guards naming grammar.
- Rename the private `_downscale_n_groups` parameter `min_per_group` → `min_assets_per_group` to match the canonical per-metric attribute and drop the last neutral `per_group` token (internal helper + tests only; no public surface).

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean.
- [x] Full suite: 1331 passed, 4 skipped.
- [x] No `min_per_group` remaining outside archived plans.

Closes #616