### PR TITLE
fix(evaluate): a not_applicable metric no longer aborts a strict battery

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -150,17 +150,22 @@ def evaluate(
             rejected. Stamped on every :class:`EvaluationResult` as
             ``forward_periods`` and injected into each metric (surfaced in
             ``result.metrics[label].metadata["forward_periods"]``).
-        strict: When ``True`` (default), raise if any metric is
-            inapplicable to the data — both apply-time short-circuits and
-            structure mismatches (a metric whose ``cell.structure``
-            disagrees with the data, e.g. a PANEL metric on TIMESERIES
-            data). When ``False``, keep those as NaN outputs with attached
-            warnings: a structure-mismatched metric is *not executed* and
-            surfaces a NaN ``MetricResult`` with
-            ``metadata["reason"]="structure_mismatch"`` plus a
-            ``WarningCode.STRUCTURE_MISMATCH`` warning, rather than
-            computing a numerically real but structurally invalid value.
-            Config-time / construct-time failures always raise.
+        strict: When ``True`` (default), raise if a metric that *fits* the
+            data could not produce a value — a data shortage
+            (``insufficient_*``), a missing input / config (``no_*``), or a
+            structure mismatch (a metric whose ``cell.structure`` disagrees
+            with the data, e.g. a PANEL metric on TIMESERIES data). A
+            ``not_applicable*`` type-routing verdict (the metric's *type* does
+            not fit this factor, e.g. a continuous-magnitude metric on a
+            discrete ±k signal) is **not** a strict failure even under
+            ``True``: it surfaces as a NaN ``MetricResult`` with
+            ``is_applicable=False`` and ``metadata["reason"]`` while the
+            applicable metrics in the same call still return — so a mixed
+            battery is not aborted by one inapplicable metric. When
+            ``strict=False``, *every* such case (including data shortages and
+            structure mismatches) is kept as a NaN output with attached
+            warnings instead of raising. Config-time / construct-time
+            failures always raise.
 
     Returns:
         ``dict[str, EvaluationResult]`` keyed by factor column name, in
@@ -629,17 +634,35 @@ def _build_nodes(
     return nodes, label_to_node, node_kwargs
 
 
+def _is_type_routing_reason(reason: object) -> bool:
+    """True for a ``not_applicable*`` short-circuit reason.
+
+    A ``not_applicable*`` outcome means the metric's *type* does not fit this
+    factor (e.g. a continuous-magnitude metric on a discrete ±k signal) — the
+    type-routing verdict, not a failure. ``strict=True`` does not hard-fail on
+    it: in a mixed battery an inapplicable metric is expected, and aborting
+    would discard the applicable results too. Data shortages (``insufficient_*``)
+    and missing input / config (``no_*``) remain strict failures — there the
+    metric *fits* but the data or call is deficient, which is worth failing loud.
+    """
+    return isinstance(reason, str) and reason.startswith("not_applicable")
+
+
 def _enforce_strict(label_outputs: "dict[str, MetricResult]") -> None:
-    """Raise when any requested metric could not produce a value (``strict=True``).
+    """Raise when a requested metric that *fits* the data could not produce a value.
 
     Apply-time short-circuits surface as a ``MetricResult`` with NaN ``value``
-    and a ``metadata['reason']`` (panel missing data / sample / upstream skip).
-    Config-time / construct-time failures already raise upstream of ``strict``.
+    and a ``metadata['reason']``. Data-shortage / missing-input reasons raise
+    under ``strict=True``; ``not_applicable*`` type-routing verdicts do not
+    (see :func:`_is_type_routing_reason`). Config-time / construct-time failures
+    already raise upstream of ``strict``.
     """
     failed = [
         (label, str(out.metadata.get("reason")))
         for label, out in label_outputs.items()
-        if math.isnan(out.value) and out.metadata.get("reason")
+        if math.isnan(out.value)
+        and out.metadata.get("reason")
+        and not _is_type_routing_reason(out.metadata.get("reason"))
     ]
     if failed:
         detail = "; ".join(f"{label}: {reason}" for label, reason in failed)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -223,6 +223,29 @@ class TestStrict:
         assert status["is_applicable"] is False
         assert status["reason"] == "insufficient_ic_periods"
 
+    def test_strict_true_keeps_not_applicable_without_aborting(self):
+        # A discrete ±k signal makes a continuous-magnitude metric
+        # not_applicable; under default strict=True the battery must still
+        # return the applicable metric rather than raising on the inapplicable
+        # one (type-routing verdict, not a failure).
+        from factrix.metrics import event_ic
+        from factrix.metrics.caar import caar
+
+        panel = _panel(n_assets=30, n_dates=120).with_columns(
+            (pl.col("factor") > 0.5).cast(pl.Float64).alias("factor")
+        )
+        with pytest.warns(UserWarning):  # caar's thin-sample advisory
+            er = fx.evaluate(
+                panel,
+                metrics={"caar": caar(), "event_ic": event_ic()},
+                factor_cols=["factor"],
+                forward_periods=5,
+            )["factor"]
+        assert er.metrics["caar"].is_applicable
+        assert not math.isnan(er.metrics["caar"].value)
+        assert er.metrics["event_ic"].is_applicable is False
+        assert er.metrics["event_ic"].reason == "not_applicable_discrete_signal"
+
 
 class TestStrictStructureSoftening:
     def _single_asset_panel(self):


### PR DESCRIPTION
## Summary
Usability fix (C1 of #715). The default `strict=True` no longer lets one **not-applicable** metric abort an entire mixed battery.

### Problem
Throwing a mixed metric battery at a panel is the core type-routed-evaluation workflow. But under the default `strict=True`, a `not_applicable*` short-circuit (e.g. `event_ic` on a discrete ±k signal → `not_applicable_discrete_signal`) raised and discarded the *applicable* results too (`caar` in the same call). You had to know which metrics fit before calling — defeating the point.

### Change
`not_applicable*` is the type-routing **verdict** (the metric's type does not fit this factor), not a failure. It is now a soft outcome **even under `strict=True`**: surfaces as `NaN` + `is_applicable=False` + `reason`, while the applicable metrics in the same call still return.

The safety net is unchanged for the cases where the metric *fits* but the data/call is deficient — these still raise under `strict=True`:
- data shortage (`insufficient_*`)
- missing input / config (`no_*`)
- structure mismatch (PANEL metric on TIMESERIES data → `IncompatibleAxisError`)

`strict=False` is unchanged (everything soft).

### Verification
- New test: a discrete-signal panel with `{caar, event_ic}` under default strict returns `caar` (applicable) and surfaces `event_ic` as `is_applicable=False, reason="not_applicable_discrete_signal"` — no raise. Existing `insufficient_*` strict-raise tests still pass.
- Full suite 1601 passed, 4 skipped. `ruff`, `ruff format --check`, `mypy factrix` clean.
- `strict` docstring updated to state the carve-out precisely; user-facing docs about structure/sample raises remain accurate (those paths are unchanged).

Part of #715 (C1).
