### PR TITLE
docs: strip issue-number refs and back-compat wording from source

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -823,7 +823,7 @@ The slicing subsystem is the worked example of the rule:
 | metric-specific `regime_<metric>` curated wrapper | **legacy metric-specific wrapper** (when describing removed surface area); for the current path, name `by_slice` + the inference function directly |
 | `EvaluationResult.to_frame()` renderer layer | **renderer** — result-side method; no separate tier implied |
 
-The rule is functional, not lexical — `dispatcher`, `function`, and `wrapper` are fine on their own when they describe what the function does. It is the **pairing** as a tier label (`dispatcher` vs `curated wrapper` as the two levels of the slicing system) that drifts; the same word as a behavioural noun is stable. Mention an issue number (`#176`) when the docstring needs to point at a specification, instead of `Layer-B (#176)` which encodes a label that will not survive.
+The rule is functional, not lexical — `dispatcher`, `function`, and `wrapper` are fine on their own when they describe what the function does. It is the **pairing** as a tier label (`dispatcher` vs `curated wrapper` as the two levels of the slicing system) that drifts; the same word as a behavioural noun is stable. Describe the specification by its content when a docstring needs to point at one, rather than `Layer-B (#176)` — the `Layer-B` tier label drifts, and an issue number does not belong in source either.
 
 #### Two-register convention: "verb" vs "function" / "entry point"
 

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -25,9 +25,7 @@ private primitives those façades and the procedure layer call into.
 - ``diagnostics`` — Residual diagnostics (Ljung-Box portmanteau).
 
 BHY multiple-testing lives in ``factrix.stats.multiple_testing``; it
-operates on *p-values* (profile-era) rather than the legacy
-``bhy_threshold(t_stats)`` helper that was removed in the profile
-migration.
+operates on *p-values*.
 
 All names re-exported below are private (leading underscore); callers
 use ``from factrix._stats import X`` and the symbol resolves regardless

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -151,7 +151,7 @@ def _spread_significance_with_inference(
        ``FEW_ASSETS`` tier code (never silent); a requested-but-overridden
        HAC is additionally flagged ``inference_overridden``.
     2. **Inference family (user-selected).** With an adequate cross-section
-       the requested member runs: ``NonOverlapping`` reproduces the legacy
+       the requested member runs: ``NonOverlapping`` reproduces the
        non-overlap t **bit-for-bit** (``_t_stat_from_array`` is the same
        ``_calc_t_stat`` formula on the same strided values, so the default
        stays byte-identical), while ``NeweyWest`` keeps the *full*

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -69,7 +69,7 @@ __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
 # event-count floor guards thin samples.
 _CAAR_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
-# Slice-test contract (#153 §5): CAAR is event-driven; the
+# Slice-test contract: CAAR is event-driven; the
 # cross-section is the event sample, not a bucketed asset universe,
 # so slice tests skip the `n_groups` downscale step. Minimum event
 # count for the cross-event t-test (FEW_EVENTS threshold)

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -67,7 +67,7 @@ _FM_CELL = cell(
     structure=DataStructure.PANEL,
 )
 
-# Slice-test contract (#153 §5): Fama-MacBeth runs a per-date
+# Slice-test contract: Fama-MacBeth runs a per-date
 # OLS regression on the cross-section, not a bucket sort, so slice
 # tests never need to downscale `n_groups`. Sample-size constraints
 # (T < HARD short-circuit, T < WARN warning) live in the procedure

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -57,7 +57,7 @@ _IC_CELL = cell(
     structure=DataStructure.PANEL,
 )
 
-# Slice-test contract (#153 §5): IC is per-date Spearman rank
+# Slice-test contract: IC is per-date Spearman rank
 # correlation, not a bucketed metric — slice tests never need to
 # downscale `n_groups`. The min-cross-section-per-date constraint
 # (Spearman ρ asymptotic distribution requires ≥ 30 obs per date,

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -47,7 +47,7 @@ __all__ = [
 ]
 
 
-# Slice-test contract (#153 §5): monotonicity buckets the
+# Slice-test contract: monotonicity buckets the
 # cross-section into `n_groups` (default 10) and computes Spearman ρ
 # across per-bucket means. Patton & Timmermann (2010) "Monotonicity
 # in Asset Returns" recommend ≥ 50 assets per bucket so the per-date


### PR DESCRIPTION
## Summary

Source comments / docstrings must not carry GitHub issue numbers or backward-compatibility narration (pre-1.0 prefers clean breaks).

- **Issue-number refs removed from source (4 files):** `(#153 §5)` dropped from the slice-test-contract comments in `fm_beta.py`, `ic.py`, `monotonicity.py`, `caar.py` — the comment already states the contract.
- **Back-compat wording removed (2 files):** `_helpers.py` ("reproduces the *legacy* non-overlap t" → "the non-overlap t") and `_stats/__init__.py` (dropped the "profile-era / *legacy* `bhy_threshold` ... removed in the profile migration" note — state current behavior only).
- **Fixed contradictory guidance:** `contributing.md` told docstrings to "mention an issue number (`#176`)" — now says describe the spec by content; an issue number does not belong in source.

## Out of scope (your call)

Issue numbers still appear in **dev-doc markdown** — chiefly `docs/development/architecture.md` (`#161`, `#147`, …) used as deliberate design-contract anchors, plus a few prose links (`where-factrix-fits.md`, `slice-test.md`). The no-issue-refs rule targets source/tests/docstrings, not `.md`, and stripping the architecture anchors loses traceability — left untouched pending a decision.

## Test plan
- [x] Source scan: zero residual issue refs / back-compat wording in `factrix/`.
- [x] `ruff` + `mypy` clean; `pytest` 1460 passed, 4 skipped.