### PR TITLE
feat(multi_factor): report all missing expand_over keys at once

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -79,7 +79,7 @@ Every `UserInputError` carries structured attributes (see [Reading a `UserInputE
 | Message hint | Trigger | Fix |
 |---|---|---|
 | `unknown metrics='...'` | Typo or metric not applicable to the data | `inspect_data(data).usable` enumerates the metrics applicable to the data shape. See [`list_metrics`](metrics/index.md#factrix.list_metrics) for the full catalog. |
-| `unknown expand_over='...'` | Context key not present on every result in the family | All results in the family must carry the key in `.context`; check that the caller is populating it consistently. |
+| `invalid expand_over=[...]` | One or more `expand_over` context keys missing on some results | The message lists every `(factor, missing_key)` pair in one pass. All results in the family must carry the key in `.context`; populate it consistently, or drop the key from `expand_over`. |
 | `Expected: list[EvaluationResult], got ...` | Passing the wrong artifact type to a screening function | Screening (`bhy`, `partial_conjunction`, `bhy_hierarchical`) consumes `list[EvaluationResult]`. |
 
 ---

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -80,10 +80,12 @@ def _partition(
                 docs_path=f"api/{func_name}#expand_over",
             )
 
+    _check_context_keys(results, keys=keys, func_name=func_name)
+
     entries: list[_FamilyEntry] = []
     seen: dict[tuple[Any, ...], int] = {}
     for idx, result in enumerate(results):
-        values = _expand_over_values(result, keys=keys, func_name=func_name)
+        values = _expand_over_values(result, keys=keys)
         identifier = (result.factor, *values)
         if identifier in seen:
             raise UserInputError(
@@ -172,28 +174,68 @@ def _resolve_family(
     return _attach_p_values(partition, func_name=func_name, metric=metric)
 
 
+def _check_context_keys(
+    results: Sequence[EvaluationResult],
+    *,
+    keys: list[str],
+    func_name: str,
+) -> None:
+    """Raise once listing every ``(factor, missing_key)`` across the input.
+
+    Built-in slicing fields (``forward_periods``) are read off the result
+    and never missing; only ``context`` keys are checked. A single failed
+    result no longer short-circuits the whole screen — integrating results
+    from several sources surfaces all context gaps in one pass, matching
+    the aggregate-then-report idiom of ``evaluate``'s strict / column
+    guards. fail-loud is preserved: any gap still raises (silently
+    dropping a result would alter family composition and the FDR
+    denominator).
+    """
+    context_keys = [k for k in keys if k not in _BUILTIN_EXPAND_OVER_FIELDS]
+    if not context_keys:
+        return
+    missing = [
+        (result.factor, name)
+        for result in results
+        for name in context_keys
+        if name not in result.context
+    ]
+    if not missing:
+        return
+    missing_keys = sorted({k for _, k in missing})
+    available = sorted({k for result in results for k in result.context})
+    detail = "; ".join(f"factor={factor!r} missing {key!r}" for factor, key in missing)
+    raise UserInputError(
+        func_name=func_name,
+        field="expand_over",
+        value=missing_keys,
+        expected=(
+            f"expand_over key(s) {missing_keys!r} present in every result's "
+            f"context. Missing — {detail}. Stamp the key on every "
+            f"EvaluationResult.context, or drop it from expand_over. "
+            f"Context keys seen across the input: "
+            f"{available or ['<none>']!r}"
+        ),
+        docs_path=f"api/{func_name}#expand_over",
+    )
+
+
 def _expand_over_values(
     result: EvaluationResult,
     *,
     keys: list[str],
-    func_name: str,
 ) -> tuple[Any, ...]:
-    values: list[Any] = []
-    for name in keys:
-        if name in _BUILTIN_EXPAND_OVER_FIELDS:
-            values.append(getattr(result, name))
-            continue
-        if name not in result.context:
-            raise UserInputError(
-                func_name=func_name,
-                field="expand_over",
-                value=name,
-                candidates=sorted(result.context)
-                or ["<no context keys on this result>"],
-                docs_path=f"api/{func_name}#expand_over",
-            )
-        values.append(result.context[name])
-    return tuple(values)
+    """Read the ``expand_over`` value tuple off one result.
+
+    Presence of every context key is guaranteed by a prior
+    ``_check_context_keys`` sweep, so this reads without re-validating.
+    """
+    return tuple(
+        getattr(result, name)
+        if name in _BUILTIN_EXPAND_OVER_FIELDS
+        else result.context[name]
+        for name in keys
+    )
 
 
 def _resolve_p_value(

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -234,6 +234,35 @@ def test_missing_context_key_raises():
         bhy(results, metrics=["ic"], expand_over=("universe",))
 
 
+def test_missing_context_key_aggregates_all_offenders():
+    make_spec("ic")
+    results = [
+        make_result(factor="f1", p=0.01, metric="ic", context={"region": "US"}),
+        make_result(factor="f2", p=0.01, metric="ic", context={}),
+        make_result(factor="f3", p=0.01, metric="ic", context={"region": "EU"}),
+    ]
+    with pytest.raises(UserInputError) as excinfo:
+        bhy(results, metrics=["ic"], expand_over=("region",))
+    msg = str(excinfo.value)
+    # Only the two gaps are reported; the result that carries the key is absent.
+    assert "factor='f2' missing 'region'" in msg
+    assert "factor='f1'" not in msg
+    assert "factor='f3'" not in msg
+
+
+def test_missing_context_key_aggregates_multiple_keys():
+    make_spec("ic")
+    results = [
+        make_result(factor="f1", p=0.01, metric="ic", context={"region": "US"}),
+        make_result(factor="f2", p=0.01, metric="ic", context={"sector": "tech"}),
+    ]
+    with pytest.raises(UserInputError) as excinfo:
+        bhy(results, metrics=["ic"], expand_over=("region", "sector"))
+    msg = str(excinfo.value)
+    assert "factor='f1' missing 'sector'" in msg
+    assert "factor='f2' missing 'region'" in msg
+
+
 def test_adj_p_monotonic_within_bucket():
     make_spec("ic")
     p_values = [0.001, 0.01, 0.02, 0.5, 0.9]

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -88,3 +88,16 @@ def test_primary_must_be_list_of_str():
             metrics="ic",  # type: ignore[arg-type]
             group="family",
         )
+
+
+def test_missing_group_key_aggregates_all_offenders():
+    make_spec("ic")
+    results = [
+        make_result(
+            factor="mom_1", p=0.01, metric="ic", context={"family": "momentum"}
+        ),
+        make_result(factor="mom_2", p=0.01, metric="ic", context={}),
+    ]
+    with pytest.raises(UserInputError) as excinfo:
+        bhy_hierarchical(results, metrics=["ic"], group="family")
+    assert "factor='mom_2' missing 'family'" in str(excinfo.value)

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -116,3 +116,16 @@ def test_pc_heterogeneous_m_warns_in_lenient_mode():
         partial_conjunction(
             results, metrics=["ic"], min_pass=2, expand_over=("region",), q=0.5
         )
+
+
+def test_missing_context_key_aggregates_all_offenders():
+    make_spec("ic")
+    results = [
+        make_result(factor="alpha", p=0.01, metric="ic", context={"region": "US"}),
+        make_result(factor="alpha", p=0.01, metric="ic", context={}),
+    ]
+    with pytest.raises(UserInputError) as excinfo:
+        partial_conjunction(
+            results, metrics=["ic"], min_pass=2, expand_over=("region",)
+        )
+    assert "factor='alpha' missing 'region'" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Aggregate `expand_over` context-key validation: instead of raising on the first result missing a key, collect every `(factor, missing_key)` pair and raise once, so multi-source factor sets surface all gaps in a single pass.
- fail-loud is preserved — any missing key still raises (no silent drop, which would alter family composition and the FDR denominator). Behavior is shared by `bhy` / `partial_conjunction` / `bhy_hierarchical` through `_partition`.
- Sync the `docs/api/errors.md` error-table row to the new aggregated message.

## Test plan
- [x] `pytest` full suite: 1446 passed, 4 skipped
- [x] New tests cover multi-factor and multi-key aggregation across all three screening paths
- [x] `ruff check`, `ruff format --check`, `mypy factrix` clean

Closes #684
