### PR TITLE
docs(readme): fix single-asset fallback example metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,18 @@ print("survivors =", [r.factor for r in bhy_ic.survivors])
 **Single-asset (timeseries) fallback**
 
 ```python
-from factrix.metrics import ts_beta
+from factrix.metrics import directional_hit_rate
 
-# Automatically resolves structure axis to DataStructure.TIMESERIES when N == 1
+# A single-asset panel auto-resolves the structure axis to
+# DataStructure.TIMESERIES (N == 1); a structure-agnostic metric such as
+# directional_hit_rate runs unchanged through the same entry point.
 results = fx.evaluate(
     single_asset_data,
-    metrics={"ts_beta": ts_beta()},
+    metrics={"dir_hit": directional_hit_rate()},
     factor_cols=["macro_factor"],
     forward_periods=5,
 )
-print(results["macro_factor"].metrics["ts_beta"].value)
+print(results["macro_factor"].metrics["dir_hit"].value)
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

- The README "Single-asset (timeseries) fallback" snippet used `ts_beta`, which declares `cell.structure=PANEL` and therefore **rejects** `N==1` data — `evaluate` raises `IncompatibleAxisError` (strict) or returns NaN + `structure_mismatch` (non-strict). The example never ran.
- Swap in `directional_hit_rate` (cell `(*, DENSE, *)`, structure-agnostic, consumes `factor_col` + `forward_return`). It runs on a single-asset panel where the structure axis auto-resolves to `TIMESERIES`, so the snippet matches what `evaluate` actually does. Verified end-to-end under default `strict=True` (`value=0.4937`, `cell.structure=timeseries`).

## Out of scope (separate issue recommended)

While fixing this I found the single-asset `ts_beta` auto-route is documented in ~5 places (`docs/api/evaluate.md` "TIMESERIES auto-routing" card + link, `docs/api/metrics/common-continuous.md`, `docs/api/metrics/ts_beta.md` which references a `ts_beta_single_asset_fallback`), but that fallback **does not exist** in the codebase (absent from the metrics namespace, the registry, and source). Resolving that needs a decision — remove the claims everywhere, or implement the fallback — so it belongs in its own issue rather than this README fix.

## Test plan

- [x] README example runs under default `strict=True` on a synthetic single-asset panel.
- [x] `test_readme_quickstart.py`, `test_docs_pages.py`, `test_docs_llms.py` green.