### PR TITLE
feat(inspect): flag single-asset event data instead of silent unusable

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -76,6 +76,16 @@ class WarningCode(StrEnum):
     CROSS_FACTOR_DENSITY_MISMATCH = "cross_factor_density_mismatch"
     CROSS_FACTOR_SCOPE_MISMATCH = "cross_factor_scope_mismatch"
 
+    # Fired by inspect_data on single-asset event-shaped data (TIMESERIES +
+    # SPARSE, i.e. n_assets=1). Every event metric expresses the event
+    # cross-section across the asset axis (cell.structure=PANEL), so all are
+    # unusable here — a data-level signal that the silence is a known gap, not
+    # a broken panel. The inference unit for an event study is the event
+    # cross-section (n_events), not assets; native single-asset support is
+    # tracked separately. Deliberately does NOT advise adding assets — pooling
+    # unrelated names mixes return-generating processes.
+    SINGLE_ASSET_EVENT_DATA = "single_asset_event_data"
+
     # Fired by evaluate(strict=False) when a metric's declared
     # cell.structure disagrees with the data's structure (e.g. a PANEL
     # metric requested on TIMESERIES data). The metric is not executed —
@@ -159,6 +169,13 @@ _WARNING_DESCRIPTIONS.update(
         "metadata['upstream'] / ['upstream_reason'] for the original cause.",
         WarningCode.CROSS_FACTOR_DENSITY_MISMATCH: "Factor columns carry inconsistent FactorDensity (dense and sparse mixed).",
         WarningCode.CROSS_FACTOR_SCOPE_MISMATCH: "Factor columns carry inconsistent FactorScope (individual and common mixed).",
+        WarningCode.SINGLE_ASSET_EVENT_DATA: "Single-asset event-shaped data (TIMESERIES + SPARSE, n_assets=1): "
+        "every event metric expresses the event cross-section across the asset "
+        "axis, so all are unusable here. The inference unit for an event study "
+        "is the event cross-section (n_events), not assets — one name with many "
+        "non-overlapping events is a valid study, but native single-asset "
+        "support is not yet wired. Do not pool unrelated assets to clear this; "
+        "that mixes return-generating processes.",
         WarningCode.STRUCTURE_MISMATCH: "Metric's declared cell.structure disagrees with the data "
         "structure (e.g. a PANEL metric on TIMESERIES data); under "
         "strict=False the metric short-circuits to NaN instead of executing. "

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -708,6 +708,16 @@ def _data_level_warnings(properties: DataProperties) -> list[Warning]:
     ):
         code = WarningCode.UNRELIABLE_SE_SHORT_PERIODS
         warnings.append(Warning(code=code, source=None, message=code.description))
+    # Single-asset event-shaped data (n_assets=1 ⇒ TIMESERIES, plus SPARSE):
+    # every event metric is cell.structure=PANEL and therefore unusable. Surface
+    # the regime as a data-level signal rather than leaving the user with a
+    # silent all-unusable verdict — the block is a known gap, not a broken panel.
+    if (
+        properties.structure is DataStructure.TIMESERIES
+        and properties.density is FactorDensity.SPARSE
+    ):
+        code = WarningCode.SINGLE_ASSET_EVENT_DATA
+        warnings.append(Warning(code=code, source=None, message=code.description))
     if properties.structure is DataStructure.PANEL:
         tier = cross_section_tier(properties.n_assets)
         if tier is not None:

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -426,6 +426,30 @@ class TestDataLevelWarnings:
         codes = [w.code.value for w in info.warnings]
         assert "few_assets" in codes
 
+    def test_single_asset_event_data_emits_guidance(self):
+        # n_assets=1 event panel ⇒ TIMESERIES + SPARSE: every event metric is
+        # blocked. Surface the regime instead of a silent all-unusable verdict.
+        info = inspect_data(
+            fx.datasets.make_event_panel(n_assets=1, n_dates=120, seed=0)
+        )
+        codes = [w.code.value for w in info.warnings]
+        assert "single_asset_event_data" in codes
+        assert all(w.source is None for w in info.warnings)
+        assert len(info.usable) == 0  # the regime the warning flags
+
+    def test_multi_asset_event_panel_no_single_asset_warning(self):
+        info = inspect_data(
+            fx.datasets.make_event_panel(n_assets=50, n_dates=400, seed=0)
+        )
+        codes = [w.code.value for w in info.warnings]
+        assert "single_asset_event_data" not in codes
+
+    def test_dense_single_asset_no_event_warning(self):
+        # A dense single-asset timeseries is not event-shaped; must not fire.
+        info = inspect_data(_single_asset_data(n_dates=120))
+        codes = [w.code.value for w in info.warnings]
+        assert "single_asset_event_data" not in codes
+
 
 class TestWarningSourceConvention:
     """Guard the `Warning.source` convention across every emission point:


### PR DESCRIPTION
## Summary

Stage A of single-asset event-study support (#633): replace the silent all-unusable verdict with honest, statistically correct guidance.

A `make_event_panel(n_assets=1, ...)` panel is `TIMESERIES + SPARSE`, so every event metric (`cell.structure=PANEL`) is blocked. Previously `inspect_data` returned `usable=[] degraded=[] unusable=[all]` with **no** data-level warning — indistinguishable from a broken panel.

This adds a data-level `Warning` (`SINGLE_ASSET_EVENT_DATA`) on that regime whose message:
- names the real inference unit — the **event** cross-section (`n_events`), not assets;
- states this is a known gap (native single-asset support tracked as Stage B), not a malformed input;
- **does not** advise adding assets — pooling unrelated names mixes return-generating processes and is the wrong fix.

This intentionally does not yet make any metric `usable` on single-asset data; that is Stage B (event-axis applicability), which will supersede this warning for the metrics that generalise.

## Test plan

- New `TestDataLevelWarnings` cases: single-asset event panel emits exactly `single_asset_event_data` (source `None`, `usable` empty); multi-asset event panel and dense single-asset series do **not** emit it.
- Full suite: `1386 passed, 4 skipped`. `ruff check`, `ruff format --check`, `mypy factrix` clean.

Advances #633 (Stage A). Does not close it — Stage B follows.
