### PR TITLE
fix(metrics): harden quantile_spread_vw against zero-variance factors

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -283,7 +283,9 @@ consistency are read separately.
 
 Value-weighted variant. Same metadata shape as `quantile_spread`
 plus a `weights_lagged` flag indicating whether the weighting input
-was lagged before the join (descriptive).
+was lagged before the join (descriptive). This includes the conditional
+no-signal `signal_status` (`"no_signal_zero_variance_factor"`, a valid
+`p_value = 1.0` result) when the factor has no cross-sectional variation.
 
 ### `k_spread` (`factrix.metrics.k_spread`)
 

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -306,6 +306,56 @@ def _short_circuit_output(
     )
 
 
+def _all_dates_degenerate(panel: pl.DataFrame, factor_col: str) -> bool:
+    """True when no date has cross-sectional variation in ``factor_col``.
+
+    A zero-variance (constant) factor carries no ranking signal: under
+    ordinal tie-breaking it manufactures a spurious spread from row order,
+    and under average tie-breaking every name shares a bucket so the
+    top/bottom legs are empty. Spread metrics test this per date — all
+    dates degenerate — and short-circuit to an explicit no-signal result
+    (:func:`_no_signal_zero_variance`) instead of ranking. Nulls are
+    excluded so an all-null date counts as degenerate, not as variation.
+    """
+    return bool(
+        panel.group_by("date")
+        .agg(
+            pl.col(factor_col)
+            .filter(pl.col(factor_col).is_not_null())
+            .n_unique()
+            .alias("_n_unique")
+        )
+        .select((pl.col("_n_unique") <= 1).all())
+        .item()
+    )
+
+
+def _no_signal_zero_variance(n_periods: int, **extra: object) -> MetricResult:
+    """Explicit no-signal result for a zero cross-sectional variance factor.
+
+    A constant factor produces an identically zero long-short spread, so the
+    honest answer is ``value=0`` with ``t=0``, ``p=1`` — a real (if null)
+    finding, not a data shortage. Returned as a normal applicable
+    ``MetricResult`` (no short-circuit ``reason``) so callers do not mis-route
+    it as a shortage. ``extra`` carries metric-specific descriptive metadata.
+    """
+    return MetricResult(
+        value=0.0,
+        p_value=1.0,
+        n_obs=n_periods,
+        n_obs_axis="periods",
+        stat=0.0,
+        metadata={
+            "n_periods": n_periods,
+            "stat_type": "t",
+            "h0": "mu=0",
+            "method": "no-signal zero-variance factor",
+            "signal_status": "no_signal_zero_variance_factor",
+            **extra,
+        },
+    )
+
+
 def _enforce_min_floor(
     metric: Any,
     name: str,

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -25,6 +25,8 @@ Notes:
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 import polars as pl
 
@@ -40,8 +42,10 @@ from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
 from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _all_dates_degenerate,
     _check_applicable_inference,
     _enforce_scaled_floor,
+    _no_signal_zero_variance,
     _sample_non_overlapping,
     _scaled_periods_threshold,
     _short_circuit_output,
@@ -89,12 +93,9 @@ def _build_k_spread_series(
     )
     if clean.is_empty():
         return None, clean
-    if bool(
-        clean.group_by("date")
-        .agg(pl.col(factor_col).n_unique().alias("_n_unique"))
-        .select((pl.col("_n_unique") <= 1).all())
-        .item()
-    ):
+    # Constant factor: skip ranking (ordinal ties would manufacture a spurious
+    # top/bottom split) and emit a spread=0 series; the body returns no-signal.
+    if _all_dates_degenerate(clean, factor_col):
         series = (
             clean.group_by("date")
             .agg(
@@ -235,6 +236,12 @@ def k_spread(
     sampled = _sample_non_overlapping(df, forward_periods)
     series, clean = _build_k_spread_series(sampled, k, factor_col, return_col)
     n_assets = clean["asset_id"].n_unique()
+    # Real per-date asset count (not the universe-wide unique count): both
+    # insufficient-assets short-circuits report it under the same reason.
+    max_per_date_value = (
+        clean.group_by("date").len()["len"].max() if not clean.is_empty() else None
+    )
+    max_per_date = 0 if max_per_date_value is None else cast(int, max_per_date_value)
     if n_assets < 2 * k:
         return _short_circuit_output(
             "k_spread",
@@ -243,12 +250,10 @@ def k_spread(
             n_obs_axis="assets",
             k=k,
             min_required=2 * k,
-            max_assets_per_date=n_assets,
+            max_assets_per_date=max_per_date,
         )
 
     if series is None:
-        per_date_counts = clean.group_by("date").len()["len"].to_numpy()
-        max_per_date = int(np.max(per_date_counts)) if per_date_counts.size else 0
         return _short_circuit_output(
             "k_spread",
             "insufficient_assets_for_k_legs",
@@ -271,31 +276,17 @@ def k_spread(
     )
     if sc is not None:
         return sc
-    if bool((series["spread"] == 0).all()) and bool(
-        clean.group_by("date")
-        .agg(pl.col(factor_col).n_unique().alias("_n_unique"))
-        .select((pl.col("_n_unique") <= 1).all())
-        .item()
-    ):
-        return MetricResult(
-            value=0.0,
-            p_value=1.0,
-            n_obs=n,
-            n_obs_axis="periods",
-            stat=0.0,
-            metadata={
-                "n_periods": n,
-                "k": k,
-                "stat_type": "t",
-                "h0": "mu=0",
-                "method": "no-signal zero-variance factor",
-                "signal_status": "no_signal_zero_variance_factor",
-                "cross_sectional_dispersion": float(
-                    np.mean(series["xs_dispersion"].drop_nulls().to_numpy())
-                ),
-                "top_return": float(np.mean(series["top_return"].to_numpy())),
-                "bottom_return": float(np.mean(series["bottom_return"].to_numpy())),
-            },
+    # ``_build_k_spread_series`` forces spread=0 for a constant factor, so a
+    # degenerate panel is detected once here and returned as no-signal.
+    if _all_dates_degenerate(clean, factor_col):
+        return _no_signal_zero_variance(
+            n,
+            k=k,
+            cross_sectional_dispersion=float(
+                np.mean(series["xs_dispersion"].drop_nulls().to_numpy())
+            ),
+            top_return=float(np.mean(series["top_return"].to_numpy())),
+            bottom_return=float(np.mean(series["bottom_return"].to_numpy())),
         )
 
     arr = spread_vals.to_numpy()

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -36,11 +36,13 @@ from factrix._types import (
 from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _all_dates_degenerate,
     _assign_quantile_groups,
     _check_applicable_inference,
     _compute_tie_ratio,
     _enforce_scaled_floor,
     _lag_within_asset,
+    _no_signal_zero_variance,
     _sample_non_overlapping,
     _scaled_periods_threshold,
     _short_circuit_output,
@@ -81,7 +83,13 @@ applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
 )
 
 
-def _quantile_spread_threshold(self) -> SampleThreshold:
+def _quantile_groups_threshold(self) -> SampleThreshold:
+    """Periods floor plus a ``min_assets >= n_groups`` cross-sectional floor.
+
+    Shared by ``quantile_spread`` and ``quantile_spread_vw``: both bucket each
+    date into ``n_groups`` quantiles, so a date needs at least ``n_groups``
+    valid names to fill the top and bottom legs.
+    """
     periods = _PORTFOLIO_PERIODS_FLOOR(self)
     return SampleThreshold(
         min_periods=periods.min_periods,
@@ -94,7 +102,7 @@ def _quantile_spread_threshold(self) -> SampleThreshold:
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     batchable=True,
-    sample_threshold=_quantile_spread_threshold,
+    sample_threshold=_quantile_groups_threshold,
 )
 def quantile_spread(
     df: pl.DataFrame,
@@ -264,22 +272,11 @@ def _quantile_spread_from_series(
             max_assets_per_date=max_assets,
         )
     if bool(series["_zero_variance_factor"].all()):
-        return MetricResult(
-            p_value=1.0,
-            value=0.0,
-            n_obs=series.height,
-            n_obs_axis="periods",
-            stat=0.0,
-            metadata={
-                "n_periods": series.height,
-                "stat_type": "t",
-                "h0": "mu=0",
-                "method": "no-signal zero-variance factor",
-                "signal_status": "no_signal_zero_variance_factor",
-                "tie_ratio": tie_ratio,
-                "tie_policy": tie_policy,
-                "n_groups": n_groups,
-            },
+        return _no_signal_zero_variance(
+            series.height,
+            tie_ratio=tie_ratio,
+            tie_policy=tie_policy,
+            n_groups=n_groups,
         )
 
     arr = spread_vals.to_numpy()
@@ -354,7 +351,7 @@ def _quantile_spread_from_series(
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
-    sample_threshold=_PORTFOLIO_PERIODS_FLOOR,
+    sample_threshold=_quantile_groups_threshold,
 )
 def quantile_spread_vw(
     df: pl.DataFrame,
@@ -496,6 +493,33 @@ def quantile_spread_vw(
     )
     if sc is not None:
         return sc
+    # Mirror the EW path (see ``_quantile_spread_from_series``): gate the
+    # n_groups buckets on per-date valid factor counts, then treat a constant
+    # factor as no-signal — otherwise value weighting manufactures an
+    # ordering-artifact spread (ordinal ties) or empty-bucket NaN (average).
+    per_date_assets = sampled.group_by("date").agg(
+        pl.col(factor_col).count().alias("_n")
+    )["_n"]
+    if bool((per_date_assets < n_groups).all()):
+        max_assets_value = per_date_assets.max()
+        max_assets = 0 if max_assets_value is None else cast(int, max_assets_value)
+        return _short_circuit_output(
+            "quantile_spread_vw",
+            "insufficient_assets_for_quantile_groups",
+            n_obs=max_assets,
+            n_obs_axis="assets",
+            n_groups=n_groups,
+            min_required=n_groups,
+            max_assets_per_date=max_assets,
+        )
+    if _all_dates_degenerate(sampled, factor_col):
+        return _no_signal_zero_variance(
+            n,
+            tie_ratio=tie_ratio,
+            tie_policy=tie_policy,
+            n_groups=n_groups,
+            weights_lagged=lag_weights,
+        )
 
     arr = spread_vals.to_numpy()
     mean_spread = float(np.mean(arr))

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -247,6 +247,58 @@ class TestQuantileSpreadVW:
         assert result.metadata.get("reason") == "no_weight_column"
         assert result.metadata.get("missing_column") == "market_cap"
 
+    @pytest.mark.parametrize("tie_policy", ["ordinal", "average"])
+    def test_constant_factor_returns_explicit_no_signal(self, tie_policy):
+        # A constant factor must not produce a value-weighted spread: under
+        # ordinal ties row order would manufacture one, under average ties the
+        # top/bottom buckets are empty (0/0 = NaN). Both collapse to no-signal.
+        rng = np.random.default_rng(7)
+        n_dates, n_assets = 10, 12
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = [
+            {
+                "date": d,
+                "asset_id": f"s_{a}",
+                "factor": 1.0,
+                "forward_return": float(rng.normal()),
+                "market_cap": float(rng.lognormal(10, 1)),
+            }
+            for d in dates
+            for a in range(n_assets)
+        ]
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        result = quantile_spread_vw(
+            panel, forward_periods=1, n_groups=5, tie_policy=tie_policy
+        )
+        assert result.value == 0.0
+        assert result.stat == 0.0
+        assert result.p_value == 1.0
+        assert result.is_applicable is True
+        assert result.metadata["signal_status"] == "no_signal_zero_variance_factor"
+        assert result.metadata.get("reason") is None
+
+    def test_per_date_assets_below_n_groups_short_circuits(self):
+        # Three valid names per date cannot fill five quantile buckets.
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(8)]
+        rows = [
+            {
+                "date": d,
+                "asset_id": f"s_{a}",
+                "factor": float(a) if a < 3 else None,
+                "forward_return": 0.01 * a,
+                "market_cap": 1e6,
+            }
+            for d in dates
+            for a in range(10)
+        ]
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        result = quantile_spread_vw(panel, forward_periods=1, n_groups=5)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_assets_for_quantile_groups"
+        assert result.metadata["max_assets_per_date"] == 3
+
 
 class TestQuantileSpreadInference:
     """The ``inference=`` knob mirrors k_spread: default bit-for-bit, HAC opt-in."""


### PR DESCRIPTION
## Summary

`quantile_spread_vw` runs its own ranking path and never received the zero-variance hardening already shipped for `quantile_spread` and `k_spread` under issue #699. On a constant (zero cross-sectional variance) factor it silently produced garbage:

- **ordinal ties** → row order fills the quantile buckets, manufacturing a spurious value-weighted spread reported as a normal result (`p≈0.28`, looks like a real signal);
- **average ties** → every name shares the middle bucket, so the top/bottom legs are empty (`0/0 = NaN`) and the result is a silent `NaN`.

Both now collapse to the explicit no-signal result (`value=0`, `t=0`, `p=1`, `signal_status="no_signal_zero_variance_factor"`), matching `quantile_spread`/`k_spread`. The `min_assets >= n_groups` cross-sectional floor is also extended to `vw` so per-date bucket fill is gated consistently.

To avoid triplicating logic, the no-signal `MetricResult` builder and the all-dates-degenerate detector are extracted into shared helpers (`_no_signal_zero_variance`, `_all_dates_degenerate`) and reused across all three spread metrics. Drive-by: `k_spread`'s insufficient-assets short-circuit now reports the true per-date asset max instead of the universe-wide unique count (the previous value mislabelled `max_assets_per_date`).

Out of scope (unchanged, consistent with siblings): all three metrics only treat a factor as no-signal when **every** date is degenerate; per-date mixed degeneracy in `vw` is a broader, separate concern.

## Test plan

- New focused tests in `TestQuantileSpreadVW`: constant factor under both `ordinal` and `average` tie policies returns the no-signal result; per-date valid-asset count below `n_groups` short-circuits with the correct `max_assets_per_date`.
- `ruff check` / `ruff format --check` / `mypy factrix` clean.
- Full suite: 1504 passed, 4 skipped.

Refs #699 (follow-up to the already-merged section 3/4 spread preflight work; does not close the epic).