### PR TITLE
fix(adapt): map ±inf to null under fill_forward, document pipeline entry

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -40,6 +40,35 @@ See [Concepts](concepts.md) for what each axis means.
 
 ---
 
+## Bringing your own data
+
+The smoke test uses synthetic data that already carries factrix's
+canonical column names (`date`, `asset_id`, `price`). Real-world panels
+rarely do, so `adapt` is the **first** step of the pipeline — it renames
+your columns to the canonical names (and optionally cleans non-finite
+values), *before* `compute_forward_return`:
+
+```python
+import factrix as fx
+from factrix.adapt import adapt
+from factrix.preprocess import compute_forward_return
+
+raw = adapt(
+    your_df,
+    date="trade_date", asset_id="ticker", price="close_adj",
+    fill_forward=True,   # map NaN/±inf → null, then forward-fill per asset
+)
+data = compute_forward_return(raw, forward_periods=5)
+results = fx.evaluate(data, metrics={"ic": fx.metrics.ic()}, factor_cols=["factor"])
+```
+
+So the full pipeline is **`adapt` → `compute_forward_return` →
+`evaluate`**. `fill_forward` is opt-in: leave it `False` (default) if
+your panel is already clean, or set it `True` for raw OHLCV that may
+contain sporadic missing or non-finite values.
+
+---
+
 ## Research question → metric mapping
 
 In `factrix`, rather than constructing a central config object, you pass metric instances imported from `factrix.metrics` directly to the `metrics` parameter of `fx.evaluate()`.

--- a/factrix/adapt.py
+++ b/factrix/adapt.py
@@ -14,7 +14,7 @@ factrix does not prescribe names for those.
 
 Usage::
 
-    from factrix import adapt
+    from factrix.adapt import adapt
 
     # Minimal: just price panel
     raw = adapt(df, date="date", asset_id="ticker", price="close_adj")
@@ -93,9 +93,12 @@ def adapt(
             ``generate_intraday_range``.
         volume: User's volume column name. Renamed to ``volume``.
             Required by ``generate_amihud`` / ``generate_volume_price_trend``.
-        fill_forward: If True, replace NaN with null then forward-fill
-            all numeric columns per asset.  Useful for raw OHLCV data
-            that may contain sporadic missing values.
+        fill_forward: If True, map every non-finite value (NaN and
+            ±inf) to null, then forward-fill all numeric columns per
+            asset. Useful for raw OHLCV data that may contain sporadic
+            missing or non-finite values. Mapping ±inf is deliberate:
+            inf is not null, so it would otherwise survive the tail
+            drop in ``compute_forward_return`` and leak into return math.
 
     Returns:
         Same polars type as input (``pl.DataFrame`` → ``pl.DataFrame``,
@@ -146,9 +149,15 @@ def adapt(
         df = df.with_columns(pl.col("date").cast(pl.Datetime("ms")))
 
     if fill_forward:
+        # Map every non-finite value (NaN and ±inf) to null in one pass, then
+        # forward-fill per asset. fill_nan alone leaves ±inf untouched, and inf
+        # survives the downstream is_not_null() drop in compute_forward_return,
+        # leaking into return math (e.g. a zero entry price yields inf return).
         df = (
             df.sort(["asset_id", "date"])
-            .with_columns(cs.numeric().fill_nan(None))
+            .with_columns(
+                pl.when(cs.numeric().is_finite()).then(cs.numeric()).otherwise(None)
+            )
             .with_columns(cs.numeric().forward_fill().over("asset_id"))
         )
 

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -167,6 +167,31 @@ class TestTypePreservation:
         assert isinstance(out, pl.LazyFrame)
         assert out.collect().height == 2
 
+    def test_fill_forward_maps_nan_and_inf_to_null_then_ffills(self):
+        raw = pl.DataFrame(
+            {
+                "trade_date": [
+                    datetime(2024, 1, 1),
+                    datetime(2024, 1, 2),
+                    datetime(2024, 1, 3),
+                    datetime(2024, 1, 4),
+                ],
+                "ticker": ["A", "A", "A", "A"],
+                "close_adj": [100.0, float("nan"), float("inf"), 103.0],
+            }
+        )
+        out = adapt(
+            raw,
+            date="trade_date",
+            asset_id="ticker",
+            price="close_adj",
+            fill_forward=True,
+        )
+        # nan (row 1) and inf (row 2) both become null, then forward-fill from
+        # the last finite value (100.0) carries through both gaps.
+        assert out["price"].to_list() == [100.0, 100.0, 100.0, 103.0]
+        assert out["price"].null_count() == 0
+
     def test_pandas_input_returns_dataframe(self):
         pd = pytest.importorskip("pandas")
         pdf = pd.DataFrame(


### PR DESCRIPTION
## What

- **inf gap in `adapt(fill_forward=True)`**: previously only `fill_nan(None)` ran, so `±inf` survived untouched. inf is not null, so it slipped past the `is_not_null()` tail drop in `compute_forward_return` and leaked into return math (e.g. a zero entry price → `inf` forward return). Now every non-finite value (NaN and ±inf) is mapped to null in one pass before the per-asset forward-fill, via `pl.when(cs.numeric().is_finite()).then(...).otherwise(None)`. Integer columns and existing nulls/dtypes are preserved.
- **Docs**: `adapt` was undocumented in every user-facing page — the quickstart jumped straight to already-canonical synthetic data. Added a "Bringing your own data" section positioning `adapt` as the first pipeline step: **`adapt` → `compute_forward_return` → `evaluate`**.
- **Import fix**: the module docstring (and the new doc example) used `from factrix import adapt`, which binds the *module* (the package does not re-export the function). Corrected to `from factrix.adapt import adapt`, matching the tests.

## Test

- New `test_fill_forward_maps_nan_and_inf_to_null_then_ffills` covering NaN + inf → null → forward-fill.
- Documented pipeline runs end-to-end on a renamed panel.
- `ruff check` / `ruff format --check` / `mypy factrix` (83 files) clean; `test_adapt.py` 14 passed.

## Note

Behavior change to `fill_forward=True` output when inputs contain `±inf` (pre-v1, shipped as a straight fix with no compat shim).