### PR TITLE
docs: correct compare/datasets/errors API surface and drop stale Survivors refs

### DIFF
--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -50,7 +50,7 @@ claims:
 `bhy_hierarchical` is the only one of the three that keeps the
 **family-level answer** first-class — readers learn both "5 of 8
 families showed signal" and "within those, factors A / B / C survived"
-from a single Survivors container.
+from a single `HierarchicalBhyResult`.
 
 ## How the math works
 
@@ -78,22 +78,32 @@ Per group $g$ with $m_g$ member p-values:
     p_i^{\text{adj}} = \max\bigl(p_{\text{outer},g(i)}^{\text{adj}},\; p_{\text{inner},i}^{\text{adj}}\bigr)
     $$
 
-   This preserves the universal Survivors duality
-   `survivor[i] iff adj_p[i] <= q` while encoding the two-layer logic:
+   This preserves the universal `survivor[i] iff adj_p[i] <= q`
+   duality while encoding the two-layer logic:
    a cell can fail because its group failed outer, because the cell
    itself failed inner, or both.
 
-## Survivors output
+## Result output
+
+`bhy_hierarchical` returns a
+[`HierarchicalBhyResult`][factrix.multi_factor.HierarchicalBhyResult] per
+metric — the `_FdrResultBase` shape (`entries` / `survivors` / `adj_p` /
+`q` / `n_tests`) plus a hierarchy-specific field:
 
 | Field | Meaning |
 |---|---|
-| `profiles` | Surviving profiles in input order |
-| `adj_p` | Max-of-layers $\text{adj}_p$; survivor iff `adj_p <= q` |
+| `survivors` | Surviving `EvaluationResult` records, input order (derived: `adj_p_all <= q`) |
+| `adj_p` | Max-of-layers $\text{adj}_p$ for the survivors; survivor iff `adj_p <= q` |
 | `q` | The `q` you passed (single target, both layers) |
-| `expand_over` | `(group,)` — single-element tuple |
+| `group` | Context key naming the group axis (a single `str`) |
 | `n_tests` | Mapping `(group_value,) -> m_group` for **every** input group (covers dead families too, so "N of M families survived" claims are computable directly). Counter to `partial_conjunction`, which keeps surviving identities only. |
 
-Per-survivor group label: `profile.context[group]`.
+Per-survivor group label: `survivor.context[result.group]`.
+
+::: factrix.multi_factor.HierarchicalBhyResult
+    options:
+      show_root_toc_entry: false
+      heading_level: 3
 
 ## When *not* to reach for `bhy_hierarchical`
 

--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -17,7 +17,8 @@ results = fx.evaluate(
     metrics={"ic": ic(inference=fx.inference.NEWEY_WEST), "spread": quantile_spread()},
     factor_cols=candidates,
 )
-df = fx.compare(results, metrics=["ic", "spread"], sort_by="ic")
+# evaluate() returns a dict keyed by factor; compare() takes the list of results.
+df = fx.compare(list(results.values()), metrics=["ic", "spread"], sort_by="ic")
 ```
 
 ## Input parameters

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -2,9 +2,10 @@
 title: factrix.datasets
 ---
 
-Synthetic panel generators for examples, tests, and documentation.
-Both emit raw canonical-column panels (`date, asset_id, price,
-factor`); attach `forward_return` via
+Synthetic panel generators for examples, tests, and documentation. All
+emit raw canonical-column panels (`date, asset_id, price`, then one
+`factor` column for the single-factor generators or `n_factors` factor
+columns for the multi-factor ones); attach `forward_return` via
 [`factrix.preprocess.compute_forward_return`](preprocess.md) before
 passing to [`evaluate`](evaluate.md).
 
@@ -14,6 +15,17 @@ synthetic signal, not a pipeline parameter. When
 realizes the nominal information coefficient (IC) / drift; other horizons realize a decayed
 signal.
 
+## Single-factor generators
+
 ::: factrix.datasets.make_cs_panel
 
 ::: factrix.datasets.make_event_panel
+
+## Multi-factor generators
+
+For factor-screening / multiple-testing workflows — each emits
+`n_factors` factor columns on one shared panel.
+
+::: factrix.datasets.make_multi_factor_panel
+
+::: factrix.datasets.make_multi_factor_event_panel

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -40,17 +40,17 @@ All factrix-raised exceptions inherit from `FactrixError`, so a single
 ```
 FactrixError                       # base
 ├── IncompatibleAxisError          # (scope, density, metric) is not a legal cell
+├── IncompatibleInferenceError     # inference= outside the metric's applicable-inference allowlist
 ├── InsufficientSampleError        # T below SampleThreshold on a TIMESERIES/PANEL procedure
-├── UnknownEstimatorError          # lookup miss in functional estimator namespace
 └── UserInputError                 # named-set typo / type mismatch / dataset schema error
 ```
 
 | Exception | When you see it | What it carries |
 |---|---|---|
 | `IncompatibleAxisError` | `(scope, density, metric)` is not a legal cell | — |
+| `IncompatibleInferenceError` | `inference=` outside the metric's `applicable_inference` allowlist | `.func_name`, `.value`, `.applicable` |
 | `InsufficientSampleError` | `T` below the procedure floor | `.actual_periods`, `.required_periods` |
-| `UnknownEstimatorError` | `get_estimator` lookup miss | — |
-| `UserInputError` | Unknown metric / estimator, column not in data, wrong type | structured `.field`, `.value`, `.candidates`, `.suggestions`, `.expected`, `.docs_url` |
+| `UserInputError` | Unknown metric, column not in data, wrong type | structured `.field`, `.value`, `.candidates`, `.suggestions`, `.expected`, `.docs_url` |
 
 ---
 
@@ -153,6 +153,11 @@ Autodoc anchors for cross-references of the form `[`FactrixError`][factrix.Factr
 ### Structural and sample failures
 
 ::: factrix.IncompatibleAxisError
+    options:
+      show_root_toc_entry: false
+      heading_level: 4
+
+::: factrix.IncompatibleInferenceError
     options:
       show_root_toc_entry: false
       heading_level: 4

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -117,10 +117,13 @@ conservative under PRDS. factrix ships only the Bonferroni-style — it
 is uniformly valid without dependence assumptions; a Simes path may
 be added later if a use case demands it.
 
-## Survivors output
+## Result output
 
-`partial_conjunction` returns the same [`Survivors`](multi-factor.md)
-container as `bhy`, populated with PC-specific metadata:
+`partial_conjunction` returns a
+[`PartialConjunctionResult`][factrix.multi_factor.PartialConjunctionResult]
+per metric — the same `_FdrResultBase` shape as `bhy`'s
+[`BhyResult`][factrix.multi_factor.BhyResult] (`entries` / `survivors` /
+`adj_p` / `q` / `n_tests`), plus PC-specific fields:
 
 | Field | Meaning |
 |---|---|
@@ -129,11 +132,16 @@ container as `bhy`, populated with PC-specific metadata:
 | `pc_p_all` | Raw PC $p$-value (pre-BHY), aligned with `entries` |
 | `survivors` / `adj_p` | Surviving subset and its adjusted p-value (derived from `adj_p_all <= q`) |
 | `min_pass` | The $k$ you passed |
-| `n_tests` | Keyed by identity tuple `(factor_id, forward_periods)` → actual $m$ used |
+| `n_tests` | Keyed by the single-element identity tuple `(factor,)` → condition count $m$ for that identity |
 | `n_passed_uncorr_all` | Per-identity count of raw $p < q$, aligned with `entries`. Descriptive — flags borderline (`n_passed_uncorr_all == min_pass`) and data-gap cases at a glance. **Cutoff is your `q`**, so the count moves with `q` — using it to override `adj_p` survivor selection is the anti-shopping failure mode this function exists to prevent. |
 
 `to_frame()` gives a `factor | adj_p | survived` DataFrame over every tested
 identity, eliminated ones included.
+
+::: factrix.multi_factor.PartialConjunctionResult
+    options:
+      show_root_toc_entry: false
+      heading_level: 3
 
 ## Validation summary
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -279,8 +279,8 @@ all functions.
 ```
 FactrixError                       # base — all factrix-raised errors
 ├── IncompatibleAxisError
+├── IncompatibleInferenceError     # inference= outside the metric's allowlist
 ├── InsufficientSampleError    # carries .actual_periods / .required_periods
-├── UnknownEstimatorError
 └── UserInputError                 # named-set typo / type mismatch
 ```
 
@@ -659,7 +659,7 @@ factrix/
 ├── _axis.py                 # FactorScope / FactorDensity / DataStructure / Tier + spec-metadata
 │                            #   enums (Aggregation / SpecRole / InputShape / OutputShape)
 ├── _codes.py                # WarningCode StrEnum
-├── _errors.py               # flat hierarchy: FactrixError → {IncompatibleAxisError, InsufficientSampleError, UnknownEstimatorError, UserInputError}
+├── _errors.py               # flat hierarchy: FactrixError → {IncompatibleAxisError, IncompatibleInferenceError, InsufficientSampleError, UserInputError}
 ├── _metric_index.py         # MetricSpec + @metric-registry SSOT (spec_by_name / list_metrics / public_specs / metric_spec)
 ├── _dag.py                  # DagExecutor — MetricSpec.requires / batchable dispatch (+ CycleError)
 ├── _results.py              # EvaluationResult / MetricResult / Warning dataclasses

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -770,7 +770,7 @@ plain prose; reach for a callout only when the elevation earns it.
 - `!!! info` — contract / convention block (e.g. event-study contracts, TS-mode conventions).
 - `!!! example` — minimal worked code that surrounding prose references.
 - `??? note "..."` (collapsible) — long content for a subset of readers (derivations, full enum tables).
-- `> **Input contract** — …` (blockquote, two lines) — appears only on raw-data `(data, ...)` entry points (`docs/api/evaluate.md`), placed between the frontmatter and the autodoc block. Format: one short sentence naming the four-column floor + a link to [Panel schema](../api/panel-schema.md). Other API pages consume pre-computed artefacts (`EvaluationResult` / `Survivors` / `MetricResult`) and do not carry the callout.
+- `> **Input contract** — …` (blockquote, two lines) — appears only on raw-data `(data, ...)` entry points (`docs/api/evaluate.md`), placed between the frontmatter and the autodoc block. Format: one short sentence naming the four-column floor + a link to [Panel schema](../api/panel-schema.md). Other API pages consume pre-computed artefacts (`EvaluationResult` / `BhyResult` / `MetricResult`) and do not carry the callout.
 
 Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
 
@@ -789,7 +789,7 @@ mkdocstrings cross-references (`[X][factrix.<...>.X]`) and intra-doc anchor link
 
 Per-block `options:` should carry **only deviations** from the globals. Common deviations:
 
-- Secondary block on a page (e.g. `Survivors` on `bhy.md`, individual error classes on `errors.md`): `show_root_toc_entry: false`, `heading_level: 3` or `4`.
+- Secondary block on a page (e.g. `BhyResult` on `bhy.md`, individual error classes on `errors.md`): `show_root_toc_entry: false`, `heading_level: 3` or `4`.
 - Dataclass page where the class name is already in the frontmatter title: `show_root_heading: false`.
 - Module-level block with a curated function list: `members: [...]`, optionally `show_root_members_full_path: true`.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -222,10 +222,13 @@ survivors does not preserve FDR ≤ q. See
 [Cross-function reference § `expand_over`](../api/bhy.md)
 for the sample-restriction vs hypothesis-dimension split.
 
-### `Survivors`
+### Screening result (`BhyResult` / `PartialConjunctionResult` / `HierarchicalBhyResult`)
 
 Result type from the screening functions (`bhy`, `partial_conjunction`,
-`bhy_hierarchical`). Carries the post-correction adjusted q-value
-(`adj_q`) per identity plus a boolean `survivor[i]` ↔ `adj_q[i] ≤ q`
-duality so downstream functions (`compare(survivors)`) can render
-leaderboards without re-applying the threshold.
+`bhy_hierarchical`) — one procedure-paired dataclass each, returned keyed
+by metric name. Each carries the full tested family (`entries`) with the
+post-correction adjusted p-value (`adj_p_all`) aligned to it, exposes the
+surviving subset as `survivors` / `adj_p`, and preserves the
+`survivor[i] ↔ adj_p_all[i] ≤ q` duality so downstream functions
+(`compare(result.survivors)`) can render leaderboards without re-applying
+the threshold.

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -30,7 +30,7 @@ def compare(
     """Render a wide leaderboard ``pl.DataFrame`` for multiple metrics.
 
     One row per :class:`EvaluationResult`; two columns per metric —
-    ``<metric_name>`` (``MetricResult.value``) and ``<metric_name>_p``
+    ``<metric_name>`` (``MetricResult.value``) and ``<metric_name>_p_value``
     (``MetricResult.p_value`` when present, else ``null``).
 
     Args:
@@ -57,7 +57,7 @@ def compare(
     Returns:
         ``pl.DataFrame`` with column order ``factor``,
         ``forward_periods``, context keys (union across results,
-        first-seen order), then ``<m_name>`` / ``<m_name>_p`` pairs
+        first-seen order), then ``<m_name>`` / ``<m_name>_p_value`` pairs
         in ``metrics`` order, then ``rank`` when ``sort_by`` is set.
 
     Raises:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -390,7 +390,6 @@ All exceptions inherit from `FactrixError`:
 - `IncompatibleAxisError`: Invalid combination of axes.
 - `IncompatibleInferenceError`: `inference=` is outside the metric's `applicable_inference` allowlist.
 - `InsufficientSampleError`: Sample size too small for statistical validity.
-- `UnknownEstimatorError`: Lookup miss for estimators.
 - `UserInputError`: Wrong schema, bad names, or mismatched shapes.
 
 ---

--- a/factrix/multi_factor.py
+++ b/factrix/multi_factor.py
@@ -1,7 +1,8 @@
 """Public ``multi_factor`` namespace — collection-level FDR control.
 
-Three procedure-paired result dataclasses (one per function) replace
-the v0.13 unified ``Survivors``; each function returns
+One procedure-paired result dataclass per function
+(:class:`BhyResult`, :class:`PartialConjunctionResult`,
+:class:`HierarchicalBhyResult`); each function returns
 ``dict[metric_name, *Result]`` keyed by ``MetricSpec.name``.
 """
 


### PR DESCRIPTION
Pre-existing documentation / API-surface drift surfaced by review.

### Fixes
- **compare.** The `compare.md` example passed `evaluate()`'s factor-keyed dict to `compare()`, which takes `list[EvaluationResult]` — copy-pasting it raised. Now passes `list(results.values())`. The `compare()` docstring also advertised `<metric>_p` columns while the implementation emits `<metric>_p_value`; docstring corrected.
- **Survivors.** v0.14 replaced the unified `Survivors` with the procedure-paired `BhyResult` / `PartialConjunctionResult` / `HierarchicalBhyResult`. Updated `partial-conjunction.md`, `bhy-hierarchical.md`, `glossary.md`, `contributing.md`, and the `multi_factor` module docstring; added the missing `PartialConjunctionResult` / `HierarchicalBhyResult` autodoc blocks so their cross-references resolve. Fixed field-name drift found in the process: hierarchical `profiles` -> `survivors`, `expand_over` -> `group`; glossary `adj_q` -> `adj_p`; PC `n_tests` key `(factor_id, forward_periods)` -> `(factor,)`.
- **datasets.** Documented `make_multi_factor_panel` / `make_multi_factor_event_panel`, which were defined but absent from `datasets.md`.
- **errors.** Removed the nonexistent `UnknownEstimatorError` (no such class, no `get_estimator` in source) from `errors.md`, `architecture.md` and the llms bundle; documented the real `IncompatibleInferenceError` (hierarchy, table, autodoc block).

### Verification
`mkdocs build --strict` passes (0 cross-reference warnings); `_compare.py` doctest + `test_compare.py` green.

### Note
Touches `docs/development/architecture.md`; overlaps (non-conflicting hunks) with the fix/metric-null-correctness PR which edits a different section of the same file.