### PR TITLE
docs: align examples and metric catalog with current public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,29 @@ print("survivors =", [(r.factor, r.forward_periods) for r in bhy_ic.survivors])
 **Single-asset (timeseries) evaluation**
 
 ```python
+import numpy as np
+import polars as pl
+from datetime import datetime, timedelta
 from factrix.metrics import directional_hit_rate
+
+# Build a one-asset panel by hand (the cross-section generators need N >= 2).
+rng    = np.random.default_rng(7)
+dates  = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(250)]
+factor = rng.standard_normal(250)
+ret    = 0.05 * factor + rng.standard_normal(250)        # factor leads next return
+single_asset_data = pl.DataFrame({
+    "date": dates,
+    "asset_id": "SPX",
+    "price": 100 * np.exp(np.cumsum(ret) / 100),
+    "macro_factor": factor,
+})
+data = fx.preprocess.compute_forward_return(single_asset_data, forward_periods=5)
 
 # A single-asset panel auto-resolves the structure axis to
 # DataStructure.TIMESERIES (N == 1); a structure-agnostic metric such as
 # directional_hit_rate runs unchanged through the same entry point.
 results = fx.evaluate(
-    single_asset_data,
+    data,
     metrics={"dir_hit": directional_hit_rate()},
     factor_cols=["macro_factor"],
     forward_periods=5,

--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -42,7 +42,7 @@ The returned `pl.DataFrame` contains the following columns:
 - Context keys: All context keys present across the evaluation results, ordered by first appearance.
 - `<metric_name>`: The metric value (e.g. `ic`).
 - `<metric_name>_p_value`: The metric p-value if applicable (e.g. `ic_p_value`).
-- `rank`: Rank column (only populated when `sort_by` is set).
+- `rank`: Rank column, present only when `sort_by` is set (the column is absent otherwise).
 
 ## Parameter details
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -100,15 +100,21 @@ Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-fri
       "p_value": 2.129e-40,
       "stat": 14.60,
       "n_obs": 494,
+      "n_obs_axis": "periods",
+      "is_applicable": true,
+      "reason": null,
       "metadata": {
         "n_periods": 494,
-        "p_value": 2.129e-40,
+        "forward_periods": 5,
         "stat_type": "t",
         "h0": "mu=0",
-        "method": "Newey-West HAC t-test on overlapping IC series",
-        "newey_west_lags": 5,
-        "forward_periods": 5,
-        "tie_ratio": 0.0
+        "method": "Newey-West HAC t-test",
+        "tie_ratio": 0.0,
+        "n_periods_in": 494,
+        "n_periods_out": 494,
+        "dropped_periods": 0,
+        "drop_rate": 0.0,
+        "drop_reason": null
       }
     }
   },

--- a/docs/guides/choosing-metric.md
+++ b/docs/guides/choosing-metric.md
@@ -40,7 +40,7 @@ results = fx.evaluate(
 )
 
 # Compare metric values and p-values side by side
-board = fx.compare(results, metrics=["ic", "fm"], sort_by="ic")
+board = fx.compare(list(results.values()), metrics=["ic", "fm"], sort_by="ic")
 print(board)
 ```
 

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -48,17 +48,23 @@ print(factor_spread.p_value)  # Non-overlapping t-test p-value
 Diagnostics like `hit_rate`, `ic_trend`, and `oos_decay` take a two-column time-series DataFrame of `(date, value)` (such as a series of per-date ICs generated upstream).
 
 ```python
+import numpy as np
 import polars as pl
+from datetime import date, timedelta
 from factrix.metrics import oos_decay
 
-# Given a time series of values (e.g. daily IC values)
+# oos_decay splits the series into in-sample / out-of-sample halves, so it
+# needs enough points to estimate both — a handful of rows returns nan.
+# Here: 24 monthly IC values that decay from ~0.10 to ~0.02.
+rng = np.random.default_rng(0)
+n = 24
 ic_series = pl.DataFrame({
-    "date": ["2026-01-01", "2026-01-02", "2026-01-03"],
-    "value": [0.05, -0.02, 0.08]
+    "date": [(date(2026, 1, 1) + timedelta(days=30 * i)).isoformat() for i in range(n)],
+    "value": np.linspace(0.10, 0.02, n) + rng.normal(0, 0.01, n),
 })
 
 decay_res = oos_decay(ic_series)
-print(decay_res.value)
+print(decay_res.value)  # OOS/IS retention ratio
 ```
 
 ---

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -15,7 +15,7 @@ Individual × Continuous:
     compute_group_returns, monotonicity, top_concentration,
     turnover, notional_turnover, breakeven_cost, net_spread,
     compute_fm_betas, fm_beta, pooled_beta, fm_beta_sign_consistency,
-    spanning_alpha, greedy_forward_selection
+    spanning_alpha, greedy_forward_selection, k_spread
 
 Individual × Sparse (the ``Common × Sparse`` cell has its own
 broadcast-dummy procedure but reuses these helper metrics — there is
@@ -32,6 +32,11 @@ Common × Continuous:
 
 Series diagnostics — axis-agnostic on ``(date, value)``:
     hit_rate, ic_trend, oos_decay
+
+Scope-agnostic (run in either scope; ``cell`` scope is ``None``):
+    directional_hit_rate — small-N robust, Pesaran-Timmermann directional
+    sibling of ``hit_rate`` (consumes a ``date, asset_id, factor,
+    forward_return`` panel rather than a pre-aggregated series)
 """
 
 from factrix._metric_index import metric_spec, register


### PR DESCRIPTION
## Summary
Documentation / public-API consistency fixes (section A of #715). All verified by running the examples against the current build.

| # | Fix | File |
|---|-----|------|
| A1 | `compare()` takes `list(results.values())`, not the `dict` from `evaluate()` — the copy-paste example raised `UserInputError` | `docs/guides/choosing-metric.md` |
| A2 | Regenerated the `to_dict()` metadata block: removed the now-gone `p_value` / `newey_west_lags` keys, shortened `method`, added `n_obs_axis` / `is_applicable` / `reason` and the drop-rate fields | `docs/getting-started/quickstart.md` |
| A3 | Added `k_spread` and `directional_hit_rate` to the metric-catalog docstring (both are public + exported but were unlisted) | `factrix/metrics/__init__.py` |
| A4 | Made the single-asset example self-contained — it referenced an undefined `single_asset_data` and no generator builds an N=1 panel | `README.md` |
| A5 | `rank` column is *absent* without `sort_by` (accessing it raises), not "only populated" | `docs/api/compare.md` |
| A6 | `oos_decay` needs enough points for an IS/OOS split; the 3-row example returned `nan` — replaced with a 24-point series | `docs/guides/standalone-metrics.md` |

## Notes
- A2 shows `"drop_reason": null` (the correct value when nothing is dropped). On `main` the field currently mis-reports the static criterion string even at `drop_rate == 0`; that code bug is fixed in the section-C PR. Showing `null` keeps this doc correct after both land.
- Verification: every edited Python example was executed and runs. Doc/API tests (`test_docs_pages`, `test_docs_matrix`, `test_metric_api_members_match_all`, `test_list_metrics`) pass; `ruff check` + `mypy factrix` clean.

Part of #715 (section A).
