### PR TITLE
fix(metrics): align single-asset diagnostics (#748)

### DIFF
--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -63,3 +63,10 @@ by significance, use the p-value column and set `descending=False`:
 ```python
 df = fx.compare(results, metrics=["ic"], sort_by="ic_p_value", descending=False)
 ```
+
+For signed metrics such as `predictive_beta`, sorting by the raw value answers
+"largest positive effect", not "strongest evidence". A strongly negative but
+highly significant factor will rank low under `sort_by="predictive_beta"` with
+the default descending order. Use the p-value column for significance screens,
+or sort on `abs(value)` in caller code when magnitude regardless of sign is the
+intended ranking.

--- a/docs/api/metrics/directional_hit_rate.md
+++ b/docs/api/metrics/directional_hit_rate.md
@@ -46,7 +46,10 @@ title: factrix.metrics.directional_hit_rate
     its sign before testing). Observations are sub-sampled at stride
     `forward_periods` so overlapping forward-return windows do not
     inflate the statistic; degenerate samples (one-signed predictions or
-    realisations) short-circuit to `NaN`.
+    realisations) short-circuit to `NaN`. `inspect_data()` also blocks
+    obviously one-sided factor signs up front, so bulk discovery does not
+    advertise `directional_hit_rate` as clean when runtime would hit
+    `degenerate_directional_variance`.
 
 </div>
 

--- a/docs/api/metrics/event_quality.md
+++ b/docs/api/metrics/event_quality.md
@@ -52,7 +52,10 @@ title: factrix.metrics.event_quality
     ---
 
     `profit_factor` reports $\sum\text{gains} / |\sum\text{losses}|$ as
-    a descriptive gross ratio; `event_skewness` reports the Fisher-
+    a descriptive gross ratio. If gains are positive and losses are zero,
+    the ratio is unbounded (`value = inf`, `profit_factor_status =
+    "unbounded_no_losses"`); if both are zero, the ratio is undefined
+    (`value = NaN`). `event_skewness` reports the Fisher-
     corrected skewness of the `signed_car` distribution with a
     D'Agostino test when `n_events >= 20`. Useful for screening
     fat-right-tail vs symmetric event payoffs.

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -41,6 +41,28 @@ flowchart LR
 
 ::: factrix.metrics_summary
 
+On Windows legacy consoles, Unicode table borders or symbols in docstring
+summaries may fail to render. The discovery object is a normal Polars
+`DataFrame`, so use an ASCII or records path when browsing interactively:
+
+```python
+import polars as pl
+import factrix as fx
+
+with pl.Config(ascii_tables=True):
+    print(fx.metrics_summary())
+
+# Or avoid console table formatting entirely:
+records = fx.metrics_summary().to_dicts()
+```
+
+In PowerShell, running Python in UTF-8 mode is also safe:
+
+```powershell
+$env:PYTHONUTF8 = "1"
+python -c "import factrix as fx; print(fx.metrics_summary())"
+```
+
 ### Full specs: `list_metrics()`
 
 ::: factrix.list_metrics

--- a/docs/api/metrics/predictive_beta.md
+++ b/docs/api/metrics/predictive_beta.md
@@ -39,6 +39,17 @@ title: factrix.metrics.predictive_beta
     so overlapping forward-return windows do not understate standard
     errors.
 
+-   __Persistent predictor diagnostic__
+
+    ---
+
+    The metric also runs a lightweight ADF check on the factor series.
+    When `adf_p` exceeds `adf_threshold`, metadata sets
+    `unit_root_suspected=True` and the result carries
+    `WarningCode.PERSISTENT_REGRESSOR`. The beta is still returned; the
+    warning tells you to read the slope as a persistent-regressor risk,
+    not as an automatically corrected estimate.
+
 </div>
 
 ## Worked example
@@ -65,5 +76,5 @@ title: factrix.metrics.predictive_beta
         forward_periods=5,
     )["factor"].metrics["predictive_beta"]
 
-    print(out.value, out.stat, out.p_value)
+    print(out.value, out.stat, out.p_value, out.metadata["unit_root_suspected"])
     ```

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -94,8 +94,10 @@ Each `factrix/metrics/*.py` module decorates its public callables with
   = `*` wildcard on any axis.
 - `spec_by_name() -> dict[str, MetricSpec]` — name → spec lookup across every
   registered metric.
-- `public_specs()` — visibility-filtered specs (drops `PIPELINE`-role stage-1
-  helpers pulled only via `requires`).
+- `public_specs()` — visibility-filtered `(family, MetricSpec)` pairs (drops
+  `PIPELINE`-role stage-1 helpers pulled only via `requires`). The family is
+  the declaring module stem; callers that only need specs should iterate
+  `for _, spec in public_specs()`.
 - `list_metrics()` — the public runtime discovery API, grouped by metric family.
 
 `@metric`-class registration feeds the index via

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -126,7 +126,7 @@ Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-fri
 The most common warnings include:
 
 - `UNRELIABLE_SE_SHORT_PERIODS` — $20 \le T < 30$; Newey-West (NW) HAC SE is unstable. (Falling below the metric's hard sample floor raises `InsufficientSampleError` under `strict=True`; the exact floor is metric-specific).
-- `PERSISTENT_REGRESSOR` — factor augmented Dickey-Fuller (ADF) $p$-value > 0.10.
+- `PERSISTENT_REGRESSOR` — factor augmented Dickey-Fuller (ADF) $p$-value exceeds the configured threshold (default 0.10).
 - `EVENT_WINDOW_OVERLAP` — event windows overlap on the same asset.
 - `SERIAL_CORRELATION_DETECTED` — Ljung-Box $p$-value < 0.05 on residuals.
 

--- a/docs/reference/_generated_warning_codes.md
+++ b/docs/reference/_generated_warning_codes.md
@@ -2,7 +2,7 @@
 |---|---|
 | `unreliable_se_short_periods` | n_periods is below the WARN floor (~30); NW HAC SE may be biased. Reused across panel time-series guards (MIN_PERIODS_WARN) and primitive inference (MIN_FM_PERIODS_WARN); both default to 30. |
 | `event_window_overlap` | Adjacent events sit within forward_periods; AR windows overlap. |
-| `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
+| `persistent_regressor` | ADF p exceeds the configured threshold on the continuous factor; beta may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
 | `few_assets` | Cross-section asset count is below the relevant WARN floor (panel-wide MIN_ASSETS_WARN=30, per-date MIN_IC_ASSETS_WARN=10, or per-date MIN_FM_ASSETS_WARN=10). The statistic is returned, but small n_assets inflates critical values or leaves minimal residual degrees of freedom. Severity scales with n_assets; read the relevant n_assets metadata. |
 | `thin_quantile_groups` | quantile_spread with the median cross-section split into n_groups buckets leaving < MIN_GROUP_ASSETS (5) assets per bucket; each bucket mean rests on a handful of names so the spread can be dominated by individual assets. Advisory only — reduce n_groups (the warning suggests a value) or treat the spread as a fragile small-cross-section diagnostic. Distinct from few_assets, which keys off the absolute cross-section size. |

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -21,15 +21,24 @@ structure-aware per-panel applicability, use
 
 ## Sample dimensions
 
-factrix expresses sample size on three axes (see
-[Concepts](../getting-started/concepts.md) for cell taxonomy):
+factrix expresses sample-size gates on four sample axes (see
+[Concepts](../getting-started/concepts.md) for cell taxonomy and
+[Architecture](../development/architecture.md#sample-guards) for the naming
+grammar):
 
-- `n_assets` — assets in the panel (`asset_id` unique count).
-- `T` — date count (`date` unique count).
-- `K` — non-zero event count for `Sparse` factors
-  (`filter(factor != 0).height`).
-- `T/h` — non-overlapping date count given
-  `forward_periods = h`.
+- `assets` / `n_assets` — assets in the panel (`asset_id` unique count), or
+  the pairwise-complete per-date asset count for IC / FM primitives.
+- `periods` / `T` — date count (`date` unique count), reported in runtime
+  metadata as `n_periods`.
+- `pairs` / `n_pairs` — complete `(date, asset)` observations, or
+  metric-specific comparable pairs such as directional trials.
+- `events` / `K` — non-zero event count for `Sparse` factors
+  (`filter(factor != 0).height`) or event-date count where the metric collapses
+  same-date events.
+
+Derived effective counts such as `T/h` are not independent axes. They are
+period-axis counts after a horizon / non-overlap stride (`forward_periods = h`)
+has reduced the usable date sample.
 
 `DataStructure` is derived from `n_assets` at evaluate-time: `PANEL` for
 `n_assets >= 2`, `TIMESERIES` for `n_assets == 1`. Each metric's `MetricSpec` declares the cell it

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -265,7 +265,11 @@ skewness in `value` only.
 Descriptive; no test.
 
 - *descriptive*: `total_gains`, `total_losses`, `n_events`, `n_wins`,
-  `n_losses`.
+  `n_losses`, `no_gains`, `no_losses`, `profit_factor_status`.
+  `profit_factor_status` is `"finite"` for ordinary gain/loss samples,
+  `"unbounded_no_losses"` when positive gains have no offsetting losses
+  (`value = inf`), and `"undefined_no_gains_or_losses"` when both gross gains
+  and gross losses are zero (`value = NaN`).
 
 #### `signal_density`
 
@@ -446,7 +450,11 @@ Newey-West HAC `t` statistic for `H0: beta = 0`.
 
 - *primary*: `p_value` — two-sided HAC slope test.
 - *descriptive*: `n_periods`, `newey_west_lags`, `forward_periods`,
-  `alpha`, `r_squared`, `factor_std`.
+  `alpha`, `r_squared`, `factor_std`, `adf_stat`, `adf_p`,
+  `adf_threshold`, `unit_root_suspected`.
+- *warning*: `WarningCode.PERSISTENT_REGRESSOR` when the ADF p-value exceeds
+  `adf_threshold`; the HAC slope is still returned, but the predictive
+  regression may carry persistent-regressor bias.
 - *short-circuit*: `reason` `insufficient_predictive_periods`,
   `degenerate_factor_variance`, `no_factor_column`, or
   `no_return_column`.

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -145,8 +145,9 @@ pipeline; we leave that branch to qlib.
 
 **Persistent-predictor flagging only, not auto-correction** —
 when the cross-sectional or time-series predictor is highly
-persistent (ADF p > 0.10), factrix raises
-`PERSISTENT_REGRESSOR` and notes that the β estimate may carry
+persistent (ADF p-value above the configured threshold; default 0.10),
+factrix raises
+`PERSISTENT_REGRESSOR` and notes that the beta estimate may carry
 Stambaugh (1999) bias. It does not silently swap in IVX
 (Phillips-Magdalinos), Stambaugh-correction, or sign-restricted
 inference, because the right correction depends on the

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -17,8 +17,9 @@ class WarningCode(StrEnum):
 
     UNRELIABLE_SE_SHORT_PERIODS = "unreliable_se_short_periods"
     EVENT_WINDOW_OVERLAP = "event_window_overlap"
-    # Fired when ADF p > 0.1 on a DENSE factor (Stambaugh-style
-    # persistent-regressor flag, §5.2 / §7.3). Not raised for SPARSE.
+    # Fired when ADF p exceeds the configured threshold on a DENSE factor
+    # (Stambaugh-style persistent-regressor flag, section 5.2 / 7.3).
+    # Not raised for SPARSE.
     PERSISTENT_REGRESSOR = "persistent_regressor"
     SERIAL_CORRELATION_DETECTED = "serial_correlation_detected"
     # Single cross-asset n_assets guard for PANEL common_continuous: the cross-asset
@@ -183,7 +184,7 @@ _WARNING_DESCRIPTIONS.update(
         "Reused across panel time-series guards (MIN_PERIODS_WARN) and "
         "primitive inference (MIN_FM_PERIODS_WARN); both default to 30.",
         WarningCode.EVENT_WINDOW_OVERLAP: "Adjacent events sit within forward_periods; AR windows overlap.",
-        WarningCode.PERSISTENT_REGRESSOR: "ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias.",
+        WarningCode.PERSISTENT_REGRESSOR: "ADF p exceeds the configured threshold on the continuous factor; beta may carry Stambaugh bias.",
         WarningCode.SERIAL_CORRELATION_DETECTED: "Ljung-Box p < 0.05 on residuals; NW lag may be under-set.",
         WarningCode.FEW_ASSETS: "Cross-section asset count is below the "
         "relevant WARN floor (panel-wide MIN_ASSETS_WARN=30, per-date "

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -150,6 +150,17 @@ def _detect_scope(raw: Any) -> tuple[FactorScope, str]:
     )
 
 
+def _factor_sign_is_one_sided(raw: Any, factor_col: str) -> bool:
+    """True when non-zero factor signs contain exactly one side."""
+    signs = (
+        raw.select(pl.col(factor_col).sign().alias("_sign"))
+        .filter(pl.col("_sign").is_not_null() & (pl.col("_sign") != 0))
+        .select(pl.col("_sign").n_unique())
+        .item()
+    )
+    return int(signs) == 1
+
+
 @dataclass(frozen=True, slots=True)
 class DataProperties:
     """Inspected data properties driving cell dispatch.
@@ -607,6 +618,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     # matching the ``factor != 0`` filter the event-driven metrics apply.
     n_events = int(data.filter(pl.col(first_col) != 0).height)
     n_unique_factor = int(data[first_col].drop_nulls().n_unique())
+    factor_sign_one_sided = _factor_sign_is_one_sided(data, first_col)
     ic_stage1_profile = _compute_ic_stage1_profile(data, first_col)
     fm_stage1_profile = _compute_fm_stage1_profile(data, first_col)
 
@@ -694,6 +706,7 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
             spec,
             properties,
             signal_discrete,
+            factor_sign_one_sided,
             ic_stage1_profile=ic_stage1_profile,
             fm_stage1_profile=fm_stage1_profile,
         )
@@ -751,6 +764,7 @@ def _evaluate_applicability(
     spec: MetricSpec,
     properties: DataProperties,
     signal_discrete: bool,
+    factor_sign_one_sided: bool = False,
     ic_stage1_profile: _ICStage1Profile | None = None,
     fm_stage1_profile: _FMStage1Profile | None = None,
 ) -> MetricApplicability:
@@ -802,6 +816,15 @@ def _evaluate_applicability(
             "(e.g. a ternary {-1, 0, +1} indicator); this metric needs a "
             "continuous magnitude and short-circuits "
             "not_applicable_discrete_signal at run time"
+        )
+
+    if spec.name == "directional_hit_rate" and factor_sign_one_sided:
+        blockers.append(
+            "one-sided directional signal: sign(factor) has only one non-zero "
+            "side, so directional_hit_rate would short-circuit "
+            "degenerate_directional_variance at run time; center, threshold, "
+            "or encode a true two-sided directional signal before using this "
+            "metric"
         )
 
     if spec.input_shape is InputShape.SCALAR:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -427,7 +427,7 @@ The canonical glosses live in `factrix._codes.WarningCode.description` and are r
 |---|---|
 | `unreliable_se_short_periods` | `n_periods` is below the WARN floor (~30, `MIN_PERIODS_WARN` / `MIN_FM_PERIODS_WARN`); NW HAC SE may be biased. |
 | `event_window_overlap` | Adjacent events sit within `forward_periods`; AR windows overlap. |
-| `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
+| `persistent_regressor` | ADF p exceeds the configured threshold on the continuous factor; beta may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
 | `few_assets` | Cross-section asset count below the relevant WARN floor (`MIN_ASSETS_WARN`, `MIN_IC_ASSETS_WARN`, or `MIN_FM_ASSETS_WARN`); severity in the n_assets metadata. |
 | `thin_quantile_groups` | `quantile_spread` left < `MIN_GROUP_ASSETS` (5) assets per bucket; spread can be dominated by individual assets. Advisory only. |

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -274,9 +274,10 @@ def profit_factor(
         ``PF > 1`` means gross gains exceed gross losses across all
         events; the metric ignores per-event variance.
 
-        factrix returns ``0.0`` rather than infinity when total losses
-        are below ``EPSILON`` so downstream aggregators do not propagate
-        non-finite floats.
+        When gains are positive and losses are zero, factrix returns
+        ``inf``: the gross gain/loss ratio is unbounded, not zero. When
+        both gains and losses are zero, the ratio is undefined and the
+        metric returns ``NaN`` with ``metadata["profit_factor_status"]``.
 
     Examples:
         >>> import factrix as fx
@@ -304,7 +305,17 @@ def profit_factor(
     gains = float(np.sum(signed[signed > 0]))
     losses = float(np.abs(np.sum(signed[signed < 0])))
 
-    pf = gains / losses if losses > EPSILON else 0.0
+    no_gains = gains <= EPSILON
+    no_losses = losses <= EPSILON
+    if no_losses and no_gains:
+        pf = float("nan")
+        status = "undefined_no_gains_or_losses"
+    elif no_losses:
+        pf = float("inf")
+        status = "unbounded_no_losses"
+    else:
+        pf = gains / losses
+        status = "finite"
 
     return MetricResult(
         value=pf,
@@ -316,6 +327,9 @@ def profit_factor(
             "n_events": n,
             "n_wins": int(np.sum(signed > 0)),
             "n_losses": int(np.sum(signed < 0)),
+            "no_gains": no_gains,
+            "no_losses": no_losses,
+            "profit_factor_status": status,
         },
     )
 

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -21,7 +21,7 @@ from factrix._axis import Aggregation, DataStructure, FactorDensity, InputShape
 from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._stats import _ols_nw_slope_t, _resolve_nw_lags
+from factrix._stats import _adf, _ols_nw_slope_t, _resolve_nw_lags
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
 from factrix._types import DDOF, EPSILON
 from factrix.metrics._decorators import metric
@@ -48,6 +48,7 @@ def predictive_beta(
     *,
     newey_west_lags: int | None = None,
     forward_periods: int = 5,
+    adf_threshold: float | None = 0.10,
     factor_col: str = "factor",
     return_col: str = "forward_return",
 ) -> MetricResult:
@@ -67,6 +68,8 @@ def predictive_beta(
             project default bandwidth.
         forward_periods: Forward-return horizon injected by ``evaluate`` from
             the panel metadata; standalone calls may pass it directly.
+        adf_threshold: Augmented Dickey-Fuller p-value above which the
+            factor is flagged as persistent. ``None`` disables the check.
         factor_col: Predictor column.
         return_col: Forward-return column.
 
@@ -80,6 +83,11 @@ def predictive_beta(
         metric. ``predictive_beta`` is the explicit TIMESERIES dense metric
         for a single asset.
     """
+    if adf_threshold is not None and not (0.0 < adf_threshold < 1.0):
+        raise ValueError(
+            f"adf_threshold must be a probability in (0, 1) or None, "
+            f"got {adf_threshold!r}"
+        )
     if factor_col not in data.columns:
         return _short_circuit_output(
             "predictive_beta",
@@ -128,7 +136,21 @@ def predictive_beta(
     ss_tot = float(np.dot(y_c, y_c))
     r_squared = 0.0 if ss_tot < EPSILON else max(0.0, 1.0 - ss_res / ss_tot)
 
+    adf_metadata: dict[str, float | bool] = {}
+    unit_root_suspected = False
+    if adf_threshold is not None:
+        adf_stat, adf_p = _adf(x)
+        unit_root_suspected = adf_p > adf_threshold
+        adf_metadata = {
+            "adf_stat": adf_stat,
+            "adf_p": adf_p,
+            "adf_threshold": adf_threshold,
+            "unit_root_suspected": unit_root_suspected,
+        }
+
     warning_codes: list[str] = []
+    if unit_root_suspected:
+        warning_codes.append(WarningCode.PERSISTENT_REGRESSOR.value)
     warn_code = _warn_below_floor(
         predictive_beta,
         n,
@@ -158,5 +180,6 @@ def predictive_beta(
             "alpha": alpha,
             "r_squared": r_squared,
             "factor_std": x_std,
+            **adf_metadata,
         },
     )

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -355,6 +355,18 @@ class TestDeclaredPeriodsFloorsVisible:
         assert da.usable is True
         assert da.warnings == []
 
+    def test_directional_hit_rate_blocks_one_sided_factor_sign(self):
+        raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=80)
+        data = raw.with_columns((pl.col("factor").abs() + 0.1).alias("factor"))
+
+        info = inspect_data(data)
+        da = _by_name(info, "directional_hit_rate")
+
+        assert da.usable is False
+        assert da in info.unusable
+        assert any("one-sided directional signal" in b for b in da.blockers)
+        assert any("degenerate_directional_variance" in b for b in da.blockers)
+
     def test_top_concentration_declares_periods_floors(self):
         from factrix._types import (
             MIN_PORTFOLIO_PERIODS_HARD,

--- a/tests/test_mfe_mae.py
+++ b/tests/test_mfe_mae.py
@@ -219,6 +219,19 @@ class TestMfeMae:
 
 
 class TestProfitFactor:
+    def _event_outcomes(self, returns: list[float]) -> pl.DataFrame:
+        n = len(returns)
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)
+                ],
+                "asset_id": ["A"] * n,
+                "factor": [1.0] * n,
+                "forward_return": returns,
+            }
+        )
+
     def test_strong_signal_above_one(self, event_data):
         result = profit_factor(event_data)
         assert result.value > 0
@@ -227,6 +240,35 @@ class TestProfitFactor:
         result = profit_factor(event_data)
         assert "total_gains" in result.metadata
         assert "total_losses" in result.metadata
+
+    def test_no_losses_returns_unbounded_ratio(self):
+        result = profit_factor(self._event_outcomes([0.01, 0.02, 0.03, 0.04]))
+        assert math.isinf(result.value)
+        assert result.metadata["no_losses"] is True
+        assert result.metadata["no_gains"] is False
+        assert result.metadata["profit_factor_status"] == "unbounded_no_losses"
+
+    def test_no_gains_with_losses_returns_zero(self):
+        result = profit_factor(self._event_outcomes([-0.01, -0.02, -0.03, -0.04]))
+        assert result.value == 0.0
+        assert result.metadata["no_gains"] is True
+        assert result.metadata["no_losses"] is False
+        assert result.metadata["profit_factor_status"] == "finite"
+
+    def test_no_gains_or_losses_returns_nan(self):
+        result = profit_factor(self._event_outcomes([0.0, 0.0, 0.0, 0.0]))
+        assert math.isnan(result.value)
+        assert result.metadata["no_gains"] is True
+        assert result.metadata["no_losses"] is True
+        assert (
+            result.metadata["profit_factor_status"]
+            == "undefined_no_gains_or_losses"
+        )
+
+    def test_mixed_events_return_finite_ratio(self):
+        result = profit_factor(self._event_outcomes([0.03, -0.01, 0.02, -0.04]))
+        assert result.value == pytest.approx(1.0)
+        assert result.metadata["profit_factor_status"] == "finite"
 
     def test_insufficient_events(self):
         df = pl.DataFrame(

--- a/tests/test_mfe_mae.py
+++ b/tests/test_mfe_mae.py
@@ -223,9 +223,7 @@ class TestProfitFactor:
         n = len(returns)
         return pl.DataFrame(
             {
-                "date": [
-                    datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)
-                ],
+                "date": [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)],
                 "asset_id": ["A"] * n,
                 "factor": [1.0] * n,
                 "forward_return": returns,
@@ -260,10 +258,7 @@ class TestProfitFactor:
         assert math.isnan(result.value)
         assert result.metadata["no_gains"] is True
         assert result.metadata["no_losses"] is True
-        assert (
-            result.metadata["profit_factor_status"]
-            == "undefined_no_gains_or_losses"
-        )
+        assert result.metadata["profit_factor_status"] == "undefined_no_gains_or_losses"
 
     def test_mixed_events_return_finite_ratio(self):
         result = profit_factor(self._event_outcomes([0.03, -0.01, 0.02, -0.04]))

--- a/tests/test_predictive_beta.py
+++ b/tests/test_predictive_beta.py
@@ -39,6 +39,38 @@ class TestPredictiveBetaStatistic:
         assert result.n_obs_axis == "periods"
         assert result.metadata["h0"] == "beta=0"
         assert result.metadata["newey_west_lags"] == _resolve_nw_lags(240, None, 5)
+        assert result.metadata["unit_root_suspected"] is False
+        assert WarningCode.PERSISTENT_REGRESSOR.value not in result.warning_codes
+
+    def test_persistent_factor_sets_adf_warning(self) -> None:
+        rng = np.random.default_rng(42)
+        x = np.cumsum(rng.normal(size=240))
+        y = 0.05 * x + rng.normal(size=240)
+
+        result = predictive_beta(_ts_panel(x, y), forward_periods=1)
+
+        assert result.metadata["adf_p"] > 0.10
+        assert result.metadata["unit_root_suspected"] is True
+        assert WarningCode.PERSISTENT_REGRESSOR.value in result.warning_codes
+
+    def test_adf_threshold_none_disables_persistence_check(self) -> None:
+        rng = np.random.default_rng(0)
+        result = predictive_beta(
+            _ts_panel(rng.normal(size=120), rng.normal(size=120)),
+            forward_periods=1,
+            adf_threshold=None,
+        )
+        assert "adf_stat" not in result.metadata
+        assert "adf_p" not in result.metadata
+        assert "unit_root_suspected" not in result.metadata
+
+    def test_adf_threshold_out_of_range_raises(self) -> None:
+        rng = np.random.default_rng(0)
+        with pytest.raises(ValueError, match="adf_threshold"):
+            predictive_beta(
+                _ts_panel(rng.normal(size=120), rng.normal(size=120)),
+                adf_threshold=1.0,
+            )
 
     def test_independent_factor_not_significant(self) -> None:
         rng = np.random.default_rng(2)


### PR DESCRIPTION
## Summary
- Fix profit_factor no-loss semantics and document unbounded/undefined statuses.
- Add predictive_beta ADF persistence metadata with PERSISTENT_REGRESSOR warning.
- Block one-sided directional_hit_rate candidates during inspect_data and sync docs for #748 contracts.

Closes #748
Refs #752
