### PR TITLE
feat(slicing): add date-disjoint cross-slice inference pair

### DIFF
--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -2,9 +2,22 @@
 title: factrix.slice_pairwise_test / factrix.slice_joint_test
 ---
 
+The cross-slice inference surface is **two function pairs**, split on
+whether the slices share dates:
+
+- **Cross-sectional / date-aligned** — `slice_pairwise_test` /
+  `slice_joint_test` (sector, size bucket, liquidity tier).
+- **Date-disjoint** — `slice_period_pairwise_test` /
+  `slice_period_joint_test` (market regime, calendar period,
+  in/out-of-sample). See [Date supports: aligned vs disjoint](#date-supports-aligned-vs-disjoint).
+
 ::: factrix.slice_pairwise_test
 
 ::: factrix.slice_joint_test
+
+::: factrix.slice_period_pairwise_test
+
+::: factrix.slice_period_joint_test
 
 Cross-slice statistical-test function pair. Both take a date-keyed
 DataFrame (data-first) and a metric callable; the `by` column carries the
@@ -36,19 +49,31 @@ See the docstring Examples blocks above for the canonical
 per-sub-universe construction (`compute_ic` per sector, concatenated
 with a `sector` label column).
 
-## Date alignment is required
+## Date supports: aligned vs disjoint
 
-Both functions join all slices on `date` and run inference on the
-intersected rows. Joint Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) over the (T, K) per-date metric panel
+`slice_pairwise_test` / `slice_joint_test` join all slices on `date` and
+run inference on the intersected rows. Joint Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) over the (T, K) per-date metric panel
 needs aligned rows so cross-slice covariance enters through the joint
 kernel. Slices with **disjoint date supports** (e.g. regimes split by
-time period) yield zero aligned rows and the functions raise `ValueError`.
+time period) yield zero aligned rows and these functions raise
+`ValueError` (`<2 aligned dates`). Date-shared slices — universe,
+sector, market-cap tier — are their intended use case.
 
-For genuinely time-disjoint slices, run inference per slice and
-compare summaries upstream (or wait for the future
-`factor_decomposition` function, which adopts a different SE geometry).
-Date-shared slices — universe, sector, market-cap tier — are the
-intended use case.
+For genuinely time-disjoint slices, reach for
+`slice_period_pairwise_test` / `slice_period_joint_test`. They build the
+same per-slice per-date series but **do not** inner-join — each slice is
+treated as an independent sample with block-diagonal cross-slice
+covariance. A two-valued `method` flag selects the estimator:
+
+| `method` | Per-slice SE | Pairwise `p_adj` | Best for |
+|---|---|---|---|
+| `"bootstrap"` (default) | Independent stationary block bootstrap (Politis-White automatic block length) | Romano-Wolf step-down | Short regimes (T ≈ 30-80); never invalid |
+| `"analytic"` | Per-slice Newey-West HAC, Welch-style pairwise contrast | Holm step-down | Long spans (T ≳ 100); fast, deterministic |
+
+Pairwise output is `(slice_a, slice_b, n_periods_a, n_periods_b,
+mean_diff, stat, p_raw, p_adj)` — per-slice `n_periods_*` because
+disjoint spans differ in length. The omnibus is a block-diagonal Wald χ²
+returning `(k_slices, df, stat, p_value)`.
 
 ## Estimator dispatch
 

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -6,7 +6,14 @@ title: Slice Analysis
     What slice analysis is, the two-role split (`by_slice` dispatcher vs `slice_pairwise_test` / `slice_joint_test` inference), and when to reach for each.
     For the API surface, see [`by_slice`](../api/by-slice.md) and [`slice_pairwise_test` / `slice_joint_test`](../api/slice-test.md).
 
-Slice analysis asks "is this factor stable across a partition of the panel?" The partition can be a market regime (bull / bear, high-vol / low-vol), a universe (large-cap / small-cap, listed-board / OTC), a sector, an ADV bucket, or any other column you can attach to the panel. The statistical question is the same regardless of axis, so factrix exposes one axis-agnostic surface rather than one function per slice dimension. Concretely: `by_slice` is the dispatcher, `slice_pairwise_test` / `slice_joint_test` are the inference function pair.
+Slice analysis asks "is this factor stable across a partition of the panel?" The partition can be a market regime (bull / bear, high-vol / low-vol), a universe (large-cap / small-cap, listed-board / OTC), a sector, an ADV bucket, a calendar period, or any other column you can attach to the panel. `by_slice` — the descriptive dispatcher — *is* axis-agnostic: it partitions on any column and runs `evaluate` per slice.
+
+The **inference** functions are not. Cross-slice testing splits on a statistical fault line the dispatcher does not see — **do the slices share dates?**
+
+- **Cross-sectional / date-aligned** slices (sector, size bucket, liquidity tier) co-exist in time; cross-slice covariance is real and enters through a joint Newey-West HAC. → [`slice_pairwise_test` / `slice_joint_test`](../api/slice-test.md).
+- **Date-disjoint** slices (market regime, calendar period, in/out-of-sample) share no dates; they are (approximately) independent samples with block-diagonal covariance. The cross-sectional pair inner-joins on `date` and raises `<2 aligned dates` here. → [`slice_period_pairwise_test` / `slice_period_joint_test`](../api/slice-test.md), which treat each slice as an independent sample (bootstrap by default, analytic HAC opt-in).
+
+Picking the wrong pair is not a tuning choice — it is the wrong statistical assumption, so the two are **separate, explicitly-named** functions rather than one auto-routing surface.
 
 factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs. The legacy regime-specific surface (`by_regime`, `regime_ic`) was removed in v0.12.0 — see the CHANGELOG migration recipe.
 
@@ -15,7 +22,8 @@ factrix splits this work into two roles because **slicing the panel** and **test
 | Role | Function | What it does | What it does not do |
 |---|---|---|---|
 | Dispatcher | [`by_slice(data, metric, *, by, factor_col)`](../api/by-slice.md) | Partitions a raw panel on an existing column and runs `evaluate` per slice; returns `dict[str, EvaluationResult]` (same shape as `evaluate`, keyed by slice) | **No cross-slice statistical test** |
-| Inference | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | Pairwise contrasts (Wald χ² + Holm / Romano-Wolf / Bonferroni) or omnibus χ² that all slice means are equal | Only accepts metrics with a `per_date_series` capability (`ic`, `fm_beta`, `hit_rate`) |
+| Inference (date-aligned) | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | Cross-sectional pairwise contrasts (joint NW-HAC Wald χ² + Holm) or omnibus χ² that all slice means are equal | Only accepts metrics with a `per_date_series` capability (`ic`, `fm_beta`, `hit_rate`); requires slices to share dates |
+| Inference (date-disjoint) | [`slice_period_pairwise_test`](../api/slice-test.md) / [`slice_period_joint_test`](../api/slice-test.md) | Independent-sample pairwise contrasts (bootstrap + Romano-Wolf, or analytic HAC + Holm) / block-diagonal omnibus χ² for regime / calendar-period splits | Same `per_date_series` requirement; treats each slice as an independent sample |
 
 **Use the dispatcher when:** you want raw per-slice numbers, or you want to compose your own cross-slice test.
 
@@ -82,19 +90,23 @@ Scalar-input utilities (`breakeven_cost`, `net_spread`) are excluded — they co
 
 ## Worked example: IC across volatility regimes
 
-The dispatcher and the inference pair take **different inputs**, because
-they answer different questions. `by_slice` partitions the **raw panel**
-and runs `evaluate` per slice (each slice an independent dataset); the
-inference functions consume the **per-date metric series** to line up
-aligned observations across slices for a cross-slice Wald test.
+The dispatcher and the inference pair are both **data-first** — raw panel
++ metric instance + `by` + `factor_col` — but answer different questions.
+`by_slice` runs `evaluate` per slice (each slice an independent dataset);
+the inference functions add the calibrated cross-slice test. Volatility
+regimes are **date-disjoint** (a given date is either high- or low-vol,
+never both), so the inference path here is the `slice_period_*` pair, not
+the cross-sectional one.
 
 ```python
 import polars as pl
-from factrix import by_slice, slice_pairwise_test
-from factrix.metrics import compute_ic, ic
+from factrix import by_slice, slice_period_pairwise_test
+from factrix.metrics import ic
+
+# Attach the regime label to the raw panel (one label per date).
+panel_reg = panel.join(vol_labels, on="date", how="inner")
 
 # --- Dispatcher: per-regime IC, raw panel in, dict[str, EvaluationResult] out
-panel_reg = panel.join(vol_labels, on="date", how="inner")  # attach regime to panel
 per_regime = by_slice(panel_reg, ic(), by="regime", factor_col="value")
 for label, result in per_regime.items():
     m = result.metrics["metric"]
@@ -106,15 +118,15 @@ pl.concat([
     for k, r in per_regime.items()
 ])
 
-# --- Inference: per-date IC series in, pairwise Wald contrasts out
-ic_df = compute_ic(panel, factor_cols=["value"], return_col="forward_return")["value"]
-merged = ic_df.join(vol_labels, on="date", how="inner")
-pairs = slice_pairwise_test(merged, ic, by="regime")
-print(pairs)  # columns: slice_a, slice_b, n_obs, stat, p_raw, p_adj
+# --- Inference: same raw panel in, pairwise regime contrasts out.
+# Bootstrap (default) is the right call for short regimes; pass
+# method="analytic" for long calendar spans (T ≳ 100).
+pairs = slice_period_pairwise_test(panel_reg, ic(), by="regime", factor_col="value")
+print(pairs)  # slice_a, slice_b, n_periods_a, n_periods_b, mean_diff, stat, p_raw, p_adj
 ```
 
 ## Related
 
 - [`by_slice`](../api/by-slice.md) — dispatcher surface and universe-overlap recipes.
-- [`slice_pairwise_test` / `slice_joint_test`](../api/slice-test.md) — cross-slice inference function pair.
+- [`slice_pairwise_test` / `slice_joint_test`](../api/slice-test.md) — cross-sectional (date-aligned) inference pair; `slice_period_*` are the date-disjoint counterparts.
 - [Benjamini-Hochberg-Yekutieli (BHY) screening](../api/bhy.md) — false discovery rate (FDR) control across factor candidates rather than slices.

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -93,6 +93,8 @@ from factrix.slicing import (
     by_slice,
     slice_joint_test,
     slice_pairwise_test,
+    slice_period_joint_test,
+    slice_period_pairwise_test,
 )
 
 
@@ -721,6 +723,8 @@ __all__ = [
     "by_slice",
     "slice_joint_test",
     "slice_pairwise_test",
+    "slice_period_joint_test",
+    "slice_period_pairwise_test",
     # Multi-factor namespace
     "multi_factor",
     # Synthetic panels

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -189,10 +189,11 @@ Typed pre-flight introspection that combines axis detection with a per-metric us
 
 ---
 
-### `by_slice` / `slice_pairwise_test` / `slice_joint_test`
+### `by_slice` / `slice_pairwise_test` / `slice_joint_test` / `slice_period_pairwise_test` / `slice_period_joint_test`
 
 - `by_slice(data, metric, *, by, factor_col)` partitions a raw panel by a grouping column and runs `evaluate` per slice, returning `dict[str, EvaluationResult]` (same shape as `evaluate`, keyed by slice). `metric` is an instance (e.g. `ic()`); DAG-consumer metrics work with no pre-computation.
-- `slice_pairwise_test` / `slice_joint_test` perform cross-slice Wald tests (Holm/Romano-Wolf adjusted) on the means.
+- `slice_pairwise_test` / `slice_joint_test` perform **cross-sectional** (date-aligned) cross-slice Wald tests (joint Newey-West HAC + slice cluster, Holm-adjusted) on the per-date means — for slices that share dates (sector, size bucket, liquidity tier).
+- `slice_period_pairwise_test` / `slice_period_joint_test` are the **date-disjoint** counterparts (market regime, calendar period, in/out-of-sample) — each slice is an independent sample with block-diagonal covariance. A `method` flag selects the estimator: `"bootstrap"` (default; independent stationary block bootstrap + Romano-Wolf, right for short regimes) or `"analytic"` (per-slice Newey-West HAC + Welch contrast + Holm, for long spans T ≳ 100). Pairwise output carries per-slice `n_periods_a` / `n_periods_b`.
 
 ---
 

--- a/factrix/slicing/__init__.py
+++ b/factrix/slicing/__init__.py
@@ -5,9 +5,12 @@ Public surface:
 - :func:`by_slice` — partition a raw panel by an existing column and
   run :func:`factrix.evaluate` per slice (no cross-slice inference).
 - :func:`slice_pairwise_test` — K(K-1)/2 cross-slice Wald contrasts
-  with Holm-adjusted p-values.
+  with Holm-adjusted p-values (cross-sectional / date-aligned slices).
 - :func:`slice_joint_test` — single-row omnibus Wald χ² that all
-  slice means are equal.
+  slice means are equal (cross-sectional / date-aligned slices).
+- :func:`slice_period_pairwise_test` / :func:`slice_period_joint_test`
+  — the date-disjoint counterparts (regime / calendar period /
+  in-out-of-sample) treating slices as independent samples.
 
 These functions are intentionally *not* hosted under
 ``factrix.metrics``: that package is a structural registry where
@@ -20,9 +23,15 @@ from __future__ import annotations
 
 from factrix.slicing.dispatcher import by_slice
 from factrix.slicing.inference import slice_joint_test, slice_pairwise_test
+from factrix.slicing.period_inference import (
+    slice_period_joint_test,
+    slice_period_pairwise_test,
+)
 
 __all__ = [
     "by_slice",
     "slice_joint_test",
     "slice_pairwise_test",
+    "slice_period_joint_test",
+    "slice_period_pairwise_test",
 ]

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -1,0 +1,450 @@
+"""Cross-slice statistical-test functions for **date-disjoint** partitions.
+
+The sibling :mod:`factrix.slicing.inference` pair
+(:func:`slice_pairwise_test` / :func:`slice_joint_test`) is
+**cross-sectional**: it inner-joins each slice's per-date series on
+``date`` and runs a joint Newey-West HAC + slice-cluster Wald. Its maths
+assumes the slices share dates (sector, size bucket, liquidity tier) so
+cross-slice covariance enters through the joint HAC.
+
+**date-disjoint** partitions — market regime (bull / bear, high-vol /
+low-vol), calendar period, in/out-of-sample — have *no* common dates:
+the cross-sectional inner-join collapses to 0 rows. Their statistical
+nature is fundamentally different: disjoint spans are (approximately)
+**independent samples** with **block-diagonal** cross-slice covariance.
+This module supplies the matching inference pair —
+:func:`slice_period_pairwise_test` / :func:`slice_period_joint_test` —
+named ``slice_period_*`` because each slice occupies a distinct span of
+time (covering regime, calendar period, and in/out-of-sample alike).
+They are **regime analysis**'s inferential entry point: ``by_slice``
+gives the descriptive per-regime numbers, this pair gives the calibrated
+cross-regime contrast with multiple-testing control.
+
+These are kept as a **separate, explicit** function pair (not folded into
+the cross-sectional pair via date-overlap auto-routing) so the two
+statistical assumptions never hide behind one name.
+
+Both consume the same per-slice per-date series as the cross-sectional
+pair (metric producer → ``per_date_series``) but **do not inner-join** —
+each slice keeps its own dates. A two-valued ``method`` flag selects the
+standard-error / p estimator:
+
+- ``"bootstrap"`` (default) — each slice's series is **independently**
+  block-bootstrapped (stationary blocks, Politis-White automatic block
+  length); pairwise multiplicity is **Romano-Wolf** step-down
+  (bootstrap-native, exploits the joint dependence through shared
+  slices). Never invalid: asymptotically valid *and* small-sample robust
+  (the block length absorbs serial autocorrelation, i.e. built-in HAC).
+  The right default for short regimes (T ≈ 30-80) where HAC asymptotics
+  are unreliable.
+- ``"analytic"`` (opt-in) — each slice mean carries a Newey-West HAC
+  variance; pairwise contrasts are Welch-style unequal-variance, the
+  omnibus is a block-diagonal Wald χ²; pairwise multiplicity is **Holm**
+  (no bootstrap distribution, so Romano-Wolf is unavailable). Faster,
+  deterministic, closed-form — choose it when T is large enough for HAC
+  asymptotics (rule of thumb T ≳ 100): decade sub-samples, pre/post,
+  in/out-of-sample.
+
+The ``p_adj`` correction family is decided *internally* by ``method``
+(bootstrap → Romano-Wolf, analytic → Holm); there is deliberately no
+separate ``multiple_testing`` knob.
+
+**Independence assumption.** Disjoint spans are treated as independent
+samples (block-diagonal covariance). Adjacent regimes may carry boundary
+serial correlation; that is not auto-detected (no general reliable
+"calendar-adjacent" semantics) — the caller owns the partition.
+
+Matrix-row: slice_period_pairwise_test, slice_period_joint_test | (*, *, *, *, *) | inference function | per-pair studentized contrast + Romano-Wolf/Holm / block-diagonal Wald χ² | _build_per_slice_series, _slice_by, resolve_per_date_series
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Literal
+
+import numpy as np
+import polars as pl
+from scipy import stats as sp_stats
+
+from factrix._errors import UserInputError
+from factrix._stats.bootstrap import (
+    Scheme,
+    _politis_white_block_length,
+    _stationary_block_indices,
+)
+from factrix._stats.multiple_testing import holm_step_down, romano_wolf
+from factrix._stats.wald import _nw_hac_vector_mean, _wald_p_linear
+from factrix._types import EPSILON
+from factrix.metrics._base import MetricBase
+from factrix.metrics._metric_capabilities import resolve_per_date_series
+from factrix.slicing._primitive import _slice_by
+from factrix.slicing.inference import (
+    _DOCS_SLICE,
+    _hac_lags,
+    _resolve_producer,
+    _validate_metric_instance,
+)
+
+Method = Literal["bootstrap", "analytic"]
+
+_N_RESAMPLES = 999
+_SCHEME: Scheme = "stationary"
+
+
+def _validate_method(method: str, func_name: str) -> None:
+    if method not in ("bootstrap", "analytic"):
+        raise UserInputError(
+            func_name=func_name,
+            field="method",
+            value=method,
+            expected='one of "bootstrap" (default) or "analytic"',
+            docs_path=_DOCS_SLICE,
+        )
+
+
+def _build_per_slice_series(
+    data: pl.DataFrame,
+    metric: MetricBase,
+    by: str,
+    *,
+    factor_col: str,
+    func_name: str,
+) -> tuple[list[str], list[np.ndarray]]:
+    """Partition ``data`` by ``by`` and build each slice's per-date series.
+
+    Mirrors the cross-sectional :func:`_build_per_date_panel` front-end
+    (producer → ``per_date_series``) but **does not inner-join on date** —
+    each slice keeps its own (disjoint) dates. Returns
+    ``(labels, [series_k])`` with each ``series_k`` a 1-D ``np.ndarray``
+    of that slice's per-date metric values.
+
+    Raises ``UserInputError`` if ``factor_col`` is absent; ``ValueError``
+    on <2 slice values or any slice with <2 dates; ``TypeError`` (via
+    resolver) if ``metric`` is not slice-test-eligible.
+    """
+    if factor_col not in data.columns:
+        raise UserInputError(
+            func_name=func_name,
+            field="factor_col",
+            value=factor_col,
+            expected=f"a column present in data; got columns {data.columns}",
+            docs_path=_DOCS_SLICE,
+        )
+    per_date_fn = resolve_per_date_series(type(metric))
+    producer = _resolve_producer(metric, func_name)
+    slices = _slice_by(data, by)
+    if len(slices) < 2:
+        raise ValueError(
+            f"{func_name}: need ≥2 slice values on {by!r}; got {len(slices)}."
+        )
+    labels = list(slices.keys())
+    series_list: list[np.ndarray] = []
+    for lbl in labels:
+        produced = producer(slices[lbl], factor_cols=[factor_col])
+        s = per_date_fn(produced[factor_col])["value"].to_numpy()
+        if s.shape[0] < 2:
+            raise ValueError(
+                f"{func_name}: slice {lbl!r} has <2 dates ({s.shape[0]}); "
+                f"each disjoint slice needs ≥2 per-date observations for a "
+                f"within-slice variance estimate."
+            )
+        series_list.append(np.asarray(s, dtype=float))
+    return labels, series_list
+
+
+def _bootstrap_slice_means(
+    series_list: list[np.ndarray],
+    *,
+    rng: np.random.Generator,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Independent stationary-block bootstrap of each slice's mean.
+
+    Each slice is resampled **on its own** (disjoint ⇒ independent), with
+    a per-slice Politis-White automatic block length that absorbs the
+    series' serial autocorrelation. Returns ``(obs_means[K],
+    boot_means[K, B])`` — the same ``B`` draws per slice so every pairwise
+    difference is formed from one shared set, preserving the joint
+    dependence (through shared slices) that Romano-Wolf exploits.
+    """
+    k = len(series_list)
+    obs_means = np.empty(k)
+    boot = np.empty((k, _N_RESAMPLES))
+    for i, s in enumerate(series_list):
+        obs_means[i] = float(s.mean())
+        block_len = _politis_white_block_length(s, scheme=_SCHEME)
+        idx = _stationary_block_indices(len(s), _N_RESAMPLES, float(block_len), rng)
+        boot[i] = s[idx].mean(axis=1)
+    return obs_means, boot
+
+
+def slice_period_pairwise_test(
+    data: pl.DataFrame,
+    metric: MetricBase,
+    *,
+    by: str,
+    factor_col: str,
+    method: Method = "bootstrap",
+    rng_seed: int | None = None,
+) -> pl.DataFrame:
+    """Pairwise cross-slice contrasts for a **date-disjoint** partition.
+
+    Date-disjoint counterpart of :func:`slice_pairwise_test`: partitions
+    a raw panel on ``by``, builds each slice's per-date metric series via
+    the metric's producer, and contrasts every slice pair as **independent
+    samples** (no date inner-join). The right tool for **regime analysis**
+    (bull / bear, high-vol / low-vol) and other time-disjoint splits
+    (calendar period, in/out-of-sample), where the cross-sectional pair
+    would raise ``<2 aligned dates``.
+
+    Args:
+        data: Raw long-format panel — same input contract as
+            :func:`factrix.evaluate` (``date, asset_id, <factor_col>,
+            forward_return``). Must contain ``by``; compose it upstream
+            if needed.
+        metric: A metric **instance** whose module declares
+            ``per_date_series`` (``ic()`` / ``fm_beta()`` / ``hit_rate()``).
+            The bare class is rejected.
+        by: Column whose values define the slice partition (regime label,
+            calendar bucket, …).
+        factor_col: The single factor column to score per slice.
+        method: ``"bootstrap"`` (default) runs an independent stationary
+            block bootstrap per slice with Romano-Wolf step-down ``p_adj``;
+            ``"analytic"`` runs Newey-West HAC per slice with Welch-style
+            pairwise contrasts and Holm ``p_adj``. Use ``"bootstrap"`` for
+            short regimes (T ≈ 30-80); ``"analytic"`` for long spans
+            (T ≳ 100) when you want speed / determinism.
+        rng_seed: Reproducibility seed for the ``"bootstrap"`` path
+            (ignored by ``"analytic"``). ``None`` draws from system
+            entropy. This is plumbing, not a statistical knob — block
+            length, ``B``, and scheme are fixed by sensible defaults.
+
+    Returns:
+        Long-form ``pl.DataFrame`` with columns ``(slice_a, slice_b,
+        n_periods_a, n_periods_b, mean_diff, stat, p_raw, p_adj)``; one row
+        per ordered slice pair ``(a, b)``. ``n_periods_*`` are each slice's
+        own date counts (disjoint spans differ in length). ``mean_diff`` is
+        the signed ``μ_a − μ_b``; ``stat`` the studentized contrast on a
+        χ²₁ scale; ``p_adj`` the family-wise correction (Romano-Wolf for
+        ``"bootstrap"``, Holm for ``"analytic"``).
+
+    Raises:
+        UserInputError: ``metric`` is not a metric instance, ``factor_col``
+            is absent, or ``method`` is invalid.
+        ValueError: Fewer than two slice values, or any slice with fewer
+            than two dates.
+        TypeError: Metric is not slice-test-eligible (no ``per_date_series``
+            capability / no producer).
+    """
+    _validate_metric_instance(metric, "slice_period_pairwise_test")
+    _validate_method(method, "slice_period_pairwise_test")
+    labels, series_list = _build_per_slice_series(
+        data, metric, by, factor_col=factor_col, func_name="slice_period_pairwise_test"
+    )
+    n_periods = [int(s.shape[0]) for s in series_list]
+    k = len(labels)
+    pairs = list(combinations(range(k), 2))
+
+    if method == "bootstrap":
+        rng = np.random.default_rng(rng_seed)
+        obs_means, boot = _bootstrap_slice_means(series_list, rng=rng)
+        t_obs: list[float] = []
+        boot_cols: list[np.ndarray] = []
+        mean_diffs: list[float] = []
+        p_raw: list[float] = []
+        for i, j in pairs:
+            diff_obs = float(obs_means[i] - obs_means[j])
+            d = boot[i] - boot[j]
+            se = float(d.std(ddof=1))
+            if se < EPSILON:
+                t = 0.0
+                col = np.zeros(_N_RESAMPLES)
+            else:
+                t = diff_obs / se
+                col = (d - d.mean()) / se
+            t_obs.append(t)
+            boot_cols.append(col)
+            mean_diffs.append(diff_obs)
+            extreme = int(np.sum(np.abs(col) >= abs(t)))
+            p_raw.append((extreme + 1.0) / (_N_RESAMPLES + 1.0))
+        boot_matrix = np.column_stack(boot_cols)
+        p_adj = romano_wolf(t_obs, boot_matrix, one_sided=False)
+        stats = [float(t * t) for t in t_obs]
+    else:
+        means, variances = _analytic_slice_moments(series_list, metric)
+        mean_diffs = []
+        stats = []
+        p_raw = []
+        for i, j in pairs:
+            diff_obs = float(means[i] - means[j])
+            se2 = float(variances[i] + variances[j])
+            if se2 <= EPSILON:
+                chi = 0.0
+                p = 1.0
+            else:
+                chi = diff_obs * diff_obs / se2
+                p = float(sp_stats.chi2.sf(chi, df=1))
+            mean_diffs.append(diff_obs)
+            stats.append(chi)
+            p_raw.append(p)
+        p_adj = holm_step_down(p_raw)
+
+    return pl.DataFrame(
+        {
+            "slice_a": [labels[i] for i, _ in pairs],
+            "slice_b": [labels[j] for _, j in pairs],
+            "n_periods_a": [n_periods[i] for i, _ in pairs],
+            "n_periods_b": [n_periods[j] for _, j in pairs],
+            "mean_diff": mean_diffs,
+            "stat": stats,
+            "p_raw": p_raw,
+            "p_adj": list(p_adj),
+        }
+    )
+
+
+def _analytic_slice_moments(
+    series_list: list[np.ndarray],
+    metric: MetricBase,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-slice mean and Newey-West HAC variance of that mean.
+
+    Each slice is treated independently: the HAC bandwidth follows the
+    slice's own length (and the metric's forward-overlap floor), so a
+    short regime and a decade sub-sample get appropriately different
+    kernels. Returns ``(means[K], variances[K])`` where ``variances`` is
+    the HAC variance *of the mean* (the diagonal of the block-diagonal
+    cross-slice covariance).
+    """
+    means = np.empty(len(series_list))
+    variances = np.empty(len(series_list))
+    for i, s in enumerate(series_list):
+        lags = _hac_lags(metric, len(s))
+        mean, var = _nw_hac_vector_mean(s.reshape(-1, 1), lags=lags)
+        means[i] = float(mean[0])
+        variances[i] = float(var[0, 0])
+    return means, variances
+
+
+def _equality_restriction(k: int) -> np.ndarray:
+    """``(K-1, K)`` contrast matrix for ``μ_0 = μ_1 = … = μ_{K-1}``.
+
+    Row ``r`` is ``[1, 0, …, -1 (at r+1), …, 0]`` — each later slice
+    contrasted against the first.
+    """
+    restriction = np.zeros((k - 1, k))
+    restriction[:, 0] = 1.0
+    for r in range(k - 1):
+        restriction[r, r + 1] = -1.0
+    return restriction
+
+
+def _wald_bootstrap_omnibus(
+    obs_means: np.ndarray,
+    boot: np.ndarray,
+    variances: np.ndarray,
+    restriction: np.ndarray,
+) -> tuple[float, float]:
+    """Block-diagonal Wald χ² with a **bootstrap** null reference.
+
+    Computes the observed omnibus Wald ``W = (Rμ)' (R V R')⁻¹ (Rμ)`` with
+    block-diagonal ``V = diag(variances)``, then calibrates it against the
+    empirical distribution of the same quadratic form over the bootstrap
+    draws recentred to H₀ (each slice's draws centred on its own observed
+    mean, so the contrasts are null). Keeps the ``"bootstrap"`` omnibus
+    bootstrap-native — consistent with the pairwise path — rather than
+    falling back to the χ² asymptotics the ``"analytic"`` path uses.
+    Returns ``(W, p)``; ``(0.0, 1.0)`` on a singular middle matrix.
+    """
+    middle = restriction @ np.diag(variances) @ restriction.T
+    try:
+        middle_inv = np.linalg.inv(middle)
+    except np.linalg.LinAlgError:
+        return 0.0, 1.0
+    contrast = restriction @ obs_means
+    stat = float(contrast @ middle_inv @ contrast)
+    # Recentre each slice's draws to its own mean → null contrasts, then
+    # the Wald quadratic form per draw (einsum over the (r, B) contrasts).
+    null_contrasts = restriction @ (boot - obs_means[:, None])
+    w_boot = np.einsum("ib,ij,jb->b", null_contrasts, middle_inv, null_contrasts)
+    b = boot.shape[1]
+    p = (int(np.sum(w_boot >= stat)) + 1.0) / (b + 1.0)
+    return stat, float(p)
+
+
+def slice_period_joint_test(
+    data: pl.DataFrame,
+    metric: MetricBase,
+    *,
+    by: str,
+    factor_col: str,
+    method: Method = "bootstrap",
+    rng_seed: int | None = None,
+) -> pl.DataFrame:
+    """Omnibus block-diagonal Wald χ² that all K disjoint-slice means are equal.
+
+    Date-disjoint counterpart of :func:`slice_joint_test`. The restriction
+    is ``μ_0 = μ_1 = … = μ_{K-1}`` (K-1 contrasts against the first slice);
+    because the slices are independent samples, the cross-slice covariance
+    is **block-diagonal** — ``Var(μ_k)`` on the diagonal, zero off it. Both
+    methods share the same Wald quadratic form; they differ in how the null
+    is referenced, mirroring the pairwise path: ``"analytic"`` uses the
+    χ²_{K-1} asymptotic distribution, while ``"bootstrap"`` calibrates the
+    statistic against its own block-bootstrap null (so a short-regime
+    omnibus stays small-sample robust instead of leaning on χ²
+    asymptotics). Useful for **regime analysis**: a single test of "does
+    this factor's edge differ across regimes at all?" before drilling into
+    pairs.
+
+    Args:
+        data: Raw long-format panel (see :func:`slice_period_pairwise_test`).
+        metric: A metric **instance** whose module declares
+            ``per_date_series``. The bare class is rejected.
+        by: Column whose values define the slice partition.
+        factor_col: The single factor column to score per slice.
+        method: ``"bootstrap"`` (default) sources each ``Var(μ_k)`` from an
+            independent stationary block bootstrap; ``"analytic"`` from a
+            per-slice Newey-West HAC. See
+            :func:`slice_period_pairwise_test`.
+        rng_seed: Reproducibility seed for the ``"bootstrap"`` path
+            (ignored by ``"analytic"``).
+
+    Returns:
+        Single-row ``pl.DataFrame`` with columns
+        ``(k_slices, df, stat, p_value)``. ``df`` is the restriction rank
+        (``K-1``); ``stat`` the joint Wald χ²; ``p_value`` from the χ²_{K-1}
+        survival function (``"analytic"``) or the bootstrap null
+        (``"bootstrap"``). No ``multiple_testing`` — a single omnibus has
+        no family-internal correction.
+
+    Raises:
+        UserInputError: ``metric`` is not a metric instance, ``factor_col``
+            is absent, or ``method`` is invalid.
+        ValueError: Fewer than two slice values, or any slice with fewer
+            than two dates.
+        TypeError: Metric is not slice-test-eligible.
+    """
+    _validate_metric_instance(metric, "slice_period_joint_test")
+    _validate_method(method, "slice_period_joint_test")
+    labels, series_list = _build_per_slice_series(
+        data, metric, by, factor_col=factor_col, func_name="slice_period_joint_test"
+    )
+    k = len(labels)
+    restriction = _equality_restriction(k)
+
+    if method == "bootstrap":
+        rng = np.random.default_rng(rng_seed)
+        obs_means, boot = _bootstrap_slice_means(series_list, rng=rng)
+        variances = boot.var(axis=1, ddof=1)
+        stat, p = _wald_bootstrap_omnibus(obs_means, boot, variances, restriction)
+    else:
+        means, variances = _analytic_slice_moments(series_list, metric)
+        stat, p = _wald_p_linear(means, np.diag(variances), restriction)
+
+    return pl.DataFrame(
+        {
+            "k_slices": [k],
+            "df": [k - 1],
+            "stat": [stat],
+            "p_value": [p],
+        }
+    )

--- a/tests/_slice_panel.py
+++ b/tests/_slice_panel.py
@@ -56,6 +56,50 @@ def build_labelled_raw_panel(
     return pl.concat(frames)
 
 
+def build_disjoint_period_panel(
+    *,
+    seed: int,
+    spans: dict[str, tuple[int, float]],
+    label_col: str,
+    n_assets: int = 40,
+    noise: float = 0.3,
+) -> pl.DataFrame:
+    """Raw panel whose labels occupy **disjoint** calendar spans.
+
+    ``spans`` maps ``label -> (n_dates, signal)``: each label gets its own
+    contiguous block of dates laid back-to-back (no shared dates across
+    labels), with ``forward_return = signal * factor + noise``. This is
+    the date-disjoint partition (market regime, calendar period) that the
+    cross-sectional slice tests reject with ``<2 aligned dates`` and the
+    ``slice_period_*`` pair handles. Spans may differ in length, exercising
+    the per-slice ``n_periods_*`` reporting.
+    """
+    rng = np.random.default_rng(seed)
+    cursor = dt.date(2024, 1, 1)
+    frames = []
+    for lbl, (n_dates, s) in spans.items():
+        dates = [cursor + dt.timedelta(days=i) for i in range(n_dates)]
+        cursor = dates[-1] + dt.timedelta(days=1)
+        date_series = pl.Series("date", dates, dtype=pl.Date)
+        idx = np.repeat(np.arange(n_dates), n_assets)
+        factor = rng.normal(size=n_dates * n_assets)
+        fwd = s * factor + rng.normal(scale=noise, size=n_dates * n_assets)
+        frames.append(
+            pl.DataFrame(
+                {
+                    "date": date_series.gather(idx),
+                    "asset_id": np.tile(
+                        [f"{lbl}_{a:03d}" for a in range(n_assets)], n_dates
+                    ),
+                    "factor": factor,
+                    "forward_return": fwd,
+                    label_col: [lbl] * (n_dates * n_assets),
+                }
+            )
+        )
+    return pl.concat(frames)
+
+
 def build_autocorrelated_ic_panel(
     *,
     n_dates: int,

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -88,9 +88,7 @@ def test_bootstrap_joint_is_bootstrap_native_for_two_slices() -> None:
     pw = slice_period_pairwise_test(
         df, ic(), by="regime", factor_col="factor", rng_seed=5
     )
-    jt = slice_period_joint_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=5
-    )
+    jt = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=5)
     # Both empirical with the same B → identical 1/(B+1) granularity.
     assert jt["p_value"][0] == pytest.approx(pw["p_raw"][0])
 

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -1,0 +1,152 @@
+"""Date-disjoint omnibus cross-slice Wald verb (regime / period)."""
+
+from __future__ import annotations
+
+import pytest
+from factrix import slice_period_joint_test
+from factrix._errors import UserInputError
+from factrix.metrics import ic, monotonicity
+
+from tests._slice_panel import build_disjoint_period_panel
+
+_JOINT_COLS = ["k_slices", "df", "stat", "p_value"]
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_single_row_shape(method: str) -> None:
+    df = build_disjoint_period_panel(
+        seed=1,
+        spans={"bull": (80, 0.1), "bear": (80, 0.1), "flat": (80, 0.1)},
+        label_col="regime",
+    )
+    out = slice_period_joint_test(
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=1
+    )
+    assert out.height == 1
+    assert out.columns == _JOINT_COLS
+    assert out["k_slices"][0] == 3
+    assert out["df"][0] == 2
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_two_slice_df_is_one(method: str) -> None:
+    df = build_disjoint_period_panel(
+        seed=2, spans={"a": (80, 0.1), "b": (80, 0.1)}, label_col="regime"
+    )
+    out = slice_period_joint_test(
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=2
+    )
+    assert out["df"][0] == 1
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_detects_difference(method: str) -> None:
+    df = build_disjoint_period_panel(
+        seed=3,
+        spans={"hot": (200, 0.4), "cold": (200, -0.2)},
+        label_col="regime",
+    )
+    out = slice_period_joint_test(
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=3
+    )
+    assert out["p_value"][0] < 0.05
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_identical_signal_less_significant_than_split(method: str) -> None:
+    """Same true edge across regimes → far weaker omnibus than a real split.
+
+    Two independent samples with identical means still differ by sampling,
+    so a single-seed ``p > α`` is not a reliable property; the robust,
+    calibration-revealing check is *relative*: an identical-signal
+    partition must yield a much larger p than a genuinely-different one.
+    """
+    same = build_disjoint_period_panel(
+        seed=4, spans={"a": (200, 0.1), "b": (200, 0.1)}, label_col="regime"
+    )
+    split = build_disjoint_period_panel(
+        seed=4, spans={"a": (200, 0.3), "b": (200, -0.2)}, label_col="regime"
+    )
+    p_same = slice_period_joint_test(
+        same, ic(), by="regime", factor_col="factor", method=method, rng_seed=4
+    )["p_value"][0]
+    p_split = slice_period_joint_test(
+        split, ic(), by="regime", factor_col="factor", method=method, rng_seed=4
+    )["p_value"][0]
+    assert p_same > p_split
+
+
+def test_bootstrap_joint_is_bootstrap_native_for_two_slices() -> None:
+    """For K=2 the omnibus *is* the single pairwise contrast, so the
+    bootstrap joint p must track the bootstrap pairwise p (both empirical),
+    not diverge to a χ² asymptotic p on the identical statistic."""
+    from factrix import slice_period_pairwise_test
+
+    df = build_disjoint_period_panel(
+        seed=11, spans={"a": (40, 0.15), "b": (40, 0.0)}, label_col="regime"
+    )
+    pw = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=5
+    )
+    jt = slice_period_joint_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=5
+    )
+    # Both empirical with the same B → identical 1/(B+1) granularity.
+    assert jt["p_value"][0] == pytest.approx(pw["p_raw"][0])
+
+
+def test_bootstrap_reproducible_under_seed() -> None:
+    df = build_disjoint_period_panel(
+        seed=5,
+        spans={"a": (80, 0.1), "b": (80, -0.05), "c": (80, 0.0)},
+        label_col="regime",
+    )
+    a = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=42)
+    b = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=42)
+    assert a["stat"][0] == b["stat"][0]
+
+
+def test_rejects_bare_class() -> None:
+    df = build_disjoint_period_panel(
+        seed=6, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(UserInputError, match="instance"):
+        slice_period_joint_test(df, ic, by="regime", factor_col="factor")  # type: ignore[arg-type]
+
+
+def test_rejects_non_eligible_metric() -> None:
+    df = build_disjoint_period_panel(
+        seed=7, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(TypeError, match="slice-test-eligible"):
+        slice_period_joint_test(df, monotonicity(), by="regime", factor_col="factor")
+
+
+def test_rejects_invalid_method() -> None:
+    df = build_disjoint_period_panel(
+        seed=8, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(UserInputError, match="method"):
+        slice_period_joint_test(
+            df,
+            ic(),
+            by="regime",
+            factor_col="factor",
+            method="welch",  # type: ignore[arg-type]
+        )
+
+
+def test_raises_when_single_slice() -> None:
+    df = build_disjoint_period_panel(
+        seed=9, spans={"only": (60, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(ValueError, match="≥2 slice values"):
+        slice_period_joint_test(df, ic(), by="regime", factor_col="factor")
+
+
+def test_raises_when_slice_too_short() -> None:
+    df = build_disjoint_period_panel(
+        seed=10, spans={"a": (1, 0.1), "b": (40, 0.1)}, label_col="regime"
+    )
+    with pytest.raises(ValueError, match="<2 dates"):
+        slice_period_joint_test(df, ic(), by="regime", factor_col="factor")

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -1,0 +1,201 @@
+"""Date-disjoint pairwise cross-slice contrast verb (regime / period)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix import slice_period_pairwise_test
+from factrix._errors import UserInputError
+from factrix.metrics import fm_beta, ic, monotonicity
+
+from tests._slice_panel import build_disjoint_period_panel
+
+_PAIRWISE_COLS = [
+    "slice_a",
+    "slice_b",
+    "n_periods_a",
+    "n_periods_b",
+    "mean_diff",
+    "stat",
+    "p_raw",
+    "p_adj",
+]
+
+
+def test_two_slice_returns_one_row() -> None:
+    df = build_disjoint_period_panel(
+        seed=1, spans={"bull": (60, 0.1), "bear": (60, 0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=1
+    )
+    assert out.height == 1
+    assert out.columns == _PAIRWISE_COLS
+
+
+def test_three_slice_returns_three_rows() -> None:
+    df = build_disjoint_period_panel(
+        seed=2,
+        spans={"bull": (60, 0.1), "bear": (60, 0.1), "flat": (60, 0.1)},
+        label_col="regime",
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=2
+    )
+    assert out.height == 3
+    pairs = set(zip(out["slice_a"].to_list(), out["slice_b"].to_list(), strict=False))
+    assert pairs == {("bull", "bear"), ("bull", "flat"), ("bear", "flat")}
+
+
+def test_per_slice_period_counts_reported() -> None:
+    """Disjoint spans differ in length → n_periods_a / n_periods_b differ."""
+    df = build_disjoint_period_panel(
+        seed=3, spans={"early": (40, 0.1), "late": (90, 0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=3
+    )
+    row = out.row(0, named=True)
+    assert row["n_periods_a"] == 40
+    assert row["n_periods_b"] == 90
+
+
+def test_disjoint_dates_do_not_raise() -> None:
+    """The cross-sectional pair raises `<2 aligned dates` here; this pair runs."""
+    df = build_disjoint_period_panel(
+        seed=4, spans={"a": (50, 0.1), "b": (50, 0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=4
+    )
+    assert out.height == 1
+    assert np.isfinite(out["stat"][0])
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_detects_signal_difference(method: str) -> None:
+    df = build_disjoint_period_panel(
+        seed=5, spans={"hot": (200, 0.4), "cold": (200, -0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=5
+    )
+    assert out["p_raw"][0] < 0.05
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_mean_diff_sign_matches_direction(method: str) -> None:
+    df = build_disjoint_period_panel(
+        seed=15, spans={"hot": (200, 0.4), "cold": (200, -0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=6
+    )
+    row = out.row(0, named=True)
+    # mean_diff = μ_a − μ_b; positive iff slice_a is the higher-IC regime.
+    assert (row["mean_diff"] > 0) == (row["slice_a"] == "hot")
+
+
+@pytest.mark.parametrize("method", ["bootstrap", "analytic"])
+def test_p_adj_dominates_raw(method: str) -> None:
+    df = build_disjoint_period_panel(
+        seed=6,
+        spans={"a": (120, 0.1), "b": (120, 0.2), "c": (120, -0.1)},
+        label_col="regime",
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=7
+    )
+    for raw, adj in zip(out["p_raw"].to_list(), out["p_adj"].to_list(), strict=False):
+        assert adj >= raw - 1e-12
+
+
+def test_bootstrap_reproducible_under_seed() -> None:
+    df = build_disjoint_period_panel(
+        seed=8, spans={"a": (80, 0.1), "b": (80, -0.05)}, label_col="regime"
+    )
+    a = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=99
+    )
+    b = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=99
+    )
+    assert a["stat"].to_list() == b["stat"].to_list()
+    assert a["p_adj"].to_list() == b["p_adj"].to_list()
+
+
+def test_fama_macbeth_metric_accepted() -> None:
+    df = build_disjoint_period_panel(
+        seed=9, spans={"x": (60, 0.1), "y": (60, 0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, fm_beta(), by="regime", factor_col="factor", rng_seed=9
+    )
+    assert out.height == 1
+    assert out.columns == _PAIRWISE_COLS
+
+
+def test_rejects_bare_class() -> None:
+    df = build_disjoint_period_panel(
+        seed=10, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(UserInputError, match="instance"):
+        slice_period_pairwise_test(df, ic, by="regime", factor_col="factor")  # type: ignore[arg-type]
+
+
+def test_rejects_non_metric() -> None:
+    def fake_metric(df: pl.DataFrame) -> None:
+        return None
+
+    df = build_disjoint_period_panel(
+        seed=11, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(UserInputError, match="metric instance"):
+        slice_period_pairwise_test(df, fake_metric, by="regime", factor_col="factor")  # type: ignore[arg-type]
+
+
+def test_rejects_non_eligible_metric() -> None:
+    df = build_disjoint_period_panel(
+        seed=12, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(TypeError, match="slice-test-eligible"):
+        slice_period_pairwise_test(df, monotonicity(), by="regime", factor_col="factor")
+
+
+def test_rejects_invalid_method() -> None:
+    df = build_disjoint_period_panel(
+        seed=13, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(UserInputError, match="method"):
+        slice_period_pairwise_test(
+            df,
+            ic(),
+            by="regime",
+            factor_col="factor",
+            method="hac",  # type: ignore[arg-type]
+        )
+
+
+def test_rejects_missing_factor_col() -> None:
+    df = build_disjoint_period_panel(
+        seed=14, spans={"a": (20, 0.0), "b": (20, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(UserInputError, match="factor_col"):
+        slice_period_pairwise_test(df, ic(), by="regime", factor_col="absent")
+
+
+def test_raises_when_single_slice() -> None:
+    df = build_disjoint_period_panel(
+        seed=16, spans={"only": (60, 0.0)}, label_col="regime"
+    )
+    with pytest.raises(ValueError, match="≥2 slice values"):
+        slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor")
+
+
+def test_raises_when_slice_too_short() -> None:
+    df = build_disjoint_period_panel(
+        seed=17, spans={"a": (1, 0.1), "b": (40, 0.1)}, label_col="regime"
+    )
+    with pytest.raises(ValueError, match="<2 dates"):
+        slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor")


### PR DESCRIPTION
## Summary

- Adds `slice_period_pairwise_test` / `slice_period_joint_test` — the date-disjoint counterparts of the cross-sectional `slice_pairwise_test` / `slice_joint_test`. They treat each slice (market regime, calendar period, in/out-of-sample) as an independent sample with block-diagonal cross-slice covariance, where the cross-sectional pair raises `<2 aligned dates`.
- A two-valued `method` flag selects the estimator: `"bootstrap"` (default — independent stationary block bootstrap + Romano-Wolf, robust for short regimes) or `"analytic"` (per-slice Newey-West HAC + Welch contrast + Holm, for long spans). No other statistical knobs — block length / B / scheme use sensible defaults; `rng_seed` is reproducibility plumbing only.
- Separate, explicitly-named pair (no date-overlap auto-routing) so the two statistical assumptions never hide behind one name. Reuses the existing block-bootstrap, Politis-White, Romano-Wolf, Holm, and NW-HAC primitives.
- Pairwise output carries per-slice `n_periods_a` / `n_periods_b`; the omnibus is a block-diagonal Wald. The bootstrap omnibus is calibrated against its own bootstrap null (not χ²), so for K=2 the joint p tracks the single pairwise contrast rather than diverging by orders of magnitude.
- Corrects the slice-analysis guide's `axis-agnostic` over-claim to name which axis each inference path supports, and documents the new pair on the API reference page.

## Test plan

- [x] 34 new tests (parametrized across both methods) (`test_slice_period_pairwise_test.py`, `test_slice_period_joint_test.py`) across both methods × pairwise/joint: shape, per-slice period counts, disjoint-dates-don't-raise, signal detection, direction, `p_adj ≥ p_raw`, K=2 joint↔pairwise consistency, bootstrap seed reproducibility, and all rejection paths.
- [x] Cross-sectional pair (#646) behaviour unchanged — its tests still pass.
- [x] Full suite green (1373 passed), `ruff check` / `ruff format --check` / `mypy factrix` clean.

Closes #645

