### PR TITLE
ci: realign disabled docs CI triggers with current state

### DIFF
--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -10,10 +10,14 @@ on:
       - 'scripts/**'
       - 'examples/**'
       - '.github/workflows/docs-deploy-dev.yml'
-  # pull_request trigger temporarily disabled while the v0.14.0 rename
-  # collapse (#466, #468, #460) lands ahead of the consolidated docs
-  # sweep (#451). Restore once #451 merges and the doc surface is
-  # back in sync with the new public API.
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'factrix/**'
+      - 'scripts/**'
+      - 'examples/**'
+      - '.github/workflows/docs-deploy-dev.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,10 +1,14 @@
 name: link-check
 
 on:
-  # pull_request trigger temporarily disabled while the v0.14.0 rename
-  # collapse (#466, #468, #460) lands ahead of the consolidated docs
-  # sweep (#451). The scheduled daily run still guards main against
-  # link rot; restore the PR trigger once #451 merges.
+  # pull_request trigger held off: the `pr:` job (fail: true) red-builds on
+  # root-relative `/factrix/...` links in the built site (theme assets +
+  # mike version-prefixed internal links). lychee errors on these at the
+  # URL-build stage — before `.lycheeignore` filtering applies — because the
+  # local `site/` tree has no `factrix/` prefix to resolve them against.
+  # These internal links are already validated by `mkdocs build --strict`,
+  # so the daily scheduled run below is sufficient. Restore the PR trigger
+  # once the lychee root-relative false-positive is resolved.
   schedule:
     # Daily at 06:00 UTC (~14:00 Asia/Taipei) — outside GitHub Actions
     # peak hours, runner availability is best.


### PR DESCRIPTION
## Summary

The `docs-deploy-dev` and `link-check` `pull_request` triggers were commented out during the v0.14.0 rename work, gated on a docs sweep that has since merged. This realigns them with the current state:

- **`docs-deploy-dev`: PR trigger restored.** Its dormant `build` job runs `mkdocs build --strict` and verifies the `_generated_*.md` files are committed — both pass locally, so PRs should gate on them again. While the trigger was off these checks only ran on `main`.
- **`link-check`: PR trigger deliberately held off**, with the stale gating comment replaced by the real blocker. The `pr:` job (`fail: true`) red-builds on root-relative `/factrix/...` links in the built site (theme assets + mike version-prefixed internal links): lychee errors on them at the URL-build stage — before `.lycheeignore` filtering applies — because the local `site/` tree has no `factrix/` prefix to resolve against. Those internal links are already validated by `mkdocs build --strict`, so the daily scheduled run remains sufficient until the lychee false-positive is fixed.

Pre-release housekeeping ahead of v0.14.0; no application code touched.

## Test plan

- `mkdocs build --strict` passes locally; `_generated_*.md` show no drift after running the generator scripts.
- `python -c "import yaml; ..."` parses both workflows; `on:` keys are `[push, pull_request, workflow_dispatch]` (docs-deploy-dev) and `[schedule, workflow_dispatch]` (link-check).
- This PR itself exercises the restored `docs-deploy-dev` PR trigger.
