### PR TITLE
fix(stats,metrics): section 2 — statistical-inference risks (Wald F, bmp_z fallback, directional cross-sectional SE)

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -154,7 +154,10 @@ Boehmer-Musumeci-Poulsen standardised-abnormal-return cross-sectional
 
 - *primary*: `p_value`.
 - *descriptive*: `n_events`, `n_dropped`, `std_sar`,
-  `estimation_window`, `include_prediction_error_variance`.
+  `estimation_window`, `include_prediction_error_variance`,
+  `vol_source` (`"price"` or `"forward_return"`), `vol_estimation_lag`
+  (rows the fallback std is lagged so its window ends before the event;
+  `0` on the price path).
 - *descriptive* (conditional, KP applied): `kolari_pynnonen_r`,
   `kolari_pynnonen_n_eff`, `kolari_pynnonen_r_source`,
   `kolari_pynnonen_applied`, `kolari_pynnonen_scaling`,
@@ -192,7 +195,12 @@ Pesaran-Timmermann `z` statistic (`stat_type="z"`), tested one-sided.
   on the marginal up/down frequencies of prediction and realisation.
 - *descriptive*: `p_correct` (realised hit rate), `p_expected`
   (hit rate under directional independence), `p_up_pred` (fraction of
-  positive predictions), `p_up_real` (fraction of positive realisations).
+  positive predictions), `p_up_real` (fraction of positive realisations),
+  `cross_sectional_r` (within-date ICC of the sign-hit indicator, `None`
+  on a single-asset series), `cross_sectional_n_eff` (mean assets-per-date),
+  `cross_sectional_adjusted` (whether the Kolari-Pynnönen deflation fired).
+- *descriptive* (conditional, adjustment applied): `stat_uncorrected`
+  (the raw `S_n` before the cross-sectional-correlation deflation).
 
 ### `event_quality` (`factrix.metrics.event_quality`)
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -74,6 +74,15 @@ class WarningCode(StrEnum):
     # reject), the conservative direction.
     RECT_KERNEL_NEGATIVE_VARIANCE = "rect_kernel_negative_variance"
 
+    # Fired by ``bmp_z`` when no ``price`` column is present and the
+    # estimation-window volatility falls back to the per-asset rolling std of
+    # ``forward_return``. Because forward_return[t] looks ahead to [t+1, t+1+h],
+    # the fallback std is lagged by ``forward_periods`` so the estimation window
+    # ends before the event's own forward window — but it is still a coarser,
+    # horizon-overlapping volatility proxy than a daily-price std. The z-test is
+    # returned; supply ``price`` for the clean estimator.
+    BMP_RETURN_VOL_FALLBACK = "bmp_return_vol_fallback"
+
     # Fired by the DAG executor when an upstream producer short-circuited
     # (returned a NaN MetricResult with metadata["reason"]) and the
     # consumer is skipped. The downstream MetricResult carries
@@ -188,6 +197,11 @@ _WARNING_DESCRIPTIONS.update(
         WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE: "Rectangular-kernel HAC variance-of-mean came out "
         "negative (no PSD guarantee, Andrews 1991); clamped to 0 → SE=0, t=0, p=1.0. "
         "Fires only on short / mildly anti-correlated samples.",
+        WarningCode.BMP_RETURN_VOL_FALLBACK: "bmp_z ran without a price column: the "
+        "estimation-window volatility falls back to the per-asset rolling std of "
+        "forward_return, lagged by forward_periods so it ends before the event's "
+        "forward window. This is a coarser, horizon-overlapping vol proxy than a "
+        "daily-price std — supply price for the clean BMP standardiser.",
         WarningCode.UPSTREAM_UNAVAILABLE: "DAG-executor consumer skipped because an upstream "
         "producer short-circuited. The downstream MetricResult carries "
         "metadata['upstream'] / ['upstream_reason'] for the original cause.",

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -41,14 +41,29 @@ def _wald_p_linear(
     V: np.ndarray,
     R: np.ndarray,
     q: np.ndarray | float = 0.0,
+    *,
+    df_denom: int | None = None,
 ) -> tuple[float, float]:
-    """Wald χ² test of the linear restriction ``Rβ = q``.
+    """Wald test of the linear restriction ``Rβ = q``.
 
-    ``R`` is ``(r, k)``; ``q`` is ``(r,)`` or scalar for r=1. Returns
-    ``(W, p)`` with ``W ~ χ²_r`` under H₀. Returns ``(0.0, 1.0)`` if
-    the middle matrix is singular (degenerate restriction).
+    ``R`` is ``(r, k)``; ``q`` is ``(r,)`` or scalar for r=1. Returns the
+    Wald statistic ``W`` and its p-value.
+
+    With ``df_denom=None`` (default) the reference distribution is the
+    asymptotic ``W ~ χ²_r`` — correct when ``V`` is an analytic covariance
+    with effectively infinite degrees of freedom (the ts_quantile /
+    ts_asymmetry NW-HAC callers). When ``V`` is a **cluster-robust**
+    covariance estimated from a finite number of clusters ``G``, the χ²
+    reference over-rejects; pass ``df_denom = G - 1`` (one-way) or
+    ``min(G_a, G_b) - 1`` (two-way) to use the finite-sample
+    ``F = W / r ~ F_{r, df_denom}`` reference instead. ``W`` itself is
+    returned unchanged in both cases; only the p-value differs.
+
+    Returns ``(0.0, 1.0)`` if the middle matrix is singular (degenerate
+    restriction) or ``df_denom`` is given but non-positive.
     """
     R = np.atleast_2d(R)
+    r = R.shape[0]
     diff = R @ beta - np.atleast_1d(q)
     middle = R @ V @ R.T
     try:
@@ -56,7 +71,12 @@ def _wald_p_linear(
     except np.linalg.LinAlgError:
         return 0.0, 1.0
     W = float(diff @ middle_inv @ diff)
-    p = float(sp_stats.chi2.sf(W, df=R.shape[0]))
+    if df_denom is None:
+        p = float(sp_stats.chi2.sf(W, df=r))
+    elif df_denom < 1:
+        return 0.0, 1.0
+    else:
+        p = float(sp_stats.f.sf(W / r, dfn=r, dfd=df_denom))
     return W, p
 
 
@@ -134,16 +154,20 @@ def _wald_nw_cluster_means(
         lags: Bartlett-kernel bandwidth; ``None`` → ``floor(T^(1/3))``.
 
     Returns:
-        ``(W, p)`` with ``W ~ χ²_r`` under H₀. Returns ``(0.0, 1.0)``
-        on degenerate input (T < 2 or singular middle matrix).
+        ``(W, p)`` with the Wald statistic ``W`` and a finite-sample
+        p-value. The covariance is a one-way (date) cluster estimate with
+        ``G = T`` clusters, so the reference is ``F = W / r ~ F_{r, T-1}``
+        rather than the over-rejecting asymptotic χ². Returns ``(0.0,
+        1.0)`` on degenerate input (T < 2 or singular middle matrix).
     """
     Y = np.asarray(per_date_metric, dtype=float)
     if Y.ndim != 2:
         raise ValueError(f"per_date_metric must be 2-D (T, K); got shape {Y.shape}.")
-    if Y.shape[0] < 2:
+    n_clusters = Y.shape[0]
+    if n_clusters < 2:
         return 0.0, 1.0
     mean, V = _nw_hac_vector_mean(Y, lags=lags)
-    return _wald_p_linear(mean, V, R, q)
+    return _wald_p_linear(mean, V, R, q, df_denom=n_clusters - 1)
 
 
 def _cluster_meat(
@@ -202,8 +226,12 @@ def _wald_two_way_cluster(
         asset_ids: ``(n,)`` asset label per observation.
 
     Returns:
-        ``(W, p)`` with ``W ~ χ²_r`` under H₀. Returns ``(0.0, 1.0)``
-        if ``X'X`` is singular or ``n < k + 1``.
+        ``(W, p)`` with the Wald statistic ``W`` and a finite-sample
+        p-value. With two-way clustering the effective cluster count is
+        ``min(G_date, G_asset)``, so the reference is ``F = W / r ~
+        F_{r, min(G_date, G_asset) - 1}`` rather than the over-rejecting
+        asymptotic χ². Returns ``(0.0, 1.0)`` if ``X'X`` is singular or
+        ``n < k + 1``.
     """
     y = np.asarray(y, dtype=float)
     X = np.asarray(X, dtype=float)
@@ -249,4 +277,8 @@ def _wald_two_way_cluster(
         return 0.0, 1.0
     if np.any(np.diag(V_dc) < -EPSILON):
         return 0.0, 1.0
-    return _wald_p_linear(beta, V_dc, R, q)
+    # Finite-sample F reference: the effective cluster count under two-way
+    # clustering is the smaller margin (Cameron-Miller 2015), so df_denom =
+    # min(G_date, G_asset) - 1.
+    n_clusters = min(len(np.unique(date_ids)), len(np.unique(asset_ids)))
+    return _wald_p_linear(beta, V_dc, R, q, df_denom=n_clusters - 1)

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -49,7 +49,7 @@ from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
 from factrix._stats.constants import MIN_ASSETS_WARN
-from factrix._types import DDOF, EPSILON, SampleAxis
+from factrix._types import DDOF, EPSILON, KPSource, SampleAxis
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
 # tie_policy="ordinal". 0.3 is the empirical cutoff for "crowded" factors
@@ -515,6 +515,80 @@ def _warn_below_scaled_floor(
         warnings.warn(message, UserWarning, stacklevel=3)
         return code.value
     return None
+
+
+def _estimate_within_date_icc(
+    df: pl.DataFrame, value_col: str
+) -> tuple[float | None, float, KPSource]:
+    r"""ICC-style within-date correlation $\hat r$ of ``value_col`` and mean cluster size.
+
+    Shared cross-sectional-correlation estimator for same-date pooled
+    observations (``bmp_z`` SAR, ``directional_hit_rate`` sign-hit indicator).
+    Decomposes the variance of ``value_col`` into
+    $\sigma^2_{\mathrm{between}} = \mathrm{var}(\overline{v}_d)$ (date means)
+    and the $(n_k - 1)$-weighted pooled within-date variance
+    $\sigma^2_{\mathrm{within}}$, returning
+    $\hat r = \sigma^2_{\mathrm{between}} /
+    (\sigma^2_{\mathrm{between}} + \sigma^2_{\mathrm{within}})$ clipped to
+    $[0, 1]$ and the mean events-per-date.
+
+    Args:
+        df: One row per pooled observation with a ``date`` column and
+            ``value_col``.
+        value_col: The clustered value (already standardised / 0-1 coded).
+
+    Returns:
+        ``(r_hat, n_eff, source)``:
+
+        - ``"icc"``: between/within decomposition across dates with
+          $n_k \geq 2$ observations each.
+        - ``"no_multi_event_dates"``: too few multi-observation dates to
+          estimate the within-variance; $\hat r$ is ``None`` (a
+          single-asset series lands here, so the caller leaves the
+          statistic uncorrected).
+    """
+    per_date = df.group_by("date").agg(
+        pl.col(value_col).mean().alias("m"),
+        pl.col(value_col).var(ddof=DDOF).alias("v"),
+        pl.len().alias("n"),
+    )
+    if per_date.height == 0:
+        return None, 0.0, "no_multi_event_dates"
+
+    multi = per_date.filter(pl.col("n") >= 2)
+    # n_eff must align with the subsample r̂ is estimated on: computing
+    # n_eff across singleton-heavy dates and scaling by r̂ from the
+    # multi-observation subset conflates two clustering regimes and biases
+    # the correction downward when singletons dominate. Using the
+    # multi-observation mean keeps the two moments commensurate
+    # (conservative on singleton-heavy datasets, per the K-P literature).
+    if multi.height < 2:
+        fallback_n_eff = float(per_date["n"].sum() / per_date.height)
+        return None, fallback_n_eff, "no_multi_event_dates"
+    n_eff = float(multi["n"].mean())  # type: ignore[arg-type]
+
+    w_num = (multi["v"] * (multi["n"] - 1)).sum()
+    w_den = (multi["n"] - 1).sum()
+    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0  # type: ignore[operator]
+
+    date_means = multi["m"].to_numpy()
+    sigma2_between = float(np.var(date_means, ddof=DDOF))
+
+    total = sigma2_between + sigma2_within
+    r_hat = 0.0 if total < EPSILON else max(0.0, min(1.0, sigma2_between / total))
+    return r_hat, n_eff, "icc"
+
+
+def _kp_cluster_scale(r_hat: float, n_eff: float) -> float:
+    r"""Kolari-Pynnönen (2010) cross-sectional-correlation shrinkage factor.
+
+    $\sqrt{(1 - \hat r) / (1 + (N_{\mathrm{eff}} - 1)\,\hat r)} \le 1$: the
+    multiplier that deflates a pooled test statistic for within-date
+    correlation, given the ICC $\hat r$ and mean cluster size
+    $N_{\mathrm{eff}}$ from :func:`_estimate_within_date_icc`. At $\hat r = 0$
+    (no clustering) it is 1 — the statistic is unchanged.
+    """
+    return float(np.sqrt((1.0 - r_hat) / (1.0 + (n_eff - 1.0) * r_hat)))
 
 
 def _pick_event_return_col(df: pl.DataFrame) -> str:

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -44,12 +44,13 @@ from factrix._types import (
     EPSILON,
     MIN_EVENTS_HARD,
     MIN_EVENTS_WARN,
-    KPSource,
 )
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
+    _estimate_within_date_icc,
+    _kp_cluster_scale,
     _sample_event_spaced,
     _scaled_min_periods,
     _short_circuit_output,
@@ -492,7 +493,9 @@ def bmp_z(
         )
 
     if kolari_pynnonen_adjust:
-        r_hat, n_eff, kp_source = _estimate_sar_icc(valid.select("date", "_sar"))
+        r_hat, n_eff, kp_source = _estimate_within_date_icc(
+            valid.select("date", "_sar"), "_sar"
+        )
         metadata["kolari_pynnonen_r"] = r_hat
         metadata["kolari_pynnonen_n_eff"] = n_eff
         metadata["kolari_pynnonen_r_source"] = kp_source
@@ -500,7 +503,7 @@ def bmp_z(
             metadata["kolari_pynnonen_applied"] = False
             z = z_bmp
         else:
-            scale = float(np.sqrt((1.0 - r_hat) / (1.0 + (n_eff - 1.0) * r_hat)))
+            scale = _kp_cluster_scale(r_hat, n_eff)
             z = z_bmp * scale
             metadata["kolari_pynnonen_scaling"] = scale
             metadata["kolari_pynnonen_applied"] = True
@@ -522,58 +525,3 @@ def bmp_z(
         metadata=metadata,
         warning_codes=tuple(warning_codes),
     )
-
-
-def _estimate_sar_icc(
-    sar_by_date: pl.DataFrame,
-) -> tuple[float | None, float, KPSource]:
-    r"""ICC-style within-date correlation $\hat r$ of SAR and average cluster size.
-
-    Uses $\sigma^2_{\mathrm{between}} = \mathrm{var}(\overline{\mathrm{SAR}}_d)$ (date-mean SAR)
-    and $\sigma^2_{\mathrm{within}}$ = the pooled within-date variance
-    (weighted by $n_k - 1$).
-    $\hat r = \sigma^2_{\mathrm{between}} / (\sigma^2_{\mathrm{between}} + \sigma^2_{\mathrm{within}})$
-    clipped to $[0, 1]$.
-
-    Args:
-        sar_by_date: Event-level DataFrame with ``date`` and ``_sar``
-            columns (one row per event, SAR already standardized).
-
-    Returns:
-        ``(r_hat, n_eff, source)`` where ``source`` is one of:
-
-        - ``"icc"``: standard between/within decomposition across event
-          dates with $n_k \geq 2$ events each.
-        - ``"no_multi_event_dates"``: not enough date-clusters to
-          estimate within-variance; $\hat r$ is ``None``.
-    """
-    per_date = sar_by_date.group_by("date").agg(
-        pl.col("_sar").mean().alias("m"),
-        pl.col("_sar").var(ddof=DDOF).alias("v"),
-        pl.len().alias("n"),
-    )
-    if per_date.height == 0:
-        return None, 0.0, "no_multi_event_dates"
-
-    multi = per_date.filter(pl.col("n") >= 2)
-    # n_eff must align with the subsample r̂ is estimated on: computing
-    # n_eff across singleton-heavy dates and scaling by r̂ from the
-    # multi-event subset conflates two different clustering regimes and
-    # biases the correction downward when singletons dominate. Using the
-    # multi-event mean keeps the two moments commensurate (conservative
-    # on singleton-heavy datasets, as recommended by the K-P literature).
-    if multi.height < 2:
-        fallback_n_eff = float(per_date["n"].sum() / per_date.height)
-        return None, fallback_n_eff, "no_multi_event_dates"
-    n_eff = float(multi["n"].mean())  # type: ignore[arg-type]
-
-    w_num = (multi["v"] * (multi["n"] - 1)).sum()
-    w_den = (multi["n"] - 1).sum()
-    sigma2_within = float(w_num / w_den) if w_den > 0 else 0.0  # type: ignore[operator]
-
-    date_means = multi["m"].to_numpy()
-    sigma2_between = float(np.var(date_means, ddof=DDOF))
-
-    total = sigma2_between + sigma2_within
-    r_hat = 0.0 if total < EPSILON else max(0.0, min(1.0, sigma2_between / total))
-    return r_hat, n_eff, "icc"

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -284,6 +284,12 @@ def bmp_z(
 
     Uses ``price`` column for estimation-window volatility if available;
     falls back to per-asset historical ``forward_return`` std otherwise.
+    The fallback std is lagged by ``forward_periods`` so the estimation
+    window ends before each event's own forward return (which spans
+    ``(t, t+h]``) rather than leaking the event AR into its own
+    standardiser; it remains a coarser, horizon-overlapping vol proxy
+    than a daily-price std and raises ``WarningCode.BMP_RETURN_VOL_FALLBACK``
+    (``metadata["vol_source"]`` records which path ran).
 
     Steps:
         1. For each event ($\text{factor} \neq 0$), look back
@@ -384,7 +390,8 @@ def bmp_z(
     """
     sorted_df = df.sort(["asset_id", "date"])
 
-    if "price" in sorted_df.columns:
+    uses_price = "price" in sorted_df.columns
+    if uses_price:
         sorted_df = sorted_df.with_columns(
             (pl.col("price") / pl.col("price").shift(1).over("asset_id") - 1).alias(
                 "_daily_ret"
@@ -393,9 +400,18 @@ def bmp_z(
         # WHY: forward_return = (price[t+1+N]/price[t+1] - 1) / N has
         # std ≈ σ_daily / sqrt(N). Scale estimation vol to match.
         vol_scale = 1.0 / np.sqrt(forward_periods)
+        # Price daily returns at [t-N+1, t] precede the event window (t, t+h],
+        # so no extra lag is needed.
+        vol_lag = 0
     else:
         sorted_df = sorted_df.with_columns(pl.col(return_col).alias("_daily_ret"))
         vol_scale = 1.0
+        # WHY: forward_return[t] realises over (t+1, t+1+h], so a rolling std
+        # ending at row t would standardise the event AR with a window that
+        # already contains that event's own (and adjacent) forward returns —
+        # the numerator leaks into its own denominator. Lag the fallback std by
+        # forward_periods so the estimation window ends before the event window.
+        vol_lag = forward_periods
 
     # Strict BMP (1991) denominator for mean-adjusted residuals: a
     # forecast SE is √(1 + 1/T) larger than the in-sample residual std.
@@ -404,16 +420,15 @@ def bmp_z(
     if include_prediction_error_variance:
         vol_scale *= float(np.sqrt(1.0 + 1.0 / estimation_window))
 
-    # WHY: no .shift(1) needed — forward_return already starts at t+1
-    # (compute_forward_return uses t+1 entry), so the estimation window
-    # at row t naturally covers [t-N+1, t] without event contamination.
+    # With price the window [t-N+1, t] already precedes the event window; the
+    # fallback adds a forward_periods lag (see above) so it too ends pre-event.
+    est_vol_expr = pl.col("_daily_ret").rolling_std(
+        window_size=estimation_window, min_samples=20
+    )
+    if vol_lag:
+        est_vol_expr = est_vol_expr.shift(vol_lag)
     sorted_df = sorted_df.with_columns(
-        (
-            pl.col("_daily_ret")
-            .rolling_std(window_size=estimation_window, min_samples=20)
-            .over("asset_id")
-            * vol_scale
-        ).alias("_est_vol")
+        (est_vol_expr.over("asset_id") * vol_scale).alias("_est_vol")
     )
 
     events = sorted_df.filter(pl.col(factor_col) != 0)
@@ -450,6 +465,7 @@ def bmp_z(
 
     z_bmp = _calc_t_stat(mean_sar, std_sar, n_valid)
 
+    warning_codes: list[str] = []
     metadata: dict = {
         "n_events": n_valid,
         "n_dropped": len(events) - n_valid,
@@ -459,7 +475,21 @@ def bmp_z(
         "h0": "mu_SAR=0",
         "method": "BMP standardized cross-sectional test",
         "include_prediction_error_variance": include_prediction_error_variance,
+        "vol_source": "price" if uses_price else "forward_return",
+        "vol_estimation_lag": vol_lag,
     }
+    if not uses_price:
+        warning_codes.append(WarningCode.BMP_RETURN_VOL_FALLBACK.value)
+        warnings.warn(
+            f"bmp_z: no 'price' column; estimation-window volatility falls back "
+            f"to the per-asset rolling std of '{return_col}', lagged by "
+            f"forward_periods={forward_periods} so the window ends before each "
+            f"event's forward return. This is a coarser, horizon-overlapping vol "
+            f"proxy than a daily-price std — supply 'price' for the clean BMP "
+            f"standardiser.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     if kolari_pynnonen_adjust:
         r_hat, n_eff, kp_source = _estimate_sar_icc(valid.select("date", "_sar"))
@@ -490,6 +520,7 @@ def bmp_z(
         n_obs_axis="events",
         stat=z,
         metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -41,6 +41,8 @@ from factrix._types import MIN_DIRECTIONAL_PAIRS_HARD, MIN_DIRECTIONAL_PAIRS_WAR
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _enforce_min_floor,
+    _estimate_within_date_icc,
+    _kp_cluster_scale,
     _sample_non_overlapping,
     _short_circuit_output,
     _warn_below_floor,
@@ -85,7 +87,11 @@ def directional_hit_rate(
 
     Returns:
         MetricResult with value = directional hit rate ``P̂`` (0.0-1.0),
-        ``stat`` = PT statistic ``S_n``, one-sided p-value.
+        ``stat`` = the PT statistic ``S_n`` (deflated for within-date
+        cross-sectional correlation on a panel — see Notes), one-sided
+        p-value. ``metadata["cross_sectional_adjusted"]`` records whether
+        the deflation fired and ``stat_uncorrected`` carries the raw
+        ``S_n`` when it did.
 
     Notes:
         On the non-overlapping subsample, drop observations where either
@@ -108,6 +114,18 @@ def directional_hit_rate(
         \hat P_x (1 - \hat P_x) + \frac1n (2\hat P_x - 1)^2 \hat P_y
         (1 - \hat P_y) + \frac{4}{n^2} \hat P_x \hat P_y (1 - \hat P_x)
         (1 - \hat P_y)$.
+
+        **Cross-sectional correlation.** Pooling every ``(date, asset)``
+        trial as independent over-states the effective sample on a panel —
+        same-date returns share shocks, so the trials are correlated and
+        $\widehat{\operatorname{var}}(\hat P)$ understates the true
+        variance. $S_n$ is therefore deflated by the Kolari-Pynnönen (2010)
+        factor $\sqrt{(1 - \hat r)/(1 + (\bar m - 1)\hat r)}$, where
+        $\hat r$ is the within-date intraclass correlation of the sign-hit
+        indicator and $\bar m$ the mean assets-per-date — the same
+        correction :func:`~factrix.metrics.caar.bmp_z` applies to clustered
+        SARs. A single-asset series has one trial per date, so $\hat r$ is
+        undefined and $S_n$ is left exact (the canonical PT setting).
 
         The test is **one-sided**: a large positive $S_n$ signals genuine
         directional skill, so $p = \Pr(Z > S_n)$. A factor expected to be
@@ -149,6 +167,7 @@ def directional_hit_rate(
 
     sampled = _sample_non_overlapping(df, forward_periods)
     paired = sampled.select(
+        pl.col("date"),
         pl.col(factor_col).sign().alias("_x_sign"),
         pl.col(return_col).sign().alias("_y_sign"),
     ).filter(
@@ -206,7 +225,26 @@ def directional_hit_rate(
         )
 
     s_n = (p_correct - p_star) / np.sqrt(var_s)
-    p = float(sp_stats.norm.sf(s_n))
+
+    # Cross-sectional correlation: pooling every (date, asset) trial as
+    # independent over-states the effective sample because same-date returns
+    # share shocks. Deflate S_n by the Kolari-Pynnönen (2010) factor built from
+    # the within-date ICC of the sign-hit indicator — the same correction
+    # bmp_z applies to clustered SARs. A single-asset series has no within-date
+    # cross-section (one trial per date), so r̂ is undefined and S_n is left
+    # exact (the canonical PT setting).
+    hit_by_date = paired.select(
+        pl.col("date"),
+        (pl.col("_x_sign") == pl.col("_y_sign")).cast(pl.Float64).alias("_hit"),
+    )
+    r_hat, n_eff, _ = _estimate_within_date_icc(hit_by_date, "_hit")
+    if r_hat is not None and n_eff > 1.0:
+        s_stat = s_n * _kp_cluster_scale(r_hat, n_eff)
+        cross_sectional_adjusted = True
+    else:
+        s_stat = s_n
+        cross_sectional_adjusted = False
+    p = float(sp_stats.norm.sf(s_stat))
 
     warning_codes: list[str] = []
     warn_code = _warn_below_floor(
@@ -224,20 +262,31 @@ def directional_hit_rate(
     if warn_code is not None:
         warning_codes.append(warn_code)
 
+    metadata: dict = {
+        "stat_type": "z",
+        "h0": "independent_direction",
+        "method": "Pesaran-Timmermann (1992)",
+        "p_correct": p_correct,
+        "p_expected": p_star,
+        "p_up_pred": p_x,
+        "p_up_real": p_y,
+        "cross_sectional_r": r_hat,
+        "cross_sectional_n_eff": n_eff,
+        "cross_sectional_adjusted": cross_sectional_adjusted,
+    }
+    if cross_sectional_adjusted:
+        metadata["stat_uncorrected"] = float(s_n)
+        metadata["method"] = (
+            "Pesaran-Timmermann (1992) + Kolari-Pynnönen (2010) "
+            "cross-sectional-correlation adjustment"
+        )
+
     return MetricResult(
         value=p_correct,
         p_value=p,
         n_obs=n,
         n_obs_axis="pairs",
-        stat=float(s_n),
-        metadata={
-            "stat_type": "z",
-            "h0": "independent_direction",
-            "method": "Pesaran-Timmermann (1992)",
-            "p_correct": p_correct,
-            "p_expected": p_star,
-            "p_up_pred": p_x,
-            "p_up_real": p_y,
-        },
+        stat=float(s_stat),
+        metadata=metadata,
         warning_codes=tuple(warning_codes),
     )

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -339,8 +339,10 @@ def slice_joint_test(
         Single-row ``pl.DataFrame`` with columns
         ``(n_obs, k_slices, df, stat, p_value)``. ``df`` is the
         restriction rank (``K-1``); ``stat`` is the joint Wald χ²;
-        ``p_value`` is the chi-squared survival function. No
-        ``multiple_testing`` — a single omnibus has no family-internal
+        ``p_value`` is the finite-sample ``F_{K-1, T-1}`` survival of
+        ``stat / (K-1)`` (the date-cluster count is ``T`` per-date
+        observations, so the asymptotic χ² reference would over-reject).
+        No ``multiple_testing`` — a single omnibus has no family-internal
         correction to apply.
 
     Raises:

--- a/tests/stats/test_wald_cluster.py
+++ b/tests/stats/test_wald_cluster.py
@@ -7,8 +7,40 @@ import pytest
 from factrix._stats.wald import (
     _nw_hac_vector_mean,
     _wald_nw_cluster_means,
+    _wald_p_linear,
     _wald_two_way_cluster,
 )
+from scipy import stats as sp_stats
+
+
+class TestWaldFiniteSampleF:
+    def test_df_denom_matches_f_reference(self):
+        # With df_denom the p-value is the F survival of W/r, strictly
+        # larger (more conservative) than the asymptotic chi2 survival.
+        beta = np.array([2.0, 0.0])
+        V = np.eye(2)
+        R = np.array([[1.0, 0.0]])
+        W, p_f = _wald_p_linear(beta, V, R, df_denom=9)
+        _, p_chi2 = _wald_p_linear(beta, V, R)
+        assert p_f == pytest.approx(sp_stats.f.sf(W / 1, dfn=1, dfd=9))
+        assert p_f > p_chi2
+
+    def test_df_denom_non_positive_returns_unity(self):
+        beta = np.array([5.0])
+        V = np.array([[1.0]])
+        R = np.array([[1.0]])
+        assert _wald_p_linear(beta, V, R, df_denom=0) == (0.0, 1.0)
+
+    def test_cluster_means_small_T_more_conservative(self):
+        # Same per-date panel, the finite-sample F reference must not
+        # under-state p relative to the asymptotic chi2 the means imply.
+        rng = np.random.default_rng(seed=7)
+        T = 12
+        Y = np.column_stack([rng.standard_normal(T), rng.standard_normal(T) + 0.4])
+        R = np.array([[1.0, -1.0]])
+        W, p = _wald_nw_cluster_means(Y, R=R, q=0.0)
+        assert p == pytest.approx(sp_stats.f.sf(W / 1, dfn=1, dfd=T - 1))
+        assert p > sp_stats.chi2.sf(W, df=1)
 
 
 class TestNWHACVectorMean:

--- a/tests/test_caar.py
+++ b/tests/test_caar.py
@@ -446,6 +446,43 @@ class TestBmpTest:
         result = bmp_z(strong_signal)
         assert result.metadata.get("n_events", 0) > 0
 
+    def test_price_path_metadata_and_no_fallback_warning(self, strong_signal):
+        import warnings as _warnings
+
+        from factrix._codes import WarningCode
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")  # any warning would fail
+            result = bmp_z(strong_signal)
+        assert result.metadata["vol_source"] == "price"
+        assert result.metadata["vol_estimation_lag"] == 0
+        assert WarningCode.BMP_RETURN_VOL_FALLBACK.value not in result.warning_codes
+
+    def test_forward_return_fallback_is_flagged_and_lagged(self, strong_signal):
+        from factrix._codes import WarningCode
+
+        no_price = strong_signal.drop("price")
+        with pytest.warns(UserWarning, match="no 'price' column"):
+            result = bmp_z(no_price, forward_periods=5)
+        assert result.metadata["vol_source"] == "forward_return"
+        # The fallback std is lagged by forward_periods so the estimation
+        # window ends before each event's own forward return.
+        assert result.metadata["vol_estimation_lag"] == 5
+        assert WarningCode.BMP_RETURN_VOL_FALLBACK.value in result.warning_codes
+        assert not math.isnan(result.stat)
+
+    def test_fallback_lag_scales_with_forward_periods(self, strong_signal):
+        # A larger horizon lags the estimation window further, nulling more
+        # early rows per asset → strictly fewer usable events. Confirms the
+        # lag is forward_periods-driven, not a fixed shift.
+        no_price = strong_signal.drop("price")
+        with pytest.warns(UserWarning, match="no 'price' column"):
+            small_h = bmp_z(no_price, forward_periods=1)
+            large_h = bmp_z(no_price, forward_periods=20)
+        assert small_h.metadata["vol_estimation_lag"] == 1
+        assert large_h.metadata["vol_estimation_lag"] == 20
+        assert large_h.metadata["n_events"] < small_h.metadata["n_events"]
+
     def test_kolari_pynnonen_shrinks_z_when_clustered(self, strong_signal):
         """K-P adjustment must not expand |z|; when ρ>0 it strictly shrinks."""
         raw = bmp_z(strong_signal, kolari_pynnonen_adjust=False)

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -193,6 +193,61 @@ class TestPairsAxisWarnTier:
         assert result.n_obs_axis == "pairs"
 
 
+class TestCrossSectionalCorrection:
+    @staticmethod
+    def _panel(common_weight: float, seed: int) -> pl.DataFrame:
+        # n_assets per date; ``common_weight`` injects a shared daily shock so
+        # same-date hits are cross-sectionally correlated.
+        rng = np.random.default_rng(seed)
+        n_dates, n_assets = 60, 30
+        rows = []
+        for di in range(n_dates):
+            d = date(2020, 1, 1) + timedelta(days=di)
+            mkt = rng.normal()
+            for a in range(n_assets):
+                f = rng.normal()
+                r = 0.3 * f + common_weight * mkt + 0.3 * rng.normal()
+                rows.append(
+                    {"date": d, "asset_id": f"A{a}", "factor": f, "forward_return": r}
+                )
+        return pl.DataFrame(rows)
+
+    def test_single_asset_is_not_adjusted(self):
+        # One trial per date → no within-date cross-section → exact PT.
+        rng = np.random.default_rng(20)
+        x = rng.normal(size=200)
+        y = 0.5 * x + rng.normal(size=200)
+        result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
+        assert result.metadata["cross_sectional_adjusted"] is False
+        assert result.metadata["cross_sectional_r"] is None
+        assert "stat_uncorrected" not in result.metadata
+        _, ref_stat = _pt_reference(x, y)
+        assert result.stat == pytest.approx(ref_stat)
+
+    def test_within_date_correlation_deflates_statistic(self):
+        # A heavy shared daily shock correlates same-date hits; the K-P
+        # deflation must shrink |S_n| and raise the one-sided p-value.
+        result = self._panel(common_weight=0.9, seed=0)
+        result = directional_hit_rate(result, forward_periods=1)
+        m = result.metadata
+        assert m["cross_sectional_adjusted"] is True
+        assert m["cross_sectional_r"] > 0.0
+        assert abs(result.stat) < abs(m["stat_uncorrected"])
+        # Axis is unchanged: the estimand stays the pooled-pairs hit rate.
+        assert result.n_obs_axis == "pairs"
+        assert "Kolari-Pynnönen" in m["method"]
+
+    def test_applies_documented_kp_scale(self):
+        # The reported statistic is exactly the raw S_n times the
+        # Kolari-Pynnönen factor √((1-r)/(1+(n_eff-1)r)) from metadata.
+        result = directional_hit_rate(self._panel(common_weight=0.5, seed=3))
+        m = result.metadata
+        assert m["cross_sectional_adjusted"] is True
+        r, n_eff = m["cross_sectional_r"], m["cross_sectional_n_eff"]
+        scale = math.sqrt((1.0 - r) / (1.0 + (n_eff - 1.0) * r))
+        assert result.stat == pytest.approx(m["stat_uncorrected"] * scale)
+
+
 class TestDispatch:
     def test_runs_on_panel(self):
         import factrix as fx


### PR DESCRIPTION
## Summary

Issue #699 section 2 (統計推論與計量風險) — three independent inference-correctness fixes. Each is its own commit.

### 1. Cluster-robust Wald — finite-sample F reference
`_wald_p_linear` gains an optional `df_denom`. When the covariance is a cluster-robust estimate from a finite number of clusters `G`, the asymptotic χ² reference over-rejects; with `df_denom` the p-value uses `F = W/r ~ F_{r, df_denom}`. Wired `df_denom = G−1` (one-way date cluster, `_wald_nw_cluster_means`) and `min(G_date, G_asset)−1` (two-way). The Wald statistic `W` is unchanged; only the reference distribution differs. Non-cluster callers (`ts_quantile`, `ts_asymmetry`, `period_inference`) pass nothing and keep the asymptotic χ² bit-for-bit.

### 2. `bmp_z` no-price volatility fallback — drop overlap contamination
Without a `price` column the standardiser is estimated from the rolling std of `forward_return`. Because `forward_return[t]` realises over `(t+1, t+1+h]`, a window ending at the event row leaks the event's own (and adjacent) forward returns into its denominator. The fallback std is now lagged by `forward_periods` so the estimation window ends before the event window. It remains a coarser, horizon-overlapping proxy, so it raises `WarningCode.BMP_RETURN_VOL_FALLBACK` and records `metadata["vol_source"]` / `vol_estimation_lag`. The price path is unchanged.

### 3. `directional_hit_rate` — cross-sectional-correlation-robust SE
Pooling every `(date, asset)` trial as independent over-states the Pesaran-Timmermann effective sample (same-date returns share shocks), understating the SE and over-rejecting the no-skill null. `S_n` is deflated by the Kolari-Pynnönen (2010) factor built from the within-date ICC of the sign-hit indicator and the mean assets-per-date — the **same correction `bmp_z` already applies to clustered SARs**. Applied by default; a single-asset series has one trial per date, so the ICC is undefined and `S_n` is left exact (PT's canonical setting). The pooled-pairs axis and the #673/#681 floor machinery are unchanged — this corrects the standard error, not the estimand. The ICC estimator and the Kolari-Pynnönen scale are extracted to shared helpers (`_estimate_within_date_icc`, `_kp_cluster_scale`) and the `bmp_z`-local `_estimate_sar_icc` is dropped so both metrics share one implementation.

> Note: an earlier draft re-specified `directional_hit_rate` as a periods-axis date-level test, which would have reverted #673/#681. That was abandoned — the ICC adjustment fixes the same cross-sectional-correlation concern while preserving #673/#681 and matching the existing `bmp_z` treatment.

## Test plan

- New tests: cluster-Wald finite-sample F is more conservative than χ² and matches the F reference (`tests/stats/test_wald_cluster.py`); `bmp_z` price vs lagged-fallback paths, flag, and `vol_estimation_lag` scaling (`tests/test_caar.py`); `directional_hit_rate` single-asset = exact PT, panel within-date correlation deflates `|S_n|`, and the documented K-P scale is applied (`tests/test_directional_hit_rate.py`).
- `stat-keys-by-metric.md` updated for the new metadata keys (enforced by `test_docs_stat_keys_by_metric.py`).
- `ruff check` / `ruff format --check` / `mypy factrix` clean. Full suite: 1513 passed, 4 skipped.

Refs #699 (section 2; other sections tracked separately, does not close the epic).