### PR TITLE
fix(multi-factor): drop insufficient short-circuits from BHY family

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ print('p_value =', round(ic_res.p_value, 4))
 **Multi-factor BHY screening**
 
 ```python
-fdr_results = fx.multi_factor.bhy(results, primary=["ic"], q=0.05)
+fdr_results = fx.multi_factor.bhy(list(results.values()), metrics=["ic"], q=0.05)
 bhy_ic = fdr_results["ic"]
 print("survivors =", [r.factor for r in bhy_ic.survivors])
 ```

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -27,8 +27,7 @@ Batch + Benjamini-Hochberg-Yekutieli (BHY)::
         metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},
         factor_cols=candidate_cols,
     )
-    ic_results = {col: er.metrics["ic"] for col, er in results.items()}
-    survivors = fx.multi_factor.bhy(ic_results, metrics=["ic"], q=0.05)
+    survivors = fx.multi_factor.bhy(list(results.values()), metrics=["ic"], q=0.05)
 
 LLM agent reference: ``llms-full.txt`` covers concepts, public API, and
 typical usage patterns in a single fetch. Two access paths::

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -389,25 +389,30 @@ def bhy(
     for idx, p_entry in enumerate(partition):
         buckets[p_entry.expand_over_values].append(idx)
 
-    singleton = sum(1 for ix in buckets.values() if len(ix) == 1)
-    if singleton and len(buckets) > 1:
-        warnings.warn(
-            f"bhy: {singleton} of {len(buckets)} expand_over buckets "
-            "contain a single result — BHY on n=1 is identical to a "
-            "raw threshold and provides no FDR correction.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-
-    n_tests: dict[tuple[Any, ...], int] = {
-        bucket_key: len(ix) for bucket_key, ix in buckets.items()
-    }
-
     out: dict[str, BhyResult] = {}
     for spec in metric_list:
         entries = _attach_p_values(partition, func_name="bhy", metric=spec)
+        active_buckets: dict[tuple[Any, ...], list[int]] = {
+            bucket_key: [
+                i
+                for i in ix
+                if not _is_insufficient_short_circuit(entries[i].result, spec)
+            ]
+            for bucket_key, ix in buckets.items()
+        }
+        active_buckets = {k: ix for k, ix in active_buckets.items() if ix}
+        n_tests = {bucket_key: len(ix) for bucket_key, ix in active_buckets.items()}
+        singleton = sum(1 for ix in active_buckets.values() if len(ix) == 1)
+        if singleton and len(active_buckets) > 1:
+            warnings.warn(
+                f"bhy: {singleton} of {len(active_buckets)} expand_over buckets "
+                "contain a single result — BHY on n=1 is identical to a "
+                "raw threshold and provides no FDR correction.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         adj_p_all = np.full(len(entries), np.nan, dtype=np.float64)
-        for ix in buckets.values():
+        for ix in active_buckets.values():
             p_array = np.array([entries[i].p_value for i in ix], dtype=np.float64)
             adj_p_all[ix] = bhy_adjusted_p(p_array)
 
@@ -421,6 +426,12 @@ def bhy(
             n_tests=n_tests,
         )
     return out
+
+
+def _is_insufficient_short_circuit(result: EvaluationResult, metric: str) -> bool:
+    """Return True when a metric output is a data-shortage placeholder."""
+    reason = result.metrics[metric].metadata.get("reason")
+    return isinstance(reason, str) and reason.startswith("insufficient_")
 
 
 def partial_conjunction(

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -243,9 +243,10 @@ def _short_circuit_output(
     a silent short-circuit. NaN propagates through downstream aggregations
     and plots, making data shortages impossible to misread as valid zeros.
 
-    ``p_value=1.0`` is the conservative default so BHY treats short-circuited
-    metrics as rejected rather than crashing; the promoted ``p_value`` field
-    mirrors it.
+    ``p_value=1.0`` is the conservative scalar default for callers that read the
+    field directly; ``multi_factor.bhy`` drops ``insufficient_*`` placeholders
+    before forming the test family, so data-shortage rows do not inflate the
+    multiple-testing denominator.
     Pass ``descriptive=True`` for metrics that emit no hypothesis test
     (`oos_decay`, `clustering_hhi`, ...) so callers cannot mis-route the
     short-circuit into BHY / gate logic expecting a probability.

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -99,10 +99,16 @@ def compute_spread_series(
     median_n = _median_universe_size(sampled)
     per_group = median_n // n_groups if n_groups > 0 else 0
     if per_group < 5:
+        guidance = (
+            "Reduce n_groups, or treat this as a fragile small-cross-section "
+            "diagnostic."
+            if n_groups > 2
+            else "This is already the coarsest long-short split; treat the spread as a fragile small-cross-section diagnostic."
+        )
         warnings.warn(
             f"Median {per_group} assets per group (N={median_n}, "
             f"n_groups={n_groups}). Spread may be dominated by "
-            f"individual assets. Consider reducing n_groups.",
+            f"individual assets. {guidance}",
             UserWarning,
             stacklevel=2,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def make_result(
     p: float | None,
     metric: str,
     value: float = 0.05,
+    metadata: dict[str, Any] | None = None,
     forward_periods: int = 5,
     context: dict[str, Any] | None = None,
     extra_outputs: dict[str, MetricResult] | None = None,
@@ -48,9 +49,11 @@ def make_result(
     ``metric`` names the metric label included in outputs. ``p=None``
     simulates a metric with no p-value.
     """
-    metadata: dict[str, Any] = {} if p is None else {"p_value": float(p)}
+    output_metadata: dict[str, Any] = {} if p is None else {"p_value": float(p)}
+    if metadata:
+        output_metadata.update(metadata)
     primary_out = MetricResult(
-        value=value, p_value=p, n_obs=100, name=metric, metadata=metadata
+        value=value, p_value=p, n_obs=100, name=metric, metadata=output_metadata
     )
     outputs = {metric: primary_out}
     if extra_outputs:

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -70,6 +70,22 @@ def test_no_surviving_results_returns_empty_record():
     assert len(out["ic"]) == 0
 
 
+def test_insufficient_short_circuits_are_dropped_from_family():
+    make_spec("ic")
+    valid = make_result(factor="valid", p=0.01, metric="ic")
+    insufficient = make_result(
+        factor="thin",
+        p=1.0,
+        metric="ic",
+        value=float("nan"),
+        metadata={"reason": "insufficient_ic_periods"},
+    )
+    out = bhy([valid, insufficient], metrics=["ic"], q=0.05)["ic"]
+
+    assert out.n_tests == {(): 1}
+    assert [r.factor for r in out.survivors] == ["valid"]
+
+
 def test_expand_over_forward_periods_partitions_by_horizon():
     make_spec("ic")
     results = [

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -66,6 +66,12 @@ class TestComputeSpreadSeriesBatch:
                 tiny_panel, forward_periods=1, n_groups=5, factor_cols=[]
             )
 
+    def test_two_group_small_cross_section_warning_is_actionable(self, tiny_panel):
+        with pytest.warns(UserWarning, match="coarsest long-short split") as caught:
+            compute_spread_series(tiny_panel, forward_periods=1, n_groups=2)
+
+        assert "Consider reducing n_groups" not in str(caught[0].message)
+
 
 class TestQuantileSpread:
     def test_noisy_panel(self, noisy_panel):


### PR DESCRIPTION
## Summary
- `multi_factor.bhy` now drops `insufficient_*` short-circuit placeholders before forming each per-metric test family, so data-shortage rows no longer inflate the multiple-testing denominator (`n_tests`) or the BHY step-up. Filtering is per-metric because a factor can be insufficient for one metric and valid for another.
- The singleton "n=1 provides no FDR correction" warning is now computed on the *active* (post-filter) buckets, so a bucket whose only sibling was a placeholder is correctly flagged.
- README BHY example was broken (`primary=["ic"]`, dict input); fixed to the real signature `bhy(list(results.values()), metrics=["ic"], q=0.05)`, matching the `factrix/__init__.py` docstring.
- Spread small-cross-section warning is now actionable when already at the coarsest 2-group long-short split (no more useless "Consider reducing n_groups" when `n_groups=2`).

## Notes for review
- Reason vocabulary is consistent: every data-shortage path uses an `insufficient_*` prefix (verified across all metric short-circuits), so `startswith("insufficient_")` is a complete filter. `no_*` reasons (missing input/config) are deliberately *kept* in the family with `p_value=1.0`, as documented in `_short_circuit_output`.
- Placeholders dropped from the family keep `adj_p = NaN` and are excluded from `survivors`.

## Test plan
- [x] `pytest tests/test_bhy.py tests/test_quantile.py` (new: family-drop + actionable-warning tests)
- [x] Full suite: 1409 passed, 4 skipped
- [x] `ruff check`, `ruff format --check`, `mypy factrix` clean