### PR TITLE
fix(directional)!: gate sample floor on pairs axis

### DIFF
--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -57,6 +57,15 @@ class WarningCode(StrEnum):
     # ``df = n - 1 < 19`` inflates t_crit relative to the asymptotic
     # cutoff. Below the HARD floor the primitive short-circuits to NaN.
     BORDERLINE_PORTFOLIO_PERIODS = "borderline_portfolio_periods"
+    # Fired by ``directional_hit_rate`` when the pooled non-overlapping
+    # (date, asset) directional observations sit in
+    # ``[MIN_DIRECTIONAL_PAIRS_HARD, MIN_DIRECTIONAL_PAIRS_WARN)`` — the
+    # Pesaran-Timmermann (1992) hit rate is returned but the normal
+    # approximation to S_n is power-thin below ~30 pooled pairs. Below the
+    # HARD floor the metric short-circuits to NaN instead. Named on the
+    # ``pairs`` axis token — the count is pooled (date, asset) trials, not
+    # periods.
+    FEW_DIRECTIONAL_PAIRS = "few_directional_pairs"
     # Fired when a rectangular-kernel HAC primitive (Hansen-Hodrick 1980)
     # produces a negative variance-of-mean estimate on short / mildly
     # anti-correlated samples. Unlike the Bartlett kernel, the rectangular
@@ -170,6 +179,12 @@ _WARNING_DESCRIPTIONS.update(
         "≤ n_periods < MIN_PORTFOLIO_PERIODS_WARN (3..19); one-sided t-test "
         "on the per-date diversification ratio is returned but df=n-1 inflates "
         "t_crit relative to the asymptotic cutoff.",
+        WarningCode.FEW_DIRECTIONAL_PAIRS: "directional_hit_rate with MIN_DIRECTIONAL_PAIRS_HARD "
+        "≤ n_pairs < MIN_DIRECTIONAL_PAIRS_WARN (10..29); the Pesaran-Timmermann "
+        "hit rate is returned but n counts pooled non-overlapping (date, asset) "
+        "directional trials, and the normal approximation to S_n is power-thin "
+        "below ~30 pooled pairs — read borderline p-values cautiously. Below the "
+        "HARD floor the metric short-circuits to NaN.",
         WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE: "Rectangular-kernel HAC variance-of-mean came out "
         "negative (no PSD guarantee, Andrews 1991); clamped to 0 → SE=0, t=0, p=1.0. "
         "Fires only on short / mildly anti-correlated samples.",

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -48,11 +48,24 @@ MIN_IC_ASSETS: int = 10
 
 # Minimum IC time-series length (periods axis) for a reliable mean / sign
 # test on the per-date IC series: the post-stride sample in ``ic()``, the
-# series-length floor in ``hit_rate`` / ``directional_hit_rate``, and the
-# raw-period base in the non-overlapping inference floor all key off this
-# "≥10 independent draws" rule. Distinct axis from
-# ``MIN_IC_ASSETS`` despite the shared value — do not collapse.
+# series-length floor in ``hit_rate``, and the raw-period base in the
+# non-overlapping inference floor all key off this "≥10 independent draws"
+# rule. Distinct axis from ``MIN_IC_ASSETS`` despite the shared value — do
+# not collapse.
 MIN_IC_PERIODS: int = 10
+
+# Two-tier guard for ``directional_hit_rate`` on its ``pairs`` axis — the
+# pooled non-overlapping (date, asset) directional trials the
+# Pesaran-Timmermann (1992) test treats as independent draws, NOT periods.
+# ``n < MIN_DIRECTIONAL_PAIRS_HARD`` short-circuits to NaN (below ~10 pooled
+# trials the PT variance estimate var_s = var(P̂) - var(P*) is numerically
+# fragile). ``HARD ≤ n < MIN_DIRECTIONAL_PAIRS_WARN`` returns the hit rate
+# with ``WarningCode.FEW_DIRECTIONAL_PAIRS`` — the normal approximation to
+# S_n is honest only near ~30 pooled trials (the same asymptotic-honesty
+# convention as ``MIN_EVENTS_WARN`` / ``MIN_ASSETS_WARN``). Pairs axis, own
+# literals — must not alias ``MIN_IC_PERIODS`` (periods axis).
+MIN_DIRECTIONAL_PAIRS_HARD: int = 10
+MIN_DIRECTIONAL_PAIRS_WARN: int = 30
 
 # Two-tier event-count guard for CAAR / Brown-Warner-family tests.
 # ``n < MIN_EVENTS_HARD`` short-circuits to NaN MetricResult (math floor —

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -34,32 +34,31 @@ from factrix._axis import (
     FactorDensity,
     InputShape,
 )
+from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._types import MIN_IC_PERIODS
+from factrix._types import MIN_DIRECTIONAL_PAIRS_HARD, MIN_DIRECTIONAL_PAIRS_WARN
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
     _sample_non_overlapping,
     _short_circuit_output,
+    _warn_below_floor,
 )
 
 __all__ = [
     "directional_hit_rate",
 ]
 
-# Minimum non-overlapping sign observations below which the PT normal
-# approximation is unreliable. Shares the IC series-length floor — both
-# gate a pooled-sign statistic on the same "≥10 independent draws" rule
-# of thumb (periods axis, not the per-date asset count).
-MIN_DIRECTIONAL_PERIODS: int = MIN_IC_PERIODS
-
 
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=None),
     aggregation=Aggregation.TS_ONLY,
     input_shape=InputShape.PANEL,
-    sample_threshold=SampleThreshold(min_periods=MIN_DIRECTIONAL_PERIODS),
+    sample_threshold=SampleThreshold(
+        min_pairs=MIN_DIRECTIONAL_PAIRS_HARD,
+        warn_pairs=MIN_DIRECTIONAL_PAIRS_WARN,
+    ),
 )
 def directional_hit_rate(
     df: pl.DataFrame,
@@ -117,6 +116,13 @@ def directional_hit_rate(
         all realisations one-signed, or a non-positive variance estimate)
         short-circuit: $P_*$ is then 1 and the statistic is undefined.
 
+        The sample floor is on the **pairs** axis — the $n$ pooled
+        ``(date, asset)`` directional trials, not the period count. Below
+        ``MIN_DIRECTIONAL_PAIRS_HARD`` the metric short-circuits; between
+        the HARD and ``MIN_DIRECTIONAL_PAIRS_WARN`` floors it returns the
+        hit rate but flags ``WarningCode.FEW_DIRECTIONAL_PAIRS`` because the
+        normal approximation to $S_n$ is power-thin on few pooled trials.
+
     References:
         Pesaran, M. H., & Timmermann, A. (1992). A simple nonparametric
         test of predictive performance. *Journal of Business & Economic
@@ -158,6 +164,7 @@ def directional_hit_rate(
         "directional_hit_rate",
         n,
         "insufficient_directional_samples",
+        axis="pairs",
     )
     if sc is not None:
         return sc
@@ -185,7 +192,7 @@ def directional_hit_rate(
             "directional_hit_rate",
             "degenerate_directional_variance",
             n_obs=n,
-            n_obs_axis="periods",
+            n_obs_axis="pairs",
             p_correct=p_correct,
             p_up_pred=p_x,
             p_up_real=p_y,
@@ -194,11 +201,27 @@ def directional_hit_rate(
     s_n = (p_correct - p_star) / np.sqrt(var_s)
     p = float(sp_stats.norm.sf(s_n))
 
+    warning_codes: list[str] = []
+    warn_code = _warn_below_floor(
+        directional_hit_rate,
+        n,
+        f"directional_hit_rate: n_pairs={n} below "
+        f"MIN_DIRECTIONAL_PAIRS_WARN={MIN_DIRECTIONAL_PAIRS_WARN}; the "
+        f"Pesaran-Timmermann hit rate is returned but n counts pooled "
+        f"non-overlapping (date, asset) directional trials, and the normal "
+        f"approximation to S_n is power-thin below ~30 pooled pairs. Read "
+        f"borderline p-values cautiously.",
+        WarningCode.FEW_DIRECTIONAL_PAIRS,
+        axis="pairs",
+    )
+    if warn_code is not None:
+        warning_codes.append(warn_code)
+
     return MetricResult(
         value=p_correct,
         p_value=p,
         n_obs=n,
-        n_obs_axis="periods",
+        n_obs_axis="pairs",
         stat=float(s_n),
         metadata={
             "stat_type": "z",
@@ -209,4 +232,5 @@ def directional_hit_rate(
             "p_up_pred": p_x,
             "p_up_real": p_y,
         },
+        warning_codes=tuple(warning_codes),
     )

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -8,10 +8,9 @@ from datetime import date, timedelta
 import numpy as np
 import polars as pl
 import pytest
-from factrix.metrics.directional_hit_rate import (
-    MIN_DIRECTIONAL_PERIODS,
-    directional_hit_rate,
-)
+from factrix._codes import WarningCode
+from factrix._types import MIN_DIRECTIONAL_PAIRS_HARD, MIN_DIRECTIONAL_PAIRS_WARN
+from factrix.metrics.directional_hit_rate import directional_hit_rate
 from factrix.metrics.hit_rate import hit_rate
 
 
@@ -112,12 +111,15 @@ class TestDivergenceFromHitRate:
 class TestShortCircuits:
     def test_insufficient_samples(self):
         rng = np.random.default_rng(5)
-        n = MIN_DIRECTIONAL_PERIODS - 1
+        n = MIN_DIRECTIONAL_PAIRS_HARD - 1
         x = rng.normal(size=n)
         y = rng.normal(size=n)
         result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
         assert math.isnan(result.value)
         assert result.metadata["reason"] == "insufficient_directional_samples"
+        # Short-circuit is labelled on the pairs axis (pooled (date, asset)
+        # directional trials), not periods.
+        assert result.n_obs_axis == "pairs"
 
     def test_degenerate_one_signed_predictor(self):
         rng = np.random.default_rng(6)
@@ -126,6 +128,7 @@ class TestShortCircuits:
         result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
         assert math.isnan(result.value)
         assert result.metadata["reason"] == "degenerate_directional_variance"
+        assert result.n_obs_axis == "pairs"
 
     def test_missing_return_column(self):
         rng = np.random.default_rng(7)
@@ -141,7 +144,53 @@ class TestShortCircuits:
         y = np.array([1.0] * 30 + [1.0] * 30 + [-1.0] * 30)
         result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
         assert result.n_obs == 60  # the 30 zero-factor rows dropped
+        assert result.n_obs_axis == "pairs"
         assert result.value == pytest.approx(1.0)
+
+
+class TestPairsAxisWarnTier:
+    def test_thin_pooled_sample_warns_but_returns(self):
+        # HARD <= n_pairs < WARN: the PT hit rate is still returned, but the
+        # normal approximation is power-thin, so the result carries
+        # FEW_DIRECTIONAL_PAIRS and a UserWarning fires.
+        rng = np.random.default_rng(11)
+        n = MIN_DIRECTIONAL_PAIRS_WARN - 5
+        assert MIN_DIRECTIONAL_PAIRS_HARD <= n < MIN_DIRECTIONAL_PAIRS_WARN
+        x = rng.normal(size=n)
+        y = 0.6 * x + rng.normal(size=n)
+        with pytest.warns(UserWarning, match="MIN_DIRECTIONAL_PAIRS_WARN"):
+            result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert not math.isnan(result.value)
+        assert result.n_obs == n
+        assert result.n_obs_axis == "pairs"
+        assert WarningCode.FEW_DIRECTIONAL_PAIRS.value in result.warning_codes
+
+    def test_ample_pooled_sample_no_warn(self):
+        # n_pairs >= WARN: clean tier, no FEW_DIRECTIONAL_PAIRS code.
+        rng = np.random.default_rng(12)
+        x = rng.normal(size=200)
+        y = 0.5 * x + rng.normal(size=200)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert WarningCode.FEW_DIRECTIONAL_PAIRS.value not in result.warning_codes
+
+    def test_wide_short_panel_clears_floor_on_pairs(self):
+        # n_periods (5) < HARD but pooled pairs (5 * 40 = 200) >> WARN: the
+        # metric computes a real result because the floor is on pairs, not
+        # periods.
+        rng = np.random.default_rng(13)
+        n_dates, n_assets = 5, 40
+        dates = [date(2020, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = {
+            "date": [d for d in dates for _ in range(n_assets)],
+            "asset_id": [f"A{a}" for _ in dates for a in range(n_assets)],
+            "factor": rng.normal(size=n_dates * n_assets),
+            "forward_return": rng.normal(size=n_dates * n_assets),
+        }
+        df = pl.DataFrame(rows)
+        result = directional_hit_rate(df, forward_periods=1)
+        assert not math.isnan(result.value)
+        assert result.n_obs == n_dates * n_assets
+        assert result.n_obs_axis == "pairs"
 
 
 class TestDispatch:

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -194,14 +194,28 @@ class TestDeclaredPeriodsFloorsVisible:
     pre-flight verdict.
     """
 
-    def test_directional_hit_rate_declares_min_periods(self):
-        from factrix.metrics.directional_hit_rate import (
-            MIN_DIRECTIONAL_PERIODS,
-            directional_hit_rate,
+    def test_directional_hit_rate_declares_pairs_floors(self):
+        from factrix._types import (
+            MIN_DIRECTIONAL_PAIRS_HARD,
+            MIN_DIRECTIONAL_PAIRS_WARN,
         )
+        from factrix.metrics.directional_hit_rate import directional_hit_rate
 
+        # directional_hit_rate gates on pooled (date, asset) directional
+        # trials, so its floor lives on the pairs axis — not periods.
         st = directional_hit_rate.spec().sample_threshold
-        assert st.min_periods == MIN_DIRECTIONAL_PERIODS
+        assert st.min_periods is None
+        assert st.min_pairs == MIN_DIRECTIONAL_PAIRS_HARD
+        assert st.warn_pairs == MIN_DIRECTIONAL_PAIRS_WARN
+
+    def test_directional_hit_rate_usable_on_wide_short_panel(self):
+        # n_periods (7) < MIN_DIRECTIONAL_PAIRS_HARD but n_pairs (7 * 40 = 280)
+        # clears the WARN floor — the pairs-axis pre-flight must not flag it
+        # UNUSABLE the way the old periods-axis floor did.
+        info = inspect_data(fx.datasets.make_cs_panel(n_assets=40, n_dates=7))
+        da = _by_name(info, "directional_hit_rate")
+        assert da.usable is True
+        assert da.warnings == []
 
     def test_top_concentration_declares_periods_floors(self):
         from factrix._types import (


### PR DESCRIPTION
## Summary
- Move `directional_hit_rate`'s sample floor to the **pairs** axis (pooled non-overlapping `(date, asset)` directional trials) — declaration, runtime gate, `n_obs_axis` label, and `inspect_data` pre-flight now all read pairs.
- Replace the periods-aliased `MIN_DIRECTIONAL_PERIODS` with own-literal `MIN_DIRECTIONAL_PAIRS_HARD = 10` / `MIN_DIRECTIONAL_PAIRS_WARN = 30`; drop `directional_hit_rate` from `MIN_IC_PERIODS`'s documented consumers.
- Add the standard two-tier guard: HARD keeps the short-circuit byte-identical, WARN returns the hit rate but flags new `WarningCode.FEW_DIRECTIONAL_PAIRS` (the PT normal approximation is power-thin on 10..30 pooled pairs).

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean
- [x] Full suite: 1428 passed, 4 skipped
- [x] New tests: wide-short panel clears the floor on pairs (no longer UNUSABLE); HARD ≤ n < WARN emits `FEW_DIRECTIONAL_PAIRS` and still returns a value; n < HARD still short-circuits `insufficient_directional_samples`; `n_obs_axis == "pairs"` on success + degenerate paths.

Closes #673
