### PR TITLE
refactor(results)!: drop MetricResultGroup for plain Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,8 @@ Entries link to **PR number** (e.g. `(#123)` — the PR that landed the change) 
 
 ### Removed
 
+- **`MetricResultGroup` wrapper class removed** (#PR). The hollow frozen-dataclass wrapper around `outputs: Mapping[str, MetricResult]` is gone — it carried zero domain logic once the v0.14 `applicable` / `primary` / `diagnostic` partition fields were removed, and 9 of 10 production access sites already reached through `.outputs` directly. `EvaluationResult.metrics` is now a read-only `Mapping[str, MetricResult]` (a `MappingProxyType`) keyed by the caller-supplied label. The symbol is dropped from the top-level namespace and `__all__`.
+  - *Migration Note*: `result.metrics["ic"]` and all dict-like access (`in`, `len`, `keys` / `values` / `items`, iteration, and now `.get`) are unchanged. Code that reached through `result.metrics.outputs` must switch to `result.metrics` directly.
 - **`ic_newey_west` removed** (#572). The function is fully retired in favor of `ic(inference=fx.inference.NeweyWest())`.
   - *Migration Note*: Replace `ic_newey_west(...)` with `ic(..., inference=fx.inference.NeweyWest())`.
 - **GMM path and estimator discovery removed** (#569). The unused public functions `list_estimators`, `get_estimator`, `UnknownEstimatorError`, and the entire GMM path (`GMM`, `MomentEstimator`, `GMMResult`) are removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,7 @@ Entries link to **PR number** (e.g. `(#123)` — the PR that landed the change) 
 
 ### Removed
 
-- **`MetricResultGroup` wrapper class removed** (#PR). The hollow frozen-dataclass wrapper around `outputs: Mapping[str, MetricResult]` is gone — it carried zero domain logic once the v0.14 `applicable` / `primary` / `diagnostic` partition fields were removed, and 9 of 10 production access sites already reached through `.outputs` directly. `EvaluationResult.metrics` is now a read-only `Mapping[str, MetricResult]` (a `MappingProxyType`) keyed by the caller-supplied label. The symbol is dropped from the top-level namespace and `__all__`.
+- **`MetricResultGroup` wrapper class removed** (#650). The hollow frozen-dataclass wrapper around `outputs: Mapping[str, MetricResult]` is gone — it carried zero domain logic once the v0.14 `applicable` / `primary` / `diagnostic` partition fields were removed, and 9 of 10 production access sites already reached through `.outputs` directly. `EvaluationResult.metrics` is now a read-only `Mapping[str, MetricResult]` (a `MappingProxyType`) keyed by the caller-supplied label. The symbol is dropped from the top-level namespace and `__all__`.
   - *Migration Note*: `result.metrics["ic"]` and all dict-like access (`in`, `len`, `keys` / `values` / `items`, iteration, and now `.get`) are unchanged. Code that reached through `result.metrics.outputs` must switch to `result.metrics` directly.
 - **`ic_newey_west` removed** (#572). The function is fully retired in favor of `ic(inference=fx.inference.NeweyWest())`.
   - *Migration Note*: Replace `ic_newey_west(...)` with `ic(..., inference=fx.inference.NeweyWest())`.

--- a/docs/api/evaluation-results.md
+++ b/docs/api/evaluation-results.md
@@ -29,17 +29,9 @@ Converts the result into a JSON-friendly nested dictionary. It normalizes floats
 
 ---
 
-::: factrix.MetricResultGroup
+## The `metrics` mapping
 
-<hr>
-
-## Key Concepts
-
-`MetricResultGroup` is a dict-like container of the metric outputs for a single factor evaluation:
-
-- **`outputs`**: A mapping from each metric label to its `MetricResult` object (including short-circuit NaN outputs). This is the group's only field.
-
-It supports dict-like lookup (`group["ic"]` to get the `MetricResult` for `"ic"`) as well as dictionary iteration methods (`keys()`, `values()`, `items()`, `__iter__`, and `__len__`).
+`EvaluationResult.metrics` is a read-only `Mapping[str, MetricResult]` (a `MappingProxyType`) keyed by the caller-supplied metric label, including short-circuit NaN outputs. Access it like any dict — `result.metrics["ic"]` returns the `MetricResult` for `"ic"`, and `keys()` / `values()` / `items()` / `get()` / `in` / `len()` / iteration all work as usual. The mapping is immutable; attempting to assign into it raises `TypeError`.
 
 
 ---

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -113,7 +113,7 @@ class EvaluationResult:
     n_periods: int
     n_pairs: int
     n_assets: int
-    metrics: MetricResultGroup
+    metrics: Mapping[str, MetricResult]
     plan: str
     context: Mapping[str, Any] = field(default_factory=dict)
     warnings: list[Warning] = field(default_factory=list)
@@ -125,8 +125,8 @@ It replaces the pre-v0.14 `FactorProfile` (inferential) / `MetricsBundle`
 (`factrix._dag.DagExecutor`) on a closed `list[MetricSpec]`.
 
 - `cell` is the `(scope, density, structure)` tuple of the dispatched cell.
-- Per-metric outputs live in `metrics`, a `MetricResultGroup` mapping each
-  label to its `MetricResult`. Screening verbs read each result's
+- Per-metric outputs live in `metrics`, a read-only `Mapping[str, MetricResult]`
+  (`MappingProxyType`) mapping each label to its `MetricResult`. Screening verbs read each result's
   `MetricResult.p_value` — by convention the mainstream metric's.
 - Advisory diagnostics are a flat `list[Warning]` on `warnings` — per-metric
   records carry `source=<metric name>`, bundle / pre-dispatch records carry
@@ -658,7 +658,7 @@ factrix/
 ├── _errors.py               # flat hierarchy: FactrixError → {IncompatibleAxisError, InsufficientSampleError, UnknownEstimatorError, UserInputError}
 ├── _metric_index.py         # MetricSpec + @metric-registry SSOT (spec_by_name / list_metrics / public_specs / metric_spec)
 ├── _dag.py                  # DagExecutor — MetricSpec.requires / batchable dispatch (+ CycleError)
-├── _results.py              # EvaluationResult / MetricResultGroup / MetricResult / Warning dataclasses
+├── _results.py              # EvaluationResult / MetricResult / Warning dataclasses
 ├── _inspect.py              # inspect_data — typed data introspection with per-metric verdict
 ├── _compare.py              # compare — multi-metric leaderboard over EvaluationResult lists
 ├── _family.py               # _resolve_family — shared family resolution for the FDR verbs
@@ -688,15 +688,15 @@ factrix/
 Hard constraints — violating these breaks the API contract:
 
 1. `MetricSpec` is `frozen=True, slots=True`; every construction path runs `__post_init__`, which enforces the field invariants (e.g. `role=METRIC → output_shape=SCALAR`).
-2. All result dataclasses — `EvaluationResult`, `MetricResultGroup`, `MetricResult`, `Warning` — are `frozen=True, slots=True`. One unified `EvaluationResult` — no per-cell subclass.
+2. All result dataclasses — `EvaluationResult`, `MetricResult`, `Warning` — are `frozen=True, slots=True`; `EvaluationResult.metrics` is a `MappingProxyType` for read-only per-metric outputs. One unified `EvaluationResult` — no per-cell subclass.
 3. The metric-spec SSOT is the `@metric` registration in each `factrix/metrics/*.py`, resolved through `factrix._metric_index` (`spec_by_name` / `public_specs` / `list_metrics`); no parallel rule table. `@metric`-class registration feeds the index via `factrix.metrics._registry.register`.
 4. The DAG executor is the single dispatch path. `DagExecutor` topologically orders specs by `MetricSpec.requires` (raising `CycleError` on cycles), runs `batchable=True` producers once per factor batch and `batchable=False` consumers once per factor, and short-circuits a downstream consumer with a NaN `MetricResult` + `WarningCode.UPSTREAM_UNAVAILABLE` rather than invoking it on missing upstream data.
 5. `MetricResult.p_value` is the single canonical p-value read path — `EvaluationResult.to_frame()` / `to_dict()`, `compare`, and the BHY family resolver all read it; `metadata["p_value"]` stays populated for tool context. `warnings` flag interpretation risk but never rebind it.
 6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over`. `_resolve_family` enforces (a) the hypothesis identity `(factor, *expand_over_values)` is unique across the input, (b) `expand_over` names come only from `EvaluationResult.context` (or the built-in `forward_periods`), never the factor, (c) `p_value` is populated everywhere before procedures read it. Cell / horizon partitioning is the caller's responsibility; mixed `forward_periods` without `expand_over` warns.
 7. `T < MIN_PERIODS_HARD` raises `InsufficientSampleError`; metrics never silently produce a result on under-sampled data. NW HAC lag selection on overlapping forward returns floors at `forward_periods - 1` (the Hansen-Hodrick floor) so serial correlation from overlap is not under-counted.
 
-For the user-facing field walk of `EvaluationResult` (and the
-`MetricResultGroup` it composes with), see
+For the user-facing field walk of `EvaluationResult` (and its
+`metrics` mapping), see
 [Reading results](../guides/reading-results.md). The `MetricResult.p_value`
 contract above is what that page links back to.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -770,7 +770,7 @@ plain prose; reach for a callout only when the elevation earns it.
 - `!!! info` — contract / convention block (e.g. event-study contracts, TS-mode conventions).
 - `!!! example` — minimal worked code that surrounding prose references.
 - `??? note "..."` (collapsible) — long content for a subset of readers (derivations, full enum tables).
-- `> **Input contract** — …` (blockquote, two lines) — appears only on raw-data `(data, ...)` entry points (`docs/api/evaluate.md`), placed between the frontmatter and the autodoc block. Format: one short sentence naming the four-column floor + a link to [Panel schema](../api/panel-schema.md). Other API pages consume pre-computed artefacts (`EvaluationResult` / `Survivors` / `MetricResultGroup`) and do not carry the callout.
+- `> **Input contract** — …` (blockquote, two lines) — appears only on raw-data `(data, ...)` entry points (`docs/api/evaluate.md`), placed between the frontmatter and the autodoc block. Format: one short sentence naming the four-column floor + a link to [Panel schema](../api/panel-schema.md). Other API pages consume pre-computed artefacts (`EvaluationResult` / `Survivors` / `MetricResult`) and do not carry the callout.
 
 Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
 
@@ -801,7 +801,7 @@ These two sections appear on pages whose primary purpose is to show the reader *
 
 - **Expected on callable entry points.** Function pages under `docs/api/` whose page subject is a callable the user invokes directly. Includes the entry-point callables (`evaluate`, `inspect_data`, `bhy`, `partial_conjunction`, `bhy_hierarchical`, `by_slice`, `slice_pairwise_test` / `slice_joint_test`, `compare`, `list_metrics`, `preprocess.compute_forward_return`), and every metric page under `docs/api/metrics/` (each documents one or more callables).
 - **Not expected** on:
-    - Dataclass / container pages (`evaluation-results.md`, which documents `EvaluationResult` / `MetricResultGroup` / `MetricResult` / `Warning`) — these describe a return type, not a workflow.
+    - Dataclass / container pages (`evaluation-results.md`, which documents `EvaluationResult` / `MetricResult` / `Warning`) — these describe a return type, not a workflow.
     - Reference / taxonomy / hub pages (`errors.md`, `panel-schema.md`, `api/index.md`, `multi-horizon.md`, `metrics/index.md`, the cell-grouped metrics index pages) — content shape is a table or a concept, not a call.
     - Namespace / module pages (`stats.md`, `datasets.md`) — content shape is a catalogue of members.
 

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -41,7 +41,7 @@ An `EvaluationResult` represents the outcome of evaluating a single factor colum
 
 ### 3. Evaluated metrics (`result.metrics`)
 
-The `metrics` attribute is a `MetricResultGroup` containing a dictionary mapping the user-supplied label to a `MetricResult`.
+The `metrics` attribute is a read-only `Mapping[str, MetricResult]` mapping the user-supplied label to a `MetricResult`.
 
 For a specific metric `key`, `result.metrics[key]` exposes:
 

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -70,8 +70,8 @@ Each metric instance carries a `MetricSpec` whose `cell`
 applies to the detected data shape; the DAG executor runs batchable
 stage-1 producers once across the factor batch and per-factor consumers
 once per factor, and returns a `list[EvaluationResult]` — one per
-factor, each holding a `MetricResultGroup` of per-metric `MetricResult`
-outputs plus a flat `list[Warning]`. The list flows into
+factor, each holding a read-only `Mapping[str, MetricResult]` of
+per-metric outputs plus a flat `list[Warning]`. The list flows into
 `multi_factor.bhy(results, metrics=[...])` for cross-test false
 discovery rate (FDR) control, which returns the surviving factors.
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -44,6 +44,7 @@ typical usage patterns in a single fetch. Two access paths::
 import dataclasses
 import inspect
 import math
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -86,7 +87,6 @@ from factrix._metric_index import (
 from factrix._results import (
     EvaluationResult,
     MetricResult,
-    MetricResultGroup,
     Warning,
 )
 from factrix.slicing import (
@@ -510,7 +510,7 @@ def _relabel_result(
     short-circuit ``MetricResult`` is synthesized here so the returned dict
     still carries every requested label, in the caller's request order.
     """
-    node_outputs = result.metrics.outputs
+    node_outputs = result.metrics
     label_outputs: dict[str, MetricResult] = {}
     mismatch_warnings: list[Warning] = []
     for label in ordered_labels:
@@ -540,7 +540,7 @@ def _relabel_result(
     warnings.extend(mismatch_warnings)
     return dataclasses.replace(
         result,
-        metrics=MetricResultGroup(outputs=label_outputs),
+        metrics=MappingProxyType(label_outputs),
         warnings=warnings,
     )
 
@@ -706,7 +706,6 @@ __all__ = [
     "DagExecutor",
     "EvaluationResult",
     "MetricResult",
-    "MetricResultGroup",
     "DataInput",
     "Warning",
     "compare",

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -103,7 +103,7 @@ def compare(
         for k in context_keys:
             row[k] = r.context.get(k)
         for spec in metric_list:
-            if spec not in r.metrics.outputs:
+            if spec not in r.metrics:
                 raise UserInputError(
                     func_name="compare",
                     field="metrics",
@@ -112,10 +112,10 @@ def compare(
                         f"every result to carry metric {spec!r}; "
                         f"missing on factor={r.factor!r}"
                     ),
-                    candidates=sorted(r.metrics.outputs),
+                    candidates=sorted(r.metrics),
                     docs_path="api/compare#metrics",
                 )
-            out = r.metrics.outputs[spec]
+            out = r.metrics[spec]
             row[spec] = _float_or_none(out.value)
             row[f"{spec}_p_value"] = _float_or_none(out.p_value)
         rows.append(row)

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -27,6 +27,7 @@ import functools
 import importlib
 import math
 from collections.abc import Callable, Mapping, Sequence
+from types import MappingProxyType
 from typing import Any, NamedTuple
 
 import polars as pl
@@ -38,7 +39,6 @@ from factrix._metric_index import MetricSpec
 from factrix._results import (
     EvaluationResult,
     MetricResult,
-    MetricResultGroup,
     Warning,
 )
 
@@ -377,7 +377,7 @@ class DagExecutor:
                 n_periods=factor_n_periods[c],
                 n_pairs=factor_n_pairs[c],
                 n_assets=n_assets,
-                metrics=MetricResultGroup(outputs=outputs),
+                metrics=MappingProxyType(outputs),
                 plan=plan,
                 warnings=warnings,
             )

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -185,7 +185,7 @@ def _resolve_p_value(
     func_name: str,
 ) -> float:
     try:
-        out = result.metrics.outputs[metric]
+        out = result.metrics[metric]
     except KeyError:
         raise UserInputError(
             func_name=func_name,
@@ -195,7 +195,7 @@ def _resolve_p_value(
                 f"every result to carry the metric "
                 f"{metric!r}; missing on factor={result.factor!r}"
             ),
-            candidates=sorted(result.metrics.outputs),
+            candidates=sorted(result.metrics),
             docs_path=f"api/{func_name}#metrics",
         ) from None
 

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -1,4 +1,4 @@
-"""v0.14 result dataclasses — ``EvaluationResult`` / ``MetricResultGroup`` / ``Warning``.
+"""v0.14 result dataclasses — ``EvaluationResult`` / ``MetricResult`` / ``Warning``.
 
 Lands the result-type group that unification surfaces from the
 DAG executor. This module ships the dataclasses + serialisation
@@ -9,17 +9,14 @@ from __future__ import annotations
 
 import html
 import math
-from collections.abc import Iterator, KeysView, Mapping, ValuesView
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope
 from factrix._codes import WarningCode
-
-if TYPE_CHECKING:
-    from collections.abc import ItemsView
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,43 +83,6 @@ class Warning:
 
 
 @dataclass(frozen=True, slots=True)
-class MetricResultGroup:
-    """Dict-like container of per-metric outputs for one factor.
-
-    The key is the caller-supplied label (from ``evaluate(metrics=...)``).
-    Supports ``[]``, ``in``, iteration, ``keys`` / ``values`` / ``items``,
-    and ``len``.
-
-    Attributes:
-        outputs: ``label -> MetricResult`` for every metric that produced
-            a value (including short-circuit NaN outputs).
-    """
-
-    outputs: Mapping[str, MetricResult] = field(default_factory=dict)
-
-    def __getitem__(self, key: str) -> MetricResult:
-        return self.outputs[key]
-
-    def __contains__(self, key: object) -> bool:
-        return key in self.outputs
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self.outputs)
-
-    def __len__(self) -> int:
-        return len(self.outputs)
-
-    def keys(self) -> KeysView[str]:
-        return self.outputs.keys()
-
-    def values(self) -> ValuesView[MetricResult]:
-        return self.outputs.values()
-
-    def items(self) -> ItemsView[str, MetricResult]:
-        return self.outputs.items()
-
-
-@dataclass(frozen=True, slots=True)
 class EvaluationResult:
     """Bundle-level result for one factor.
 
@@ -142,8 +102,8 @@ class EvaluationResult:
             factor panel. A panel structural property.
         n_assets: Unique assets in the panel (cell-invariant;
             ``1`` is legal for TIMESERIES).
-        metrics: :class:`MetricResultGroup` carrying per-metric outputs,
-            keyed by the caller-supplied label.
+        metrics: Read-only ``label -> MetricResult`` mapping carrying
+            per-metric outputs, keyed by the caller-supplied label.
         context: Caller-supplied free-form labels (e.g.
             ``{"region": "US"}``). Read by
             ``bhy(expand_over=...)`` / ``partial_conjunction`` /
@@ -161,7 +121,7 @@ class EvaluationResult:
     n_periods: int
     n_pairs: int
     n_assets: int
-    metrics: MetricResultGroup
+    metrics: Mapping[str, MetricResult]
     plan: str
     context: Mapping[str, Any] = field(default_factory=dict)
     warnings: list[Warning] = field(default_factory=list)
@@ -196,7 +156,7 @@ class EvaluationResult:
                 "n_assets": self.n_assets,
                 **_output_row(key, out, by_metric),
             }
-            for key, out in self.metrics.outputs.items()
+            for key, out in self.metrics.items()
         ]
         return pl.DataFrame(rows, schema=_TO_FRAME_SCHEMA)
 
@@ -228,7 +188,7 @@ class EvaluationResult:
             "context": dict(self.context),
             "metrics": {
                 name: _metric_output_to_record(out)
-                for name, out in self.metrics.outputs.items()
+                for name, out in self.metrics.items()
             },
             "warnings": [
                 {
@@ -263,7 +223,7 @@ class EvaluationResult:
         )
 
         metric_rows = []
-        for name, out in sorted(self.metrics.outputs.items()):
+        for name, out in sorted(self.metrics.items()):
             if isinstance(out, MetricResult):
                 val_repr = "null" if math.isnan(out.value) else f"{out.value:.4g}"
                 p_repr = f"{out.p_value:.4g}" if isinstance(out.p_value, float) else ""

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -328,7 +328,7 @@ Dataclass containing the evaluation outputs:
 - `n_periods`: Unique non-null dates in the factor column (panel time-series depth).
 - `n_pairs`: Non-null `(date, asset_id)` pairs (effective cross-sectional coverage).
 - `n_assets`: Unique asset count.
-- `metrics`: `MetricResultGroup` holding metric results (dict-like, keyed by user label).
+- `metrics`: read-only `Mapping[str, MetricResult]` holding metric results, keyed by user label.
 - `plan`: Execution plan string.
 - `context`: Free-form context dictionary.
 - `warnings`: Attached `Warning` records.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ synthetic panels locally.
 """
 
 from datetime import datetime, timedelta
+from types import MappingProxyType
 from typing import Any
 
 import numpy as np
@@ -20,7 +21,7 @@ from factrix._axis import (
     FactorScope,
 )
 from factrix._metric_index import Cell, MetricSpec
-from factrix._results import EvaluationResult, MetricResult, MetricResultGroup
+from factrix._results import EvaluationResult, MetricResult
 
 
 def make_spec(name: str) -> MetricSpec:
@@ -61,7 +62,7 @@ def make_result(
         n_periods=100,
         n_pairs=2500,
         n_assets=25,
-        metrics=MetricResultGroup(outputs=outputs),
+        metrics=MappingProxyType(outputs),
         plan="1. test [per-factor]",
         context=context or {},
     )

--- a/tests/test_cross_type_invariants.py
+++ b/tests/test_cross_type_invariants.py
@@ -9,8 +9,7 @@ mutually consistent, no matter which metric is added:
 - **applicability** — :class:`~factrix._inspect.MetricApplicability`,
   the per-data pre-flight verdict :func:`factrix.inspect_data`
   attaches to every public spec.
-- **result** — :class:`~factrix._results.MetricResult` /
-  :class:`~factrix._results.MetricResultGroup`, what
+- **result** — :class:`~factrix._results.MetricResult`, what
   :func:`factrix.evaluate` produces for an applicable metric.
 
 Each test asserts a *property* that must hold for **every** registered
@@ -248,24 +247,24 @@ class TestResultMirrorsSpecAndApplicability:
 
     def test_outputs_are_all_metric_labels(self, evaluated) -> None:
         # All requested metric labels appear in outputs.
-        assert set(evaluated.metrics.outputs) == set(_CORE_METRICS)
+        assert set(evaluated.metrics) == set(_CORE_METRICS)
 
     def test_result_keys_resolve_to_metric_specs(self, evaluated) -> None:
         # Result dict keys are a join key back into the spec table; each must
         # resolve to a real, user-facing METRIC spec (never a PIPELINE node).
         sbn = spec_by_name()
-        for key in evaluated.metrics.outputs:
+        for key in evaluated.metrics:
             assert key in sbn
             assert sbn[key].role is SpecRole.METRIC
 
     def test_result_name_matches_its_key(self, evaluated) -> None:
-        for key, out in evaluated.metrics.outputs.items():
+        for key, out in evaluated.metrics.items():
             assert out.name == key
 
     def test_metric_outputs_are_scalar(self, evaluated) -> None:
         # role=METRIC ⟹ output_shape=SCALAR (TestSpecMirrorsClass), so every
         # produced value is a plain float and any p-value is a probability.
-        for out in evaluated.metrics.outputs.values():
+        for out in evaluated.metrics.values():
             assert isinstance(out.value, float)
             assert out.p_value is None or 0.0 <= out.p_value <= 1.0
 
@@ -276,4 +275,4 @@ class TestResultMirrorsSpecAndApplicability:
         # flagged unusable by inspect_data for the same data.
         info = inspect_data(panel)
         runnable = set(info.usable.names) | set(info.degraded.names)
-        assert set(evaluated.metrics.outputs) <= runnable
+        assert set(evaluated.metrics) <= runnable

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -33,7 +33,7 @@ class TestLabelKeying:
         results = _eval({"my_ic": ic(), "my_ir": ic_ir()})
         assert "factor" in results
         er = results["factor"]
-        assert list(er.metrics.outputs) == ["my_ic", "my_ir"]
+        assert list(er.metrics) == ["my_ic", "my_ir"]
         assert er.metrics["my_ic"].name == "my_ic"
 
     def test_to_frame_uses_labels(self):
@@ -98,7 +98,7 @@ class TestMetricsValidation:
 class TestByValueDedup:
     def test_same_config_alias_is_one_node_two_labels(self):
         er = _eval({"a": ic_ir(), "b": ic_ir()})["factor"]
-        assert set(er.metrics.outputs) == {"a", "b"}
+        assert set(er.metrics) == {"a", "b"}
 
     def test_different_config_coexists(self):
         from factrix.metrics import quantile_spread
@@ -106,7 +106,7 @@ class TestByValueDedup:
         er = _eval(
             {"a": quantile_spread(n_groups=5), "b": quantile_spread(n_groups=10)}
         )["factor"]
-        assert set(er.metrics.outputs) == {"a", "b"}
+        assert set(er.metrics) == {"a", "b"}
 
     def test_per_instance_forward_periods_override(self):
         er = fx.evaluate(
@@ -227,7 +227,7 @@ class TestStrictStructureSoftening:
             forward_periods=5,
             strict=False,
         )["factor"]
-        assert list(er.metrics.outputs.keys()) == ["hhi", "ic"]
+        assert list(er.metrics.keys()) == ["hhi", "ic"]
         # On PANEL data neither is mismatched, so ic computes a real value.
         assert not math.isnan(er.metrics["ic"].value)
         # And on single-asset data only hhi is mismatched.

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -1,21 +1,23 @@
-"""``EvaluationResult`` / ``MetricResultGroup`` dataclasses + serialisation."""
+"""``EvaluationResult`` / ``MetricResult`` dataclasses + serialisation."""
 
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from types import MappingProxyType
 
 import polars as pl
+import pytest
 from factrix import (
     EvaluationResult,
     MetricResult,
-    MetricResultGroup,
     Warning,
     WarningCode,
 )
 from factrix._axis import DataStructure, FactorDensity, FactorScope
 
 
-def _sample_group() -> MetricResultGroup:
+def _sample_group() -> Mapping[str, MetricResult]:
     ic_out = MetricResult(
         value=0.05,
         p_value=0.012,
@@ -29,11 +31,11 @@ def _sample_group() -> MetricResultGroup:
         n_obs=100,
         name="ic_ir",
     )
-    return MetricResultGroup(outputs={"ic": ic_out, "ic_ir": ic_ir_out})
+    return MappingProxyType({"ic": ic_out, "ic_ir": ic_ir_out})
 
 
 def _sample_result(
-    group: MetricResultGroup, warnings=None, plan: str = "1. ic [per-factor]"
+    group: Mapping[str, MetricResult], warnings=None, plan: str = "1. ic [per-factor]"
 ) -> EvaluationResult:
     return EvaluationResult(
         factor="mom_12_1",
@@ -48,23 +50,24 @@ def _sample_result(
     )
 
 
-class TestMetricResultGroup:
+class TestMetricsMapping:
     def test_dict_like_access(self):
         g = _sample_group()
         assert "ic" in g
         assert "missing" not in g
         assert g["ic"].value == 0.05
+        assert g.get("ic").value == 0.05
+        assert g.get("missing") is None
         assert len(g) == 2
         assert set(g.keys()) == {"ic", "ic_ir"}
         assert {o.name for o in g.values()} == {"ic", "ic_ir"}
         assert {k for k, _ in g.items()} == {"ic", "ic_ir"}
         assert list(iter(g)) == ["ic", "ic_ir"]
 
-    def test_no_partition_fields(self):
-        g = _sample_group()
-        assert not hasattr(g, "primary")
-        assert not hasattr(g, "diagnostic")
-        assert not hasattr(g, "applicable")
+    def test_mapping_is_read_only(self):
+        g = _sample_result(_sample_group()).metrics
+        with pytest.raises(TypeError):
+            g["ic"] = MetricResult(value=0.0, name="ic")
 
 
 class TestEvaluationResultToFrame:
@@ -90,14 +93,14 @@ class TestEvaluationResultToFrame:
     def test_n_obs_carries_per_metric_sample_size(self):
         ic_out = MetricResult(value=0.05, n_obs=114, name="ic")
         spread_out = MetricResult(value=0.01, n_obs=23, name="spread")
-        g = MetricResultGroup(outputs={"ic": ic_out, "spread": spread_out})
+        g = MappingProxyType({"ic": ic_out, "spread": spread_out})
         df = _sample_result(g).to_frame()
         assert df.filter(pl.col("metric_name") == "ic")["n_obs"][0] == 114
         assert df.filter(pl.col("metric_name") == "spread")["n_obs"][0] == 23
 
     def test_short_circuit_row_is_null(self):
         bad = MetricResult(value=float("nan"), name="ic")
-        g = MetricResultGroup(outputs={"ic": bad})
+        g = MappingProxyType({"ic": bad})
         df = _sample_result(g).to_frame()
         row = df.row(0, named=True)
         assert row["value"] is None
@@ -121,7 +124,7 @@ class TestEvaluationResultToFrame:
 
     def test_metric_name_from_name_field(self):
         out = MetricResult(value=0.01, name="fm_beta")
-        g = MetricResultGroup(outputs={"fm_beta": out})
+        g = MappingProxyType({"fm_beta": out})
         df = _sample_result(g).to_frame()
         assert df.row(0, named=True)["metric_name"] == "fm_beta"
 
@@ -155,7 +158,7 @@ class TestEvaluationResultToDict:
             metadata={"p_value": float("nan")},
             name="ic",
         )
-        g = MetricResultGroup(outputs={"ic": bad})
+        g = MappingProxyType({"ic": bad})
         d = _sample_result(g).to_dict()
         assert d["metrics"]["ic"]["value"] is None
         assert d["metrics"]["ic"]["stat"] is None

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -588,7 +588,7 @@ class TestMetricApplicabilityGroup:
             strict=False,
         )
         for name in md:
-            assert name in results["factor"].metrics.outputs
+            assert name in results["factor"].metrics
 
 
 class TestCrossFactorConsistency:

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -285,8 +285,8 @@ class TestSpanningEvaluate:
         )
         er1, er2 = results["factor"], results["factor2"]
 
-        assert "gfs" in er1.metrics.outputs
-        assert "gfs" in er2.metrics.outputs
+        assert "gfs" in er1.metrics
+        assert "gfs" in er2.metrics
         result1 = er1.metrics["gfs"]
         result2 = er2.metrics["gfs"]
         assert isinstance(result1, ForwardSelectionResult)


### PR DESCRIPTION
## Summary

- Remove the `MetricResultGroup` wrapper — a frozen dataclass that delegated seven dict methods to a single `outputs` field with zero domain logic once the v0.14 partition fields were dropped.
- `EvaluationResult.metrics` is now a read-only `Mapping[str, MetricResult]` backed by `MappingProxyType`: frozen semantics preserved, native dict access (including the previously-missing `.get()`).
- No backward-compatible alias kept — the name has no external consumers, so an alias would be dead public surface (dropped from the top-level namespace and `__all__`).

## Test plan

- [x] `pytest` — 1373 passed, 4 skipped
- [x] `mypy factrix` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `TestMetricResultGroup` rewritten as `TestMetricsMapping`, adding `.get()` and read-only (`MappingProxyType` raises `TypeError`) coverage that the old wrapper lacked

Closes #648
