### PR TITLE
refactor(metrics): drop redundant pooled-count metadata keys from hit-rate metrics

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -177,7 +177,8 @@ runs, the normal `z` when the approximation branch runs;
 
 - *primary*: `p_value` — binomial / normal-approximation test on
   non-overlapping wins (stride `forward_periods`).
-- *descriptive*: `n_hits`, `n_total`.
+- *descriptive*: `n_hits`. The trial count is the period-axis drop-stat
+  `n_periods_out` (the surviving non-overlapping observations).
 
 ### `directional_hit_rate` (`factrix.metrics.directional_hit_rate`)
 

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -206,6 +206,5 @@ def directional_hit_rate(
             "p_expected": p_star,
             "p_up_pred": p_x,
             "p_up_real": p_y,
-            "n_obs": n,
         },
     )

--- a/factrix/metrics/hit_rate.py
+++ b/factrix/metrics/hit_rate.py
@@ -144,7 +144,6 @@ def hit_rate(
 
     metadata: dict[str, object] = {
         "n_hits": hits,
-        "n_total": n,
         "stat_type": stat_type,
         "h0": "p=0.5",
         "method": _binomial_test_method_name(n),


### PR DESCRIPTION
## Resolution
Two sibling metrics duplicated their sample count into a redundant, neutral-token metadata key. Both duplicates are dropped; the canonical count stays on its proper axis-token home.

- **`directional_hit_rate`**: `metadata["n_obs"]` duplicated the first-class `MetricResult.n_obs` field (same pooled-sign count, no consumer). Dropped — count stays on the first-class `n_obs` field (the right home for a genuinely pooled `(date, asset)` count).
- **`hit_rate`**: `metadata["n_total"]` duplicated the period-axis drop-stat `n_periods_out` (both equal the surviving non-overlapping trial count) and used the neutral `total` token. Dropped — the trial count stays on the axis-token `n_periods_out` from the standard null-drop schema.

This also settles the convention: the neutral `n_obs` token is reserved for the cross-metric layers (`MetricResult.n_obs`, `fx.inference`); per-metric counts live on axis-token keys (or the first-class field when genuinely pooled). After this, the three hit-rate siblings are consistent: `hit_rate` (`n_periods_out` + `n_hits`), `event_hit_rate` (`n_events` + `n_hits`), `directional_hit_rate` (first-class `n_obs`).

## Summary
- Remove `"n_obs": n` from `directional_hit_rate` metadata (first-class `MetricResult.n_obs` unchanged).
- Remove `"n_total": n` from `hit_rate` metadata; document that the trial count is `n_periods_out`.

## Notes
- Minor output-shape change: `directional_hit_rate.metadata` no longer has `"n_obs"` (use `result.n_obs`); `hit_rate.metadata` no longer has `"n_total"` (use `n_periods_out`). No in-repo consumer read either key.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean.
- [x] Full suite: 1331 passed, 4 skipped (incl. metadata drift-guard `test_docs_stat_keys_by_metric`).

Closes #608