### PR TITLE
refactor(naming)!: replace ambiguous bare df with data

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -281,6 +281,38 @@ runs; the warning surfaces the inflation so callers can read p ≈ 0.04 as
 
 ---
 
+## Naming: `data` (DataFrame) vs `df_*` (degrees of freedom)
+
+`df` is ambiguous — **degrees of freedom** in a statistics context, **DataFrame**
+in the polars/pandas idiom. The collision is killed by **position**, so every name
+resolves to one meaning on sight:
+
+- **`df_…` prefix → degrees of freedom.** `df_num` (numerator / restriction rank
+  `K-1`), `df_denom` (denominator), `df_resid` (residual). A DoF value never goes
+  unqualified.
+- **`…_df` suffix → DataFrame.** A *named* frame keeps the informative idiom
+  (`ic_df`, `caar_df`, `beta_df`, `ts_betas_df`) — the prefix is the content, the
+  `_df` says "frame". A *standalone* frame uses **`data`**, or a semantic noun where
+  one reads better (`panel`, `per_date`, `factor_panel`, `subset`, `residuals`).
+- **bare `df` / `_df` → banned.** The unqualified token is exactly the ambiguous
+  case (could be either register), so factrix never declares a parameter, local,
+  dataclass field, or dict / column key named `df` or `_df`.
+
+The one tolerated bare `df` is the **scipy distribution kwarg**
+(`sp_stats.chi2.sf(q, df=h)`, `t.sf(t, df=...)`): it is scipy's own parameter name
+at the call site, not a name factrix declares, and carries no DataFrame ambiguity
+inside a `dist.sf(...)` call. The positional split keeps DoF self-describing rather
+than loosening to a bare `df` — the same read-it-once principle as the
+[sample-axis naming grammar](#naming-grammar).
+
+**Enforcement.** `tests/test_naming_df.py` walks every `factrix/` module with `ast`
+and fails if any function parameter, assignment target, or dataclass field is named
+exactly `df` or `_df` — closing the abbreviation back-flow at CI rather than relying
+on review. (ruff has no built-in for an identifier-name ban; the AST guard mirrors
+`tests/test_docs_matrix.py`.)
+
+---
+
 ## Error UX contract
 
 User-facing raises follow a single canonical message format so callers

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -535,7 +535,7 @@ def _resolve_forward_periods(data: pl.DataFrame, declared: int | None) -> int:
         value=None,
         expected=(
             "the data's overlap horizon. Either build forward_return via "
-            "factrix.preprocess.compute_forward_return(df, forward_periods=N) "
+            "factrix.preprocess.compute_forward_return(data, forward_periods=N) "
             "(which stamps the horizon), or, for a self-attached forward_return "
             "column, declare it once with evaluate(..., forward_periods=N)."
         ),

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -120,13 +120,13 @@ def compare(
             row[f"{spec}_p_value"] = _float_or_none(out.p_value)
         rows.append(row)
 
-    df = pl.DataFrame(rows)
+    data = pl.DataFrame(rows)
     if sort_by is not None:
-        df = df.sort(sort_by, descending=descending, nulls_last=True)
-        df = df.with_columns(
-            pl.int_range(1, df.height + 1, dtype=pl.Int64).alias("rank")
+        data = data.sort(sort_by, descending=descending, nulls_last=True)
+        data = data.with_columns(
+            pl.int_range(1, data.height + 1, dtype=pl.Int64).alias("rank")
         )
-    return df
+    return data
 
 
 def _ordered_keys(maps: Iterable[Mapping[str, Any]]) -> list[str]:

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -9,10 +9,10 @@ memory efficiency on large sources).
 ``pd.DataFrame`` is **not** accepted on these entry points by design.
 pandas users have two clean paths:
 
-- ``factrix.adapt(df, ...)`` — converts and renames columns in one
+- ``factrix.adapt(data, ...)`` — converts and renames columns in one
   step; the natural entry point when pandas column names are not
   already canonical.
-- ``pl.from_pandas(df)`` — when columns are already canonical and
+- ``pl.from_pandas(data)`` — when columns are already canonical and
   only the type conversion is needed.
 
 This keeps the type contract honest (factrix's internal pipeline is
@@ -45,18 +45,18 @@ _OPTIONAL_COLUMNS: tuple[str, ...] = ("price",)
 _FORWARD_PERIODS_COL: str = "_forward_periods"
 
 
-def _stamp_forward_periods(df: pl.DataFrame, forward_periods: int) -> pl.DataFrame:
+def _stamp_forward_periods(data: pl.DataFrame, forward_periods: int) -> pl.DataFrame:
     """Stamp the panel's single overlap horizon as a reserved constant column."""
-    return df.with_columns(
+    return data.with_columns(
         pl.lit(forward_periods, dtype=pl.Int32).alias(_FORWARD_PERIODS_COL)
     )
 
 
-def _read_forward_periods_stamp(df: pl.DataFrame) -> int | None:
+def _read_forward_periods_stamp(data: pl.DataFrame) -> int | None:
     """Read the stamped overlap horizon, or ``None`` when the panel carries none."""
-    if _FORWARD_PERIODS_COL not in df.columns or df.height == 0:
+    if _FORWARD_PERIODS_COL not in data.columns or data.height == 0:
         return None
-    return int(df[_FORWARD_PERIODS_COL][0])
+    return int(data[_FORWARD_PERIODS_COL][0])
 
 
 def _is_pandas_dataframe(obj: object) -> bool:
@@ -78,8 +78,8 @@ def _coerce_data(data: DataInput) -> pl.DataFrame:
     if _is_pandas_dataframe(data):
         raise TypeError(
             "data must be pl.DataFrame or pl.LazyFrame; got pandas DataFrame. "
-            "factrix is polars-native — convert with `pl.from_pandas(df)`, "
-            "or use `factrix.adapt(df, ...)` if column renaming is needed."
+            "factrix is polars-native — convert with `pl.from_pandas(data)`, "
+            "or use `factrix.adapt(data, ...)` if column renaming is needed."
         )
     raise TypeError(
         f"data must be pl.DataFrame or pl.LazyFrame; got {type(data).__name__}."

--- a/factrix/_stats/slice_policy.py
+++ b/factrix/_stats/slice_policy.py
@@ -53,13 +53,13 @@ def _detect_strict_subsets(
     """
     key_cols = tuple(key_cols)
     key_sets: dict[str, frozenset[tuple]] = {}
-    for label, df in slices.items():
-        missing = [c for c in key_cols if c not in df.columns]
+    for label, data in slices.items():
+        missing = [c for c in key_cols if c not in data.columns]
         if missing:
             raise ValueError(
-                f"slice {label!r}: missing key columns {missing}; have {df.columns}."
+                f"slice {label!r}: missing key columns {missing}; have {data.columns}."
             )
-        keys = df.select(list(key_cols)).unique().rows()
+        keys = data.select(list(key_cols)).unique().rows()
         key_sets[label] = frozenset(keys)
 
     labels = list(slices.keys())

--- a/factrix/adapt.py
+++ b/factrix/adapt.py
@@ -17,11 +17,11 @@ Usage::
     from factrix.adapt import adapt
 
     # Minimal: just price panel
-    raw = adapt(df, date="date", asset_id="ticker", price="close_adj")
+    raw = adapt(data, date="date", asset_id="ticker", price="close_adj")
 
     # Full OHLCV — unlocks technical / liquidity factor generators
     raw = adapt(
-        df,
+        data,
         date="date", asset_id="ticker", price="close_adj",
         open="open_adj", high="high_adj", low="low_adj", volume="volume",
     )
@@ -42,24 +42,24 @@ if TYPE_CHECKING:
 type AdaptInput = pl.DataFrame | pl.LazyFrame | pd.DataFrame
 
 
-def _to_polars(df: AdaptInput) -> pl.DataFrame | pl.LazyFrame:
+def _to_polars(data: AdaptInput) -> pl.DataFrame | pl.LazyFrame:
     """Coerce ``adapt`` input to polars, preserving ``LazyFrame``.
 
     ``pl.DataFrame`` / ``pl.LazyFrame`` pass through unchanged.
     ``pd.DataFrame`` is converted via ``pl.from_pandas`` (pandas has
     no lazy equivalent).
     """
-    if isinstance(df, pl.DataFrame | pl.LazyFrame):
-        return df
-    if _is_pandas_dataframe(df):
-        return pl.from_pandas(df)
+    if isinstance(data, pl.DataFrame | pl.LazyFrame):
+        return data
+    if _is_pandas_dataframe(data):
+        return pl.from_pandas(data)
     raise TypeError(
-        f"adapt: expected pl.DataFrame, pl.LazyFrame, or pd.DataFrame; got {type(df).__name__}"
+        f"adapt: expected pl.DataFrame, pl.LazyFrame, or pd.DataFrame; got {type(data).__name__}"
     )
 
 
 def adapt(
-    df: AdaptInput,
+    data: AdaptInput,
     *,
     date: str = "date",
     asset_id: str = "asset_id",
@@ -80,7 +80,7 @@ def adapt(
     columns pass through unchanged.
 
     Args:
-        df: Input frame — ``pl.DataFrame``, ``pl.LazyFrame``, or
+        data: Input frame — ``pl.DataFrame``, ``pl.LazyFrame``, or
             ``pd.DataFrame``.
         date: User's date column name.
         asset_id: User's asset identifier column name.
@@ -106,12 +106,12 @@ def adapt(
         names. ``pd.DataFrame`` input returns ``pl.DataFrame``.
 
     Raises:
-        TypeError: If *df* is none of ``pl.DataFrame``, ``pl.LazyFrame``,
+        TypeError: If *data* is none of ``pl.DataFrame``, ``pl.LazyFrame``,
             ``pd.DataFrame``.
         ValueError: If any specified source column does not exist.
     """
-    df = _to_polars(df)
-    schema = df.collect_schema()
+    data = _to_polars(data)
+    schema = data.collect_schema()
     columns = schema.names()
 
     renames: list[tuple[str, str | None]] = [
@@ -138,7 +138,7 @@ def adapt(
         mapping[source] = canonical
 
     if mapping:
-        df = df.rename(mapping)
+        data = data.rename(mapping)
 
     # Promote pl.Date → pl.Datetime("ms") losslessly so downstream joins
     # (regime_labels / spanning_base_spreads / user panels) can share a
@@ -146,19 +146,19 @@ def adapt(
     # Other Datetime variants (any time_unit, any TZ) pass through — the
     # library is TZ-agnostic and trusts the caller's precision choice.
     if schema.get(date) == pl.Date:
-        df = df.with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        data = data.with_columns(pl.col("date").cast(pl.Datetime("ms")))
 
     if fill_forward:
         # Map every non-finite value (NaN and ±inf) to null in one pass, then
         # forward-fill per asset. fill_nan alone leaves ±inf untouched, and inf
         # survives the downstream is_not_null() drop in compute_forward_return,
         # leaking into return math (e.g. a zero entry price yields inf return).
-        df = (
-            df.sort(["asset_id", "date"])
+        data = (
+            data.sort(["asset_id", "date"])
             .with_columns(
                 pl.when(cs.numeric().is_finite()).then(cs.numeric()).otherwise(None)
             )
             .with_columns(cs.numeric().forward_fill().over("asset_id"))
         )
 
-    return df
+    return data

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -8,7 +8,7 @@ metric accept?" is answered per-metric (e.g. ``ic`` accepts
 ``NON_OVERLAPPING`` / ``NEWEY_WEST``).
 
 This release scopes the namespace to the **series-mean** family
-(``compute(df, *, value_col, forward_periods)``). Slice / panel methods
+(``compute(data, *, value_col, forward_periods)``). Slice / panel methods
 keep their multivariate compute in ``factrix.slicing`` until they move
 onto the same ``metric(inference=...)`` path; they are deliberately not
 listed here to avoid re-creating a heterogeneous discovery surface.

--- a/factrix/inference/_base.py
+++ b/factrix/inference/_base.py
@@ -29,7 +29,7 @@ class Inference(Protocol):
 
     Implementations are frozen dataclasses that additionally carry a
     ``compute`` whose signature is fixed per target shape (series-mean
-    members share ``compute(df, *, value_col, forward_periods)``).
+    members share ``compute(data, *, value_col, forward_periods)``).
     ``compute`` is intentionally absent here — see module docstring.
     """
 

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -4,7 +4,7 @@ Each member is a frozen dataclass carrying its whole ``compute`` plus
 identity ClassVars (``test`` / ``se`` / ``summary``). The family shares
 one date-aware input contract::
 
-    compute(df: pl.DataFrame, *, value_col: str, forward_periods: int) -> InferenceResult
+    compute(data: pl.DataFrame, *, value_col: str, forward_periods: int) -> InferenceResult
 
 ``compute`` owns date-sort + null-drop (callers pass the raw per-date
 DataFrame). ``NonOverlapping`` strides the cleaned series at
@@ -32,16 +32,16 @@ if TYPE_CHECKING:
     import polars as pl
 
 
-def _clean_series(df: pl.DataFrame, value_col: str) -> pl.Series:
+def _clean_series(data: pl.DataFrame, value_col: str) -> pl.Series:
     """Date-sorted, null-dropped values of ``value_col``.
 
     Order is fixed (sort → drop-null) so the stride / HAC lag math sees a
     time-coherent series regardless of caller row order. Sorting is mean-
     and OLS-invariant but load-bearing for the autocovariance terms.
     """
-    if df["date"].is_sorted():
-        return df[value_col].drop_nulls()
-    return df.sort("date").get_column(value_col).drop_nulls()
+    if data["date"].is_sorted():
+        return data[value_col].drop_nulls()
+    return data.sort("date").get_column(value_col).drop_nulls()
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,11 +67,11 @@ class NonOverlapping:
         return MIN_IC_PERIODS * max(forward_periods, 1)
 
     def compute(
-        self, df: pl.DataFrame, *, value_col: str, forward_periods: int
+        self, data: pl.DataFrame, *, value_col: str, forward_periods: int
     ) -> InferenceResult:
         from factrix._stats import _p_value_from_t, _t_stat_from_array
 
-        vals = _clean_series(df, value_col).to_numpy()
+        vals = _clean_series(data, value_col).to_numpy()
         sampled = vals[::forward_periods]
         n_sampled = len(sampled)
 
@@ -117,12 +117,12 @@ class NeweyWest:
         return MIN_PERIODS_HARD
 
     def compute(
-        self, df: pl.DataFrame, *, value_col: str, forward_periods: int
+        self, data: pl.DataFrame, *, value_col: str, forward_periods: int
     ) -> InferenceResult:
         from factrix._stats import _newey_west_t_test, _resolve_nw_lags
         from factrix._stats.constants import auto_bartlett
 
-        vals = _clean_series(df, value_col).to_numpy()
+        vals = _clean_series(data, value_col).to_numpy()
         n = len(vals)
         nw_lags = (
             _resolve_nw_lags(n, auto_bartlett(n), forward_periods) if n >= 2 else 0
@@ -168,11 +168,11 @@ class HansenHodrick:
         return MIN_PERIODS_HARD
 
     def compute(
-        self, df: pl.DataFrame, *, value_col: str, forward_periods: int
+        self, data: pl.DataFrame, *, value_col: str, forward_periods: int
     ) -> InferenceResult:
         from factrix._stats import _hansen_hodrick_t_test
 
-        vals = _clean_series(df, value_col).to_numpy()
+        vals = _clean_series(data, value_col).to_numpy()
         t_stat, p_value, _, clamped = _hansen_hodrick_t_test(
             vals, forward_periods=forward_periods
         )

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -97,7 +97,7 @@ class MetricMeta(type):
                 expected=(
                     f"{name!r} is no longer a metric parameter — it is the "
                     f"panel's overlap horizon, read from the data. Set it once "
-                    f"via factrix.preprocess.compute_forward_return(df, "
+                    f"via factrix.preprocess.compute_forward_return(data, "
                     f"forward_periods=N); evaluate reads it from there."
                 ),
                 docs_path="api/evaluate#forward_periods",

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -224,7 +224,7 @@ def _spread_significance_with_inference(
 
 
 def _aggregate_to_per_date(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -240,7 +240,7 @@ def _aggregate_to_per_date(
     aggregation in their own docstrings.
     """
     return (
-        df.lazy()
+        data.lazy()
         .group_by("date")
         .agg(
             pl.col(factor_col).mean().alias(factor_alias),
@@ -518,7 +518,7 @@ def _warn_below_scaled_floor(
 
 
 def _estimate_within_date_icc(
-    df: pl.DataFrame, value_col: str
+    data: pl.DataFrame, value_col: str
 ) -> tuple[float | None, float, KPSource]:
     r"""ICC-style within-date correlation $\hat r$ of ``value_col`` and mean cluster size.
 
@@ -533,7 +533,7 @@ def _estimate_within_date_icc(
     $[0, 1]$ and the mean events-per-date.
 
     Args:
-        df: One row per pooled observation with a ``date`` column and
+        data: One row per pooled observation with a ``date`` column and
             ``value_col``.
         value_col: The clustered value (already standardised / 0-1 coded).
 
@@ -547,7 +547,7 @@ def _estimate_within_date_icc(
           single-asset series lands here, so the caller leaves the
           statistic uncorrected).
     """
-    per_date = df.group_by("date").agg(
+    per_date = data.group_by("date").agg(
         pl.col(value_col).mean().alias("m"),
         pl.col(value_col).var(ddof=DDOF).alias("v"),
         pl.len().alias("n"),
@@ -591,7 +591,7 @@ def _kp_cluster_scale(r_hat: float, n_eff: float) -> float:
     return float(np.sqrt((1.0 - r_hat) / (1.0 + (n_eff - 1.0) * r_hat)))
 
 
-def _pick_event_return_col(df: pl.DataFrame) -> str:
+def _pick_event_return_col(data: pl.DataFrame) -> str:
     """Return the preferred return column for event analysis.
 
     ``abnormal_return`` (cross-sectionally de-meaned return) is preferred
@@ -601,19 +601,19 @@ def _pick_event_return_col(df: pl.DataFrame) -> str:
     pipeline agree on the same choice — diverging would silently route
     the same Factor call through different series.
     """
-    return "abnormal_return" if "abnormal_return" in df.columns else "forward_return"
+    return "abnormal_return" if "abnormal_return" in data.columns else "forward_return"
 
 
 def _sample_non_overlapping(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int,
 ) -> pl.DataFrame:
     """Keep every N-th date to produce a non-overlapping series.
 
     Algorithm:
-        1. ``unique_dates = sort(df[date].unique())``
+        1. ``unique_dates = sort(data[date].unique())``
         2. ``sampled = unique_dates[::forward_periods]``  (every N-th)
-        3. Return ``df.filter(date ∈ sampled)``
+        3. Return ``data.filter(date ∈ sampled)``
 
     Why: with h-period forward returns, consecutive dates' forward
     returns share h−1 bars of future data — the series has an MA(h−1)
@@ -630,7 +630,7 @@ def _sample_non_overlapping(
     even if they don't short-circuit.
 
     Args:
-        df: DataFrame with a ``date`` column.
+        data: DataFrame with a ``date`` column.
         forward_periods: Sampling interval (typically equals the
             ``forward_periods`` of the forward-return column).
 
@@ -641,14 +641,14 @@ def _sample_non_overlapping(
     from factrix._logging import get_metrics_logger
     from factrix._types import MIN_IC_PERIODS
 
-    sampled_dates = df["date"].unique().sort().gather_every(forward_periods)
-    result = df.filter(pl.col("date").is_in(sampled_dates.implode()))
+    sampled_dates = data["date"].unique().sort().gather_every(forward_periods)
+    result = data.filter(pl.col("date").is_in(sampled_dates.implode()))
     n_after = len(sampled_dates)
     logger = get_metrics_logger()
     logger.debug(
         "non_overlap_sample: forward_periods=%d n_dates_before=%d n_after=%d",
         forward_periods,
-        df["date"].n_unique(),
+        data["date"].n_unique(),
         n_after,
     )
     # WARNING: post-sampling series shorter than 1.5x the usual minimum is
@@ -668,7 +668,7 @@ def _sample_non_overlapping(
 
 
 def _sample_event_spaced(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int,
     *,
     ordinal_col: str = "date_ordinal",
@@ -692,11 +692,11 @@ def _sample_event_spaced(
     non-overlap sampling, made calendar-aware for the event-date axis).
 
     ``forward_periods <= 1`` is a no-op (consecutive events already
-    independent); an empty frame returns unchanged. ``df`` must be sorted by
+    independent); an empty frame returns unchanged. ``data`` must be sorted by
     date and carry ``ordinal_col`` (``compute_caar`` emits ``date_ordinal``).
 
     Args:
-        df: Event-date series, sorted by date, with an ``ordinal_col``
+        data: Event-date series, sorted by date, with an ``ordinal_col``
             integer column giving each date's position on the full calendar.
         forward_periods: Minimum calendar gap (in those ordinal steps)
             required between consecutive kept events.
@@ -706,16 +706,16 @@ def _sample_event_spaced(
         Filtered DataFrame containing only the kept event rows; all
         columns untouched.
     """
-    if forward_periods <= 1 or df.height == 0:
-        return df
-    ordinals = df[ordinal_col].to_numpy()
-    keep = np.zeros(df.height, dtype=bool)
+    if forward_periods <= 1 or data.height == 0:
+        return data
+    ordinals = data[ordinal_col].to_numpy()
+    keep = np.zeros(data.height, dtype=bool)
     last_kept: int | None = None
     for i, ordinal in enumerate(ordinals):
         if last_kept is None or ordinal - last_kept >= forward_periods:
             keep[i] = True
             last_kept = int(ordinal)
-    return df.filter(pl.Series(keep))
+    return data.filter(pl.Series(keep))
 
 
 def _scaled_min_periods(base: int, forward_periods: int) -> int:
@@ -723,7 +723,7 @@ def _scaled_min_periods(base: int, forward_periods: int) -> int:
 
     ``MIN_*_PERIODS`` constants are calibrated for the *effective*
     sample size the downstream t-test operates on. When the metric
-    first runs ``_sample_non_overlapping(df, h)`` the effective n
+    first runs ``_sample_non_overlapping(data, h)`` the effective n
     shrinks to ``raw_n / h``, so the pre-sampling guard needs
     ``raw_n ≥ base · h`` to land with ≥ ``base`` independent
     observations after sampling. Clamps ``h ≥ 1`` so ``h = 1`` is a
@@ -733,7 +733,7 @@ def _scaled_min_periods(base: int, forward_periods: int) -> int:
 
 
 def _lag_within_asset(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     col: str,
     *,
     periods: int = 1,
@@ -749,14 +749,14 @@ def _lag_within_asset(
     asset, drop the first row per asset.
     """
     return (
-        df.sort([by, "date"])
+        data.sort([by, "date"])
         .with_columns(pl.col(col).shift(periods).over(by).alias(col))
         .drop_nulls([col])
     )
 
 
 def _assign_quantile_groups(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
     n_groups: int = 5,
     tie_policy: str = "ordinal",
@@ -778,7 +778,7 @@ def _assign_quantile_groups(
     """
     rank_expr = pl.col(factor_col).rank(method=tie_policy).over("date").alias("_rank")  # type: ignore[arg-type]
     return (
-        df.with_columns(
+        data.with_columns(
             rank_expr,
             # Denominator is the per-date *non-null* factor count, not the row
             # count: a null factor gets a null rank (it never lands in a bucket),
@@ -797,7 +797,7 @@ def _assign_quantile_groups(
 
 
 def _assign_quantile_groups_batch(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_cols: list[str],
     n_groups: int,
     tie_policy: str = "ordinal",
@@ -821,7 +821,7 @@ def _assign_quantile_groups_batch(
     # quantile widths and leave the top bucket unreachable (see
     # :func:`_assign_quantile_groups`).
     n_exprs = [pl.col(f).count().over("date").alias(f"_n__{f}") for f in factor_cols]
-    with_ranks = df.with_columns(*rank_exprs, *n_exprs)
+    with_ranks = data.with_columns(*rank_exprs, *n_exprs)
     group_exprs = [
         ((pl.col(f"_rank__{f}") - 1) * n_groups / pl.col(f"_n__{f}"))
         .cast(pl.Int32)
@@ -833,7 +833,7 @@ def _assign_quantile_groups_batch(
 
 
 def _compute_tie_ratio(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
 ) -> float:
     """Median-across-dates tie ratio ``1 - n_unique / n`` for ``factor_col``.
@@ -847,10 +847,10 @@ def _compute_tie_ratio(
     stash the value in ``MetricResult.metadata["tie_ratio"]`` for
     downstream inspection.
     """
-    if df.is_empty():
+    if data.is_empty():
         return float("nan")
     per_date = (
-        df.group_by("date")
+        data.group_by("date")
         .agg(
             pl.col(factor_col).n_unique().alias("_u"),
             pl.len().alias("_n"),
@@ -1092,7 +1092,7 @@ def _surface_null_drop(
 
 
 def _is_sparse_magnitude_weighted(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
 ) -> bool:
     """``True`` iff ``factor_col`` is mixed-sign and not a clean ±1 ternary.
@@ -1108,7 +1108,7 @@ def _is_sparse_magnitude_weighted(
     numerically); all-non-negative columns do not trigger (no flip
     ambiguity).
     """
-    nz = df.filter(pl.col(factor_col) != 0)[factor_col].unique().to_list()
+    nz = data.filter(pl.col(factor_col) != 0)[factor_col].unique().to_list()
     if not nz:
         return False
     has_neg = any(v < 0 for v in nz)
@@ -1124,7 +1124,7 @@ def _is_sparse_magnitude_weighted(
 
 
 def _event_signal_is_discrete(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
 ) -> bool:
     """``True`` iff ``|factor|`` over event rows has no magnitude variance.
@@ -1141,22 +1141,24 @@ def _event_signal_is_discrete(
     ("too few events"), handled by the event-count floor, not a discreteness
     blocker.
     """
-    events = df.filter(pl.col(factor_col) != 0)
+    events = data.filter(pl.col(factor_col) != 0)
     if events.is_empty():
         return False
     abs_signal = np.abs(events[factor_col].to_numpy())
     return bool(np.ptp(abs_signal) < EPSILON)
 
 
-def _median_universe_size(df: pl.DataFrame) -> int:
+def _median_universe_size(data: pl.DataFrame) -> int:
     """Median number of unique assets per date."""
     return int(
-        df.group_by("date").agg(pl.col("asset_id").n_unique().alias("n"))["n"].median()  # type: ignore[arg-type]
+        data.group_by("date")
+        .agg(pl.col("asset_id").n_unique().alias("n"))["n"]
+        .median()  # type: ignore[arg-type]
     )
 
 
 def _signed_car(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
     return_col: str = "forward_return",
 ) -> np.ndarray:
@@ -1165,9 +1167,9 @@ def _signed_car(
     ``signed_car = return × sign(factor)``
 
     Args:
-        df: Event-filtered DataFrame (factor ≠ 0 rows only).
+        data: Event-filtered DataFrame (factor ≠ 0 rows only).
 
     Returns:
         1-D numpy array of signed abnormal returns.
     """
-    return df[return_col].to_numpy() * np.sign(df[factor_col].to_numpy())
+    return data[return_col].to_numpy() * np.sign(data[factor_col].to_numpy())

--- a/factrix/metrics/_metric_capabilities.py
+++ b/factrix/metrics/_metric_capabilities.py
@@ -36,7 +36,7 @@ class PerDateSeries(Protocol):
     (IC), per-date Fama-MacBeth lambda, per-date hit indicator, etc.).
     """
 
-    def __call__(self, df: pl.DataFrame, /) -> pl.DataFrame: ...
+    def __call__(self, data: pl.DataFrame, /) -> pl.DataFrame: ...
 
 
 def per_date_series_rename(source_col: str) -> PerDateSeries:
@@ -49,8 +49,8 @@ def per_date_series_rename(source_col: str) -> PerDateSeries:
     etc.) define their own ``per_date_series`` instead.
     """
 
-    def _per_date(df: pl.DataFrame) -> pl.DataFrame:
-        return df.select(
+    def _per_date(data: pl.DataFrame) -> pl.DataFrame:
+        return data.select(
             [pl.col("date"), pl.col(source_col).alias("value")]
         ).drop_nulls()
 
@@ -70,7 +70,7 @@ def resolve_per_date_series(metric: Callable) -> PerDateSeries:
         raise TypeError(
             f"metric {metric.__name__!r} is not slice-test-eligible: "
             f"module {metric.__module__!r} does not declare a top-level "
-            f"`per_date_series(df) -> pl.DataFrame[(date, value)]` callable."
+            f"`per_date_series(data) -> pl.DataFrame[(date, value)]` callable."
         )
     return fn
 

--- a/factrix/metrics/_primitives/_caar.py
+++ b/factrix/metrics/_primitives/_caar.py
@@ -27,7 +27,7 @@ from factrix.metrics._helpers import _is_sparse_magnitude_weighted
     role=SpecRole.PIPELINE,
 )
 def compute_caar(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -47,7 +47,7 @@ def compute_caar(
             transparency (a date built on 1 event vs 500 is otherwise
             indistinguishable), not used to weight or drop dates.
         date_ordinal: 0-based position of the date on the *full* input
-            calendar (dense rank over every date in ``df``, including
+            calendar (dense rank over every date in ``data``, including
             non-event dates). Consumers that sub-sample for non-overlap
             independence measure the gap between kept event dates in
             these calendar steps rather than in event-index steps —
@@ -57,7 +57,7 @@ def compute_caar(
             sparse or clustered events, so the ordinal is what makes the
             forward-return overlap window measurable downstream.
     """
-    if _is_sparse_magnitude_weighted(df, factor_col):
+    if _is_sparse_magnitude_weighted(data, factor_col):
         warnings.warn(
             "compute_caar: factor column is mixed-sign and not a clean ±1 "
             "ternary. The result is the Sefcik-Thompson (1986) "
@@ -68,7 +68,9 @@ def compute_caar(
             stacklevel=2,
         )
     return (
-        df.with_columns((pl.col("date").rank(method="dense") - 1).alias("date_ordinal"))
+        data.with_columns(
+            (pl.col("date").rank(method="dense") - 1).alias("date_ordinal")
+        )
         .filter(pl.col(factor_col) != 0)
         .with_columns((pl.col(return_col) * pl.col(factor_col)).alias("_signed_car"))
         .group_by("date")

--- a/factrix/metrics/_primitives/_event_returns.py
+++ b/factrix/metrics/_primitives/_event_returns.py
@@ -26,7 +26,7 @@ from factrix.metrics._decorators import metric
     role=SpecRole.PIPELINE,
 )
 def compute_event_returns(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     offsets: list[int] | None = None,
     factor_col: str = "factor",
@@ -36,7 +36,7 @@ def compute_event_returns(
     if offsets is None:
         offsets = [-6, -3, -1, 1, 6, 12, 24]
 
-    date_dtype = df.schema["date"]
+    date_dtype = data.schema["date"]
     empty_schema = {
         "offset": pl.Int32,
         "date": date_dtype,
@@ -44,10 +44,10 @@ def compute_event_returns(
         "signed_return": pl.Float64,
     }
 
-    if price_col not in df.columns:
+    if price_col not in data.columns:
         return pl.DataFrame(schema=empty_schema)  # type: ignore[arg-type]
 
-    sorted_df = df.sort(["asset_id", "date"])
+    sorted_df = data.sort(["asset_id", "date"])
     events = sorted_df.filter(pl.col(factor_col) != 0)
 
     if len(events) == 0:

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -34,7 +34,7 @@ MIN_FM_ASSETS: int = 3
     batchable=True,
 )
 def compute_fm_betas(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
 ) -> dict[str, pl.DataFrame]:
@@ -52,7 +52,7 @@ def compute_fm_betas(
     specialised.
 
     Args:
-        df: Panel with ``date``, ``asset_id``, every name in
+        data: Panel with ``date``, ``asset_id``, every name in
             ``factor_cols``, and ``return_col``.
         factor_cols: Factor column names to score. All factors run in a
             single query regardless of N.
@@ -93,7 +93,7 @@ def compute_fm_betas(
             .alias(f"_beta__{f}")
         )
 
-    wide = df.lazy().group_by("date").agg(agg_exprs).sort("date").collect()
+    wide = data.lazy().group_by("date").agg(agg_exprs).sort("date").collect()
     # ``wide`` holds every date before the per-factor thinness / degeneracy
     # filter; its height is the shared pre-drop date count. ``n_periods_out``
     # differs per factor (each factor has its own ``_cnt`` and null betas).

--- a/factrix/metrics/_primitives/_group_returns.py
+++ b/factrix/metrics/_primitives/_group_returns.py
@@ -29,7 +29,7 @@ from factrix.metrics._helpers import (
     role=SpecRole.PIPELINE,
 )
 def compute_group_returns(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
     factor_col: str = "factor",
@@ -73,7 +73,7 @@ def compute_group_returns(
         >>> set(groups.columns) >= {"group", "mean_return"}
         True
     """
-    sampled = _sample_non_overlapping(df, forward_periods)
+    sampled = _sample_non_overlapping(data, forward_periods)
     grouped = _assign_quantile_groups(
         sampled,
         factor_col,

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -30,14 +30,14 @@ from factrix.metrics._helpers import _attach_drop_stats
     batchable=True,
 )
 def compute_ic(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
 ) -> dict[str, pl.DataFrame]:
     r"""Per-date Spearman Rank information coefficient (IC).
 
     Args:
-        df: Panel with ``date``, ``asset_id``, every name in
+        data: Panel with ``date``, ``asset_id``, every name in
             ``factor_cols``, and ``return_col``.
         factor_cols: Factor column names to score. All factors run in a
             single polars query (one ``with_columns`` + one
@@ -106,7 +106,11 @@ def compute_ic(
     # pre-drop date count is observable. The floor is applied per factor on its
     # own valid-pair count, so the drop stats are per factor, not shared.
     grouped = (
-        df.lazy().with_columns(rank_exprs).group_by("date").agg(agg_exprs).sort("date")
+        data.lazy()
+        .with_columns(rank_exprs)
+        .group_by("date")
+        .agg(agg_exprs)
+        .sort("date")
     ).collect()
     n_periods_in = grouped.height
     drop_reason = f"n_assets below MIN_IC_ASSETS ({MIN_IC_ASSETS})"

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -46,7 +46,7 @@ def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
     role=SpecRole.PIPELINE,
 )
 def compute_mfe_mae(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     window: int = 20,
     estimation_window: int = 60,
@@ -66,13 +66,13 @@ def compute_mfe_mae(
             f"and at least 2 observations), got {min_estimation_periods}"
         )
 
-    date_dtype = df.schema["date"]
+    date_dtype = data.schema["date"]
     empty_schema = _empty_mfe_mae_schema(date_dtype)
 
-    if price_col not in df.columns:
+    if price_col not in data.columns:
         return pl.DataFrame(schema=empty_schema)
 
-    sorted_df = df.sort(["asset_id", "date"])
+    sorted_df = data.sort(["asset_id", "date"])
     events = sorted_df.filter(pl.col(factor_col) != 0)
 
     if len(events) == 0:

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -34,7 +34,7 @@ from factrix.metrics._helpers import (
     batchable=True,
 )
 def compute_spread_series(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
     factor_cols: Sequence[str] = ("factor",),
@@ -49,7 +49,7 @@ def compute_spread_series(
     ``n_groups=10`` the bottom is Q10, not Q5.
 
     Args:
-        df: Panel with ``date, asset_id, factor, forward_return``.
+        data: Panel with ``date, asset_id, factor, forward_return``.
         forward_periods: Number of periods forward.
         n_groups: Number of quantile groups.
         factor_cols: Factor column names to score. All factors run in a
@@ -94,7 +94,7 @@ def compute_spread_series(
     if not cols:
         raise ValueError("factor_cols must be non-empty")
 
-    sampled = _sample_non_overlapping(df, forward_periods)
+    sampled = _sample_non_overlapping(data, forward_periods)
 
     median_n = _median_universe_size(sampled)
     per_group = median_n // n_groups if n_groups > 0 else 0

--- a/factrix/metrics/_primitives/_ts_betas.py
+++ b/factrix/metrics/_primitives/_ts_betas.py
@@ -43,7 +43,7 @@ _TS_BETA_DROP_REASON = (
     batchable=True,
 )
 def compute_ts_betas(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
 ) -> dict[str, pl.DataFrame]:
@@ -67,7 +67,7 @@ def compute_ts_betas(
     one ``collect`` across all factors — no per-asset Python loop.
 
     Args:
-        df: Panel with ``date``, ``asset_id``, every name in
+        data: Panel with ``date``, ``asset_id``, every name in
             ``factor_cols``, and ``return_col``.
         factor_cols: Factor column names to score. All factors run in a
             single query regardless of N.
@@ -87,15 +87,15 @@ def compute_ts_betas(
     if not cols:
         raise ValueError("factor_cols must be non-empty")
 
-    return {f: _ts_betas_one(df, f, return_col) for f in cols}
+    return {f: _ts_betas_one(data, f, return_col) for f in cols}
 
 
-def _ts_betas_one(df: pl.DataFrame, factor_col: str, return_col: str) -> pl.DataFrame:
+def _ts_betas_one(data: pl.DataFrame, factor_col: str, return_col: str) -> pl.DataFrame:
     # In-line asset count vs the raw universe, captured before the valid-mask
     # filter so the carried drop rate reflects the silent reduction the
     # cross-asset consumers see — including assets dropped for having no
     # complete (factor, return) pairs at all.
-    n_assets_in = df["asset_id"].n_unique()
+    n_assets_in = data["asset_id"].n_unique()
 
     # Restrict every moment to the pairwise-complete (factor, return) set so
     # cov and var share one sample (polars cov pairwise-drops; bare var would
@@ -103,7 +103,7 @@ def _ts_betas_one(df: pl.DataFrame, factor_col: str, return_col: str) -> pl.Data
     valid_mask = pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
 
     moments = (
-        df.lazy()
+        data.lazy()
         .filter(valid_mask)
         .group_by("asset_id")
         .agg(

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -266,7 +266,7 @@ def caar(
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def bmp_z(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -301,7 +301,7 @@ def bmp_z(
         4. $z = \mathrm{mean}(\mathrm{SAR}) / (\mathrm{std}(\mathrm{SAR}) / \sqrt{N})$.
 
     Args:
-        df: Full panel (including non-event rows) with ``date, asset_id,
+        data: Full panel (including non-event rows) with ``date, asset_id,
             factor, forward_return``. Must include enough history for
             estimation window.
         estimation_window: Number of periods before each event for
@@ -389,7 +389,7 @@ def bmp_z(
         >>> result.name == ""
         True
     """
-    sorted_df = df.sort(["asset_id", "date"])
+    sorted_df = data.sort(["asset_id", "date"])
 
     uses_price = "price" in sorted_df.columns
     if uses_price:

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -46,7 +46,7 @@ __all__ = [
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def clustering_hhi(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     cluster_window: int = 3,
@@ -63,7 +63,7 @@ def clustering_hhi(
     assumption violated → CAAR $t$-stat may be inflated.
 
     Args:
-        df: Panel with ``date, asset_id, factor``.
+        data: Panel with ``date, asset_id, factor``.
         cluster_window: Not used in HHI calculation but preserved for
             future block-bootstrap clustering adjustment.
 
@@ -93,7 +93,7 @@ def clustering_hhi(
         >>> result.name == ""
         True
     """
-    events = df.filter(pl.col(factor_col) != 0)
+    events = data.filter(pl.col(factor_col) != 0)
     n_events = len(events)
 
     sc = _enforce_min_floor(

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -63,7 +63,7 @@ __all__ = [
     ),
 )
 def top_concentration(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     q_top: float = 0.2,
     factor_col: str = "factor",
@@ -77,7 +77,7 @@ def top_concentration(
     independent bets.
 
     Args:
-        df: Panel with ``date, asset_id, factor`` (and ``forward_return``
+        data: Panel with ``date, asset_id, factor`` (and ``forward_return``
             if ``weight_by="alpha_contribution"``).
         q_top: Fraction of top-ranked stocks to include (default 0.2 =
             top 20%).
@@ -129,7 +129,7 @@ def top_concentration(
         >>> result.name == ""
         True
     """
-    if weight_by == "alpha_contribution" and return_col not in df.columns:
+    if weight_by == "alpha_contribution" and return_col not in data.columns:
         return _short_circuit_output(
             "top_concentration",
             "no_return_column",
@@ -137,7 +137,7 @@ def top_concentration(
             weight_by=weight_by,
         )
 
-    filtered = _sample_non_overlapping(df, forward_periods)
+    filtered = _sample_non_overlapping(data, forward_periods)
     tie_ratio = _compute_tie_ratio(filtered, factor_col)
 
     q1 = filtered.with_columns(
@@ -172,7 +172,7 @@ def top_concentration(
 
     # Raw (pre-sampling) date count: the axis the stride-scaled periods floors
     # are calibrated against.
-    n_raw_periods = df["date"].n_unique()
+    n_raw_periods = data["date"].n_unique()
     sc = _enforce_scaled_floor(
         "top_concentration",
         n_raw_periods,

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -35,7 +35,7 @@ __all__ = [
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def corrado_rank(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -58,7 +58,7 @@ def corrado_rank(
         $z = \mathrm{mean}(U_{\text{event,signed}}) / (\mathrm{std}(U_{\text{all}}) / \sqrt{N_{\text{events}}})$.
 
     Args:
-        df: Full panel with ``date, asset_id, factor, forward_return``.
+        data: Full panel with ``date, asset_id, factor, forward_return``.
             Must include non-event rows for ranking.
 
     Returns:
@@ -103,7 +103,7 @@ def corrado_rank(
         >>> result.name == ""
         True
     """
-    ranked = df.with_columns(
+    ranked = data.with_columns(
         (
             pl.col(return_col).rank(method="average").over("asset_id")
             / (pl.col(return_col).count().over("asset_id") + 1)

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -63,7 +63,7 @@ __all__ = [
     ),
 )
 def directional_hit_rate(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -76,7 +76,7 @@ def directional_hit_rate(
     PT independence null.
 
     Args:
-        df: Panel with ``date, asset_id``, ``factor_col`` and
+        data: Panel with ``date, asset_id``, ``factor_col`` and
             ``return_col``. Pooled across all ``(date, asset)``
             observations on the non-overlapping subsample.
         forward_periods: Sampling stride for non-overlapping dates;
@@ -158,14 +158,14 @@ def directional_hit_rate(
         >>> result.name == ""
         True
     """
-    if return_col not in df.columns:
+    if return_col not in data.columns:
         return _short_circuit_output(
             "directional_hit_rate",
             "no_return_column",
             missing_column=return_col,
         )
 
-    sampled = _sample_non_overlapping(df, forward_periods)
+    sampled = _sample_non_overlapping(data, forward_periods)
     paired = sampled.select(
         pl.col("date"),
         pl.col(factor_col).sign().alias("_x_sign"),

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -47,7 +47,7 @@ _EH_CELL = cell(None, FactorDensity.SPARSE, structure=None)
     sample_threshold=SampleThreshold(),
 )
 def event_around_return(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     offsets: list[int] | None = None,
     factor_col: str = "factor",
@@ -64,7 +64,7 @@ def event_around_return(
     High leakage → density may be reactive, not predictive.
 
     Args:
-        df: Panel with ``date, asset_id, factor, price``.
+        data: Panel with ``date, asset_id, factor, price``.
         offsets: Defaults to ``[-6, -3, -1, 1, 6, 12, 24]``.
 
     Returns:
@@ -100,7 +100,7 @@ def event_around_return(
         offsets = [-6, -3, -1, 1, 6, 12, 24]
 
     event_rets = compute_event_returns(
-        df,
+        data,
         offsets=offsets,
         factor_col=factor_col,
         price_col=price_col,

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -64,7 +64,7 @@ _EQ_CELL = cell(None, FactorDensity.SPARSE, structure=None)
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def event_hit_rate(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -74,7 +74,7 @@ def event_hit_rate(
     The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the hit-rate binomial test on the count of non-zero (event) observations.
 
     Args:
-        df: Panel with event density and forward return.
+        data: Panel with event density and forward return.
 
     Returns:
         MetricResult with value=hit_rate, stat=z from binomial test.
@@ -101,7 +101,7 @@ def event_hit_rate(
         >>> result.name == ""
         True
     """
-    events = df.filter(pl.col(factor_col) != 0)
+    events = data.filter(pl.col(factor_col) != 0)
 
     n = len(events)
     sc = _enforce_min_floor(
@@ -146,7 +146,7 @@ def event_hit_rate(
     requires_continuous_magnitude=True,
 )
 def event_ic(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -166,7 +166,7 @@ def event_ic(
     (not all ±1). Profile auto-skips when variance is absent.
 
     Args:
-        df: Panel with event density and forward return.
+        data: Panel with event density and forward return.
 
     Returns:
         MetricResult with value=Spearman rho, stat=z from Fisher transform.
@@ -196,7 +196,7 @@ def event_ic(
     """
     from scipy import stats as sp_stats
 
-    events = df.filter(pl.col(factor_col) != 0)
+    events = data.filter(pl.col(factor_col) != 0)
     n = len(events)
 
     sc = _enforce_min_floor(
@@ -205,7 +205,7 @@ def event_ic(
     if sc is not None:
         return sc
 
-    if _event_signal_is_discrete(df, factor_col):
+    if _event_signal_is_discrete(data, factor_col):
         # Signal is discrete {±1}: event_ic is not defined (no magnitude variance).
         # Flagged as "not_applicable" rather than "insufficient" — this is by
         # design, not a shortfall; profiles suppress the field (→ None).
@@ -247,7 +247,7 @@ def event_ic(
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def profit_factor(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -260,7 +260,7 @@ def profit_factor(
     means gross gains exceed gross losses across all events.
 
     Args:
-        df: Panel with event density and forward return.
+        data: Panel with event density and forward return.
 
     Returns:
         MetricResult with value=profit_factor.
@@ -288,7 +288,7 @@ def profit_factor(
         >>> result.name == ""
         True
     """
-    events = df.filter(pl.col(factor_col) != 0)
+    events = data.filter(pl.col(factor_col) != 0)
     n = len(events)
 
     sc = _enforce_min_floor(
@@ -324,7 +324,7 @@ def profit_factor(
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def event_skewness(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -340,7 +340,7 @@ def event_skewness(
     Also tests H₀: skewness = 0 via D'Agostino's skew test.
 
     Args:
-        df: Panel with event density and forward return.
+        data: Panel with event density and forward return.
 
     Returns:
         MetricResult with value=skewness, stat=z from D'Agostino test.
@@ -371,7 +371,7 @@ def event_skewness(
     """
     from scipy import stats as sp_stats
 
-    events = df.filter(pl.col(factor_col) != 0)
+    events = data.filter(pl.col(factor_col) != 0)
     n = len(events)
 
     sc = _enforce_min_floor(
@@ -419,7 +419,7 @@ def event_skewness(
     sample_threshold=SampleThreshold(),
 )
 def signal_density(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
 ) -> MetricResult:
@@ -440,7 +440,7 @@ def signal_density(
     higher but independence may be weaker.
 
     Args:
-        df: Panel with ``date, asset_id, factor``.
+        data: Panel with ``date, asset_id, factor``.
 
     Returns:
         MetricResult with value = mean bars-per-event across assets.
@@ -463,7 +463,7 @@ def signal_density(
         >>> result.name == ""
         True
     """
-    events = df.filter(pl.col(factor_col) != 0).sort(["asset_id", "date"])
+    events = data.filter(pl.col(factor_col) != 0).sort(["asset_id", "date"])
     n_events = len(events)
 
     if n_events < 2:
@@ -496,7 +496,7 @@ def signal_density(
         )
 
     # Total bars per asset (from full panel, not just events)
-    bars_per_asset = df.group_by("asset_id").agg(
+    bars_per_asset = data.group_by("asset_id").agg(
         pl.col("date").count().alias("total_bars")
     )
     per_asset = per_asset.join(bars_per_asset, on="asset_id", how="left")

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -336,7 +336,7 @@ _MIN_DK_PERIODS: int = 3
 
 
 def _pooled_beta_driscoll_kraay(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     X: np.ndarray,
     resid: np.ndarray,
     slope: float,
@@ -364,7 +364,7 @@ def _pooled_beta_driscoll_kraay(
 
     from factrix._stats.hac import _driscoll_kraay_cov as _dk_cov
 
-    period_ids = df[cluster_col].to_numpy()
+    period_ids = data[cluster_col].to_numpy()
     try:
         cov, n_periods, lags_used = _dk_cov(X, resid, period_ids, lags=lags)
         dk_meta = {"n_periods": n_periods, "driscoll_kraay_lags": lags_used}
@@ -437,7 +437,7 @@ def _pooled_beta_driscoll_kraay(
     ),
 )
 def pooled_beta(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -575,11 +575,11 @@ def pooled_beta(
     # Pooled OLS is estimated on the complete (factor, return) pairs: drop
     # incomplete rows up front so a null factor or return cannot feed a NaN into
     # ``lstsq`` (poisoning the slope) and so ``n_obs`` — the pairs-axis floor —
-    # counts what the regression actually uses. Dropping on ``df`` keeps the
+    # counts what the regression actually uses. Dropping on ``data`` keeps the
     # downstream cluster / Driscoll-Kraay arrays positionally aligned.
-    df = df.drop_nulls([return_col, factor_col])
-    y = df[return_col].to_numpy().astype(np.float64)
-    x = df[factor_col].to_numpy().astype(np.float64)
+    data = data.drop_nulls([return_col, factor_col])
+    y = data[return_col].to_numpy().astype(np.float64)
+    x = data[factor_col].to_numpy().astype(np.float64)
     n_obs = len(y)
 
     sc = _enforce_min_floor(
@@ -609,7 +609,7 @@ def pooled_beta(
 
     if driscoll_kraay:
         return _pooled_beta_driscoll_kraay(
-            df,
+            data,
             X,
             resid,
             slope,
@@ -619,7 +619,7 @@ def pooled_beta(
             lags=driscoll_kraay_lags,
         )
 
-    clusters_a = df[cluster_col].to_numpy()
+    clusters_a = data[cluster_col].to_numpy()
     meat_a, g_a = _cluster_meat(X, resid, clusters_a)
 
     # Finite-sample factor shared across all meat components (Stata /
@@ -646,7 +646,7 @@ def pooled_beta(
         method_desc = f"Pooled OLS + clustered SE ({cluster_col})"
         cluster_metadata: dict = {"n_clusters": g_a}
     else:
-        clusters_b = df[two_way_cluster_col].to_numpy()
+        clusters_b = data[two_way_cluster_col].to_numpy()
         meat_b, g_b = _cluster_meat(X, resid, clusters_b)
         # Composite key for intersection cells. Factor each side to
         # integer ids then combine — np.unique(axis=0) chokes on object

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -145,7 +145,7 @@ def _build_k_spread_series(
     sample_threshold=_k_spread_threshold,
 )
 def k_spread(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     k: int = 5,
     factor_col: str = "factor",
@@ -161,7 +161,7 @@ def k_spread(
     tested across time.
 
     Args:
-        df: Panel with ``date, asset_id``, ``factor_col`` and
+        data: Panel with ``date, asset_id``, ``factor_col`` and
             ``return_col``.
         forward_periods: Sampling stride for non-overlapping dates;
             match the forward-return horizon.
@@ -221,7 +221,7 @@ def k_spread(
     if k < 1:
         raise ValueError(f"k must be >= 1; got {k}")
     _check_applicable_inference(inference, applicable_inference, func_name="k_spread")
-    if return_col not in df.columns:
+    if return_col not in data.columns:
         return _short_circuit_output(
             "k_spread",
             "no_return_column",
@@ -233,7 +233,7 @@ def k_spread(
     # overcount and the bottom-leg cutoff (``_rank > _n_date - k``) would point
     # past the last real rank — silently shrinking or emptying the short leg.
     # forward_return is null on the last ``forward_periods`` rows per asset.
-    sampled = _sample_non_overlapping(df, forward_periods)
+    sampled = _sample_non_overlapping(data, forward_periods)
     series, clean = _build_k_spread_series(sampled, k, factor_col, return_col)
     n_assets = clean["asset_id"].n_unique()
     # Real per-date asset count (not the universe-wide unique count): both
@@ -268,7 +268,7 @@ def k_spread(
     n = len(spread_vals)
     sc = _enforce_scaled_floor(
         "k_spread",
-        df["date"].n_unique(),
+        data["date"].n_unique(),
         MIN_PORTFOLIO_PERIODS_HARD,
         forward_periods,
         "insufficient_portfolio_periods",
@@ -294,7 +294,7 @@ def k_spread(
     # build it once on the unsampled panel.
     full_series: pl.DataFrame | None = None
     if isinstance(inference, NeweyWest):
-        full_series, _ = _build_k_spread_series(df, k, factor_col, return_col)
+        full_series, _ = _build_k_spread_series(data, k, factor_col, return_col)
     mean_spread, t, p, sig_method, sig_extra, sig_codes = (
         _spread_significance_with_inference(
             inference,

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -71,7 +71,7 @@ min_assets_per_group: int | None = 50
     sample_threshold=_scaled_periods_threshold(MIN_MONOTONICITY_PERIODS),
 )
 def monotonicity(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 10,
     factor_cols: Sequence[str] = ("factor",),
@@ -87,7 +87,7 @@ def monotonicity(
     strong monotonicity but the direction flips across dates.
 
     Args:
-        df: Panel with ``date, asset_id, factor, forward_return``.
+        data: Panel with ``date, asset_id, factor, forward_return``.
         n_groups: Number of quantile groups (default 10 for Taiwan ~2000 stocks).
             Use 5 for N < 1000, 3 for N < 200.
         tie_policy: Bucketing tie-break policy, see ``_assign_quantile_groups``.
@@ -126,11 +126,11 @@ def monotonicity(
 
     # Raw (pre-sampling) date count: the axis the stride-scaled periods floor is
     # calibrated against, shared across all factors.
-    n_raw_periods = df["date"].n_unique()
+    n_raw_periods = data["date"].n_unique()
 
     # Sample non-overlapping once — shared across all factors on the
     # same panel (depends only on `date` + `forward_periods`).
-    filtered = _sample_non_overlapping(df, forward_periods)
+    filtered = _sample_non_overlapping(data, forward_periods)
     tie_ratios = _compute_tie_ratios_batch(filtered, cols)
     for f in cols:
         _warn_high_tie_ratio(tie_ratios[f], "monotonicity", tie_policy)
@@ -228,7 +228,7 @@ def monotonicity(
 
 
 def _compute_tie_ratios_batch(
-    df: pl.DataFrame, factor_cols: list[str]
+    data: pl.DataFrame, factor_cols: list[str]
 ) -> dict[str, float]:
     """Median-across-dates tie ratio (``1 - n_unique / n``) for many factors.
 
@@ -243,7 +243,7 @@ def _compute_tie_ratios_batch(
     """
     if not factor_cols:
         return {}
-    per_date = df.group_by("date").agg(
+    per_date = data.group_by("date").agg(
         pl.len().alias("_n"),
         *[pl.col(f).n_unique().alias(f"_u__{f}") for f in factor_cols],
     )

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -105,7 +105,7 @@ def _quantile_groups_threshold(self) -> SampleThreshold:
     sample_threshold=_quantile_groups_threshold,
 )
 def quantile_spread(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
     factor_cols: Sequence[str] = ("factor",),
@@ -178,12 +178,12 @@ def quantile_spread(
     # Sample once across all factors; bucketing tie_ratio is computed
     # on the sampled subset (what bucketing actually sees) rather than
     # the full panel — ~N/forward_periods smaller scan.
-    sampled = _sample_non_overlapping(df, forward_periods)
+    sampled = _sample_non_overlapping(data, forward_periods)
     series_by_factor = (
         _precomputed_series
         if _precomputed_series is not None
         else compute_spread_series(
-            df,
+            data,
             n_groups=n_groups,
             factor_cols=cols,
             tie_policy=tie_policy,
@@ -194,7 +194,7 @@ def quantile_spread(
     # ``forward_periods=1`` is the no-stride build of the same primitive.
     full_series_by_factor: dict[str, pl.DataFrame] | None = (
         compute_spread_series(
-            df,
+            data,
             n_groups=n_groups,
             factor_cols=cols,
             tie_policy=tie_policy,
@@ -205,7 +205,7 @@ def quantile_spread(
     )
     # Raw (pre-sampling) date count: the axis the stride-scaled periods floor is
     # calibrated against, shared across factors.
-    n_raw_periods = df["date"].n_unique()
+    n_raw_periods = data["date"].n_unique()
     return {
         f: _quantile_spread_from_series(
             series=series_by_factor[f],
@@ -354,7 +354,7 @@ def _quantile_spread_from_series(
     sample_threshold=_quantile_groups_threshold,
 )
 def quantile_spread_vw(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     n_groups: int = 5,
     factor_col: str = "factor",
@@ -391,7 +391,7 @@ def quantile_spread_vw(
     and may not survive capacity / liquidity constraints.
 
     Args:
-        df: Panel with ``date, asset_id, factor, forward_return,
+        data: Panel with ``date, asset_id, factor, forward_return,
             market_cap`` (or whatever ``weight_col`` names).
         weight_col: Column for value weighting (default ``market_cap``).
         lag_weights: When True (default), shift ``weight_col`` by 1
@@ -435,14 +435,14 @@ def quantile_spread_vw(
         >>> result.name == ""
         True
     """
-    if weight_col not in df.columns:
+    if weight_col not in data.columns:
         return _short_circuit_output(
             "quantile_spread_vw",
             "no_weight_column",
             missing_column=weight_col,
         )
 
-    sampled = _sample_non_overlapping(df, forward_periods)
+    sampled = _sample_non_overlapping(data, forward_periods)
     if lag_weights:
         sampled = _lag_within_asset(sampled, weight_col)
     tie_ratio = _compute_tie_ratio(sampled, factor_col)
@@ -484,7 +484,7 @@ def quantile_spread_vw(
     n = len(spread_vals)
     sc = _enforce_scaled_floor(
         "quantile_spread_vw",
-        df["date"].n_unique(),
+        data["date"].n_unique(),
         MIN_PORTFOLIO_PERIODS_HARD,
         forward_periods,
         "insufficient_portfolio_periods",

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -135,8 +135,8 @@ def _align_spread_series(
     # WHY: inner join on dates ensures only dates present in ALL series;
     # then filter out any date where any series has null spread
     all_dates = None
-    for df in series_dict.values():
-        valid = df.filter(pl.col("spread").is_not_null()).select("date").unique()
+    for data in series_dict.values():
+        valid = data.filter(pl.col("spread").is_not_null()).select("date").unique()
         if all_dates is None:
             all_dates = valid
         else:
@@ -147,9 +147,9 @@ def _align_spread_series(
 
     common_dates = all_dates.sort("date")
     arrays = {}
-    for name, df in series_dict.items():
+    for name, data in series_dict.items():
         arrays[name] = common_dates.join(
-            df.select("date", "spread"), on="date", how="inner"
+            data.select("date", "spread"), on="date", how="inner"
         )["spread"].to_numpy()
     return common_dates, arrays
 

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -87,7 +87,7 @@ def _turnover_sample_threshold(self: MetricBase) -> SampleThreshold:
     sample_threshold=_turnover_sample_threshold,
 )
 def turnover(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
     forward_periods: int = 1,
     quantile: float | None = None,
@@ -118,7 +118,7 @@ def turnover(
     window with the forward-return horizon used elsewhere in the profile.
 
     Args:
-        df: Panel with ``date, asset_id, factor``.
+        data: Panel with ``date, asset_id, factor``.
         factor_col: Name of the factor column. Defaults to ``"factor"``.
         forward_periods: Sampling stride in periods — should match the
             forward-return horizon the factor is being evaluated against.
@@ -178,7 +178,7 @@ def turnover(
     if forward_periods < 1:
         raise ValueError(f"forward_periods must be ≥ 1, got {forward_periods!r}")
 
-    all_dates = df["date"].unique().sort()
+    all_dates = data["date"].unique().sort()
     # Need ≥ 2 non-overlapping pairs so std(ρ) is defined; that requires
     # ≥ 3 sampled dates (Hansen & Hodrick 1980), i.e. ≥ 2·h + 1 raw dates.
     min_required = _turnover_min_dates(forward_periods)
@@ -191,7 +191,7 @@ def turnover(
             forward_periods=forward_periods,
         )
 
-    sampled_df = _sample_non_overlapping(df, forward_periods)
+    sampled_df = _sample_non_overlapping(data, forward_periods)
 
     ranked = sampled_df.select(
         "date",
@@ -263,7 +263,7 @@ def turnover(
     sample_threshold=SampleThreshold(min_periods=2),
 )
 def notional_turnover(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
     *,
     n_groups: int = 10,
@@ -291,7 +291,7 @@ def notional_turnover(
     ``breakeven_cost = spread / (2 × turnover) × 1e4`` consistent.
 
     Args:
-        df: Panel with ``date, asset_id, factor``.
+        data: Panel with ``date, asset_id, factor``.
         factor_col: Name of the factor column.
         n_groups: Number of quantile groups (default ``10`` = deciles).
             Must be ≥ 3 so top and bottom are distinct buckets.
@@ -342,9 +342,9 @@ def notional_turnover(
         )
 
     if forward_periods > 1:
-        df = _sample_non_overlapping(df, forward_periods)
+        data = _sample_non_overlapping(data, forward_periods)
 
-    dates = df["date"].unique().sort()
+    dates = data["date"].unique().sort()
     sc = _enforce_min_floor(
         notional_turnover,
         "notional_turnover",
@@ -357,7 +357,7 @@ def notional_turnover(
 
     top_g = n_groups - 1
     bot_g = 0
-    grouped = _assign_quantile_groups(df, factor_col, n_groups).select(
+    grouped = _assign_quantile_groups(data, factor_col, n_groups).select(
         "date",
         "asset_id",
         (pl.col("_group") == top_g).alias("is_top"),

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -71,7 +71,7 @@ __all__ = [
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
 def ts_asymmetry(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -92,7 +92,7 @@ def ts_asymmetry(
     reason.
 
     Args:
-        df: Long panel; aggregated to per-date ``(_f, _r)`` internally.
+        data: Long panel; aggregated to per-date ``(_f, _r)`` internally.
         factor_col: Column carrying the factor.
         return_col: Column carrying the forward return.
         forward_periods: Overlap horizon of the forward return; used
@@ -147,20 +147,20 @@ def ts_asymmetry(
         >>> result.name == ""
         True
     """
-    if "date" not in df.columns:
+    if "date" not in data.columns:
         return _short_circuit_output(
             "ts_asymmetry",
             "no_date_column",
         )
     for col in (factor_col, return_col):
-        if col not in df.columns:
+        if col not in data.columns:
             return _short_circuit_output(
                 "ts_asymmetry",
                 f"no_{col}_column",
             )
 
     per_date = _aggregate_to_per_date(
-        df,
+        data,
         factor_col=factor_col,
         return_col=return_col,
     )

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -226,7 +226,7 @@ def mean_r_squared(ts_betas_df: pl.DataFrame) -> MetricResult:
     role=SpecRole.PIPELINE,
 )
 def compute_rolling_mean_beta(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     window: int = 60,
     factor_col: str = "factor",
@@ -273,7 +273,7 @@ def compute_rolling_mean_beta(
         >>> set(rolling.columns) >= {"date", "value"}
         True
     """
-    dates = df["date"].unique().sort()
+    dates = data["date"].unique().sort()
     if len(dates) < window:
         return pl.DataFrame(
             {
@@ -290,7 +290,7 @@ def compute_rolling_mean_beta(
     # asset row whose date lands in it, located by ``searchsorted`` on the
     # asset's sorted dates — which replaces the per-date ``is_in`` filter and the
     # per-asset ``asset_id ==`` filter the loop used to run.
-    valid = df.filter(
+    valid = data.filter(
         pl.col(factor_col).is_not_null() & pl.col(return_col).is_not_null()
     )
     asset_arrays: dict[object, tuple[np.ndarray, np.ndarray, np.ndarray]] = {}

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -57,7 +57,7 @@ __all__ = [
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
 )
 def ts_quantile_spread(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     *,
     factor_col: str = "factor",
     return_col: str = "forward_return",
@@ -80,7 +80,7 @@ def ts_quantile_spread(
     a redirect to ``event_quality.*`` for binary / sparse signals.
 
     Args:
-        df: Long panel; aggregated to per-date ``(_f, _r)`` internally.
+        data: Long panel; aggregated to per-date ``(_f, _r)`` internally.
         factor_col: Column carrying the factor.
         return_col: Column carrying the forward return.
         n_groups: Number of quantile buckets ``K`` to cut the factor
@@ -132,20 +132,20 @@ def ts_quantile_spread(
         >>> result.name == ""
         True
     """
-    if "date" not in df.columns:
+    if "date" not in data.columns:
         return _short_circuit_output(
             "ts_quantile_spread",
             "no_date_column",
         )
     for col in (factor_col, return_col):
-        if col not in df.columns:
+        if col not in data.columns:
             return _short_circuit_output(
                 "ts_quantile_spread",
                 f"no_{col}_column",
             )
 
     per_date = _aggregate_to_per_date(
-        df,
+        data,
         factor_col=factor_col,
         return_col=return_col,
     )

--- a/factrix/preprocess/normalize.py
+++ b/factrix/preprocess/normalize.py
@@ -24,7 +24,7 @@ def _mad_expressions(factor_col: str) -> tuple[pl.Expr, pl.Expr]:
 
 
 def mad_winsorize(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
     n_mad: float = 3.0,
 ) -> pl.DataFrame:
@@ -51,12 +51,12 @@ def mad_winsorize(
         True
     """
     if n_mad <= 0:
-        return df
+        return data
 
     median_expr, mad_expr = _mad_expressions(factor_col)
     half_width = mad_expr * MAD_CONSISTENCY_CONSTANT * n_mad
 
-    return df.with_columns(
+    return data.with_columns(
         pl.col(factor_col)
         .clip(median_expr - half_width, median_expr + half_width)
         .alias(factor_col)
@@ -64,7 +64,7 @@ def mad_winsorize(
 
 
 def cross_sectional_zscore(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     factor_col: str = "factor",
 ) -> pl.DataFrame:
     """Step 5: MAD-robust z-score within each cross-section (date).
@@ -84,7 +84,7 @@ def cross_sectional_zscore(
     """
     median_expr, mad_expr = _mad_expressions(factor_col)
 
-    return df.with_columns(
+    return data.with_columns(
         ((pl.col(factor_col) - median_expr) / (mad_expr * MAD_CONSISTENCY_CONSTANT))
         .fill_nan(0.0)
         .fill_null(0.0)

--- a/factrix/preprocess/orthogonalize.py
+++ b/factrix/preprocess/orthogonalize.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class OrthogonalizeResult:
     """Result of factor orthogonalization with attribution info."""
 
-    df: pl.DataFrame
+    data: pl.DataFrame
     mean_betas: dict[str, float] = field(default_factory=dict)
     mean_r_squared: float = 0.0
     n_dates: int = 0
@@ -53,7 +53,7 @@ def orthogonalize_factor(
             If None, uses all columns except ``date`` and ``asset_id``.
 
     Returns:
-        OrthogonalizeResult with: ``df`` (factor_df with ``factor_col``
+        OrthogonalizeResult with: ``data`` (factor_df with ``factor_col``
         replaced by the residual and ``factor_pre_ortho`` preserving the
         original value), ``mean_betas`` (average beta per base factor
         across dates), and ``mean_r_squared`` (average R² across dates).
@@ -73,7 +73,7 @@ def orthogonalize_factor(
         ...     pl.col("price").rank().over("date").alias("size")
         ... ).select("date", "asset_id", "size")
         >>> result = orthogonalize_factor(factor_df, base, base_cols=["size"])
-        >>> "factor_pre_ortho" in result.df.columns
+        >>> "factor_pre_ortho" in result.data.columns
         True
         >>> isinstance(result.mean_r_squared, float)
         True
@@ -85,7 +85,7 @@ def orthogonalize_factor(
         logger.warning(
             "orthogonalize_factor: no base_cols specified, returning unchanged"
         )
-        return OrthogonalizeResult(df=factor_df)
+        return OrthogonalizeResult(data=factor_df)
 
     # WHY: join enforces date × asset_id alignment.
     merged = factor_df.join(
@@ -141,7 +141,7 @@ def orthogonalize_factor(
 
     if not residuals_list:
         logger.warning("orthogonalize_factor: no valid dates after join")
-        return OrthogonalizeResult(df=factor_df)
+        return OrthogonalizeResult(data=factor_df)
 
     residuals_df = pl.concat(residuals_list)
 
@@ -186,7 +186,7 @@ def orthogonalize_factor(
         mean_r2 = float(np.mean(all_r2))
 
     return OrthogonalizeResult(
-        df=result,
+        data=result,
         mean_betas=mean_betas,
         mean_r_squared=mean_r2,
         n_dates=n_dates,

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -64,7 +64,7 @@ def _validate_winsorize_bounds(lower: object, upper: object) -> tuple[float, flo
 
 
 def compute_forward_return(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     forward_periods: int = 5,
     *,
     overwrite: bool = False,
@@ -90,14 +90,14 @@ def compute_forward_return(
     (see Notes for the scope boundary).
 
     Args:
-        df: Must contain ``date``, ``asset_id``, ``price``. Must already
+        data: Must contain ``date``, ``asset_id``, ``price``. Must already
             be sorted with **regular spacing per asset** on the time axis;
             this function shifts by row count and does not inspect ``date``.
         forward_periods: Holding horizon in **rows** of the time axis,
             not calendar time (default 5). On a daily panel this is 5
             trading days; on a weekly panel, 5 weeks; on 1-min bars,
             5 minutes. Frequency is the caller's responsibility.
-        overwrite: Allow recomputation when ``df`` already carries a
+        overwrite: Allow recomputation when ``data`` already carries a
             ``forward_return`` column. ``False`` (default) raises rather
             than silently overwrite — the function is **not idempotent**:
             the previous call already dropped the last ``forward_periods + 1``
@@ -108,7 +108,7 @@ def compute_forward_return(
 
     Raises:
         UserInputError: ``forward_periods`` is not a positive ``int``;
-            ``df`` already has a ``forward_return`` column and
+            ``data`` already has a ``forward_return`` column and
             ``overwrite`` is ``False``; or the row horizon / price data
             leaves no finite forward returns after filtering.
 
@@ -185,12 +185,12 @@ def compute_forward_return(
     """
     forward_periods = _validate_forward_periods(forward_periods)
 
-    if "forward_return" in df.columns:
+    if "forward_return" in data.columns:
         if not overwrite:
             raise UserInputError(
                 func_name="compute_forward_return",
-                field="df",
-                value=list(df.columns),
+                field="data",
+                value=list(data.columns),
                 expected=(
                     "a panel without 'forward_return'. This function is not "
                     "idempotent — a prior call already dropped the last "
@@ -201,12 +201,12 @@ def compute_forward_return(
                 ),
                 docs_path=_DOCS_FORWARD_RETURN,
             )
-        df = df.drop("forward_return")
+        data = data.drop("forward_return")
 
     from factrix._data_input import _stamp_forward_periods
 
     out = (
-        df.sort(["asset_id", "date"])
+        data.sort(["asset_id", "date"])
         .with_columns(
             (
                 (
@@ -222,8 +222,8 @@ def compute_forward_return(
     if out.is_empty():
         raise UserInputError(
             func_name="compute_forward_return",
-            field="df",
-            value=f"{df.height} rows",
+            field="data",
+            value=f"{data.height} rows",
             expected=(
                 "at least one finite forward_return after applying the row "
                 f"horizon forward_periods={forward_periods}; the panel may be "
@@ -238,7 +238,7 @@ def compute_forward_return(
 
 
 def winsorize_forward_return(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     lower: float = 0.01,
     upper: float = 0.99,
 ) -> pl.DataFrame:
@@ -274,17 +274,17 @@ def winsorize_forward_return(
     """
     lower, upper = _validate_winsorize_bounds(lower, upper)
     if lower <= 0.0 and upper >= 1.0:
-        return df
+        return data
 
     lb = pl.col("forward_return").quantile(lower).over("date")
     ub = pl.col("forward_return").quantile(upper).over("date")
 
-    return df.with_columns(
+    return data.with_columns(
         pl.col("forward_return").clip(lb, ub).alias("forward_return")
     )
 
 
-def compute_abnormal_return(df: pl.DataFrame) -> pl.DataFrame:
+def compute_abnormal_return(data: pl.DataFrame) -> pl.DataFrame:
     """Step 3: Cross-sectional abnormal return.
 
     ``abnormal_return = forward_return - mean(forward_return) per date``
@@ -304,7 +304,7 @@ def compute_abnormal_return(df: pl.DataFrame) -> pl.DataFrame:
         >>> "abnormal_return" in adjusted.columns
         True
     """
-    return df.with_columns(
+    return data.with_columns(
         (pl.col("forward_return") - pl.col("forward_return").mean().over("date")).alias(
             "abnormal_return"
         )

--- a/factrix/slicing/_primitive.py
+++ b/factrix/slicing/_primitive.py
@@ -6,37 +6,37 @@ import polars as pl
 
 
 def _slice_by(
-    df: pl.DataFrame,
+    data: pl.DataFrame,
     by: str,
 ) -> dict[str, pl.DataFrame]:
-    """Partition ``df`` by the values of an existing column.
+    """Partition ``data`` by the values of an existing column.
 
     Returns ``{value: sub_df}`` with the ``by`` column dropped from each
     sub-frame (it is constant within a partition and consumers do not
     need it). Raises ``ValueError`` if ``by`` is not a column of
-    ``df`` or ``df`` is empty.
+    ``data`` or ``data`` is empty.
     """
-    if not isinstance(df, pl.DataFrame):
+    if not isinstance(data, pl.DataFrame):
         raise TypeError(
-            f"_slice_by expects a polars DataFrame; got {type(df).__name__}."
+            f"_slice_by expects a polars DataFrame; got {type(data).__name__}."
         )
-    if by not in df.columns:
+    if by not in data.columns:
         raise ValueError(
-            f"_slice_by: column {by!r} not found in df; "
-            f"got columns {df.columns}. Compose the column upstream "
-            "(e.g. df.with_columns(pl.lit(...).alias(...)) or a join) "
+            f"_slice_by: column {by!r} not found in data; "
+            f"got columns {data.columns}. Compose the column upstream "
+            "(e.g. data.with_columns(pl.lit(...).alias(...)) or a join) "
             "before calling by_slice."
         )
-    if df.is_empty():
-        raise ValueError(f"_slice_by: df is empty; nothing to slice on {by!r}.")
-    if df.get_column(by).null_count() > 0:
+    if data.is_empty():
+        raise ValueError(f"_slice_by: data is empty; nothing to slice on {by!r}.")
+    if data.get_column(by).null_count() > 0:
         raise ValueError(
             f"_slice_by: column {by!r} contains nulls; "
-            f"drop or impute before slicing (e.g. df.drop_nulls({by!r}))."
+            f"drop or impute before slicing (e.g. data.drop_nulls({by!r}))."
         )
     return {
         str(key): sub_df
-        for (key,), sub_df in df.partition_by(
+        for (key,), sub_df in data.partition_by(
             by, as_dict=True, include_key=False
         ).items()
     }

--- a/tests/test_by_slice.py
+++ b/tests/test_by_slice.py
@@ -63,7 +63,7 @@ class TestSliceByLabel:
 
     def test_missing_label_raises(self):
         df = _label_series(10)
-        with pytest.raises(ValueError, match="not found in df"):
+        with pytest.raises(ValueError, match="not found in data"):
             _slice_by(df, "sector")
 
     def test_empty_df_raises(self):
@@ -135,7 +135,7 @@ class TestBySlice:
 
     def test_missing_by_raises(self):
         panel = _sector_panel()
-        with pytest.raises(ValueError, match="not found in df"):
+        with pytest.raises(ValueError, match="not found in data"):
             by_slice(panel, ic(), by="industry", factor_col="factor")
 
     def test_bare_class_rejected(self):

--- a/tests/test_metric_base.py
+++ b/tests/test_metric_base.py
@@ -230,23 +230,23 @@ def test_metric_parameter_ordering_and_reflection():
             cell=_TEST_CELL,
             aggregation=Aggregation.TS_ONLY,
         )
-        def ordered_metric(df: pl.DataFrame, a: int = 10, *, b: int) -> str:
+        def ordered_metric(data: pl.DataFrame, a: int = 10, *, b: int) -> str:
             return f"a={a}, b={b}"
 
         assert issubclass(ordered_metric, MetricBase)
-        assert ordered_metric._first_param_name == "df"
+        assert ordered_metric._first_param_name == "data"
         # The fields should be sorted: non-default ("b") first, then default ("a")
         assert ordered_metric._param_names == ("b", "a")
 
         # Test instantiation & execution (ordering is checked and bound properly)
         inst = ordered_metric(b=42, a=5)
-        df = pl.DataFrame({"value": [1]})
-        res = inst(df)
+        data = pl.DataFrame({"value": [1]})
+        res = inst(data)
         assert res == "a=5, b=42"
 
         # Test default value preservation
         inst_default = ordered_metric(b=99)
-        res_default = inst_default(df)
+        res_default = inst_default(data)
         assert res_default == "a=10, b=99"
     finally:
         if "ordered_metric" in REGISTRY:

--- a/tests/test_naming_df.py
+++ b/tests/test_naming_df.py
@@ -1,0 +1,107 @@
+"""Naming guard: bare ``df`` / ``_df`` identifiers are banned in ``factrix/``.
+
+``df`` is ambiguous — *degrees of freedom* in a statistics context,
+*DataFrame* in the polars idiom. The architecture doc kills the
+collision by **position** (see
+``docs/development/architecture.md`` → "Naming: ``data`` vs ``df_*``"):
+
+- ``df_…`` **prefix** → degrees of freedom (``df_num``, ``df_denom``,
+  ``df_resid``, ``df_t``). KEPT.
+- ``…_df`` **suffix** with a content prefix → DataFrame (``ic_df``,
+  ``caar_df``, ``factor_df``, ``sorted_df``). KEPT.
+- bare ``df`` / ``_df`` → BANNED — the unqualified token is exactly the
+  ambiguous case. A standalone frame uses ``data`` (or a semantic noun).
+
+This walks every ``factrix/`` module with :mod:`ast` and fails if any
+function/lambda parameter, assignment target (a bare ``Name``), or
+annotated/dataclass field is named exactly ``df`` or ``_df``.
+
+The scipy distribution kwarg (``sp_stats.chi2.sf(q, df=h)``) is *not*
+flagged: it is a keyword argument inside a :class:`ast.Call`, never a
+parameter/assignment/field *definition*, so the visitor below — which
+only inspects definitions and assignment targets — never sees it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+FACTRIX_DIR = pathlib.Path("factrix")
+
+# The exact banned identifiers. ``df_num``/``ic_df``/etc. are NOT here:
+# this is an equality check, not a prefix/suffix match.
+_BANNED = {"df", "_df"}
+
+
+def _python_modules() -> list[pathlib.Path]:
+    """Every ``.py`` module under ``factrix/``."""
+    return sorted(FACTRIX_DIR.rglob("*.py"))
+
+
+def _banned_definitions(tree: ast.AST) -> list[str]:
+    """Return ``"<lineno>: <name>"`` for each banned-name definition.
+
+    Inspected definition sites:
+
+    * function / lambda parameters (positional, ``*args``-style,
+      keyword-only, ``**kwargs``),
+    * assignment targets that are a bare ``Name`` (``df = ...``,
+      including tuple/list unpacking and augmented/walrus assignment),
+    * annotated assignments / dataclass fields (``df: pl.DataFrame``).
+    """
+    hits: list[str] = []
+
+    def _flag(name: str | None, lineno: int) -> None:
+        if name in _BANNED:
+            hits.append(f"line {lineno}: {name}")
+
+    def _flag_target(node: ast.expr) -> None:
+        # Recurse into tuple/list unpacking targets; flag bare Names.
+        if isinstance(node, ast.Name):
+            _flag(node.id, node.lineno)
+        elif isinstance(node, ast.Tuple | ast.List):
+            for elt in node.elts:
+                _flag_target(elt)
+        elif isinstance(node, ast.Starred):
+            _flag_target(node.value)
+
+    for node in ast.walk(tree):
+        # Function / lambda parameters.
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            args = node.args
+            for arg in (
+                *args.posonlyargs,
+                *args.args,
+                *args.kwonlyargs,
+                args.vararg,
+                args.kwarg,
+            ):
+                if arg is not None:
+                    _flag(arg.arg, arg.lineno)
+        # Plain assignment targets: ``df = ...``.
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                _flag_target(target)
+        # Augmented assignment (``df += ...``), annotated assignment /
+        # dataclass field (``df: pl.DataFrame``), or walrus (``(df := ...)``).
+        elif isinstance(node, ast.AugAssign | ast.AnnAssign | ast.NamedExpr):
+            _flag_target(node.target)
+
+    return hits
+
+
+@pytest.mark.parametrize(
+    "path", _python_modules(), ids=lambda p: str(p.relative_to(FACTRIX_DIR))
+)
+def test_no_bare_df_identifier(path: pathlib.Path) -> None:
+    """No ``factrix/`` module may define a bare ``df`` / ``_df`` identifier."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    hits = _banned_definitions(tree)
+    assert not hits, (
+        f"{path}: bare ``df``/``_df`` identifier(s) are banned — rename to "
+        f"``data`` (or a semantic noun). See docs/development/architecture.md "
+        f"'Naming: data vs df_*'.\n  " + "\n  ".join(hits)
+    )

--- a/tests/test_orthogonalize.py
+++ b/tests/test_orthogonalize.py
@@ -45,14 +45,14 @@ class TestOrthogonalizeFactor:
     def test_residual_mean_near_zero(self):
         factor_df, base_df = _make_ortho_data()
         ortho = orthogonalize_factor(factor_df, base_df)
-        for dt in ortho.df["date"].unique():
-            residuals = ortho.df.filter(pl.col("date") == dt)["factor"].to_numpy()
+        for dt in ortho.data["date"].unique():
+            residuals = ortho.data.filter(pl.col("date") == dt)["factor"].to_numpy()
             assert abs(np.mean(residuals)) < 1e-10
 
     def test_residual_uncorrelated_with_base(self):
         factor_df, base_df = _make_ortho_data()
         ortho = orthogonalize_factor(factor_df, base_df)
-        merged = ortho.df.join(base_df, on=["date", "asset_id"])
+        merged = ortho.data.join(base_df, on=["date", "asset_id"])
         for dt in merged["date"].unique():
             chunk = merged.filter(pl.col("date") == dt)
             residual = chunk["factor"].to_numpy()
@@ -64,9 +64,9 @@ class TestOrthogonalizeFactor:
     def test_preserves_original(self):
         factor_df, base_df = _make_ortho_data()
         ortho = orthogonalize_factor(factor_df, base_df)
-        assert "factor_pre_ortho" in ortho.df.columns
+        assert "factor_pre_ortho" in ortho.data.columns
         orig = factor_df.sort(["date", "asset_id"])["factor"].to_numpy()
-        pre_ortho = ortho.df.sort(["date", "asset_id"])["factor_pre_ortho"].to_numpy()
+        pre_ortho = ortho.data.sort(["date", "asset_id"])["factor_pre_ortho"].to_numpy()
         np.testing.assert_array_almost_equal(orig, pre_ortho)
 
     def test_no_base_cols_unchanged(self):
@@ -74,7 +74,7 @@ class TestOrthogonalizeFactor:
         empty_base = factor_df.select("date", "asset_id")
         ortho = orthogonalize_factor(factor_df, empty_base)
         orig = factor_df.sort(["date", "asset_id"])["factor"].to_list()
-        after = ortho.df.sort(["date", "asset_id"])["factor"].to_list()
+        after = ortho.data.sort(["date", "asset_id"])["factor"].to_list()
         assert orig == after
 
     def test_attribution_betas(self):


### PR DESCRIPTION
## Summary

- `df` is ambiguous — degrees-of-freedom in a stats context, DataFrame in the polars/pandas idiom. Codify a positional naming rule so every name resolves to one meaning on sight: `df_` prefix = degrees-of-freedom, `_df` suffix = DataFrame, bare `df`/`_df` = banned.
- Rename every bare `df`/`_df` DataFrame identifier to `data` (or a semantic noun) across `factrix/`; DoF `df_num`/`df_denom`/`df_resid`, content-prefixed `*_df` names, and scipy's `df=` distribution kwarg are left as-is.
- Document the convention in `docs/development/architecture.md` and add `tests/test_naming_df.py`, an AST guard that fails CI if any parameter, assignment target, or dataclass field is named exactly `df`/`_df`.

**Breaking (pre-v1, no shims):** DataFrame params renamed `df` → `data` on `adapt`, `compute_forward_return`, `compute_abnormal_return`, `pooled_beta`, and the normalize entrypoints; the `OrthogonalizeResult.df` field is now `OrthogonalizeResult.data`. All existing call sites are positional, so only the `OrthogonalizeResult` attribute access needed updating.

## Test plan

- [x] `ruff check factrix tests` — pass
- [x] `ruff format --check factrix tests` — pass
- [x] `mypy factrix` — pass (83 files)
- [x] `pytest` — 1601 passed, 4 skipped (incl. 83 new naming-guard cases)
- [x] Verified remaining bare `df` tokens are DoF prose in docstrings only; scipy `df=` kwargs untouched
- [x] Probed the new guard directly: flags `df`/`_df`, ignores `df_num`/`ic_df`/`data`

Closes #712
