### PR TITLE
refactor(forward-periods)!: converge forward_periods to a single data attribute

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -42,7 +42,6 @@ typical usage patterns in a single fetch. Two access paths::
 """
 
 import dataclasses
-import inspect
 import math
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -62,7 +61,13 @@ from factrix._axis import (  # DataStructure used by the structure pre-flight; r
 from factrix._codes import WarningCode
 from factrix._compare import compare
 from factrix._dag import CycleError, DagExecutor, _Node
-from factrix._data_input import _BASELINE_COLUMNS, DataInput, _coerce_data
+from factrix._data_input import (
+    _BASELINE_COLUMNS,
+    _FORWARD_PERIODS_COL,
+    DataInput,
+    _coerce_data,
+    _read_forward_periods_stamp,
+)
 from factrix._errors import (
     FactrixError,
     IncompatibleAxisError,
@@ -128,19 +133,23 @@ def evaluate(
             rather than ``ic()``), a ``str`` or a :class:`MetricSpec` is
             rejected with a targeted error. One metric class may run under
             several labels with **different** config — e.g.
-            ``{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}`` — via
-            by-value DAG dedup; shared upstream producers are computed
-            once per distinct config.
+            ``{"spread5": quantile_spread(n_groups=5), "spread10":
+            quantile_spread(n_groups=10)}`` — via by-value DAG dedup; shared
+            upstream producers are computed once per distinct config.
+            ``forward_periods`` is **not** a metric knob: every metric runs at
+            the data's single overlap horizon. To compare horizons, build two
+            panels and evaluate each.
         factor_cols: Names of factor columns on ``data``. List-only —
             single ``str`` is rejected. Non-empty, no duplicates, every
             name must exist on ``data``.
-        forward_periods: Default forward-return horizon (rows of the data's
-            time axis) for metrics left at their signature default. A
-            per-instance value — ``ic(forward_periods=20)`` — always overrides
-            it. ``None`` (default) leaves every metric at its own default.
-            Stamped on every :class:`EvaluationResult` as
-            ``forward_periods``; per-metric resolved horizons are in
-            ``result.metrics[label].metadata["forward_periods"]``.
+        forward_periods: The data's overlap horizon (rows of the time axis).
+            Normally omitted — :func:`factrix.preprocess.compute_forward_return`
+            stamps it on the panel and it is read from there. Pass it only to
+            **declare** the horizon for a self-attached ``forward_return``
+            column that carries no stamp; a value disagreeing with the stamp is
+            rejected. Stamped on every :class:`EvaluationResult` as
+            ``forward_periods`` and injected into each metric (surfaced in
+            ``result.metrics[label].metadata["forward_periods"]``).
         strict: When ``True`` (default), raise if any metric is
             inapplicable to the data — both apply-time short-circuits and
             structure mismatches (a metric whose ``cell.structure``
@@ -165,7 +174,9 @@ def evaluate(
             duplicates / references a column not on ``data``; ``data``
             missing a baseline column; a metric ``requires`` a producer
             absent from the registry; under ``strict=True``, a metric
-            inapplicable to the data.
+            inapplicable to the data; ``data`` carries no horizon stamp and
+            none is declared via ``forward_periods``, or the declared
+            ``forward_periods`` disagrees with the stamp.
 
     Examples:
         Single-factor IC + IC information ratio (IR):
@@ -191,11 +202,16 @@ def evaluate(
     _validate_baseline_columns(data)
     _validate_factor_cols_on_data(data, cols)
 
+    # The overlap horizon is a property of the data: read the stamp left by
+    # compute_forward_return, then strip it so it never reaches a metric,
+    # projection, or to_frame. A self-attached forward_return panel (no stamp)
+    # must declare its horizon once via forward_periods= (path B).
+    fp = _resolve_forward_periods(data, forward_periods)
+    if _FORWARD_PERIODS_COL in data.columns:
+        data = data.drop(_FORWARD_PERIODS_COL)
+
     label_spec = {label: type(inst).spec() for label, inst in metrics.items()}
-    label_params = {
-        label: _resolve_instance_params(inst, forward_periods)
-        for label, inst in metrics.items()
-    }
+    label_params = {label: dict(inst._params()) for label, inst in metrics.items()}
 
     # Structure pre-flight: a metric whose declared cell.structure disagrees
     # with the data structure (e.g. a PANEL metric on TIMESERIES data) can
@@ -212,8 +228,6 @@ def evaluate(
 
     nodes, label_to_node, node_kwargs = _build_nodes(runnable_spec, runnable_params)
     node_to_label = {nid: label for label, nid in label_to_node.items()}
-
-    fp = forward_periods if forward_periods is not None else 5
 
     executor = DagExecutor(nodes)
     result_dict = executor.execute(
@@ -336,45 +350,46 @@ def _validate_metrics_arg(metrics: object) -> None:
             )
 
 
-_NO_DEFAULT = object()
+def _resolve_forward_periods(data: pl.DataFrame, declared: int | None) -> int:
+    """Resolve the panel's single overlap horizon for this evaluation.
 
-
-def _forward_periods_default(cls: "type[MetricBase]") -> object:
-    """The ``forward_periods`` signature default declared by a metric class.
-
-    Read from the wrapped ``_impl`` so the evaluate-level ``forward_periods``
-    fallback can tell an instance still at its default apart from an explicit
-    per-instance override. Returns a unique sentinel when the metric has no
-    ``forward_periods`` parameter.
+    Path A (primary): a panel built by ``compute_forward_return`` carries a
+    horizon stamp — the single source of truth. Path B (escape hatch): a
+    self-attached ``forward_return`` panel carries no stamp, so the caller must
+    declare the horizon once via ``forward_periods=`` (a statement about the
+    data's overlap, not a per-metric knob). A declaration that disagrees with
+    the stamp is rejected rather than silently resolved.
     """
-    try:
-        param = inspect.signature(cls._impl).parameters.get("forward_periods")
-    except (TypeError, ValueError):
-        return _NO_DEFAULT
-    if param is None or param.default is inspect.Parameter.empty:
-        return _NO_DEFAULT
-    return param.default
-
-
-def _resolve_instance_params(
-    inst: "MetricBase", top_forward_periods: int | None
-) -> dict[str, Any]:
-    """Per-instance params with ``forward_periods`` resolved against the fallback.
-
-    Per-instance override is the rule: an instance's configured
-    ``forward_periods`` always wins. The top-level ``evaluate(forward_periods=)``
-    is a *default fallback* — it fills only instances still sitting at the
-    metric's signature default (and only when the caller passed one). Passing
-    the default value explicitly is indistinguishable from not passing it and
-    is therefore also treated as "use the fallback".
-    """
-    params = dict(inst._params())
-    if top_forward_periods is None or "forward_periods" not in params:
-        return params
-    default = _forward_periods_default(type(inst))
-    if params["forward_periods"] == default:
-        params["forward_periods"] = top_forward_periods
-    return params
+    stamp = _read_forward_periods_stamp(data)
+    if stamp is not None:
+        if declared is not None and declared != stamp:
+            raise UserInputError(
+                func_name="evaluate",
+                field="forward_periods",
+                value=declared,
+                expected=(
+                    f"forward_periods to match the data's stamped overlap "
+                    f"horizon ({stamp}, set by compute_forward_return). The "
+                    f"horizon is a property of the data — omit forward_periods, "
+                    f"or rebuild forward_return at horizon {declared}."
+                ),
+                docs_path="api/evaluate#forward_periods",
+            )
+        return stamp
+    if declared is not None:
+        return declared
+    raise UserInputError(
+        func_name="evaluate",
+        field="forward_periods",
+        value=None,
+        expected=(
+            "the data's overlap horizon. Either build forward_return via "
+            "factrix.preprocess.compute_forward_return(df, forward_periods=N) "
+            "(which stamps the horizon), or, for a self-attached forward_return "
+            "column, declare it once with evaluate(..., forward_periods=N)."
+        ),
+        docs_path="api/evaluate#forward_periods",
+    )
 
 
 def _build_nodes(
@@ -385,10 +400,11 @@ def _build_nodes(
 
     Dedups user metrics into **consumer nodes** keyed by ``(name, config)`` —
     so one class under two labels with *identical* config is a single node
-    (harmless alias) while *different* config is two nodes. Then closes ``requires``: each consumer pulls a **producer
-    node** whose config inherits only the consumer's ``forward_periods`` (the
-    sole consumer param any ``requires``-pulled producer accepts), reusing one
-    producer node across consumers that share that inherited config.
+    (harmless alias) while *different* config is two nodes. Then closes
+    ``requires``: each consumer pulls a **producer node** carrying no inherited
+    config (the overlap horizon, once the sole inherited param, is now injected
+    globally from the data stamp at dispatch), so one producer node is reused
+    across every consumer that names it.
 
     Returns ``(nodes, label -> node_id, node_id -> kwargs)``.
     """
@@ -431,7 +447,6 @@ def _build_nodes(
         if nid in requires_nodes:
             continue
         spec = node_spec[nid]
-        consumer_params = node_kwargs[nid]
         edges: list[tuple[str, str]] = []
         for param_key, producer in spec.requires.items():
             pname = producer.__name__
@@ -446,13 +461,11 @@ def _build_nodes(
                     ),
                     docs_path=_DOCS_METRICS,
                 )
-            accepted = set(getattr(producer, "_param_names", ()))
-            inherited = {
-                k: consumer_params[k]
-                for k in ("forward_periods",)
-                if k in consumer_params and k in accepted
-            }
-            pid = intern(by_name[pname], inherited)
+            # Producers carry no inherited consumer config: the sole parameter a
+            # requires-pulled producer ever shared was ``forward_periods``, now
+            # injected globally from the data stamp at dispatch. One producer
+            # node is reused across all consumers naming it.
+            pid = intern(by_name[pname], {})
             edges.append((param_key, pid))
             if pid not in requires_nodes:
                 queue.append(pid)

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -213,7 +213,9 @@ class DagExecutor:
 
         for node in (step.node for step in self._plan_steps):
             nid = node.node_id
-            handle = self._batch_handle(node.spec, kwargs_by_metric.get(nid, {}))
+            handle = self._batch_handle(
+                node.spec, kwargs_by_metric.get(nid, {}), forward_periods
+            )
 
             # Split factors by upstream short-circuit: dead factors get the
             # propagated skip output and never reach the metric.
@@ -271,23 +273,30 @@ class DagExecutor:
         )
 
     def _batch_handle(
-        self, spec: MetricSpec, kwargs: Mapping[str, Any]
+        self, spec: MetricSpec, kwargs: Mapping[str, Any], forward_periods: int
     ) -> Callable[..., dict[str, Any]]:
         """Return the spec's unified batch dispatcher.
 
         Registry ``MetricBase`` classes expose ``__call_batch__`` directly
         (bound to a configured instance); bare ``fn_resolver`` callables are
         wrapped through the same :func:`_dispatch_batch` so both paths share
-        one dispatch body.
+        one dispatch body. ``forward_periods`` is the data's stamped overlap
+        horizon, injected into whichever callables declare it.
         """
+        import functools
+
         from factrix.metrics._base import MetricBase, _dispatch_batch
 
         fn = self._fn(spec)
         kw = dict(kwargs)
         if isinstance(fn, type) and issubclass(fn, MetricBase):
-            return fn(**kw).__call_batch__
+            return functools.partial(
+                fn(**kw).__call_batch__, forward_periods=forward_periods
+            )
 
         bare: Callable[..., Any] = fn
+        accepts_fp = "forward_periods" in _callable_params(bare)
+        inj = {"forward_periods": forward_periods} if accepts_fp else {}
 
         def handle(
             data: pl.DataFrame,
@@ -299,11 +308,11 @@ class DagExecutor:
             if spec.requires:
 
                 def run_batch() -> dict[str, Any]:
-                    return bare(**{**upstream, **kw})
+                    return bare(**{**upstream, **kw, **inj})
             else:
 
                 def run_batch() -> dict[str, Any]:
-                    return bare(data, factor_cols=list(factor_cols), **kw)
+                    return bare(data, factor_cols=list(factor_cols), **kw, **inj)
 
             return _dispatch_batch(
                 name=spec.name,
@@ -315,6 +324,7 @@ class DagExecutor:
                 factor_cols=factor_cols,
                 project=project,
                 upstream=upstream,
+                inject=inj,
             )
 
         return handle
@@ -382,6 +392,16 @@ class DagExecutor:
                 warnings=warnings,
             )
         return results
+
+
+def _callable_params(fn: Callable[..., Any]) -> frozenset[str]:
+    """Parameter names a bare callable accepts, or empty on an opaque signature."""
+    import inspect
+
+    try:
+        return frozenset(inspect.signature(fn).parameters)
+    except (TypeError, ValueError):
+        return frozenset()
 
 
 def _default_fn_resolver(name: str) -> Callable[..., Any]:

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -34,6 +34,30 @@ type DataInput = pl.DataFrame | pl.LazyFrame
 _BASELINE_COLUMNS: tuple[str, ...] = ("date", "asset_id", "forward_return")
 _OPTIONAL_COLUMNS: tuple[str, ...] = ("price",)
 
+# Reserved column carrying the panel's single overlap horizon (the
+# ``forward_periods`` used to build ``forward_return``). ``compute_forward_return``
+# stamps it once; ``evaluate`` reads it and strips it before dispatch, so it
+# never reaches a metric, a projection, or ``EvaluationResult.to_frame``. A
+# constant int column is the one carrier that survives the ordinary polars
+# transforms a panel goes through between construction and evaluation
+# (``with_columns`` winsorize / abnormal-return, ``partition_by`` in ``by_slice``,
+# user ``.with_columns(sector)`` / joins) — DataFrame-level metadata does not.
+_FORWARD_PERIODS_COL: str = "_forward_periods"
+
+
+def _stamp_forward_periods(df: pl.DataFrame, forward_periods: int) -> pl.DataFrame:
+    """Stamp the panel's single overlap horizon as a reserved constant column."""
+    return df.with_columns(
+        pl.lit(forward_periods, dtype=pl.Int32).alias(_FORWARD_PERIODS_COL)
+    )
+
+
+def _read_forward_periods_stamp(df: pl.DataFrame) -> int | None:
+    """Read the stamped overlap horizon, or ``None`` when the panel carries none."""
+    if _FORWARD_PERIODS_COL not in df.columns or df.height == 0:
+        return None
+    return int(df[_FORWARD_PERIODS_COL][0])
+
 
 def _is_pandas_dataframe(obj: object) -> bool:
     """Detect ``pd.DataFrame`` without importing pandas (optional dep)."""

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -33,6 +33,7 @@ import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope, Tier
 from factrix._codes import WarningCode, cross_section_tier
+from factrix._data_input import _FORWARD_PERIODS_COL
 from factrix._metric_index import MetricSpec, public_specs
 from factrix._results import Warning
 
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
 
 _SPARSITY_THRESHOLD: float = 0.5
 _INSPECT_RESERVED: frozenset[str] = frozenset(
-    {"date", "asset_id", "forward_return", "price"}
+    {"date", "asset_id", "forward_return", "price", _FORWARD_PERIODS_COL}
 )
 
 

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -93,8 +93,9 @@ class EvaluationResult:
             ``DataStructure.PANEL`` or ``DataStructure.TIMESERIES``
             resolved from the panel's asset count; ``scope`` and
             ``density`` default to INDIVIDUAL / DENSE.
-        forward_periods: Forward-return horizon passed to
-            :func:`factrix.evaluate`.
+        forward_periods: The data's overlap horizon — read from the panel's
+            ``compute_forward_return`` stamp (or the declared fallback for a
+            self-attached panel). A property of the data, not a per-metric knob.
         n_periods: Number of unique dates in the factor panel where
             the factor column is non-null. A panel structural property —
             independent of any individual metric's estimator.

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -60,11 +60,48 @@ class MetricMeta(type):
             resolved_kwargs = kwargs.copy()
             for name, val in zip(param_names, remaining_args, strict=False):
                 resolved_kwargs[name] = val
+            # A direct call may carry the injected horizon (``forward_periods``) —
+            # it is not a constructor field, so route it to the call as the
+            # per-invocation horizon rather than into ``cls(**...)``.
+            injected = getattr(cls, "_injected_param_names", ())
+            call_kwargs = {
+                k: resolved_kwargs.pop(k)
+                for k in list(resolved_kwargs)
+                if k in injected
+            }
             instance = cls(**resolved_kwargs)
-            return instance(first_arg)
+            return instance(first_arg, **call_kwargs)
         else:
             # Standard instantiation
+            cls._reject_injected_params(kwargs)
             return super().__call__(*args, **kwargs)
+
+    def _reject_injected_params(cls, supplied: dict[str, Any]) -> None:
+        """Reject user-supplied injected params (e.g. ``forward_periods``).
+
+        These are data-derived: ``evaluate`` injects the panel's stamped overlap
+        horizon at dispatch. A metric never carries its own ``forward_periods``,
+        so there is no per-metric knob left to diverge from the data — the
+        guarantee is structural, enforced here at the constructor boundary.
+        """
+        injected = getattr(cls, "_injected_param_names", ())
+        offending = [name for name in supplied if name in injected]
+        if offending:
+            from factrix._errors import UserInputError
+
+            name = offending[0]
+            raise UserInputError(
+                func_name=cls.__name__,
+                field=name,
+                value=supplied[name],
+                expected=(
+                    f"{name!r} is no longer a metric parameter — it is the "
+                    f"panel's overlap horizon, read from the data. Set it once "
+                    f"via factrix.preprocess.compute_forward_return(df, "
+                    f"forward_periods=N); evaluate reads it from there."
+                ),
+                docs_path="api/evaluate#forward_periods",
+            )
 
 
 class MetricBase(metaclass=MetricMeta):
@@ -102,6 +139,11 @@ class MetricBase(metaclass=MetricMeta):
     _impl: ClassVar[Callable]
     _first_param_name: ClassVar[str | None]
     _param_names: ClassVar[tuple[str, ...]]
+    # Params injected from the data rather than configured per metric
+    # (``forward_periods``): kept out of ``_param_names``, rejected at the
+    # constructor, and injected at dispatch into the metrics whose ``_impl``
+    # declares them. Empty for a metric that takes no injected param.
+    _injected_param_names: ClassVar[tuple[str, ...]] = ()
     _logger: ClassVar[logging.Logger]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -147,11 +189,28 @@ class MetricBase(metaclass=MetricMeta):
         """Configured parameter values, pulled from the instance's slots."""
         return {name: getattr(self, name) for name in self._param_names}
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+    def _inject(self, forward_periods: int | None) -> dict[str, Any]:
+        """Dispatch-time injected kwargs for ``_impl`` (the data's horizon).
+
+        Only the horizon, and only when the body declares it; a standalone call
+        (``forward_periods=None``) leaves the metric at its signature default.
+        """
+        if (
+            forward_periods is not None
+            and "forward_periods" in self._injected_param_names
+        ):
+            return {"forward_periods": forward_periods}
+        return {}
+
+    def __call__(
+        self, *args: Any, forward_periods: int | None = None, **kwargs: Any
+    ) -> Any:
         """Evaluate the metric on a single input (one factor's view / upstream)."""
         try:
             # Accessed via __class__ to avoid binding ``_impl`` as a method.
-            return self.__class__._impl(*args, **{**self._params(), **kwargs})
+            return self.__class__._impl(
+                *args, **{**self._params(), **self._inject(forward_periods), **kwargs}
+            )
         except Exception as e:
             _log_exception_once(
                 self._logger,
@@ -169,6 +228,7 @@ class MetricBase(metaclass=MetricMeta):
         *,
         project: Callable[[str], Any],
         upstream: dict[str, dict[str, Any]],
+        forward_periods: int | None = None,
     ) -> dict[str, Any]:
         """Run this metric across a factor batch; return ``{factor: output}``.
 
@@ -179,16 +239,17 @@ class MetricBase(metaclass=MetricMeta):
         ``batchable`` (whole panel), ``requires`` (consume upstream), plain
         (thin view) — are unified in :func:`_dispatch_batch`.
         """
+        inj = self._inject(forward_periods)
         if self.requires:
 
             def run_batch() -> dict[str, Any]:
-                return self.__class__._impl(**{**self._params(), **upstream})
+                return self.__class__._impl(**{**self._params(), **inj, **upstream})
         else:
 
             def run_batch() -> dict[str, Any]:
                 return self.__class__._impl(
                     panel,
-                    **{**self._params(), "factor_cols": list(factor_cols)},
+                    **{**self._params(), **inj, "factor_cols": list(factor_cols)},
                 )
 
         return _dispatch_batch(
@@ -201,6 +262,7 @@ class MetricBase(metaclass=MetricMeta):
             factor_cols=factor_cols,
             project=project,
             upstream=upstream,
+            inject=inj,
         )
 
 
@@ -215,13 +277,17 @@ def _dispatch_batch(
     factor_cols: Sequence[str],
     project: Callable[[str], Any],
     upstream: dict[str, dict[str, Any]],
+    inject: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Single source of truth for metric batch dispatch.
 
     Shared by :meth:`MetricBase.__call_batch__` and the DAG executor's
-    bare-callable (``fn_resolver``) path.
+    bare-callable (``fn_resolver``) path. ``inject`` is the dispatch-time
+    injected kwargs (the data's overlap horizon), already resolved by the
+    caller against the callable's signature.
     """
     logger = logging.getLogger(f"factrix.metric.{name}") if name else None
+    inj = inject or {}
 
     if batchable:
         try:
@@ -242,10 +308,10 @@ def _dispatch_batch(
             if requires:
                 # Metric consumes upstream data via kwargs, replacing the raw panel
                 c_kwargs = {k: upstream[k][c] for k in requires}
-                out[c] = call_one(**c_kwargs)
+                out[c] = call_one(**c_kwargs, **inj)
             else:
                 # Metric consumes the raw thin view
-                out[c] = call_one(project(c))
+                out[c] = call_one(project(c), **inj)
         except Exception as e:
             if logger:
                 _log_exception_once(

--- a/factrix/metrics/_decorators.py
+++ b/factrix/metrics/_decorators.py
@@ -17,6 +17,12 @@ from factrix.metrics._registry import register
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
+# Parameters that ``evaluate`` injects from the data rather than the user
+# configuring per metric. They remain dataclass fields (so threshold hooks can
+# read them and standalone calls keep the signature default) but are kept out of
+# the user-facing ``_param_names`` — the public constructor rejects them.
+_INJECTED_PARAMS: frozenset[str] = frozenset({"forward_periods"})
+
 
 def metric(
     cell: Cell,
@@ -72,6 +78,19 @@ def metric(
 
         fields = non_default_fields + default_fields
 
+        # ``forward_periods`` is the panel's overlap horizon — a property of the
+        # data, not a per-metric knob. It stays a dataclass field (so threshold
+        # hooks can read ``self.forward_periods`` and the body keeps its
+        # signature default for standalone calls), but it is removed from the
+        # user-configurable ``_param_names``: ``evaluate`` injects the data's
+        # stamped horizon at dispatch time and the public constructor rejects it.
+        injected_param_names = tuple(
+            name for name, *_ in fields if name in _INJECTED_PARAMS
+        )
+        user_param_names = tuple(
+            name for name, *_ in fields if name not in _INJECTED_PARAMS
+        )
+
         # 2. Build the class namespace with metadata ClassVars
         cls_attrs = {
             "cell": cell,
@@ -89,7 +108,8 @@ def metric(
             "requires_continuous_magnitude": requires_continuous_magnitude,
             "_impl": fn,
             "_first_param_name": first_param_name,
-            "_param_names": tuple(f[0] for f in fields),
+            "_param_names": user_param_names,
+            "_injected_param_names": injected_param_names,
             "__module__": fn.__module__,
             "__doc__": fn.__doc__,
         }

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -132,10 +132,10 @@ def quantile_spread(
         if _precomputed_series is not None
         else compute_spread_series(
             df,
-            forward_periods,
-            n_groups,
+            n_groups=n_groups,
             factor_cols=cols,
             tie_policy=tie_policy,
+            forward_periods=forward_periods,
         )
     )
     return {

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -443,7 +443,7 @@ def breakeven_cost(
     gross_spread: float,
     turnover: float,
     *,
-    forward_periods: int,
+    forward_periods: int = 1,
 ) -> MetricResult:
     """Breakeven single-leg trading cost in bps.
 
@@ -535,7 +535,7 @@ def net_spread(
     turnover: float,
     estimated_cost_bps: float = 30.0,
     *,
-    forward_periods: int,
+    forward_periods: int = 1,
 ) -> MetricResult:
     """Net spread after estimated trading costs (per-period).
 

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -63,7 +63,10 @@ def compute_forward_return(
             ``overwrite`` is ``False``.
 
     Returns:
-        Input DataFrame with ``forward_return`` column appended.
+        Input DataFrame with ``forward_return`` column appended and the
+        overlap horizon ``forward_periods`` stamped on as a reserved column —
+        the single source of truth ``factrix.evaluate`` reads (it strips the
+        column before dispatch, so it never reaches a metric or ``to_frame``).
         Rows where forward return is null (end of series) are dropped.
 
     Notes:
@@ -147,7 +150,9 @@ def compute_forward_return(
             )
         df = df.drop("forward_return")
 
-    return (
+    from factrix._data_input import _stamp_forward_periods
+
+    out = (
         df.sort(["asset_id", "date"])
         .with_columns(
             (
@@ -161,6 +166,10 @@ def compute_forward_return(
         )
         .filter(pl.col("forward_return").is_not_null())
     )
+    # Stamp the overlap horizon as the single source of truth for the data;
+    # evaluate reads it instead of taking forward_periods at the metric / call
+    # layer (the three could silently diverge — see compute_forward_return docs).
+    return _stamp_forward_periods(out, forward_periods)
 
 
 def winsorize_forward_return(

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -94,9 +94,11 @@ def by_slice(
         factor_col: The factor column to evaluate. Single-factor by
             design — multi-factor / multi-metric batching is the job of
             :func:`factrix.evaluate`.
-        forward_periods: Default forward-return horizon, forwarded to
-            ``evaluate`` on every per-slice call. ``None`` leaves the
-            metric at its own default.
+        forward_periods: The data's overlap horizon, forwarded to
+            ``evaluate`` on every per-slice call. Normally omitted — it is
+            read from the panel's ``compute_forward_return`` stamp (which
+            survives partitioning). Pass it only to declare the horizon for a
+            self-attached ``forward_return`` panel that carries no stamp.
         strict: Forwarded to ``evaluate``. ``True`` (default) raises if
             the metric is inapplicable to a slice; ``False`` surfaces a
             NaN result with a warning.

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -39,6 +39,7 @@ from itertools import combinations
 import numpy as np
 import polars as pl
 
+from factrix._data_input import _read_forward_periods_stamp
 from factrix._errors import UserInputError
 from factrix._stats.multiple_testing import holm_step_down
 from factrix._stats.wald import _wald_nw_cluster_means
@@ -143,17 +144,18 @@ def _build_per_date_panel(
     return labels, panel, aligned.height
 
 
-def _hac_lags(metric: MetricBase, n_obs: int) -> int:
+def _hac_lags(forward_periods: int | None, n_obs: int) -> int:
     """Newey-West Bartlett bandwidth for the slice HAC.
 
     Defaults to ``floor(T^(1/3))`` but floors at ``forward_periods - 1``:
     overlapping ``h``-period forward returns make the per-date series
     autocorrelated up to lag ``h - 1`` (MA(h-1) overlap structure), so
     the kernel must cover it or the variance is under-estimated and the
-    test over-rejects. Mirrors ``fm_beta``'s own NW-lag floor.
+    test over-rejects. ``forward_periods`` is the panel's stamped overlap
+    horizon — a property of the data, not the metric. Mirrors ``fm_beta``'s
+    own NW-lag floor.
     """
     default = int(np.floor(n_obs ** (1.0 / 3.0)))
-    forward_periods = getattr(metric, "forward_periods", None)
     overlap_floor = forward_periods - 1 if forward_periods else 0
     return max(default, overlap_floor)
 
@@ -231,7 +233,7 @@ def slice_pairwise_test(
         data, metric, by, factor_col=factor_col, func_name="slice_pairwise_test"
     )
     k = panel.shape[1]
-    lags = _hac_lags(metric, n_obs)
+    lags = _hac_lags(_read_forward_periods_stamp(data), n_obs)
     pairs = list(combinations(range(k), 2))
     col_means = panel.mean(axis=0)
 
@@ -328,7 +330,7 @@ def slice_joint_test(
         data, metric, by, factor_col=factor_col, func_name="slice_joint_test"
     )
     k = panel.shape[1]
-    lags = _hac_lags(metric, n_obs)
+    lags = _hac_lags(_read_forward_periods_stamp(data), n_obs)
 
     # K-1 contrasts against slice 0: rows are [1, -1, 0, …], [1, 0, -1, …], …
     restriction = np.zeros((k - 1, k))

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -66,6 +66,7 @@ import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
 
+from factrix._data_input import _read_forward_periods_stamp
 from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
     Scheme,
@@ -270,7 +271,9 @@ def slice_period_pairwise_test(
         p_adj = romano_wolf(t_obs, boot_matrix, one_sided=False)
         stats = [float(t * t) for t in t_obs]
     else:
-        means, variances = _analytic_slice_moments(series_list, metric)
+        means, variances = _analytic_slice_moments(
+            series_list, _read_forward_periods_stamp(data)
+        )
         mean_diffs = []
         stats = []
         p_raw = []
@@ -304,12 +307,12 @@ def slice_period_pairwise_test(
 
 def _analytic_slice_moments(
     series_list: list[np.ndarray],
-    metric: MetricBase,
+    forward_periods: int | None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Per-slice mean and Newey-West HAC variance of that mean.
 
     Each slice is treated independently: the HAC bandwidth follows the
-    slice's own length (and the metric's forward-overlap floor), so a
+    slice's own length (and the data's forward-overlap floor), so a
     short regime and a decade sub-sample get appropriately different
     kernels. Returns ``(means[K], variances[K])`` where ``variances`` is
     the HAC variance *of the mean* (the diagonal of the block-diagonal
@@ -318,7 +321,7 @@ def _analytic_slice_moments(
     means = np.empty(len(series_list))
     variances = np.empty(len(series_list))
     for i, s in enumerate(series_list):
-        lags = _hac_lags(metric, len(s))
+        lags = _hac_lags(forward_periods, len(s))
         mean, var = _nw_hac_vector_mean(s.reshape(-1, 1), lags=lags)
         means[i] = float(mean[0])
         variances[i] = float(var[0, 0])
@@ -437,7 +440,9 @@ def slice_period_joint_test(
         variances = boot.var(axis=1, ddof=1)
         stat, p = _wald_bootstrap_omnibus(obs_means, boot, variances, restriction)
     else:
-        means, variances = _analytic_slice_moments(series_list, metric)
+        means, variances = _analytic_slice_moments(
+            series_list, _read_forward_periods_stamp(data)
+        )
         stat, p = _wald_p_linear(means, np.diag(variances), restriction)
 
     return pl.DataFrame(

--- a/tests/test_dynamic_sample_threshold.py
+++ b/tests/test_dynamic_sample_threshold.py
@@ -11,6 +11,7 @@ declared an empty ``SampleThreshold()`` and hid the floor in the body.
 from __future__ import annotations
 
 import factrix as fx
+import pytest
 from factrix._inspect import DataInspection, inspect_data
 from factrix._types import MIN_IC_PERIODS
 from factrix.metrics._registry import REGISTRY
@@ -30,11 +31,12 @@ class TestHookResolution:
         st = ic.spec().sample_threshold
         assert st.min_periods == MIN_IC_PERIODS * 5
 
-    def test_hook_reflects_configured_params(self):
-        # The hook reads params off the instance, so a non-default
-        # forward_periods scales the floor.
-        inst = REGISTRY["ic"](forward_periods=10)
-        assert inst.sample_threshold_for().min_periods == MIN_IC_PERIODS * 10
+    def test_forward_periods_is_not_a_metric_param(self):
+        # forward_periods is the data's overlap horizon, not a per-metric knob:
+        # constructing a metric with it is rejected (the floor scales off the
+        # signature default, resolved at spec() time — see the test above).
+        with pytest.raises(fx.UserInputError):
+            REGISTRY["ic"](forward_periods=10)
 
     def test_static_metric_keeps_empty_spec_threshold(self):
         # A hookless metric resolves to its static (here empty) threshold.

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,4 +1,4 @@
-"""``fx.evaluate`` dict[str, Metric] API — labels, strict, per-instance
+"""``fx.evaluate`` dict[str, Metric] API — labels, strict, data-stamped
 forward_periods + by-value DAG dedup."""
 
 from __future__ import annotations
@@ -108,42 +108,83 @@ class TestByValueDedup:
         )["factor"]
         assert set(er.metrics) == {"a", "b"}
 
-    def test_per_instance_forward_periods_override(self):
+    def test_horizon_injected_from_data_into_every_metric(self):
+        # forward_periods is the data's stamped overlap horizon (5 here),
+        # injected into every metric — there is no per-metric override.
         er = fx.evaluate(
             _panel(),
             metrics={
-                "fp5": ic(inference=fx.inference.NEWEY_WEST),
-                "fp20": ic(forward_periods=20, inference=fx.inference.NEWEY_WEST),
+                "t": ic(),
+                "nw": ic(inference=fx.inference.NEWEY_WEST),
             },
             factor_cols=["factor"],
         )["factor"]
-        assert er.metrics["fp5"].metadata["forward_periods"] == 5
-        assert er.metrics["fp20"].metadata["forward_periods"] == 20
+        assert er.metrics["t"].metadata["forward_periods"] == 5
+        assert er.metrics["nw"].metadata["forward_periods"] == 5
+        assert er.forward_periods == 5
 
     def test_shared_producer_runs_once_across_configs(self):
+        # Two ic configs (different inference) share one compute_ic producer.
         er = fx.evaluate(
             _panel(),
             metrics={
-                "fp5": ic(inference=fx.inference.NEWEY_WEST),
-                "fp20": ic(forward_periods=20, inference=fx.inference.NEWEY_WEST),
+                "t": ic(),
+                "nw": ic(inference=fx.inference.NEWEY_WEST),
             },
             factor_cols=["factor"],
         )["factor"]
         assert er.plan.count("compute_ic [batchable]") == 1
 
-    def test_top_level_forward_periods_is_default_fallback(self):
+    def test_metric_level_forward_periods_is_rejected(self):
+        # The mixed-horizon usage {"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}
+        # is gone: forward_periods is not a metric parameter.
+        with pytest.raises(fx.UserInputError):
+            ic(forward_periods=20)
+
+
+class TestForwardPeriodsContract:
+    """The overlap horizon is a property of the data (stamp), declared once for
+    a self-attached panel (path B), never a per-metric knob."""
+
+    def test_horizon_read_from_stamp_when_omitted(self):
+        er = fx.evaluate(_panel(), metrics={"ic": ic()}, factor_cols=["factor"])[
+            "factor"
+        ]
+        assert er.forward_periods == 5  # read from the compute_forward_return stamp
+
+    def test_self_attached_panel_without_declaration_raises(self):
+        from factrix._data_input import _FORWARD_PERIODS_COL
+
+        unstamped = _panel().drop(_FORWARD_PERIODS_COL)
+        with pytest.raises(UserInputError, match="overlap horizon"):
+            fx.evaluate(unstamped, metrics={"ic": ic()}, factor_cols=["factor"])
+
+    def test_self_attached_panel_with_declaration_runs(self):
+        from factrix._data_input import _FORWARD_PERIODS_COL
+
+        unstamped = _panel().drop(_FORWARD_PERIODS_COL)
         er = fx.evaluate(
-            _panel(),
-            metrics={
-                "dflt": ic(inference=fx.inference.NEWEY_WEST),
-                "expl": ic(forward_periods=10, inference=fx.inference.NEWEY_WEST),
-            },
-            factor_cols=["factor"],
-            forward_periods=20,
+            unstamped, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
         )["factor"]
-        assert er.metrics["dflt"].metadata["forward_periods"] == 20
-        assert er.metrics["expl"].metadata["forward_periods"] == 10
-        assert er.forward_periods == 20  # top-level fp stamped on bundle
+        assert er.forward_periods == 5
+
+    def test_declaration_conflicting_with_stamp_raises(self):
+        with pytest.raises(UserInputError, match="stamp"):
+            fx.evaluate(
+                _panel(),
+                metrics={"ic": ic()},
+                factor_cols=["factor"],
+                forward_periods=20,
+            )
+
+    def test_stamp_column_never_leaks_into_outputs(self):
+        from factrix._data_input import _FORWARD_PERIODS_COL
+
+        er = fx.evaluate(_panel(), metrics={"ic": ic()}, factor_cols=["factor"])[
+            "factor"
+        ]
+        assert _FORWARD_PERIODS_COL not in er.to_frame().columns
+        assert _FORWARD_PERIODS_COL not in er.metrics["ic"].metadata
 
 
 class TestStrict:

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -141,6 +141,7 @@ class TestEventMetricThroughEvaluate:
             event_data,
             metrics={"ear": event_around_return()},
             factor_cols=["factor"],
+            forward_periods=1,
             strict=False,
         )
         m = res["factor"].metrics["ear"]
@@ -152,6 +153,7 @@ class TestEventMetricThroughEvaluate:
             no_price_data,
             metrics={"ear": event_around_return()},
             factor_cols=["factor"],
+            forward_periods=1,
             strict=False,
         )
         m = res["factor"].metrics["ear"]

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -81,6 +81,28 @@ class TestComputeForwardReturn:
         assert changed["forward_return"].null_count() == 0
         assert changed["forward_return"].to_list() != once["forward_return"].to_list()
 
+    def test_stamps_overlap_horizon(self):
+        from factrix._data_input import (
+            _FORWARD_PERIODS_COL,
+            _read_forward_periods_stamp,
+        )
+
+        result = compute_forward_return(_make_price_data(), forward_periods=3)
+        assert _FORWARD_PERIODS_COL in result.columns
+        assert _read_forward_periods_stamp(result) == 3
+        # one constant value across all rows
+        assert result[_FORWARD_PERIODS_COL].n_unique() == 1
+
+    def test_overwrite_restamps_new_horizon(self):
+        import factrix as fx
+        from factrix._data_input import _read_forward_periods_stamp
+
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=60, seed=0)
+        once = compute_forward_return(raw, forward_periods=1)
+        changed = compute_forward_return(once, forward_periods=2, overwrite=True)
+        assert changed.height > 0
+        assert _read_forward_periods_stamp(changed) == 2
+
 
 class TestWinsorizeForwardReturn:
     def test_noop(self):

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -6,6 +6,7 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix import slice_pairwise_test
+from factrix._data_input import _stamp_forward_periods
 from factrix._errors import UserInputError
 from factrix.metrics import fm_beta, ic, monotonicity
 
@@ -138,7 +139,11 @@ def test_raises_when_dates_dont_align() -> None:
 def test_overlap_bandwidth_inflates_variance() -> None:
     """A longer HAC bandwidth (forward_periods overlap) widens the SE on an
     autocorrelated IC series → smaller Wald χ², larger p than the naive
-    ``floor(T^(1/3))`` bandwidth. T=120 → floor=4; forward_periods=12 → 11."""
+    ``floor(T^(1/3))`` bandwidth. T=120 → floor=4; forward_periods=12 → 11.
+
+    The overlap horizon is a property of the data (the stamp), not a metric
+    knob, so the two regimes are two differently-stamped panels.
+    """
     df = build_autocorrelated_ic_panel(
         n_dates=120,
         seed=42,
@@ -149,10 +154,10 @@ def test_overlap_bandwidth_inflates_variance() -> None:
         noise=0.1,
     )
     short = slice_pairwise_test(
-        df, ic(forward_periods=1), by="universe", factor_col="factor"
+        _stamp_forward_periods(df, 1), ic(), by="universe", factor_col="factor"
     )
     long = slice_pairwise_test(
-        df, ic(forward_periods=12), by="universe", factor_col="factor"
+        _stamp_forward_periods(df, 12), ic(), by="universe", factor_col="factor"
     )
     assert long["stat"][0] < short["stat"][0]
     assert long["p_adj"][0] > short["p_adj"][0]


### PR DESCRIPTION
## Why

`forward_periods` was exposed at three uncoordinated layers — `compute_forward_return`, every metric, and `evaluate` — that all had to agree but were never validated against each other. A stride that disagreed with the data's actual overlap horizon produced statistically wrong t-stats with **zero** error. The horizon is a property of the data (the overlap structure of `forward_return`), not a per-metric knob, so it should be carried once and read everywhere.

## What changed (breaking)

- **`compute_forward_return` stamps the horizon** on the returned panel as a reserved constant column. `evaluate` reads it and strips it before dispatch, so it never reaches a metric, a projection, or `EvaluationResult.to_frame`. The stamp survives the ordinary polars transforms a panel goes through (winsorize / abnormal-return, `by_slice` partitioning, user `with_columns` / joins).
- **`forward_periods` leaves the user-configurable metric surface.** Constructing a metric with it (`ic(forward_periods=20)`) is rejected at the constructor — the guarantee that a metric cannot diverge from the data horizon is structural, not a runtime check. `_impl` still receives the horizon (injected at dispatch), and `self.forward_periods` still backs the dynamic sample-threshold hooks.
- **`evaluate` drops the per-metric override and the hardcoded `else 5`.** `EvaluationResult.forward_periods` now reflects the data's real horizon. A self-attached `forward_return` panel that carries no stamp must declare the horizon once via `forward_periods=` (path B); a declaration that disagrees with the stamp is rejected.
- **Cross-slice / period-disjoint HAC bandwidth** reads the data stamp instead of the metric.

The mixed-horizon usage `{"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}` on a single panel — always statistically wrong, since both labels read one `forward_return` column — is removed. To compare horizons, build two panels and evaluate each.

## Migration

```python
# before
data = compute_forward_return(raw, forward_periods=5)
evaluate(data, metrics={"ic_5d": ic(), "ic_20d": ic(forward_periods=20)}, factor_cols=[...])

# after — horizon comes from the data; one horizon per evaluate
data = compute_forward_return(raw, forward_periods=5)
evaluate(data, metrics={"ic": ic()}, factor_cols=[...])           # reads the stamp
# term structure: two panels
evaluate(compute_forward_return(raw, 5),  metrics={"ic": ic()}, factor_cols=[...])
evaluate(compute_forward_return(raw, 20), metrics={"ic": ic()}, factor_cols=[...])
```

A self-attached `forward_return` panel (no stamp) declares its horizon once: `evaluate(data, ..., forward_periods=N)`.

## Tests

Full suite + doctests green (1382 passed). New coverage: the stamp + overwrite re-stamp, the three new contract paths (no-stamp-no-declaration raises, stamp/declaration conflict raises, path-B declaration runs), the stamp-never-leaks invariant, and construction-time rejection. `ruff check`, `ruff format --check`, `mypy factrix` clean.

Per-metric docstring prose (Args/examples still framed around the old knob) is deferred to the epic doc pass; this PR fixes the primary-contract docs (`evaluate` / `by_slice` / `compute_forward_return` / `EvaluationResult`).

Closes #651