### PR TITLE
feat(results): expose is_applicable/reason on metric results

### DIFF
--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -66,7 +66,7 @@ title: factrix.evaluate
     # 2. Run evaluation
     results = fx.evaluate(
         data,
-        metrics={"ic": ic(), "spread": quantile_spread(n_quantiles=5)},
+        metrics={"ic": ic(), "spread": quantile_spread(n_groups=5)},
         factor_cols=["factor"],
         forward_periods=5,
     )
@@ -82,6 +82,28 @@ title: factrix.evaluate
     print(f"IC Value: {ic_res.value:.4f}")
     print(f"IC p-value: {ic_res.p_value:.4f}")
     ```
+
+## Sensitivity grids
+
+For exploratory grids across asset counts, horizons, or factor families, run
+with `strict=False` and stack each result's long-form table. The table carries
+`is_applicable` and `reason`, so the grid can keep running while still making
+failed metric/input combinations visible.
+
+```python
+import polars as pl
+
+results = fx.evaluate(
+    data,
+    metrics={"ic": ic(), "spread": quantile_spread(n_groups=2)},
+    factor_cols=["factor"],
+    forward_periods=5,
+    strict=False,
+)
+
+status = pl.concat([r.to_frame() for r in results.values()])
+failed = status.filter(~pl.col("is_applicable"))
+```
 
 ## Evaluating under different cell contexts
 

--- a/docs/api/evaluation-results.md
+++ b/docs/api/evaluation-results.md
@@ -22,6 +22,7 @@ Converts the metric results into a stable, long-form Polars `pl.DataFrame`. This
 - `stat` (`f64` | `null`): The underlying test statistic, if applicable.
 - `n_obs` (`i64` | `null`): Sample size seen by the metric.
 - `is_applicable` (`bool`): `false` when `strict=False` returned a short-circuit placeholder for an unsupported metric/input combination.
+- `reason` (`str` | `null`): Short-circuit reason when `is_applicable` is `false`.
 - `warning_codes` (`list[str]`): List of warnings attached to the metric.
 
 ### `to_dict()`
@@ -48,10 +49,11 @@ Converts the result into a JSON-friendly nested dictionary. It normalizes floats
 - **`value`** (`float`): The calculated numeric output of the metric.
 - **`p_value`** (`float` | `None`): The statistical p-value.
     > [!IMPORTANT]
-    > In v0.14.0, the `p` attribute was renamed to `p_value` to unify p-value naming conventions. There is no transitional alias.
+    > `p_value` is the canonical field for metric p-values.
 - **`stat`** (`float` | `None`): The test statistic (e.g. t-statistic, z-statistic).
 - **`n_obs`** (`int` | `None`): The number of observations used in this specific metric calculation.
 - **`is_applicable`** (`bool`): `False` for `strict=False` short-circuit placeholders, so reporting code can filter them without inspecting `metadata["reason"]`.
+- **`reason`** (`str` | `None`): Stable short-circuit reason, copied from `metadata["reason"]` when present.
 - **`metadata`** (`dict`): Underlying dictionary of metric-specific metadata.
 - **`warning_codes`** (`tuple[str, ...]`): Advisory warnings attached to the metric.
 - **`name`** (`str`): The name of the metric, automatically populated during dispatch.

--- a/docs/api/evaluation-results.md
+++ b/docs/api/evaluation-results.md
@@ -21,6 +21,7 @@ Converts the metric results into a stable, long-form Polars `pl.DataFrame`. This
 - `p_value` (`f64` | `null`): The p-value, if applicable.
 - `stat` (`f64` | `null`): The underlying test statistic, if applicable.
 - `n_obs` (`i64` | `null`): Sample size seen by the metric.
+- `is_applicable` (`bool`): `false` when `strict=False` returned a short-circuit placeholder for an unsupported metric/input combination.
 - `warning_codes` (`list[str]`): List of warnings attached to the metric.
 
 ### `to_dict()`
@@ -50,6 +51,7 @@ Converts the result into a JSON-friendly nested dictionary. It normalizes floats
     > In v0.14.0, the `p` attribute was renamed to `p_value` to unify p-value naming conventions. There is no transitional alias.
 - **`stat`** (`float` | `None`): The test statistic (e.g. t-statistic, z-statistic).
 - **`n_obs`** (`int` | `None`): The number of observations used in this specific metric calculation.
+- **`is_applicable`** (`bool`): `False` for `strict=False` short-circuit placeholders, so reporting code can filter them without inspecting `metadata["reason"]`.
 - **`metadata`** (`dict`): Underlying dictionary of metric-specific metadata.
 - **`warning_codes`** (`tuple[str, ...]`): Advisory warnings attached to the metric.
 - **`name`** (`str`): The name of the metric, automatically populated during dispatch.

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -329,7 +329,7 @@ def _validate_metrics_arg(metrics: object) -> None:
                 value=f"{key!r} -> {type(val).__name__}",
                 expected=(
                     "every value to be a metric instance imported from "
-                    "factrix.metrics, e.g. ic() / quantile_spread(n_quantiles=5)"
+                    "factrix.metrics, e.g. ic() / quantile_spread(n_groups=5)"
                 ),
                 docs_path=_DOCS_METRICS,
             )
@@ -498,7 +498,8 @@ def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
             value=f"{len(failed)} metric(s) inapplicable to this panel",
             expected=(
                 f"all metrics applicable to the panel. Inapplicable — {detail}. "
-                f"Pass strict=False to keep them as NaN with warnings, or "
+                f"For sensitivity grids, pass strict=False and stack "
+                f"EvaluationResult.to_frame() to inspect is_applicable/reason. Or "
                 f"pre-filter with [m.name for m in factrix.inspect_data(data).usable]."
             ),
             docs_path=_DOCS_METRICS,

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -61,6 +61,16 @@ class MetricResult:
             parts.append(f"stat={self.stat:.2f}")
         return f"MetricResult({', '.join(parts)})"
 
+    @property
+    def is_applicable(self) -> bool:
+        """Whether the metric produced a usable result for this input.
+
+        ``strict=False`` short-circuits unsupported metrics into placeholder
+        outputs with ``metadata["reason"]``. This flag lets reporting and
+        grid-search code filter those rows without relying on metadata shape.
+        """
+        return "reason" not in self.metadata
+
 
 @dataclass(frozen=True, slots=True)
 class Warning:
@@ -144,6 +154,7 @@ class EvaluationResult:
         | ``p_value`` | f64 \| null | ``MetricResult.p_value`` |
         | ``stat`` | f64 \| null | ``MetricResult.stat`` |
         | ``n_obs`` | i64 \| null | ``MetricResult.n_obs`` — estimator effective sample size |
+        | ``is_applicable`` | bool | false for ``strict=False`` short-circuits |
         | ``warning_codes`` | list[str] | per-metric warning codes |
 
         Designed for stacking across factors:
@@ -171,7 +182,8 @@ class EvaluationResult:
 
         - ``factor`` / ``cell`` / ``forward_periods`` / ``n_periods`` /
           ``n_pairs`` / ``n_assets`` / ``context``
-        - ``metrics``: ``label -> {value, p_value, stat, n_obs, metadata}``
+        - ``metrics``: ``label -> {value, p_value, stat, n_obs,
+          is_applicable, metadata}``
         - ``warnings``: list of ``{code, source, message}``
         - ``plan``
 
@@ -280,6 +292,7 @@ _TO_FRAME_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
     "p_value": pl.Float64,
     "stat": pl.Float64,
     "n_obs": pl.Int64,
+    "is_applicable": pl.Boolean,
     "warning_codes": pl.List(pl.Utf8),
 }
 
@@ -296,6 +309,7 @@ def _output_row(
         "p_value": _float_or_none(out.p_value),
         "stat": _float_or_none(out.stat),
         "n_obs": out.n_obs,
+        "is_applicable": out.is_applicable,
         "warning_codes": list(warnings_by_metric.get(label, [])),
     }
 
@@ -316,6 +330,7 @@ def _metric_output_to_record(out: MetricResult) -> dict[str, Any]:
         "p_value": _float_or_none(out.p_value),
         "stat": _float_or_none(out.stat),
         "n_obs": out.n_obs,
+        "is_applicable": out.is_applicable,
         "metadata": {k: _scrub_nonfinite(v) for k, v in out.metadata.items()},
     }
 

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -62,6 +62,12 @@ class MetricResult:
         return f"MetricResult({', '.join(parts)})"
 
     @property
+    def reason(self) -> str | None:
+        """Stable short-circuit reason, when the metric did not run cleanly."""
+        reason = self.metadata.get("reason")
+        return reason if isinstance(reason, str) else None
+
+    @property
     def is_applicable(self) -> bool:
         """Whether the metric produced a usable result for this input.
 
@@ -69,7 +75,7 @@ class MetricResult:
         outputs with ``metadata["reason"]``. This flag lets reporting and
         grid-search code filter those rows without relying on metadata shape.
         """
-        return "reason" not in self.metadata
+        return self.reason is None
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,6 +161,7 @@ class EvaluationResult:
         | ``stat`` | f64 \| null | ``MetricResult.stat`` |
         | ``n_obs`` | i64 \| null | ``MetricResult.n_obs`` — estimator effective sample size |
         | ``is_applicable`` | bool | false for ``strict=False`` short-circuits |
+        | ``reason`` | str \| null | short-circuit reason when not applicable |
         | ``warning_codes`` | list[str] | per-metric warning codes |
 
         Designed for stacking across factors:
@@ -183,7 +190,7 @@ class EvaluationResult:
         - ``factor`` / ``cell`` / ``forward_periods`` / ``n_periods`` /
           ``n_pairs`` / ``n_assets`` / ``context``
         - ``metrics``: ``label -> {value, p_value, stat, n_obs,
-          is_applicable, metadata}``
+          is_applicable, reason, metadata}``
         - ``warnings``: list of ``{code, source, message}``
         - ``plan``
 
@@ -293,6 +300,7 @@ _TO_FRAME_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
     "stat": pl.Float64,
     "n_obs": pl.Int64,
     "is_applicable": pl.Boolean,
+    "reason": pl.Utf8,
     "warning_codes": pl.List(pl.Utf8),
 }
 
@@ -310,6 +318,7 @@ def _output_row(
         "stat": _float_or_none(out.stat),
         "n_obs": out.n_obs,
         "is_applicable": out.is_applicable,
+        "reason": out.reason,
         "warning_codes": list(warnings_by_metric.get(label, [])),
     }
 
@@ -331,6 +340,7 @@ def _metric_output_to_record(out: MetricResult) -> dict[str, Any]:
         "stat": _float_or_none(out.stat),
         "n_obs": out.n_obs,
         "is_applicable": out.is_applicable,
+        "reason": out.reason,
         "metadata": {k: _scrub_nonfinite(v) for k, v in out.metadata.items()},
     }
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -190,10 +190,14 @@ class TestForwardPeriodsContract:
 class TestStrict:
     def test_strict_true_raises_on_inapplicable(self):
         thin = _panel(n_dates=12)
-        with pytest.raises(UserInputError, match="inapplicable"):
+        with pytest.raises(UserInputError) as exc:
             fx.evaluate(
                 thin, metrics={"ic": ic()}, factor_cols=["factor"], forward_periods=5
             )
+        msg = str(exc.value)
+        assert "inapplicable" in msg
+        assert "strict=False" in msg
+        assert "is_applicable/reason" in msg
 
     def test_strict_false_keeps_nan(self):
         thin = _panel(n_dates=12)
@@ -205,6 +209,9 @@ class TestStrict:
             strict=False,
         )["factor"]
         assert er.metrics["ic"].value != er.metrics["ic"].value  # NaN
+        status = er.to_frame().row(0, named=True)
+        assert status["is_applicable"] is False
+        assert status["reason"] == "insufficient_ic_periods"
 
 
 class TestStrictStructureSoftening:

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -82,11 +82,13 @@ class TestEvaluationResultToFrame:
             "p_value",
             "stat",
             "n_obs",
+            "is_applicable",
             "warning_codes",
         ]
         assert df.schema["value"] == pl.Float64
         assert df.schema["p_value"] == pl.Float64
         assert df.schema["n_obs"] == pl.Int64
+        assert df.schema["is_applicable"] == pl.Boolean
         assert df.schema["warning_codes"] == pl.List(pl.Utf8)
         assert df.height == 2
 
@@ -105,6 +107,20 @@ class TestEvaluationResultToFrame:
         row = df.row(0, named=True)
         assert row["value"] is None
         assert row["p_value"] is None
+
+    def test_short_circuit_marks_metric_inapplicable(self):
+        bad = MetricResult(
+            value=float("nan"),
+            metadata={"reason": "insufficient_ic_periods"},
+            name="ic",
+        )
+        g = MappingProxyType({"ic": bad})
+        r = _sample_result(g)
+        row = r.to_frame().row(0, named=True)
+
+        assert bad.is_applicable is False
+        assert row["is_applicable"] is False
+        assert r.to_dict()["metrics"]["ic"]["is_applicable"] is False
 
     def test_warning_codes_filter_by_source(self):
         warnings = [
@@ -147,6 +163,7 @@ class TestEvaluationResultToDict:
         assert "n_obs" not in back
         assert "metrics_partition" not in back
         assert back["metrics"]["ic"]["p_value"] == 0.012
+        assert back["metrics"]["ic"]["is_applicable"] is True
         assert back["warnings"][0]["code"] == WarningCode.FEW_ASSETS.value
         assert back["plan"] == "1. ic [per-factor]"
 

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -83,12 +83,14 @@ class TestEvaluationResultToFrame:
             "stat",
             "n_obs",
             "is_applicable",
+            "reason",
             "warning_codes",
         ]
         assert df.schema["value"] == pl.Float64
         assert df.schema["p_value"] == pl.Float64
         assert df.schema["n_obs"] == pl.Int64
         assert df.schema["is_applicable"] == pl.Boolean
+        assert df.schema["reason"] == pl.Utf8
         assert df.schema["warning_codes"] == pl.List(pl.Utf8)
         assert df.height == 2
 
@@ -119,8 +121,11 @@ class TestEvaluationResultToFrame:
         row = r.to_frame().row(0, named=True)
 
         assert bad.is_applicable is False
+        assert bad.reason == "insufficient_ic_periods"
         assert row["is_applicable"] is False
+        assert row["reason"] == "insufficient_ic_periods"
         assert r.to_dict()["metrics"]["ic"]["is_applicable"] is False
+        assert r.to_dict()["metrics"]["ic"]["reason"] == "insufficient_ic_periods"
 
     def test_warning_codes_filter_by_source(self):
         warnings = [
@@ -164,6 +169,7 @@ class TestEvaluationResultToDict:
         assert "metrics_partition" not in back
         assert back["metrics"]["ic"]["p_value"] == 0.012
         assert back["metrics"]["ic"]["is_applicable"] is True
+        assert back["metrics"]["ic"]["reason"] is None
         assert back["warnings"][0]["code"] == WarningCode.FEW_ASSETS.value
         assert back["plan"] == "1. ic [per-factor]"
 


### PR DESCRIPTION
## Summary
- Add `MetricResult.is_applicable` and `MetricResult.reason` computed properties. `reason` surfaces `metadata["reason"]` (when a string); `is_applicable` is `reason is None`. No parallel result type — the payload stays in `metadata`, these are read-only views over it.
- Surface both in `to_frame()` (`is_applicable: Boolean`, `reason: Utf8`) and `to_dict()` so sensitivity-grid / reporting code can filter failed metric/input combinations without poking at `metadata` shape.
- `evaluate(strict=True)` error message now points at the `strict=False` + `to_frame()` `is_applicable/reason` workflow.
- Docs: add a "Sensitivity grids" recipe to `evaluate.md`; fix stale `n_quantiles=` -> `n_groups=` examples; drop the v0.14 `p` -> `p_value` migration note (no longer transitional).

## Notes for review
- **Schema breaking, intended**: `to_frame()` gains two columns and `to_dict()` gains two keys. Per prior decision we go breaking with no transitional alias.
- `is_applicable=False` covers *any* short-circuit (`insufficient_*` and `no_*`), since both mean "no usable result". This is intentionally broader than `multi_factor.bhy`'s family filter (which drops only `insufficient_*`); the two predicates answer different questions and stay coherent.
- Verified no successful metric path writes `metadata["reason"]`, so `is_applicable` cannot false-negative on a clean result.

## Test plan
- [x] `pytest tests/test_evaluate.py tests/test_evaluation_result.py`
- [x] Full suite: 1408 passed, 4 skipped
- [x] `ruff check`, `ruff format --check`, `mypy factrix` clean