### PR TITLE
refactor(metrics): remove compute_rolling_mean_beta from public __all__ (#610)

### DIFF
--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -85,7 +85,6 @@ from factrix.metrics.tradability import (
 from factrix.metrics.trend import ic_trend
 from factrix.metrics.ts_asymmetry import ts_asymmetry
 from factrix.metrics.ts_beta import (
-    compute_rolling_mean_beta,
     mean_r_squared,
     ts_beta,
     ts_beta_sign_consistency,
@@ -98,7 +97,6 @@ __all__ = [
     "breakeven_cost",
     "caar",
     "clustering_hhi",
-    "compute_rolling_mean_beta",
     "corrado_rank",
     "directional_hit_rate",
     "event_around_return",


### PR DESCRIPTION
## Summary

- Removes `compute_rolling_mean_beta` from `factrix/metrics/__init__.__all__` and its import in `__init__.py`
- All other `compute_*` functions follow the convention that they are internal primitives not exported from the top-level namespace; this aligns `compute_rolling_mean_beta` with that convention
- Users who need the function should import directly from `factrix.metrics.ts_beta`, which is already the pattern shown in the function's docstring example

## Test plan

- [ ] 1332 existing tests pass, no regressions
- [ ] `from factrix.metrics import compute_rolling_mean_beta` now raises `ImportError` (expected — correct resolution of the inconsistency)
- [ ] `from factrix.metrics.ts_beta import compute_rolling_mean_beta` still works

Closes #610