### PR TITLE
fix(api): improve inspect_data / bhy ergonomics

### DIFF
--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -252,7 +252,7 @@ class DataInspection:
     Pure data — no execution methods.
 
     Attributes:
-        detected: :class:`DataProperties` with typed enum axes, the
+        properties: :class:`DataProperties` with typed enum axes, the
             per-axis rationale strings, and shape numerics.
         metrics: Flat ``list[MetricApplicability]`` — one verdict
             per ``visibility=PUBLIC`` spec the inspector considered.
@@ -266,7 +266,7 @@ class DataInspection:
             each :class:`MetricApplicability`.
     """
 
-    detected: DataProperties
+    properties: DataProperties
     metrics: list[MetricApplicability]
     warnings: list[Warning] = field(default_factory=list)
 
@@ -322,7 +322,7 @@ class DataInspection:
 
         Layout (top-level keys, stable order):
 
-        - ``detected``: ``{scope, density, structure, n_assets, n_periods,
+        - ``properties``: ``{scope, density, structure, n_assets, n_periods,
           n_pairs, sparse_ratio}`` — enum fields rendered as their
           ``.value`` string; ``sparse_ratio`` ``NaN`` emitted as
           ``None``.
@@ -336,9 +336,9 @@ class DataInspection:
         ``to_dict`` convention across the public result-type group so
         log / parquet sinks treat them uniformly.
         """
-        d = self.detected
+        d = self.properties
         return {
-            "detected": {
+            "properties": {
                 "scope": d.scope.value,
                 "density": d.density.value,
                 "structure": d.structure.value,
@@ -382,7 +382,7 @@ class DataInspection:
         }
 
     def _repr_html_(self) -> str:
-        d = self.detected
+        d = self.properties
         header_rows = [
             ("scope", d.scope.value),
             ("density", d.density.value),
@@ -445,7 +445,7 @@ class DataInspection:
 
         return (
             "<div class='factrix-data-inspection'>"
-            "<table><caption>DataInspection — detected</caption>"
+            "<table><caption>DataInspection — properties</caption>"
             f"<tbody>{header_html}</tbody></table>"
             "<table><caption>reasoning</caption>"
             f"<tbody>{reasoning_rows}</tbody></table>"
@@ -475,7 +475,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     such as a ternary ``{-1, 0, +1}`` indicator), matching its run-time
     ``not_applicable_discrete_signal`` short-circuit.
 
-    Multi-factor input: the detected :class:`DataProperties` and every
+    Multi-factor input: the inspected :class:`DataProperties` and every
     per-metric verdict are computed from the **first** factor column only
     (deterministic first-detected). When columns disagree on
     ``FactorDensity`` or ``FactorScope`` a ``CROSS_FACTOR_*_MISMATCH``
@@ -500,7 +500,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
         >>> import factrix as fx
         >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
         >>> info = fx.inspect_data(raw)
-        >>> all(m.spec.cell.matches(info.detected.scope, info.detected.density, info.detected.structure) for m in info.usable)
+        >>> all(m.spec.cell.matches(info.properties.scope, info.properties.density, info.properties.structure) for m in info.usable)
         True
     """
     if isinstance(factor_cols, str):
@@ -616,7 +616,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     ]
 
     return DataInspection(
-        detected=properties,
+        properties=properties,
         metrics=metrics,
         warnings=data_warnings,
     )

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -81,10 +81,23 @@ def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str
 def _require_non_empty_results(
     results: Sequence[EvaluationResult], *, func_name: str
 ) -> None:
-    """Shared empty-input guard: every public function raises rather than
+    """Shared results-input guard: every public function raises rather than
     returning an empty container — FDR over an empty candidate set has
-    no meaning and ranking an empty leaderboard is undefined.
+    no meaning and ranking an empty leaderboard is undefined. Also catches
+    the natural ``evaluate`` follow-up mistake of forwarding its ``dict``
+    return directly, pointing at ``list(results.values())``.
     """
+    if isinstance(results, Mapping):
+        raise UserInputError(
+            func_name=func_name,
+            field="results",
+            value=type(results).__name__,
+            expected=(
+                "list[EvaluationResult], not the dict returned by evaluate() — "
+                "pass list(results.values())"
+            ),
+            docs_path=f"api/{func_name}#results",
+        )
     if not results:
         raise UserInputError(
             func_name=func_name,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -64,7 +64,7 @@ data = compute_forward_return(raw, forward_periods=5)
 
 # 2. Run pre-flight check
 info = fx.inspect_data(data, factor_cols=["factor"])
-print("Detected structure:", info.detected.structure)
+print("Detected structure:", info.properties.structure)
 
 # 3. Evaluate using ic with Newey-West HAC inference
 results = fx.evaluate(
@@ -179,7 +179,7 @@ def inspect_data(
 
 Typed pre-flight introspection that combines axis detection with a per-metric usability verdict.
 
-- `DataInspection.detected: DataProperties` carries the detected enums (`scope` / `density` / `structure`), per-axis rationale strings (`scope_reason` / `density_reason` / `structure_reason`), plus shape numerics (`n_assets` / `n_periods` / `n_pairs` / `sparse_ratio`).
+- `DataInspection.properties: DataProperties` carries the detected enums (`scope` / `density` / `structure`), per-axis rationale strings (`scope_reason` / `density_reason` / `structure_reason`), plus shape numerics (`n_assets` / `n_periods` / `n_pairs` / `sparse_ratio`).
 - `DataInspection.metrics: list[MetricApplicability]` provides verdicts grouped into three usability `Tier` categories:
   - `usable` (`MetricApplicabilityGroup` / `Tier.CLEAN`): Clean metrics ready to run.
   - `degraded` (`MetricApplicabilityGroup` / `Tier.DEGRADED`): Metrics runnable with warnings.

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -54,6 +54,15 @@ def test_empty_input_raises():
         bhy([], metrics=["ic"], q=0.05)
 
 
+def test_dict_input_suggests_values():
+    make_spec("ic")
+    results = {
+        f"f{i}": make_result(factor=f"f{i}", p=0.01, metric="ic") for i in range(3)
+    }
+    with pytest.raises(UserInputError, match=r"list\(results\.values\(\)\)"):
+        bhy(results, metrics=["ic"], q=0.05)  # type: ignore[arg-type]
+
+
 def test_no_surviving_results_returns_empty_record():
     make_spec("ic")
     results = [make_result(factor=f"f{i}", p=0.9, metric="ic") for i in range(5)]

--- a/tests/test_cross_type_invariants.py
+++ b/tests/test_cross_type_invariants.py
@@ -221,7 +221,7 @@ class TestApplicabilityMirrorsSpec:
         # A metric is only usable when its cell admits the detected axes —
         # the spec.cell ↔ detected-properties seam inspect_data enforces.
         info: DataInspection = inspect_data(request.getfixturevalue(panel_name))
-        d = info.detected
+        d = info.properties
         for m in info.usable:
             assert m.spec.cell.matches(d.scope, d.density, d.structure)
 

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -36,30 +36,30 @@ def _by_name(info: DataInspection, name: str) -> MetricApplicability:
 class TestDataPropertiesDetection:
     def test_individual_continuous_cs_panel(self):
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
-        assert info.detected.scope is fx.FactorScope.INDIVIDUAL
-        assert info.detected.density is fx.FactorDensity.DENSE
-        assert info.detected.structure is fx.DataStructure.PANEL
-        assert info.detected.n_assets == 20
-        assert info.detected.n_periods == 80
-        assert info.detected.n_pairs == 20 * 80
-        assert 0.0 <= info.detected.sparse_ratio < 0.5
+        assert info.properties.scope is fx.FactorScope.INDIVIDUAL
+        assert info.properties.density is fx.FactorDensity.DENSE
+        assert info.properties.structure is fx.DataStructure.PANEL
+        assert info.properties.n_assets == 20
+        assert info.properties.n_periods == 80
+        assert info.properties.n_pairs == 20 * 80
+        assert 0.0 <= info.properties.sparse_ratio < 0.5
 
     def test_n1_routes_to_timeseries(self):
         info = inspect_data(_single_asset_data(n_dates=80))
-        assert info.detected.structure is fx.DataStructure.TIMESERIES
-        assert info.detected.n_assets == 1
-        assert "TIMESERIES" in info.detected.structure_reason
+        assert info.properties.structure is fx.DataStructure.TIMESERIES
+        assert info.properties.n_assets == 1
+        assert "TIMESERIES" in info.properties.structure_reason
 
     def test_common_continuous_detection(self):
         info = inspect_data(_common_continuous_data())
-        assert info.detected.scope is fx.FactorScope.COMMON
-        assert info.detected.density is fx.FactorDensity.DENSE
+        assert info.properties.scope is fx.FactorScope.COMMON
+        assert info.properties.density is fx.FactorDensity.DENSE
 
     def test_empty_panel_sparse_ratio_is_nan(self):
         empty = fx.datasets.make_cs_panel(n_assets=4, n_dates=10).head(0)
         info = inspect_data(empty)
-        assert math.isnan(info.detected.sparse_ratio)
-        assert info.detected.n_pairs == 0
+        assert math.isnan(info.properties.sparse_ratio)
+        assert info.properties.n_pairs == 0
 
     def test_n_pairs_counts_non_null_factor_only(self):
         raw = fx.datasets.make_cs_panel(n_assets=4, n_dates=10)
@@ -70,16 +70,16 @@ class TestDataPropertiesDetection:
             .alias("factor")
         )
         info = inspect_data(with_nulls)
-        assert info.detected.n_pairs == with_nulls.drop_nulls("factor").height
-        assert info.detected.n_pairs < raw.height
+        assert info.properties.n_pairs == with_nulls.drop_nulls("factor").height
+        assert info.properties.n_pairs < raw.height
 
 
 class TestDataReasoning:
     def test_three_axis_fields_populated(self):
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=80))
-        assert "INDIVIDUAL" in info.detected.scope_reason
-        assert "DENSE" in info.detected.density_reason
-        assert "PANEL" in info.detected.structure_reason
+        assert "INDIVIDUAL" in info.properties.scope_reason
+        assert "DENSE" in info.properties.density_reason
+        assert "PANEL" in info.properties.structure_reason
 
 
 class TestCellMatchGate:
@@ -147,7 +147,7 @@ class TestSampleThresholdGate:
         from factrix._metric_index import SampleThreshold
 
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
-        floor = SampleThreshold(min_pairs=info.detected.n_pairs + 1)
+        floor = SampleThreshold(min_pairs=info.properties.n_pairs + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_ir")
         from dataclasses import replace
 
@@ -155,7 +155,7 @@ class TestSampleThresholdGate:
 
         verdict = _evaluate_applicability(
             replace(spec, sample_threshold=floor),
-            info.detected,
+            info.properties,
             signal_discrete=False,
         )
         assert verdict.usable is False
@@ -168,12 +168,12 @@ class TestSampleThresholdGate:
         from factrix._metric_index import SampleThreshold
 
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=120))
-        n = info.detected.n_pairs
+        n = info.properties.n_pairs
         floor = SampleThreshold(min_pairs=n - 1, warn_pairs=n + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "ic_ir")
         verdict = _evaluate_applicability(
             replace(spec, sample_threshold=floor),
-            info.detected,
+            info.properties,
             signal_discrete=False,
         )
         assert verdict.usable is True
@@ -283,7 +283,7 @@ class TestEventAxisPreflight:
 
         panel = self._event_panel()
         info = inspect_data(panel)
-        assert info.detected.n_events == panel.filter(pl.col("factor") != 0).height
+        assert info.properties.n_events == panel.filter(pl.col("factor") != 0).height
 
     def test_below_min_events_is_unusable(self):
         from dataclasses import replace
@@ -292,11 +292,11 @@ class TestEventAxisPreflight:
         from factrix._metric_index import SampleThreshold
 
         info = inspect_data(self._event_panel())
-        floor = SampleThreshold(min_events=info.detected.n_events + 1)
+        floor = SampleThreshold(min_events=info.properties.n_events + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "corrado_rank")
         verdict = _evaluate_applicability(
             replace(spec, sample_threshold=floor),
-            info.detected,
+            info.properties,
             signal_discrete=False,
         )
         assert verdict.usable is False
@@ -309,12 +309,12 @@ class TestEventAxisPreflight:
         from factrix._metric_index import SampleThreshold
 
         info = inspect_data(self._event_panel())
-        n = info.detected.n_events
+        n = info.properties.n_events
         floor = SampleThreshold(min_events=n - 1, warn_events=n + 1)
         spec = next(m.spec for m in info.metrics if m.spec.name == "corrado_rank")
         verdict = _evaluate_applicability(
             replace(spec, sample_threshold=floor),
-            info.detected,
+            info.properties,
             signal_discrete=False,
         )
         assert verdict.usable is True
@@ -457,9 +457,9 @@ class TestToDict:
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=20, n_dates=25))
         d = info.to_dict()
         back = json.loads(json.dumps(d))
-        assert back["detected"]["scope"] == "individual"
-        assert back["detected"]["structure"] == "panel"
-        assert back["detected"]["n_assets"] == 20
+        assert back["properties"]["scope"] == "individual"
+        assert back["properties"]["structure"] == "panel"
+        assert back["properties"]["n_assets"] == 20
         assert back["reasoning"]["scope"]
         assert any(m["name"] == "ic_ir" for m in back["metrics"])
         nw = next(m for m in back["metrics"] if m["name"] == "ic_ir")
@@ -469,8 +469,8 @@ class TestToDict:
     def test_nan_sparse_ratio_becomes_null(self):
         empty = fx.datasets.make_cs_panel(n_assets=4, n_dates=10).head(0)
         d = inspect_data(empty).to_dict()
-        assert d["detected"]["sparse_ratio"] is None
-        assert d["detected"]["n_pairs"] == 0
+        assert d["properties"]["sparse_ratio"] is None
+        assert d["properties"]["n_pairs"] == 0
 
     def test_data_level_warnings_serialised(self):
         info = inspect_data(fx.datasets.make_cs_panel(n_assets=5, n_dates=120))


### PR DESCRIPTION
## Summary

Resolves the three API ergonomics frictions raised in the issue:

- **`DataInspection.detected` → `.properties`** — callers reached for `.properties`/`.data` and hit `AttributeError`. Renamed the attribute (and the matching `to_dict()` key) to the name users actually try and that matches the `DataProperties` type it holds. *(breaking)*
- **`bhy` dict input** — `evaluate()` returns a `dict`, but `bhy`/`partial_conjunction`/`bhy_hierarchical` take a `list`. The shared results validator now detects a `Mapping` and points at `list(results.values())` rather than restating the expected type.
- **`evaluate` default `forward_periods=5`** — no longer applicable. The earlier forward-periods convergence work removed the silent default entirely: `forward_periods=None` now reads the data's stamped horizon or raises `UserInputError`, so there is no invisible-default case left to warn about.

## Test plan

- `tests/test_bhy.py::test_dict_input_suggests_values` — new, asserts the dict-input error names `list(results.values())`.
- `tests/test_inspect_data.py` / `tests/test_cross_type_invariants.py` — updated to the `.properties` attribute and `to_dict()` key.
- Full suite: `1383 passed, 4 skipped`. `ruff check`, `ruff format --check`, `mypy factrix` all clean.

Closes #638
