### PR TITLE
docs(allocation): document dense diagnostics (#727)

### DIFF
--- a/docs/api/metrics/ts_beta.md
+++ b/docs/api/metrics/ts_beta.md
@@ -44,6 +44,9 @@ title: factrix.metrics.ts_beta
     Cross-asset iid $t$ is used because the per-asset betas come from
     non-overlapping time-series fits and are approximately independent
     unless a strong latent common factor links them.
+    `metadata["beta_std"]` and `metadata["median_beta"]` are reported so
+    asset-allocation users can see whether offsetting positive and negative
+    betas are cancelling the average.
 
 -   __Explanatory power across the cross-section__
 
@@ -55,6 +58,15 @@ title: factrix.metrics.ts_beta
     its cross-asset mean $\beta$ looks nonzero; large mean-vs-median
     gaps say the factor explains a small subset of assets rather than
     the cross-section as a whole.
+
+-   __Heterogeneous allocation rotations__
+
+    ---
+
+    A common macro factor can separate asset classes even when its average
+    beta is close to zero. Pair `compute_ts_betas` with
+    `ts_beta_sign_consistency` and inspect the beta vector when equities,
+    duration, commodities, or currencies may load with opposite signs.
 
 -   __Rolling-window stability__
 
@@ -76,6 +88,24 @@ title: factrix.metrics.ts_beta
 | Average explanatory power $\overline{R^2}$ across assets                | `mean_r_squared`                  |
 | Direction-agnostic sign agreement on per-asset $\beta$                  | `ts_beta_sign_consistency`        |
 | Rolling cross-asset mean $\beta$ series for trend / out-of-sample (OOS) pipes | `compute_rolling_mean_beta`       |
+
+## Allocation reading
+
+For asset-allocation panels, read `ts_beta` as the average exposure test, not
+as the whole common-factor story. A non-significant mean beta can still sit on
+top of a useful rotation profile when one group of assets has positive beta and
+another has negative beta.
+
+| Signal in the output | What to inspect |
+|---|---|
+| Mean beta is near zero, but the factor seems economically relevant | `ts_beta.metadata["beta_std"]`, `compute_ts_betas(...)[factor]["beta"]` |
+| Betas split between positive and negative assets | `ts_beta_sign_consistency.value`, `metadata["fraction_positive"]` |
+| A few assets drive the common-factor fit | `mean_r_squared.value`, `metadata["median_r_squared"]` |
+| The factor matters only in high / low states | [`ts_quantile_spread`](ts_quantile.md) |
+
+These are diagnostics for factor validation. Turning the beta profile into
+weights, hedges, leverage, or rebalance rules belongs in the downstream
+portfolio/backtest layer.
 
 ## Worked example — per-asset TS betas then cross-asset $t$
 

--- a/docs/guides/allocation-experiment.md
+++ b/docs/guides/allocation-experiment.md
@@ -44,7 +44,8 @@ print(result.metrics["spread"].value, result.metrics["spread"].p_value)
 
 `ic` asks whether the rank relation is statistically different from zero.
 `quantile_spread` asks whether a simple top-minus-bottom portfolio spread is
-positive on average.
+positive on average. In small allocation universes, add `k_spread`: it keeps
+each leg at a fixed name count instead of forcing unstable quantile buckets.
 
 ## Build a simple allocation proxy
 
@@ -88,21 +89,100 @@ borrow constraints, no capacity model, and no weight optimization.
 
 ## Small universes
 
-If the universe is small, reduce the number of groups. With only five assets,
-`n_groups=5` means one asset per bucket, so the spread is dominated by
-individual names. `n_groups=2` is the coarsest useful long-short split.
+If the universe is small, reduce the number of groups or use the fixed-count
+spread. With only five assets, `n_groups=5` means one asset per bucket, so the
+spread is dominated by individual names. `n_groups=2` is the coarsest useful
+long-short split, while `k_spread(k=1)` / `k_spread(k=2)` states the leg size
+directly.
 
 ```python
+from factrix.metrics import k_spread
+
 series = compute_spread_series(
     panel,
     factor_cols=["factor"],
     forward_periods=5,
     n_groups=2,
 )["factor"]
+
+spread_metric = k_spread(panel, forward_periods=5, k=2)
+print(spread_metric.value, spread_metric.p_value, spread_metric.metadata["method"])
 ```
 
-When `n_groups=2` is still too thin, treat the result as a fragile
-small-cross-section diagnostic rather than a portfolio claim.
+When even `k=1` is too noisy, treat the result as a fragile
+small-cross-section diagnostic rather than a portfolio claim. Pair it with
+`directional_hit_rate` when the question is "does the signal get the direction
+right?" rather than "does a long-short spread clear zero?"
+
+```python
+from factrix.metrics import directional_hit_rate
+
+hit = directional_hit_rate(panel, forward_periods=5)
+print(hit.value, hit.p_value, hit.metadata["p_expected"])
+```
+
+For 5-20 asset panels, read IC / FM output as the canonical inference layer when
+available, but expect `WarningCode.FEW_ASSETS` on thin cross-sections. The
+small-N spread and directional diagnostics are supplementary; they do not
+replace the canonical p-value family for screening.
+
+## Common macro factors and heterogeneous betas
+
+Common factors such as growth surprises, inflation shocks, VIX, DXY, or policy
+expectations are shared across assets on a date. A single average beta can hide
+rotation value: equities may load positively while duration or gold loads
+negatively, leaving `ts_beta` close to zero even though the factor separates the
+asset classes.
+
+Use the beta profile before reading the average-beta test:
+
+```python
+import polars as pl
+from factrix.metrics import mean_r_squared, ts_beta, ts_beta_sign_consistency
+from factrix.metrics import ts_quantile_spread
+from factrix.metrics.ts_beta import compute_ts_betas
+
+macro = (
+    panel.select("date")
+    .unique()
+    .sort("date")
+    .with_row_index("t")
+    .with_columns((pl.col("t").cast(pl.Float64) / 20.0).sin().alias("macro_growth"))
+    .select("date", "macro_growth")
+)
+macro_panel = panel.join(macro, on="date")
+betas_df = compute_ts_betas(macro_panel, factor_cols=["macro_growth"])["macro_growth"]
+
+avg_beta = ts_beta(betas_df)
+r2 = mean_r_squared(betas_df)
+signs = ts_beta_sign_consistency(betas_df)
+spread = ts_quantile_spread(
+    macro_panel,
+    factor_col="macro_growth",
+    forward_periods=5,
+    n_groups=3,
+)
+
+print(avg_beta.value, avg_beta.p_value)
+print(avg_beta.metadata["beta_std"], avg_beta.metadata["median_beta"])
+print(r2.value, signs.value, signs.metadata["fraction_positive"])
+print(spread.value, spread.p_value)
+```
+
+Read the pieces together:
+
+| Question | Diagnostic |
+|---|---|
+| Is the average exposure different from zero? | `ts_beta.value`, `ts_beta.p_value` |
+| Are asset betas dispersed enough for rotation? | `ts_beta.metadata["beta_std"]`, `compute_ts_betas(...)[factor]["beta"]` |
+| Does one sign dominate, or do signs split by asset class? | `ts_beta_sign_consistency.value`, `metadata["fraction_positive"]` |
+| Does the factor explain individual asset returns? | `mean_r_squared.value`, `metadata["median_r_squared"]` |
+| Is the common factor nonlinear or extreme-state driven? | `ts_quantile_spread` |
+
+This remains a factor diagnostic. If the beta vector suggests a long-equity /
+short-duration rotation, convert that insight into weights, risk budgets,
+rebalance rules, and transaction-cost assumptions in a downstream portfolio or
+backtest layer.
 
 ## Multi-factor screens
 

--- a/docs/guides/choosing-metric.md
+++ b/docs/guides/choosing-metric.md
@@ -15,6 +15,8 @@ output.
 | Whether an event signal produces abnormal returns | [`caar`](../api/metrics/caar.md) | Mainstream event-time significance test for sparse factors. |
 | Whether event-study inference is sensitive to variance or ranking assumptions | [`bmp_z`](../api/metrics/caar.md), [`corrado_rank`](../api/metrics/corrado_rank.md) | Robustness checks for event-induced variance and non-normal returns. |
 | Whether a market-wide time-series factor is priced across assets | [`ts_beta`](../api/metrics/ts_beta.md) | Cross-asset test on per-asset beta estimates; requires `N >= 2`. |
+| Whether a common macro factor separates assets with opposite beta signs | [`ts_beta`](../api/metrics/ts_beta.md), [`ts_beta_sign_consistency`](../api/metrics/ts_beta.md#factrix.metrics.ts_beta.ts_beta_sign_consistency) | Read the beta profile, sign split, and explanatory power before turning it into an allocation rule. |
+| Whether a small allocation universe has a fixed-count long-short edge | [`k_spread`](../api/metrics/k_spread.md), [`directional_hit_rate`](../api/metrics/directional_hit_rate.md) | Supplementary small-N diagnostics when quantile buckets are too thin; not a replacement for the canonical IC/FM p-value family. |
 | Whether a signal is tradable after turnover / cost pressure | [`tradability`](../api/metrics/tradability.md), [`concentration`](../api/metrics/concentration.md) | Descriptive diagnostics around implementation pressure. |
 | Whether a result decays, trends, or keeps the right sign over time | [`oos_decay`](../api/metrics/oos_decay.md), [`ic_trend`](../api/metrics/trend.md), [`hit_rate`](../api/metrics/hit_rate.md) | Series diagnostics layered on top of a cell's primary result. |
 
@@ -37,10 +39,19 @@ Both metrics evaluate individual, continuous factors (`FactorScope.INDIVIDUAL` a
 | **Statistical Method** | Per-date Spearman rank correlation $\rho_t$ → Newey-West HAC $t$-test on $\mathbb{E}[\rho_t]$. | Per-date cross-sectional OLS regression slope $\lambda_t$ → Newey-West HAC $t$-test on $\mathbb{E}[\lambda_t]$. |
 | **Robustness** | Extremely robust to outliers (rank-based). | Sensitive to outliers and extreme values (OLS-based). |
 | **Economic Interpretation** | Rank-ordering capability (signal quality). | Return premium per unit of factor exposure. |
-| **Sample Sensitivity** | Drops dates with fewer than 10 assets. | Requires at least 3 assets per date but can be unstable at low $N$. |
+| **Sample Sensitivity** | Drops dates with fewer than 2 complete pairs; warns when retained dates have fewer than 10 assets. | Drops dates with fewer than 3 complete pairs; warns when retained dates have fewer than 10 assets. |
 
 - **Use IC** (`ic`) when you are building a ranking-based stock selection strategy.
 - **Use FM** (`fm_beta`) when you need to estimate risk premia or require an economically interpretable slope premium.
+
+## Allocation panels
+
+For common macro factors, `ts_beta` is the average exposure test. Inspect
+`metadata["beta_std"]`, `metadata["median_beta"]`,
+`ts_beta_sign_consistency`, and `mean_r_squared` when assets may load with
+opposite signs. For small individual dense panels, use `k_spread` and
+`directional_hit_rate` as supplementary reads alongside IC / FM, not as a new
+screening family.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document small-N dense allocation diagnostics with k_spread and directional_hit_rate.
- Document common macro beta-profile reads using ts_beta metadata, sign consistency, mean R2, and ts_quantile_spread.
- Cross-link the metric chooser and ts_beta API docs without changing metric behavior.

## Test plan
- git diff --check
- PYTHONUTF8=1 ./.venv/Scripts/python.exe -m pytest tests/test_docs_pages.py tests/test_docs_matrix.py -q -p no:faulthandler
- PYTHONUTF8=1 ./.venv/Scripts/python.exe -m mkdocs build --strict

Refs #727
