### PR TITLE
docs: drop issue-number anchors from dev docs

### DIFF
--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -32,8 +32,7 @@ The two functions answer **different statistical questions**:
 | `slice_pairwise_test` | "Which pairs differ?" — K(K−1)/2 contrasts with family-internal multiple-testing correction | One row per pair: `(slice_a, slice_b, n_obs, stat, p_raw, p_adj)` |
 | `slice_joint_test` | "Do any slices differ at all?" — single omnibus Wald χ² | One row: `(n_obs, k_slices, df, stat, p)` |
 
-Both functions sit in the **View** class (per [#148](https://github.com/awwesomeman/factrix/issues/148)
-function classification): their headline output is a comparison test
+Both functions sit in the **View** class: their headline output is a comparison test
 result. They do **not** participate in Benjamini-Hochberg-Yekutieli (BHY) family expansion — adjusted
 p is a within-slice-family closure, not a cell-level discovery
 commitment.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -548,7 +548,7 @@ Multiple-testing functions (`bhy` today; `bhy_hierarchical` / `partial_conjuncti
 layer in `factrix/_family.py::_resolve_family`. Each function's procedure runs *after*
 the family-resolution invariants pass.
 
-### Two signature classes (#161)
+### Two signature classes
 
 The shared layer admits two function shapes — important to keep distinct so a
 resampling-based function cannot retroactively force a kwarg onto the closed-form
@@ -576,7 +576,7 @@ and `metric: str` (one resolved spec):
 4. Resolved `p_value` per entry: the p-value read from the specified `metric`.
 
 All three user-facing raises route through `factrix._errors.UserInputError`
-(#165) so fuzzy suggestions and docs links render uniformly.
+so fuzzy suggestions and docs links render uniformly.
 
 ### `expand_over` semantics
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -609,7 +609,7 @@ The project's style policy is split between two complementary but distinct conve
 
 NumPy-style underline sections (`Parameters\n----------`) and Sphinx field lists (`:param x:` / `:returns:`) are not parsed by the Google handler and render as plain prose under generic headings. Convert on sight.
 
-`Examples:` blocks are covered by `pytest --doctest-modules` (enabled in #314). Any sweep touching `Examples:` must keep them runnable; non-runnable illustrative code belongs in `.md` under the intent-layer policy below, not in docstrings.
+`Examples:` blocks are covered by `pytest --doctest-modules` in CI. Any sweep touching `Examples:` must keep them runnable; non-runnable illustrative code belongs in `.md` under the intent-layer policy below, not in docstrings.
 
 **Narrative subsection headings** (`Algorithm:`, `Formula:`, `Construction:`, `Aggregation:`, `Scale:`, `Steps:`, `Invariants:`, `Reported:`, etc.) are permitted as in-body prose subsection labels — they sit before the structured-section block, are griffe-rendered as generic colon-terminated headings rather than typed admonitions, and document the algorithm / math / pipeline structure that does not belong in `Notes:`. They are not part of the recognised structured-section set listed above and have no canonical ordering among themselves; place each where it best explains the docstring's flow. Reach for one only when the content is a self-contained explanatory block; otherwise keep it in body prose.
 
@@ -823,13 +823,13 @@ The slicing subsystem is the worked example of the rule:
 | metric-specific `regime_<metric>` curated wrapper | **legacy metric-specific wrapper** (when describing removed surface area); for the current path, name `by_slice` + the inference function directly |
 | `EvaluationResult.to_frame()` renderer layer | **renderer** — result-side method; no separate tier implied |
 
-The rule is functional, not lexical — `dispatcher`, `function`, and `wrapper` are fine on their own when they describe what the function does. It is the **pairing** as a tier label (`dispatcher` vs `curated wrapper` as the two levels of the slicing system) that drifts; the same word as a behavioural noun is stable. Describe the specification by its content when a docstring needs to point at one, rather than `Layer-B (#176)` — the `Layer-B` tier label drifts, and an issue number does not belong in source either.
+The rule is functional, not lexical — `dispatcher`, `function`, and `wrapper` are fine on their own when they describe what the function does. It is the **pairing** as a tier label (`dispatcher` vs `curated wrapper` as the two levels of the slicing system) that drifts; the same word as a behavioural noun is stable. Describe the specification by its content when a docstring needs to point at one, rather than `Layer-B (#NNN)` — the `Layer-B` tier label drifts, and an issue number does not belong in source either.
 
 #### Two-register convention: "verb" vs "function" / "entry point"
 
 User-facing surface uses **function** when referring to one specific callable, and **entry point** when referring to the set of public callables (the seven that appear in nav under "Entry points"). Design-issue bodies and RFC comments may keep **verb** as RFC vocabulary — that register is internal to design discussion and does not propagate to user docs. When sweeping prose from a design issue into a guide or docstring, translate `verb` → `function` (or rephrase to name the specific callable) as part of the move.
 
-User-facing surface covers `docs/**/*.md`, README, docstrings, CHANGELOG, **and the error contract** — the structured attributes on `UserInputError` (and any future user-facing exception) belong to the user-facing register. The failing-function slot is named `func_name`, not `verb`, on every error class users can catch and read. The 59 internal source-side raise sites may pass `verb=` as a kwarg until they are swept (tracked in #317); the rule is about what the user sees on the caught exception, not what internal source uses to populate it.
+User-facing surface covers `docs/**/*.md`, README, docstrings, CHANGELOG, **and the error contract** — the structured attributes on `UserInputError` (and any future user-facing exception) belong to the user-facing register. The failing-function slot is named `func_name`, not `verb`, on every error class users can catch and read. The 59 internal source-side raise sites may pass `verb=` as a kwarg until they are swept; the rule is about what the user sees on the caught exception, not what internal source uses to populate it.
 
 ---
 

--- a/docs/stylesheets/nav.css
+++ b/docs/stylesheets/nav.css
@@ -21,7 +21,7 @@
 /* Stronger active-page highlight than Material's default (text-tint only is
  * easy to miss on a long nav list). Scoped to the primary sidebar so the
  * secondary TOC (right-side, in-page headings) keeps a lighter treatment —
- * the filled-block style swallows the TOC item's text node (#360).
+ * the filled-block style swallows the TOC item's text node.
  */
 .md-nav--primary .md-nav__item--active > .md-nav__link--active,
 .md-nav--primary .md-nav__link--active {

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -162,10 +162,9 @@ fires.
 Six peers occupy the *factor-evaluation / hypothesis-test* space.
 Each subsection follows the same shape: positioning, where the peer
 wins, where factrix wins, and the user profile that should pick the
-peer instead. Code side-by-side snippets are tracked separately as
-[#143](https://github.com/awwesomeman/factrix/issues/143) and will
-land here once the migration examples are validated against the same
-input panel both ways.
+peer instead. Code side-by-side snippets are not included here yet;
+they will land once the migration examples are validated against the
+same input panel both ways.
 
 ### 4.1 alphalens-reloaded
 


### PR DESCRIPTION
## Summary

Carries the no-issue-numbers rule into the dev-doc markdown / CSS (option B from the prior discussion). Every reference was a heading-label suffix or redundant provenance — none deferred essential content to the issue, so nothing needed inlining.

- `architecture.md` — drop the `(#161)` heading suffix and the `(#165)` parenthetical.
- `contributing.md` — `(enabled in #314)` → `in CI`; drop `(tracked in #317)`; the negative teaching example now uses a `#NNN` placeholder instead of a live number.
- `slice-test.md` / `where-factrix-fits.md` — drop the `#148` / `#143` issue links; the surrounding prose already gives the reason.
- `nav.css` — drop the `(#360)` reference from the workaround comment.

Provenance stays in git history + PRs, not inline.

## Test plan
- [x] Repo-wide scan: zero real issue-number refs left in `docs/` / README / CSS (excluding the intentional `#NNN` placeholder and `docs/plans/` archive).
- [x] `test_docs_pages` / `test_docs_llms` green.