### PR TITLE
fix(api): clarify allocation diagnostics (#749)

### DIFF
--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -40,8 +40,13 @@ The returned `pl.DataFrame` contains the following columns:
 - `factor`: The name of the evaluated factor.
 - `forward_periods`: The forward periods horizon.
 - Context keys: All context keys present across the evaluation results, ordered by first appearance.
-- `<metric_name>`: The metric value (e.g. `ic`).
-- `<metric_name>_p_value`: The metric p-value if applicable (e.g. `ic_p_value`).
+- `<metric_label>`: The metric value, where `metric_label` is the key in
+  `EvaluationResult.metrics` and the string passed in `metrics=[...]` (e.g.
+  `ic`).
+- `<metric_label>_p_value`: The metric p-value if applicable (e.g.
+  `ic_p_value`). With a custom evaluation label such as
+  `metrics={"ic_nw": ic(...)}`, pass `metrics=["ic_nw"]` to `compare()` and
+  the p-value column is `ic_nw_p_value`.
 - `rank`: Rank column, present only when `sort_by` is set (the column is absent otherwise).
 
 ## Parameter details
@@ -49,5 +54,12 @@ The returned `pl.DataFrame` contains the following columns:
 | Kwarg | Default | Meaning |
 |-------|---------|---------|
 | `metrics` | (required) | `list[str]` of metric labels to include in the leaderboard. |
-| `sort_by` | `None` | The metric label to sort the leaderboard by. `None` keeps the original list order. |
+| `sort_by` | `None` | Any output column produced before ranking: `factor`, `forward_periods`, context keys, metric value columns such as `ic`, or p-value columns such as `ic_p_value` / `<metric_label>_p_value`. `None` keeps the original list order. |
 | `descending` | `True` | Whether to sort in descending order (higher is better). Set to `False` for lower-is-better metrics. |
+
+`rank` is created after sorting, so it is not a valid `sort_by` key. To sort
+by significance, use the p-value column and set `descending=False`:
+
+```python
+df = fx.compare(results, metrics=["ic"], sort_by="ic_p_value", descending=False)
+```

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -6,6 +6,8 @@ title: factrix.evaluate
 > four-column floor documented in [Data schema](data-schema.md).
 > `evaluate_horizons` consumes a raw canonical panel with `price` and factor
 > columns, then computes `forward_return` internally for each horizon.
+> Scalar post-processing helpers such as `breakeven_cost` and `net_spread`
+> are direct-call utilities, not `evaluate()` metrics.
 
 ::: factrix.evaluate
 

--- a/docs/api/inspect-data.md
+++ b/docs/api/inspect-data.md
@@ -14,6 +14,11 @@ title: factrix.inspect_data
 - **Degraded**: The metric is applicable but runs with a warning because the sample size is borderline (falls between the hard `min_*` floor and the soft `warn_*` threshold).
 - **Unusable**: The metric cannot be run on this data, either because of a cell mismatch or because a hard sample floor (`min_*`) is violated.
 
+Scalar-input helpers such as `breakeven_cost` and `net_spread` are also listed
+as **unusable** for panel data. They consume already computed scalar values
+(`quantile_spread.value`, `notional_turnover.value`) rather than a panel, so run
+the upstream diagnostics first and call the helper directly.
+
 <hr>
 
 ## Result structure

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -58,12 +58,12 @@ overview["ic"]       # [MetricSpec(name="ic", ...), MetricSpec(name="ic_ir", ...
 sorted(overview)     # ['caar', 'fm_beta', 'ic', ...] — the concept families
 ```
 
-The catalog is a *reference*, not a runnable input — wire concrete
-callables up from `factrix.metrics` and pass them to
+The catalog is a *reference*, not a runnable input — import concrete metric
+classes from `factrix.metrics`, instantiate them, and pass those instances to
 [`evaluate`](../evaluate.md):
 
 ```python
-from factrix.metrics import ic, fm_beta, breakeven_cost
+from factrix.metrics import ic, fm_beta, quantile_spread
 ```
 
 ### Per-cell applicability → `inspect_data`
@@ -142,13 +142,15 @@ required distinction is the zero non-event state. Always-in-market
 `{-1, +1}` columns are dense directional signals because they have no non-event
 zero state.
 
-**What stays out of `evaluate()`**: strategy return metrics (Sharpe, Sortino,
-max drawdown, Calmar, annualized return), execution-cost metrics (slippage,
-market impact, borrow cost, liquidity capacity), threshold sweeps that select
-the best entry/exit cutoff, and walk-forward optimization. Those require a
-trading rule, portfolio weights, execution assumptions, or model-selection
-discipline. factrix evaluates factor density; feed screened factors into a
-backtest or execution simulator downstream.
+**What stays out of `evaluate()`**: scalar post-processing helpers such as
+`breakeven_cost` and `net_spread`; strategy return metrics (Sharpe, Sortino,
+max drawdown, Calmar, annualized return); execution-cost metrics (slippage,
+market impact, borrow cost, liquidity capacity); threshold sweeps that select
+the best entry/exit cutoff; and walk-forward optimization. Those require
+already computed diagnostic values, a trading rule, portfolio weights,
+execution assumptions, or model-selection discipline. factrix evaluates factor
+density; feed screened factors into a backtest or execution simulator
+downstream.
 
 ## How to read a metric page
 

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -103,6 +103,12 @@ title: factrix.metrics.tradability
     # 291.7   0.00189   (approximate; bps and per-period spread)
     ```
 
+`breakeven_cost` and `net_spread` are scalar post-processing helpers, not
+panel-evaluation metrics. Keep `n_groups`, `forward_periods`, and any weighting
+choice aligned between `quantile_spread` and `notional_turnover`, then pass their
+`.value` fields into the cost helper. `inspect_data()` marks these helpers as
+standalone so they are not included in `inspect_data().usable.to_metrics_dict()`.
+
 ## See also
 
 <div class="grid cards" markdown>

--- a/docs/guides/allocation-experiment.md
+++ b/docs/guides/allocation-experiment.md
@@ -47,6 +47,15 @@ print(result.metrics["spread"].value, result.metrics["spread"].p_value)
 positive on average. In small allocation universes, add `k_spread`: it keeps
 each leg at a fixed name count instead of forcing unstable quantile buckets.
 
+When a research sheet mixes asset-specific signals (for example trend or carry
+scores that differ by asset) with common macro signals (for example the same
+growth surprise value broadcast to every asset on a date), preflight and
+evaluate them in separate batches. `inspect_data(..., factor_cols=[...])` bases
+the displayed applicability table on one detected factor cell and warns when
+the requested columns mix scope or density; the clean workflow is one batch for
+`Individual x Dense` metrics such as `ic` / `fm_beta`, and a separate batch for
+`Common x Dense` metrics such as `common_beta` and its diagnostics.
+
 ## Build a simple allocation proxy
 
 For a custom composite signal, create the signal column upstream and use

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -2,7 +2,10 @@
 title: Standalone metrics
 ---
 
-Every metric under `factrix.metrics` can be run either as part of a multi-metric execution plan using [`evaluate()`][factrix.evaluate] or invoked directly as a **standalone metric** helper on a Polars DataFrame.
+Panel and series metrics under `factrix.metrics` can be run as part of a
+multi-metric execution plan using [`evaluate()`][factrix.evaluate] or invoked
+directly as **standalone metric** helpers. Scalar post-processing helpers are
+direct-call only.
 
 This guide covers direct-call mechanics: input shape, return shape, and
 when to prefer `evaluate()` so the DAG can resolve shared dependencies. For
@@ -14,13 +17,16 @@ metric selection by research question, use [Choosing a metric](choosing-metric.m
 |---|---|---|
 | Long panel `(date, asset_id, factor, forward_return)` | `quantile_spread`, `monotonicity`, `directional_hit_rate`, `rank_turnover` | `MetricResult` or `dict[str, MetricResult]` for batchable helpers |
 | Two-column series `(date, value)` | `oos_decay`, `ic_trend`, `positive_rate` | `MetricResult` |
-| Producer output / aligned auxiliary input | `caar`, `spanning_alpha`, `greedy_forward_selection`, `breakeven_cost`, `net_spread` | `MetricResult` |
+| Producer output / aligned auxiliary input | `caar`, `spanning_alpha`, `greedy_forward_selection` | `MetricResult` |
+| Scalar post-processing values | `breakeven_cost`, `net_spread` | `MetricResult` |
 
 ---
 
 ## 1. Direct standalone calls
 
-You can call any metric callable directly. If the first argument is a Polars DataFrame or Series, the metric runs immediately and returns its results.
+You can call any metric callable directly. If the first argument is a Polars
+DataFrame, Series, or scalar input expected by the helper, the metric runs
+immediately and returns its results.
 
 ### Panel-input metrics
 
@@ -70,7 +76,13 @@ print(decay_res.value)  # OOS/IS retention ratio
 
 ## 2. Integrated evaluation with `evaluate()`
 
-Instead of calling multiple metrics manually and managing intermediate outputs, you can pass them together in the `metrics` dictionary of `fx.evaluate()`. The DAG executor automatically schedules and resolves any shared dependencies (like `compute_ic` or bucketing) to ensure optimal performance.
+Instead of calling multiple panel or series metrics manually and managing
+intermediate outputs, you can pass them together in the `metrics` dictionary of
+`fx.evaluate()`. The DAG executor automatically schedules and resolves any
+shared dependencies (like `compute_ic` or bucketing) to ensure optimal
+performance. Scalar helpers such as `breakeven_cost` and `net_spread` stay
+outside this path: run the upstream diagnostics first, then call the helper
+directly.
 
 ```python
 import factrix as fx

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -77,8 +77,8 @@ contrasts, not a sidecar to a primary value.
 | [`common_quantile_spread`][factrix.metrics.common_quantile.common_quantile_spread] | Wald F (NW HAC, finite-sample) on bucket β contrast | `p_value` | top − bottom bucket β |
 | [`rank_turnover`][factrix.metrics.tradability.rank_turnover] | none — descriptive | — | 1 − mean(rank-AC) |
 | [`notional_turnover`][factrix.metrics.tradability.notional_turnover] | none — descriptive | — | replaced fraction |
-| [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | none — descriptive | — | breakeven spread (bps) |
-| [`net_spread`][factrix.metrics.tradability.net_spread] | none — descriptive | — | net spread (bps) |
+| [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | none — descriptive | — | breakeven single-leg cost (bps) |
+| [`net_spread`][factrix.metrics.tradability.net_spread] | none — descriptive | — | net spread (per-period return) |
 
 ## Per-metric schemas
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -55,6 +55,7 @@ from factrix._axis import (  # DataStructure used by the structure pre-flight; r
     DataStructure,
     FactorDensity,
     FactorScope,
+    InputShape,
     Tier,
 )
 from factrix._codes import WarningCode
@@ -144,6 +145,10 @@ def evaluate(
             ``forward_periods`` is **not** a metric knob: every metric runs at
             the data's single overlap horizon. To compare horizons, build two
             panels and evaluate each.
+            Scalar-input helpers (for example ``breakeven_cost`` /
+            ``net_spread``) are post-processing utilities, not
+            panel-evaluation metrics; compute their upstream diagnostics first
+            and call them directly.
         factor_cols: Names of factor columns on ``data``. List-only —
             single ``str`` is rejected. Non-empty, no duplicates, every
             name must exist on ``data``.
@@ -539,7 +544,8 @@ def _validate_metrics_arg(metrics: object) -> None:
 
         from factrix._axis import SpecRole
 
-        if val.__class__.spec().role is SpecRole.PIPELINE:
+        spec = val.__class__.spec()
+        if spec.role is SpecRole.PIPELINE:
             raise UserInputError(
                 func_name="evaluate",
                 field="metrics",
@@ -548,6 +554,19 @@ def _validate_metrics_arg(metrics: object) -> None:
                     "a standalone metric. Pipeline producers (like compute_ic) "
                     "cannot be evaluated directly; they are pulled automatically "
                     "when you evaluate a downstream metric via its `requires=` dependency."
+                ),
+                docs_path=_DOCS_METRICS,
+            )
+        if spec.input_shape is InputShape.SCALAR:
+            raise UserInputError(
+                func_name="evaluate",
+                field="metrics",
+                value=f"{key!r} -> {val.__class__.__name__}() (input_shape=SCALAR)",
+                expected=(
+                    "a panel- or series-evaluation metric. Scalar helpers such "
+                    "as breakeven_cost() / net_spread() consume already "
+                    "computed metric values; run the upstream diagnostics first "
+                    "and call the helper directly."
                 ),
                 docs_path=_DOCS_METRICS,
             )

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -29,9 +29,11 @@ def compare(
 ) -> pl.DataFrame:
     """Render a wide leaderboard ``pl.DataFrame`` for multiple metrics.
 
-    One row per :class:`EvaluationResult`; two columns per metric —
-    ``<metric_name>`` (``MetricResult.value``) and ``<metric_name>_p_value``
-    (``MetricResult.p_value`` when present, else ``null``).
+    One row per :class:`EvaluationResult`; two columns per requested metric
+    label — ``<metric_label>`` (``MetricResult.value``) and
+    ``<metric_label>_p_value`` (``MetricResult.p_value`` when present,
+    else ``null``). The label is the key in ``EvaluationResult.metrics``,
+    usually the user-supplied key from ``evaluate(metrics={...})``.
 
     Args:
         results: Non-empty list of :class:`EvaluationResult`. Each must
@@ -41,9 +43,10 @@ def compare(
             callers still pass a one-element list; mirrors the
             ``metrics`` contract on ``fx.multi_factor.bhy`` so the
             whole multi-factor API surface uses one shape.
-        sort_by: Optional :class:`str` (must be in ``metrics``)
-            naming the sort key. ``None`` keeps input order and omits
-            the ``rank`` column.
+        sort_by: Optional :class:`str` naming any output column produced
+            before ranking: identity columns, context keys, metric value
+            columns, or ``<metric_label>_p_value`` columns. ``None`` keeps
+            input order and omits the ``rank`` column.
         descending: Sort direction applied to ``sort_by``. Default
             ``True`` (higher-is-better, the common case for ``ic`` /
             ``alpha`` / information ratio). Pass ``descending=False``
@@ -57,42 +60,30 @@ def compare(
     Returns:
         ``pl.DataFrame`` with column order ``factor``,
         ``forward_periods``, context keys (union across results,
-        first-seen order), then ``<m_name>`` / ``<m_name>_p_value`` pairs
+        first-seen order), then ``<metric_label>`` /
+        ``<metric_label>_p_value`` pairs
         in ``metrics`` order, then ``rank`` when ``sort_by`` is set.
 
     Raises:
         UserInputError: Empty ``results``; ``metrics`` not a non-empty
             ``list[str]``; any metric absent from any result's
-            outputs; ``sort_by`` not present in ``metrics``.
+            outputs; ``sort_by`` not present in the output columns.
 
     Examples:
         Multi-metric wide leaderboard sorted on IC:
 
-        >>> ic = fx.metrics.spec_by_name()["ic"]  # doctest: +SKIP
-        >>> sharpe = fx.metrics.spec_by_name()["sharpe"]  # doctest: +SKIP
         >>> board = fx.compare(  # doctest: +SKIP
-        ...     results, metrics=[ic, sharpe], sort_by=ic
+        ...     results, metrics=["ic", "sharpe"], sort_by="ic"
         ... )
 
         Lower-is-better metric (``descending=False``):
 
-        >>> rank_turnover = fx.metrics.spec_by_name()["rank_turnover"]  # doctest: +SKIP
         >>> board = fx.compare(  # doctest: +SKIP
-        ...     results, metrics=[rank_turnover], sort_by=rank_turnover, descending=False
+        ...     results, metrics=["rank_turnover"], sort_by="rank_turnover", descending=False
         ... )
     """
     metric_list = _validate_metric_list(metrics, func_name="compare", field="metrics")
     _require_non_empty_results(results, func_name="compare")
-    if sort_by is not None and sort_by not in {m for m in metric_list}:
-        raise UserInputError(
-            func_name="compare",
-            field="sort_by",
-            value=sort_by,
-            expected="str that appears in `metrics`",
-            candidates=[m for m in metric_list],
-            docs_path="api/compare#sort_by",
-        )
-
     context_keys = _ordered_keys(r.context for r in results)
     rows: list[dict[str, Any]] = []
     for r in results:
@@ -122,6 +113,16 @@ def compare(
 
     data = pl.DataFrame(rows)
     if sort_by is not None:
+        sort_candidates = list(data.columns)
+        if sort_by not in sort_candidates:
+            raise UserInputError(
+                func_name="compare",
+                field="sort_by",
+                value=sort_by,
+                expected="one of the columns produced by compare()",
+                candidates=sort_candidates,
+                docs_path="api/compare#sort_by",
+            )
         data = data.sort(sort_by, descending=descending, nulls_last=True)
         data = data.with_columns(
             pl.int_range(1, data.height + 1, dtype=pl.Int64).alias("rank")

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
-from factrix._axis import DataStructure, FactorDensity, FactorScope, Tier
+from factrix._axis import DataStructure, FactorDensity, FactorScope, InputShape, Tier
 from factrix._codes import WarningCode, cross_section_tier
 from factrix._data_input import _FORWARD_PERIODS_COL
 from factrix._metric_index import MetricSpec, public_specs
@@ -261,9 +261,8 @@ class _FMStage1Profile:
 def _default_constructible(metric: Any) -> bool:
     """True when the metric class can be instantiated with no arguments.
 
-    Scalar-input utilities (e.g. ``breakeven_cost`` / ``net_spread``) declare
-    required parameters (``turnover`` / ``forward_periods`` …) and consume
-    pre-aggregated scalars rather than a data, so they are not part of the
+    Scalar-input utilities (e.g. ``breakeven_cost`` / ``net_spread``) consume
+    pre-aggregated scalars rather than panel data, so they are not part of the
     zero-config discovery -> :func:`factrix.evaluate` flow.
     """
     return all(
@@ -305,8 +304,9 @@ class MetricApplicabilityGroup(list["MetricApplicability"]):
             results = fx.evaluate(data, metrics=info.usable.to_metrics_dict(),
                                   factor_cols=[...], forward_periods=5)
 
-        Metrics whose class needs explicit construction arguments (the
-        scalar-input utilities) are omitted — construct and add those by hand.
+        Scalar-input utilities are kept out of ``usable`` and therefore out
+        of this bridge: compute their upstream values first, then call the
+        helper directly.
         """
         return {m.name: m.metric() for m in self if _default_constructible(m.metric)}
 
@@ -655,7 +655,8 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
                         f"Factor columns carry inconsistent FactorDensity: {{{detail}}}. "
                         f"Metric applicability is based on '{first_col}'; call "
                         f"inspect_data(data, factor_cols=[<col>]) for a verdict "
-                        f"specific to that column."
+                        f"specific to that column. Split heterogeneous factor "
+                        f"columns into separate inspect_data/evaluate batches."
                     ),
                 )
             )
@@ -672,7 +673,9 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
                         f"Factor columns carry inconsistent FactorScope: {{{detail}}}. "
                         f"Metric applicability is based on '{first_col}'; call "
                         f"inspect_data(data, factor_cols=[<col>]) for a verdict "
-                        f"specific to that column."
+                        f"specific to that column. Split asset-specific and "
+                        f"common macro factors into separate inspect_data/evaluate "
+                        f"batches."
                     ),
                 )
             )
@@ -799,6 +802,13 @@ def _evaluate_applicability(
             "(e.g. a ternary {-1, 0, +1} indicator); this metric needs a "
             "continuous magnitude and short-circuits "
             "not_applicable_discrete_signal at run time"
+        )
+
+    if spec.input_shape is InputShape.SCALAR:
+        blockers.append(
+            "scalar input utility: compute the upstream metric values first, "
+            "then call this helper directly; it is not runnable from "
+            "inspect_data().usable.to_metrics_dict()"
         )
 
     threshold_properties = properties

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -46,7 +46,6 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _short_circuit_output,
 )
-from factrix.metrics.quantile import quantile_spread
 
 _TR_CELL = cell(
     FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
@@ -439,7 +438,6 @@ def notional_turnover(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     input_shape=InputShape.SCALAR,
-    requires={"gross_spread": quantile_spread, "turnover": notional_turnover},
     sample_threshold=SampleThreshold(),
 )
 def breakeven_cost(
@@ -530,7 +528,6 @@ def breakeven_cost(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     input_shape=InputShape.SCALAR,
-    requires={"gross_spread": quantile_spread, "turnover": notional_turnover},
     sample_threshold=SampleThreshold(),
 )
 def net_spread(

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -49,6 +49,22 @@ def test_multi_metric_wide_layout():
     assert df["sharpe"].to_list() == [pytest.approx(1.2), pytest.approx(0.8)]
 
 
+def test_p_value_column_uses_requested_metric_label():
+    make_spec("custom_ic")
+    results = [make_result(factor="a", p=0.03, metric="custom_ic", value=0.07)]
+
+    df = compare(results, metrics=["custom_ic"], sort_by="custom_ic_p_value")
+
+    assert df.columns == [
+        "factor",
+        "forward_periods",
+        "custom_ic",
+        "custom_ic_p_value",
+        "rank",
+    ]
+    assert df["custom_ic_p_value"].to_list() == [pytest.approx(0.03)]
+
+
 def test_sort_by_descending_true_adds_rank():
     make_spec("ic")
     results = [
@@ -73,6 +89,32 @@ def test_sort_by_descending_false_ranks_low_first():
     )
     assert df["factor"].to_list() == ["low_to", "mid_to", "high_to"]
     assert df["rank"].to_list() == [1, 2, 3]
+
+
+def test_sort_by_p_value_column():
+    make_spec("ic")
+    results = [
+        make_result(factor="weak", p=0.5, metric="ic", value=0.10),
+        make_result(factor="strong", p=0.01, metric="ic", value=0.01),
+        make_result(factor="mid", p=0.1, metric="ic", value=0.05),
+    ]
+    df = compare(results, metrics=["ic"], sort_by="ic_p_value", descending=False)
+    assert df["factor"].to_list() == ["strong", "mid", "weak"]
+    assert df["rank"].to_list() == [1, 2, 3]
+
+
+def test_sort_by_identity_and_context_columns():
+    make_spec("ic")
+    results = [
+        make_result(factor="b", p=0.1, metric="ic", context={"region": "US"}),
+        make_result(factor="a", p=0.1, metric="ic", context={"region": "EU"}),
+    ]
+
+    by_factor = compare(results, metrics=["ic"], sort_by="factor", descending=False)
+    assert by_factor["factor"].to_list() == ["a", "b"]
+
+    by_context = compare(results, metrics=["ic"], sort_by="region", descending=False)
+    assert by_context["region"].to_list() == ["EU", "US"]
 
 
 def test_no_sort_keeps_input_order_omits_rank():
@@ -142,9 +184,10 @@ def test_missing_metric_raises():
         compare(results, metrics=["other"])
 
 
-def test_sort_by_not_in_metrics_raises():
+def test_sort_by_unknown_output_column_raises():
     make_spec("ic")
     make_spec("sharpe")
     results = [make_result(factor="f", p=0.01, metric="ic")]
-    with pytest.raises(UserInputError, match="unknown sort_by"):
+    with pytest.raises(UserInputError, match="unknown sort_by") as excinfo:
         compare(results, metrics=["ic"], sort_by="sharpe")
+    assert "ic_p_value" in str(excinfo.value)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -15,6 +15,7 @@ from factrix.metrics import (
     ic,
     ic_ir,
     ic_trend,
+    net_spread,
     oos_decay,
     positive_rate,
 )
@@ -100,6 +101,10 @@ class TestMetricsValidation:
     def test_overview_rejected_with_guidance(self):
         with pytest.raises(UserInputError, match="overview catalog"):
             _eval(fx.list_metrics())
+
+    def test_scalar_input_helper_rejected_with_guidance(self):
+        with pytest.raises(UserInputError, match="Scalar helpers"):
+            _eval({"net": net_spread(turnover=0.2)})
 
     def test_non_numeric_factor_column_rejected_at_entry(self):
         panel = _panel().with_columns(pl.lit("buy").alias("factor_text"))

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -770,7 +770,7 @@ class TestMetricApplicabilityGroup:
         info = self._info()
         assert info.usable.names == [m.name for m in info.usable]
 
-    def test_to_metrics_dict_shape_and_excludes_scalar_utilities(self):
+    def test_to_metrics_dict_shape_and_flags_scalar_utilities(self):
         from factrix.metrics._base import MetricBase
 
         info = self._info()
@@ -778,9 +778,15 @@ class TestMetricApplicabilityGroup:
         assert md, "fixture should have usable metrics"
         assert all(isinstance(v, MetricBase) for v in md.values())
         assert set(md) <= set(info.usable.names)
-        # breakeven_cost / net_spread need required scalar args -> omitted.
         assert "breakeven_cost" not in md
         assert "net_spread" not in md
+        scalar_blocked = {
+            m.name: m.blockers
+            for m in info.unusable
+            if m.name in {"breakeven_cost", "net_spread"}
+        }
+        assert set(scalar_blocked) == {"breakeven_cost", "net_spread"}
+        assert all("scalar input utility" in blockers[0] for blockers in scalar_blocked.values())
 
     def test_slice_preserves_type(self):
         info = self._info()
@@ -874,12 +880,14 @@ class TestCrossFactorConsistency:
         )
         assert "'factor': dense" in density_warning.message
         assert "'factor3': sparse" in density_warning.message
+        assert "separate inspect_data/evaluate batches" in density_warning.message
 
         scope_warning = next(
             w for w in info.warnings if w.code.value == "cross_factor_scope_mismatch"
         )
         assert "'factor': individual" in scope_warning.message
         assert "'factor2': common" in scope_warning.message
+        assert "asset-specific and common macro factors" in scope_warning.message
 
     def test_factor_cols_restricts_scope(self):
         raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=30, seed=1)

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -786,7 +786,10 @@ class TestMetricApplicabilityGroup:
             if m.name in {"breakeven_cost", "net_spread"}
         }
         assert set(scalar_blocked) == {"breakeven_cost", "net_spread"}
-        assert all("scalar input utility" in blockers[0] for blockers in scalar_blocked.values())
+        assert all(
+            "scalar input utility" in blockers[0]
+            for blockers in scalar_blocked.values()
+        )
 
     def test_slice_preserves_type(self):
         info = self._info()


### PR DESCRIPTION
## Summary
- Keep scalar cost helpers out of inspect_data usable metrics and evaluate panel dispatch.
- Let compare sort by produced output columns, including custom-label p-value columns.
- Clarify allocation diagnostics, tradability helpers, and mixed factor batch guidance in docs.

## Test plan
- [x] .\.venv\Scripts\python.exe -m ruff check factrix\__init__.py factrix\_compare.py factrix\_inspect.py factrix\metrics\tradability.py tests\test_compare.py tests\test_evaluate.py tests\test_inspect_data.py
- [x] .\.venv\Scripts\python.exe -m pytest -q -p no:faulthandler

Closes #749
