### PR TITLE
docs(api): restore evaluate_horizons surfacing + clarify overview (slice_period, inference vs screening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ bhy_ic = fdr_results["ic"]
 print("survivors =", [r.factor for r in bhy_ic.survivors])
 ```
 
+**Multi-horizon sweep and BHY screening**
+
+```python
+results_sweep = fx.evaluate_horizons(
+    raw,  # raw panel — no forward_return attached
+    metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},
+    factor_cols=["factor"],
+    forward_periods=[1, 5, 10],
+)
+
+fdr_results = fx.multi_factor.bhy(
+    results_sweep,
+    metrics=["ic"],
+    expand_over=("forward_periods",),
+    q=0.05,
+)
+bhy_ic = fdr_results["ic"]
+print("survivors =", [(r.factor, r.forward_periods) for r in bhy_ic.survivors])
+```
+
 **Single-asset (timeseries) fallback**
 
 ```python

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,6 +12,7 @@ flowchart LR
 
     subgraph Compute
         EV[evaluate]
+        EVH[evaluate_horizons]
     end
 
     subgraph Screening["Screening (FDR)"]
@@ -35,6 +36,7 @@ flowchart LR
     end
 
     P ==> EV
+    P ==> EVH
     P -.-> BS
     P -.-> ST
     P -.-> ID
@@ -42,12 +44,15 @@ flowchart LR
     EV ==>|results| PC
     EV ==>|results| BHYH
     EV ==>|results| CMP
+    EVH ==>|results| BHY
+    EVH ==>|results| CMP
     BHY ==>|survivors| CMP
     PC ==>|survivors| CMP
     BHYH ==>|survivors| CMP
     LM -.->|metric names| EV
 
     click EV "evaluate/" "evaluate API"
+    click EVH "evaluate/#factrix.evaluate_horizons" "evaluate_horizons API"
     click BS "by-slice/" "by_slice API"
     click ST "slice-test/" "slice_pairwise_test / slice_joint_test API"
     click BHY "multi-factor/" "bhy API"
@@ -74,6 +79,7 @@ Click any node to jump to its API page.
 | Goal | Pipeline |
 |---|---|
 | Single-factor/multi-factor inference | `evaluate(data, metrics=...)` → `dict[str, EvaluationResult]` |
+| Multi-horizon sweep | `evaluate_horizons(data, metrics=..., forward_periods=[...])` → `list[EvaluationResult]` |
 | Slice exploration (single axis) | `by_slice(data, metric, by="...", factor_col="...")` → `dict[str, EvaluationResult]` |
 | Slice statistical test | `slice_pairwise_test(df, metric, by="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
 | Metric catalog discovery | `list_metrics()` → family-grouped `dict` of specs |
@@ -90,6 +96,7 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 | Page | Category | What it is | When to read |
 |---|---|---|---|
 | [`evaluate`](evaluate.md) | Compute | Single dispatch entry — runs the registered metrics on a panel and returns the evaluation results. | Running an analysis. |
+| [`evaluate_horizons`](evaluate.md#factrix.evaluate_horizons) | Compute | Sweep `evaluate` across several overlap horizons of one raw panel. | Multi-horizon analysis / sweeping. |
 | [`by_slice`](by-slice.md) | Descriptive view | Partition a panel on a column and run `evaluate` per slice; returns `dict[str, EvaluationResult]`. | Per-slice metric exploration. |
 | [`slice_pairwise_test` / `slice_joint_test`](slice-test.md) | Inference (no FDR) | Statistical tests over slice families (pairwise / omnibus). | Testing whether slice means differ. |
 | [`multi_factor`](multi-factor.md) | Screening (FDR) | Module-level overview of collection-level FDR functions. | Multi-factor FDR screening overview. |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,19 +10,19 @@ Reference for every public symbol exported from `factrix`.
 flowchart LR
     P[data]
 
-    subgraph Compute
+    subgraph PerFactor["Inference · per factor"]
         EV[evaluate]
         EVH[evaluate_horizons]
     end
 
-    subgraph Screening["Screening (FDR)"]
+    subgraph Screening["Screening · FDR across factors"]
         BHY[bhy]
         PC[partial_conjunction]
         BHYH[bhy_hierarchical]
     end
 
-    subgraph Inference["Inference (no FDR)"]
-        ST["slice_pairwise_test<br/>slice_joint_test"]
+    subgraph Slices["Inference · across slices (no FDR)"]
+        ST["slice_pairwise_test / slice_joint_test<br/>slice_period_pairwise_test / slice_period_joint_test"]
     end
 
     subgraph View["Descriptive view"]
@@ -54,7 +54,7 @@ flowchart LR
     click EV "evaluate/" "evaluate API"
     click EVH "evaluate/#factrix.evaluate_horizons" "evaluate_horizons API"
     click BS "by-slice/" "by_slice API"
-    click ST "slice-test/" "slice_pairwise_test / slice_joint_test API"
+    click ST "slice-test/" "slice tests — cross-sectional + period-disjoint API"
     click BHY "multi-factor/" "bhy API"
     click PC "partial-conjunction/" "partial_conjunction API"
     click BHYH "bhy-hierarchical/" "bhy_hierarchical API"
@@ -72,6 +72,12 @@ Click any node to jump to its API page.
     - `bhy` / `partial_conjunction` / `bhy_hierarchical` consume `evaluate` outputs as `list[EvaluationResult]` (via `list(results.values())`).
 - **Dashed `-.->` — suggested workflow.** The source is data-derived, but the target's signature differs in shape.
 
+**Inference vs screening** (the two test-bearing stages above):
+
+- **Inference** produces the primary statistical test — a *p*-value — for a **single** hypothesis. `evaluate` / `evaluate_horizons` do this **per factor** ("tests one factor"); the `slice_*_test` family does it **across slices** of one factor (sector, size, market regime). Neither corrects for testing more than one thing.
+- **Screening** is what you add when you test **many** factors at once: `bhy` / `partial_conjunction` / `bhy_hierarchical` take a `list[EvaluationResult]` and control the false-discovery rate across the family ("screens a thousand"). Screening consumes inference output; it does not re-run the test.
+- `by_slice` / `compare` are **descriptive** — they arrange or rank results into a view, without adding a test of their own.
+
 ---
 
 ## Typical patterns
@@ -81,7 +87,8 @@ Click any node to jump to its API page.
 | Single-factor/multi-factor inference | `evaluate(data, metrics=...)` → `dict[str, EvaluationResult]` |
 | Multi-horizon sweep | `evaluate_horizons(data, metrics=..., forward_periods=[...])` → `list[EvaluationResult]` |
 | Slice exploration (single axis) | `by_slice(data, metric, by="...", factor_col="...")` → `dict[str, EvaluationResult]` |
-| Slice statistical test | `slice_pairwise_test(df, metric, by="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
+| Slice statistical test (date-aligned) | `slice_pairwise_test(df, metric, by="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
+| Slice statistical test (date-disjoint) | `slice_period_pairwise_test(...)` or `slice_period_joint_test(...)` → pairwise / omnibus across regimes / calendar periods |
 | Metric catalog discovery | `list_metrics()` → family-grouped `dict` of specs |
 | Per-panel applicability | `inspect_data(data)` → `.usable` / `.degraded` / `.unusable` |
 | Multi-factor screening with FDR | `evaluate(...)` → `multi_factor.bhy(list(results.values()), metrics=[...])` |
@@ -95,10 +102,10 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 
 | Page | Category | What it is | When to read |
 |---|---|---|---|
-| [`evaluate`](evaluate.md) | Compute | Single dispatch entry — runs the registered metrics on a panel and returns the evaluation results. | Running an analysis. |
-| [`evaluate_horizons`](evaluate.md#factrix.evaluate_horizons) | Compute | Sweep `evaluate` across several overlap horizons of one raw panel. | Multi-horizon analysis / sweeping. |
+| [`evaluate`](evaluate.md) | Inference (per factor) | Single dispatch entry — runs the registered metrics on a panel and returns the evaluation results. | Running an analysis. |
+| [`evaluate_horizons`](evaluate.md#factrix.evaluate_horizons) | Inference (per factor) | Sweep `evaluate` across several overlap horizons of one raw panel. | Multi-horizon analysis / sweeping. |
 | [`by_slice`](by-slice.md) | Descriptive view | Partition a panel on a column and run `evaluate` per slice; returns `dict[str, EvaluationResult]`. | Per-slice metric exploration. |
-| [`slice_pairwise_test` / `slice_joint_test`](slice-test.md) | Inference (no FDR) | Statistical tests over slice families (pairwise / omnibus). | Testing whether slice means differ. |
+| [`slice_*_test` family](slice-test.md) | Inference (across slices) | `slice_pairwise_test` / `slice_joint_test` (date-aligned) and `slice_period_pairwise_test` / `slice_period_joint_test` (date-disjoint regimes): pairwise / omnibus tests over slice families. | Testing whether slice means differ. |
 | [`multi_factor`](multi-factor.md) | Screening (FDR) | Module-level overview of collection-level FDR functions. | Multi-factor FDR screening overview. |
 | [`bhy`](bhy.md) | Screening (FDR) | Benjamini-Hochberg-Yekutieli step-up FDR. | Screening candidate factors. |
 | [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction screening. | "Factor passes in ≥ k of m contexts." |

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -12,7 +12,7 @@
 - [Guides](https://awwesomeman.github.io/factrix/guides/): Panel vs timeseries, large-scale evaluation, custom metrics, choosing a metric
 - [API — inspect_data](https://awwesomeman.github.io/factrix/api/inspect-data/): pre-flight data inspection
 - [API — evaluate](https://awwesomeman.github.io/factrix/api/evaluate/): single-factor and multi-factor evaluation entry point
-- [API — Multi-horizon](https://awwesomeman.github.io/factrix/api/multi-horizon/): multi-horizon evaluation recipes using evaluate per horizon + bhy(expand_over=)
+- [API — Multi-horizon](https://awwesomeman.github.io/factrix/api/multi-horizon/): multi-horizon evaluation recipes using evaluate_horizons + bhy(expand_over=)
 - [API — EvaluationResult](https://awwesomeman.github.io/factrix/api/evaluation-result/): unified result schema, to_dict() / to_frame()
 - [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() / bhy_hierarchical() / partial_conjunction() — FDR-corrected screening
 - [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode enum


### PR DESCRIPTION
## Summary

Two related fixes to the API overview (`docs/api/index.md` + the README/llms surfacing).

**1. Restore lost `evaluate_horizons` surfacing (regression).** PR #689 was merged via a rebase request that GitHub resolved as a squash, and the third commit (`cc59b35`, "surface evaluate_horizons in README, API index, and llms.txt") was **dropped** — it never landed on `main`. This restores it by cherry-picking that commit: the README multi-horizon block, the `EVH` node + edges in the function-flow mermaid, and the `factrix/llms.txt` line.

**2. Clarify the overview (this PR's new work).**
- The function-flow mermaid omitted the date-disjoint slice tests (`slice_period_pairwise_test` / `slice_period_joint_test`) — added to the slice node, the Typical-patterns table, and the Entry-points table (they share `slice-test.md`).
- The `evaluate` block was labelled "Compute" while only the slice block said "Inference", which hid that `evaluate` *is* the per-factor inference entry. Relabelled the subgraphs along the inference/screening axis and added an **"Inference vs screening"** prose block: inference = a *p*-value for one hypothesis (per factor via `evaluate`, or across slices via the `slice_*_test` family); screening = FDR control across many factors (`bhy` family), consuming inference output; `by_slice`/`compare` are descriptive.

## Test plan

- [x] `test_docs_pages` / `test_docs_llms` / `test_readme_quickstart` green.
- [x] Mermaid sanity-checked: every edge endpoint is a defined node.

## Note
The dropped-commit regression came from `gh pr merge --rebase` resolving to a squash on #689. Worth preferring an explicit squash (and verifying landed commits) on future merges.