### PR TITLE
docs(guides): add allocation-style experiment recipe

### DIFF
--- a/docs/guides/allocation-experiment.md
+++ b/docs/guides/allocation-experiment.md
@@ -1,0 +1,142 @@
+---
+title: Allocation-style experiments
+---
+
+# Allocation-style experiments
+
+factrix answers the research question before portfolio construction:
+
+> Does this factor carry predictive edge?
+
+It does not optimize weights, model slippage, rebalance a live book, or
+produce a full backtest. Those belong downstream. Still, it is often useful
+to run an allocation-style proxy while screening factors: "if I rank assets by
+this signal, does a simple long-short allocation earn a positive spread?"
+
+This guide shows the boundary.
+
+## Use factrix for the signal test
+
+Start with the standard cross-sectional panel and evaluate the factor:
+
+```python
+import factrix as fx
+from factrix.metrics import ic, quantile_spread
+from factrix.preprocess import compute_forward_return
+
+raw = fx.datasets.make_cs_panel(n_assets=50, n_dates=252, seed=2024)
+panel = compute_forward_return(raw, forward_periods=5)
+
+results = fx.evaluate(
+    panel,
+    metrics={
+        "ic": ic(inference=fx.inference.NEWEY_WEST),
+        "spread": quantile_spread(n_groups=5),
+    },
+    factor_cols=["factor"],
+    forward_periods=5,
+)
+
+result = results["factor"]
+print(result.metrics["ic"].value, result.metrics["ic"].p_value)
+print(result.metrics["spread"].value, result.metrics["spread"].p_value)
+```
+
+`ic` asks whether the rank relation is statistically different from zero.
+`quantile_spread` asks whether a simple top-minus-bottom portfolio spread is
+positive on average.
+
+## Build a simple allocation proxy
+
+For a custom composite signal, create the signal column upstream and use
+`compute_spread_series` to inspect the per-rebalance long-short path:
+
+```python
+import numpy as np
+import polars as pl
+from factrix.metrics.quantile import compute_spread_series
+
+panel = panel.with_columns(
+    (
+        0.5 * pl.col("factor")
+        + 0.5 * pl.col("factor").rank().over("date")
+    ).alias("composite_signal")
+)
+
+series = compute_spread_series(
+    panel,
+    factor_cols=["composite_signal"],
+    forward_periods=5,
+    n_groups=5,
+)["composite_signal"]
+
+spread = series["spread"].drop_nulls().to_numpy()
+periods_per_year = 252 / 5
+
+annualized_spread = float(np.mean(spread) * periods_per_year)
+annualized_sharpe = float(
+    np.mean(spread) / np.std(spread, ddof=1) * np.sqrt(periods_per_year)
+)
+hit_rate = float(np.mean(spread > 0))
+
+print(annualized_spread, annualized_sharpe, hit_rate)
+```
+
+This is not a production backtest. It is a diagnostic allocation proxy:
+equal-weight top bucket, equal-weight bottom bucket, no turnover costs, no
+borrow constraints, no capacity model, and no weight optimization.
+
+## Small universes
+
+If the universe is small, reduce the number of groups. With only five assets,
+`n_groups=5` means one asset per bucket, so the spread is dominated by
+individual names. `n_groups=2` is the coarsest useful long-short split.
+
+```python
+series = compute_spread_series(
+    panel,
+    factor_cols=["factor"],
+    forward_periods=5,
+    n_groups=2,
+)["factor"]
+```
+
+When `n_groups=2` is still too thin, treat the result as a fragile
+small-cross-section diagnostic rather than a portfolio claim.
+
+## Multi-factor screens
+
+After evaluating many candidate factors, pass the `EvaluationResult` values to
+BHY false discovery rate control:
+
+```python
+results = fx.evaluate(
+    panel,
+    metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},
+    factor_cols=["factor_0000", "factor_0001", "factor_0002"],
+    forward_periods=5,
+    strict=False,
+)
+
+bhy_ic = fx.multi_factor.bhy(list(results.values()), metrics=["ic"], q=0.05)["ic"]
+print([r.factor for r in bhy_ic.survivors])
+```
+
+`strict=False` is useful for sensitivity grids where some small-universe cells
+may be too thin for a metric. Data-shortage placeholders are kept in
+`evaluate` output for inspection, while `bhy` excludes `insufficient_*`
+placeholders from the tested family.
+
+## Windows console output
+
+Polars may render tables with box-drawing characters. On some Windows consoles
+using legacy encodings, that can fail with a `UnicodeEncodeError`. If a script
+prints Polars tables, set ASCII formatting near the top:
+
+```python
+import polars as pl
+
+pl.Config.set_tbl_formatting("ASCII_MARKDOWN")
+```
+
+This only affects display formatting; it does not change the data.

--- a/docs/guides/allocation-experiment.md
+++ b/docs/guides/allocation-experiment.md
@@ -107,11 +107,19 @@ small-cross-section diagnostic rather than a portfolio claim.
 ## Multi-factor screens
 
 After evaluating many candidate factors, pass the `EvaluationResult` values to
-BHY false discovery rate control:
+BHY false discovery rate control. Build a panel with several factor columns —
+`make_multi_factor_panel` emits `factor_0000`, `factor_0001`, ...:
 
 ```python
+multi = compute_forward_return(
+    fx.datasets.make_multi_factor_panel(
+        n_assets=50, n_dates=252, n_factors=3, seed=2024
+    ),
+    forward_periods=5,
+)
+
 results = fx.evaluate(
-    panel,
+    multi,
     metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},
     factor_cols=["factor_0000", "factor_0001", "factor_0002"],
     forward_periods=5,

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,7 @@ Step-by-step guides for common factrix workflows:
 - **Data structure dispatch (PANEL ↔ TIMESERIES) and the N=1 special path** — [Panel vs timeseries](panel-timeseries.md)
 - **Reading EvaluationResult, MetricResult, and FDR results** — [Reading results](reading-results.md)
 - **False Discovery Rate (FDR) control across a factor batch (BHY / partial conjunction / hierarchical)** — [BHY FDR screening](../api/bhy.md)
+- **Allocation-style diagnostics without turning factrix into a portfolio optimizer** — [Allocation-style experiments](allocation-experiment.md)
 - **Bounding peak memory when screening 100–1000+ factors (caller-side batched loop)** — [Large-scale evaluation and memory protection](large-scale-evaluation.md)
 - **Slicing one metric by an attached label column (sector / regime / universe / ADV bucket)** — [Slice analysis](slice-analysis.md)
 - **Running every descriptive metric applicable to a cell** — [Standalone metrics](standalone-metrics.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
           - Information coefficient vs Fama-MacBeth: guides/choosing-metric.md
           - Panel vs timeseries: guides/panel-timeseries.md
           - Reading results: guides/reading-results.md
+          - Allocation-style experiments: guides/allocation-experiment.md
           - Observability: guides/observability.md
           - Large-scale evaluation: guides/large-scale-evaluation.md
           - Slice analysis: guides/slice-analysis.md


### PR DESCRIPTION
## Summary
- New guide `docs/guides/allocation-experiment.md` (+ nav wiring) walking through using factrix for the *signal test* before portfolio construction: IC + quantile spread, a diagnostic long-short allocation proxy via `compute_spread_series`, small-universe `n_groups` guidance, and a multi-factor BHY screen.
- Explicitly draws the boundary: factrix does not optimize weights, model slippage/turnover/borrow/capacity, rebalance a live book, or produce a full backtest — those are downstream. The proxy is framed as a "fragile small-cross-section diagnostic rather than a portfolio claim."

## Notes for review
- Tone check (per review focus): the guide states the "not a portfolio optimizer" boundary up front and again at the proxy ("This is not a production backtest... no weight optimization") and small-universe sections.
- **Ordering matters**: the recipe documents `bhy` excluding `insufficient_*` placeholders and the corrected `bhy(list(results.values()), metrics=[...])` signature — both land in the BHY fix PR. This guide should merge *after* that PR so the docs don't describe behavior ahead of the API.
- Review fix applied on this branch: the multi-factor section originally reused the single-factor panel while referencing `factor_0000..0002` (raised `UserInputError`); now builds a real multi-factor panel with `make_multi_factor_panel`. All code fences verified to execute.

## Test plan
- [x] Ran every Python code fence in the guide end-to-end (IC/spread, allocation proxy, small-universe split, multi-factor BHY screen)