### PR TITLE
docs(directional): explain why pairs floor is not stride-scaled

### DIFF
--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -159,6 +159,13 @@ def directional_hit_rate(
     )
 
     n = paired.height
+    # Pairs floor is NOT stride-scaled (unlike the periods-axis samplers that
+    # route through _enforce_scaled_floor): n here is the PT test's effective
+    # sample size and feeds var_s directly, and sampled_pairs cannot be derived
+    # from a param-only resolver — Σ assets-per-sampled-date drifts unboundedly
+    # from n_pairs/forward_periods on unbalanced panels. The full-panel
+    # pre-flight stays deliberately loose; this post-sampling count is the
+    # authoritative gate.
     sc = _enforce_min_floor(
         directional_hit_rate,
         "directional_hit_rate",


### PR DESCRIPTION
Annotates the pairs-axis sample gate in `directional_hit_rate` with the rationale for *not* folding it into the `forward_periods` stride-scaling that the periods-axis samplers use.

`n = paired.height` is the Pesaran-Timmermann test's effective sample size (it feeds `var_s` directly), and `sampled_pairs` cannot be derived from a param-only resolver — `Σ assets-per-sampled-date` drifts unboundedly from `n_pairs / forward_periods` on unbalanced panels. The full-panel pre-flight stays deliberately loose; the post-sampling count is the authoritative gate.

Comment-only; no behaviour change. Records the design decision at the spot where the divergence from `_enforce_scaled_floor` is visible.

Closes #681
