### PR TITLE
perf+fix(metrics): vectorize mfe_mae/rolling-beta loops; drop incomplete pairs in rolling-beta & pooled_beta

### DIFF
--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -78,10 +78,18 @@ def compute_mfe_mae(
     if len(events) == 0:
         return pl.DataFrame(schema=empty_schema)
 
+    # One partition pass over the event-bearing assets instead of an
+    # ``asset_id == a`` filter per asset (which re-scanned the whole panel N
+    # times). Restrict to event assets first so non-event assets are not
+    # materialised.
     event_assets = set(events["asset_id"].unique().to_list())
     asset_groups: dict[str, tuple[dict, np.ndarray]] = {}
-    for asset_id in event_assets:
-        asset_data = sorted_df.filter(pl.col("asset_id") == asset_id)
+    for key, asset_data in (
+        sorted_df.filter(pl.col("asset_id").is_in(list(event_assets)))
+        .partition_by("asset_id", as_dict=True, maintain_order=True)
+        .items()
+    ):
+        asset_id = key[0]
         date_to_idx = {d: i for i, d in enumerate(asset_data["date"].to_list())}
         prices = asset_data[price_col].to_numpy()
         asset_groups[asset_id] = (date_to_idx, prices)

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -572,6 +572,12 @@ def pooled_beta(
         >>> result.name == ""
         True
     """
+    # Pooled OLS is estimated on the complete (factor, return) pairs: drop
+    # incomplete rows up front so a null factor or return cannot feed a NaN into
+    # ``lstsq`` (poisoning the slope) and so ``n_obs`` — the pairs-axis floor —
+    # counts what the regression actually uses. Dropping on ``df`` keeps the
+    # downstream cluster / Driscoll-Kraay arrays positionally aligned.
+    df = df.drop_nulls([return_col, factor_col])
     y = df[return_col].to_numpy().astype(np.float64)
     x = df[factor_col].to_numpy().astype(np.float64)
     n_obs = len(y)

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -282,20 +282,44 @@ def compute_rolling_mean_beta(
             }
         )
 
+    # Partition by asset once into date-sorted numpy arrays, dropping rows with a
+    # null factor or return up front: an incomplete pair is unobserved, and
+    # leaving it in would feed a NaN into the per-asset OLS and poison that
+    # asset's slope (and the cross-asset mean). The trailing date window for each
+    # ``t`` is the closed interval ``[dates[i-window], dates[i-1]]`` — every
+    # asset row whose date lands in it, located by ``searchsorted`` on the
+    # asset's sorted dates — which replaces the per-date ``is_in`` filter and the
+    # per-asset ``asset_id ==`` filter the loop used to run.
+    valid = df.filter(
+        pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
+    )
+    asset_arrays: dict[object, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}
+    for key, a_data in (
+        valid.sort("date")
+        .partition_by("asset_id", as_dict=True, maintain_order=True)
+        .items()
+    ):
+        asset_arrays[key[0]] = (
+            a_data["date"].to_numpy(),
+            a_data[factor_col].to_numpy().astype(np.float64),
+            a_data[return_col].to_numpy().astype(np.float64),
+        )
+
+    date_vals = dates.to_numpy()
     rows: list[dict] = []
     for i in range(window, len(dates)):
-        window_dates = dates[i - window : i]
-        chunk = df.filter(pl.col("date").is_in(window_dates.implode()))
+        lo = date_vals[i - window]  # first date in the trailing window (inclusive)
+        hi = date_vals[i - 1]  # last date in the trailing window (inclusive)
 
         betas_per_asset: list[float] = []
-        for asset in chunk["asset_id"].unique():
-            a_data = chunk.filter(pl.col("asset_id") == asset)
-            y = a_data[return_col].to_numpy().astype(np.float64)
-            x = a_data[factor_col].to_numpy().astype(np.float64)
-            n = min(len(y), len(x))
+        for a_dates, x_all, y_all in asset_arrays.values():
+            left = int(np.searchsorted(a_dates, lo, side="left"))
+            right = int(np.searchsorted(a_dates, hi, side="right"))
+            n = right - left
             if n < 10:
                 continue
-            y, x = y[:n], x[:n]
+            x = x_all[left:right]
+            y = y_all[left:right]
             X = np.column_stack([np.ones(n), x])
             try:
                 b, _, _, _ = np.linalg.lstsq(X, y, rcond=None)

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -125,3 +125,42 @@ class TestDriscollKraayPath:
         t_stat = res.stat
         expected_p = float(2 * sp_stats.t.sf(abs(t_stat), dof))
         assert res.p_value == pytest.approx(expected_p)
+
+
+class TestPooledBetaNullPairs:
+    """Null factor/return rows must not poison the pooled OLS slope."""
+
+    def test_null_factor_does_not_nan_the_slope(self):
+        # Factor undefined for some names (common in real research). The slope
+        # must be estimated on the complete (factor, return) pairs, and n_obs
+        # must count those pairs — not the raw rows including nulls.
+        rng = np.random.default_rng(5)
+        rows = []
+        for d in range(120):
+            for a in range(20):
+                f = rng.normal()
+                r = 1.5 * f + 0.5 * rng.normal()
+                if rng.random() < 0.05:  # factor undefined here
+                    f = None
+                if rng.random() < 0.02:  # return unobserved here
+                    r = None
+                rows.append(
+                    {
+                        "date": d,
+                        "asset_id": a,
+                        "factor": None if f is None else float(f),
+                        "forward_return": None if r is None else float(r),
+                    }
+                )
+        df = pl.DataFrame(rows)
+
+        res = pooled_beta(df)
+        complete = df.drop_nulls(["factor", "forward_return"])
+        ref_slope = float(
+            np.polyfit(
+                complete["factor"].to_numpy(), complete["forward_return"].to_numpy(), 1
+            )[0]
+        )
+        assert np.isfinite(res.value)
+        assert res.value == pytest.approx(ref_slope, abs=1e-9)
+        assert res.n_obs == complete.height

--- a/tests/test_ts_betas.py
+++ b/tests/test_ts_betas.py
@@ -14,6 +14,7 @@ import polars as pl
 import pytest
 from factrix._types import EPSILON
 from factrix.metrics._primitives._ts_betas import MIN_TS_PERIODS, compute_ts_betas
+from factrix.metrics.ts_beta import compute_rolling_mean_beta
 
 _OUT_COLS = ["asset_id", "beta", "alpha", "t_stat", "r_squared", "n_obs"]
 
@@ -168,3 +169,95 @@ class TestComputeTSBetasBatch:
     def test_empty_factor_list_rejected(self):
         with pytest.raises(ValueError, match="factor_cols must be non-empty"):
             compute_ts_betas(_common_factor_panel(3, 30, seed=8), factor_cols=[])
+
+
+def _rolling_mean_beta_reference(
+    df: pl.DataFrame, window: int, fc: str = "factor", rc: str = "forward_return"
+) -> pl.DataFrame:
+    """Brute-force rolling mean beta: trailing-window date membership, per-asset
+    OLS on the complete (factor, return) pairs, cross-asset mean. Independent of
+    the optimized searchsorted/partition implementation.
+    """
+    dates = df["date"].unique().sort()
+    rows: list[dict] = []
+    for i in range(window, len(dates)):
+        window_dates = dates[i - window : i]
+        chunk = df.filter(pl.col("date").is_in(window_dates.implode()))
+        betas: list[float] = []
+        for a in chunk["asset_id"].unique():
+            c = chunk.filter(
+                (pl.col("asset_id") == a)
+                & pl.col(fc).is_not_null()
+                & pl.col(rc).is_not_null()
+            )
+            x = c[fc].to_numpy().astype(np.float64)
+            y = c[rc].to_numpy().astype(np.float64)
+            if len(x) < 10:
+                continue
+            X = np.column_stack([np.ones(len(x)), x])
+            b, _, _, _ = np.linalg.lstsq(X, y, rcond=None)
+            betas.append(float(b[1]))
+        if betas:
+            rows.append({"date": dates[i], "value": float(np.mean(betas))})
+    return pl.DataFrame(rows, schema={"date": dates.dtype, "value": pl.Float64}).sort(
+        "date"
+    )
+
+
+class TestRollingMeanBeta:
+    def test_matches_bruteforce_reference_on_sparse_panel(self):
+        # Sparse panel (assets miss random dates) — the optimized window slicing
+        # must agree with the trailing-date-membership reference.
+        rng = np.random.default_rng(11)
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(90)]
+        rows = []
+        for d in dates:
+            for a in range(6):
+                if rng.random() < 0.1:  # drop ~10% of rows
+                    continue
+                f = rng.standard_normal()
+                rows.append(
+                    {
+                        "date": d,
+                        "asset_id": f"A{a}",
+                        "factor": float(f),
+                        "forward_return": float(2.0 * f + 0.5 * rng.standard_normal()),
+                    }
+                )
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        got = compute_rolling_mean_beta(df, window=30).sort("date")
+        ref = _rolling_mean_beta_reference(df, window=30)
+        assert got["date"].to_list() == ref["date"].to_list()
+        assert np.allclose(got["value"].to_numpy(), ref["value"].to_numpy(), atol=1e-9)
+
+    def test_null_return_pairs_do_not_poison_beta(self):
+        # A null factor/return must be dropped from the per-asset OLS, not fed in
+        # as NaN (which would poison the slope and the cross-asset mean).
+        rng = np.random.default_rng(3)
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(60)]
+        rows = []
+        for di, d in enumerate(dates):
+            for a in range(5):
+                f = rng.standard_normal()
+                r = 2.0 * f + 0.5 * rng.standard_normal()
+                # scatter a few null returns through every asset's window
+                if di % 17 == a:
+                    r = None
+                rows.append(
+                    {
+                        "date": d,
+                        "asset_id": f"A{a}",
+                        "factor": float(f),
+                        "forward_return": None if r is None else float(r),
+                    }
+                )
+        df = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        got = compute_rolling_mean_beta(df, window=30)
+        vals = got["value"].to_numpy()
+        assert got.height > 0
+        assert not np.any(np.isnan(vals))
+        assert np.allclose(
+            vals,
+            _rolling_mean_beta_reference(df, window=30)["value"].to_numpy(),
+            atol=1e-9,
+        )


### PR DESCRIPTION
Two supplementary-metric improvements, continuing the effective-sample / null-handling line. Both are no-ops on a dense panel; the null fixes trigger on **factor** nulls, which are normal in real factor research (a factor undefined for some names/dates) and are not dropped upstream.

### compute_mfe_mae — perf
Built its per-asset price arrays with one `asset_id == a` filter per asset, re-scanning the whole panel N times. Replaced with a single `partition_by` over the event-bearing assets. Output unchanged (17 tests green).

### compute_rolling_mean_beta — perf + correctness
- **perf:** ran an `is_in(window_dates)` filter per date and an `asset_id ==` filter per asset inside it. Now partitions by asset once into date-sorted numpy arrays and slices each trailing window via `searchsorted`. Byte-identical on a dense panel.
- **correctness:** dropped null `(factor, return)` pairs up front. Previously a single null factor (or return) fed a NaN into the per-asset OLS, poisoning that asset's slope and the whole date's cross-asset mean to NaN. Now estimated on the complete pairs, validated against an independent brute-force reference.

### pooled_beta — correctness
Extracted the raw factor/return columns to numpy and ran `lstsq` directly, so a null factor or return poisoned the pooled slope to NaN and `n_obs` (the pairs-axis floor) over-counted the incomplete rows. Drop the incomplete `(factor, return)` pairs on `df` up front: the slope is estimated on the complete pairs, the cluster / Driscoll-Kraay arrays stay positionally aligned, and `n_obs` counts what the regression uses — the same effective-sample treatment as `compute_ic` / `compute_fm_betas`.

### Scope note
Return-only-null fragility in the event-family metrics (`corrado_rank`, `bmp_z`, `event_quality`, `event_horizon`) is deliberately left untouched: `forward_return` is guaranteed null-clean by `compute_forward_return`, so a per-metric guard there would defend a case the pipeline already prevents. Only the **factor**-null paths (reachable in practice) are fixed.

### Verification
ruff / ruff format / mypy clean; full suite 1480 passed, 4 skipped. Regression tests added for rolling-beta (perf equivalence + null robustness vs brute-force reference) and pooled_beta (null factor does not NaN the slope).