### PR TITLE
docs(examples): add gross-to-net feasibility (#750)

### DIFF
--- a/docs/examples/stock_factor_evaluation.md
+++ b/docs/examples/stock_factor_evaluation.md
@@ -29,6 +29,7 @@ import factrix as fx
 import factrix.preprocess as fprep
 import polars as pl
 from factrix.metrics import fm_beta, ic, notional_turnover, quantile_spread
+from factrix.metrics.tradability import breakeven_cost, net_spread
 ```
 
 ## 2. Build a panel with stock-style exposures
@@ -257,7 +258,41 @@ Read the diagnostics table before treating a low p-value as comparable across fa
 - `tie_ratio` flags low-cardinality dense signals. A high value can mean the factor is closer to a group exposure than an idiosyncratic stock-ranking signal.
 - `reason` and `warning_codes` should remain in the table so NaNs and degraded estimates do not disappear during sorting.
 
-## 8. Check whether all-market IC is really stock selection
+## 8. Translate gross spread into net feasibility
+
+The `spread` metric is a gross per-period Q1/Q5 spread, and the `turnover` metric below is notional Q1/Q5 membership churn per rebalance because it came from `notional_turnover(n_groups=5)`. That pair can feed the scalar cost helpers. Keep this arithmetic outside `evaluate()`: it is a pre-strategy feasibility read, not an execution simulation.
+
+```python
+cost_rows = []
+for res in results.values():
+    gross_spread = res.metrics["spread"].value
+    turnover = res.metrics["turnover"].value
+    cost_rows.append(
+        {
+            "factor": res.factor,
+            "gross_spread": gross_spread,
+            "notional_turnover": turnover,
+            "breakeven_cost_bps": breakeven_cost(
+                gross_spread,
+                turnover,
+                forward_periods=res.forward_periods,
+            ).value,
+            "net_spread_30bps": net_spread(
+                gross_spread,
+                turnover,
+                estimated_cost_bps=30.0,
+                forward_periods=res.forward_periods,
+            ).value,
+        }
+    )
+
+cost_table = pl.DataFrame(cost_rows).sort("net_spread_30bps", descending=True)
+print(cost_table)
+```
+
+Read `breakeven_cost_bps` as the single-leg cost threshold that would take the gross spread to zero at the observed notional turnover. `net_spread_30bps` is still per-period, matching the scale of `quantile_spread`. If this column flips sign under a plausible cost assumption, the factor may remain statistically real but weak as a tradable candidate. Capacity, impact, borrow, and venue-specific microstructure remain downstream concerns.
+
+## 9. Check whether all-market IC is really stock selection
 
 A sector-level factor can pass all-market IC because sectors rotate. That is a valid group-exposure result, but it is not the same as within-sector stock selection. A high tie ratio or a low-cardinality warning should prompt this check.
 
@@ -277,7 +312,7 @@ for sector, res in per_sector.items():
 
 If the all-market IC is significant but within-sector IC is weak or undefined, the next research question is sector rotation or allocation, not stock selection. Keep that distinction outside the factor-ranking table so the downstream strategy does not double-count a sector bet as idiosyncratic alpha.
 
-## 9. Point-in-time checklist
+## 10. Point-in-time checklist
 
 factrix cannot infer whether a factor was available at the signal timestamp. A future-return leak will look like a strong factor because the input hypothesis is already invalid. Before passing data to factrix, check:
 
@@ -291,4 +326,4 @@ factrix cannot infer whether a factor was available at the signal timestamp. A f
 
 ## What to do next
 
-Use this page for the single-factor workflow. For batch FDR control across many candidates, continue with [Multi-factor screening](multi_factor_screening.md). For scalar gross-to-net cost arithmetic after `spread` and `turnover`, use [`breakeven_cost` and `net_spread`](../api/metrics/tradability.md) as standalone post-processing helpers.
+Use this page for the single-factor workflow. For batch FDR control across many candidates, continue with [Multi-factor screening](multi_factor_screening.md). For API details on scalar cost helpers, see [`breakeven_cost` and `net_spread`](../api/metrics/tradability.md).

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -54,7 +54,8 @@
     "import factrix as fx\n",
     "import factrix.preprocess as fprep\n",
     "import polars as pl\n",
-    "from factrix.metrics import fm_beta, ic, notional_turnover, quantile_spread"
+    "from factrix.metrics import fm_beta, ic, notional_turnover, quantile_spread\n",
+    "from factrix.metrics.tradability import breakeven_cost, net_spread"
    ]
   },
   {
@@ -393,10 +394,62 @@
   },
   {
    "cell_type": "markdown",
+   "id": "stock-gross-to-net-heading",
+   "metadata": {},
+   "source": [
+    "## 8. Translate gross spread into net feasibility\n",
+    "\n",
+    "The `spread` metric is a gross per-period Q1/Q5 spread, and the `turnover` metric below is notional Q1/Q5 membership churn per rebalance because it came from `notional_turnover(n_groups=5)`. That pair can feed the scalar cost helpers. Keep this arithmetic outside `evaluate()`: it is a pre-strategy feasibility read, not an execution simulation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "stock-gross-to-net-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cost_rows = []\n",
+    "for res in results.values():\n",
+    "    gross_spread = res.metrics[\"spread\"].value\n",
+    "    turnover = res.metrics[\"turnover\"].value\n",
+    "    cost_rows.append(\n",
+    "        {\n",
+    "            \"factor\": res.factor,\n",
+    "            \"gross_spread\": gross_spread,\n",
+    "            \"notional_turnover\": turnover,\n",
+    "            \"breakeven_cost_bps\": breakeven_cost(\n",
+    "                gross_spread,\n",
+    "                turnover,\n",
+    "                forward_periods=res.forward_periods,\n",
+    "            ).value,\n",
+    "            \"net_spread_30bps\": net_spread(\n",
+    "                gross_spread,\n",
+    "                turnover,\n",
+    "                estimated_cost_bps=30.0,\n",
+    "                forward_periods=res.forward_periods,\n",
+    "            ).value,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "cost_table = pl.DataFrame(cost_rows).sort(\"net_spread_30bps\", descending=True)\n",
+    "print(cost_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "stock-gross-to-net-read",
+   "metadata": {},
+   "source": [
+    "Read `breakeven_cost_bps` as the single-leg cost threshold that would take the gross spread to zero at the observed notional turnover. `net_spread_30bps` is still per-period, matching the scale of `quantile_spread`. If this column flips sign under a plausible cost assumption, the factor may remain statistically real but weak as a tradable candidate. Capacity, impact, borrow, and venue-specific microstructure remain downstream concerns.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "stock-sector-check-heading",
    "metadata": {},
    "source": [
-    "## 8. Check whether all-market IC is really stock selection\n",
+    "## 9. Check whether all-market IC is really stock selection\n",
     "\n",
     "A sector-level factor can pass all-market IC because sectors rotate. That is a valid group-exposure result, but it is not the same as within-sector stock selection. A high tie ratio or a low-cardinality warning should prompt this check.\n"
    ]
@@ -434,7 +487,7 @@
    "id": "stock-pit-heading",
    "metadata": {},
    "source": [
-    "## 9. Point-in-time checklist\n",
+    "## 10. Point-in-time checklist\n",
     "\n",
     "factrix cannot infer whether a factor was available at the signal timestamp. A future-return leak will look like a strong factor because the input hypothesis is already invalid. Before passing data to factrix, check:\n",
     "\n",
@@ -454,7 +507,7 @@
    "source": [
     "## What to do next\n",
     "\n",
-    "Use this page for the single-factor workflow. For batch FDR control across many candidates, continue with [Multi-factor screening](multi_factor_screening.md). For scalar gross-to-net cost arithmetic after `spread` and `turnover`, use [`breakeven_cost` and `net_spread`](../api/metrics/tradability.md) as standalone post-processing helpers.\n"
+    "Use this page for the single-factor workflow. For batch FDR control across many candidates, continue with [Multi-factor screening](multi_factor_screening.md). For API details on scalar cost helpers, see [`breakeven_cost` and `net_spread`](../api/metrics/tradability.md).\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Add a gross-to-net feasibility section to the stock factor notebook.
- Show quantile_spread + notional_turnover feeding scalar breakeven_cost and net_spread helpers.
- Regenerate the MkDocs example page from the notebook source of truth.

## Quant review notes
- Keeps cost arithmetic outside evaluate/DAG and frames it as pre-strategy feasibility, not execution simulation.
- Uses notional_turnover, not rank_turnover, for the cost helper input.
- Leaves capacity, impact, borrow, and venue-specific microstructure downstream.

## Test plan
- [x] Executed stock_factor_evaluation.ipynb code cells via the project venv
- [x] .\.venv\Scripts\ruff.exe check .
- [x] .\.venv\Scripts\ruff.exe format --check .
- [x] PYTHONUTF8=1 .\.venv\Scripts\python.exe -m pytest -q -p no:faulthandler tests\test_example_notebook_docs.py tests\test_docs_pages.py tests\test_docs_matrix.py tests\test_tradability.py
- [x] PYTHONUTF8=1 .\.venv\Scripts\python.exe -m mkdocs build --strict

Refs #750