### PR TITLE
refactor(metrics): make sample thresholds explicit (#727)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -251,6 +251,13 @@ would let the gate, the report, and the estimate silently disagree.
 
 ### Backing constants
 
+User-facing `@metric` decorators must spell out `sample_threshold=...`.
+Use a non-empty `SampleThreshold` when `inspect_data()` can pre-flight a
+runtime sample gate; use `SampleThreshold()` when the lack of a static
+panel-shape floor is deliberate. Primitive producers under
+`factrix/metrics/_primitives/` may omit the decorator field because consumers
+surface the user-facing threshold or drop statistics.
+
 `factrix/_stats/constants.py`:
 
 - `MIN_PERIODS_HARD = 20`, `MIN_PERIODS_WARN = 30` — the two-tier `n_periods` thresholds.

--- a/factrix/metrics/ts_beta.py
+++ b/factrix/metrics/ts_beta.py
@@ -224,6 +224,9 @@ def mean_r_squared(ts_betas_df: pl.DataFrame) -> MetricResult:
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
+    # Pipeline producer: window-specific eligibility is enforced in-body; no
+    # static panel-shape floor can pre-flight how many rolling dates survive.
+    sample_threshold=SampleThreshold(),
 )
 def compute_rolling_mean_beta(
     data: pl.DataFrame,

--- a/tests/test_sample_naming_lint.py
+++ b/tests/test_sample_naming_lint.py
@@ -56,3 +56,26 @@ def test_sample_constant_naming_lint() -> None:
         "MIN_[<DOMAIN>_]<AXIS>[_<TIER>] with AXIS in "
         "{PERIODS, ASSETS, EVENTS, PAIRS}:\n  " + "\n  ".join(violations)
     )
+
+
+def test_user_facing_metrics_declare_sample_threshold() -> None:
+    """Lint FX004: public metric decorators make pre-flight policy explicit."""
+    violations: list[str] = []
+    for path in sorted((PACKAGE_DIR / "metrics").glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for decorator in node.decorator_list:
+                if not (
+                    isinstance(decorator, ast.Call)
+                    and getattr(decorator.func, "id", "") == "metric"
+                ):
+                    continue
+                if not any(kw.arg == "sample_threshold" for kw in decorator.keywords):
+                    violations.append(f"{path}:{node.lineno}: {node.name}")
+    assert not violations, (
+        "FX004: user-facing @metric decorators must explicitly declare "
+        "sample_threshold=...; use SampleThreshold() for deliberate no-op "
+        "pre-flight floors:\n  " + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Summary
- Make compute_rolling_mean_beta explicitly declare SampleThreshold() as a deliberate no-op pre-flight floor.
- Document the user-facing metric convention for explicit sample_threshold declarations.
- Add FX004 lint so public metric decorators keep pre-flight policy explicit without touching primitive producers.

## Test plan
- ruff format --check
- ruff check
- mypy factrix
- pytest -q -p no:faulthandler

Refs #727
