### PR TITLE
docs: correct stale DAG plan strings (requires=ic_df -> requires=compute_ic)

### DIFF
--- a/docs/examples/stock_factor_evaluation.md
+++ b/docs/examples/stock_factor_evaluation.md
@@ -115,6 +115,6 @@ Illustrative output:
     }
   },
   "warnings": [],
-  "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=ic_df"
+  "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=compute_ic"
 }
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -84,7 +84,7 @@ Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-fri
     }
   },
   "warnings": [],
-  "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=ic_df"
+  "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=compute_ic"
 }
 ```
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -59,8 +59,8 @@ print(results["factor"].plan)
 **Output:**
 ```text
 1. compute_ic [batchable]
-2. ic [per-factor] requires=ic_df
-3. ic_ir [per-factor] requires=ic_df
+2. ic [per-factor] requires=compute_ic
+3. ic_ir [per-factor] requires=compute_ic
 ```
 
 This output lets you verify that shared upstream producers (like `compute_ic`) are computed exactly once across all factors before downstream consumers run.


### PR DESCRIPTION
## Summary

The rendered `EvaluationResult.plan` string joins **producer node ids**, not consumer param names (`_dag.py:163`). Three hand-written examples predate that and showed the stale `requires=ic_df`; the real output is `requires=compute_ic`. Verified by running each snippet.

- `docs/getting-started/quickstart.md:87`
- `docs/guides/observability.md:62-63`
- `docs/examples/stock_factor_evaluation.md:118`

Not touched: the `requires={"ic_df": compute_ic}` **spec declarations** in `concepts.md` / `custom-metrics.md` — those are the param-name binding and remain correct.

## Test plan
- [x] Reproduced actual render: `requires=compute_ic`.
- [x] `test_docs_pages` green.