### PR TITLE
feat(metrics): support single-asset event studies via event-axis cells

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -77,13 +77,13 @@ class WarningCode(StrEnum):
     CROSS_FACTOR_SCOPE_MISMATCH = "cross_factor_scope_mismatch"
 
     # Fired by inspect_data on single-asset event-shaped data (TIMESERIES +
-    # SPARSE, i.e. n_assets=1). Every event metric expresses the event
-    # cross-section across the asset axis (cell.structure=PANEL), so all are
-    # unusable here — a data-level signal that the silence is a known gap, not
-    # a broken panel. The inference unit for an event study is the event
-    # cross-section (n_events), not assets; native single-asset support is
-    # tracked separately. Deliberately does NOT advise adding assets — pooling
-    # unrelated names mixes return-generating processes.
+    # SPARSE, i.e. n_assets=1). Event-axis metrics run over the event
+    # cross-section (n_events) and are usable on a single name; only a metric
+    # that needs the asset cross-section (cell.structure=PANEL, e.g.
+    # clustering_hhi, whose same-date event clustering is degenerate at
+    # ≤1 event/date) stays unusable. The warning names those so their absence
+    # from `usable` is explained, not silent. Deliberately does NOT advise
+    # adding assets — pooling unrelated names mixes return-generating processes.
     SINGLE_ASSET_EVENT_DATA = "single_asset_event_data"
 
     # Fired by evaluate(strict=False) when a metric's declared
@@ -170,12 +170,11 @@ _WARNING_DESCRIPTIONS.update(
         WarningCode.CROSS_FACTOR_DENSITY_MISMATCH: "Factor columns carry inconsistent FactorDensity (dense and sparse mixed).",
         WarningCode.CROSS_FACTOR_SCOPE_MISMATCH: "Factor columns carry inconsistent FactorScope (individual and common mixed).",
         WarningCode.SINGLE_ASSET_EVENT_DATA: "Single-asset event-shaped data (TIMESERIES + SPARSE, n_assets=1): "
-        "every event metric expresses the event cross-section across the asset "
-        "axis, so all are unusable here. The inference unit for an event study "
-        "is the event cross-section (n_events), not assets — one name with many "
-        "non-overlapping events is a valid study, but native single-asset "
-        "support is not yet wired. Do not pool unrelated assets to clear this; "
-        "that mixes return-generating processes.",
+        "event-axis metrics run over the event cross-section (n_events) and are "
+        "usable on a single name. Metrics that need the asset cross-section — "
+        "same-date event clustering (clustering_hhi) is degenerate at one "
+        "event per date — need n_assets>=2 and are unavailable. Do not pool "
+        "unrelated assets to clear this; that mixes return-generating processes.",
         WarningCode.STRUCTURE_MISMATCH: "Metric's declared cell.structure disagrees with the data "
         "structure (e.g. a PANEL metric on TIMESERIES data); under "
         "strict=False the metric short-circuits to NaN instead of executing. "

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -614,12 +614,52 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
         _evaluate_applicability(spec, properties, signal_discrete)
         for _, spec in public_specs()
     ]
+    data_warnings.extend(_single_asset_event_warning(properties, metrics))
 
     return DataInspection(
         properties=properties,
         metrics=metrics,
         warnings=data_warnings,
     )
+
+
+def _single_asset_event_warning(
+    properties: DataProperties, metrics: list[MetricApplicability]
+) -> list[Warning]:
+    """Explain why a cross-sectional event metric is missing from `usable` on
+    single-asset event data.
+
+    On TIMESERIES + SPARSE data (n_assets=1) the event-axis metrics run over the
+    event cross-section and are usable; only a metric that still needs the asset
+    cross-section (``cell.structure=PANEL``, e.g. ``clustering_hhi``, whose
+    same-date event clustering is degenerate when a single name has at most one
+    event per date) stays blocked. Name those so their absence is explained
+    rather than silent. Fires only when such a metric is actually present and
+    unusable — dynamic on the verdicts, not on shape alone.
+    """
+    if not (
+        properties.structure is DataStructure.TIMESERIES
+        and properties.density is FactorDensity.SPARSE
+    ):
+        return []
+    cross_sectional = sorted(
+        m.name
+        for m in metrics
+        if m.spec.cell.density is FactorDensity.SPARSE
+        and m.spec.cell.structure is DataStructure.PANEL
+        and not m.usable
+    )
+    if not cross_sectional:
+        return []
+    names = ", ".join(cross_sectional)
+    message = (
+        f"Single-asset event data (n_assets=1): event-axis metrics run over the "
+        f"event cross-section and are usable. Metrics that need the asset "
+        f"cross-section ({names}) need n_assets>=2 and are unavailable here."
+    )
+    return [
+        Warning(code=WarningCode.SINGLE_ASSET_EVENT_DATA, source=None, message=message)
+    ]
 
 
 def _evaluate_applicability(
@@ -707,16 +747,6 @@ def _data_level_warnings(properties: DataProperties) -> list[Warning]:
         and MIN_PERIODS_HARD <= properties.n_periods < MIN_PERIODS_WARN
     ):
         code = WarningCode.UNRELIABLE_SE_SHORT_PERIODS
-        warnings.append(Warning(code=code, source=None, message=code.description))
-    # Single-asset event-shaped data (n_assets=1 ⇒ TIMESERIES, plus SPARSE):
-    # every event metric is cell.structure=PANEL and therefore unusable. Surface
-    # the regime as a data-level signal rather than leaving the user with a
-    # silent all-unusable verdict — the block is a known gap, not a broken panel.
-    if (
-        properties.structure is DataStructure.TIMESERIES
-        and properties.density is FactorDensity.SPARSE
-    ):
-        code = WarningCode.SINGLE_ASSET_EVENT_DATA
         warnings.append(Warning(code=code, source=None, message=code.description))
     if properties.structure is DataStructure.PANEL:
         tier = cross_section_tier(properties.n_assets)

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -29,7 +29,6 @@ import polars as pl
 
 from factrix._axis import (
     Aggregation,
-    DataStructure,
     FactorDensity,
     InputShape,
 )
@@ -62,7 +61,11 @@ __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
     "bmp_z",
 ]
 
-_CAAR_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
+# structure=None (event-axis): caar/bmp_z aggregate over the event cross-section
+# (event dates / events), not the asset cross-section, so they run on single-asset
+# multi-event data too. Density stays SPARSE — the event-shaped signal — and the
+# event-count floor guards thin samples.
+_CAAR_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
 # Slice-test contract (#153 §5): CAAR is event-driven; the
 # cross-section is the event sample, not a bucketed asset universe,

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -36,6 +36,11 @@ __all__ = [
 
 
 @metric(
+    # structure=PANEL (kept, unlike the other event metrics): HHI measures
+    # same-date event clustering, which needs a cross-section of assets so that
+    # multiple events can share a date. A single name has at most one event per
+    # date, so HHI degenerates to 1/n_events (uninformative) — hence this stays
+    # multi-asset rather than relaxing to structure=None like caar / bmp_z / etc.
     cell=cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.CS_SNAPSHOT,
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -12,7 +12,6 @@ import polars as pl
 
 from factrix._axis import (
     Aggregation,
-    DataStructure,
     FactorDensity,
 )
 from factrix._metric_index import SampleThreshold, cell
@@ -28,7 +27,10 @@ __all__ = [
 
 
 @metric(
-    cell=cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL),
+    # structure=None (event-axis): the rank test runs across events, so a single
+    # name with enough events is a valid sample. Density stays SPARSE; the event
+    # floor guards thin samples.
+    cell=cell(None, FactorDensity.SPARSE, structure=None),
     aggregation=Aggregation.EVENT_TIME,
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -22,7 +22,6 @@ import polars as pl
 
 from factrix._axis import (
     Aggregation,
-    DataStructure,
     FactorDensity,
 )
 from factrix._metric_index import SampleThreshold, cell
@@ -35,7 +34,10 @@ __all__ = [
     "event_around_return",
 ]
 
-_EH_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
+# structure=None (event-axis): event-window returns aggregate over events, so a
+# single name with enough events is valid. Density stays SPARSE; the event floor
+# guards thin samples.
+_EH_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
 
 @metric(

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -26,7 +26,6 @@ import polars as pl
 
 from factrix._axis import (
     Aggregation,
-    DataStructure,
     FactorDensity,
 )
 from factrix._metric_index import SampleThreshold, cell
@@ -53,7 +52,10 @@ __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
     "signal_density",
 ]
 
-_EQ_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
+# structure=None (event-axis): event_hit_rate / event_ic / profit_factor aggregate
+# over events, so a single name with enough events is valid. Density stays SPARSE;
+# the event floor guards thin samples.
+_EQ_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
 
 @metric(

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -22,7 +22,6 @@ import polars as pl
 
 from factrix._axis import (
     Aggregation,
-    DataStructure,
     FactorDensity,
     InputShape,
 )
@@ -37,7 +36,10 @@ __all__ = [
     "mfe_mae",
 ]
 
-_MFE_CELL = cell(None, FactorDensity.SPARSE, structure=DataStructure.PANEL)
+# structure=None (event-axis): MFE/MAE excursions aggregate over events, so a
+# single name with enough events is valid. Density stays SPARSE; the event floor
+# guards thin samples.
+_MFE_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
 
 @metric(

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -427,15 +427,20 @@ class TestDataLevelWarnings:
         assert "few_assets" in codes
 
     def test_single_asset_event_data_emits_guidance(self):
-        # n_assets=1 event panel ⇒ TIMESERIES + SPARSE: every event metric is
-        # blocked. Surface the regime instead of a silent all-unusable verdict.
+        # n_assets=1 event panel ⇒ TIMESERIES + SPARSE: event-axis metrics are
+        # usable, but the cross-sectional clustering_hhi stays blocked. The
+        # data-level warning names it so its absence from `usable` is explained.
         info = inspect_data(
-            fx.datasets.make_event_panel(n_assets=1, n_dates=120, seed=0)
+            fx.datasets.make_event_panel(n_assets=1, n_dates=400, seed=0)
         )
-        codes = [w.code.value for w in info.warnings]
-        assert "single_asset_event_data" in codes
-        assert all(w.source is None for w in info.warnings)
-        assert len(info.usable) == 0  # the regime the warning flags
+        warn = [w for w in info.warnings if w.code.value == "single_asset_event_data"]
+        assert len(warn) == 1
+        assert warn[0].source is None
+        assert "clustering_hhi" in warn[0].message
+        # event-axis metrics run on a single name; the cross-sectional one does not
+        assert len(info.usable) > 0
+        usable_names = {m.name for m in info.usable}
+        assert "clustering_hhi" not in usable_names
 
     def test_multi_asset_event_panel_no_single_asset_warning(self):
         info = inspect_data(
@@ -449,6 +454,38 @@ class TestDataLevelWarnings:
         info = inspect_data(_single_asset_data(n_dates=120))
         codes = [w.code.value for w in info.warnings]
         assert "single_asset_event_data" not in codes
+
+
+class TestEventAxisSingleAsset:
+    """Event metrics whose inference unit is the event cross-section run on
+    single-asset (TIMESERIES) data; the cross-sectional clustering_hhi does not.
+    """
+
+    @staticmethod
+    def _panel() -> pl.DataFrame:
+        return fx.datasets.make_event_panel(n_assets=1, n_dates=400, seed=0)
+
+    def test_event_axis_metrics_usable_on_single_asset(self):
+        info = inspect_data(self._panel())
+        usable = {m.name for m in info.usable}
+        # representative event-axis metrics, event-count floor permitting
+        assert {"bmp_z", "corrado_rank", "mfe_mae", "event_hit_rate"} <= usable
+
+    def test_clustering_hhi_stays_cross_sectional(self):
+        info = inspect_data(self._panel())
+        hhi = _by_name(info, "clustering_hhi")
+        assert hhi.usable is False
+        assert any("cell mismatch" in b for b in hhi.blockers)
+
+    def test_event_axis_metric_computes_finite_value(self):
+        # applicability is not enough — the primitive must produce a real value
+        # on single-asset data, not a structure short-circuit.
+        panel = fx.preprocess.compute_forward_return(self._panel(), forward_periods=5)
+        res = fx.evaluate(
+            panel, metrics={"bmp_z": fx.metrics.bmp_z()}, factor_cols=["factor"]
+        )
+        value = res["factor"].metrics["bmp_z"].value
+        assert value is not None and not math.isnan(value)
 
 
 class TestWarningSourceConvention:


### PR DESCRIPTION
## Summary

Stage B of single-asset event-study support (#633), **stacked on #656** (base is that branch; retarget to `main` once #656 merges).

Event metrics declared `cell.structure=PANEL`, so a single-asset (`TIMESERIES`) event panel left every one unusable. But their inference unit is the **event** cross-section, not the asset cross-section — verified empirically that each primitive produces a finite, valid value on single-asset multi-event data:

| Metric | Why it generalises |
|---|---|
| `caar` / `bmp_z` | event-date portfolio t-test / across-events standardized z-test (N = events) |
| `corrado_rank` | across-events nonparametric rank test |
| `mfe_mae`, `event_horizon`, `event_quality` (`event_hit_rate` / `event_ic` / `profit_factor` / …) | per-event quantities aggregated over events |

Relaxing those cells to `structure=None` makes them usable on a single name with enough events. The multi-asset path is unchanged — the new cell match only **adds** `TIMESERIES + SPARSE`.

### Correctness note — `clustering_hhi` stays `PANEL`

While auditing I found `clustering_hhi` is *not* a cross-asset metric as I first assumed — it measures **same-date** event clustering (`HHI = Σ_d s_d²`). But for a single name there is at most one event per date, so `HHI ≡ 1/n_events` (degenerate, uninformative). It genuinely needs a cross-section of assets (multiple events sharing a date), so it correctly stays `structure=PANEL`. A comment at its cell records this so it is not relaxed by analogy later.

### Warning becomes verdict-aware

The `single_asset_event_data` data-level warning added in #656 is reworked: instead of the old "everything is unusable" note, it now fires **only** when a metric that still needs the asset cross-section (`clustering_hhi`) remains blocked, naming it so its absence from `usable` is explained. Dynamic on the actual verdicts, not on data shape alone.

## Test plan

- `TestEventAxisSingleAsset`: event-axis metrics (`bmp_z`, `corrado_rank`, `mfe_mae`, `event_hit_rate`) are `usable` on a single-asset event panel; `clustering_hhi` stays unusable (cell mismatch); `bmp_z` produces a finite value through `evaluate` (not a structure short-circuit).
- `TestDataLevelWarnings` updated: the warning names `clustering_hhi` and `usable` is non-empty.
- Full suite: `1389 passed, 4 skipped`. `ruff check`, `ruff format --check`, `mypy factrix`, doctests all clean.

Closes #633.
