### PR TITLE
fix(dag): preserve optional price column in per-factor projection

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -61,7 +61,7 @@ from factrix._axis import (  # noqa: F401  DataStructure re-exported for namespa
 from factrix._codes import WarningCode
 from factrix._compare import compare
 from factrix._dag import CycleError, DagExecutor, _Node
-from factrix._data_input import DataInput, _coerce_data
+from factrix._data_input import _BASELINE_COLUMNS, DataInput, _coerce_data
 from factrix._errors import (
     FactrixError,
     IncompatibleAxisError,
@@ -552,9 +552,6 @@ def _validate_factor_cols_on_data(data: pl.DataFrame, cols: list[str]) -> None:
             ),
             docs_path=_DOCS_FACTOR_COLS,
         )
-
-
-_BASELINE_COLUMNS: tuple[str, ...] = ("date", "asset_id", "forward_return")
 
 
 def _validate_baseline_columns(data: pl.DataFrame) -> None:

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -33,6 +33,7 @@ import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope, SpecRole
 from factrix._codes import WarningCode
+from factrix._data_input import _BASELINE_COLUMNS, _OPTIONAL_COLUMNS
 from factrix._metric_index import MetricSpec
 from factrix._results import (
     EvaluationResult,
@@ -43,19 +44,21 @@ from factrix._results import (
 
 
 def _project_factor(data: pl.DataFrame, col: str) -> pl.DataFrame:
-    """Project ``data`` to the canonical 4-column per-factor view.
+    """Project ``data`` to the canonical per-factor view.
 
     Non-batch primitives expect data whose factor column is literally
     named ``"factor"``; this projection renames ``col`` and drops any
     sibling columns so primitives see an identical schema regardless of
-    the caller's ``factor_cols`` choice.
+    the caller's ``factor_cols`` choice. Beyond the required baseline
+    columns it carries the optional schema columns (``_OPTIONAL_COLUMNS``)
+    when present — event metrics (``event_around_return``, ``mfe_mae``)
+    need ``price`` to compute price paths, and dropping it would
+    short-circuit them with a false ``no_price_data`` verdict.
     """
-    return data.select(
-        pl.col("date"),
-        pl.col("asset_id"),
-        pl.col("forward_return"),
-        pl.col(col).alias("factor"),
-    )
+    cols = [pl.col(c) for c in _BASELINE_COLUMNS]
+    cols.append(pl.col(col).alias("factor"))
+    cols.extend(pl.col(c) for c in _OPTIONAL_COLUMNS if c in data.columns)
+    return data.select(cols)
 
 
 class CycleError(ValueError):

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -26,6 +26,14 @@ import polars as pl
 
 type DataInput = pl.DataFrame | pl.LazyFrame
 
+# Canonical input-data schema — single source of truth shared by evaluate's
+# baseline validation and the DAG executor's per-factor projection.
+# Required columns every panel must carry; optional columns are passed
+# through to metrics when present (e.g. ``price`` for event-study metrics)
+# but never required.
+_BASELINE_COLUMNS: tuple[str, ...] = ("date", "asset_id", "forward_return")
+_OPTIONAL_COLUMNS: tuple[str, ...] = ("price",)
+
 
 def _is_pandas_dataframe(obj: object) -> bool:
     """Detect ``pd.DataFrame`` without importing pandas (optional dep)."""

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -14,7 +14,7 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._codes import WarningCode
-from factrix._dag import CycleError, DagExecutor, _Node, _topo_sort
+from factrix._dag import CycleError, DagExecutor, _Node, _project_factor, _topo_sort
 from factrix._metric_index import MetricSpec, cell, spec_by_name
 from factrix._results import MetricResult
 
@@ -54,6 +54,38 @@ def _nodes(*specs: MetricSpec) -> list[_Node]:
         )
         for spec in specs
     ]
+
+
+class TestProjectFactor:
+    def test_renames_factor_and_drops_other_factors(self):
+        df = pl.DataFrame(
+            {
+                "date": [1, 2],
+                "asset_id": ["a", "a"],
+                "forward_return": [0.1, 0.2],
+                "alpha": [1.0, 2.0],
+                "beta": [3.0, 4.0],
+            }
+        )
+        out = _project_factor(df, "alpha")
+        assert out.columns == ["date", "asset_id", "forward_return", "factor"]
+        assert out["factor"].to_list() == [1.0, 2.0]
+
+    def test_preserves_price_column_when_present(self):
+        # Event metrics need ``price`` to compute price paths; the thin
+        # projection must not drop it.
+        df = pl.DataFrame(
+            {
+                "date": [1, 2],
+                "asset_id": ["a", "a"],
+                "forward_return": [0.1, 0.2],
+                "alpha": [1.0, 2.0],
+                "price": [100.0, 101.0],
+            }
+        )
+        out = _project_factor(df, "alpha")
+        assert "price" in out.columns
+        assert out["price"].to_list() == [100.0, 101.0]
 
 
 class TestTopoSort:

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -3,6 +3,7 @@
 import math
 from datetime import datetime, timedelta
 
+import factrix as fx
 import numpy as np
 import polars as pl
 import pytest
@@ -129,6 +130,33 @@ class TestEventAroundReturn:
         assert math.isnan(result.value)
         assert result.metadata["reason"] == "no_price_data"
         assert result.metadata["per_offset"] == {}
+
+
+class TestEventMetricThroughEvaluate:
+    def test_price_survives_dag_projection(self, event_data):
+        # The DAG executor projects a thin per-factor view; that projection
+        # must retain ``price`` so event metrics do not falsely short-circuit
+        # with ``no_price_data`` when the caller did supply prices.
+        res = fx.evaluate(
+            event_data,
+            metrics={"ear": event_around_return()},
+            factor_cols=["factor"],
+            strict=False,
+        )
+        m = res["factor"].metrics["ear"]
+        assert m.metadata.get("reason") != "no_price_data"
+        assert not math.isnan(m.value)
+
+    def test_short_circuits_when_price_absent(self, no_price_data):
+        res = fx.evaluate(
+            no_price_data,
+            metrics={"ear": event_around_return()},
+            factor_cols=["factor"],
+            strict=False,
+        )
+        m = res["factor"].metrics["ear"]
+        assert m.metadata["reason"] == "no_price_data"
+        assert math.isnan(m.value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`_project_factor` (the DAG executor's thin per-factor view) hardcoded a 4-column allow-list — `date, asset_id, forward_return, factor` — and dropped `price`. Event metrics (`event_around_return`, `mfe_mae`) consume `price` to build price paths, so they short-circuited with a false `no_price_data` verdict even when the caller supplied prices.

Rather than special-casing `price` with a one-off branch, this hoists the canonical input-data schema to `_data_input` as a single source of truth:
- `_BASELINE_COLUMNS` — required columns (was duplicated as a literal both in `evaluate`'s baseline validation and inside the projection)
- `_OPTIONAL_COLUMNS = ("price",)` — passed through to metrics when present, never required

Both `evaluate`'s baseline validation and the projection now reference these constants. The projection keeps optional columns through to metrics; adding a future optional column is a one-line change in one place.

## Test plan
- `tests/test_dag.py::TestProjectFactor` — projection renames factor / drops sibling factors, and preserves `price` when present
- `tests/test_event_horizon.py::TestEventMetricThroughEvaluate` — through `fx.evaluate`: event metric computes a real value (no `no_price_data`) when price is supplied, and still short-circuits to NaN when it is absent
- `python -m pytest` — 1338 passed, 4 skipped
- `ruff check`, `ruff format --check`, `mypy factrix` — clean

Closes #630
