### PR TITLE
fix(ic,drop-stats): axis-correct IC shortfall reason; null drop_reason when nothing dropped

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -85,6 +85,7 @@ contrasts, not a sidecar to a primary value.
 
 - *primary*: `p_value` — `t`-test on the per-date IC series (non-overlapping stride with stride `forward_periods` by default, or Newey-West HAC if configured).
 - *descriptive*: `n_periods`, `forward_periods`, `tie_ratio` (median across dates), `stat_type` (`"t"`), `h0` (`"mu=0"`), `method`.
+- *short-circuit*: `reason` `insufficient_ic_periods` (too few dates) carries `min_required`; `insufficient_ic_assets` (every cross-section below `MIN_IC_ASSETS`, so no per-date IC survived — common on few-asset panels) carries `min_assets_required`.
 
 #### `ic_ir`
 

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -945,7 +945,11 @@ def _make_drop_stats(
         f"n_{axis}_out": n_out,
         f"dropped_{axis}": dropped,
         "drop_rate": drop_rate,
-        "drop_reason": drop_reason,
+        # ``drop_reason`` names the criterion that *fired*; with nothing
+        # dropped there is no reason, so report null rather than the static
+        # predicate label (which otherwise reads as a contradiction at
+        # ``drop_rate == 0``).
+        "drop_reason": drop_reason if dropped > 0 else None,
     }
 
 

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -31,15 +31,18 @@ from factrix._results import MetricResult
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 from factrix._types import (
     EPSILON,
+    MIN_IC_ASSETS,
     MIN_IC_PERIODS,
 )
 from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _DROP_STATS_COL,
     TIE_RATIO_WARN_THRESHOLD,
     _check_applicable_inference,
     _enforce_min_floor,
+    _read_drop_stats,
     _short_circuit_output,
     _surface_drop_stats,
     _warn_below_floor,
@@ -121,6 +124,29 @@ def _ic_sample_threshold(self: MetricBase) -> SampleThreshold:
     return SampleThreshold(
         min_periods=inference.min_input_periods(self.forward_periods)
     )
+
+
+def _ic_shortfall_is_asset_driven(ic_df: pl.DataFrame, raw_min: int) -> bool:
+    """True when a thin/empty IC series reflects too few *assets per date*.
+
+    ``compute_ic`` drops any date whose valid (factor, return) cross-section is
+    below ``MIN_IC_ASSETS``, so a series that falls under the periods floor is
+    often an asset-axis problem (few-asset panels such as asset allocation), not
+    a genuine shortage of dates. Naming the failure by its real axis follows the
+    dimension-token grammar used across the drop-rate schema.
+
+    - A readable carrier (thin frame) is asset-driven when the per-date floor
+      dropped dates (``dropped_periods > 0``) and enough raw dates entered
+      (``n_periods_in >= raw_min``) — i.e. the drop, not a short panel, is what
+      pushed the series under the floor.
+    - A fully-dropped (0-row) frame still carrying the ``compute_ic`` drop column
+      means *every* cross-section was dropped by the asset floor. A hand-built
+      empty series carries no such column.
+    """
+    stats = _read_drop_stats(ic_df)
+    if stats is not None:
+        return bool(stats["dropped_periods"] > 0 and stats["n_periods_in"] >= raw_min)
+    return _DROP_STATS_COL in ic_df.columns and ic_df.is_empty()
 
 
 @metric(
@@ -209,6 +235,22 @@ def ic(
     n = len(ic_vals)
     raw_min = inference.min_input_periods(forward_periods)
     if n < raw_min:
+        if _ic_shortfall_is_asset_driven(ic_df, raw_min):
+            return _short_circuit_output(
+                "ic",
+                "insufficient_ic_assets",
+                n_obs=n,
+                n_obs_axis="periods",
+                min_assets_required=MIN_IC_ASSETS,
+                forward_periods=forward_periods,
+                hint=(
+                    "every cross-section has fewer than MIN_IC_ASSETS valid "
+                    "(factor, return) pairs, so no per-date IC survived. IC "
+                    "needs a wide cross-section; for few-asset panels (e.g. "
+                    "asset allocation) use a time-series metric such as "
+                    "directional_hit_rate or ts_quantile_spread."
+                ),
+            )
         return _short_circuit_output(
             "ic",
             "insufficient_ic_periods",

--- a/tests/test_drop_rate_warning.py
+++ b/tests/test_drop_rate_warning.py
@@ -83,6 +83,14 @@ class TestSchema:
         assert stats is not None
         assert stats["dropped_periods"] == 0
         assert stats["drop_rate"] == 0.0
+        # Nothing dropped → reason is null, not the static criterion label.
+        assert stats["drop_reason"] is None
+
+    def test_partial_drop_reports_reason(self):
+        stats = _read_drop_stats(compute_ic(_thinned_panel())["factor"])
+        assert stats is not None
+        assert stats["dropped_periods"] > 0
+        assert "MIN_IC_ASSETS" in stats["drop_reason"]
 
     def test_hand_built_series_has_no_stats(self):
         # A series without the primitive's diagnostic column reads as None.

--- a/tests/test_drop_rate_warning_phase2.py
+++ b/tests/test_drop_rate_warning_phase2.py
@@ -126,10 +126,9 @@ class TestSpreadTools:
         # spread to drop — the five-key schema is still recorded on success.
         result = quantile_spread_vw(_spread_panel(), forward_periods=1)
         assert set(DROP_STAT_KEYS) <= set(result.metadata)
-        assert (
-            result.metadata["drop_reason"] == "null spread observations in the series"
-        )
-        assert result.metadata["drop_rate"] >= 0.0
+        # Nothing dropped → drop_reason is null (not the static criterion label).
+        assert result.metadata["drop_rate"] == 0.0
+        assert result.metadata["drop_reason"] is None
 
     def test_k_spread_records_schema(self):
         # k_spread's top-k/bottom-k yields a spread even on thin dates, so the

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -264,6 +264,21 @@ class TestIC:
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = ic(df, forward_periods=1)
         assert math.isnan(result.value)
+        # Genuine date shortfall (no compute_ic carrier) → periods-axis reason.
+        assert result.metadata["reason"] == "insufficient_ic_periods"
+
+    def test_few_assets_reports_asset_axis_reason(self):
+        # 8 assets < MIN_IC_ASSETS=10 on every date, but plenty of dates: every
+        # cross-section is dropped, so the shortfall is asset-driven, not a date
+        # shortage. The reason must name the asset axis (dimension-token grammar).
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=8, n_dates=120, seed=0)
+        panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        result = ic(compute_ic(panel)["factor"], forward_periods=5)
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_ic_assets"
+        assert result.metadata["min_assets_required"] == 10
 
 
 class TestICIR:


### PR DESCRIPTION
## Summary
Usability / consistency fixes (section C of #715). Scoped to the two clear correctness-flavoured items; the broader behavioural redesigns are left for a product decision (see below).

### C2 — IC small-cross-section shortfall named by the wrong axis
On a few-asset panel (e.g. asset allocation, N=8, 600 dates) `ic()` returned `reason="insufficient_ic_periods"` — baffling with 600 dates. The real cause is that every date's valid cross-section is below `MIN_IC_ASSETS`, so `compute_ic` drops them all and no per-date IC survives. Naming a period shortfall for an asset-axis cause contradicts the project's dimension-token grammar.

- Detect the asset-driven case from the `compute_ic` drop carrier (readable thin frame, or a fully-dropped frame still carrying the drop column) and emit `reason="insufficient_ic_assets"` with `min_assets_required` + a redirect hint (use `directional_hit_rate` / `ts_quantile_spread` for few-asset panels).
- Genuine date shortfalls (hand-built series, short panels with ample assets) keep `insufficient_ic_periods`.

### C3 — `drop_reason` contradicted `drop_rate == 0`
`_make_drop_stats` always stamped the static criterion label, so a result with nothing dropped (`drop_rate == 0.0`, `n_in == n_out`) still reported e.g. `"n_assets below MIN_IC_ASSETS (10)"`. Now `drop_reason` is `null` when `dropped == 0`; it carries the criterion only when a drop actually fired. Central fix, applies to every metric using the shared drop schema. (The section-A quickstart doc already shows the corrected `null`.)

## Dropped from the issue after checking the code
- **C8 (`partial_conjunction` `expand_over` default `()`):** rejected. Unlike `bhy`, an empty `expand_over` is *always invalid* for a partial-conjunction test (it defines the "k of m" condition axis, intrinsic like `min_pass`, and the function raises `UserInputError` on empty). Defaulting it to `()` would only swap a clear `TypeError` for a deferred `UserInputError` — not a real improvement.

## Left for your decision (not in this PR — behavioural / API-surface changes)
- **C1** strict-mode `evaluate` aborts the whole battery on one inapplicable metric (changing the default is a product call).
- **C4** metric factories expose `(*args, **kwargs)` — restore real `__signature__` for IDE/`help()`.
- **C5** `list_metrics()` returns full `MetricSpec` reprs — add a compact name→summary view.
- **C6** route the per-group-thinness warning through the structured `WarningCode` channel (a new code) rather than only `warnings.warn`.
- **C7** `quantile_spread` default `n_groups=5` on small cross-sections — auto-cap (silently changes results) vs. just a sharper warning.

## Verification
- New tests: `insufficient_ic_assets` on a few-asset panel; periods reason preserved for a genuine date shortfall; `drop_reason` null on a full panel and populated on a partial drop; corrected the one test that had encoded the C3 bug.
- Full suite 1603 passed, 4 skipped. `ruff check`, `ruff format --check`, `mypy factrix` clean.

Part of #715 (section C, scoped).
