### PR TITLE
test(metrics): add FX003 lint for sample-size constant naming

### DIFF
--- a/tests/test_sample_naming_lint.py
+++ b/tests/test_sample_naming_lint.py
@@ -1,0 +1,58 @@
+"""FX003 lint: module-level sample-size constants follow the axis-token grammar.
+
+AST-scans every ``factrix/**/*.py`` for module-level ``MIN_*`` /
+``DEFAULT_MIN_*`` constant assignments and asserts each name matches
+``MIN_[<DOMAIN>_]<AXIS>[_<TIER>]`` (the axis token is mandatory). Companion to
+the ``compute_* <-> PIPELINE`` naming lint (FX001/FX002) in
+``test_metric_index.py``; the grammar itself is documented in
+``docs/development/architecture.md`` (Sample guards).
+
+Scope is deliberately the module-level ``MIN_*`` constant — an open set anyone
+can extend in any module, with no other guard. The closed ``SampleThreshold``
+field set (backed by ``_AXES``) and metadata keys (guarded by
+``test_docs_stat_keys_by_metric``) are covered elsewhere and intentionally not
+re-linted here.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+PACKAGE_DIR = pathlib.Path("factrix")
+
+# A name that looks like a sample-size floor constant — what the lint inspects.
+_CANDIDATE = re.compile(r"^(DEFAULT_)?MIN_[A-Z0-9_]+$")
+
+# The axis-token grammar it must follow: optional ``DEFAULT_`` prefix, optional
+# ``<DOMAIN>_`` prefix(es), a mandatory axis token, optional ``_HARD`` / ``_WARN``.
+_VALID = re.compile(
+    r"^(DEFAULT_)?MIN_([A-Z0-9]+_)*(PERIODS|ASSETS|EVENTS|PAIRS)(_HARD|_WARN)?$"
+)
+
+
+def _module_level_names(path: pathlib.Path) -> set[str]:
+    """Names bound by a top-level ``Assign`` / ``AnnAssign`` in one source file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def test_sample_constant_naming_lint() -> None:
+    """Lint FX003: every ``MIN_*`` constant carries an axis token."""
+    violations: list[str] = []
+    for path in sorted(PACKAGE_DIR.rglob("*.py")):
+        for name in _module_level_names(path):
+            if _CANDIDATE.match(name) and not _VALID.match(name):
+                violations.append(f"{path}: {name}")
+    assert not violations, (
+        "FX003: sample-size constants must match "
+        "MIN_[<DOMAIN>_]<AXIS>[_<TIER>] with AXIS in "
+        "{PERIODS, ASSETS, EVENTS, PAIRS}:\n  " + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Summary
- Add `tests/test_sample_naming_lint.py::test_sample_constant_naming_lint` (FX003): AST-scans `factrix/**/*.py` for module-level `MIN_*` / `DEFAULT_MIN_*` constants and asserts each matches `MIN_[<DOMAIN>_]<AXIS>[_<TIER>]` (axis token mandatory; `AXIS` ∈ PERIODS/ASSETS/EVENTS/PAIRS). Companion to the FX001/FX002 pipeline-naming lint.

## Scope (lean by design)
Only the module-level `MIN_*` constant — an open set with no existing guard, and the actual entry point for the drift this epic fixed. Deliberately **not** re-linted (already guarded, would be over-engineering):
- `SampleThreshold` fields — closed set backed by `_AXES`; a typo breaks the metric's own tests.
- metadata keys — already guarded by `test_docs_stat_keys_by_metric`; a denylist would be arbitrary and risk false positives on non-axis `n_*` (`n_hits`, `n_groups`).

## Test plan
- [x] FX003 passes on current tree (all `MIN_*` constants already conform after the #614 de-drift).
- [x] Self-validated the regex flags known-bad names (`MIN_ASSETS_PER_DATE_IC`, `MIN_SAMPLES`, `MIN_FM_CS_OBS`, `DEFAULT_MIN_ESTIMATION_SAMPLES`) and passes conforming ones.
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean.
- [x] Full suite: 1332 passed, 4 skipped.

Closes #617