### PR TITLE
fix(metrics): harden spread preflight

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -274,6 +274,10 @@ consistency are read separately.
 - *secondary-test*: `short_alpha`, `short_stat`, `short_p_value`,
   `short_significance` — short-leg attribution.
 - *descriptive*: `n_periods`, `tie_ratio`, `tie_policy`, `method`.
+- *descriptive* (conditional, no-signal): `signal_status`
+  (`"no_signal_zero_variance_factor"`) when the factor has observations
+  but no cross-sectional variation. This is a valid `p_value = 1.0`
+  result, not a short-circuit `reason`.
 
 #### `quantile_spread_vw`
 
@@ -295,6 +299,10 @@ Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
   (mean per-date cross-sectional return std), `top_return`,
   `bottom_return`, `n_periods`, `method`. The `k`-too-large
   short-circuit reports `max_assets_per_date`.
+- *descriptive* (conditional, no-signal): `signal_status`
+  (`"no_signal_zero_variance_factor"`) when the factor has observations
+  but no cross-sectional variation. This is a valid `p_value = 1.0`
+  result, not a short-circuit `reason`.
 
 #### Shared small-N significance keys
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -201,6 +201,7 @@ def evaluate(
     data = _coerce_data(data)
     _validate_baseline_columns(data)
     _validate_factor_cols_on_data(data, cols)
+    _validate_factor_cols_numeric(data, cols)
 
     # The overlap horizon is a property of the data: read the stamp left by
     # compute_forward_return, then strip it so it never reaches a metric,
@@ -210,7 +211,13 @@ def evaluate(
     if _FORWARD_PERIODS_COL in data.columns:
         data = data.drop(_FORWARD_PERIODS_COL)
 
-    label_spec = {label: type(inst).spec() for label, inst in metrics.items()}
+    label_spec = {
+        label: dataclasses.replace(
+            type(inst).spec(),
+            sample_threshold=type(inst)._resolve_sample_threshold(inst),
+        )
+        for label, inst in metrics.items()
+    }
     label_params = {label: dict(inst._params()) for label, inst in metrics.items()}
 
     # Structure pre-flight: a metric whose declared cell.structure disagrees
@@ -749,6 +756,23 @@ def _validate_factor_cols_on_data(data: pl.DataFrame, cols: list[str]) -> None:
             ),
             docs_path=_DOCS_FACTOR_COLS,
         )
+
+
+def _validate_factor_cols_numeric(data: pl.DataFrame, cols: list[str]) -> None:
+    non_numeric = [(c, data.schema[c]) for c in cols if not data.schema[c].is_numeric()]
+    if not non_numeric:
+        return
+    col, dtype = non_numeric[0]
+    raise UserInputError(
+        func_name="evaluate",
+        field="factor_cols",
+        value=f"{col!r} has dtype {dtype}",
+        expected=(
+            "factor columns to be numeric. Encode categorical/string signals "
+            "before evaluate(), or pass a numeric exposure / event indicator."
+        ),
+        docs_path=_DOCS_FACTOR_COLS,
+    )
 
 
 def _validate_baseline_columns(data: pl.DataFrame) -> None:

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -191,13 +191,23 @@ class DagExecutor:
         n_assets = data.select(pl.col("asset_id").n_unique()).item()
         structure = DataStructure.PANEL if n_assets > 1 else DataStructure.TIMESERIES
 
-        # per-factor panel structure stats (computed before dispatch)
-        factor_n_periods: dict[str, int] = {}
-        factor_n_pairs: dict[str, int] = {}
-        for c in cols:
-            mask = data[c].is_not_null()
-            factor_n_pairs[c] = int(mask.sum())
-            factor_n_periods[c] = int(data.filter(mask)["date"].n_unique())
+        stats_row = data.select(
+            *(
+                pl.col(c).is_not_null().sum().alias(f"__pairs_{i}")
+                for i, c in enumerate(cols)
+            ),
+            *(
+                pl.col("date")
+                .filter(pl.col(c).is_not_null())
+                .n_unique()
+                .alias(f"__periods_{i}")
+                for i, c in enumerate(cols)
+            ),
+        ).row(0, named=True)
+        factor_n_pairs = {c: int(stats_row[f"__pairs_{i}"]) for i, c in enumerate(cols)}
+        factor_n_periods = {
+            c: int(stats_row[f"__periods_{i}"]) for i, c in enumerate(cols)
+        }
 
         projections: dict[str, pl.DataFrame] = {}
 

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -39,7 +39,9 @@ def _clean_series(df: pl.DataFrame, value_col: str) -> pl.Series:
     time-coherent series regardless of caller row order. Sorting is mean-
     and OLS-invariant but load-bearing for the autocovariance terms.
     """
-    return df.sort("date").drop_nulls(value_col)[value_col]
+    if df["date"].is_sorted():
+        return df[value_col].drop_nulls()
+    return df.sort("date").get_column(value_col).drop_nulls()
 
 
 @dataclass(frozen=True, slots=True)

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -124,6 +124,13 @@ def compute_spread_series(
     ]
     for f in cols:
         agg_exprs.append(
+            pl.col(f)
+            .filter(pl.col(f).is_not_null())
+            .n_unique()
+            .alias(f"_n_unique__{f}")
+        )
+        agg_exprs.append(pl.col(f).count().alias(f"_n_assets__{f}"))
+        agg_exprs.append(
             pl.col(return_col)
             .filter(pl.col(f"_group__{f}") == top_group)
             .mean()
@@ -141,10 +148,23 @@ def compute_spread_series(
     return {
         f: wide.select(
             pl.col("date"),
-            pl.col(f"_top__{f}").alias("top_return"),
-            pl.col(f"_bot__{f}").alias("bottom_return"),
+            pl.when((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1))
+            .then(pl.col("universe_return"))
+            .otherwise(pl.col(f"_top__{f}"))
+            .alias("top_return"),
+            pl.when((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1))
+            .then(pl.col("universe_return"))
+            .otherwise(pl.col(f"_bot__{f}"))
+            .alias("bottom_return"),
             pl.col("universe_return"),
-            (pl.col(f"_top__{f}") - pl.col(f"_bot__{f}")).alias("spread"),
+            pl.when((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1))
+            .then(pl.lit(0.0))
+            .otherwise(pl.col(f"_top__{f}") - pl.col(f"_bot__{f}"))
+            .alias("spread"),
+            ((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1)).alias(
+                "_zero_variance_factor"
+            ),
+            pl.col(f"_n_assets__{f}").alias("_n_assets"),
         )
         for f in cols
     }

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -34,7 +34,7 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
 )
-from factrix._metric_index import cell
+from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
 from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
@@ -61,6 +61,17 @@ applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
     {NON_OVERLAPPING, NEWEY_WEST}
 )
 
+_K_SPREAD_PERIODS_FLOOR = _scaled_periods_threshold(MIN_PORTFOLIO_PERIODS_HARD)
+
+
+def _k_spread_threshold(self) -> SampleThreshold:
+    periods = _K_SPREAD_PERIODS_FLOOR(self)
+    return SampleThreshold(
+        min_periods=periods.min_periods,
+        warn_periods=periods.warn_periods,
+        min_assets=2 * self.k,
+    )
+
 
 def _build_k_spread_series(
     panel: pl.DataFrame, k: int, factor_col: str, return_col: str
@@ -76,6 +87,25 @@ def _build_k_spread_series(
     clean = panel.filter(
         pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
     )
+    if clean.is_empty():
+        return None, clean
+    if bool(
+        clean.group_by("date")
+        .agg(pl.col(factor_col).n_unique().alias("_n_unique"))
+        .select((pl.col("_n_unique") <= 1).all())
+        .item()
+    ):
+        series = (
+            clean.group_by("date")
+            .agg(
+                pl.col(return_col).mean().alias("top_return"),
+                pl.col(return_col).mean().alias("bottom_return"),
+                pl.col(return_col).std(ddof=DDOF).alias("xs_dispersion"),
+            )
+            .with_columns(pl.lit(0.0).alias("spread"))
+            .sort("date")
+        )
+        return series, clean
     ranked = clean.with_columns(
         pl.col(factor_col)
         .rank(method="ordinal", descending=True)
@@ -111,7 +141,7 @@ def _build_k_spread_series(
     # Periods floor scales with the non-overlap stride (see ``quantile``): the
     # spread series is sub-sampled at ``forward_periods``, so pre-flight and the
     # in-body gate share ``MIN_PORTFOLIO_PERIODS_HARD`` + ``_scaled_min_periods``.
-    sample_threshold=_scaled_periods_threshold(MIN_PORTFOLIO_PERIODS_HARD),
+    sample_threshold=_k_spread_threshold,
 )
 def k_spread(
     df: pl.DataFrame,
@@ -204,6 +234,17 @@ def k_spread(
     # forward_return is null on the last ``forward_periods`` rows per asset.
     sampled = _sample_non_overlapping(df, forward_periods)
     series, clean = _build_k_spread_series(sampled, k, factor_col, return_col)
+    n_assets = clean["asset_id"].n_unique()
+    if n_assets < 2 * k:
+        return _short_circuit_output(
+            "k_spread",
+            "insufficient_assets_for_k_legs",
+            n_obs=n_assets,
+            n_obs_axis="assets",
+            k=k,
+            min_required=2 * k,
+            max_assets_per_date=n_assets,
+        )
 
     if series is None:
         per_date_counts = clean.group_by("date").len()["len"].to_numpy()
@@ -230,9 +271,34 @@ def k_spread(
     )
     if sc is not None:
         return sc
+    if bool((series["spread"] == 0).all()) and bool(
+        clean.group_by("date")
+        .agg(pl.col(factor_col).n_unique().alias("_n_unique"))
+        .select((pl.col("_n_unique") <= 1).all())
+        .item()
+    ):
+        return MetricResult(
+            value=0.0,
+            p_value=1.0,
+            n_obs=n,
+            n_obs_axis="periods",
+            stat=0.0,
+            metadata={
+                "n_periods": n,
+                "k": k,
+                "stat_type": "t",
+                "h0": "mu=0",
+                "method": "no-signal zero-variance factor",
+                "signal_status": "no_signal_zero_variance_factor",
+                "cross_sectional_dispersion": float(
+                    np.mean(series["xs_dispersion"].drop_nulls().to_numpy())
+                ),
+                "top_return": float(np.mean(series["top_return"].to_numpy())),
+                "bottom_return": float(np.mean(series["bottom_return"].to_numpy())),
+            },
+        )
 
     arr = spread_vals.to_numpy()
-    n_assets = clean["asset_id"].n_unique()
     # The HAC path needs the full overlapping spread series (every date);
     # build it once on the unsampled panel.
     full_series: pl.DataFrame | None = None

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -15,6 +15,7 @@ Notes:
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import cast
 
 import numpy as np
 import polars as pl
@@ -25,7 +26,7 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
 )
-from factrix._metric_index import cell
+from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
@@ -80,11 +81,20 @@ applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
 )
 
 
+def _quantile_spread_threshold(self) -> SampleThreshold:
+    periods = _PORTFOLIO_PERIODS_FLOOR(self)
+    return SampleThreshold(
+        min_periods=periods.min_periods,
+        warn_periods=periods.warn_periods,
+        min_assets=self.n_groups,
+    )
+
+
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     batchable=True,
-    sample_threshold=_PORTFOLIO_PERIODS_FLOOR,
+    sample_threshold=_quantile_spread_threshold,
 )
 def quantile_spread(
     df: pl.DataFrame,
@@ -197,6 +207,7 @@ def quantile_spread(
             tie_policy=tie_policy,
             inference=inference,
             forward_periods=forward_periods,
+            n_groups=n_groups,
             full_series=(
                 full_series_by_factor[f] if full_series_by_factor is not None else None
             ),
@@ -214,6 +225,7 @@ def _quantile_spread_from_series(
     tie_policy: str,
     inference: NonOverlapping | NeweyWest,
     forward_periods: int,
+    n_groups: int,
     full_series: pl.DataFrame | None,
 ) -> MetricResult:
     """Per-factor t-test pipeline shared by single and batch paths.
@@ -238,6 +250,37 @@ def _quantile_spread_from_series(
     )
     if sc is not None:
         return sc
+    per_date_assets = series["_n_assets"]
+    if bool((per_date_assets < n_groups).all()):
+        max_assets_value = per_date_assets.max()
+        max_assets = 0 if max_assets_value is None else cast(int, max_assets_value)
+        return _short_circuit_output(
+            "quantile_spread",
+            "insufficient_assets_for_quantile_groups",
+            n_obs=max_assets,
+            n_obs_axis="assets",
+            n_groups=n_groups,
+            min_required=n_groups,
+            max_assets_per_date=max_assets,
+        )
+    if bool(series["_zero_variance_factor"].all()):
+        return MetricResult(
+            p_value=1.0,
+            value=0.0,
+            n_obs=series.height,
+            n_obs_axis="periods",
+            stat=0.0,
+            metadata={
+                "n_periods": series.height,
+                "stat_type": "t",
+                "h0": "mu=0",
+                "method": "no-signal zero-variance factor",
+                "signal_status": "no_signal_zero_variance_factor",
+                "tie_ratio": tie_ratio,
+                "tie_policy": tie_policy,
+                "n_groups": n_groups,
+            },
+        )
 
     arr = spread_vals.to_numpy()
     # Headline test: ``inference`` selects non-overlap t vs Newey-West HAC;

--- a/tests/test_dynamic_sample_threshold.py
+++ b/tests/test_dynamic_sample_threshold.py
@@ -47,6 +47,20 @@ class TestHookResolution:
         assert st.min_periods is None
         assert REGISTRY["net_spread"].sample_threshold.min_periods is None
 
+    def test_spread_asset_floors_follow_metric_params(self):
+        from factrix.metrics.k_spread import k_spread
+        from factrix.metrics.quantile import quantile_spread
+
+        assert quantile_spread.spec().sample_threshold.min_assets == 5
+        assert k_spread.spec().sample_threshold.min_assets == 10
+        assert (
+            quantile_spread._resolve_sample_threshold(
+                quantile_spread(n_groups=7)
+            ).min_assets
+            == 7
+        )
+        assert k_spread._resolve_sample_threshold(k_spread(k=4)).min_assets == 8
+
 
 class TestInspectDataPreflight:
     def test_dynamic_floor_gates_short_panel(self):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -94,6 +94,16 @@ class TestMetricsValidation:
         with pytest.raises(UserInputError, match="overview catalog"):
             _eval(fx.list_metrics())
 
+    def test_non_numeric_factor_column_rejected_at_entry(self):
+        panel = _panel().with_columns(pl.lit("buy").alias("factor_text"))
+        with pytest.raises(UserInputError, match="factor columns to be numeric"):
+            fx.evaluate(
+                panel,
+                metrics={"ic": ic()},
+                factor_cols=["factor_text"],
+                forward_periods=5,
+            )
+
 
 class TestByValueDedup:
     def test_same_config_alias_is_one_node_two_labels(self):

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -127,6 +127,18 @@ class TestShortCircuits:
         with pytest.raises(ValueError, match="k must be"):
             k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=0)
 
+    def test_constant_factor_returns_explicit_no_signal(self):
+        rng = np.random.default_rng(9)
+        factor = np.ones(8, dtype=float)
+        returns = rng.normal(0.0, 0.02, size=(6, 8))
+        result = k_spread(_panel_from_matrix(factor, returns), forward_periods=1, k=2)
+
+        assert result.value == 0.0
+        assert result.stat == 0.0
+        assert result.p_value == 1.0
+        assert result.is_applicable is True
+        assert result.metadata["signal_status"] == "no_signal_zero_variance_factor"
+
 
 class TestUnderfilledDatesDropped:
     def test_dates_with_fewer_than_2k_assets_excluded(self):

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -117,6 +117,79 @@ class TestQuantileSpread:
             assert "short_stat" in result.metadata
             assert result.p_value is not None
 
+    def test_constant_factor_returns_explicit_no_signal(self):
+        rng = np.random.default_rng(12)
+        n_dates, n_assets = 8, 10
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = [
+            {
+                "date": d,
+                "asset_id": f"A{a}",
+                "factor": 1.0,
+                "forward_return": float(rng.normal()),
+            }
+            for d in dates
+            for a in range(n_assets)
+        ]
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        series = compute_spread_series(panel, forward_periods=1, n_groups=5)["factor"]
+        assert series["spread"].to_list() == [0.0] * n_dates
+
+        result = quantile_spread(panel, forward_periods=1, n_groups=5)["factor"]
+        assert result.value == 0.0
+        assert result.stat == 0.0
+        assert result.p_value == 1.0
+        assert result.is_applicable is True
+        assert result.metadata["signal_status"] == "no_signal_zero_variance_factor"
+
+    def test_n_groups_asset_floor_short_circuits(self, tiny_panel):
+        result = quantile_spread(tiny_panel, forward_periods=1, n_groups=6)["factor"]
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_assets_for_quantile_groups"
+        assert result.metadata["min_required"] == 6
+
+    def test_all_null_factor_is_not_no_signal(self):
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(8)]
+        rows = [
+            {
+                "date": d,
+                "asset_id": f"A{a}",
+                "factor": None,
+                "forward_return": 0.01 * a,
+            }
+            for d in dates
+            for a in range(10)
+        ]
+        panel = pl.DataFrame(rows).with_columns(
+            pl.col("date").cast(pl.Datetime("ms")),
+            pl.col("factor").cast(pl.Float64),
+        )
+
+        result = quantile_spread(panel, forward_periods=1, n_groups=5)["factor"]
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_assets_for_quantile_groups"
+        assert result.metadata["max_assets_per_date"] == 0
+
+    def test_per_date_factor_count_gates_n_groups(self):
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(8)]
+        rows = [
+            {
+                "date": d,
+                "asset_id": f"A{a}",
+                "factor": float(a) if a < 3 else None,
+                "forward_return": 0.01 * a,
+            }
+            for d in dates
+            for a in range(10)
+        ]
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        result = quantile_spread(panel, forward_periods=1, n_groups=5)["factor"]
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_assets_for_quantile_groups"
+        assert result.metadata["max_assets_per_date"] == 3
+
 
 class TestQuantileSpreadVW:
     def _make_panel_with_cap(self, n_dates: int = 60, n_assets: int = 20):


### PR DESCRIPTION
## Summary
- Gate quantile spread on per-date valid factor counts and keep all-null factors from being treated as no-signal.
- Preserve zero-variance spread results as applicable p=1.0 outputs via signal_status instead of reason.
- Vectorize DAG factor stats and skip redundant series sorting when date order is already valid.

## Test plan
- [x] .\.venv\Scripts\python.exe -m ruff check factrix\metrics\_primitives\_spread_series.py factrix\metrics\quantile.py factrix\metrics\k_spread.py tests\test_quantile.py tests\test_k_spread.py
- [x] .\.venv\Scripts\python.exe -m pytest -q -p no:faulthandler

Refs https://github.com/awwesomeman/factrix/issues/699