### PR TITLE
feat(metrics): add inference= to quantile_spread and k_spread

### DIFF
--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -33,12 +33,15 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import polars as pl
 
 from factrix._codes import WarningCode, cross_section_tier
+
+if TYPE_CHECKING:
+    from factrix.inference import NeweyWest, NonOverlapping
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
 from factrix._stats.constants import MIN_ASSETS_WARN
@@ -116,6 +119,80 @@ def _spread_significance(
     tier: WarningCode | None = cross_section_tier(n_assets)
     codes = (tier.value,) if tier is not None else ()
     return t, float(p_boot), "block-bootstrap CI", extra, codes
+
+
+def _spread_significance_with_inference(
+    inference: NonOverlapping | NeweyWest,
+    *,
+    strided_spread: np.ndarray,
+    full_spread: pl.DataFrame | None,
+    forward_periods: int,
+    n_assets: int,
+    rng_seed: int = _SPREAD_BOOTSTRAP_SEED,
+) -> tuple[float, float, float, str, dict[str, object], tuple[str, ...]]:
+    """Single headline-significance chokepoint shared by every spread metric.
+
+    Returns ``(value, stat, p_value, method, extra_metadata, warning_codes)``
+    where ``value`` is the mean-spread point estimate under the chosen
+    inference: the full-sample mean for the HAC path, the non-overlap mean
+    otherwise.
+
+    Two deliberate layers — both ``quantile_spread`` and ``k_spread`` route
+    here so the policy lives in one place:
+
+    1. **Small-cross-section fallback (automatic, data-driven).** When the
+       cross-section is thin (``n_assets < MIN_ASSETS_WARN``) the per-date
+       spread is heavy-tailed, so the distribution-free block-bootstrap CI
+       overrides whatever ``inference`` was requested — HAC / OLS-t correct
+       *autocorrelation*, not tail thickness. The switch emits the
+       ``FEW_ASSETS`` tier code (never silent); a requested-but-overridden
+       HAC is additionally flagged ``inference_overridden``.
+    2. **Inference family (user-selected).** With an adequate cross-section
+       the requested member runs: ``NonOverlapping`` reproduces the legacy
+       non-overlap t **bit-for-bit** (``_t_stat_from_array`` is the same
+       ``_calc_t_stat`` formula on the same strided values, so the default
+       stays byte-identical), while ``NeweyWest`` keeps the *full*
+       overlapping ``full_spread`` series and HAC-corrects the MA(h-1) SE.
+
+    The two series inputs are a perf split, not duplicated logic: the cheap
+    panel-stride feeds ``strided_spread`` for the common path; the full
+    series is built (h× more bucketing) only when the HAC path needs it.
+    ``full_spread`` is ``None`` off the HAC path; a missing one degrades to
+    the non-overlap path defensively. The block bootstrap is intentionally
+    *not* a family member — it is an automatic small-cross-section fallback,
+    not a blind-selectable method.
+    """
+    from factrix.inference import NeweyWest
+
+    strided_mean = float(np.mean(strided_spread))
+    use_hac = (
+        isinstance(inference, NeweyWest)
+        and n_assets >= MIN_ASSETS_WARN
+        and full_spread is not None
+    )
+    if not use_hac:
+        t, p, method, extra, codes = _spread_significance(
+            strided_spread, n_assets, rng_seed=rng_seed
+        )
+        if isinstance(inference, NeweyWest):
+            # Requested HAC but the small-cross-section bootstrap (or a
+            # missing full series) took precedence — surface the override.
+            extra = {
+                **extra,
+                "inference_requested": inference.summary,
+                "inference_overridden": True,
+            }
+        return strided_mean, t, p, method, extra, codes
+
+    assert full_spread is not None  # narrowed by use_hac
+    res = inference.compute(
+        full_spread, value_col="spread", forward_periods=forward_periods
+    )
+    full_vals = full_spread["spread"].drop_nulls()
+    full_mean = float(full_vals.mean())  # type: ignore[arg-type]
+    extra = {**res.metadata, "n_periods_full": len(full_vals)}
+    codes = tuple(code.value for code in res.warnings)
+    return full_mean, res.stat, res.p_value, inference.summary, extra, codes
 
 
 def _aggregate_to_per_date(

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -37,18 +37,60 @@ from factrix._axis import (
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
+from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
     _sample_non_overlapping,
     _short_circuit_output,
-    _spread_significance,
+    _spread_significance_with_inference,
     _surface_null_drop,
 )
 
 __all__ = [
     "k_spread",
 ]
+
+
+def _build_k_spread_series(
+    panel: pl.DataFrame, k: int, factor_col: str, return_col: str
+) -> tuple[pl.DataFrame | None, pl.DataFrame]:
+    """Per-date Top-K/Bottom-K spread series from a (possibly sampled) panel.
+
+    Returns ``(series, clean)``: ``series`` has ``date, top_return,
+    bottom_return, xs_dispersion, spread`` (``None`` when no date clears the
+    ``2*k`` floor), and ``clean`` is the null-filtered panel for the
+    short-circuit diagnostics / ``n_assets`` count. Shared by the
+    non-overlap path (sampled panel) and the HAC path (full panel).
+    """
+    clean = panel.filter(
+        pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
+    )
+    ranked = clean.with_columns(
+        pl.col(factor_col)
+        .rank(method="ordinal", descending=True)
+        .over("date")
+        .alias("_rank"),
+        pl.len().over("date").alias("_n_date"),
+    ).filter(pl.col("_n_date") >= 2 * k)
+
+    if ranked.height == 0:
+        return None, clean
+
+    series = (
+        ranked.group_by("date")
+        .agg(
+            pl.col(return_col).filter(pl.col("_rank") <= k).mean().alias("top_return"),
+            pl.col(return_col)
+            .filter(pl.col("_rank") > pl.col("_n_date") - k)
+            .mean()
+            .alias("bottom_return"),
+            pl.col(return_col).std(ddof=DDOF).alias("xs_dispersion"),
+        )
+        .with_columns((pl.col("top_return") - pl.col("bottom_return")).alias("spread"))
+        .sort("date")
+    )
+    return series, clean
 
 
 @metric(
@@ -65,6 +107,7 @@ def k_spread(
     factor_col: str = "factor",
     return_col: str = "forward_return",
     rng_seed: int = 0,
+    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
 ) -> MetricResult:
     r"""Fixed-K Top-K vs Bottom-K long-short spread.
 
@@ -85,6 +128,12 @@ def k_spread(
         return_col: Realised-return column (default ``"forward_return"``).
         rng_seed: Seed for the small-N block-bootstrap branch
             (reproducible by default).
+        inference: Headline significance method. ``fx.inference.NON_OVERLAPPING``
+            (default) runs the OLS t-test on the non-overlap stride;
+            ``fx.inference.NEWEY_WEST`` keeps every date and HAC-corrects the
+            MA(h-1) SE. The small-cross-section block bootstrap still takes
+            precedence over either when it fires (HAC corrects autocorrelation,
+            not heavy tails); the override is flagged in ``metadata``.
 
     Returns:
         MetricResult with value = mean spread, ``stat`` = ``t`` on the
@@ -134,24 +183,15 @@ def k_spread(
             missing_column=return_col,
         )
 
-    sampled = _sample_non_overlapping(df, forward_periods)
     # Drop rows with no factor or no realised return BEFORE ranking: ``rank``
     # skips nulls but ``pl.len`` would still count them, so ``_n_date`` would
     # overcount and the bottom-leg cutoff (``_rank > _n_date - k``) would point
     # past the last real rank — silently shrinking or emptying the short leg.
     # forward_return is null on the last ``forward_periods`` rows per asset.
-    clean = sampled.filter(
-        pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
-    )
-    ranked = clean.with_columns(
-        pl.col(factor_col)
-        .rank(method="ordinal", descending=True)
-        .over("date")
-        .alias("_rank"),
-        pl.len().over("date").alias("_n_date"),
-    ).filter(pl.col("_n_date") >= 2 * k)
+    sampled = _sample_non_overlapping(df, forward_periods)
+    series, clean = _build_k_spread_series(sampled, k, factor_col, return_col)
 
-    if ranked.height == 0:
+    if series is None:
         per_date_counts = clean.group_by("date").len()["len"].to_numpy()
         max_per_date = int(np.max(per_date_counts)) if per_date_counts.size else 0
         return _short_circuit_output(
@@ -163,20 +203,6 @@ def k_spread(
             max_assets_per_date=max_per_date,
         )
 
-    series = (
-        ranked.group_by("date")
-        .agg(
-            pl.col(return_col).filter(pl.col("_rank") <= k).mean().alias("top_return"),
-            pl.col(return_col)
-            .filter(pl.col("_rank") > pl.col("_n_date") - k)
-            .mean()
-            .alias("bottom_return"),
-            pl.col(return_col).std(ddof=DDOF).alias("xs_dispersion"),
-        )
-        .with_columns((pl.col("top_return") - pl.col("bottom_return")).alias("spread"))
-        .sort("date")
-    )
-
     spread_vals = series["spread"].drop_nulls()
     n = len(spread_vals)
     sc = _enforce_min_floor(
@@ -186,10 +212,21 @@ def k_spread(
         return sc
 
     arr = spread_vals.to_numpy()
-    mean_spread = float(np.mean(arr))
     n_assets = clean["asset_id"].n_unique()
-    t, p, sig_method, sig_extra, sig_codes = _spread_significance(
-        arr, n_assets, rng_seed=rng_seed
+    # The HAC path needs the full overlapping spread series (every date);
+    # build it once on the unsampled panel.
+    full_series: pl.DataFrame | None = None
+    if isinstance(inference, NeweyWest):
+        full_series, _ = _build_k_spread_series(df, k, factor_col, return_col)
+    mean_spread, t, p, sig_method, sig_extra, sig_codes = (
+        _spread_significance_with_inference(
+            inference,
+            strided_spread=arr,
+            full_spread=full_series,
+            forward_periods=forward_periods,
+            n_assets=n_assets,
+            rng_seed=rng_seed,
+        )
     )
 
     mean_dispersion = float(np.mean(series["xs_dispersion"].drop_nulls().to_numpy()))

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -32,6 +32,7 @@ from factrix._types import (
     DDOF,
     MIN_PORTFOLIO_PERIODS_HARD,
 )
+from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
@@ -40,7 +41,7 @@ from factrix.metrics._helpers import (
     _lag_within_asset,
     _sample_non_overlapping,
     _short_circuit_output,
-    _spread_significance,
+    _spread_significance_with_inference,
     _surface_null_drop,
     _warn_high_tie_ratio,
 )
@@ -73,30 +74,42 @@ def quantile_spread(
     n_groups: int = 5,
     factor_cols: Sequence[str] = ("factor",),
     tie_policy: str = "ordinal",
+    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
     *,
     _precomputed_series: dict[str, pl.DataFrame] | None = None,
 ) -> dict[str, MetricResult]:
     """long-short spread (per-period mean).
 
     Args:
+        inference: Headline significance method on the per-date spread.
+            ``fx.inference.NON_OVERLAPPING`` (default) runs the OLS t-test
+            on the non-overlap stride subsample; ``fx.inference.NEWEY_WEST``
+            keeps every date and absorbs the MA(h-1) overlap in a HAC SE.
+            On a small cross-section (``n_assets < 30``) the heavy-tail
+            block bootstrap takes precedence over either (see Notes).
         _precomputed_series: If provided, skip recomputing ``compute_spread_series``.
         tie_policy: Bucketing tie-break policy, see ``_assign_quantile_groups``.
             When ``_precomputed_series`` is passed, this only affects the
             ``tie_ratio`` diagnostic — the series itself was already built.
 
     Returns:
-        MetricResult with per-period mean spread, t-stat from non-overlapping periods.
+        MetricResult with per-period mean spread, t-stat from the chosen
+        ``inference``.
 
     Notes:
         ``t = mean(spread) / (std(spread) / sqrt(n))`` on the non-overlap
-        spread series. H0: ``E[spread] = 0``. Long/short alpha decomposition
-        runs the same t-test on ``top_return - universe_return`` and
-        ``universe_return - bottom_return`` so callers can attribute the
-        spread to long-side vs short-side excess.
+        spread series. H0: ``E[spread] = 0``. The Newey-West (NW)
+        heteroskedasticity-and-autocorrelation-consistent (HAC) route is
+        the sibling that keeps the full overlapping series instead of
+        striding — select it via ``inference=fx.inference.NEWEY_WEST``.
+        Because HAC corrects autocorrelation rather than heavy tails, the
+        small-cross-section block bootstrap still wins when it fires and the
+        requested HAC is flagged ``inference_overridden`` in metadata.
 
-        factrix performs the t-test on the non-overlap series rather than
-        applying Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) on an overlapping series; the two approaches are
-        sibling routes — the HAC variant is ``ic(inference=fx.inference.NEWEY_WEST)``.
+        Long/short alpha decomposition stays a descriptive OLS t-test on
+        ``top_return - universe_return`` and ``universe_return -
+        bottom_return`` regardless of ``inference`` — it attributes the
+        spread to long-side vs short-side excess, it is not the headline H0.
 
     References:
         [Hansen-Hodrick 1980][hansen-hodrick-1980]: overlapping-return
@@ -138,12 +151,30 @@ def quantile_spread(
             forward_periods=forward_periods,
         )
     )
+    # The HAC path needs the full overlapping spread series (every date);
+    # ``forward_periods=1`` is the no-stride build of the same primitive.
+    full_series_by_factor: dict[str, pl.DataFrame] | None = (
+        compute_spread_series(
+            df,
+            n_groups=n_groups,
+            factor_cols=cols,
+            tie_policy=tie_policy,
+            forward_periods=1,
+        )
+        if isinstance(inference, NeweyWest)
+        else None
+    )
     return {
         f: _quantile_spread_from_series(
             series=series_by_factor[f],
             sampled=sampled,
             factor_col=f,
             tie_policy=tie_policy,
+            inference=inference,
+            forward_periods=forward_periods,
+            full_series=(
+                full_series_by_factor[f] if full_series_by_factor is not None else None
+            ),
         )
         for f in cols
     }
@@ -155,6 +186,9 @@ def _quantile_spread_from_series(
     sampled: pl.DataFrame,
     factor_col: str,
     tie_policy: str,
+    inference: NonOverlapping | NeweyWest,
+    forward_periods: int,
+    full_series: pl.DataFrame | None,
 ) -> MetricResult:
     """Per-factor t-test pipeline shared by single and batch paths.
 
@@ -179,12 +213,20 @@ def _quantile_spread_from_series(
         return sc
 
     arr = spread_vals.to_numpy()
-    mean_spread = float(np.mean(arr))
-    # Headline test: small cross-sections (n_assets < MIN_ASSETS_WARN) switch
-    # from the non-overlapping t to a block-bootstrap CI (shared policy with
-    # k_spread); larger cross-sections keep the t-test.
+    # Headline test: ``inference`` selects non-overlap t vs Newey-West HAC;
+    # small cross-sections (n_assets < MIN_ASSETS_WARN) switch either to a
+    # block-bootstrap CI (shared policy with k_spread). ``mean_spread`` is the
+    # full-sample mean under HAC, the non-overlap mean otherwise.
     n_assets = sampled["asset_id"].n_unique()
-    t, p, sig_method, sig_extra, sig_codes = _spread_significance(arr, n_assets)
+    mean_spread, t, p, sig_method, sig_extra, sig_codes = (
+        _spread_significance_with_inference(
+            inference,
+            strided_spread=arr,
+            full_spread=full_series,
+            forward_periods=forward_periods,
+            n_assets=n_assets,
+        )
+    )
 
     # Long/short decomposition (spread = long_alpha + short_alpha)
     long_excess = (series["top_return"] - series["universe_return"]).drop_nulls()

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -217,6 +217,50 @@ class TestQuantileSpreadSharesPolicy:
         assert out.metadata["method"] == "non-overlapping t-test"
 
 
+class TestInference:
+    """The ``inference=`` knob: bit-for-bit default, HAC opt-in, bootstrap guard."""
+
+    @staticmethod
+    def _ample_panel():
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=60, n_dates=400, seed=3)
+        return fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    def test_explicit_non_overlapping_is_bit_for_bit_default(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        default = k_spread(panel, forward_periods=5, k=5)
+        explicit = k_spread(
+            panel, forward_periods=5, k=5, inference=fx.inference.NON_OVERLAPPING
+        )
+        assert explicit.value == default.value
+        assert explicit.p_value == default.p_value
+        assert explicit.stat == default.stat
+        assert explicit.metadata["method"] == "non-overlapping t-test"
+
+    def test_newey_west_runs_hac_on_full_series(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        nw = k_spread(panel, forward_periods=5, k=5, inference=fx.inference.NEWEY_WEST)
+        assert nw.metadata["method"] == "Newey-West HAC t-test"
+        assert "nw_lags" in nw.metadata
+        # HAC keeps every date; the full series is longer than the strided one.
+        assert nw.metadata["n_periods_full"] > nw.metadata["n_periods"]
+
+    def test_small_cross_section_bootstrap_overrides_requested_hac(self):
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=400, seed=4)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        nw = k_spread(panel, forward_periods=5, k=3, inference=fx.inference.NEWEY_WEST)
+        assert nw.metadata["method"] == "block-bootstrap CI"
+        assert nw.metadata["inference_overridden"] is True
+        assert nw.metadata["inference_requested"] == "Newey-West HAC t-test"
+
+
 class TestDispatch:
     def test_runs_via_evaluate(self):
         import factrix as fx

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -167,3 +167,50 @@ class TestQuantileSpreadVW:
         assert math.isnan(result.value)
         assert result.metadata.get("reason") == "no_weight_column"
         assert result.metadata.get("missing_column") == "market_cap"
+
+
+class TestQuantileSpreadInference:
+    """The ``inference=`` knob mirrors k_spread: default bit-for-bit, HAC opt-in."""
+
+    @staticmethod
+    def _ample_panel():
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=80, n_dates=400, seed=5)
+        return fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    def test_explicit_non_overlapping_is_bit_for_bit_default(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        default = quantile_spread(panel, forward_periods=5, n_groups=5)["factor"]
+        explicit = quantile_spread(
+            panel, forward_periods=5, n_groups=5, inference=fx.inference.NON_OVERLAPPING
+        )["factor"]
+        assert explicit.value == default.value
+        assert explicit.p_value == default.p_value
+        assert explicit.stat == default.stat
+        assert explicit.metadata["method"] == "non-overlapping t-test"
+
+    def test_newey_west_runs_hac_on_full_series(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        nw = quantile_spread(
+            panel, forward_periods=5, n_groups=5, inference=fx.inference.NEWEY_WEST
+        )["factor"]
+        assert nw.metadata["method"] == "Newey-West HAC t-test"
+        assert "nw_lags" in nw.metadata
+        assert nw.metadata["n_periods_full"] > nw.metadata["n_periods"]
+
+    def test_small_cross_section_bootstrap_overrides_requested_hac(self):
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=400, seed=6)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        nw = quantile_spread(
+            panel, forward_periods=5, n_groups=5, inference=fx.inference.NEWEY_WEST
+        )["factor"]
+        assert nw.metadata["method"] == "block-bootstrap CI"
+        assert nw.metadata["inference_overridden"] is True
+        assert nw.metadata["inference_requested"] == "Newey-West HAC t-test"


### PR DESCRIPTION
## Summary
- Add `inference: NonOverlapping | NeweyWest = NON_OVERLAPPING` to `quantile_spread` and `k_spread`, matching the knob `ic` already exposes — callers can now opt into a Newey-West HAC standard error on the full overlapping spread series instead of the lossy non-overlapping stride.
- Both metrics route through one significance chokepoint (`_spread_significance_with_inference`). The default non-overlapping path is byte-identical to before; the full series is built only when the HAC path needs it.
- The small cross-section block bootstrap stays an automatic heavy-tail fallback: it overrides a requested HAC (HAC corrects autocorrelation, not tails) and flags the override in metadata rather than switching silently.

Scope is intentionally limited to the two genuine per-date-spread-mean metrics; proportion / descriptive metrics and the default-policy flip are out of scope (see issue discussion).

## Test plan
- [x] `quantile_spread` / `k_spread` default equals explicit `NON_OVERLAPPING` (value, p, stat) — bit-for-bit preserved
- [x] `NEWEY_WEST` on an ample cross-section runs HAC on the full series (`nw_lags` present, full periods > strided)
- [x] Small cross-section overrides a requested HAC to the block bootstrap and surfaces `inference_overridden`
- [x] Full suite green (1406 passed, 4 skipped); `ruff check` / `ruff format --check` / `mypy` clean

Refs #652
