### PR TITLE
docs(allocation): clarify sparse event workflow (#727)

### DIFF
--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -21,7 +21,7 @@ market-cap tier, ADV bucket all share the same dispatcher.
 - `data` — a raw long-format panel, the **same input contract as
   `evaluate`** (`date, asset_id, <factor_col>, forward_return`), with the
   slicing column `by` already present.
-- `metric` — a metric **instance** (`ic()`, `caar(forward_periods=5)`),
+- `metric` — a metric **instance** (`ic()`, `caar()`),
   consistent with `evaluate(metrics={...})`. The bare class (`ic`) is
   rejected.
 - `by` — the partition column.

--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -70,6 +70,31 @@ title: factrix.metrics.caar
 | Mean-CAAR significance, deterministic non-overlap subsample   | `caar`         |
 | Variance-robust event-induced significance (BMP standardised $z$) | `bmp_z`     |
 
+## Event counts
+
+`compute_caar` collapses same-date event rows before the `caar` test runs.
+The event-study path therefore exposes these related counts:
+
+| Field | Where to read it | Meaning |
+|---|---|---|
+| `n_events` | `compute_caar(...).select("date", "n_events")` | Raw event rows collapsed into each event date |
+| `total_events` | `caar(...).metadata["total_events"]` | Sum of raw non-zero event rows behind the study |
+| `n_event_periods` | `caar(...).metadata["n_event_periods"]` | Distinct event dates in the CAAR series |
+| `n_event_periods_sampled` | `caar(...).metadata["n_event_periods_sampled"]` | Event dates kept by the calendar-aware non-overlap sampler used for the t-test |
+
+`MetricResult.n_obs` equals `n_event_periods_sampled`, because that is the
+sample entering the headline `p_value`. A large gap between `total_events` and
+`n_event_periods` means events cluster on the same dates. A large gap between
+`n_event_periods` and `n_event_periods_sampled` means the forward-return
+windows overlap heavily, so the non-overlap sampler thins the effective test
+sample.
+
+For asset-allocation policy events, make sure the sparse factor sign encodes
+the expected return direction, not just the raw event type. If `+1` means
+"central-bank hike" but hikes are bearish for one asset group and bullish for
+another, map the raw event into an asset-specific expected-return signal before
+calling `compute_caar`, `event_hit_rate`, or `profit_factor`.
+
 ## Worked example — per-event-date CAAR then mean significance
 
 !!! example "compute_caar → caar on a synthetic event panel"

--- a/docs/api/metrics/common-sparse.md
+++ b/docs/api/metrics/common-sparse.md
@@ -13,6 +13,12 @@ combines two traits:
 2. **Common scope**: the same value is broadcast to every asset on an
    event date rather than varying cross-sectionally.
 
+The non-zero sign still means expected return direction. A raw policy-event
+dummy is `Common × Sparse` only when the same signed interpretation applies to
+every asset. If the raw event needs asset-specific bullish/bearish mapping,
+create the mapped signal first; the resulting factor may become
+`Individual × Sparse` because values differ by asset on the same date.
+
 Because the event-time column contract is identical to
 `Individual × Sparse`, this cell **reuses the same scope-agnostic sparse
 metrics** — there is no separate Common-sparse module set. Use the

--- a/docs/api/metrics/individual-sparse.md
+++ b/docs/api/metrics/individual-sparse.md
@@ -10,6 +10,12 @@ or any magnitude). Common forms: `{0, 1}` for a pure event flag, or
 `{0, R}` for any real-valued magnitude; both flow through (see
 [`caar`](caar.md) for the input-form table).
 
+The non-zero sign is interpreted as the **expected return direction**.
+For raw event taxonomies such as `hike=+1` / `cut=-1`, map the event type into
+an asset-specific bullish/bearish signal before running sparse metrics. If a
+hike is expected to hurt duration assets but help a currency basket, the two
+asset groups should receive opposite factor signs on the same policy date.
+
 | Metric | Page |
 |---|---|
 | Cumulative average abnormal return — $t$-test or BMP $z$-test | [`caar`](caar.md) |

--- a/docs/guides/allocation-experiment.md
+++ b/docs/guides/allocation-experiment.md
@@ -126,6 +126,41 @@ available, but expect `WarningCode.FEW_ASSETS` on thin cross-sections. The
 small-N spread and directional diagnostics are supplementary; they do not
 replace the canonical p-value family for screening.
 
+## Country-level momentum
+
+Country equity, rates, FX, or commodity momentum is usually an
+asset-specific dense signal: each asset has its own score on each date. Keep it
+in the `Individual × Dense` cell and read a small set of complementary
+diagnostics:
+
+```python
+from factrix.metrics import directional_hit_rate, fm_beta, k_spread
+
+country_panel = panel.rename({"factor": "country_momentum"})
+
+country = fx.evaluate(
+    country_panel,
+    metrics={
+        "fm": fm_beta(),
+        "spread": k_spread(k=2),
+        "direction": directional_hit_rate(),
+    },
+    factor_cols=["country_momentum"],
+    forward_periods=5,
+    strict=False,
+)
+
+result = country["country_momentum"]
+print(result.metrics["fm"].value, result.metrics["fm"].p_value)
+print(result.metrics["spread"].value, result.metrics["spread"].p_value)
+print(result.metrics["direction"].value, result.metrics["direction"].p_value)
+```
+
+`fm_beta` keeps the economic unit of the signal, `k_spread` gives a
+fixed-count long-short read when the asset universe is small, and
+`directional_hit_rate` checks whether the signal gets the sign right. Treat the
+three as factor diagnostics, not as a completed allocation rule.
+
 ## Common macro factors and heterogeneous betas
 
 Common factors such as growth surprises, inflation shocks, VIX, DXY, or policy
@@ -183,6 +218,130 @@ This remains a factor diagnostic. If the beta vector suggests a long-equity /
 short-duration rotation, convert that insight into weights, risk budgets,
 rebalance rules, and transaction-cost assumptions in a downstream portfolio or
 backtest layer.
+
+## Mapped policy event factors
+
+Sparse event factors use their non-zero sign as the expected return direction.
+That is not always the raw event type. A central-bank hike can be bearish for
+duration-sensitive assets, bullish for a currency basket, and neutral for some
+commodities. Encode the factor after that mapping, then run the sparse metrics.
+
+```python
+from factrix.metrics import caar, clustering_hhi, event_hit_rate, profit_factor
+from factrix.metrics.caar import compute_caar
+
+dates = (
+    panel.select("date")
+    .unique()
+    .sort("date")
+    .with_row_index("t")
+    .with_columns(
+        pl.when(pl.col("t") % 5 == 0)
+        .then(1.0)      # raw hike
+        .when(pl.col("t") % 11 == 0)
+        .then(-1.0)     # raw cut
+        .otherwise(0.0)
+        .alias("policy_event_type")
+    )
+    .select("date", "policy_event_type")
+)
+asset_map = (
+    panel.select("asset_id")
+    .unique()
+    .sort("asset_id")
+    .with_row_index("i")
+    .with_columns(
+        pl.when(pl.col("i") % 3 == 0)
+        .then(-1.0)     # hike expected to hurt this asset group
+        .otherwise(1.0)
+        .alias("policy_expected_direction")
+    )
+    .select("asset_id", "policy_expected_direction")
+)
+
+policy_panel = (
+    panel.join(dates, on="date")
+    .join(asset_map, on="asset_id")
+    .with_columns(
+        (pl.col("policy_event_type") * pl.col("policy_expected_direction"))
+        .alias("policy_signal")
+    )
+)
+
+hit = event_hit_rate(policy_panel, factor_col="policy_signal")
+pf = profit_factor(policy_panel, factor_col="policy_signal")
+caar_series = compute_caar(policy_panel, factor_col="policy_signal")
+caar_out = caar(caar_series, forward_periods=5)
+crowding = clustering_hhi(policy_panel, factor_col="policy_signal")
+
+print(hit.value, hit.p_value)
+print(pf.value)
+print(
+    caar_out.metadata["total_events"],
+    caar_out.metadata["n_event_periods"],
+    caar_out.metadata["n_event_periods_sampled"],
+)
+print(crowding.value, crowding.metadata["hhi_normalized"])
+```
+
+Read the counts in that order:
+
+| Count | Meaning |
+|---|---|
+| `total_events` | Non-zero `(date, asset_id)` event rows behind the study |
+| `n_event_periods` | Distinct event dates after same-date events are collapsed into one CAAR observation |
+| `n_event_periods_sampled` | Event dates kept by the non-overlap sampler used for the `caar` t-test |
+
+`event_hit_rate` and `profit_factor` use `sign(policy_signal)`, so they answer
+whether the mapped direction was right. `caar` preserves magnitude in
+`forward_return * policy_signal`; use a clean `{0, -1, +1}` signal when you want
+signed CAAR rather than magnitude-weighted CAAR.
+
+## Regime workflow
+
+factrix does not infer regimes. Attach labels upstream, then choose the
+descriptive or inferential path deliberately:
+
+```python
+from factrix import by_slice, slice_period_pairwise_test
+
+regime_labels = macro.with_columns(
+    pl.when(pl.col("macro_growth") >= 0)
+    .then(pl.lit("growth_up"))
+    .otherwise(pl.lit("growth_down"))
+    .alias("regime")
+).select("date", "regime")
+
+regime_panel = policy_panel.join(regime_labels, on="date")
+
+per_regime = by_slice(
+    regime_panel,
+    caar(),
+    by="regime",
+    factor_col="policy_signal",
+    strict=False,
+)
+
+pairs = slice_period_pairwise_test(
+    regime_panel,
+    caar(),
+    by="regime",
+    factor_col="policy_signal",
+    rng_seed=7,
+)
+print(pairs)
+```
+
+Use `by_slice` for per-regime result tables. Use
+`slice_period_pairwise_test` / `slice_period_joint_test` when regimes are
+date-disjoint and you need a calibrated cross-regime contrast. Do not compare
+two per-regime p-values and call that a regime difference.
+
+Date-axis slicing can truncate history for metrics that look across dates
+(`ts_beta`, event windows, rolling/OOS diagnostics). `by_slice` emits
+`WarningCode.SLICE_BOUNDARY_TRUNCATION` for those cases. For pure per-date
+metrics such as IC / FM, a date-axis split is closer to a normal period
+decomposition.
 
 ## Multi-factor screens
 

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -52,6 +52,12 @@ For a specific metric `key`, `result.metrics[key]` exposes:
 - **`warning_codes`**: Advisory warnings attached by the metric (e.g. `FEW_EVENTS`).
 - **`metadata`**: Tool-specific context.
 
+For CAAR event studies, distinguish raw events from the effective test sample:
+`metadata["total_events"]` is the raw non-zero event-row count,
+`metadata["n_event_periods"]` is the number of event dates after same-date
+events are collapsed, and `metadata["n_event_periods_sampled"]` is the
+non-overlapping event-date sample used for the headline `p_value`.
+
 ### 4. Warnings and Execution Plan
 
 - **`warnings`**: Flat list of `Warning` objects. A per-metric warning carries `source == metric_name`; a panel-level warning carries `source is None`.

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -251,6 +251,13 @@ abnormal-return definitions, estimation windows, and overlap
 conventions diverge from each other by design. Surfacing the contracts
 here so each metric page can reference one canonical definition.
 
+For sparse event factors, the non-zero sign encodes the **expected return
+direction**. It is not necessarily the raw event type. A raw taxonomy such as
+`hike=+1` / `cut=-1` should be mapped into the asset's expected bullish/bearish
+direction before entering the metrics. Magnitude may carry event strength for
+metrics that preserve magnitude, but the sign should already mean "positive
+return expected" vs "negative return expected".
+
 ### Abnormal-return definition per metric
 
 factrix follows MacKinlay (1997) event-window vocabulary but each


### PR DESCRIPTION
## Summary
- Expand the allocation guide with country momentum, mapped policy-event factors, and regime workflow examples.
- Clarify sparse event sign semantics: factor signs encode expected return direction, not raw event type.
- Document CAAR raw-vs-effective event counts and fix the by_slice caar() metric-instance example.

## Test plan
- git diff --check
- Docs API snippet covering country momentum, policy mapping, CAAR counts, by_slice, and slice_period_pairwise_test
- PYTHONUTF8=1 ./.venv/Scripts/python.exe -m pytest tests/test_docs_pages.py tests/test_docs_matrix.py -q -p no:faulthandler
- PYTHONUTF8=1 ./.venv/Scripts/python.exe -m mkdocs build --strict

Closes #727
