### PR TITLE
docs: correct N==1 Common x Continuous behavior; drop dead ts_beta fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ bhy_ic = fdr_results["ic"]
 print("survivors =", [r.factor for r in bhy_ic.survivors])
 ```
 
-**Single-asset (timeseries) fallback**
+**Single-asset (timeseries) evaluation**
 
 ```python
 from factrix.metrics import directional_hit_rate

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -42,13 +42,17 @@ title: factrix.evaluate
     against broadcast macro factors. Return shape is identical across
     cells.
 
--   __TIMESERIES auto-routing__
+-   __TIMESERIES dispatch__
 
     ---
 
-    `Common × Continuous` with `N == 1` falls back to single-series
-    ordinary least squares (OLS) with Newey-West heteroskedasticity-and-autocorrelation-consistent (HAC) SE, so single-asset macro factors flow
-    through the same entry point without a parallel code path.
+    At `N == 1` there is no cross-section, so any `DENSE` metric whose
+    cell is `PANEL` — `Individual × Continuous` (`ic`, `fm`) **and**
+    `Common × Continuous` (`ts_beta`, `ts_quantile`, `ts_asymmetry`) —
+    raises `IncompatibleAxisError` (or NaN + `structure_mismatch` under
+    `strict=False`). Single-asset data runs through the same entry point
+    with `(*, SPARSE, *)` metrics and the scope-agnostic TIMESERIES
+    metrics (`hit_rate`, `oos_decay`, `ic_trend`, `directional_hit_rate`).
 
 </div>
 
@@ -182,8 +186,8 @@ derivation are automatically resolved at dispatch time.
 
     ---
 
-    The `N == 1` auto-routing rules and SE conventions for single-series
-    paths.
+    The `N == 1` dispatch rules and SE conventions for the per-asset
+    time-series stage.
 
     [reference/ts-mode-conventions →](../reference/ts-mode-conventions.md)
 

--- a/docs/api/metrics/common-continuous.md
+++ b/docs/api/metrics/common-continuous.md
@@ -17,11 +17,13 @@ betas.
 `ts_beta` carries the cross-asset significance test; `ts_quantile` and
 `ts_asymmetry` are descriptive profile diagnostics.
 
-At `N == 1` the cross-asset $t$ degenerates; factrix auto-routes to a
-TIMESERIES single-series test (null: $\beta = 0$, **not**
-$\mathbb{E}[\beta] = 0$). The statistic lands in the same
-`MetricResult.stat` field in both modes, but the null differs —
-`metadata["method"]` records which test ran.
+These metrics test the **cross-asset** distribution of per-asset
+$\beta_i$, so they need $N \ge 2$ assets. At `N == 1` there is no
+cross-section: the cell is `PANEL`, so `evaluate` raises
+`IncompatibleAxisError` (or returns NaN + `structure_mismatch` under
+`strict=False`) rather than running. For single-asset time-series
+questions use the scope-agnostic TIMESERIES metrics (`hit_rate`,
+`oos_decay`, `ic_trend`, `directional_hit_rate`) or `ic` on the series.
 
 The `Common × Sparse` cell swaps this continuous regressor for a
 `{0, R}` broadcast event dummy (`R` unrestricted; `{0, 1}` for a pure

--- a/docs/api/metrics/ts_asymmetry.md
+++ b/docs/api/metrics/ts_asymmetry.md
@@ -11,9 +11,9 @@ title: factrix.metrics.ts_asymmetry
 <hr>
 
 !!! info "Timeseries-mode conventions"
-    `FACTOR_ADF_P` persistence diagnostic, plain stage-1 SE rationale,
-    and the `forward_periods` vs `signal_horizon` bias framing apply
-    here as for the rest of the TS-mode family. See
+    Plain stage-1 SE rationale and the `forward_periods` vs
+    `signal_horizon` bias framing apply here as for the rest of the
+    Common × Continuous family. See
     [Timeseries-mode conventions](../../reference/ts-mode-conventions.md).
 
 ## Use cases
@@ -132,8 +132,8 @@ title: factrix.metrics.ts_asymmetry
 
     ---
 
-    `FACTOR_ADF_P`, plain stage-1 SE rationale, `forward_periods` vs
-    `signal_horizon` bias framing.
+    Plain stage-1 SE rationale, `forward_periods` vs `signal_horizon`
+    bias framing.
 
     [reference/ts-mode-conventions →](../../reference/ts-mode-conventions.md)
 

--- a/docs/api/metrics/ts_beta.md
+++ b/docs/api/metrics/ts_beta.md
@@ -16,8 +16,8 @@ title: factrix.metrics.ts_beta
 !!! info "Timeseries-mode conventions"
     Stage-1 per-asset ordinary least squares (OLS) uses **plain SE**, not heteroskedasticity-and-autocorrelation-consistent (HAC) — the dominant
     bias under a persistent predictor is Stambaugh coefficient bias,
-    which HAC does not address. `FACTOR_ADF_P` is emitted on the input
-    series; non-overlap resampling is **not** applied. See
+    which HAC does not address. Non-overlap resampling is **not**
+    applied (stage-1 runs on the full overlapping series). See
     [Timeseries-mode conventions](../../reference/ts-mode-conventions.md)
     for the full rationale.
 
@@ -76,7 +76,6 @@ title: factrix.metrics.ts_beta
 | Average explanatory power $\overline{R^2}$ across assets                | `mean_r_squared`                  |
 | Direction-agnostic sign agreement on per-asset $\beta$                  | `ts_beta_sign_consistency`        |
 | Rolling cross-asset mean $\beta$ series for trend / out-of-sample (OOS) pipes | `compute_rolling_mean_beta`       |
-| $N=1$ degenerate-case fallback used by Profile / Factor entry points    | `ts_beta_single_asset_fallback`   |
 
 ## Worked example — per-asset TS betas then cross-asset $t$
 

--- a/docs/api/metrics/ts_quantile.md
+++ b/docs/api/metrics/ts_quantile.md
@@ -11,9 +11,9 @@ title: factrix.metrics.ts_quantile
 <hr>
 
 !!! info "Timeseries-mode conventions"
-    `FACTOR_ADF_P` persistence diagnostic, plain stage-1 SE rationale,
-    and the `forward_periods` vs `signal_horizon` bias framing apply
-    here as for the rest of the TS-mode family. See
+    Plain stage-1 SE rationale and the `forward_periods` vs
+    `signal_horizon` bias framing apply here as for the rest of the
+    Common × Continuous family. See
     [Timeseries-mode conventions](../../reference/ts-mode-conventions.md).
 
 ## Use cases
@@ -131,8 +131,8 @@ title: factrix.metrics.ts_quantile
 
     ---
 
-    `FACTOR_ADF_P`, plain stage-1 SE rationale, `forward_periods` vs
-    `signal_horizon` bias framing.
+    Plain stage-1 SE rationale, `forward_periods` vs `signal_horizon`
+    bias framing.
 
     [reference/ts-mode-conventions →](../../reference/ts-mode-conventions.md)
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -469,11 +469,10 @@ Failure modes:
 
 - per-asset `n_periods < MIN_TS_OBS = 20` → asset dropped.
 - `n_assets < MIN_ASSETS_WARN = 30` → `WarningCode.FEW_ASSETS` (still runs; severity scales with `n_assets`).
-- `n_assets = 1` → degenerate cross-asset test → mode auto-routed to
-  TIMESERIES single-series β test (null: β = 0, **not** E[β] = 0). The
-  statistic lands in the same `MetricResult.stat` field across both
-  modes, so it carries different statistical meaning depending on
-  `profile.mode` (read `metadata["method"]` to tell them apart); see
+- `n_assets = 1` → no asset cross-section to aggregate the per-asset βs
+  over. The cell declares `cell.structure = PANEL`, so `evaluate` raises
+  `IncompatibleAxisError` under `strict=True` (NaN + `structure_mismatch`
+  under `strict=False`); there is no single-series β fallback. See
   §PANEL/TIMESERIES equivalence.
 
 ### `common_sparse` (PANEL) — time-series first
@@ -505,21 +504,17 @@ Failure modes:
   return correlation the standard t over-states significance — Petersen
   (2009) clustered SE deferred.
 
-### `common_continuous` (TIMESERIES, N=1) — time-series only
+### `common_continuous` at N=1 — not supported
 
-```
-single-asset OLS y_t = α + β·F_t + ε   (time-series step)
-                                     →  NW HAC t-test on β
-                                     +  ADF persistence diagnostic on F
-```
-
-The N=1 collapse of `common_continuous`. Null is `β = 0` for the single
-series, not `E[β] = 0` across assets — semantically distinct from the
-PANEL form.
-
-Failure modes:
-
-- ADF p > 0.10 → `WarningCode.PERSISTENT_REGRESSOR`.
+`common_continuous` metrics (`ts_beta`, `ts_quantile`, `ts_asymmetry`)
+test the **cross-asset** distribution of per-asset βs, so they require
+`N ≥ 2`. At `N = 1` the cell (`COMMON, DENSE, PANEL`) does not match the
+derived `TIMESERIES` structure, so `evaluate` raises
+`IncompatibleAxisError` (or NaN + `structure_mismatch` under
+`strict=False`). There is **no** single-series β collapse — for
+single-asset time-series inference use `ic(inference=fx.inference.NEWEY_WEST)`
+(Individual × Continuous) or the scope-agnostic TIMESERIES metrics
+(`hit_rate`, `oos_decay`, `ic_trend`, `directional_hit_rate`).
 
 ### `(*, SPARSE, *) × N=1` (TS dummy) — time-series only
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -60,4 +60,4 @@ An evaluation cell is defined by three orthogonal axes:
 | **FactorDensity** | `DENSE` / `SPARSE` | Is the signal a continuous numeric exposure, or a sparse event trigger (non-events are zero; event magnitude is a real number)? |
 | **DataStructure** | `PANEL` / `TIMESERIES` | Derived from the asset count at evaluate-time: `PANEL` for $N \ge 2$, and `TIMESERIES` for $N == 1$. |
 
-Any metric cell can run under either `DataStructure` — the dispatcher automatically routes to the correct statistical procedure. For example, evaluating a continuous macro factor on $N=1$ asset automatically falls back to a single-series time-series regression.
+A metric's cell declares which `DataStructure` it applies to. A `PANEL`-cell metric needs a cross-section, so on $N=1$ data — `Individual × Continuous` (`ic`, `fm`) or `Common × Continuous` (`ts_beta`) — `evaluate` raises `IncompatibleAxisError` (or returns NaN + `structure_mismatch` under `strict=False`). Single-asset data is served by `(*, SPARSE, *)` metrics and the scope-agnostic TIMESERIES metrics (`hit_rate`, `oos_decay`, `ic_trend`, `directional_hit_rate`), whose cells apply at `TIMESERIES`.

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -27,7 +27,7 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 |---|---|---|---|---|
 | `INDIVIDUAL` × `DENSE` (IC) | raises `UserInputError` or `IncompatibleAxisError` | all dates dropped (MIN_IC_ASSETS=10) → NaN | normal PANEL | normal PANEL |
 | `INDIVIDUAL` × `DENSE` (FM) | raises `UserInputError` or `IncompatibleAxisError` | per-date guard; low df | normal PANEL | normal PANEL |
-| `COMMON` × `DENSE` | TIMESERIES single-series β | emits `FEW_ASSETS` | emits `FEW_ASSETS` | normal PANEL |
+| `COMMON` × `DENSE` | raises `IncompatibleAxisError` (no cross-section) | emits `FEW_ASSETS` | emits `FEW_ASSETS` | normal PANEL |
 | `INDIVIDUAL` × `SPARSE` / `COMMON` × `SPARSE` | `_SCOPE_COLLAPSED` → TS dummy | normal PANEL CAAR | normal PANEL CAAR | normal PANEL CAAR |
 
 ## Sample-deficiency surfacing
@@ -40,4 +40,4 @@ The same insufficient-sample condition surfaces differently depending on `strict
 
 ## Aggregation order
 
-PANEL procedures split into **cross-section first** (`cs-first` — `individual` density metrics like IC / FM, sparse CAAR) and **time-series first** (`ts-first` — `common` density metrics). The order determines small-sample failure modes and the N=1 collapse behaviour: `common_continuous` at N=1 degenerates to a single-series β test (null: β=0, not E[β]=0), which is still well-defined; `individual_continuous` at N=1 has no cross-section to aggregate over, so it raises.
+PANEL procedures split into **cross-section first** (`cs-first` — `individual` density metrics like IC / FM, sparse CAAR) and **time-series first** (`ts-first` — `common` density metrics). The order determines small-sample failure modes. At N=1 both DENSE cells raise: `common_continuous` (`ts_beta`) has no asset cross-section to aggregate the per-asset βs over, and `individual_continuous` (IC / FM) has no cross-section to rank/regress within — both declare `cell.structure = PANEL`, so `evaluate` raises `IncompatibleAxisError`. Single-asset series are served instead by `(*, SPARSE, *)` metrics and the scope-agnostic TIMESERIES metrics.

--- a/docs/reference/ts-mode-conventions.md
+++ b/docs/reference/ts-mode-conventions.md
@@ -3,20 +3,22 @@ title: Timeseries-mode conventions
 ---
 
 !!! tip "Canonical reference"
-    For the `DataStructure.PANEL` vs `DataStructure.TIMESERIES` dispatch concept and sample-guard contract, see [Panel vs timeseries](../guides/panel-timeseries.md). For the statistical disciplines (heteroskedasticity-and-autocorrelation-consistent (HAC) SE, augmented Dickey-Fuller (ADF) / Stambaugh, non-overlap default) that the rules below build on, see [Statistical methods](statistical-methods.md). This page is the `DataStructure.TIMESERIES`-specific operational conventions table.
+    For the `DataStructure.PANEL` vs `DataStructure.TIMESERIES` dispatch concept and sample-guard contract, see [Panel vs timeseries](../guides/panel-timeseries.md). For the statistical disciplines (heteroskedasticity-and-autocorrelation-consistent (HAC) SE, augmented Dickey-Fuller (ADF) / Stambaugh, non-overlap default) that the rules below build on, see [Statistical methods](statistical-methods.md). This page documents the per-asset (stage-1) time-series conventions of the `Common × Continuous` metrics.
 
-`Common × Continuous` evaluations on a single time series (`ts_beta`,
-`ts_quantile`, `ts_asymmetry` and their variants) inherit four shared
-conventions that are not visible from the per-metric API page. Each
-metric page links here so the rationale is reachable without
-source-diving.
+`Common × Continuous` metrics (`ts_beta`, `ts_quantile`, `ts_asymmetry`
+and their variants) are **PANEL** metrics: they need `N ≥ 2` assets and
+raise `IncompatibleAxisError` at `N = 1` (there is no single-asset
+mode). This page documents the conventions that govern their **stage-1
+per-asset time-series regressions** — run inside `compute_ts_betas` —
+which are not visible from the per-metric API page. Each metric page
+links here so the rationale is reachable without source-diving.
 
 ## Plain SE in stage-1 per-asset ordinary least squares (OLS)
 
 `ts_beta` is a two-stage estimator: stage 1 is a per-asset OLS of
 `forward_return ~ factor`, stage 2 is the cross-asset distribution of
 the resulting β. **Stage 1 deliberately retains plain OLS SE rather
-than Newey-West (NW) / HAC** in TIMESERIES mode even when `forward_periods > 1`
+than Newey-West (NW) / HAC** even when `forward_periods > 1`
 introduces overlap.
 
 The rationale lives in
@@ -31,24 +33,14 @@ concern, prefer `ic(inference=fx.inference.NEWEY_WEST)` on the same series (Indi
 Continuous cell) where the HAC adjustment is the canonical
 inferential primitive.
 
-## `FACTOR_ADF_P` persistence diagnostic
+## No persistence diagnostic on this family
 
-Every TIMESERIES-mode procedure emits `FACTOR_ADF_P` on the input
-factor series (see `_procedures.py`). A failed unit-root rejection
-(`FACTOR_ADF_P > 0.05`) does not short-circuit the metric — the slope
-is still returned — but the diagnostic surfaces on the profile and
-slope significance should be read with that caveat.
-
-Full derivation, threshold rationale, and interpolation accuracy live
-in
-[Statistical methods § Persistence diagnostics](statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors).
-The `FACTOR_ADF_P` persistence diagnostic on `EvaluationResult`
-maps to that section directly. The
-`unit_root_suspected=True` flag is `ic_trend` metadata only — the
-TIMESERIES-mode cells expose the raw `FACTOR_ADF_P` *p*-value and
-leave the threshold call to the caller.
-
-The diagnostic is on the *input* factor, not the regression residual.
+The `ts_beta` family emits **no** unit-root / ADF persistence
+diagnostic — the only ADF diagnostic in factrix is on `ic_trend`
+(`metadata["adf_p"]` / `unit_root_suspected`, see
+[Statistical methods § Persistence diagnostics](statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors)).
+The persistence *caveat* below still matters for interpreting the
+stage-1 slopes, but it is not surfaced automatically on these metrics.
 
 ## `forward_periods` vs `signal_horizon`: bias under mismatch
 [](){ #non-overlap-convention }
@@ -56,16 +48,16 @@ The diagnostic is on the *input* factor, not the regression residual.
 The mainstream `Individual × Continuous` metrics (`ic`, `caar`)
 use non-overlapping resampling as the inferential default
 ([Statistical methods § non-overlap default](statistical-methods.md#non-overlap-default)).
-TIMESERIES mode inverts this: the per-asset stage-1 regression runs
-on the **full** overlapping series — TIMESERIES lacks the
-cross-section axis to "burn" `h` periods of samples, so
+The `ts_beta` family inverts this: the per-asset stage-1 regression
+runs on the **full** overlapping series — a single asset's series
+lacks a cross-section axis to "burn" `h` periods of samples, so
 non-overlapping resampling at stage 1 would leave inadequate `T` for
 the per-asset OLS at typical horizons.
 
 When the dataset's `signal_horizon` differs from the
 `forward_periods` passed to `evaluate()`
 ([`datasets.md`](../api/datasets.md) frames the *decay* side of this),
-the realised TIMESERIES-mode signal is also **biased**, not only
+the realised stage-1 signal is also **biased**, not only
 decayed. Two distinct sources compound:
 
 - **Overlap structure**: `h ≠ signal_horizon` produces an MA(h−1)
@@ -74,7 +66,7 @@ decayed. Two distinct sources compound:
   this for HAC-using metrics; the plain-SE stage-1 in `ts_beta` does
   not.
 - **Stambaugh-style coefficient bias**: when the predictor is
-  persistent (the typical regime flagged by `FACTOR_ADF_P`),
+  persistent (a near-unit-root regressor),
   `forward_periods ≠ signal_horizon` shifts the OLS coefficient
   itself, not only its SE.
 
@@ -83,14 +75,3 @@ TIMESERIES-mode inference is calibrated; other horizons are
 exploratory and the reported *p*-values should be discounted
 accordingly. This is a **bias** caveat distinct from the IC-decay
 framing on the synthetic datasets page.
-
-## Single-series null
-
-TIMESERIES dispatch routes `Common × Continuous` to a single-asset β
-whose null is `H₀: β = 0` for the one series — **not** the PANEL null
-`H₀: E[β] = 0` over the cross-section. The two tests answer different
-questions and their *p*-values are not comparable.
-`describe_analysis_modes(format="text")` annotates the routing
-distinction inline ("`single-series test (null differs from PANEL)`")
-when listing the TIMESERIES side of a `Common × Continuous` cell, so
-callers comparing PANEL and TIMESERIES outputs do not assume parity.

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -27,8 +27,9 @@ data-generating process:
 - **Common factors** — a factor whose realisation is shared across
   the cross-section in a given period (Fama-French market / size /
   value, or a macro variable). factrix tests these as a panel
-  exposure, falling back to single-series β when only one asset is
-  available.
+  exposure across the asset cross-section ($N \ge 2$); a single asset
+  has no cross-section to aggregate over, so these metrics raise on
+  $N=1$ data.
 
 Each type also runs a multi-metric *diagnostic battery* — never
 collapsed into a single score. This is a deliberate design choice,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -115,29 +115,33 @@ print("Survivors:", [p.factor for p in ic_screen.survivors])
 
 ### 3. Single-asset timeseries evaluation
 
-Continuous common factors fall back to timeseries when `n_assets == 1`.
+A single-asset panel (`n_assets == 1`) resolves to `DataStructure.TIMESERIES`.
+`Common × Continuous` metrics (`ts_beta`, `ts_quantile_spread`, `ts_asymmetry`)
+are `PANEL` and need `N >= 2` — they raise `IncompatibleAxisError` at `N == 1`.
+Single-asset data is served by `(*, SPARSE, *)` metrics and the scope-agnostic
+TIMESERIES metrics (`hit_rate`, `oos_decay`, `ic_trend`, `directional_hit_rate`).
 
 ```python
 import factrix as fx
 import polars as pl
 from factrix.preprocess import compute_forward_return
-from factrix.metrics import ts_beta
+from factrix.metrics import directional_hit_rate
 
 # 1. Generate single-asset timeseries data (make_cs_panel requires n_assets>=2; filter after)
-raw = fx.datasets.make_cs_panel(n_assets=2, n_dates=200, seed=2024)
+raw = fx.datasets.make_cs_panel(n_assets=2, n_dates=300, seed=2024)
 raw = raw.filter(pl.col("asset_id") == raw["asset_id"].item(0))
 data = compute_forward_return(raw, forward_periods=5)
 
-# 2. Evaluate using timeseries beta metric
+# 2. Evaluate with a structure-agnostic metric that runs at N == 1
 results = fx.evaluate(
     data,
-    metrics={"ts_beta": ts_beta()},
+    metrics={"dir_hit": directional_hit_rate()},
     factor_cols=["factor"],
     forward_periods=5,
 )
 res = results["factor"]
 
-print("Timeseries Beta:", res.metrics["ts_beta"].value)
+print("Directional hit rate:", res.metrics["dir_hit"].value)
 ```
 
 ---

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -1,7 +1,7 @@
 """Long-side / short-side asymmetry test.
 
-Diagnostic for `(COMMON, DENSE, *)` and single-asset TIMESERIES
-cells. Ordinary least squares (OLS) β reports a single slope and assumes the response is
+Diagnostic for the `(COMMON, DENSE, PANEL)` cell (needs `N >= 2`
+assets; raises at `N == 1`). Ordinary least squares (OLS) β reports a single slope and assumes the response is
 symmetric around zero — `β > 0` could be "rises more on positive
 factor" *or* "falls less on negative factor", and a strategy team
 needs to know which.

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -53,55 +53,6 @@ _TSB_CELL = cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructur
 @metric(
     cell=_TSB_CELL,
     aggregation=Aggregation.TS_THEN_CS,
-    role=SpecRole.PIPELINE,
-)
-def compute_ts_beta_single_asset_fallback(ts_betas_df: pl.DataFrame) -> MetricResult:
-    r"""$N=1$ fallback: report the single-asset regression's own $t$-stat.
-
-    The cross-sectional $t$-test in ``ts_beta`` needs $N \geq 2$ assets.
-    With a single asset, both ``MacroCommonProfile.from_artifacts`` and
-    ``MacroCommonFactor.ts_beta`` want the same degenerate-case output:
-    take the row's per-asset beta + t_stat, mark ``p_value=1.0`` so the
-    row is suppressed from Benjamini-Hochberg-Yekutieli (BHY), and label the method. Centralizing here
-    keeps Profile and Factor paths bit-identical.
-
-    Statistical caveat: the returned $t$-stat tests the **time-series**
-    hypothesis $H_0: \beta_i = 0$ for this asset, which is **not** the
-    ``ts_beta`` cross-sectional hypothesis
-    $H_0: \mathrm{mean}(\beta) = 0$ across assets. The two are not
-    exchangeable — a single-asset $t$-stat of 2.5 says that asset's
-    $\beta$ differs from zero over time, it does not say the common
-    factor is priced. ``p_value=1.0`` enforces this by keeping the row
-    out of BHY adjudication.
-
-    Notes:
-        N=1 path: ``value = beta_1``, ``stat = t_1`` from the single
-        asset's TS ordinary least squares (OLS), ``p_value = 1.0`` so BHY skips the row. No
-        cross-asset inference is attempted.
-
-        factrix centralises the degenerate-case output here so
-        Profile / Factor paths produce bit-identical metadata —
-        otherwise each entry point would coerce the single-asset row
-        differently and the downstream inference surface would
-        diverge.
-    """
-    row = ts_betas_df.row(0, named=True)
-    return MetricResult(
-        p_value=1.0,
-        value=float(row["beta"]),
-        n_obs=1,
-        n_obs_axis="assets",
-        stat=float(row["t_stat"]),
-        metadata={
-            "n_assets": 1,
-            "method": "single-asset TS regression (no cross-asset test)",
-        },
-    )
-
-
-@metric(
-    cell=_TSB_CELL,
-    aggregation=Aggregation.TS_THEN_CS,
     input_shape=InputShape.SERIES,
     requires={"ts_betas_df": compute_ts_betas},
     sample_threshold=SampleThreshold(min_assets=3),

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -1,7 +1,7 @@
 """Time-series quantile bucketing + monotonicity test.
 
-Diagnostic for `(COMMON, DENSE, *)` and single-asset TIMESERIES
-cells: bucket factor history into quantiles and check the conditional
+Diagnostic for the `(COMMON, DENSE, PANEL)` cell (needs `N >= 2`
+assets; raises at `N == 1`): bucket factor history into quantiles and check the conditional
 mean forward return per bucket. Catches U-shape / inverted-U /
 extreme-only signals that ordinary least squares (OLS) β assumes away (linear) and reports
 pass / fail on as a single slope.


### PR DESCRIPTION
## Summary

The docs claimed `Common × Continuous` metrics (`ts_beta`, `ts_quantile`, `ts_asymmetry`) "auto-route" / "fall back" to a single-series β test at `N == 1`. **That capability does not exist in the code.** These are `(COMMON, DENSE, PANEL)` cells, so at `N == 1` `evaluate` raises `IncompatibleAxisError` (or NaN + `structure_mismatch` under `strict=False`) — exactly like the Individual × Continuous metrics. Only `(*, SPARSE, *)` and the scope-agnostic TIMESERIES metrics (`hit_rate`, `oos_decay`, `ic_trend`, `directional_hit_rate`) run at `N == 1`. Verified empirically across all three metrics.

Changes:
- **Removed dead code** `compute_ts_beta_single_asset_fallback` (`role=PIPELINE`, never required/called, no tests, docstring referenced the removed `MacroCommonProfile`/`MacroCommonFactor` API).
- **Corrected the N==1 claim** across user docs (`evaluate.md`, `common-continuous.md`, `concepts.md`, `panel-timeseries.md`, `where-factrix-fits.md`, README), the architecture/design notes, and the `ts_quantile`/`ts_asymmetry` docstrings.
- **Fixed the `llms-full.txt` single-asset example** (SSOT), which imported `ts_beta` and raised; now uses `directional_hit_rate`.
- **Dropped stale symbols** in `ts-mode-conventions.md` + the `ts_*` metric pages: `FACTOR_ADF_P`, `_procedures.py`, `describe_analysis_modes` are all gone from the codebase. The only ADF persistence diagnostic is on `ic_trend`; the `ts_beta` family emits none.
- **Verified-true claims retained**: stage-1 per-asset OLS uses plain SE (`_ts_betas.py:136`) and runs on the full overlapping series (`_ts_betas.py:103-118`); only the inaccurate "TIMESERIES mode" framing was reworded to "per-asset stage-1 of the PANEL computation."

A verification subagent independently re-ran the N==1 behavior matrix, confirmed the stale symbols are absent, and swept the repo for residual claims.

## Test plan

- [x] `python -m pytest tests/ -q` → 1460 passed, 4 skipped (dead-code removal left the suite green).
- [x] `ruff check` / `ruff format --check` / `mypy factrix` clean.
- [x] `test_docs_pages` / `test_docs_llms` / `test_docs_matrix` / `test_readme_quickstart` / `test_ts_betas` green.
- [x] Re-verified empirically: `ts_beta`/`ts_quantile_spread`/`ts_asymmetry`/`ic` raise at N==1; `caar`/`directional_hit_rate` run.