### PR TITLE
fix(slicing): distinguish date-disjoint from metric-dropout slice errors

### DIFF
--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -59,6 +59,20 @@ time period) yield zero aligned rows and these functions raise
 `ValueError` (`<2 aligned dates`). Date-shared slices — universe,
 sector, market-cap tier — are their intended use case.
 
+A `<2 aligned dates` error has **two distinct causes**, and the message
+distinguishes them:
+
+- **Date-disjoint partition** — the slices share fewer than two raw dates
+  by construction (the case above). The message names the date-disjoint
+  partition and points at `slice_period_*`.
+- **Date-aligned but metric-dropped** — the slices *do* share dates, but
+  the per-slice metric dropped most of its per-date values, so the joined
+  panel still collapses below two rows. The usual cause is too few assets
+  per slice (e.g. `ic` drops any date below `MIN_IC_ASSETS`); a `sector`
+  cut with thin cross-sections triggers it. The message reports the raw
+  shared-date count and blames the thin universe — widen each slice's
+  asset universe or use a coarser partition.
+
 For genuinely time-disjoint slices, reach for
 `slice_period_pairwise_test` / `slice_period_joint_test`. They build the
 same per-slice per-date series but **do not** inner-join — each slice is

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -104,6 +104,46 @@ def _run_producer_for_factor(
     return producer(data)
 
 
+def _too_few_aligned_dates_msg(
+    func_name: str,
+    slices: dict[str, pl.DataFrame],
+    aligned_height: int,
+) -> str:
+    """Branch the ``<2 aligned dates`` error on the raw shared-date count.
+
+    Two distinct failures collapse the joined panel to <2 rows:
+    (1) the slices are genuinely date-disjoint (e.g. calendar regime); or
+    (2) the slices share dates, but the per-slice metric dropped its per-date
+    values — typically too few assets per slice. The cause changes the fix,
+    so the message must too. The raw shared-date count (dates common to every
+    slice *before* the metric runs) tells the two apart, which
+    ``aligned_height`` alone cannot.
+    """
+    shared: set[object] | None = None
+    for sub in slices.values():
+        dates = set(sub.get_column("date").unique().to_list())
+        shared = dates if shared is None else (shared & dates)
+    raw_shared = len(shared) if shared is not None else 0
+    if raw_shared < 2:
+        return (
+            f"{func_name}: <2 aligned dates across slices ({aligned_height}); "
+            f"joint HAC inference requires aligned rows. These tests are "
+            f"cross-sectional — slices must share ≥2 common dates. A "
+            f"date-disjoint partition (e.g. calendar regime) shares no dates "
+            f"and is not supported here — use slice_period_pairwise_test / "
+            f"slice_period_joint_test for date-disjoint partitions."
+        )
+    return (
+        f"{func_name}: slices share {raw_shared} raw dates but only "
+        f"{aligned_height} aligned dates survived metric computation; joint "
+        f"HAC inference requires ≥2. The partition is date-aligned — the "
+        f"per-slice metric dropped most of its per-date values, typically "
+        f"because each slice has too few assets to compute the metric "
+        f"cross-sectionally. Widen each slice's universe (more assets per "
+        f"slice) or use a coarser partition."
+    )
+
+
 def _build_per_date_panel(
     data: pl.DataFrame,
     metric: MetricBase,
@@ -148,13 +188,7 @@ def _build_per_date_panel(
             how="inner",
         )
     if aligned.height < 2:
-        raise ValueError(
-            f"{func_name}: <2 aligned dates across slices ({aligned.height}); "
-            f"joint HAC inference requires aligned rows. These tests are "
-            f"cross-sectional — slices must share ≥2 common dates. A "
-            f"date-disjoint partition (e.g. calendar regime) shares no dates "
-            f"and is not supported here."
-        )
+        raise ValueError(_too_few_aligned_dates_msg(func_name, slices, aligned.height))
     panel = aligned.drop("date").to_numpy()
     return labels, panel, aligned.height
 

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -151,10 +151,31 @@ def test_raises_when_dates_dont_align() -> None:
     df_b = build_labelled_raw_panel(
         n_dates=30, seed=13, signal={"b": 0.1}, label_col="regime"
     ).with_columns(pl.col("date") + pl.duration(days=100))
-    with pytest.raises(ValueError, match="aligned dates"):
+    # Genuinely date-disjoint slices share no raw dates: the message points
+    # at the slice_period_* path, not at a small-sample cause.
+    with pytest.raises(ValueError, match="date-disjoint partition") as exc:
         slice_pairwise_test(
             pl.concat([df_a, df_b]), ic(), by="regime", factor_col="factor"
         )
+    assert "slice_period_pairwise_test" in str(exc.value)
+
+
+def test_aligned_slices_but_metric_dropped_reports_small_sample() -> None:
+    """Date-aligned slices whose tiny cross-sections (N < MIN_IC_ASSETS) make
+    every per-date IC drop must blame the thin universe, not call the
+    partition date-disjoint."""
+    df = build_labelled_raw_panel(
+        n_dates=40,
+        seed=14,
+        signal={"a": 0.1, "b": 0.1},
+        label_col="universe",
+        n_assets=5,
+    )
+    with pytest.raises(ValueError, match="too few assets") as exc:
+        slice_pairwise_test(df, ic(), by="universe", factor_col="factor")
+    msg = str(exc.value)
+    assert "date-aligned" in msg
+    assert "date-disjoint" not in msg
 
 
 def test_overlap_bandwidth_inflates_variance() -> None:


### PR DESCRIPTION
## Summary
- `slice_pairwise_test` / `slice_joint_test` raised the same date-disjoint `ValueError` for two different `<2 aligned dates` failures: genuinely date-disjoint slices, and date-aligned slices whose per-date metric dropped most values (e.g. `ic` below `MIN_IC_ASSETS` on thin cross-sections). The latter wrongly told the user they passed a date-disjoint partition.
- Branch the message on the raw shared-date count (computed before the metric runs): `<2` shared raw dates keeps the date-disjoint guidance and points at `slice_period_*`; `>=2` reports the count and blames the thin per-slice universe.
- Doc note in `docs/api/slice-test.md` distinguishing the two causes.

## Test plan
- [x] New test: genuinely date-disjoint slices route to the date-disjoint branch and name `slice_period_pairwise_test`
- [x] New test: date-aligned slices with `n_assets=5` (< `MIN_IC_ASSETS`) route to the "too few assets" / "date-aligned" branch, no "date-disjoint" wording
- [x] Existing disjoint-date tests in pairwise/joint suites still pass
- [x] `ruff check`, `ruff format --check`, `mypy factrix` clean

Closes #670
