### PR TITLE
fix(api): tighten diagnostic input contracts (#699)

### DIFF
--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -16,6 +16,21 @@ orthogonalization against base factors (`orthogonalize_factor`).
 
 ## Forward return
 
+`compute_forward_return` accepts `forward_periods` as a positive `int`
+row horizon. `0`, negative values, floats, strings, and `bool` values
+raise [`UserInputError`](errors.md). The function shifts by row count
+within each `asset_id`, computes the per-period normalized
+`forward_return`, then drops rows whose computed return is not finite
+(`null`, `NaN`, `+inf`, or `-inf`). If the horizon is too long for the
+panel, or price data leaves no finite forward returns after filtering,
+the function raises [`UserInputError`](errors.md) instead of returning
+an empty panel.
+
+`winsorize_forward_return` clips `forward_return` by per-date quantiles.
+Its bounds must satisfy `0 <= lower <= upper <= 1`; invalid ordering,
+out-of-range values, non-numeric values, and `bool` bounds raise
+[`UserInputError`](errors.md).
+
 ::: factrix.preprocess.compute_forward_return
 
 ::: factrix.preprocess.winsorize_forward_return

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -94,6 +94,22 @@ uv add <pkg>         # add dep, sync pyproject + uv.lock
 uv lock --upgrade    # upgrade lock to the latest within current pyproject constraints
 ```
 
+### Windows test notes
+
+On Windows consoles, prefer UTF-8 mode for tests that read Markdown or
+render diagnostics with non-ASCII characters:
+
+```powershell
+$env:PYTHONUTF8="1"
+.\.venv\Scripts\python.exe -m pytest -q -p no:faulthandler
+```
+
+Timezone-aware Polars tests also need Python timezone data available
+for `ZoneInfo("UTC")` / UTC conversions. Run `uv sync --extra dev`
+from the repo lockfile before testing; if a local environment was
+manually altered and timezone tests fail with missing timezone data,
+resync the environment instead of patching tests.
+
 ### Git hooks (pre-push CHANGELOG check)
 
 `.githooks/` at the repo root holds version-controlled hook scripts.

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -160,7 +160,9 @@ Three responsibilities sit upstream of `compute_forward_return`:
 | Source | factrix behaviour | Caller action |
 |---|---|---|
 | NaN in `factor` | Not auto-imputed; flows through to the procedure, where it depresses `n_obs` and may trip sample-size guards. | Drop or impute before `compute_forward_return`. |
-| NaN in `price` | `compute_forward_return` produces NaN `forward_return` for the row and then drops it from the output. Tail rows where `t + 1 + N` runs off the end of the series are dropped by the same filter. | If a daily NaN reflects a true gap (suspended trading, holiday), the drop is correct. If imputable (forward-fill from previous close), impute before calling. |
+| NaN / inf in `price` | `compute_forward_return` drops rows whose computed `forward_return` is not finite (`null`, `NaN`, `+inf`, or `-inf`). Tail rows where `t + 1 + N` runs off the end of the series are dropped by the same filter. | If a daily NaN reflects a true gap (suspended trading, holiday), the drop is correct. If imputable (forward-fill from previous close), impute before calling. |
+| `forward_periods <= 0`, non-`int`, or `bool` | Raises [`UserInputError`](../api/errors.md); the horizon must be a positive integer row count. | Pass an explicit row horizon such as `1`, `5`, or `20`. |
+| Horizon too long / no finite returns after filtering | Raises [`UserInputError`](../api/errors.md) instead of returning an empty panel. | Shorten the horizon, extend the panel, or clean price values before calling. |
 | Single-asset panel (N = 1) | `DataStructure` auto-switches to `TIMESERIES`. `individual_continuous` at N = 1 raises [`IncompatibleAxisError`](../api/errors.md). | Use a `*_sparse` or `common_*` metric instead. |
 | T < `MIN_PERIODS_HARD` (= 20) periods | Raises [`InsufficientSampleError`](../api/errors.md); procedures never silently produce a result on under-sample data. | Extend the window or accept the procedure's refusal. |
 

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -387,8 +387,13 @@ class DagExecutor:
                         )
                     )
                 for code in out.warning_codes:
+                    warning_code = WarningCode(code)
                     warnings.append(
-                        Warning(code=WarningCode(code), source=label, message="")
+                        Warning(
+                            code=warning_code,
+                            source=label,
+                            message=warning_code.description,
+                        )
                     )
             results[c] = EvaluationResult(
                 factor=c,

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -107,6 +107,21 @@ def _require_non_empty_results(
             expected="non-empty list[EvaluationResult]",
             docs_path=f"api/{func_name}#results",
         )
+    from factrix._results import EvaluationResult
+
+    for idx, result in enumerate(results):
+        if not isinstance(result, EvaluationResult):
+            raise UserInputError(
+                func_name=func_name,
+                field=f"results[{idx}]",
+                value=type(result).__name__,
+                expected=(
+                    "EvaluationResult objects. If this list came from "
+                    "evaluate(), pass list(results.values()); do not extend "
+                    "a list with the dict itself, because that appends keys"
+                ),
+                docs_path=f"api/{func_name}#results",
+            )
 
 
 def _render_table(headers: tuple[str, ...], rows: list[tuple[str, ...]]) -> str:

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -13,6 +13,54 @@ import polars as pl
 from factrix._errors import UserInputError
 
 _DOCS_FORWARD_RETURN = "api/preprocess#compute_forward_return"
+_DOCS_WINSORIZE_FORWARD_RETURN = "api/preprocess#winsorize_forward_return"
+
+
+def _validate_forward_periods(forward_periods: object) -> int:
+    if not isinstance(forward_periods, int) or isinstance(forward_periods, bool):
+        raise UserInputError(
+            func_name="compute_forward_return",
+            field="forward_periods",
+            value=forward_periods,
+            expected="a positive int row horizon, e.g. 5",
+            docs_path=_DOCS_FORWARD_RETURN,
+        )
+    if forward_periods <= 0:
+        raise UserInputError(
+            func_name="compute_forward_return",
+            field="forward_periods",
+            value=forward_periods,
+            expected="a positive int row horizon (> 0)",
+            docs_path=_DOCS_FORWARD_RETURN,
+        )
+    return forward_periods
+
+
+def _validate_winsorize_bounds(lower: object, upper: object) -> tuple[float, float]:
+    if (
+        isinstance(lower, bool)
+        or isinstance(upper, bool)
+        or not isinstance(lower, int | float)
+        or not isinstance(upper, int | float)
+    ):
+        raise UserInputError(
+            func_name="winsorize_forward_return",
+            field="bounds",
+            value={"lower": lower, "upper": upper},
+            expected="numeric quantile bounds satisfying 0 <= lower <= upper <= 1",
+            docs_path=_DOCS_WINSORIZE_FORWARD_RETURN,
+        )
+    lower_f = float(lower)
+    upper_f = float(upper)
+    if not 0.0 <= lower_f <= upper_f <= 1.0:
+        raise UserInputError(
+            func_name="winsorize_forward_return",
+            field="bounds",
+            value={"lower": lower, "upper": upper},
+            expected="0 <= lower <= upper <= 1",
+            docs_path=_DOCS_WINSORIZE_FORWARD_RETURN,
+        )
+    return lower_f, upper_f
 
 
 def compute_forward_return(
@@ -59,15 +107,18 @@ def compute_forward_return(
             place anyway, accepting the additional truncation.
 
     Raises:
-        UserInputError: ``df`` already has a ``forward_return`` column and
-            ``overwrite`` is ``False``.
+        UserInputError: ``forward_periods`` is not a positive ``int``;
+            ``df`` already has a ``forward_return`` column and
+            ``overwrite`` is ``False``; or the row horizon / price data
+            leaves no finite forward returns after filtering.
 
     Returns:
         Input DataFrame with ``forward_return`` column appended and the
         overlap horizon ``forward_periods`` stamped on as a reserved column —
         the single source of truth ``factrix.evaluate`` reads (it strips the
         column before dispatch, so it never reaches a metric or ``to_frame``).
-        Rows where forward return is null (end of series) are dropped.
+        Rows where forward return is not finite (tail nulls, NaN, +inf, -inf)
+        are dropped.
 
     Notes:
         The ``÷N`` per-period normalization is a *scale* choice with
@@ -132,6 +183,8 @@ def compute_forward_return(
         >>> isinstance(results, dict) and "factor" in results
         True
     """
+    forward_periods = _validate_forward_periods(forward_periods)
+
     if "forward_return" in df.columns:
         if not overwrite:
             raise UserInputError(
@@ -164,8 +217,20 @@ def compute_forward_return(
                 / forward_periods
             ).alias("forward_return")
         )
-        .filter(pl.col("forward_return").is_not_null())
+        .filter(pl.col("forward_return").is_finite())
     )
+    if out.is_empty():
+        raise UserInputError(
+            func_name="compute_forward_return",
+            field="df",
+            value=f"{df.height} rows",
+            expected=(
+                "at least one finite forward_return after applying the row "
+                f"horizon forward_periods={forward_periods}; the panel may be "
+                "too short, or price contains only non-finite returns"
+            ),
+            docs_path=_DOCS_FORWARD_RETURN,
+        )
     # Stamp the overlap horizon as the single source of truth for the data;
     # evaluate reads it instead of taking forward_periods at the metric / call
     # layer (the three could silently diverge — see compute_forward_return docs).
@@ -181,8 +246,14 @@ def winsorize_forward_return(
 
     Args:
         lower: Lower quantile bound (default 0.01 = 1st percentile).
+            Must satisfy ``0 <= lower <= upper <= 1``.
         upper: Upper quantile bound (default 0.99 = 99th percentile).
-            Set to (0.0, 1.0) to disable.
+            Must satisfy ``0 <= lower <= upper <= 1``. Set to
+            ``(0.0, 1.0)`` to disable.
+
+    Raises:
+        UserInputError: ``lower`` / ``upper`` are not numeric quantile
+            bounds satisfying ``0 <= lower <= upper <= 1``.
 
     Returns:
         DataFrame with ``forward_return`` clipped in-place.
@@ -201,6 +272,7 @@ def winsorize_forward_return(
         >>> clipped["forward_return"].max() <= panel["forward_return"].max()
         True
     """
+    lower, upper = _validate_winsorize_bounds(lower, upper)
     if lower <= 0.0 and upper >= 1.0:
         return df
 

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -64,6 +64,18 @@ def test_dict_input_suggests_values():
         bhy(results, metrics=["ic"], q=0.05)  # type: ignore[arg-type]
 
 
+def test_list_of_dict_keys_suggests_values():
+    make_spec("ic")
+    results = {
+        f"f{i}": make_result(factor=f"f{i}", p=0.01, metric="ic") for i in range(3)
+    }
+    mistaken: list[str] = []
+    mistaken.extend(results)
+
+    with pytest.raises(UserInputError, match=r"list\(results\.values\(\)\)"):
+        bhy(mistaken, metrics=["ic"], q=0.05)  # type: ignore[arg-type]
+
+
 def test_no_surviving_results_returns_empty_record():
     make_spec("ic")
     results = [make_result(factor=f"f{i}", p=0.9, metric="ic") for i in range(5)]

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -80,6 +80,22 @@ def test_empty_input_raises():
         bhy_hierarchical([], metrics=["ic"], group="family", q=0.05)
 
 
+def test_list_of_dict_keys_suggests_values():
+    make_spec("ic")
+    results = {
+        "mom_1": make_result(
+            factor="mom_1", p=0.01, metric="ic", context={"family": "momentum"}
+        )
+    }
+    mistaken: list[str] = []
+    mistaken.extend(results)
+
+    with pytest.raises(UserInputError, match=r"list\(results\.values\(\)\)"):
+        bhy_hierarchical(  # type: ignore[arg-type]
+            mistaken, metrics=["ic"], group="family", q=0.05
+        )
+
+
 def test_primary_must_be_list_of_str():
     make_spec("ic")
     with pytest.raises(UserInputError, match="always a list"):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -327,6 +327,9 @@ class TestWarningCodeLift:
         assert (WarningCode.FEW_EVENTS, "flagged") in [
             (w.code, w.source) for w in er.warnings
         ]
+        assert (WarningCode.FEW_EVENTS, WarningCode.FEW_EVENTS.description) in [
+            (w.code, w.message) for w in er.warnings
+        ]
         row = (
             er.to_frame().filter(pl.col("metric_name") == "flagged").row(0, named=True)
         )

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -60,6 +60,22 @@ def test_pc_empty_results_raises():
         partial_conjunction([], metrics=["ic"], min_pass=2, expand_over=("region",))
 
 
+def test_pc_list_of_dict_keys_suggests_values():
+    make_spec("ic")
+    results = {
+        "alpha": make_result(
+            factor="alpha", p=0.01, metric="ic", context={"region": "US"}
+        )
+    }
+    mistaken: list[str] = []
+    mistaken.extend(results)
+
+    with pytest.raises(UserInputError, match=r"list\(results\.values\(\)\)"):
+        partial_conjunction(  # type: ignore[arg-type]
+            mistaken, metrics=["ic"], min_pass=2, expand_over=("region",)
+        )
+
+
 def test_pc_n_conditions_strict_mismatch_raises():
     make_spec("ic")
     results = _replicate("alpha_1", [0.01, 0.01], "ic", regions=("US", "EU"))

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import polars as pl
 import pytest
+from factrix._errors import UserInputError
 from factrix.preprocess.returns import (
     compute_abnormal_return,
     compute_forward_return,
@@ -26,6 +27,11 @@ def _make_price_data():
 
 
 class TestComputeForwardReturn:
+    @pytest.mark.parametrize("forward_periods", [0, -1, True, 1.5])
+    def test_rejects_non_positive_or_non_int_horizon(self, forward_periods):
+        with pytest.raises(UserInputError, match="positive int"):
+            compute_forward_return(_make_price_data(), forward_periods=forward_periods)
+
     def test_basic(self):
         df = _make_price_data()
         result = compute_forward_return(df, forward_periods=1)
@@ -74,7 +80,14 @@ class TestComputeForwardReturn:
         assert twice.height < once.height
 
     def test_overwrite_changes_horizon(self):
-        raw = _make_price_data()
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(8)]
+        raw = pl.DataFrame(
+            {
+                "date": dates,
+                "asset_id": ["A"] * 8,
+                "price": [100.0, 101.0, 103.0, 106.0, 110.0, 115.0, 121.0, 128.0],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         once = compute_forward_return(raw, forward_periods=1)
         changed = compute_forward_return(once, forward_periods=2, overwrite=True)
         assert "forward_return" in changed.columns
@@ -103,8 +116,61 @@ class TestComputeForwardReturn:
         assert changed.height > 0
         assert _read_forward_periods_stamp(changed) == 2
 
+    def test_drops_nan_and_inf_forward_returns(self):
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(6)]
+        df = pl.DataFrame(
+            {
+                "date": dates * 2,
+                "asset_id": ["A"] * 6 + ["B"] * 6,
+                "price": [
+                    100.0,
+                    101.0,
+                    float("nan"),
+                    103.0,
+                    float("inf"),
+                    105.0,
+                    200.0,
+                    202.0,
+                    204.0,
+                    206.0,
+                    208.0,
+                    210.0,
+                ],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        result = compute_forward_return(df, forward_periods=1)
+
+        assert result.height > 0
+        assert result["forward_return"].is_finite().all()
+
+    def test_horizon_too_long_raises_clear_error(self):
+        with pytest.raises(UserInputError, match=r"too short|forward_periods=10"):
+            compute_forward_return(_make_price_data(), forward_periods=10)
+
 
 class TestWinsorizeForwardReturn:
+    @pytest.mark.parametrize(
+        ("lower", "upper"),
+        [
+            (-0.1, 0.9),
+            (0.9, 0.1),
+            (0.1, 1.1),
+            ("0.1", 0.9),
+            (False, 0.9),
+        ],
+    )
+    def test_rejects_invalid_bounds(self, lower, upper):
+        df = pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1)] * 5,
+                "forward_return": [0.01, 0.02, 0.03, 0.04, 0.05],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        with pytest.raises(UserInputError, match=r"0 <= lower <= upper <= 1|numeric"):
+            winsorize_forward_return(df, lower=lower, upper=upper)
+
     def test_noop(self):
         df = pl.DataFrame(
             {


### PR DESCRIPTION
## Summary
- Validate forward-return horizons, non-finite returns, empty output, and winsorization bounds through clear UserInputError contracts.
- Populate lifted EvaluationResult warning messages from WarningCode descriptions.
- Catch list-of-dict-key mistakes in family functions with the existing list(results.values()) recovery hint.
- Document preprocess contracts and Windows test notes.

## Test plan
- .\.venv\Scripts\python.exe -m ruff check factrix\preprocess\returns.py factrix\_dag.py factrix\_multi_factor.py tests\test_returns.py tests\test_bhy.py tests\test_bhy_hierarchical.py tests\test_partial_conjunction.py tests\test_dag.py
- .\.venv\Scripts\python.exe -m ruff format --check factrix\preprocess\returns.py factrix\_dag.py factrix\_multi_factor.py tests\test_returns.py tests\test_bhy.py tests\test_bhy_hierarchical.py tests\test_partial_conjunction.py tests\test_dag.py
- $env:PYTHONUTF8='1'; .\.venv\Scripts\python.exe -m pytest -q -p no:faulthandler tests\test_returns.py tests\test_bhy.py tests\test_partial_conjunction.py tests\test_bhy_hierarchical.py tests\test_dag.py

Refs https://github.com/awwesomeman/factrix/issues/699