### PR TITLE
fix(slicing)!: refuse sub-floor slices in date-disjoint period tests

### DIFF
--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -29,6 +29,15 @@ factrix splits this work into two roles because **slicing the panel** and **test
 
 **Use the inference functions when:** you want a calibrated cross-slice statistic with multiple-testing control and your metric exposes `per_date_series`.
 
+!!! warning "Don't compare per-slice p-values to claim slices differ"
+    Each `by_slice` p-value tests one slice against its *own* null
+    (e.g. CAAR = 0, hit rate = 0.5) — not against another slice. "Significant
+    in bull (p=0.03) but not in bear (p=0.20), therefore the regimes differ"
+    is the difference-of-significances fallacy — *a difference in
+    significance is not a significant difference* ([Gelman & Stern, 2006](https://doi.org/10.1198/000313006X152649)).
+    To test `value_a − value_b ≠ 0`, use the `slice_*_test` pair, which forms
+    the contrast directly with calibrated SE and multiple-testing control.
+
 ## Why no generic cross-slice test on `by_slice`
 
 A single dispatcher carrying a single built-in cross-slice test would silently over-claim. The appropriate test depends on the metric family:

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -203,6 +203,16 @@ _WARNING_DESCRIPTIONS.update(
         "factor variance); the cross-asset aggregate was computed on a shortened "
         "sample. Exact counts are in MetricResult.metadata (n_assets_in / "
         "n_assets_out / dropped_assets / drop_rate / drop_reason).",
+        WarningCode.SLICE_BOUNDARY_TRUNCATION: "by_slice partitioned a panel on "
+        "a date-axis column (one whose value varies within an asset over time, "
+        "e.g. calendar year or regime label) while the metric's aggregation "
+        "looks across dates (TS_ONLY / TS_THEN_CS / EVENT_TIME / "
+        "RETURN_SPANNING). Each slice is evaluated on its own rows, so a "
+        "rolling window / per-asset time-series regression / event window sees "
+        "truncated history at the slice boundary — the per-slice value differs "
+        "from the full-sample value decomposed by period. Per-date metrics "
+        "(CS_THEN_TS / CS_SNAPSHOT) and cross-sectional partitions (constant "
+        "within an asset, e.g. sector) are unaffected and do not trigger.",
     }
 )
 

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -68,6 +68,7 @@ from scipy import stats as sp_stats
 
 from factrix._data_input import _read_forward_periods_stamp
 from factrix._errors import UserInputError
+from factrix._metric_index import SampleThreshold
 from factrix._stats.bootstrap import (
     Scheme,
     _politis_white_block_length,
@@ -102,6 +103,65 @@ def _validate_method(method: str, func_name: str) -> None:
             expected='one of "bootstrap" (default) or "analytic"',
             docs_path=_DOCS_SLICE,
         )
+
+
+def _resolve_sample_threshold(metric: MetricBase) -> SampleThreshold:
+    """Resolve the metric instance's ``SampleThreshold``, honouring config.
+
+    Mirrors :meth:`MetricBase.spec` but evaluates the dynamic
+    ``sample_threshold_for`` hook against the **actual instance** (not a
+    default-built one), so a metric configured with a non-default
+    ``forward_periods`` (e.g. ``caar``) reports the floor for its own
+    horizon rather than the default-config floor.
+    """
+    cls = type(metric)
+    hook = cls.sample_threshold_for
+    return hook(metric) if hook is not None else cls.sample_threshold
+
+
+def _require_slice_floor(
+    metric: MetricBase,
+    labels: list[str],
+    series_list: list[np.ndarray],
+    *,
+    func_name: str,
+) -> None:
+    """Raise when any slice's per-date series is below the metric's own floor.
+
+    ``by_slice`` short-circuits a thin metric to NaN via the metric body; the
+    date-disjoint slice tests build each slice's per-date series directly and
+    would otherwise return a calibrated-looking p-value on a sub-floor regime.
+    Reuse the metric's own :class:`SampleThreshold` — the single source of
+    truth both paths read — so they agree on what counts as a thin sample, and
+    refuse (rather than emit) the contrast at that size: the inferential path
+    must be at least as protective as the descriptive one. The per-date series
+    length is the slice's time-axis sample, so only the time-series floors
+    (``min_periods`` / ``min_events``) bind — the cross-section floors
+    (``min_assets`` / ``min_pairs``) describe within-date width, which the
+    series has already collapsed.
+    """
+    threshold = _resolve_sample_threshold(metric)
+    floor = max(
+        (f for f in (threshold.min_periods, threshold.min_events) if f is not None),
+        default=None,
+    )
+    if floor is None:
+        return
+    thin = [
+        (lbl, int(s.shape[0]))
+        for lbl, s in zip(labels, series_list, strict=True)
+        if s.shape[0] < floor
+    ]
+    if not thin:
+        return
+    detail = ", ".join(f"{lbl!r} (n_periods={n})" for lbl, n in thin)
+    raise ValueError(
+        f"{func_name}: slice(s) {detail} fall below {type(metric).__name__!r}'s "
+        f"minimum sample floor ({floor}); by_slice short-circuits this metric "
+        f"to NaN at that size, so the date-disjoint tests refuse to return a "
+        f"contrast that is not calibrated. Use coarser regimes (each ≥{floor} "
+        f"periods) or a metric with a lower sample floor."
+    )
 
 
 def _build_per_slice_series(
@@ -151,6 +211,7 @@ def _build_per_slice_series(
                 f"within-slice variance estimate."
             )
         series_list.append(np.asarray(s, dtype=float))
+    _require_slice_floor(metric, labels, series_list, func_name=func_name)
     return labels, series_list
 
 
@@ -232,8 +293,10 @@ def slice_period_pairwise_test(
     Raises:
         UserInputError: ``metric`` is not a metric instance, ``factor_col``
             is absent, or ``method`` is invalid.
-        ValueError: Fewer than two slice values, or any slice with fewer
-            than two dates.
+        ValueError: Fewer than two slice values, any slice with fewer than
+            two dates, or any slice whose per-date series is below the
+            metric's own ``SampleThreshold`` floor (the size at which
+            :func:`factrix.by_slice` short-circuits the metric to NaN).
         TypeError: Metric is not slice-test-eligible (no ``per_date_series``
             capability / no producer).
     """
@@ -423,8 +486,10 @@ def slice_period_joint_test(
     Raises:
         UserInputError: ``metric`` is not a metric instance, ``factor_col``
             is absent, or ``method`` is invalid.
-        ValueError: Fewer than two slice values, or any slice with fewer
-            than two dates.
+        ValueError: Fewer than two slice values, any slice with fewer than
+            two dates, or any slice whose per-date series is below the
+            metric's own ``SampleThreshold`` floor (the size at which
+            :func:`factrix.by_slice` short-circuits the metric to NaN).
         TypeError: Metric is not slice-test-eligible.
     """
     _validate_metric_instance(metric, "slice_period_joint_test")

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -83,7 +83,7 @@ def test_bootstrap_joint_is_bootstrap_native_for_two_slices() -> None:
     from factrix import slice_period_pairwise_test
 
     df = build_disjoint_period_panel(
-        seed=11, spans={"a": (40, 0.15), "b": (40, 0.0)}, label_col="regime"
+        seed=11, spans={"a": (60, 0.15), "b": (60, 0.0)}, label_col="regime"
     )
     pw = slice_period_pairwise_test(
         df, ic(), by="regime", factor_col="factor", rng_seed=5
@@ -148,3 +148,13 @@ def test_raises_when_slice_too_short() -> None:
     )
     with pytest.raises(ValueError, match="<2 dates"):
         slice_period_joint_test(df, ic(), by="regime", factor_col="factor")
+
+
+def test_raises_when_slice_below_metric_floor() -> None:
+    """Below ic's min_periods floor (50) the omnibus refuses rather than emit
+    an uncalibrated contrast — the same sub-floor size by_slice NaNs."""
+    df = build_disjoint_period_panel(
+        seed=11, spans={"a": (30, 0.1), "b": (30, 0.1)}, label_col="regime"
+    )
+    with pytest.raises(ValueError, match="sample floor"):
+        slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=11)

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -52,13 +52,13 @@ def test_three_slice_returns_three_rows() -> None:
 def test_per_slice_period_counts_reported() -> None:
     """Disjoint spans differ in length → n_periods_a / n_periods_b differ."""
     df = build_disjoint_period_panel(
-        seed=3, spans={"early": (40, 0.1), "late": (90, 0.1)}, label_col="regime"
+        seed=3, spans={"early": (50, 0.1), "late": (90, 0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
         df, ic(), by="regime", factor_col="factor", rng_seed=3
     )
     row = out.row(0, named=True)
-    assert row["n_periods_a"] == 40
+    assert row["n_periods_a"] == 50
     assert row["n_periods_b"] == 90
 
 
@@ -224,3 +224,27 @@ def test_raises_when_slice_too_short() -> None:
     )
     with pytest.raises(ValueError, match="<2 dates"):
         slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor")
+
+
+def test_raises_when_slice_below_metric_floor() -> None:
+    """A slice shorter than ic's min_periods floor (50) is the size at which
+    by_slice short-circuits to NaN; the date-disjoint test must refuse rather
+    than emit a contrast that is not calibrated."""
+    df = build_disjoint_period_panel(
+        seed=18, spans={"a": (30, 0.1), "b": (30, 0.1)}, label_col="regime"
+    )
+    with pytest.raises(ValueError, match="sample floor"):
+        slice_period_pairwise_test(
+            df, ic(), by="regime", factor_col="factor", rng_seed=18
+        )
+
+
+def test_runs_at_metric_floor() -> None:
+    """The floor is strict (``<``): a slice exactly at ic's floor (50) runs."""
+    df = build_disjoint_period_panel(
+        seed=19, spans={"a": (50, 0.1), "b": (60, 0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", rng_seed=19
+    )
+    assert out.height == 1


### PR DESCRIPTION
## Summary
- `slice_period_pairwise_test` / `slice_period_joint_test` now raise `ValueError` when any slice's per-date series is below the metric's own `SampleThreshold` floor (`min_periods` / `min_events`), resolved against the actual metric instance so configured horizons scale. Previously they returned a calibrated-looking p-value at a size where `by_slice` short-circuits the same metric to NaN — the descriptive and inferential paths disagreed on what counts as a thin sample, inviting false positives on short regimes.
- The check lives in the shared `_build_per_slice_series`, alongside the existing `<2-dates` / `<2-slice` guards (which still fire first for the degenerate cases). No new threshold concept — it reuses the metric's own `SampleThreshold` as the single source of truth.
- docs(slice-analysis): added a guardrail against the difference-of-significances fallacy — comparing two per-slice `by_slice` p-values to claim the slices differ — pointing to the `slice_*_test` pair for the actual contrast.
- Drive-by: added the missing `SLICE_BOUNDARY_TRUNCATION` description so `mkdocs build` (the `gen_code_descriptions` hook iterates every `WarningCode`, and `.description` has no fallback) stops raising `KeyError`. Pre-existing build breakage surfaced while validating the docs note.

## Breaking change
`slice_period_pairwise_test` / `slice_period_joint_test` raise `ValueError` below the metric's sample floor instead of returning a contrast. Use coarser regimes (each at least the metric's floor) or a lower-floor metric.

## Test plan
- [x] `pytest` — 1420 passed, 4 skipped
- [x] `ruff check` / `ruff format --check` / `mypy factrix` — clean
- [x] New regression tests, both pairwise and joint: below-floor raises `ValueError`; at-floor (strict `<`) runs