### PR TITLE
fix(preprocess): guard compute_forward_return against silent double-compute

### DIFF
--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -10,10 +10,16 @@ Use ``adapt()`` to rename before calling.
 
 import polars as pl
 
+from factrix._errors import UserInputError
+
+_DOCS_FORWARD_RETURN = "api/preprocess#compute_forward_return"
+
 
 def compute_forward_return(
     df: pl.DataFrame,
     forward_periods: int = 5,
+    *,
+    overwrite: bool = False,
 ) -> pl.DataFrame:
     """Step 1: Compute per-period forward return per asset.
 
@@ -43,6 +49,18 @@ def compute_forward_return(
             not calendar time (default 5). On a daily panel this is 5
             trading days; on a weekly panel, 5 weeks; on 1-min bars,
             5 minutes. Frequency is the caller's responsibility.
+        overwrite: Allow recomputation when ``df`` already carries a
+            ``forward_return`` column. ``False`` (default) raises rather
+            than silently overwrite — the function is **not idempotent**:
+            the previous call already dropped the last ``forward_periods + 1``
+            rows per asset, so recomputing on the result drops a *further*
+            tail. To change the horizon, recompute from the original
+            (pre-forward-return) panel; ``overwrite=True`` recomputes in
+            place anyway, accepting the additional truncation.
+
+    Raises:
+        UserInputError: ``df`` already has a ``forward_return`` column and
+            ``overwrite`` is ``False``.
 
     Returns:
         Input DataFrame with ``forward_return`` column appended.
@@ -111,6 +129,24 @@ def compute_forward_return(
         >>> isinstance(results, dict) and "factor" in results
         True
     """
+    if "forward_return" in df.columns:
+        if not overwrite:
+            raise UserInputError(
+                func_name="compute_forward_return",
+                field="df",
+                value="DataFrame already has a 'forward_return' column",
+                expected=(
+                    "a panel without 'forward_return'. This function is not "
+                    "idempotent — a prior call already dropped the last "
+                    "forward_periods+1 rows per asset, so recomputing drops a "
+                    "further tail and silently shrinks the data. To change the "
+                    "horizon, recompute from the original (pre-forward-return) "
+                    "panel; pass overwrite=True to recompute in place anyway."
+                ),
+                docs_path=_DOCS_FORWARD_RETURN,
+            )
+        df = df.drop("forward_return")
+
     return (
         df.sort(["asset_id", "date"])
         .with_columns(

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -134,7 +134,7 @@ def compute_forward_return(
             raise UserInputError(
                 func_name="compute_forward_return",
                 field="df",
-                value="DataFrame already has a 'forward_return' column",
+                value=list(df.columns),
                 expected=(
                     "a panel without 'forward_return'. This function is not "
                     "idempotent — a prior call already dropped the last "

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -57,6 +57,24 @@ class TestComputeForwardReturn:
         a_ret = result.filter(pl.col("asset_id") == "A")["forward_return"][0]
         assert a_ret == pytest.approx(0.21 / 2)
 
+    def test_raises_when_forward_return_already_present(self):
+        from factrix._errors import UserInputError
+
+        once = compute_forward_return(_make_price_data(), forward_periods=1)
+        with pytest.raises(UserInputError, match="not"):
+            compute_forward_return(once, forward_periods=1)
+
+    def test_overwrite_recomputes_in_place(self):
+        once = compute_forward_return(_make_price_data(), forward_periods=1)
+        # overwrite drops the old column and recomputes; not idempotent — the
+        # already-truncated tail is dropped again, so the row count shrinks.
+        twice = compute_forward_return(once, forward_periods=1, overwrite=True)
+        assert "forward_return" in twice.columns
+        assert twice["forward_return"].null_count() == 0
+        assert twice.height < once.height
+        # Exactly one forward_return column (old dropped, not duplicated).
+        assert twice.columns.count("forward_return") == 1
+
 
 class TestWinsorizeForwardReturn:
     def test_noop(self):

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -61,7 +61,7 @@ class TestComputeForwardReturn:
         from factrix._errors import UserInputError
 
         once = compute_forward_return(_make_price_data(), forward_periods=1)
-        with pytest.raises(UserInputError, match="not"):
+        with pytest.raises(UserInputError, match="not idempotent"):
             compute_forward_return(once, forward_periods=1)
 
     def test_overwrite_recomputes_in_place(self):
@@ -72,8 +72,14 @@ class TestComputeForwardReturn:
         assert "forward_return" in twice.columns
         assert twice["forward_return"].null_count() == 0
         assert twice.height < once.height
-        # Exactly one forward_return column (old dropped, not duplicated).
-        assert twice.columns.count("forward_return") == 1
+
+    def test_overwrite_changes_horizon(self):
+        raw = _make_price_data()
+        once = compute_forward_return(raw, forward_periods=1)
+        changed = compute_forward_return(once, forward_periods=2, overwrite=True)
+        assert "forward_return" in changed.columns
+        assert changed["forward_return"].null_count() == 0
+        assert changed["forward_return"].to_list() != once["forward_return"].to_list()
 
 
 class TestWinsorizeForwardReturn:


### PR DESCRIPTION
## Summary

`compute_forward_return` was not idempotent and silently lost data. Called on a panel that already carries `forward_return`, it recomputed from `price` and re-applied the null-tail filter — but the previous call had already dropped the last `forward_periods + 1` rows per asset, so the second call dropped a further tail:

```python
p1 = compute_forward_return(raw, forward_periods=5)   # (12350, 5)
p2 = compute_forward_return(p1, forward_periods=5)     # (12200, 5)  ← 150 rows gone, no warning
```

### Fix

- Raise `UserInputError` when `forward_return` is already present, with a message that explains the non-idempotency and points the user to recompute from the original (pre-forward-return) panel — or pass `overwrite=True`.
- New keyword-only `overwrite: bool = False`. `overwrite=True` drops the stale column and recomputes in place, accepting that an already-truncated panel is truncated again (documented).
- `UserInputError.value` carries `list(df.columns)` — the actual column list — so callers can inspect the structured attribute without parsing the message string.

### Why raise, not warn

The DoD allows `UserWarning` or `UserInputError`. A hard raise is the correct default: a warning would still overwrite the column and drop the rows — it only makes the loss loud, not preventable. For a silent-data-loss footgun, the correct default is to not lose data. The escape hatch (`overwrite=True`) keeps the intentional path one keyword away.

### Safety

No existing call site double-computes — the dataset factories (`make_cs_panel`, `make_event_panel`) emit raw panels — so the new default does not break any current flow.

## Test plan

- `tests/test_returns.py::TestComputeForwardReturn`
  - `test_raises_when_forward_return_already_present` — raises `UserInputError` matching "not idempotent"
  - `test_overwrite_recomputes_in_place` — column present, no nulls, row count shrinks (re-truncation)
  - `test_overwrite_changes_horizon` — `overwrite=True` with a different `forward_periods` produces different return values; covers the primary use-case
- `python -m pytest` — 1348 passed, 4 skipped; doctests on `returns.py` pass
- `ruff check` / `ruff format --check` / `mypy factrix` — clean

Closes #635