### PR TITLE
fix(metrics): correct null handling in IC, quantile buckets, tie-ratio

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -230,6 +230,18 @@ Silent-drop diagnostics emit a fixed per-axis metadata schema
 `dropped_<axis>`, `drop_rate`, `drop_rate_threshold` — the count keys carry the
 axis token, the rate keys are axis-neutral.
 
+**Effective-sample single source.** The count a metric *gates* on
+(`min_<axis>`), *reports* (`n_obs` / `n_<axis>`), and records in *drop-stats*
+must be the one the statistic is actually *estimated* on — the complete
+observations after pairwise null-drop, not the raw row count. `forward_return`
+is null-clean before it reaches a metric, but factor nulls are not dropped
+upstream and are normal in real research, so a cross-sectional reduction counts
+the **valid `(factor, return)` cross-section per date**: `compute_fm_betas`
+(`MIN_FM_ASSETS`) and `compute_ic` (`MIN_IC_ASSETS`) both gate on that
+pairwise-complete count, dropping a date with many names but a factor defined
+for few rather than leaking a high-variance estimate. Counting null-padded rows
+would let the gate, the report, and the estimate silently disagree.
+
 ### Backing constants
 
 `factrix/_stats/constants.py`:
@@ -246,8 +258,10 @@ axis token, the rate keys are axis-neutral.
 `factrix/_types.py` and the metric primitives keep the older per-metric thresholds used
 internally by the primitives that procedures wrap:
 
-- `MIN_IC_ASSETS = 10` — `compute_ic` drops dates with fewer than 10 assets;
-  at `n_assets` < 10 the IC procedure short-circuits to NaN because every date is dropped.
+- `MIN_IC_ASSETS = 10` — `compute_ic` drops dates with fewer than 10 complete
+  `(factor, return)` pairs (the participating cross-section the per-date Spearman
+  ρ is estimated on, mirroring `MIN_FM_ASSETS`); at fewer than 10 every date is
+  dropped and the IC procedure short-circuits to NaN.
 - `MIN_EVENTS_HARD = 4`, `MIN_EVENTS_WARN = 30` — two-tier sparse-cell
   event-count floor. `n < HARD` short-circuits the CAAR / event-quality
   primitives; `HARD ≤ n < WARN` emits `WarningCode.FEW_EVENTS`.

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -656,7 +656,11 @@ def _assign_quantile_groups(
     return (
         df.with_columns(
             rank_expr,
-            pl.len().over("date").alias("_n"),
+            # Denominator is the per-date *non-null* factor count, not the row
+            # count: a null factor gets a null rank (it never lands in a bucket),
+            # so counting it would shrink every quantile width and leave the top
+            # bucket unreachable (max rank / N < 1).
+            pl.col(factor_col).count().over("date").alias("_n"),
         )
         .with_columns(
             ((pl.col("_rank") - 1) * n_groups / pl.col("_n"))
@@ -688,10 +692,14 @@ def _assign_quantile_groups_batch(
         pl.col(f).rank(method=tie_policy).over("date").alias(f"_rank__{f}")  # type: ignore[arg-type]
         for f in factor_cols
     ]
-    n_per_date_expr = pl.len().over("date").alias("_n_per_date")
-    with_ranks = df.with_columns(*rank_exprs, n_per_date_expr)
+    # Per-date *non-null* count is per factor: each factor may null out a
+    # different set of assets, and a null-inclusive denominator would shrink the
+    # quantile widths and leave the top bucket unreachable (see
+    # :func:`_assign_quantile_groups`).
+    n_exprs = [pl.col(f).count().over("date").alias(f"_n__{f}") for f in factor_cols]
+    with_ranks = df.with_columns(*rank_exprs, *n_exprs)
     group_exprs = [
-        ((pl.col(f"_rank__{f}") - 1) * n_groups / pl.col("_n_per_date"))
+        ((pl.col(f"_rank__{f}") - 1) * n_groups / pl.col(f"_n__{f}"))
         .cast(pl.Int32)
         .clip(0, n_groups - 1)
         .alias(f"_group__{f}")

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -59,32 +59,61 @@ def compute_ic(
     if not cols:
         raise ValueError("factor_cols must be non-empty")
 
-    rank_exprs: list[pl.Expr] = [
-        pl.col(return_col).rank(method="average").over("date").alias("_rank_return"),
-        *[
-            pl.col(f).rank(method="average").over("date").alias(f"_rank__{f}")
-            for f in cols
-        ],
-    ]
-    agg_exprs: list[pl.Expr] = [pl.len().alias("n")]
+    # Spearman ρ must rank each factor and the return over the *pairwise-complete*
+    # (factor, return) set per date: a null in either column would otherwise shift
+    # the surviving assets' ranks in the other column (polars' ``pl.corr`` drops
+    # the null-paired rows only *after* ranking, so ranking the raw column first
+    # distorts the ρ). The return rank is therefore masked per factor — each
+    # factor has its own complete set — and collapses to the shared single rank
+    # when the panel is dense (the common DENSE case).
+    rank_exprs: list[pl.Expr] = []
     for f in cols:
-        agg_exprs.append(pl.corr(f"_rank__{f}", "_rank_return").alias(f"_ic__{f}"))
-        agg_exprs.append((1.0 - pl.col(f).n_unique() / pl.len()).alias(f"_tie__{f}"))
+        valid = pl.col(f).is_not_null() & pl.col(return_col).is_not_null()
+        rank_exprs.append(
+            pl.when(valid)
+            .then(pl.col(return_col))
+            .rank(method="average")
+            .over("date")
+            .alias(f"_rank_return__{f}")
+        )
+        rank_exprs.append(
+            pl.when(valid)
+            .then(pl.col(f))
+            .rank(method="average")
+            .over("date")
+            .alias(f"_rank__{f}")
+        )
+    # The effective cross-section is the per-date *valid-pair* count: the IC ρ is
+    # estimated on the complete (factor, return) names only, so that same count —
+    # not the raw row count — is what gates the date (``MIN_IC_ASSETS``) and
+    # denominates the tie ratio. Counting null-factor names would let a thin
+    # cross-section (e.g. a factor defined for 8 of 200 names) clear the floor and
+    # leak a high-variance IC into the series. The count is therefore per factor
+    # (each factor nulls out a different set); it collapses to the row count on a
+    # dense panel.
+    agg_exprs: list[pl.Expr] = []
+    for f in cols:
+        valid = pl.col(f).is_not_null() & pl.col(return_col).is_not_null()
+        agg_exprs.append(valid.sum().alias(f"_n__{f}"))
+        agg_exprs.append(
+            pl.corr(f"_rank__{f}", f"_rank_return__{f}").alias(f"_ic__{f}")
+        )
+        agg_exprs.append(
+            (1.0 - pl.col(f).filter(valid).n_unique() / valid.sum()).alias(f"_tie__{f}")
+        )
 
     # Collect the per-date frame *before* the cross-section filter so the
-    # pre-drop date count is observable; the filter is shared across factors
-    # (``n`` is per-date, not per-factor), so the drop stats are identical
-    # for every factor.
+    # pre-drop date count is observable. The floor is applied per factor on its
+    # own valid-pair count, so the drop stats are per factor, not shared.
     grouped = (
         df.lazy().with_columns(rank_exprs).group_by("date").agg(agg_exprs).sort("date")
     ).collect()
     n_periods_in = grouped.height
-    wide = grouped.filter(pl.col("n") >= MIN_IC_ASSETS)
     drop_reason = f"n_assets below MIN_IC_ASSETS ({MIN_IC_ASSETS})"
 
     return {
         f: _attach_drop_stats(
-            wide.select(
+            grouped.filter(pl.col(f"_n__{f}") >= MIN_IC_ASSETS).select(
                 pl.col("date"),
                 pl.col(f"_ic__{f}").alias("ic"),
                 pl.col(f"_tie__{f}").alias("tie_ratio"),

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -229,16 +229,31 @@ def monotonicity(
 def _compute_tie_ratios_batch(
     df: pl.DataFrame, factor_cols: list[str]
 ) -> dict[str, float]:
-    """Tie ratio (``1 - n_unique / n``) for many factors in one scan.
+    """Median-across-dates tie ratio (``1 - n_unique / n``) for many factors.
 
     The single-factor :func:`_compute_tie_ratio` runs a separate polars
-    aggregation per factor; this batches them into one ``select`` so
-    the sampled panel is scanned once for any number of factors.
+    aggregation per factor; this batches them into one ``group_by("date")`` so
+    the sampled panel is scanned once for any number of factors. The tie ratio
+    is **per date** then median-reduced — the same statistic the single-factor
+    helper returns. Computing it globally (``n_unique`` / ``len`` over the whole
+    frame) would conflate cross-sectional ties with values merely repeating
+    across dates, inflating the ratio toward 1 and tripping spurious
+    high-tie-ratio warnings on a continuous factor.
     """
     if not factor_cols:
         return {}
-    exprs = [
-        (1.0 - pl.col(f).n_unique() / pl.len()).alias(f"_tr__{f}") for f in factor_cols
-    ]
-    row = df.select(exprs).row(0, named=True)
-    return {f: float(row[f"_tr__{f}"]) for f in factor_cols}
+    per_date = df.group_by("date").agg(
+        pl.len().alias("_n"),
+        *[pl.col(f).n_unique().alias(f"_u__{f}") for f in factor_cols],
+    )
+    # ``median`` over the (possibly empty) per-date ratio yields ``None`` on an
+    # empty frame, which maps to ``nan`` below — the same empty-panel contract as
+    # the single-factor :func:`_compute_tie_ratio`, no separate guard needed.
+    medians = per_date.select(
+        (1.0 - pl.col(f"_u__{f}") / pl.col("_n")).median().alias(f"_tr__{f}")
+        for f in factor_cols
+    ).row(0, named=True)
+    return {
+        f: float("nan") if medians[f"_tr__{f}"] is None else float(medians[f"_tr__{f}"])
+        for f in factor_cols
+    }

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ import pytest
 from factrix.metrics._helpers import (
     TIE_RATIO_WARN_THRESHOLD,
     _assign_quantile_groups,
+    _assign_quantile_groups_batch,
     _compute_tie_ratio,
     _sample_event_spaced,
     _sample_non_overlapping,
@@ -151,6 +152,44 @@ class TestAssignQuantileGroups:
         assert len(groups) == 1, (
             f"average tie_policy should keep tied values in one bucket, got {groups}"
         )
+
+    def test_null_factor_does_not_dilute_top_bucket(self):
+        # 8 ranked assets + 2 null-factor assets. The denominator must be the
+        # per-date non-null count (8), not the row count (10); otherwise the max
+        # rank / N never reaches the top bucket and group n_groups-1 stays empty.
+        df = pl.DataFrame(
+            {
+                "date": pl.Series([datetime(2024, 1, 1)] * 10, dtype=pl.Datetime("ms")),
+                "asset_id": [f"a{i}" for i in range(10)],
+                "factor": [1.0, 2, 3, 4, 5, 6, 7, 8, None, None],
+            }
+        )
+        result = _assign_quantile_groups(df, n_groups=5)
+        non_null = result.drop_nulls("_group")
+        assert set(non_null["_group"].to_list()) == {0, 1, 2, 3, 4}
+        # null-factor rows fall in no bucket
+        assert result.filter(pl.col("factor").is_null())["_group"].null_count() == 2
+
+    def test_batch_null_factor_does_not_dilute_top_bucket(self):
+        # Batch path: each factor's denominator is its own non-null count, so a
+        # factor with nulls still reaches its top bucket independently.
+        df = pl.DataFrame(
+            {
+                "date": pl.Series([datetime(2024, 1, 1)] * 10, dtype=pl.Datetime("ms")),
+                "asset_id": [f"a{i}" for i in range(10)],
+                "f1": [1.0, 2, 3, 4, 5, 6, 7, 8, None, None],
+                "f2": [float(i) for i in range(10)],
+            }
+        )
+        result = _assign_quantile_groups_batch(df, ["f1", "f2"], n_groups=5)
+        assert set(result.drop_nulls("_group__f1")["_group__f1"].to_list()) == {
+            0,
+            1,
+            2,
+            3,
+            4,
+        }
+        assert set(result["_group__f2"].to_list()) == {0, 1, 2, 3, 4}
 
 
 class TestComputeTieRatio:

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -42,6 +42,72 @@ class TestComputeIC:
         result = compute_ic(df)["factor"]
         assert len(result) == 0
 
+    def test_gate_counts_valid_pairs_not_rows(self):
+        """The cross-section floor gates on the per-date *valid-pair* count, not
+        the raw row count: a date with many names but a factor defined for only a
+        few must be dropped (its IC is estimated on those few), and the tie_ratio
+        is denominated by the valid count.
+        """
+        n = 30
+        factor = [float(i) if i < 6 else None for i in range(n)]  # 6 valid < 10
+        df = pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1)] * n,
+                "asset_id": [f"A{i}" for i in range(n)],
+                "factor": factor,
+                "forward_return": [float(i) * 0.01 for i in range(n)],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        # 6 valid pairs < MIN_IC_ASSETS=10 → the date is dropped even though 30 rows.
+        assert len(compute_ic(df)["factor"]) == 0
+
+    def test_tie_ratio_denominated_by_valid_pairs(self):
+        """tie_ratio uses the non-null factor count as denominator, so null
+        names neither inflate the denominator nor count as a tie category.
+        """
+        n = 16
+        # 12 valid names, 3 unique factor values → tie_ratio = 1 - 3/12 = 0.75.
+        valid_vals = [float(i % 3) for i in range(12)]
+        factor = valid_vals + [None] * 4
+        df = pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1)] * n,
+                "asset_id": [f"A{i}" for i in range(n)],
+                "factor": factor,
+                "forward_return": [float(i) * 0.01 for i in range(n)],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = compute_ic(df)["factor"]
+        assert result["tie_ratio"][0] == pytest.approx(0.75)
+
+    def test_null_return_does_not_distort_other_ranks(self):
+        """A null in one column must not shift the surviving assets' ranks in
+        the other: Spearman ρ is computed on the pairwise-complete set, so the
+        result matches scipy's spearmanr over the non-null pairs rather than
+        ranking the raw columns and dropping null pairs only afterward.
+        """
+        from scipy.stats import spearmanr
+
+        n = 12
+        factor = [float(i) for i in range(1, n + 1)]
+        ret = [0.5, -0.2, 0.9, 0.1, -0.4, None, 0.3, 0.95, -0.7, -1.2, -0.6, 0.04]
+        df = pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1)] * n,
+                "asset_id": [f"A{i}" for i in range(n)],
+                "factor": factor,
+                "forward_return": ret,
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        got = compute_ic(df)["factor"]["ic"][0]
+
+        f = np.array(factor)
+        r = np.array([np.nan if x is None else x for x in ret])
+        mask = ~np.isnan(r)
+        expected, _ = spearmanr(f[mask], r[mask])
+        assert got == pytest.approx(expected)
+
     def test_output_schema(self, noisy_panel):
         result = compute_ic(noisy_panel)["factor"]
         # ``_drop_stats`` is an internal diagnostic struct column appended by

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -90,3 +90,53 @@ class TestMonotonicityBatch:
     def test_empty_factor_list_rejected(self, noisy_panel):
         with pytest.raises(ValueError, match="non-empty"):
             monotonicity(noisy_panel, forward_periods=1, n_groups=5, factor_cols=[])
+
+
+class TestBatchTieRatio:
+    """``_compute_tie_ratios_batch`` reports the per-date-then-median tie ratio."""
+
+    def test_batch_matches_single_factor_per_date_median(self):
+        from datetime import datetime, timedelta
+
+        import polars as pl
+        from factrix.metrics._helpers import _compute_tie_ratio
+        from factrix.metrics.monotonicity import _compute_tie_ratios_batch
+
+        # f_cont: continuous, unique within each date but the same value set
+        # recurs across dates → per-date tie ratio 0. A global n_unique/len would
+        # report ~1 here (spurious). f_bucket: 3 buckets → genuine per-date ties.
+        n_assets, n_dates = 100, 40
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = [
+            {
+                "date": dt,
+                "asset_id": a,
+                "f_cont": float(a),
+                "f_bucket": float(a % 3),
+            }
+            for dt in dates
+            for a in range(n_assets)
+        ]
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        batch = _compute_tie_ratios_batch(df, ["f_cont", "f_bucket"])
+        assert batch["f_cont"] == pytest.approx(_compute_tie_ratio(df, "f_cont"))
+        assert batch["f_bucket"] == pytest.approx(_compute_tie_ratio(df, "f_bucket"))
+        # The continuous factor has no within-date ties — must not be flagged.
+        assert batch["f_cont"] == pytest.approx(0.0)
+
+    def test_empty_frame_returns_nan(self):
+        import math
+
+        import polars as pl
+        from factrix.metrics.monotonicity import _compute_tie_ratios_batch
+
+        empty = pl.DataFrame(
+            {"date": [], "asset_id": [], "factor": []},
+            schema={
+                "date": pl.Datetime("ms"),
+                "asset_id": pl.Int64,
+                "factor": pl.Float64,
+            },
+        )
+        assert math.isnan(_compute_tie_ratios_batch(empty, ["factor"])["factor"])


### PR DESCRIPTION
Four cross-section correctness bugs, each surfacing when null values reach a metric. `forward_return` is null-clean by the time it reaches a metric (`compute_forward_return` drops it), but **factor** nulls are not dropped upstream and are normal in real factor research (a factor undefined for some names/dates), so these paths are exercised in practice.

### Fixes
- **IC rank distortion.** `compute_ic` ranked factor and return over the raw per-date column and let `pl.corr` drop null-paired rows only afterward, so a null in either column shifted the surviving assets' ranks in the other and distorted the Spearman IC. Now ranks each factor and the return over the pairwise-complete set; the dense path is byte-identical.
- **IC effective-sample gate.** The cross-section floor (`MIN_IC_ASSETS`) and `tie_ratio` were denominated by the raw row count, so a date with many names but a factor defined for only a few cleared the floor and leaked a high-variance IC into the series. Gate, reported count, `tie_ratio` and drop-stats now share one per-factor valid-pair count — the same sample the ρ is estimated on, mirroring `compute_fm_betas`. Drop-stats become per factor.
- **Quantile denominator dilution.** `_assign_quantile_groups{,_batch}` used the null-inclusive row count as the rank denominator, shrinking every quantile width so the top bucket was unreachable and the long leg came back empty. Now uses the per-date non-null factor count (per factor in the batch path).
- **Monotonicity tie-ratio.** `_compute_tie_ratios_batch` computed a single global `n_unique/len` instead of the per-date-then-median ratio the single-factor helper returns, tripping spurious high-tie-ratio warnings on continuous factors.

Each fix carries a regression test pinned against the reference (scipy `spearmanr` / the single-factor helper). `architecture.md` records the effective-sample single-source convention the IC gate now follows.

### Verification
ruff / ruff format / mypy clean; full suite 1477 passed, 4 skipped.

### Note
Touches `docs/development/architecture.md`; overlaps (non-conflicting hunks) with the docs/api-corrections PR which edits a different section of the same file.