### PR TITLE
docs(api): clarify panel flow

### DIFF
--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -2,8 +2,10 @@
 title: factrix.evaluate
 ---
 
-> **Input contract** — the panel must satisfy the four-column floor
-> documented in [Data schema](data-schema.md).
+> **Input contracts:** `evaluate` consumes an evaluation panel with the
+> four-column floor documented in [Data schema](data-schema.md).
+> `evaluate_horizons` consumes a raw canonical panel with `price` and factor
+> columns, then computes `forward_return` internally for each horizon.
 
 ::: factrix.evaluate
 
@@ -174,9 +176,9 @@ derivation are automatically resolved at dispatch time.
 
     ---
 
-    New to the input contract? Start here for the four-column floor
-    (`date`, `asset_id`, `factor`, `forward_return`), dtype semantics,
-    and optional columns that activate extra metrics.
+    New to the fixed-horizon input contract? Start here for the evaluation
+    panel floor (`date`, `asset_id`, `factor`, `forward_return`), dtype
+    semantics, and optional columns that activate extra metrics.
 
     [Read the schema →](data-schema.md)
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,33 +4,33 @@ title: API
 
 Reference for every public symbol exported from `factrix`.
 
-## Function flow
+## Data and result flow
 
 ```mermaid
-flowchart LR
-    R[raw data]
+flowchart TD
+    R[Raw data]
     AD[adapt]
-    C["canonical raw panel<br/>date / asset_id / price / factors"]
+    RAW["Raw canonical panel<br/>date / asset_id / price / factors"]
     FR[compute_forward_return]
-    P["evaluation panel<br/>date / asset_id / factor / forward_return"]
+    EVALP["Evaluation panel<br/>date / asset_id / factor / forward_return"]
 
-    subgraph PerFactor["Inference · per factor"]
+    subgraph Infer["Per-factor inference"]
         EV[evaluate]
         EVH[evaluate_horizons]
     end
 
-    subgraph Screening["Screening · FDR across factors"]
-        BHY[bhy]
-        PC[partial_conjunction]
-        BHYH[bhy_hierarchical]
-    end
-
-    subgraph Slices["Inference · across slices (no FDR)"]
-        ST["slice_pairwise_test / slice_joint_test<br/>slice_period_pairwise_test / slice_period_joint_test"]
-    end
-
-    subgraph View["Descriptive view"]
+    subgraph Slice["Slice analysis"]
         BS[by_slice]
+        ST[slice tests]
+    end
+
+    subgraph Screen["FDR screening"]
+        BHY[bhy]
+        PC[partial conjunction]
+        BHYH[hierarchical BHY]
+    end
+
+    subgraph View["Views"]
         CMP[compare]
     end
 
@@ -41,32 +41,33 @@ flowchart LR
     end
 
     R -.-> AD
-    AD -.-> C
-    C -.-> FR
-    FR -.-> P
-    P ==> EV
-    C ==> EVH
-    P -.-> BS
-    P -.-> ST
-    P -.-> ID
+    AD -.-> RAW
+    RAW ==> EVH
+    RAW -.-> FR
+    RAW -.-> ID
+    FR -.-> EVALP
+    EVALP ==> EV
+    EVALP -.-> BS
+    EVALP -.-> ST
+    EVALP -.-> ID
     EV ==>|results| BHY
     EV ==>|results| PC
     EV ==>|results| BHYH
     EV ==>|results| CMP
-    EVH ==>|results| BHY
     EVH ==>|results| CMP
+    EVH ==>|results| BHY
     BHY ==>|survivors| CMP
     PC ==>|survivors| CMP
     BHYH ==>|survivors| CMP
-    LM -.->|metric names| EV
-    MS -.->|metric names| EV
+    LM -.-> EV
+    MS -.-> EV
 
     click AD "preprocess/#factrix.adapt.adapt" "adapt API"
     click FR "preprocess/#factrix.preprocess.compute_forward_return" "compute_forward_return API"
     click EV "evaluate/" "evaluate API"
     click EVH "multi-horizon/" "evaluate_horizons API"
     click BS "by-slice/" "by_slice API"
-    click ST "slice-test/" "slice tests — cross-sectional + period-disjoint API"
+    click ST "slice-test/" "slice tests API"
     click BHY "multi-factor/" "bhy API"
     click PC "partial-conjunction/" "partial_conjunction API"
     click BHYH "bhy-hierarchical/" "bhy_hierarchical API"
@@ -78,25 +79,39 @@ flowchart LR
 
 Click any node to jump to its API page.
 
+**Panel contracts:**
+
+| Panel | Minimum columns | Used by |
+|---|---|---|
+| Raw canonical panel | `date`, `asset_id`, `price`, factor column(s) | `evaluate_horizons`; it computes `forward_return` internally for each horizon. `inspect_data` can pre-flight the factor shape before returns are attached. |
+| Evaluation panel | `date`, `asset_id`, factor column(s), `forward_return` | `evaluate`, slice analysis, `inspect_data`, and most metric dispatch. |
+
 **Edge convention:**
 
-- **Solid `==>` — hard signature dependency.** The target's call signature accepts the source object.
-    - `evaluate(data, metrics=...)` consumes `P` (data).
-    - `bhy` / `partial_conjunction` / `bhy_hierarchical` consume `evaluate` outputs as `list[EvaluationResult]` (via `list(results.values())`).
-- **Dashed `-.->` — suggested workflow.** The source is data-derived, but the target's signature differs in shape.
+- **Solid `==>`: primary statistical handoff.** `evaluate(panel, ...)` consumes
+  an evaluation panel; `evaluate_horizons(raw, ...)` consumes a raw canonical
+  panel; FDR functions consume `list[EvaluationResult]`.
+- **Dashed `-.->`: preparation, inspection, or descriptive flow.** These calls
+  help shape, inspect, or view the analysis input/output without changing the
+  main inference-to-screening path.
 
 `adapt(...)` is optional when the source already uses factrix's canonical names,
-but it is the documented bridge from vendor column names to `date`, `asset_id`,
-`price`, and optional OHLCV canonicals.
-For fixed-horizon `evaluate`, attach `forward_return` with
-`compute_forward_return`; `evaluate_horizons` performs that step internally
-for each requested horizon.
+but it is the documented bridge from vendor columns to `date`, `asset_id`,
+`price`, and optional OHLCV canonicals. For fixed-horizon `evaluate`, attach
+`forward_return` first with `compute_forward_return`. For horizon sweeps, pass
+the raw canonical panel to `evaluate_horizons`; it rebuilds `forward_return` for
+each requested horizon.
 
-**Inference vs screening** (the two test-bearing stages above):
+**Inference vs screening:**
 
-- **Inference** produces the primary statistical test — a *p*-value — for a **single** hypothesis. `evaluate` / `evaluate_horizons` do this **per factor** ("tests one factor"); the `slice_*_test` family does it **across slices** of one factor (sector, size, market regime). Neither corrects for testing more than one thing.
-- **Screening** is what you add when you test **many** factors at once: `bhy` / `partial_conjunction` / `bhy_hierarchical` take a `list[EvaluationResult]` and control the false-discovery rate across the family ("screens a thousand"). Screening consumes inference output; it does not re-run the test.
-- `by_slice` / `compare` are **descriptive** — they arrange or rank results into a view, without adding a test of their own.
+- **Inference** produces a p-value for one hypothesis. `evaluate` and
+  `evaluate_horizons` do this per factor; `slice_*_test` functions test across
+  slices of one factor. None of these corrects for testing many candidates.
+- **Screening** starts after inference. `bhy`, `partial_conjunction`, and
+  `bhy_hierarchical` take `list[EvaluationResult]` and control false discoveries
+  across the declared family.
+- **Views** such as `by_slice` and `compare` arrange or rank results; they do
+  not add another statistical test.
 
 ---
 
@@ -105,16 +120,16 @@ for each requested horizon.
 | Goal | Pipeline |
 |---|---|
 | Bring external data into factrix's schema | `adapt(raw, date=..., asset_id=..., price=...)` -> canonical column names |
-| Single-factor/multi-factor inference | `evaluate(data, metrics=...)` → `dict[str, EvaluationResult]` |
-| Multi-horizon sweep | `evaluate_horizons(data, metrics=..., forward_periods=[...])` → `list[EvaluationResult]` |
-| Slice exploration (single axis) | `by_slice(data, metric, by="...", factor_col="...")` → `dict[str, EvaluationResult]` |
-| Slice statistical test (date-aligned) | `slice_pairwise_test(df, metric, by="...")` or `slice_joint_test(...)` → pairwise / omnibus test result |
-| Slice statistical test (date-disjoint) | `slice_period_pairwise_test(...)` or `slice_period_joint_test(...)` → pairwise / omnibus across regimes / calendar periods |
-| Metric catalog discovery (full specs) | `list_metrics()` → family-grouped `dict` of specs |
-| Metric catalog discovery (browse) | `metrics_summary()` → `pl.DataFrame` of `(family, metric, summary)` |
-| Per-panel applicability | `inspect_data(data)` → `.usable` / `.degraded` / `.unusable` |
-| Multi-factor screening with FDR | `evaluate(...)` → `multi_factor.bhy(list(results.values()), metrics=[...])` |
-| Cross-factor leaderboard | `compare(list(results.values()), metrics=[...])` → `pl.DataFrame` |
+| Fixed-horizon inference | `evaluate(panel, metrics=...)` on an evaluation panel -> `dict[str, EvaluationResult]` |
+| Multi-horizon sweep | `evaluate_horizons(raw, metrics=..., forward_periods=[...])` on a raw canonical panel -> `list[EvaluationResult]` |
+| Slice exploration | `by_slice(panel, metric, by="...", factor_col="...")` -> `dict[str, EvaluationResult]` |
+| Slice statistical test, date-aligned | `slice_pairwise_test(panel, metric, by="...")` or `slice_joint_test(...)` -> pairwise / omnibus result |
+| Slice statistical test, date-disjoint | `slice_period_pairwise_test(...)` or `slice_period_joint_test(...)` -> pairwise / omnibus result across regimes or calendar periods |
+| Metric catalog discovery, full specs | `list_metrics()` -> family-grouped `dict` of specs |
+| Metric catalog discovery, browse | `metrics_summary()` -> `pl.DataFrame` of `(family, metric, summary)` |
+| Per-panel applicability | `inspect_data(raw_or_panel)` -> `.usable` / `.degraded` / `.unusable` |
+| Multi-factor screening with FDR | `evaluate(...)` -> `multi_factor.bhy(list(results.values()), metrics=[...])` |
+| Cross-factor leaderboard | `compare(list(results.values()), metrics=[...])` -> `pl.DataFrame` |
 
 See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surface end-to-end.
 
@@ -124,18 +139,18 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 
 | Page | Category | What it is | When to read |
 |---|---|---|---|
-| [`evaluate`](evaluate.md) | Inference (per factor) | Single dispatch entry — runs the registered metrics on a panel and returns the evaluation results. | Running an analysis. |
-| [`evaluate_horizons`](multi-horizon.md) | Inference (per factor) | Sweep `evaluate` across several overlap horizons of one raw panel. | Multi-horizon analysis / sweeping. |
-| [`by_slice`](by-slice.md) | Descriptive view | Partition a panel on a column and run `evaluate` per slice; returns `dict[str, EvaluationResult]`. | Per-slice metric exploration. |
-| [`slice_*_test` family](slice-test.md) | Inference (across slices) | `slice_pairwise_test` / `slice_joint_test` (date-aligned) and `slice_period_pairwise_test` / `slice_period_joint_test` (date-disjoint regimes): pairwise / omnibus tests over slice families. | Testing whether slice means differ. |
+| [`evaluate`](evaluate.md) | Inference (per factor) | Runs registered metrics on an evaluation panel and returns one result per factor. | Running fixed-horizon analysis. |
+| [`evaluate_horizons`](multi-horizon.md) | Inference (per factor) | Rebuilds `forward_return` from one raw panel for each requested horizon, then evaluates each panel. | Multi-horizon analysis / sweeping. |
+| [`by_slice`](by-slice.md) | Descriptive view | Partitions a panel on one column and runs `evaluate` per slice. | Per-slice metric exploration. |
+| [`slice_*_test` family](slice-test.md) | Inference (across slices) | Pairwise / omnibus tests over date-aligned or date-disjoint slice families. | Testing whether slice means differ. |
 | [`multi_factor`](multi-factor.md) | Screening (FDR) | Module-level overview of collection-level FDR functions. | Multi-factor FDR screening overview. |
 | [`bhy`](bhy.md) | Screening (FDR) | Benjamini-Hochberg-Yekutieli step-up FDR. | Screening candidate factors. |
-| [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction screening. | "Factor passes in ≥ k of m contexts." |
+| [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction screening. | "Factor passes in k of m contexts." |
 | [`bhy_hierarchical`](bhy-hierarchical.md) | Screening (FDR) | Two-stage hierarchical BHY FDR. | Grouped / nested-context screening. |
-| [`compare`](compare.md) | Descriptive view | Cross-factor leaderboard — stacks evaluation results into a `pl.DataFrame`. | Ranking candidate factors. |
+| [`compare`](compare.md) | Descriptive view | Cross-factor leaderboard; stacks evaluation results into a `pl.DataFrame`. | Ranking candidate factors. |
 | [`list_metrics`](metrics/index.md#factrix.list_metrics) | Introspection | Family-grouped catalog of public metric specs. | Programmatic browsing over the metric catalog. |
 | [`metrics_summary`](metrics/index.md#factrix.metrics_summary) | Introspection | One-line-per-metric `pl.DataFrame` (`family`, `metric`, `summary`). | Browsing the metric catalog at a glance. |
-| [`inspect_data`](inspect-data.md) | Introspection | Inspects a panel's applicability metrics. | Pre-flight check on data dimensions. |
+| [`inspect_data`](inspect-data.md) | Introspection | Inspects a panel's applicable, degraded, and unusable metrics. | Pre-flight check on data dimensions. |
 | [`Metrics`](metrics/index.md) | Catalogue | Per-module reference for every public function under `factrix.metrics`. | Calling a standalone metric directly. |
 | [`stats`](stats.md) | Catalogue | Statistical estimators and HAC/bootstrap utilities. | Under-the-hood statistical details. |
 
@@ -145,10 +160,10 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 
 | Page | What it is |
 |---|---|
-| [Data schema](data-schema.md) | The four-column input contract every panel-consuming function depends on. |
+| [Data schema](data-schema.md) | The four-column evaluation-panel contract used by fixed-horizon metric dispatch. |
 | [`EvaluationResult`](evaluation-results.md) | The bundle result returned by `evaluate`. Includes groups, metric results, and warnings. |
 | [`datasets`](datasets.md) | Synthetic panels for testing and examples. |
-| [`adapt`](preprocess.md#factrix.adapt.adapt) / [`preprocess`](preprocess.md) | Column-name adaptation plus helpers for preprocessing (e.g. computing forward returns). |
+| [`adapt`](preprocess.md#factrix.adapt.adapt) / [`preprocess`](preprocess.md) | Column-name adaptation plus helpers for preprocessing, including forward returns. |
 
 ## Naming convention
 
@@ -157,5 +172,5 @@ Sidebar entries mirror the actual Python identifier:
 | Sidebar entry | Identifier kind | Example call |
 |---|---|---|
 | `EvaluationResult` | Class | `fx.EvaluationResult` |
-| `evaluate`, `inspect_data` | Function | `fx.evaluate(data, metrics=...)` |
+| `evaluate`, `inspect_data` | Function | `fx.evaluate(panel, metrics=...)` |
 | `multi_factor`, `datasets`, `Metrics` | Module | `fx.multi_factor.bhy(list(results.values()), metrics=[...])` |

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -32,7 +32,7 @@ automatically.
 ## Recipes
 
 [`evaluate_horizons`](evaluate.md) is the convenience entry for both
-recipes: it rebuilds the panel with
+recipes: it rebuilds an evaluation panel from the raw input with
 [`compute_forward_return`](preprocess.md) per horizon, runs
 [`evaluate`](evaluate.md) at each, and flattens to a single
 `list[EvaluationResult]` — one entry per `(factor, forward_periods)`,
@@ -52,8 +52,10 @@ import factrix as fx
 import polars as pl
 from factrix.metrics import ic
 
+raw = fx.datasets.make_cs_panel(n_assets=80, n_dates=240)
+
 results = fx.evaluate_horizons(
-    panel,  # raw panel — no forward_return attached
+    raw,  # no forward_return attached
     metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},
     factor_cols=["mom_12_1"],
     forward_periods=[1, 5, 10, 20],
@@ -72,8 +74,10 @@ the BHY null per horizon so the step-up threshold is correct.
 import factrix as fx
 from factrix.metrics import ic
 
+raw = fx.datasets.make_cs_panel(n_assets=80, n_dates=240)
+
 results = fx.evaluate_horizons(
-    panel,  # raw panel — no forward_return attached
+    raw,  # no forward_return attached
     metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},
     factor_cols=["mom_12_1"],
     forward_periods=[1, 5, 10, 20],


### PR DESCRIPTION
## Summary
- Clarify raw canonical panel vs evaluation panel contracts in the API index.
- Rework the API flow diagram to reduce Mermaid width and improve readability.
- Align evaluate and multi-horizon docs with the evaluate_horizons input contract.

## Test plan
- [x] python -m mkdocs build --strict
- [x] python -m pytest -q tests/test_docs_matrix.py -p no:faulthandler
