### PR TITLE
docs(inference): document inference applicability and union policy

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -386,21 +386,12 @@ to keep the regime unambiguous.
 
 ### Inference selection (`inference=`)
 
-A selectable `inference=` is offered **only** to the series-mean family —
-metrics that average an overlapping per-date series and test `mean != 0`
-(`ic`, `quantile_spread`, `k_spread`), where non-overlap sub-sampling vs a
-HAC SE genuinely changes the standard error. Every other metric carries a
-fixed estimator dictated by its statistical shape (event-study
-Brown-Warner / standardized-AR; `fm_beta` Fama-MacBeth / Driscoll-Kraay;
-fixed-distribution `directional_hit_rate` / `hit_rate`; descriptive
-diagnostics), so it takes no `inference` knob — the absence is by design.
-
-The parameter is a **closed union** of curated members, never an open
-`Protocol` the caller implements: an unvetted SE estimator would silently
-emit invalid p-values, so extension is gated per metric family. The full
-rationale, plus why `HANSEN_HODRICK` is exported yet absent from the metric
-unions (polymorphic `ic` dispatch vs the `NeweyWest`-specific spread
-dispatch), lives in the `factrix.inference` module docstring as the SSOT.
+Only the series-mean family (`ic`, `quantile_spread`, `k_spread`) takes a
+selectable `inference=`; every other metric carries a fixed estimator by
+its statistical shape, so the absence of the knob is by design. The
+`factrix.inference` module docstring is the SSOT for the full rule — the
+per-family rationale, the closed-union policy, and why `HANSEN_HODRICK` is
+exported yet absent from the metric unions.
 
 ### `individual_continuous(IC)` — cross-section first
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -384,6 +384,24 @@ step with `(cross-section step)` or `(time-series step)` inline:
 Unqualified `per-event` is **not** used — always written as `per-event-date`
 to keep the regime unambiguous.
 
+### Inference selection (`inference=`)
+
+A selectable `inference=` is offered **only** to the series-mean family —
+metrics that average an overlapping per-date series and test `mean != 0`
+(`ic`, `quantile_spread`, `k_spread`), where non-overlap sub-sampling vs a
+HAC SE genuinely changes the standard error. Every other metric carries a
+fixed estimator dictated by its statistical shape (event-study
+Brown-Warner / standardized-AR; `fm_beta` Fama-MacBeth / Driscoll-Kraay;
+fixed-distribution `directional_hit_rate` / `hit_rate`; descriptive
+diagnostics), so it takes no `inference` knob — the absence is by design.
+
+The parameter is a **closed union** of curated members, never an open
+`Protocol` the caller implements: an unvetted SE estimator would silently
+emit invalid p-values, so extension is gated per metric family. The full
+rationale, plus why `HANSEN_HODRICK` is exported yet absent from the metric
+unions (polymorphic `ic` dispatch vs the `NeweyWest`-specific spread
+dispatch), lives in the `factrix.inference` module docstring as the SSOT.
+
 ### `individual_continuous(IC)` — cross-section first
 
 ```

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -34,8 +34,8 @@ design, not an omission:
 - **Fixed-distribution tests** (``directional_hit_rate`` is
   Pesaran-Timmermann, ``hit_rate`` is a binomial) — no SE to choose.
 - **Descriptive diagnostics** (``oos_decay``, ``concentration``,
-  ``trend`` = Theil-Sen, ``ts_asymmetry``, ``spanning``) — no single
-  headline H0, or an estimator-specific CI.
+  ``trend`` = Theil-Sen, ``ts_asymmetry``) — no single headline H0, or an
+  estimator-specific CI.
 
 Closed-union policy
 -------------------

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -12,6 +12,65 @@ This release scopes the namespace to the **series-mean** family
 keep their multivariate compute in ``factrix.slicing`` until they move
 onto the same ``metric(inference=...)`` path; they are deliberately not
 listed here to avoid re-creating a heterogeneous discovery surface.
+
+Which metrics expose ``inference=``
+-----------------------------------
+A selectable ``inference`` is offered **only** to the metrics whose
+headline test is "average an overlapping per-date series and test
+``mean != 0``" — currently ``ic``, ``quantile_spread`` and ``k_spread``.
+There the choice between non-overlap sub-sampling and a HAC SE genuinely
+changes the standard error, so it is the caller's to make.
+
+Every other metric carries a **fixed** estimator dictated by its own
+statistical shape, and so takes no ``inference`` knob — the absence is by
+design, not an omission:
+
+- **Event-study** (``caar``, ``corrado_rank``, ``event_quality.*``,
+  ``mfe_mae``, ``clustering_hhi``) — Brown-Warner / standardized-AR on the
+  event axis; a different inference family from the series-mean one.
+- **Cross-sectional regression aggregates** (``fm_beta`` family) —
+  Fama-MacBeth / Driscoll-Kraay SE built into the estimator.
+- **Per-asset time-series** (``ts_beta``) — its own SE.
+- **Fixed-distribution tests** (``directional_hit_rate`` is
+  Pesaran-Timmermann, ``hit_rate`` is a binomial) — no SE to choose.
+- **Descriptive diagnostics** (``oos_decay``, ``concentration``,
+  ``trend`` = Theil-Sen, ``ts_asymmetry``, ``spanning``) — no single
+  headline H0, or an estimator-specific CI.
+
+Closed-union policy
+-------------------
+The ``inference=`` parameter is typed as a **closed union** of named
+members (e.g. ``NonOverlapping | NeweyWest``), never an open ``Inference``
+``Protocol`` the caller can implement. This is deliberate for a statistics
+library: an unvetted user-supplied SE estimator (wrong-axis HAC,
+mis-calibrated bandwidth) would silently emit invalid p-values. Each
+curated member instead ships a calibrated ``min_input_periods`` and a
+vetted ``compute``. The ``Inference`` ``Protocol`` (``_base.py``) exists
+to constrain *member identity*, not to invite external implementations.
+The union grows only when a new member is validated **for that metric
+family** — extension is gated, not open.
+
+``HANSEN_HODRICK`` vs the metric unions
+---------------------------------------
+``HansenHodrick`` is a complete series-mean member (same ``compute``
+contract as the other two) and is exported for explicit / comparison use,
+but it is **not** in any metric's ``inference=`` union today, for two
+different reasons per dispatch style:
+
+- ``ic`` dispatches **polymorphically** (``inference.compute(...)`` /
+  ``inference.min_input_periods(...)``), so it could in principle accept
+  ``HANSEN_HODRICK`` — its union is narrower than its capability. The pair
+  is kept as the vetted default; ``NeweyWest`` (Bartlett kernel, PSD-
+  guaranteed) is the recommended HAC, while ``HansenHodrick``'s
+  rectangular kernel has no PSD guarantee (it can clamp a negative
+  variance — see ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``).
+- ``quantile_spread`` / ``k_spread`` dispatch through
+  ``_spread_significance_with_inference``, which hard-branches on
+  ``isinstance(inference, NeweyWest)`` for the HAC path. Any non-
+  ``NeweyWest`` member (including ``HansenHodrick``) would silently fall
+  into the non-overlap branch, so for these metrics the union is
+  **load-bearing**: it admits exactly what the dispatch handles. Widening
+  it requires making that dispatch polymorphic first.
 """
 
 from __future__ import annotations

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -148,6 +148,12 @@ class HansenHodrick:
     ([Andrews 1991][andrews-1991] §3): on short / mildly anti-correlated
     samples the estimate can come out negative; ``compute`` clamps the
     variance to 0 and surfaces ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``.
+
+    Exported for explicit / comparison use but **not** in any metric's
+    ``inference=`` union today: ``NeweyWest`` (Bartlett, PSD-guaranteed) is
+    the recommended HAC, and the spread-metric dispatch is ``NeweyWest``-
+    specific. See ``factrix.inference``'s module docstring for the full
+    rationale.
     """
 
     test: ClassVar[str] = "t"


### PR DESCRIPTION
## Summary
- Document the `inference=` applicability rule as SSOT in the `factrix.inference` module docstring: only the series-mean family (`ic` / `quantile_spread` / `k_spread`) gets a selectable inference; every other metric carries a fixed estimator by its statistical shape (event-study, FM, fixed-distribution, descriptive), so the absence of `inference=` is by design.
- Record the **closed-union policy** — curated members only, never an open `Protocol`, because an unvetted user SE would silently emit invalid p-values; extension is gated per metric family.
- Clarify `HANSEN_HODRICK`: exported as a complete series-mean member but absent from the metric unions — `ic` dispatches polymorphically (union merely narrow), while `quantile_spread` / `k_spread` branch on `isinstance(NeweyWest)` (union load-bearing).
- Cross-reference from `architecture.md` and the `HansenHodrick` docstring.

## Test plan
- [x] Docs-only; no public symbols added.
- [x] `tests/test_docs_pages.py` + `tests/test_docs_llms.py` pass (symbol references resolve).
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean.

Closes #676
