### PR TITLE
fix(inspect): block magnitude-dependent metrics on discrete signals

### DIFF
--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -468,6 +468,22 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     (``caar``) is pre-flighted at its default config, and its in-body
     short-circuit on the actual run-time params stays authoritative.
 
+    A third, content-based gate beyond cell and sample shape: a metric
+    declaring ``requires_continuous_magnitude`` (e.g. ``event_ic``) is
+    blocked on a discrete ±k signal (``|factor|`` constant across events,
+    such as a ternary ``{-1, 0, +1}`` indicator), matching its run-time
+    ``not_applicable_discrete_signal`` short-circuit.
+
+    Multi-factor input: the detected :class:`DataProperties` and every
+    per-metric verdict are computed from the **first** factor column only
+    (deterministic first-detected). When columns disagree on
+    ``FactorDensity`` or ``FactorScope`` a ``CROSS_FACTOR_*_MISMATCH``
+    data-level warning is emitted directing the caller to re-run
+    ``inspect_data(data, factor_cols=[col])`` for a column-specific verdict.
+    Other per-column properties (e.g. signal magnitude, ``n_events``) are
+    likewise first-column-based; for a heterogeneous panel prefer the
+    per-column call.
+
     Args:
         data: Long-format factor data with the canonical columns.
             The baseline columns ``date`` / ``asset_id`` /
@@ -584,7 +600,19 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
                 )
             )
 
-    metrics = [_evaluate_applicability(spec, properties) for _, spec in public_specs()]
+    # Signal magnitude is a content gate beyond cell/sample shape: a discrete
+    # ±k factor (e.g. ternary {-1, 0, +1}) makes magnitude-dependent metrics
+    # (event_ic) undefined. Computed on the first column — the verdict basis
+    # for multi-factor input (see docstring) — using the same predicate the
+    # metric short-circuits on at run time.
+    from factrix.metrics._helpers import _event_signal_is_discrete
+
+    signal_discrete = _event_signal_is_discrete(data, first_col)
+
+    metrics = [
+        _evaluate_applicability(spec, properties, signal_discrete)
+        for _, spec in public_specs()
+    ]
 
     return DataInspection(
         detected=properties,
@@ -594,7 +622,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
 
 
 def _evaluate_applicability(
-    spec: MetricSpec, properties: DataProperties
+    spec: MetricSpec, properties: DataProperties, signal_discrete: bool
 ) -> MetricApplicability:
     from factrix.metrics._registry import REGISTRY
 
@@ -609,6 +637,14 @@ def _evaluate_applicability(
             f"({properties.scope.value.upper()}, "
             f"{properties.density.value.upper()}, "
             f"*, {properties.structure.value.upper()})"
+        )
+
+    if spec.requires_continuous_magnitude and signal_discrete:
+        blockers.append(
+            "discrete signal: |factor| has no magnitude variance over events "
+            "(e.g. a ternary {-1, 0, +1} indicator); this metric needs a "
+            "continuous magnitude and short-circuits "
+            "not_applicable_discrete_signal at run time"
         )
 
     floor = spec.sample_threshold

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -268,6 +268,11 @@ class MetricSpec:
       unusable / degraded. Defaults to ``SampleThreshold()`` (all
       ``None`` — no pre-flight gate); :func:`inspect_data` applies
       the cell-match check and any declared thresholds.
+    - ``requires_continuous_magnitude``: ``True`` when the metric needs a
+      continuous-magnitude factor (``|factor|`` must vary across events);
+      :func:`inspect_data` blocks it on a discrete ±k signal, matching the
+      metric's run-time ``not_applicable_discrete_signal`` short-circuit.
+      Defaults to ``False``.
     """
 
     name: str
@@ -279,6 +284,10 @@ class MetricSpec:
     requires: dict[str, Callable] = field(default_factory=dict)
     batchable: bool = False
     sample_threshold: SampleThreshold = field(default_factory=SampleThreshold)
+    # Pre-flight gate beyond cell/sample: the metric needs a continuous-magnitude
+    # factor (``|factor|`` varies across events). ``inspect_data`` blocks it on a
+    # discrete ±k signal, matching the metric's run-time short-circuit.
+    requires_continuous_magnitude: bool = False
 
     def __post_init__(self) -> None:
         if self.role is SpecRole.METRIC and self.output_shape is not OutputShape.SCALAR:

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -92,6 +92,12 @@ class MetricBase(metaclass=MetricMeta):
     sample_threshold_for: ClassVar[Callable[[MetricBase], SampleThreshold] | None] = (
         None
     )
+    # Declares that the metric needs a continuous-magnitude factor (``|factor|``
+    # must vary across events). A discrete ±k indicator makes it undefined; the
+    # metric short-circuits ``not_applicable_discrete_signal`` at run time and
+    # ``inspect_data`` blocks it pre-flight. Default ``False`` — most metrics
+    # accept any cardinality.
+    requires_continuous_magnitude: ClassVar[bool] = False
 
     _impl: ClassVar[Callable]
     _first_param_name: ClassVar[str | None]
@@ -134,6 +140,7 @@ class MetricBase(metaclass=MetricMeta):
             requires=cls.requires,
             batchable=cls.batchable,
             sample_threshold=threshold,
+            requires_continuous_magnitude=cls.requires_continuous_magnitude,
         )
 
     def _params(self) -> dict[str, Any]:

--- a/factrix/metrics/_decorators.py
+++ b/factrix/metrics/_decorators.py
@@ -29,6 +29,7 @@ def metric(
     batchable: bool = False,
     sample_threshold: SampleThreshold | None = None,
     sample_threshold_for: Callable[[Any], SampleThreshold] | None = None,
+    requires_continuous_magnitude: bool = False,
 ) -> Callable[[_F], _F]:
     """Decorator to define a Metric class from a function definition.
 
@@ -85,6 +86,7 @@ def metric(
             # reads the instance's configured param fields. ``None`` falls back
             # to the inherited static ``sample_threshold``.
             "sample_threshold_for": sample_threshold_for,
+            "requires_continuous_magnitude": requires_continuous_magnitude,
             "_impl": fn,
             "_first_param_name": first_param_name,
             "_param_names": tuple(f[0] for f in fields),

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -798,6 +798,31 @@ def _is_sparse_magnitude_weighted(
     return not all(abs(abs(v) - 1.0) < EPSILON for v in nz)
 
 
+def _event_signal_is_discrete(
+    df: pl.DataFrame,
+    factor_col: str = "factor",
+) -> bool:
+    """``True`` iff ``|factor|`` over event rows has no magnitude variance.
+
+    Event rows are ``factor_col != 0``. A discrete ±k indicator (e.g. the
+    canonical ternary ``{-1, 0, +1}`` from ``make_event_panel``) has a single
+    ``|factor|`` value, so the magnitude→return rank correlation that
+    ``event_ic`` measures is undefined — there is no magnitude variation to
+    correlate. This is the single source of truth for that condition: both
+    ``event_ic``'s run-time short-circuit and ``inspect_data``'s pre-flight
+    verdict call it, so the two cannot diverge.
+
+    Returns ``False`` for an empty event set — that is a sample shortage
+    ("too few events"), handled by the event-count floor, not a discreteness
+    blocker.
+    """
+    events = df.filter(pl.col(factor_col) != 0)
+    if events.is_empty():
+        return False
+    abs_signal = np.abs(events[factor_col].to_numpy())
+    return bool(np.ptp(abs_signal) < EPSILON)
+
+
 def _median_universe_size(df: pl.DataFrame) -> int:
     """Median number of unique assets per date."""
     return int(

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -40,6 +40,7 @@ from factrix._types import EPSILON, MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
+    _event_signal_is_discrete,
     _short_circuit_output,
     _signed_car,
 )
@@ -138,6 +139,7 @@ def event_hit_rate(
     cell=_EQ_CELL,
     aggregation=Aggregation.EVENT_TIME,
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
+    requires_continuous_magnitude=True,
 )
 def event_ic(
     df: pl.DataFrame,
@@ -199,18 +201,19 @@ def event_ic(
     if sc is not None:
         return sc
 
-    abs_signal = np.abs(events[factor_col].to_numpy())
-
-    if np.ptp(abs_signal) < EPSILON:
+    if _event_signal_is_discrete(df, factor_col):
         # Signal is discrete {±1}: event_ic is not defined (no magnitude variance).
         # Flagged as "not_applicable" rather than "insufficient" — this is by
         # design, not a shortfall; profiles suppress the field (→ None).
+        # Same predicate drives inspect_data's pre-flight verdict (declared via
+        # MetricSpec.requires_continuous_magnitude) so the two cannot diverge.
         return _short_circuit_output(
             "event_ic",
             "not_applicable_discrete_signal",
             n_events=n,
         )
 
+    abs_signal = np.abs(events[factor_col].to_numpy())
     signed = _signed_car(events, factor_col, return_col)
 
     rho, p = sp_stats.spearmanr(abs_signal, signed)

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -154,7 +154,9 @@ class TestSampleThresholdGate:
         from factrix._inspect import _evaluate_applicability
 
         verdict = _evaluate_applicability(
-            replace(spec, sample_threshold=floor), info.detected
+            replace(spec, sample_threshold=floor),
+            info.detected,
+            signal_discrete=False,
         )
         assert verdict.usable is False
         assert any("min_pairs" in b for b in verdict.blockers)
@@ -170,7 +172,9 @@ class TestSampleThresholdGate:
         floor = SampleThreshold(min_pairs=n - 1, warn_pairs=n + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_ir")
         verdict = _evaluate_applicability(
-            replace(spec, sample_threshold=floor), info.detected
+            replace(spec, sample_threshold=floor),
+            info.detected,
+            signal_discrete=False,
         )
         assert verdict.usable is True
         assert any("n_pairs" in w.message for w in verdict.warnings)
@@ -291,7 +295,9 @@ class TestEventAxisPreflight:
         floor = SampleThreshold(min_events=info.detected.n_events + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "corrado_rank")
         verdict = _evaluate_applicability(
-            replace(spec, sample_threshold=floor), info.detected
+            replace(spec, sample_threshold=floor),
+            info.detected,
+            signal_discrete=False,
         )
         assert verdict.usable is False
         assert any("min_events" in b for b in verdict.blockers)
@@ -307,10 +313,66 @@ class TestEventAxisPreflight:
         floor = SampleThreshold(min_events=n - 1, warn_events=n + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "corrado_rank")
         verdict = _evaluate_applicability(
-            replace(spec, sample_threshold=floor), info.detected
+            replace(spec, sample_threshold=floor),
+            info.detected,
+            signal_discrete=False,
         )
         assert verdict.usable is True
         assert "few_events" in [w.code.value for w in verdict.warnings]
+
+
+class TestContinuousMagnitudePreflight:
+    """event_ic declares requires_continuous_magnitude: the pre-flight must
+    block it on a discrete ±k signal, matching its run-time short-circuit."""
+
+    def _ternary_event_panel(self):
+        raw = fx.datasets.make_event_panel(n_assets=50, n_dates=400, seed=0)
+        return fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    def _continuous_magnitude_panel(self):
+        # Scale the ±1 events by a random positive magnitude so |factor| varies.
+        import numpy as np
+
+        df = self._ternary_event_panel()
+        rng = np.random.default_rng(0)
+        scale = pl.Series(rng.uniform(0.5, 2.0, len(df)))
+        return df.with_columns(
+            pl.when(pl.col("factor") != 0)
+            .then(pl.col("factor") * scale)
+            .otherwise(0.0)
+            .alias("factor")
+        )
+
+    def test_event_ic_blocked_on_discrete_signal(self):
+        info = inspect_data(self._ternary_event_panel())
+        eic = _by_name(info, "event_ic")
+        assert eic.usable is False
+        assert any("discrete signal" in b for b in eic.blockers)
+
+    def test_event_ic_usable_on_continuous_magnitude(self):
+        info = inspect_data(self._continuous_magnitude_panel())
+        eic = _by_name(info, "event_ic")
+        assert eic.usable is True
+        assert not any("discrete" in b for b in eic.blockers)
+
+    def test_preflight_verdict_matches_evaluate(self):
+        # The pre-flight gate and the run-time short-circuit share one predicate
+        # (_event_signal_is_discrete), so a discrete signal must agree on both
+        # paths: inspect_data says unusable AND evaluate short-circuits to NaN.
+        panel = self._ternary_event_panel()
+        from factrix.metrics import event_ic
+
+        eic = _by_name(inspect_data(panel), "event_ic")
+        assert eic.usable is False
+
+        res = fx.evaluate(
+            panel,
+            metrics={"eic": event_ic()},
+            factor_cols=["factor"],
+            strict=False,
+        )["factor"].metrics["eic"]
+        assert math.isnan(res.value)
+        assert res.metadata["reason"] == "not_applicable_discrete_signal"
 
 
 class TestTierPartition:


### PR DESCRIPTION
## Summary
Two pre-flight accuracy gaps in `inspect_data` (issue #632).

### Gap 1 — `event_ic` falsely usable on discrete signals
`make_event_panel` produces a ternary `{-1, 0, +1}` factor. `inspect_data` marked `event_ic` usable (cell SPARSE×PANEL matches, event floor met), but `evaluate` immediately short-circuits with `not_applicable_discrete_signal` — `event_ic` needs a continuous magnitude (`|factor|` must vary across events) and the ±1 indicator has none. A classic pre-flight ↔ run-time divergence.

**Fix — a content-based pre-flight gate, declarative and drift-proof:**
- The discreteness condition is extracted to one shared helper, `_event_signal_is_discrete(df, factor_col)`, called by **both** `event_ic`'s run-time short-circuit and `inspect_data`'s pre-flight. Single source of truth → the two can't drift again (the root cause of the bug).
- Metrics declare the requirement via a new `MetricSpec.requires_continuous_magnitude` flag (`event_ic` sets it). The pre-flight adds a clear blocker on a discrete signal — **no metric is matched by name**.
- No new `DataProperties` field: discreteness is computed inline in `inspect_data` (a first-column-only field would mislead on multi-factor input, and `event_ic`'s blocker reason already conveys it).

### Gap 2 — multi-factor verdict basis
The detected properties and per-metric verdicts are computed from the **first** factor column. This is now documented on `inspect_data`. Heterogeneous-density/scope panels already emit `CROSS_FACTOR_*_MISMATCH` directing the caller to `inspect_data(data, factor_cols=[col])`. The discrete-vs-continuous case almost always also differs in `FactorDensity` (a ternary sparse indicator → SPARSE; a continuous factor → DENSE), so the existing density-mismatch guidance already covers it — no third warning code is added (its marginal value is low and it would mostly duplicate the density warning).

## Design notes (consistency / simplicity / UX)
- **Consistency**: mirrors the established declare-once pattern (`sample_threshold`); the shared-helper guarantee parallels the existing direct-call-vs-evaluate consistency discipline.
- **Simplicity**: 2 wiring points (spec flag + inspect branch) + 1 helper; deliberately *no* `DataProperties` field and *no* new `WarningCode`.
- **UX**: a discrete-signal blocker now reads clearly and matches what `evaluate` does, instead of `usable=True` followed by a NaN at run time.

## Test plan
- `tests/test_inspect_data.py::TestContinuousMagnitudePreflight`
  - `event_ic` blocked on a ternary panel (discrete-signal blocker present)
  - `event_ic` usable once events carry continuous magnitude
  - pre-flight verdict matches `evaluate` (unusable ↔ run-time `not_applicable_discrete_signal`)
- existing `_evaluate_applicability` direct-call tests updated for the new `signal_discrete` parameter
- `python -m pytest` — 1343 passed, 4 skipped; `ruff check` / `ruff format --check` / `mypy factrix` clean; doctests pass

Closes #632
