### PR TITLE
fix(stats): correct degrees of freedom in spanning_alpha and single-series NW-HAC Wald

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -20,6 +20,7 @@ class _OLSResult:
     alpha_t: float
     betas: list[float] = field(default_factory=list)
     r_squared: float = 0.0
+    df_resid: int = 0
 
 
 def ols_alpha(
@@ -29,7 +30,8 @@ def ols_alpha(
     """Ordinary least squares (OLS) regression: candidate = alpha + beta @ base + epsilon.
 
     Returns:
-        _OLSResult with alpha, t_stat, betas, and R².
+        _OLSResult with alpha, t_stat, betas, R², and residual degrees of
+        freedom ``df_resid = n_obs - (1 + n_base_factors)``.
     """
     n_obs = len(candidate)
     if n_obs < 3:
@@ -59,20 +61,27 @@ def ols_alpha(
 
     sigma2 = ss_res / dof
     if sigma2 < EPSILON:
-        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(
+            alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
+        )
 
     try:
         xtx_inv = np.linalg.inv(X.T @ X)
         se_alpha = float(np.sqrt(sigma2 * xtx_inv[0, 0]))
     except np.linalg.LinAlgError:
-        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(
+            alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
+        )
 
     if se_alpha < EPSILON:
-        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        return _OLSResult(
+            alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
+        )
 
     return _OLSResult(
         alpha=alpha,
         alpha_t=alpha / se_alpha,
         betas=betas,
         r_squared=r_squared,
+        df_resid=dof,
     )

--- a/factrix/_stats/core.py
+++ b/factrix/_stats/core.py
@@ -52,15 +52,21 @@ def _p_value_from_t(
     t_stat: float,
     n: int,
     alternative: str = "two-sided",
+    *,
+    dof: int | None = None,
 ) -> float:
     """P-value from t-statistic using t-distribution.
 
     Args:
         alternative: "two-sided" (default), "less" (left-tail), "greater" (right-tail).
+        dof: Residual degrees of freedom. Defaults to ``n - 1`` (single-sample
+            mean t-test). Pass an explicit value for a regression t-test where
+            ``k > 1`` parameters are estimated (``dof = n - k``). Returns 1.0
+            if the resolved ``dof`` is below 1.
     """
-    if n <= 1:
+    dof = n - 1 if dof is None else dof
+    if dof < 1:
         return 1.0
-    dof = n - 1
     if alternative == "less":
         return float(sp_stats.t.cdf(t_stat, dof))
     if alternative == "greater":

--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -50,14 +50,18 @@ def _wald_p_linear(
     Wald statistic ``W`` and its p-value.
 
     With ``df_denom=None`` (default) the reference distribution is the
-    asymptotic ``W ~ χ²_r`` — correct when ``V`` is an analytic covariance
-    with effectively infinite degrees of freedom (the ts_quantile /
-    ts_asymmetry NW-HAC callers). When ``V`` is a **cluster-robust**
-    covariance estimated from a finite number of clusters ``G``, the χ²
-    reference over-rejects; pass ``df_denom = G - 1`` (one-way) or
-    ``min(G_a, G_b) - 1`` (two-way) to use the finite-sample
-    ``F = W / r ~ F_{r, df_denom}`` reference instead. ``W`` itself is
-    returned unchanged in both cases; only the p-value differs.
+    asymptotic ``W ~ χ²_r`` — correct only when ``V`` is an analytic
+    covariance with effectively infinite degrees of freedom. When ``V`` is
+    estimated from a finite sample the χ² reference over-rejects; pass an
+    explicit ``df_denom`` to use the finite-sample ``F = W / r ~ F_{r,
+    df_denom}`` reference instead:
+
+    - single-series NW-HAC regression (ts_quantile / ts_asymmetry):
+      ``df_denom = T - k`` (residual dof, ``k`` = regressors);
+    - one-way cluster-robust: ``df_denom = G - 1``;
+    - two-way cluster-robust: ``df_denom = min(G_a, G_b) - 1``.
+
+    ``W`` itself is returned unchanged in both cases; only the p-value differs.
 
     Returns ``(0.0, 1.0)`` if the middle matrix is singular (degenerate
     restriction) or ``df_denom`` is given but non-positive.

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -252,7 +252,9 @@ def spanning_alpha(
     base_names = list(base_arrays.keys())
     beta_dict = dict(zip(base_names, ols.betas, strict=False)) if base_names else {}
     n_obs = len(candidate_arr)
-    p = _p_value_from_t(ols.alpha_t, n_obs)
+    # Reference the regression residual dof (n - 1 - n_base_factors), not the
+    # single-sample n - 1: the alpha t-stat is built on the full design matrix.
+    p = _p_value_from_t(ols.alpha_t, n_obs, dof=ols.df_resid)
 
     return MetricResult(
         p_value=p,

--- a/factrix/metrics/ts_asymmetry.py
+++ b/factrix/metrics/ts_asymmetry.py
@@ -7,7 +7,7 @@ factor" *or* "falls less on negative factor", and a strategy team
 needs to know which.
 
 Two methods, both fit by OLS with Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) covariance and
-tested by Wald χ² so cross-method p-values stay comparable and the
+tested by a finite-sample Wald F so cross-method p-values stay comparable and the
 overlapping-forward-return autocorrelation is handled the same way
 as `ts_beta_t_nw`. Welch t is intentionally avoided — its iid
 assumption breaks under `forward_periods > 1`.
@@ -30,8 +30,8 @@ Standalone metric — does not enter the registry.
 Notes:
     **Pipeline.** Per-date aggregation of factor and forward return to
     a common ``(_f, _r)`` series (cross-section step), then NW HAC OLS
-    with sign-asymmetric slopes on the resulting time series; Wald χ²
-    on the slope difference.
+    with sign-asymmetric slopes on the resulting time series; Wald
+    (finite-sample F) on the slope difference.
 """
 
 from __future__ import annotations
@@ -216,7 +216,9 @@ def ts_asymmetry(
     asym_var = float((R_a @ V_a @ R_a.T)[0, 0])
     asym_se = float(np.sqrt(asym_var)) if asym_var > 0 else 0.0
     asym_t = asym_value / asym_se if asym_se > 0 else 0.0
-    _, p_a = _wald_p_linear(beta_a, V_a, R_a, q=0.0)
+    # Finite-sample F_{r, T-k} reference (k = X_a regressors), matching the
+    # cluster-Wald paths; the asymptotic χ² over-rejects on short T.
+    _, p_a = _wald_p_linear(beta_a, V_a, R_a, q=0.0, df_denom=n_periods - X_a.shape[1])
 
     e_long = float(beta_a[0])
     e_short = float(beta_a[1])
@@ -239,7 +241,9 @@ def ts_asymmetry(
         X_b = np.column_stack([np.ones(n_periods), f_pos, f_neg])
         beta_b, V_b, _ = _ols_nw_multivariate(r, X_b, lags=lags)
         R_b = np.array([[0.0, 1.0, -1.0]])
-        _, p_b = _wald_p_linear(beta_b, V_b, R_b, q=0.0)
+        _, p_b = _wald_p_linear(
+            beta_b, V_b, R_b, q=0.0, df_denom=n_periods - X_b.shape[1]
+        )
         method_b.update(
             method_b="method B: split-slope regression on signed factor",
             stat_type_method_b="wald (NW HAC)",

--- a/factrix/metrics/ts_quantile.py
+++ b/factrix/metrics/ts_quantile.py
@@ -14,7 +14,7 @@ redirects to `event_quality` helpers.
 Notes:
     **Pipeline.** Per-date aggregation to a common ``(_f, _r)`` series
     (cross-section step), then quantile-bucketed Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) OLS on that
-    time series; Wald χ² on the top-bottom bucket spread.
+    time series; Wald (finite-sample F) on the top-bottom bucket spread.
 """
 
 from __future__ import annotations
@@ -206,7 +206,9 @@ def ts_quantile_spread(
     R[0, n_groups - 1] = 1.0
     R[0, 0] = -1.0
     spread_value = float(beta[n_groups - 1] - beta[0])
-    _, p_spread = _wald_p_linear(beta, V_hac, R, q=0.0)
+    # Finite-sample F_{r, T-k} reference (k = n_groups regressors), matching the
+    # cluster-Wald paths; the asymptotic χ² over-rejects on short T.
+    _, p_spread = _wald_p_linear(beta, V_hac, R, q=0.0, df_denom=n_periods - n_groups)
 
     spread_var = float((R @ V_hac @ R.T)[0, 0])
     spread_t = (

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -62,6 +62,21 @@ class TestSpanningTest:
         result = spanning_alpha(factor)
         assert isinstance(result, MetricResult)
 
+    def test_pvalue_uses_regression_dof(self):
+        # p-value must reference the regression residual dof (n - 1 - n_base),
+        # not the single-sample n - 1.
+        from scipy import stats as sp_stats
+
+        factor = _make_spread_series(40, 0.02, 0.01, 7)
+        base = {
+            "b1": _make_spread_series(40, 0.0, 0.01, 1),
+            "b2": _make_spread_series(40, 0.0, 0.01, 2),
+        }
+        result = spanning_alpha(factor, base_spreads=base)
+        n, n_base = 40, 2
+        expected = float(2 * sp_stats.t.sf(abs(result.stat), n - 1 - n_base))
+        assert result.p_value == pytest.approx(expected)
+
 
 class TestOLSAlpha:
     def test_alpha_with_empty_base(self):
@@ -89,6 +104,15 @@ class TestOLSAlpha:
     def test_insufficient_data(self):
         ols = _ols_alpha(np.array([0.01, 0.02]), np.empty((2, 0)))
         assert ols.alpha == 0.0 and ols.alpha_t == 0.0
+
+    def test_df_resid_excludes_base_regressors(self):
+        rng = np.random.default_rng(42)
+        n = 40
+        base = rng.normal(size=(n, 5))
+        candidate = rng.normal(0.01, 0.5, n)
+        ols = _ols_alpha(candidate, base)
+        # df = n - (intercept + 5 base factors)
+        assert ols.df_resid == n - 6
 
 
 class TestGreedyForwardSelection:

--- a/tests/test_ts_quantile.py
+++ b/tests/test_ts_quantile.py
@@ -36,6 +36,20 @@ class TestLinearDgp:
         assert out.p_value < 0.05
         assert out.metadata["spearman_rho"] > 0.5
 
+    def test_pvalue_uses_finite_sample_f_reference(self):
+        # Single-restriction Wald p must use the finite-sample F_{1, T-k}
+        # reference (== two-sided t_{T-k} on the reported spread t-stat), not
+        # the over-rejecting asymptotic χ²_1.
+        from scipy import stats as sp_stats
+
+        rng = np.random.default_rng(3)
+        T, n_groups = 30, 5
+        f = rng.standard_normal(T)
+        r = 0.10 * f + rng.standard_normal(T) * 0.5
+        out = ts_quantile_spread(_series_panel(f, r), n_groups=n_groups)
+        expected = float(2 * sp_stats.t.sf(abs(out.stat), T - n_groups))
+        assert out.p_value == pytest.approx(expected)
+
     def test_top_bucket_mean_exceeds_bottom(self):
         rng = np.random.default_rng(7)
         T = 600


### PR DESCRIPTION
## Summary
Statistical-correctness fixes (section B of #715). Two degrees-of-freedom corrections to inference references.

### B1 — `spanning_alpha` p-value used the wrong dof
`spanning_alpha` computed the alpha p-value with `_p_value_from_t(t, n_obs)`, which uses `dof = n - 1` — the single-sample mean reference. But the alpha t-stat is built on the full design matrix (`dof = n_obs - 1 - n_base_factors`). The p-value was anti-conservative, and the gap grew with more base factors and shorter series (exactly the greedy-selection regime).

- `_OLSResult` now carries `df_resid`; `_p_value_from_t` gained an optional `dof` override (default unchanged, all other callers untouched).
- `spanning_alpha` passes `dof=ols.df_resid`.

### B2 — single-series NW-HAC Wald used the asymptotic χ²
`ts_quantile_spread` and `ts_asymmetry` (methods A and B) tested their NW-HAC Wald restriction against `χ²_r`, which over-rejects on short `T`. The cluster-Wald paths already use the finite-sample `F_{r, df}` reference. Switched the single-series callers to `F_{r, T-k}` (k = regressors) for parity. `W` is unchanged; only the p-value reference differs.

## Verification
- New regression tests: spanning p-value matches `t_{n-1-n_base}`; OLS `df_resid` excludes base regressors; ts_quantile p-value matches `F_{1, T-k}` (= two-sided `t_{T-k}` on the reported spread t).
- Full suite: 1604 passed, 4 skipped. `ruff check`, `ruff format --check`, `mypy factrix` all clean.
- Updated the `_wald_p_linear` / module docstrings that previously stated those callers correctly used the χ² reference.

Part of #715 (section B; the A docs-consistency and C usability PRs follow separately and will close the issue).
