### PR TITLE
fix(evaluate): raise IncompatibleAxisError on structure mismatch

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -90,7 +90,7 @@ Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-fri
 
 The most common warnings include:
 
-- `UNRELIABLE_SE_SHORT_PERIODS` — $20 \le T < 30$; Newey-West (NW) HAC SE is unstable. (Note that $T < 20$ raises `InsufficientSampleError`).
+- `UNRELIABLE_SE_SHORT_PERIODS` — $20 \le T < 30$; Newey-West (NW) HAC SE is unstable. (Falling below the metric's hard sample floor raises `InsufficientSampleError` under `strict=True`; the exact floor is metric-specific).
 - `PERSISTENT_REGRESSOR` — factor augmented Dickey-Fuller (ADF) $p$-value > 0.10.
 - `EVENT_WINDOW_OVERLAP` — event windows overlap on the same asset.
 - `SERIAL_CORRELATION_DETECTED` — Ljung-Box $p$-value < 0.05 on residuals.

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -654,19 +654,13 @@ def _raise_structure_mismatch(
 ) -> None:
     """Raise the ``strict=True`` structure-mismatch error (first offender)."""
     label, (cell_structure, data_structure, n_assets) = next(iter(mismatches.items()))
-    raise UserInputError(
-        func_name="evaluate",
-        field="metrics",
-        value=label,
-        expected=(
-            f"metric {label!r} declares "
-            f"cell.structure={cell_structure.value!r} but data has "
-            f"structure={data_structure.value!r} (n_assets={n_assets}); "
-            f"call fx.inspect_data(data) to see metrics applicable "
-            f"to this data shape, or pass strict=False to keep mismatched "
-            f"metrics as NaN with warnings"
-        ),
-        docs_path=_DOCS_METRICS,
+    raise IncompatibleAxisError(
+        f"evaluate(): metric {label!r} declares "
+        f"cell.structure={cell_structure.value!r} but data has "
+        f"structure={data_structure.value!r} (n_assets={n_assets}); "
+        f"call fx.inspect_data(data) to see metrics applicable "
+        f"to this data shape, or pass strict=False to keep mismatched "
+        f"metrics as NaN with warnings"
     )
 
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -119,11 +119,13 @@ Continuous common factors fall back to timeseries when `n_assets == 1`.
 
 ```python
 import factrix as fx
+import polars as pl
 from factrix.preprocess import compute_forward_return
 from factrix.metrics import ts_beta
 
-# 1. Generate single-asset timeseries data
-raw = fx.datasets.make_cs_panel(n_assets=1, n_dates=200, seed=2024)
+# 1. Generate single-asset timeseries data (make_cs_panel requires n_assets>=2; filter after)
+raw = fx.datasets.make_cs_panel(n_assets=2, n_dates=200, seed=2024)
+raw = raw.filter(pl.col("asset_id") == raw["asset_id"].item(0))
 data = compute_forward_return(raw, forward_periods=5)
 
 # 2. Evaluate using timeseries beta metric

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -221,7 +221,7 @@ class TestStrictStructureSoftening:
         return panel.filter(pl.col("asset_id") == first)
 
     def test_strict_true_raises_on_structure_mismatch(self):
-        with pytest.raises(UserInputError, match="structure"):
+        with pytest.raises(fx.IncompatibleAxisError, match="structure"):
             fx.evaluate(
                 self._single_asset_panel(),
                 metrics={"ic": ic()},


### PR DESCRIPTION
## Summary
- `_raise_structure_mismatch` now raises `IncompatibleAxisError` instead of `UserInputError`, making the specific error type catchable by callers
- `_enforce_strict` intentionally stays `UserInputError` — it aggregates any inapplicable-metric reason (missing column, upstream skip, event count), not only sample-floor violations where `InsufficientSampleError` would apply
- Fixed `llms-full.txt` single-asset example: `make_cs_panel` requires `n_assets>=2`; generate two assets and filter to one with `.item(0)`
- Updated quickstart warning note to remove the hard-coded `T < 20` threshold (the floor is metric-specific)

## Test plan
- [ ] `test_strict_true_raises_on_structure_mismatch` asserts `IncompatibleAxisError`
- [ ] Full suite: 1428 passed, 4 skipped
- [ ] `ruff check`, `ruff format --check`, `mypy factrix` clean

Closes #677