### PR TITLE
fix(event): caar slice tests, continuous event magnitudes, event-ic data

### DIFF
--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -6,6 +6,7 @@ title: factrix.metrics.caar
     options:
       show_root_members_full_path: true
       members:
+        - compute_caar
         - caar
         - bmp_z
 
@@ -75,12 +76,15 @@ title: factrix.metrics.caar
 
     ```python
     import factrix as fx
+    import polars as pl
     from factrix.metrics.caar import compute_caar, caar, bmp_z
     from factrix.preprocess import compute_forward_return
 
+    pl.Config.set_tbl_formatting("ASCII_MARKDOWN")
+
     raw   = fx.datasets.make_event_panel(
         n_assets=200, n_dates=500, event_rate=0.02,
-        post_event_drift=0.004, seed=2024,
+        post_event_drift_bps=40.0, seed=2024,
     )
     panel = compute_forward_return(raw, forward_periods=5)
 

--- a/docs/api/metrics/corrado_rank.md
+++ b/docs/api/metrics/corrado_rank.md
@@ -57,7 +57,7 @@ title: factrix.metrics.corrado_rank
 
     raw   = fx.datasets.make_event_panel(
         n_assets=200, n_dates=500, event_rate=0.02,
-        post_event_drift=0.004, seed=2024,
+        post_event_drift_bps=40.0, seed=2024,
     )
     panel = compute_forward_return(raw, forward_periods=5)
 

--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -80,7 +80,7 @@ title: factrix.metrics.event_horizon
 
     panel = fx.datasets.make_event_panel(
         n_assets=200, n_dates=500, event_rate=0.02,
-        post_event_drift=0.004, with_price=True, seed=2024,
+        post_event_drift_bps=40.0, seed=2024,
     )
 
     rets = compute_event_returns(panel, offsets=[-6, -3, -1, 1, 6, 12, 24])

--- a/docs/api/metrics/event_quality.md
+++ b/docs/api/metrics/event_quality.md
@@ -90,7 +90,7 @@ title: factrix.metrics.event_quality
 
     raw   = fx.datasets.make_event_panel(
         n_assets=200, n_dates=500, event_rate=0.02,
-        post_event_drift=0.004, seed=2024,
+        event_magnitude_jitter=0.5, post_event_drift_bps=40.0, seed=2024,
     )
     panel = compute_forward_return(raw, forward_periods=5)
 

--- a/docs/api/metrics/mfe_mae.md
+++ b/docs/api/metrics/mfe_mae.md
@@ -60,7 +60,7 @@ title: factrix.metrics.mfe_mae
 
     panel = fx.datasets.make_event_panel(
         n_assets=200, n_dates=500, event_rate=0.02,
-        post_event_drift=0.004, with_price=True, seed=2024,
+        post_event_drift_bps=40.0, seed=2024,
     )
 
     per_event = compute_mfe_mae(panel, window=20, estimation_window=60)

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -185,6 +185,7 @@ def make_event_panel(
     n_dates: int = 252,
     event_rate: float = 0.02,
     event_magnitude: float = 1.0,
+    event_magnitude_jitter: float = 0.0,
     post_event_drift_bps: float = 10.0,
     signal_horizon: int = 5,
     seed: int = 42,
@@ -213,6 +214,9 @@ def make_event_panel(
         event_rate: Per-cell event probability (≈ expected events per
             asset per date).
         event_magnitude: Magnitude of the event signal.
+        event_magnitude_jitter: Relative half-width for continuous event
+            magnitudes. ``0.0`` emits ternary ``{-R, 0, +R}``; positive
+            values make ``event_ic`` usable by giving ``|factor|`` variation.
         post_event_drift_bps: Total drift in basis points injected
             across the ``signal_horizon`` bars of the forward-return
             window (bars ``t+2 .. t+1+H``).
@@ -228,7 +232,8 @@ def make_event_panel(
 
     Returns:
         Long DataFrame with ``date, asset_id, price, factor``. Factor
-        is ``Float64`` with values in ``{-R, 0.0, +R}``. Attach
+        is ``Float64`` with values in ``{-R, 0.0, +R}`` when
+        ``event_magnitude_jitter=0``. Attach
         ``forward_return`` (e.g. via
         ``factrix.preprocess.compute_forward_return``) before
         passing to ``fx.evaluate``.
@@ -248,6 +253,10 @@ def make_event_panel(
         )
     if not 0.0 <= event_rate <= 1.0:
         raise ValueError(f"event_rate must be in [0, 1], got {event_rate}")
+    if event_magnitude_jitter < 0.0:
+        raise ValueError(
+            f"event_magnitude_jitter must be >= 0, got {event_magnitude_jitter}"
+        )
 
     rng = np.random.default_rng(seed)
     sigmas = rng.uniform(0.01, 0.03, size=n_assets)
@@ -255,7 +264,13 @@ def make_event_panel(
 
     has_event = rng.random((n_dates, n_assets)) < event_rate
     signs = rng.choice([-1.0, 1.0], size=(n_dates, n_assets))
-    factor = np.where(has_event, signs * event_magnitude, 0.0)
+    if event_magnitude_jitter:
+        low = max(0.0, 1.0 - event_magnitude_jitter)
+        high = 1.0 + event_magnitude_jitter
+        magnitude_scale = rng.uniform(low, high, size=(n_dates, n_assets))
+    else:
+        magnitude_scale = np.ones((n_dates, n_assets))
+    factor = np.where(has_event, signs * event_magnitude * magnitude_scale, 0.0)
 
     # compute_forward_return uses (p[t+1+H] / p[t+1] - 1)/H, whose realized
     # returns span bars t+2..t+1+H — NOT t+1..t+H. Drift has to be injected
@@ -264,7 +279,9 @@ def make_event_panel(
     event_idx = np.argwhere(has_event)
     for t, i in event_idx:
         end = min(t + 2 + signal_horizon, n_dates)
-        daily_ret[t + 2 : end, i] += signs[t, i] * drift_per_bar
+        daily_ret[t + 2 : end, i] += (
+            signs[t, i] * drift_per_bar * magnitude_scale[t, i]
+        )
 
     prices = 100.0 * np.cumprod(1.0 + daily_ret, axis=0)
 
@@ -400,6 +417,7 @@ def make_multi_factor_event_panel(
     n_dates: int = 400,
     event_rate: float = 0.04,
     event_magnitude: float = 1.0,
+    event_magnitude_jitter: float = 0.0,
     post_event_drift_bps: float = 10.0,
     signal_horizon: int = 5,
     seed: int = 42,
@@ -408,7 +426,8 @@ def make_multi_factor_event_panel(
     """Synthetic multi-factor event-density panel.
 
     Each of ``n_factors`` factor columns is independently sampled as a sparse
-    ternary matrix with values in ``{-R, 0, +R}`` where ``R = event_magnitude``.
+    matrix with values in ``{-R, 0, +R}`` where ``R = event_magnitude`` when
+    ``event_magnitude_jitter=0``; positive jitter emits continuous magnitudes.
     Post-event drift from all factors accumulates into the shared underlying
     asset returns.
 
@@ -420,6 +439,9 @@ def make_multi_factor_event_panel(
         n_dates: Number of calendar dates.
         event_rate: Per-cell event probability.
         event_magnitude: Magnitude of the event signal.
+        event_magnitude_jitter: Relative half-width for continuous event
+            magnitudes. ``0.0`` emits ternary event signals; positive values
+            make ``event_ic`` usable in synthetic screening experiments.
         post_event_drift_bps: Total drift in basis points injected per event
             across the ``signal_horizon`` bars of the forward-return
             window (bars ``t+2 .. t+1+H``).
@@ -453,6 +475,10 @@ def make_multi_factor_event_panel(
         )
     if not 0.0 <= event_rate <= 1.0:
         raise ValueError(f"event_rate must be in [0, 1], got {event_rate}")
+    if event_magnitude_jitter < 0.0:
+        raise ValueError(
+            f"event_magnitude_jitter must be >= 0, got {event_magnitude_jitter}"
+        )
 
     rng = np.random.default_rng(seed)
     sigmas = rng.uniform(0.01, 0.03, size=n_assets)
@@ -465,12 +491,20 @@ def make_multi_factor_event_panel(
     for k in range(n_factors):
         has_event = rng.random((n_dates, n_assets)) < event_rate
         signs = rng.choice([-1.0, 1.0], size=(n_dates, n_assets))
-        factor_k = np.where(has_event, signs * event_magnitude, 0.0)
+        if event_magnitude_jitter:
+            low = max(0.0, 1.0 - event_magnitude_jitter)
+            high = 1.0 + event_magnitude_jitter
+            magnitude_scale = rng.uniform(low, high, size=(n_dates, n_assets))
+        else:
+            magnitude_scale = np.ones((n_dates, n_assets))
+        factor_k = np.where(has_event, signs * event_magnitude * magnitude_scale, 0.0)
 
         event_idx = np.argwhere(has_event)
         for t, i in event_idx:
             end = min(t + 2 + signal_horizon, n_dates)
-            daily_ret[t + 2 : end, i] += signs[t, i] * drift_per_bar
+            daily_ret[t + 2 : end, i] += (
+                signs[t, i] * drift_per_bar * magnitude_scale[t, i]
+            )
 
         factor_columns[f"factor_{k:0{width}d}"] = factor_k
 

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -279,9 +279,7 @@ def make_event_panel(
     event_idx = np.argwhere(has_event)
     for t, i in event_idx:
         end = min(t + 2 + signal_horizon, n_dates)
-        daily_ret[t + 2 : end, i] += (
-            signs[t, i] * drift_per_bar * magnitude_scale[t, i]
-        )
+        daily_ret[t + 2 : end, i] += signs[t, i] * drift_per_bar * magnitude_scale[t, i]
 
     prices = 100.0 * np.cumprod(1.0 + daily_ret, axis=0)
 

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -54,9 +54,11 @@ from factrix.metrics._helpers import (
     _scaled_min_periods,
     _short_circuit_output,
 )
+from factrix.metrics._metric_capabilities import per_date_series_rename
 from factrix.metrics._primitives import compute_caar
 
 __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
+    "compute_caar",
     "caar",
     "bmp_z",
 ]
@@ -74,6 +76,7 @@ _CAAR_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 # lives in the procedure short-circuit and is parallel to (not
 # exposed via) this attribute.
 min_assets_per_group: int | None = None
+per_date_series = per_date_series_rename("caar")
 
 
 def _caar_sample_threshold(self: Any) -> SampleThreshold:
@@ -220,8 +223,7 @@ def caar(
     # Normal input arrives from compute_caar carrying date_ordinal (the
     # full-calendar position). A hand-built caar_df that bypasses
     # compute_caar lacks it; fall back to the dense rank of the event dates
-    # themselves — degrades to event-index spacing, the legacy behaviour, but
-    # never raises.
+    # themselves — event-index spacing is less calendar-aware, but never raises.
     if "date_ordinal" not in caar_df.columns:
         caar_df = caar_df.with_columns(
             (pl.col("date").rank(method="dense") - 1).alias("date_ordinal")

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -89,6 +89,21 @@ def _resolve_producer(metric: MetricBase, func_name: str) -> Callable:
     return next(iter(requires.values()))
 
 
+def _run_producer_for_factor(
+    producer: Callable,
+    data: pl.DataFrame,
+    factor_col: str,
+) -> pl.DataFrame:
+    """Run either a batch producer or a single-factor producer for one factor."""
+    param_names = set(getattr(producer, "_param_names", ()))
+    if "factor_cols" in param_names:
+        produced = producer(data, factor_cols=[factor_col])
+        return produced[factor_col]
+    if "factor_col" in param_names:
+        return producer(data, factor_col=factor_col)
+    return producer(data)
+
+
 def _build_per_date_panel(
     data: pl.DataFrame,
     metric: MetricBase,
@@ -122,8 +137,8 @@ def _build_per_date_panel(
     labels = list(slices.keys())
 
     def series_for(sub: pl.DataFrame) -> pl.DataFrame:
-        produced = producer(sub, factor_cols=[factor_col])
-        return per_date_fn(produced[factor_col])
+        produced = _run_producer_for_factor(producer, sub, factor_col)
+        return per_date_fn(produced)
 
     aligned = series_for(slices[labels[0]]).rename({"value": "v_0"})
     for i, lbl in enumerate(labels[1:], start=1):

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -83,6 +83,7 @@ from factrix.slicing.inference import (
     _DOCS_SLICE,
     _hac_lags,
     _resolve_producer,
+    _run_producer_for_factor,
     _validate_metric_instance,
 )
 
@@ -141,8 +142,8 @@ def _build_per_slice_series(
     labels = list(slices.keys())
     series_list: list[np.ndarray] = []
     for lbl in labels:
-        produced = producer(slices[lbl], factor_cols=[factor_col])
-        s = per_date_fn(produced[factor_col])["value"].to_numpy()
+        produced = _run_producer_for_factor(producer, slices[lbl], factor_col)
+        s = per_date_fn(produced)["value"].to_numpy()
         if s.shape[0] < 2:
             raise ValueError(
                 f"{func_name}: slice {lbl!r} has <2 dates ({s.shape[0]}); "

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import polars as pl
 import pytest
 from factrix import datasets
+from factrix.metrics.event_quality import event_ic
+from factrix.preprocess import compute_forward_return
 
 
 class TestMakeCsPanelSchema:
@@ -75,6 +77,20 @@ class TestMakeEventPanelSchema:
         )
         assert set(df["factor"].unique().to_list()) <= {-2.0, 0.0, 2.0}
 
+    def test_event_magnitude_jitter_makes_event_ic_usable(self):
+        raw = datasets.make_event_panel(
+            n_assets=30,
+            n_dates=252,
+            event_rate=0.08,
+            event_magnitude_jitter=0.5,
+            post_event_drift_bps=50.0,
+            seed=0,
+        )
+        panel = compute_forward_return(raw, forward_periods=5)
+        result = event_ic(panel)
+        assert result.metadata.get("reason") is None
+        assert result.value > 0
+
     def test_seed_is_deterministic(self):
         a = datasets.make_event_panel(n_assets=8, n_dates=30, seed=7)
         b = datasets.make_event_panel(n_assets=8, n_dates=30, seed=7)
@@ -111,6 +127,22 @@ class TestMakeMultiFactorEventPanelSchema:
         )
         for col in ["factor_0000", "factor_0001", "factor_0002"]:
             assert set(df[col].unique().to_list()) <= {-1.0, 0.0, 1.0}
+
+    def test_magnitude_jitter_adds_continuous_event_values(self):
+        df = datasets.make_multi_factor_event_panel(
+            n_factors=1,
+            n_assets=20,
+            n_dates=120,
+            event_rate=0.10,
+            event_magnitude_jitter=0.5,
+            seed=0,
+        )
+        events = df.filter(pl.col("factor_0000") != 0)["factor_0000"].abs()
+        assert events.n_unique() > 2
+
+    def test_rejects_negative_magnitude_jitter(self):
+        with pytest.raises(ValueError, match="event_magnitude_jitter"):
+            datasets.make_multi_factor_event_panel(event_magnitude_jitter=-0.1)
 
     def test_seed_is_deterministic(self):
         a = datasets.make_multi_factor_event_panel(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -83,11 +83,14 @@ class TestMakeEventPanelSchema:
             n_dates=252,
             event_rate=0.08,
             event_magnitude_jitter=0.5,
-            post_event_drift_bps=50.0,
+            post_event_drift_bps=250.0,
             seed=0,
         )
         panel = compute_forward_return(raw, forward_periods=5)
         result = event_ic(panel)
+        # jitter gives |factor| variation (not just sign), and drift scales
+        # with magnitude, so event_ic resolves to a detectable positive IC
+        # instead of short-circuiting on a degenerate ternary signal.
         assert result.metadata.get("reason") is None
         assert result.value > 0
 

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import numpy as np
+import factrix as fx
 import polars as pl
 import pytest
 from factrix import slice_pairwise_test
 from factrix._data_input import _stamp_forward_periods
 from factrix._errors import UserInputError
-from factrix.metrics import fm_beta, ic, monotonicity
+from factrix.metrics import caar, fm_beta, ic, monotonicity
 
 from tests._slice_panel import (
     build_autocorrelated_ic_panel,
@@ -76,6 +77,26 @@ def test_fama_macbeth_metric_accepted() -> None:
         n_dates=60, seed=6, signal={"x": 0.1, "y": 0.1}, label_col="regime"
     )
     out = slice_pairwise_test(df, fm_beta(), by="regime", factor_col="factor")
+    assert out.height == 1
+    assert out.columns == _PAIRWISE_COLS
+
+
+def test_caar_metric_accepted_for_event_slices() -> None:
+    raw = fx.datasets.make_multi_factor_event_panel(
+        n_factors=1,
+        n_assets=40,
+        n_dates=160,
+        event_rate=0.20,
+        post_event_drift_bps=30.0,
+        seed=6,
+    )
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    assets = panel["asset_id"].unique().sort().to_list()
+    universe = {a: ("u1" if i % 2 else "u0") for i, a in enumerate(assets)}
+    panel = panel.with_columns(
+        pl.col("asset_id").replace_strict(universe).alias("universe")
+    )
+    out = slice_pairwise_test(panel, caar(), by="universe", factor_col="factor_0000")
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS
 

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import numpy as np
 import factrix as fx
+import numpy as np
 import polars as pl
 import pytest
 from factrix import slice_pairwise_test

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import numpy as np
 import factrix as fx
+import numpy as np
 import polars as pl
 import pytest
 from factrix import slice_period_pairwise_test

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import numpy as np
+import factrix as fx
 import polars as pl
 import pytest
 from factrix import slice_period_pairwise_test
 from factrix._errors import UserInputError
-from factrix.metrics import fm_beta, ic, monotonicity
+from factrix.metrics import caar, fm_beta, ic, monotonicity
 
 from tests._slice_panel import build_disjoint_period_panel
 
@@ -131,6 +132,30 @@ def test_fama_macbeth_metric_accepted() -> None:
     )
     out = slice_period_pairwise_test(
         df, fm_beta(), by="regime", factor_col="factor", rng_seed=9
+    )
+    assert out.height == 1
+    assert out.columns == _PAIRWISE_COLS
+
+
+def test_caar_metric_accepted_for_event_regimes() -> None:
+    raw = fx.datasets.make_multi_factor_event_panel(
+        n_factors=1,
+        n_assets=30,
+        n_dates=180,
+        event_rate=0.18,
+        post_event_drift_bps=30.0,
+        seed=9,
+    )
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    midpoint = panel["date"].median()
+    panel = panel.with_columns(
+        pl.when(pl.col("date") < midpoint)
+        .then(pl.lit("early"))
+        .otherwise(pl.lit("late"))
+        .alias("regime")
+    )
+    out = slice_period_pairwise_test(
+        panel, caar(), by="regime", factor_col="factor_0000", rng_seed=9
     )
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS


### PR DESCRIPTION
## Summary
- **`event_magnitude_jitter`** on `make_event_panel` / `make_multi_factor_event_panel`: `0.0` keeps the legacy ternary `{-R, 0, +R}` (fully backward compatible); positive values draw a per-event magnitude scale from `Uniform(max(0, 1-jitter), 1+jitter)`. Post-event drift is scaled by the *same* per-event factor, so `|factor|` and forward return move together and `event_ic` resolves to a real value instead of a degenerate-signal short-circuit.
- **caar slice-test eligibility**: export `compute_caar` and register `per_date_series = per_date_series_rename("caar")` so `caar` can drive `slice_pairwise_test` / `slice_period_pairwise_test` from a raw panel.
- **Producer dispatch**: `_run_producer_for_factor` lets the slice-test machinery run both batch producers (`factor_cols=[...]`, e.g. `compute_ic`) and single-factor producers (`factor_col=...`, e.g. `compute_caar`) off their declared `_param_names`.
- Event docs: fix stale `make_event_panel` args (`post_event_drift=0.004`/`with_price=True` -> `post_event_drift_bps=`), and show `event_magnitude_jitter` in the event_quality example.

## Notes for review (the three focus areas)
- **`event_magnitude_jitter` semantics — sound.** Verified the mechanism: at adequate drift the magnitude->return relationship yields a robust positive `event_ic` (min 0.07 across 20 seeds at 250bps); the sign/magnitude scaling and the matching drift scale are correct. The clamp `max(0, 1-jitter)` keeps magnitudes non-negative for `jitter > 1` (sign stays in `signs`). Minor: "jitter" reads as small noise but the knob can span `[0, 2R]`; naming is acceptable given the docstring spells out the intent.
- **caar slice eligibility — just right.** `compute_caar` emits a per-date `(date, caar)` series; the slice test compares that calendar-time series across slices, which is a legitimate event-response contrast. `_resolve_producer` still rejects metrics with no producer.
- **producer helper — just right, not too broad.** It dispatches on the producer's declared `_param_names` (`factor_cols` vs `factor_col`); `compute_caar` carries `factor_col` so the user's actual column is passed (no silent default). The bare `producer(data)` branch is a defensive fallback for a no-factor-param producer and isn't reached by current producers.

## Fixes applied on this branch during review
- The `event_magnitude_jitter` test asserted `event_ic > 0` at 50bps drift, where IC sits below noise and flips sign across seeds (seed=0 = -0.013, **test failed as pushed**). Raised drift to 250bps; positive IC now holds across 20 seeds.
- Branch was not lint-clean as pushed: sorted imports in the two new slice-test modules and reflowed `datasets.py` (`ruff check`/`ruff format` now clean).

## Out of scope — pre-existing, flagged for a separate cleanup
- `metadata["p_value"]` in the metric-doc examples is dead (p-value is the promoted `MetricResult.p_value` field, not a metadata key). This is systemic across ~15 doc pages (`caar.md`, `event_quality.md`, `ic.md`, ...), a leftover from a metadata refactor — not specific to event analysis. Left untouched here to keep this PR scoped; worth a dedicated docs PR/issue.

## Test plan
- [x] `pytest tests/test_datasets.py tests/test_slice_pairwise_test.py tests/test_slice_period_pairwise_test.py`
- [x] Full suite: 1412 passed, 4 skipped
- [x] `ruff check`, `ruff format --check`, `mypy factrix` clean
- [x] Ran caar.md / event_quality.md fences (run end-to-end except the pre-existing `metadata["p_value"]` line noted above)