### PR TITLE
fix(metrics,slicing): unify metric mechanism disclosure

### DIFF
--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -29,8 +29,8 @@ The two functions answer **different statistical questions**:
 
 | Function | Question | Output shape |
 |---|---|---|
-| `slice_pairwise_test` | "Which pairs differ?" — K(K−1)/2 contrasts with family-internal multiple-testing correction | One row per pair: `(slice_a, slice_b, n_obs, stat, p_raw, p_adj)` |
-| `slice_joint_test` | "Do any slices differ at all?" — single omnibus Wald χ² | One row: `(n_obs, k_slices, df, stat, p)` |
+| `slice_pairwise_test` | "Which pairs differ?" — K(K−1)/2 contrasts with family-internal multiple-testing correction | One row per pair: `(slice_a, slice_b, n_obs, mean_diff, stat, p_raw, p_adj, stat_type, reference_dist, df_num, df_denom, multiplicity)` |
+| `slice_joint_test` | "Do any slices differ at all?" — single omnibus Wald χ² | One row: `(n_obs, k_slices, stat, p_value, stat_type, reference_dist, df_num, df_denom, multiplicity)` |
 
 Both functions sit in the **View** class: their headline output is a comparison test
 result. They do **not** participate in Benjamini-Hochberg-Yekutieli (BHY) family expansion — adjusted
@@ -84,9 +84,11 @@ covariance. A two-valued `method` flag selects the estimator:
 | `"analytic"` | Per-slice Newey-West HAC, Welch-style pairwise contrast | Holm step-down | Long spans (T ≳ 100); fast, deterministic |
 
 Pairwise output is `(slice_a, slice_b, n_periods_a, n_periods_b,
-mean_diff, stat, p_raw, p_adj)` — per-slice `n_periods_*` because
-disjoint spans differ in length. The omnibus is a block-diagonal Wald χ²
-returning `(k_slices, df, stat, p_value)`.
+mean_diff, stat, p_raw, p_adj, stat_type, reference_dist, df_num,
+df_denom, multiplicity)` — per-slice `n_periods_*` because disjoint spans
+differ in length. The omnibus is a block-diagonal Wald χ² returning
+`(k_slices, stat, p_value, stat_type, reference_dist, df_num, df_denom,
+multiplicity)`.
 
 ## Estimator dispatch
 

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -131,7 +131,9 @@ pl.concat([
 # Bootstrap (default) is the right call for short regimes; pass
 # method="analytic" for long calendar spans (T ≳ 100).
 pairs = slice_period_pairwise_test(panel_reg, ic(), by="regime", factor_col="value")
-print(pairs)  # slice_a, slice_b, n_periods_a, n_periods_b, mean_diff, stat, p_raw, p_adj
+print(pairs)  # slice_a, slice_b, n_periods_a, n_periods_b, mean_diff, stat,
+#              p_raw, p_adj + mechanism cols (stat_type, reference_dist,
+#              df_num, df_denom, multiplicity)
 ```
 
 ## Related

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -196,9 +196,9 @@ Pesaran-Timmermann `z` statistic (`stat_type="z"`), tested one-sided.
 - *descriptive*: `p_correct` (realised hit rate), `p_expected`
   (hit rate under directional independence), `p_up_pred` (fraction of
   positive predictions), `p_up_real` (fraction of positive realisations),
-  `cross_sectional_r` (within-date ICC of the sign-hit indicator, `None`
-  on a single-asset series), `cross_sectional_n_eff` (mean assets-per-date),
-  `cross_sectional_adjusted` (whether the Kolari-Pynnönen deflation fired).
+  `kolari_pynnonen_r` (within-date ICC of the sign-hit indicator, `None`
+  on a single-asset series), `kolari_pynnonen_n_eff` (mean assets-per-date),
+  `kolari_pynnonen_applied` (whether the Kolari-Pynnönen deflation fired).
 - *descriptive* (conditional, adjustment applied): `stat_uncorrected`
   (the raw `S_n` before the cross-sectional-correlation deflation).
 
@@ -253,8 +253,9 @@ Pre/post-event return profile; descriptive.
 
 - *descriptive*: `per_offset` (dict `offset → {mean, median, p25, p75,
   hit_rate, n}`), `interpretation`.
-- *descriptive*: `p_value` (sentinel; not a test result — kept for
-  uniform `MetricResult` shape).
+- `p_value` is `None` — no hypothesis test runs; the headline `value` is
+  the pre-event leakage score, and per-horizon `hit_rate` is a raw
+  fraction.
 
 ### `monotonicity` (`factrix.metrics.monotonicity`)
 
@@ -355,7 +356,7 @@ Descriptive; no test.
   `bars_to_mfe_mean`, `bars_to_mae_mean`, `n_events`.
 - *descriptive* (conditional, when σ-normalised inputs available):
   `mfe_z_p50`, `mae_z_p75`, `mfe_mae_ratio_z`, `n_events_z`.
-- *descriptive*: `p_value` (sentinel).
+- `p_value` is `None` — descriptive metric, no hypothesis test.
 ### `oos` (`factrix.metrics.oos_decay`)
 
 #### `oos_decay` (emits `MetricResult.name = "oos_decay"`)
@@ -439,7 +440,8 @@ Two complementary methods:
 
 - *primary*: `p_value` — Method A.
 - *secondary-test* (conditional, Method B ran):
-  `beta_pos`, `beta_neg`, `p_wald_slopes`.
+  `method_b`, `stat_type_method_b`, `beta_pos`, `beta_neg`,
+  `p_wald_slopes`.
 - *descriptive*: `beta_long`, `beta_short`, `abs_short_over_long`,
   `n_pos`, `n_neg`, `n_zero`, `n_periods`, `nw_lags_used`,
   `method_b_skipped` (conditional), `intercept` (conditional),

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -89,7 +89,7 @@ def directional_hit_rate(
         MetricResult with value = directional hit rate ``P̂`` (0.0-1.0),
         ``stat`` = the PT statistic ``S_n`` (deflated for within-date
         cross-sectional correlation on a panel — see Notes), one-sided
-        p-value. ``metadata["cross_sectional_adjusted"]`` records whether
+        p-value. ``metadata["kolari_pynnonen_applied"]`` records whether
         the deflation fired and ``stat_uncorrected`` carries the raw
         ``S_n`` when it did.
 
@@ -240,10 +240,10 @@ def directional_hit_rate(
     r_hat, n_eff, _ = _estimate_within_date_icc(hit_by_date, "_hit")
     if r_hat is not None and n_eff > 1.0:
         s_stat = s_n * _kp_cluster_scale(r_hat, n_eff)
-        cross_sectional_adjusted = True
+        kolari_pynnonen_applied = True
     else:
         s_stat = s_n
-        cross_sectional_adjusted = False
+        kolari_pynnonen_applied = False
     p = float(sp_stats.norm.sf(s_stat))
 
     warning_codes: list[str] = []
@@ -270,11 +270,11 @@ def directional_hit_rate(
         "p_expected": p_star,
         "p_up_pred": p_x,
         "p_up_real": p_y,
-        "cross_sectional_r": r_hat,
-        "cross_sectional_n_eff": n_eff,
-        "cross_sectional_adjusted": cross_sectional_adjusted,
+        "kolari_pynnonen_r": r_hat,
+        "kolari_pynnonen_n_eff": n_eff,
+        "kolari_pynnonen_applied": kolari_pynnonen_applied,
     }
-    if cross_sectional_adjusted:
+    if kolari_pynnonen_applied:
         metadata["stat_uncorrected"] = float(s_n)
         metadata["method"] = (
             "Pesaran-Timmermann (1992) + Kolari-Pynnönen (2010) "

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -11,8 +11,9 @@ Metrics:
 
 Notes:
     **Pipeline.** Per-event return profile across `k` offsets
-    (per-event step); descriptive curve plus binomial test on
-    per-horizon hit rate.
+    (per-event step); a descriptive curve only — no hypothesis test, so
+    ``p_value`` is ``None`` and the per-horizon ``hit_rate`` in
+    ``per_offset`` is a raw fraction, not a tested statistic.
 """
 
 from __future__ import annotations
@@ -109,6 +110,7 @@ def event_around_return(
         return _short_circuit_output(
             "event_around_return",
             "no_price_data",
+            descriptive=True,
             per_offset={},
         )
 
@@ -140,7 +142,7 @@ def event_around_return(
     leakage = float(np.mean(pre_leakage_vals)) if pre_leakage_vals else 0.0
 
     return MetricResult(
-        p_value=1.0,
+        p_value=None,
         value=leakage,
         metadata={
             "per_offset": per_offset,

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -213,6 +213,7 @@ def monotonicity(
             n_obs_axis="periods",
             stat=t,
             metadata={
+                "method": "t-test on per-period signed monotonicity",
                 "stat_type": "t",
                 "h0": "mu=0",
                 "mean_signed": mean_mono,

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -529,6 +529,7 @@ def quantile_spread_vw(
     p = _p_value_from_t(t, n)
     metadata: dict[str, object] = {
         "n_periods": n,
+        "method": "non-overlapping t-test",
         "stat_type": "t",
         "h0": "mu=0",
         "tie_ratio": tie_ratio,

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -241,6 +241,8 @@ def ts_asymmetry(
         R_b = np.array([[0.0, 1.0, -1.0]])
         _, p_b = _wald_p_linear(beta_b, V_b, R_b, q=0.0)
         method_b.update(
+            method_b="method B: split-slope regression on signed factor",
+            stat_type_method_b="wald (NW HAC)",
             intercept=float(beta_b[0]),
             beta_pos=float(beta_b[1]),
             beta_neg=float(beta_b[2]),

--- a/factrix/slicing/inference.py
+++ b/factrix/slicing/inference.py
@@ -236,13 +236,19 @@ def slice_pairwise_test(
         factor_col: The single factor column to score per slice.
 
     Returns:
-        Long-form ``pl.DataFrame`` with columns
-        ``(slice_a, slice_b, n_obs, mean_diff, stat, p_raw, p_adj)``; one
-        row per ordered slice pair ``(a, b)`` with ``a`` before ``b`` in
-        the partition's iteration order. ``mean_diff`` is the signed
-        ``μ_a − μ_b`` (direction / effect size), ``stat`` the Wald χ²,
-        and ``p_adj`` the Holm step-down family-wise correction across
-        the K(K-1)/2 pairs.
+        Long-form ``pl.DataFrame`` with columns ``(slice_a, slice_b,
+        n_obs, mean_diff, stat, p_raw, p_adj, stat_type, reference_dist,
+        df_num, df_denom, multiplicity)``; one row per ordered slice pair
+        ``(a, b)`` with ``a`` before ``b`` in the partition's iteration
+        order. ``mean_diff`` is the signed ``μ_a − μ_b`` (direction /
+        effect size), ``stat`` the Wald statistic, and ``p_adj`` the Holm
+        step-down family-wise correction across the K(K-1)/2 pairs. The
+        trailing five columns disclose the active mechanism (constant
+        across rows): ``stat_type="wald"``; ``reference_dist="F"`` with
+        ``df_num=1`` (single contrast) and ``df_denom=n_obs-1`` — the
+        date-cluster count is ``T=n_obs``, so the finite-sample
+        ``F_{1, T-1}`` reference is used in place of the over-rejecting
+        asymptotic χ²; ``multiplicity="holm"``.
 
     Raises:
         UserInputError: ``metric`` is not a metric instance, or
@@ -274,7 +280,7 @@ def slice_pairwise_test(
         ...     panel, ic(), by="sector", factor_col="factor"
         ... )
         >>> pairs.columns
-        ['slice_a', 'slice_b', 'n_obs', 'mean_diff', 'stat', 'p_raw', 'p_adj']
+        ['slice_a', 'slice_b', 'n_obs', 'mean_diff', 'stat', 'p_raw', 'p_adj', 'stat_type', 'reference_dist', 'df_num', 'df_denom', 'multiplicity']
     """
     _validate_metric_instance(metric, "slice_pairwise_test")
 
@@ -300,15 +306,21 @@ def slice_pairwise_test(
 
     p_adj = holm_step_down(p_raw)
 
+    n_pairs = len(pairs)
     return pl.DataFrame(
         {
             "slice_a": [labels[i] for i, _ in pairs],
             "slice_b": [labels[j] for _, j in pairs],
-            "n_obs": [n_obs] * len(pairs),
+            "n_obs": [n_obs] * n_pairs,
             "mean_diff": mean_diffs,
             "stat": stats,
             "p_raw": p_raw,
             "p_adj": list(p_adj),
+            "stat_type": ["wald"] * n_pairs,
+            "reference_dist": ["F"] * n_pairs,
+            "df_num": [1] * n_pairs,
+            "df_denom": [n_obs - 1] * n_pairs,
+            "multiplicity": ["holm"] * n_pairs,
         }
     )
 
@@ -336,14 +348,16 @@ def slice_joint_test(
         factor_col: The single factor column to score per slice.
 
     Returns:
-        Single-row ``pl.DataFrame`` with columns
-        ``(n_obs, k_slices, df, stat, p_value)``. ``df`` is the
-        restriction rank (``K-1``); ``stat`` is the joint Wald χ²;
-        ``p_value`` is the finite-sample ``F_{K-1, T-1}`` survival of
-        ``stat / (K-1)`` (the date-cluster count is ``T`` per-date
-        observations, so the asymptotic χ² reference would over-reject).
-        No ``multiple_testing`` — a single omnibus has no family-internal
-        correction to apply.
+        Single-row ``pl.DataFrame`` with columns ``(n_obs, k_slices, stat,
+        p_value, stat_type, reference_dist, df_num, df_denom,
+        multiplicity)``. ``stat`` is the joint Wald statistic. The
+        mechanism columns disclose the reference: ``stat_type="wald"``,
+        ``reference_dist="F"``, ``df_num=K-1`` (restriction rank) and
+        ``df_denom=n_obs-1`` — ``p_value`` is the finite-sample
+        ``F_{K-1, T-1}`` survival of ``stat / (K-1)`` (the date-cluster
+        count is ``T=n_obs``, so the asymptotic χ² reference would
+        over-reject). ``multiplicity`` is ``None`` — a single omnibus has
+        no family-internal correction to apply.
 
     Raises:
         UserInputError: ``metric`` is not a metric instance, or
@@ -372,7 +386,7 @@ def slice_joint_test(
         >>> joint = fx.slice_joint_test(
         ...     panel, ic(), by="sector", factor_col="factor"
         ... )
-        >>> joint["df"][0]
+        >>> joint["df_num"][0]
         1
     """
     _validate_metric_instance(metric, "slice_joint_test")
@@ -395,8 +409,12 @@ def slice_joint_test(
         {
             "n_obs": [n_obs],
             "k_slices": [k],
-            "df": [k - 1],
             "stat": [stat],
             "p_value": [p],
+            "stat_type": ["wald"],
+            "reference_dist": ["F"],
+            "df_num": [k - 1],
+            "df_denom": [n_obs - 1],
+            "multiplicity": [None],
         }
     )

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -281,12 +281,18 @@ def slice_period_pairwise_test(
 
     Returns:
         Long-form ``pl.DataFrame`` with columns ``(slice_a, slice_b,
-        n_periods_a, n_periods_b, mean_diff, stat, p_raw, p_adj)``; one row
-        per ordered slice pair ``(a, b)``. ``n_periods_*`` are each slice's
-        own date counts (disjoint spans differ in length). ``mean_diff`` is
-        the signed ``μ_a − μ_b``; ``stat`` the studentized contrast on a
-        χ²₁ scale; ``p_adj`` the family-wise correction (Romano-Wolf for
-        ``"bootstrap"``, Holm for ``"analytic"``).
+        n_periods_a, n_periods_b, mean_diff, stat, p_raw, p_adj, stat_type,
+        reference_dist, df_num, df_denom, multiplicity)``; one row per
+        ordered slice pair ``(a, b)``. ``n_periods_*`` are each slice's own
+        date counts (disjoint spans differ in length). ``mean_diff`` is the
+        signed ``μ_a − μ_b``; ``stat`` the studentized contrast on a χ²₁
+        scale. The mechanism columns disclose the path (constant across
+        rows): ``stat_type="wald"``, ``df_num=1`` and ``df_denom=None``
+        (the disjoint-sample reference has no finite-cluster denominator);
+        ``reference_dist`` is ``"bootstrap_null"`` (``method="bootstrap"``)
+        or ``"chi2"`` (``method="analytic"``, asymptotic χ²₁); and
+        ``multiplicity`` the family-wise correction (``"romano_wolf"`` for
+        ``"bootstrap"``, ``"holm"`` for ``"analytic"``).
 
     Raises:
         UserInputError: ``metric`` is not a metric instance, ``factor_col``
@@ -353,6 +359,9 @@ def slice_period_pairwise_test(
             p_raw.append(p)
         p_adj = holm_step_down(p_raw)
 
+    n_pairs = len(pairs)
+    reference_dist = "bootstrap_null" if method == "bootstrap" else "chi2"
+    multiplicity = "romano_wolf" if method == "bootstrap" else "holm"
     return pl.DataFrame(
         {
             "slice_a": [labels[i] for i, _ in pairs],
@@ -363,6 +372,11 @@ def slice_period_pairwise_test(
             "stat": stats,
             "p_raw": p_raw,
             "p_adj": list(p_adj),
+            "stat_type": ["wald"] * n_pairs,
+            "reference_dist": [reference_dist] * n_pairs,
+            "df_num": [1] * n_pairs,
+            "df_denom": [None] * n_pairs,
+            "multiplicity": [multiplicity] * n_pairs,
         }
     )
 
@@ -474,12 +488,17 @@ def slice_period_joint_test(
             (ignored by ``"analytic"``).
 
     Returns:
-        Single-row ``pl.DataFrame`` with columns
-        ``(k_slices, df, stat, p_value)``. ``df`` is the restriction rank
-        (``K-1``); ``stat`` the joint Wald χ²; ``p_value`` from the χ²_{K-1}
-        survival function (``"analytic"``) or the bootstrap null
-        (``"bootstrap"``). No ``multiple_testing`` — a single omnibus has
-        no family-internal correction.
+        Single-row ``pl.DataFrame`` with columns ``(k_slices, stat,
+        p_value, stat_type, reference_dist, df_num, df_denom,
+        multiplicity)``. ``stat`` is the joint Wald statistic. The mechanism
+        columns
+        disclose the reference: ``stat_type="wald"``, ``df_num=K-1``
+        (restriction rank) and ``df_denom=None`` (disjoint samples have no
+        finite-cluster denominator); ``reference_dist`` is ``"chi2"`` —
+        ``p_value`` from the χ²_{K-1} survival function — for
+        ``method="analytic"``, or ``"bootstrap_null"`` for
+        ``method="bootstrap"``. ``multiplicity`` is ``None`` — a single
+        omnibus has no family-internal correction.
 
     Raises:
         UserInputError: ``metric`` is not a metric instance, ``factor_col``
@@ -512,8 +531,12 @@ def slice_period_joint_test(
     return pl.DataFrame(
         {
             "k_slices": [k],
-            "df": [k - 1],
             "stat": [stat],
             "p_value": [p],
+            "stat_type": ["wald"],
+            "reference_dist": ["bootstrap_null" if method == "bootstrap" else "chi2"],
+            "df_num": [k - 1],
+            "df_denom": [None],
+            "multiplicity": [None],
         }
     )

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -218,8 +218,8 @@ class TestCrossSectionalCorrection:
         x = rng.normal(size=200)
         y = 0.5 * x + rng.normal(size=200)
         result = directional_hit_rate(_ts_panel(x, y), forward_periods=1)
-        assert result.metadata["cross_sectional_adjusted"] is False
-        assert result.metadata["cross_sectional_r"] is None
+        assert result.metadata["kolari_pynnonen_applied"] is False
+        assert result.metadata["kolari_pynnonen_r"] is None
         assert "stat_uncorrected" not in result.metadata
         _, ref_stat = _pt_reference(x, y)
         assert result.stat == pytest.approx(ref_stat)
@@ -230,8 +230,8 @@ class TestCrossSectionalCorrection:
         result = self._panel(common_weight=0.9, seed=0)
         result = directional_hit_rate(result, forward_periods=1)
         m = result.metadata
-        assert m["cross_sectional_adjusted"] is True
-        assert m["cross_sectional_r"] > 0.0
+        assert m["kolari_pynnonen_applied"] is True
+        assert m["kolari_pynnonen_r"] > 0.0
         assert abs(result.stat) < abs(m["stat_uncorrected"])
         # Axis is unchanged: the estimand stays the pooled-pairs hit rate.
         assert result.n_obs_axis == "pairs"
@@ -242,8 +242,8 @@ class TestCrossSectionalCorrection:
         # Kolari-Pynnönen factor √((1-r)/(1+(n_eff-1)r)) from metadata.
         result = directional_hit_rate(self._panel(common_weight=0.5, seed=3))
         m = result.metadata
-        assert m["cross_sectional_adjusted"] is True
-        r, n_eff = m["cross_sectional_r"], m["cross_sectional_n_eff"]
+        assert m["kolari_pynnonen_applied"] is True
+        r, n_eff = m["kolari_pynnonen_r"], m["kolari_pynnonen_n_eff"]
         scale = math.sqrt((1.0 - r) / (1.0 + (n_eff - 1.0) * r))
         assert result.stat == pytest.approx(m["stat_uncorrected"] * scale)
 

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -113,6 +113,14 @@ class TestEventAroundReturn:
         assert result is not None
         assert "per_offset" in result.metadata
 
+    def test_descriptive_no_p_value(self, event_data):
+        # Descriptive multi-horizon summary: no hypothesis test runs, so the
+        # contract is p_value=None — not a fabricated 1.0 placeholder.
+        assert event_around_return(event_data).p_value is None
+
+    def test_short_circuit_is_descriptive(self, no_price_data):
+        assert event_around_return(no_price_data).p_value is None
+
     def test_per_offset_has_stats(self, event_data):
         result = event_around_return(event_data, offsets=[-3, 1, 6])
         per_offset = result.metadata["per_offset"]

--- a/tests/test_slice_joint_test.py
+++ b/tests/test_slice_joint_test.py
@@ -10,7 +10,17 @@ from factrix.metrics import ic, monotonicity
 
 from tests._slice_panel import build_labelled_raw_panel
 
-_JOINT_COLS = ["n_obs", "k_slices", "df", "stat", "p_value"]
+_JOINT_COLS = [
+    "n_obs",
+    "k_slices",
+    "stat",
+    "p_value",
+    "stat_type",
+    "reference_dist",
+    "df_num",
+    "df_denom",
+    "multiplicity",
+]
 
 
 def test_two_slice_returns_single_row() -> None:
@@ -22,7 +32,11 @@ def test_two_slice_returns_single_row() -> None:
     assert out.columns == _JOINT_COLS
     assert out["n_obs"][0] == 120
     assert out["k_slices"][0] == 2
-    assert out["df"][0] == 1
+    assert out["df_num"][0] == 1
+    assert out["stat_type"][0] == "wald"
+    assert out["reference_dist"][0] == "F"
+    assert out["df_denom"][0] == 119
+    assert out["multiplicity"][0] is None
 
 
 def test_three_slice_df_equals_k_minus_one() -> None:
@@ -34,7 +48,7 @@ def test_three_slice_df_equals_k_minus_one() -> None:
     )
     out = slice_joint_test(df, ic(), by="sector", factor_col="factor")
     assert out["k_slices"][0] == 3
-    assert out["df"][0] == 2
+    assert out["df_num"][0] == 2
 
 
 def test_detects_omnibus_signal() -> None:

--- a/tests/test_slice_pairwise_test.py
+++ b/tests/test_slice_pairwise_test.py
@@ -16,7 +16,20 @@ from tests._slice_panel import (
     build_labelled_raw_panel,
 )
 
-_PAIRWISE_COLS = ["slice_a", "slice_b", "n_obs", "mean_diff", "stat", "p_raw", "p_adj"]
+_PAIRWISE_COLS = [
+    "slice_a",
+    "slice_b",
+    "n_obs",
+    "mean_diff",
+    "stat",
+    "p_raw",
+    "p_adj",
+    "stat_type",
+    "reference_dist",
+    "df_num",
+    "df_denom",
+    "multiplicity",
+]
 
 
 def test_two_slice_returns_one_row() -> None:
@@ -27,6 +40,11 @@ def test_two_slice_returns_one_row() -> None:
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS
     assert out["n_obs"][0] == 120
+    assert out["stat_type"][0] == "wald"
+    assert out["reference_dist"][0] == "F"
+    assert out["df_num"][0] == 1
+    assert out["df_denom"][0] == 119
+    assert out["multiplicity"][0] == "holm"
 
 
 def test_three_slice_returns_three_rows() -> None:

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -9,7 +9,16 @@ from factrix.metrics import ic, monotonicity
 
 from tests._slice_panel import build_disjoint_period_panel
 
-_JOINT_COLS = ["k_slices", "df", "stat", "p_value"]
+_JOINT_COLS = [
+    "k_slices",
+    "stat",
+    "p_value",
+    "stat_type",
+    "reference_dist",
+    "df_num",
+    "df_denom",
+    "multiplicity",
+]
 
 
 @pytest.mark.parametrize("method", ["bootstrap", "analytic"])
@@ -25,7 +34,13 @@ def test_single_row_shape(method: str) -> None:
     assert out.height == 1
     assert out.columns == _JOINT_COLS
     assert out["k_slices"][0] == 3
-    assert out["df"][0] == 2
+    assert out["df_num"][0] == 2
+    assert out["stat_type"][0] == "wald"
+    assert out["reference_dist"][0] == (
+        "bootstrap_null" if method == "bootstrap" else "chi2"
+    )
+    assert out["df_denom"][0] is None
+    assert out["multiplicity"][0] is None
 
 
 @pytest.mark.parametrize("method", ["bootstrap", "analytic"])
@@ -36,7 +51,7 @@ def test_two_slice_df_is_one(method: str) -> None:
     out = slice_period_joint_test(
         df, ic(), by="regime", factor_col="factor", method=method, rng_seed=2
     )
-    assert out["df"][0] == 1
+    assert out["df_num"][0] == 1
 
 
 @pytest.mark.parametrize("method", ["bootstrap", "analytic"])

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -21,18 +21,34 @@ _PAIRWISE_COLS = [
     "stat",
     "p_raw",
     "p_adj",
+    "stat_type",
+    "reference_dist",
+    "df_num",
+    "df_denom",
+    "multiplicity",
 ]
 
 
-def test_two_slice_returns_one_row() -> None:
+@pytest.mark.parametrize(
+    ("method", "reference_dist", "multiplicity"),
+    [("bootstrap", "bootstrap_null", "romano_wolf"), ("analytic", "chi2", "holm")],
+)
+def test_two_slice_returns_one_row(
+    method: str, reference_dist: str, multiplicity: str
+) -> None:
     df = build_disjoint_period_panel(
         seed=1, spans={"bull": (60, 0.1), "bear": (60, 0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=1
+        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=1
     )
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS
+    assert out["stat_type"][0] == "wald"
+    assert out["reference_dist"][0] == reference_dist
+    assert out["df_num"][0] == 1
+    assert out["df_denom"][0] is None
+    assert out["multiplicity"][0] == multiplicity
 
 
 def test_three_slice_returns_three_rows() -> None:

--- a/tests/test_slice_test_reference_cells.py
+++ b/tests/test_slice_test_reference_cells.py
@@ -75,5 +75,5 @@ def test_joint_sector_wald_nw_cluster() -> None:
 
     out = slice_joint_test(panel, ic(), by="sector", factor_col="factor")
     assert out.height == 1
-    assert out["df"][0] == 2
+    assert out["df_num"][0] == 2
     assert out["p_value"][0] < 0.05

--- a/uv.lock
+++ b/uv.lock
@@ -670,10 +670,10 @@ requires-dist = [
     { name = "pandera", specifier = ">=0.29" },
     { name = "polars", specifier = ">=1.38" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.18" },
     { name = "scipy", specifier = ">=1.13" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
@@ -2158,7 +2158,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2167,9 +2167,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -2565,27 +2565,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #710.

Makes "which test actually ran in this sample" uniformly machine-readable across metrics, the follow-up to #709 (#699 §2).

## Slice tests — reference-distribution disclosure
All four `slice_*_test` functions now return a constant 5-column mechanism block, in identical order: `stat_type`, `reference_dist`, `df_num`, `df_denom`, `multiplicity`.

- The cluster Wald reference distribution (finite-sample `F` vs asymptotic `chi2` vs `bootstrap_null`) and its `df_denom` were previously only in docstrings — now in the result.
- Joint tests `df` column renamed to `df_num` to pair with the new `df_denom` (breaking; pre-v1, no shim).

| function | reference_dist | df_num | df_denom | multiplicity |
|---|---|---|---|---|
| `slice_pairwise_test` | F | 1 | T-1 | holm |
| `slice_joint_test` | F | K-1 | T-1 | — |
| `slice_period_pairwise_test` | bootstrap_null / chi2 | 1 | — | romano_wolf / holm |
| `slice_period_joint_test` | bootstrap_null / chi2 | K-1 | — | — |

## Metric metadata gaps
- Add `method` to `monotonicity` and `quantile_spread_vw`.
- Label `ts_asymmetry`s method-B sub-test: `method_b`, `stat_type_method_b`.

## Kolari-Pynnönen key vocabulary
`directional_hit_rate`s `cross_sectional_{adjusted,r,n_eff}` → `kolari_pynnonen_{applied,r,n_eff}`, matching `bmp_z` so one mechanism uses one key vocabulary (breaking).

## event_around_return correctness
It is a descriptive multi-horizon summary with no hypothesis test, so it now returns `p_value=None` (was a fabricated `1.0`) and the no-price short-circuit is marked descriptive. Dropped the docstrings claim of a binomial test that never ran.

## Decision: no new "active mechanism" key
After filling the gaps, `stat_type` (machine token) + `method` (human string) cover every inferential metric and the slice tests; regime flags now use consistent author-named keys. No additional cross-metric key is warranted.

## Verification
- `ruff check`, `ruff format --check`, `mypy factrix` clean.
- Full suite: 1518 passed, 4 skipped; doctests pass.

Docstrings, the stat-keys reference, the slice-analysis guide, and tests updated to match. CHANGELOG/docs prose batched to the disclosure epic wrap-up.