### PR TITLE
feat(metrics)!: enforce per-metric inference allowlist

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -70,6 +70,7 @@ from factrix._data_input import (
 from factrix._errors import (
     FactrixError,
     IncompatibleAxisError,
+    IncompatibleInferenceError,
     InsufficientSampleError,
     UserInputError,
 )
@@ -844,6 +845,7 @@ __all__ = [
     # Errors
     "FactrixError",
     "IncompatibleAxisError",
+    "IncompatibleInferenceError",
     "InsufficientSampleError",
     "UserInputError",
     # Result + dispatch

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -109,6 +109,40 @@ class IncompatibleAxisError(FactrixError):
     """
 
 
+class IncompatibleInferenceError(FactrixError):
+    """``inference=`` is not in the metric's applicable-inference allowlist.
+
+    Each metric that exposes ``inference=`` declares an
+    ``applicable_inference`` frozenset of the methods it actually
+    dispatches. Passing anything outside it — a valid ``Inference`` the
+    metric does not vet (e.g. ``HansenHodrick`` to ``ic``) or a non-
+    ``Inference`` object — raises here instead of silently running an
+    unintended test or falling back to the default.
+
+    Structured attributes carry the diagnostic so callers do not parse
+    the rendered message:
+
+    - ``func_name``: the calling metric name (no parens)
+    - ``value``: the value the caller passed as ``inference``
+    - ``applicable``: tuple of allowed inference names for that metric
+    """
+
+    def __init__(
+        self,
+        *,
+        func_name: str,
+        value: object,
+        applicable: Iterable[str],
+    ) -> None:
+        self.func_name = func_name
+        self.value = value
+        self.applicable: tuple[str, ...] = tuple(applicable)
+        super().__init__(
+            f"{func_name}(): inference={_truncate_repr(value)} is not applicable; "
+            f"choose one of {list(self.applicable)!r}"
+        )
+
+
 class InsufficientSampleError(FactrixError):
     """``T < MIN_PERIODS_HARD`` for a TIMESERIES procedure.
 

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -50,27 +50,37 @@ to constrain *member identity*, not to invite external implementations.
 The union grows only when a new member is validated **for that metric
 family** — extension is gated, not open.
 
-``HANSEN_HODRICK`` vs the metric unions
----------------------------------------
+Per-metric allowlist enforcement
+--------------------------------
+The closed union is a type annotation, not a runtime gate, so every
+``inference=``-bearing metric additionally declares a module-level
+``applicable_inference`` frozenset and validates against it on entry (via
+``_check_applicable_inference``). A method outside the set raises
+:class:`~factrix.IncompatibleInferenceError` listing the allowed members,
+rather than running an unintended test or silently falling back to the
+default. ``ic`` / ``quantile_spread`` / ``k_spread`` all allow
+``{NON_OVERLAPPING, NEWEY_WEST}``; ``resolve_applicable_inference`` reads
+the set back for discovery.
+
+``HANSEN_HODRICK`` vs the metric allowlists
+-------------------------------------------
 ``HansenHodrick`` is a complete series-mean member (same ``compute``
 contract as the other two) and is exported for explicit / comparison use,
-but it is **not** in any metric's ``inference=`` union today, for two
-different reasons per dispatch style:
+but it is **not** in any metric's ``applicable_inference`` today, for
+reasons that differ per dispatch style:
 
 - ``ic`` dispatches **polymorphically** (``inference.compute(...)`` /
-  ``inference.min_input_periods(...)``), so it could in principle accept
-  ``HANSEN_HODRICK`` — its union is narrower than its capability. The pair
-  is kept as the vetted default; ``NeweyWest`` (Bartlett kernel, PSD-
-  guaranteed) is the recommended HAC, while ``HansenHodrick``'s
-  rectangular kernel has no PSD guarantee (it can clamp a negative
-  variance — see ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``).
+  ``inference.min_input_periods(...)``), so it could in principle run
+  ``HANSEN_HODRICK`` — its allowlist is narrower than its capability. The
+  vetted pair is kept: ``NeweyWest`` (Bartlett kernel, PSD-guaranteed) is
+  the recommended HAC, while ``HansenHodrick``'s rectangular kernel has no
+  PSD guarantee (it can clamp a negative variance — see
+  ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``).
 - ``quantile_spread`` / ``k_spread`` dispatch through
   ``_spread_significance_with_inference``, which hard-branches on
-  ``isinstance(inference, NeweyWest)`` for the HAC path. Any non-
-  ``NeweyWest`` member (including ``HansenHodrick``) would silently fall
-  into the non-overlap branch, so for these metrics the union is
-  **load-bearing**: it admits exactly what the dispatch handles. Widening
-  it requires making that dispatch polymorphic first.
+  ``isinstance(inference, NeweyWest)`` for the HAC path. The allowlist is
+  **load-bearing** there: it admits exactly the two members that dispatch
+  handles, so widening it requires making that dispatch polymorphic first.
 """
 
 from __future__ import annotations

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -388,6 +388,7 @@ Dataclass for a single metric's output:
 
 All exceptions inherit from `FactrixError`:
 - `IncompatibleAxisError`: Invalid combination of axes.
+- `IncompatibleInferenceError`: `inference=` is outside the metric's `applicable_inference` allowlist.
 - `InsufficientSampleError`: Sample size too small for statistical validity.
 - `UnknownEstimatorError`: Lookup miss for estimators.
 - `UserInputError`: Wrong schema, bad names, or mismatched shapes.

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -40,6 +40,7 @@ import numpy as np
 import polars as pl
 
 from factrix._codes import WarningCode, cross_section_tier
+from factrix._errors import IncompatibleInferenceError
 
 if TYPE_CHECKING:
     from factrix.inference import NeweyWest, NonOverlapping
@@ -122,6 +123,30 @@ def _spread_significance(
     tier: WarningCode | None = cross_section_tier(n_assets)
     codes = (tier.value,) if tier is not None else ()
     return t, float(p_boot), "block-bootstrap CI", extra, codes
+
+
+def _check_applicable_inference(
+    inference: object,
+    applicable: frozenset[NonOverlapping | NeweyWest],
+    *,
+    func_name: str,
+) -> None:
+    """Reject an ``inference=`` outside the metric's allowlist.
+
+    Single chokepoint every ``inference=``-bearing metric calls before it
+    dispatches: membership is by value (the members are frozen
+    dataclasses), so it catches both a non-vetted ``Inference``
+    (``HansenHodrick``) and a non-``Inference`` object (a stray string)
+    without the metric body reaching an unintended ``compute`` or a silent
+    non-overlap fallback. Raises :class:`IncompatibleInferenceError`
+    listing the allowed methods.
+    """
+    if inference not in applicable:
+        raise IncompatibleInferenceError(
+            func_name=func_name,
+            value=inference,
+            applicable=sorted(type(member).__name__ for member in applicable),
+        )
 
 
 def _spread_significance_with_inference(

--- a/factrix/metrics/_metric_capabilities.py
+++ b/factrix/metrics/_metric_capabilities.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import polars as pl
+
+if TYPE_CHECKING:
+    from factrix.inference import NeweyWest, NonOverlapping
 
 
 class PerDateSeries(Protocol):
@@ -81,3 +84,23 @@ def resolve_min_assets_per_group(metric: Callable) -> int | None:
     """
     mod = sys.modules[metric.__module__]
     return getattr(mod, "min_assets_per_group", None)
+
+
+def resolve_applicable_inference(
+    metric: Callable,
+) -> frozenset[NonOverlapping | NeweyWest] | None:
+    """Look up the inference allowlist for ``metric``.
+
+    Returns the frozenset of inference methods the metric accepts at
+    ``inference=``, or ``None`` when the metric exposes no ``inference=``
+    knob (a singleton-inference metric). The allowlist is declared once per
+    module (``applicable_inference``), but a module may host both an
+    ``inference=``-bearing metric and a singleton-inference sibling
+    (``quantile_spread`` / ``quantile_spread_vw``) — so the result is gated
+    on the callable actually carrying an ``inference`` parameter, not just
+    on the module attribute existing.
+    """
+    if "inference" not in getattr(metric, "_param_names", ()):
+        return None
+    mod = sys.modules[metric.__module__]
+    return getattr(mod, "applicable_inference", None)

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -33,11 +33,12 @@ from factrix._types import (
     EPSILON,
     MIN_IC_PERIODS,
 )
-from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
+from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     TIE_RATIO_WARN_THRESHOLD,
+    _check_applicable_inference,
     _enforce_min_floor,
     _short_circuit_output,
     _surface_drop_stats,
@@ -66,6 +67,14 @@ _IC_CELL = cell(
 # via) this attribute.
 min_assets_per_group: int | None = None
 per_date_series = per_date_series_rename("ic")
+
+# Inference allowlist: ``ic`` dispatches an ``Inference.compute`` polymorphically,
+# so it *could* run any series-mean member, but the vetted pair is the
+# non-overlap t-test and the Bartlett-kernel Newey-West HAC. ``HansenHodrick``
+# (rectangular kernel, no PSD guarantee) is deliberately excluded.
+applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
+    {NON_OVERLAPPING, NEWEY_WEST}
+)
 
 
 def _median_tie_ratio(ic_df: pl.DataFrame) -> float:
@@ -192,6 +201,7 @@ def ic(
         >>> result.name == ""
         True
     """
+    _check_applicable_inference(inference, applicable_inference, func_name="ic")
     median_tie = _warn_if_high_ic_tie_ratio(ic_df, "ic")
     # Mean is order-invariant; the inference method owns date-ordering for
     # its stride / lag math.

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -37,9 +37,10 @@ from factrix._axis import (
 from factrix._metric_index import cell
 from factrix._results import MetricResult
 from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
-from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
+from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _check_applicable_inference,
     _enforce_scaled_floor,
     _sample_non_overlapping,
     _scaled_periods_threshold,
@@ -51,6 +52,14 @@ from factrix.metrics._helpers import (
 __all__ = [
     "k_spread",
 ]
+
+# Inference allowlist: like ``quantile_spread``, the spread dispatch handles
+# exactly the non-overlap t-test and the Newey-West HAC; anything else
+# (``HansenHodrick``, a non-``Inference`` object) is rejected rather than
+# silently reported as non-overlap.
+applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
+    {NON_OVERLAPPING, NEWEY_WEST}
+)
 
 
 def _build_k_spread_series(
@@ -180,6 +189,7 @@ def k_spread(
     """
     if k < 1:
         raise ValueError(f"k must be >= 1; got {k}")
+    _check_applicable_inference(inference, applicable_inference, func_name="k_spread")
     if return_col not in df.columns:
         return _short_circuit_output(
             "k_spread",

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -32,10 +32,11 @@ from factrix._types import (
     DDOF,
     MIN_PORTFOLIO_PERIODS_HARD,
 )
-from factrix.inference import NON_OVERLAPPING, NeweyWest, NonOverlapping
+from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
+    _check_applicable_inference,
     _compute_tie_ratio,
     _enforce_scaled_floor,
     _lag_within_asset,
@@ -69,6 +70,14 @@ _Q_CELL = cell(
 # periods. The resolver and the in-body :func:`_enforce_scaled_floor` gate share
 # ``MIN_PORTFOLIO_PERIODS_HARD`` + ``_scaled_min_periods``, so the floors agree.
 _PORTFOLIO_PERIODS_FLOOR = _scaled_periods_threshold(MIN_PORTFOLIO_PERIODS_HARD)
+
+# Inference allowlist: the spread dispatch hard-branches on ``NeweyWest`` for the
+# HAC path and runs the non-overlap t-test otherwise, so the union is the exact
+# set it handles. Anything else (``HansenHodrick``, a non-``Inference`` object)
+# is rejected rather than silently reported as non-overlap.
+applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
+    {NON_OVERLAPPING, NEWEY_WEST}
+)
 
 
 @metric(
@@ -144,6 +153,9 @@ def quantile_spread(
             "_precomputed_series keys must match factor_cols "
             f"(got {sorted(_precomputed_series)} vs {sorted(cols)})"
         )
+    _check_applicable_inference(
+        inference, applicable_inference, func_name="quantile_spread"
+    )
 
     # Sample once across all factors; bucketing tie_ratio is computed
     # on the sampled subset (what bucketing actually sees) rather than

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -294,6 +294,79 @@ class TestICInferenceWarningPropagation:
         assert len(result.warning_codes) == len(set(result.warning_codes))
 
 
+class TestICInferenceAllowlist:
+    """``ic`` validates ``inference=`` against ``applicable_inference`` and
+    rejects anything outside it — ``HansenHodrick`` (which would otherwise
+    run a non-vetted HAC) and non-``Inference`` objects (which would hit an
+    ``AttributeError`` on dispatch).
+    """
+
+    @staticmethod
+    def _ic_series(n: int) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)],
+                "ic": [0.05 + 0.01 * (i % 3) for i in range(n)],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_hansen_hodrick_raises_not_silently_runs(self):
+        import factrix as fx
+
+        with pytest.raises(fx.IncompatibleInferenceError) as exc:
+            ic(
+                self._ic_series(40),
+                forward_periods=1,
+                inference=fx.inference.HANSEN_HODRICK,
+            )
+        assert exc.value.func_name == "ic"
+        assert exc.value.applicable == ("NeweyWest", "NonOverlapping")
+        assert "HansenHodrick" in str(exc.value)
+
+    def test_non_inference_object_raises_cleanly(self):
+        import factrix as fx
+
+        with pytest.raises(fx.IncompatibleInferenceError):
+            ic(self._ic_series(40), forward_periods=1, inference="newey")
+
+    def test_allowlisted_members_pass(self):
+        import factrix as fx
+
+        for member in (fx.inference.NON_OVERLAPPING, fx.inference.NEWEY_WEST):
+            result = ic(self._ic_series(40), forward_periods=1, inference=member)
+            assert not math.isnan(result.value)
+
+
+class TestApplicableInferenceDiscovery:
+    """``resolve_applicable_inference`` surfaces a metric's allowlist, and
+    returns ``None`` for singleton-inference metrics — even when they share
+    a module with an ``inference=``-bearing sibling.
+    """
+
+    def test_inference_metrics_expose_allowlist(self):
+        from factrix.metrics._metric_capabilities import resolve_applicable_inference
+        from factrix.metrics.k_spread import k_spread
+        from factrix.metrics.quantile import quantile_spread
+
+        for m in (ic, quantile_spread, k_spread):
+            allow = resolve_applicable_inference(m)
+            assert allow is not None
+            assert sorted(type(x).__name__ for x in allow) == [
+                "NeweyWest",
+                "NonOverlapping",
+            ]
+
+    def test_singleton_inference_metric_returns_none(self):
+        from factrix.metrics._metric_capabilities import resolve_applicable_inference
+        from factrix.metrics.hit_rate import hit_rate
+        from factrix.metrics.quantile import quantile_spread_vw
+
+        # quantile_spread_vw shares its module with quantile_spread but has no
+        # inference= knob; hit_rate is in a module with no allowlist at all.
+        assert resolve_applicable_inference(quantile_spread_vw) is None
+        assert resolve_applicable_inference(hit_rate) is None
+
+
 class TestICDispatch:
     """``ic()`` delegates its significance test to ``NonOverlappingSample``.
 

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -260,6 +260,24 @@ class TestInference:
         assert nw.metadata["inference_overridden"] is True
         assert nw.metadata["inference_requested"] == "Newey-West HAC t-test"
 
+    def test_unapplicable_inference_raises_not_silent_fallback(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        with pytest.raises(fx.IncompatibleInferenceError) as exc:
+            k_spread(
+                panel, forward_periods=5, k=5, inference=fx.inference.HANSEN_HODRICK
+            )
+        assert exc.value.func_name == "k_spread"
+        assert exc.value.applicable == ("NeweyWest", "NonOverlapping")
+
+    def test_non_inference_object_raises(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        with pytest.raises(fx.IncompatibleInferenceError):
+            k_spread(panel, forward_periods=5, k=5, inference="newey")
+
 
 class TestDispatch:
     def test_runs_via_evaluate(self):

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -220,3 +220,25 @@ class TestQuantileSpreadInference:
         assert nw.metadata["method"] == "block-bootstrap CI"
         assert nw.metadata["inference_overridden"] is True
         assert nw.metadata["inference_requested"] == "Newey-West HAC t-test"
+
+    def test_unapplicable_inference_raises_not_silent_fallback(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        # HansenHodrick used to be silently swallowed -> non-overlap t-test.
+        with pytest.raises(fx.IncompatibleInferenceError) as exc:
+            quantile_spread(
+                panel,
+                forward_periods=5,
+                n_groups=5,
+                inference=fx.inference.HANSEN_HODRICK,
+            )
+        assert exc.value.func_name == "quantile_spread"
+        assert exc.value.applicable == ("NeweyWest", "NonOverlapping")
+
+    def test_non_inference_object_raises(self):
+        import factrix as fx
+
+        panel = self._ample_panel()
+        with pytest.raises(fx.IncompatibleInferenceError):
+            quantile_spread(panel, forward_periods=5, n_groups=5, inference="newey")


### PR DESCRIPTION
## Summary

The three metrics exposing `inference=` (`ic`, `quantile_spread`, `k_spread`) typed the method as a closed union but never enforced it at runtime, so a method outside the intended set behaved inconsistently and silently:

- `ic(inference=HANSEN_HODRICK)` actually ran Hansen-Hodrick HAC (polymorphic `compute` dispatch).
- `quantile_spread` / `k_spread` swallowed any non-`NeweyWest` method into the non-overlap path with no flag.
- A non-`Inference` object (e.g. a string) hit an `AttributeError` deep in dispatch.

This adds one consistent validation surface:

- `IncompatibleInferenceError` (`factrix._errors`, exported as `fx.IncompatibleInferenceError`); message lists the metric's allowed set.
- Per-metric module-level `applicable_inference = {NON_OVERLAPPING, NEWEY_WEST}`, validated on entry via a single shared `_check_applicable_inference` chokepoint.
- `resolve_applicable_inference` for discovery, gated on the callable carrying an `inference` parameter so the singleton-inference sibling `quantile_spread_vw` correctly reports none.
- `HansenHodrick` stays excluded from all three allowlists (per the original design); the `factrix.inference` SSOT docstring is rewritten to describe the allowlist rather than the old silent-fallback rationale.

The legitimate, data-driven small-cross-section bootstrap override (`FEW_ASSETS` / `inference_overridden`) is unchanged — only the unidentified-inference path is removed.

Per the epic-deferral convention (#575 tracks #558 follow-ups), no CHANGELOG prose is added here; the only doc touch is the mandatory `llms-full.txt` public-symbol entry.

## Test plan

- New per-metric tests: `HansenHodrick` raises, non-`Inference` raises, allowlisted members pass (`test_ic.py`, `test_quantile.py`, `test_k_spread.py`).
- New discovery tests: allowlist readable for the three metrics; `None` for `quantile_spread_vw` / `hit_rate`.
- Full suite green (1469 passed, 4 skipped); `ruff check`, `ruff format --check`, `mypy factrix` clean.

Closes #696
