### PR TITLE
fix(metrics): handle mixed VW zero-variance dates (#708)

### DIFF
--- a/docs/reference/_generated_warning_codes.md
+++ b/docs/reference/_generated_warning_codes.md
@@ -2,7 +2,7 @@
 |---|---|
 | `unreliable_se_short_periods` | n_periods is below the WARN floor (~30); NW HAC SE may be biased. Reused across panel time-series guards (MIN_PERIODS_WARN) and primitive inference (MIN_FM_PERIODS_WARN); both default to 30. |
 | `event_window_overlap` | Adjacent events sit within forward_periods; AR windows overlap. |
-| `persistent_regressor` | ADF p > 0.10 on the continuous factor; β may carry Stambaugh bias. |
+| `persistent_regressor` | ADF p exceeds the configured threshold on the continuous factor; beta may carry Stambaugh bias. |
 | `serial_correlation_detected` | Ljung-Box p < 0.05 on residuals; NW lag may be under-set. |
 | `few_assets` | Cross-section asset count is below the relevant WARN floor (panel-wide MIN_ASSETS_WARN=30, per-date MIN_IC_ASSETS_WARN=10, or per-date MIN_FM_ASSETS_WARN=10). The statistic is returned, but small n_assets inflates critical values or leaves minimal residual degrees of freedom. Severity scales with n_assets; read the relevant n_assets metadata. |
 | `thin_quantile_groups` | quantile_spread with the median cross-section split into n_groups buckets leaving < MIN_GROUP_ASSETS (5) assets per bucket; each bucket mean rests on a handful of names so the spread can be dominated by individual assets. Advisory only — reduce n_groups (the warning suggests a value) or treat the spread as a fragile small-cross-section diagnostic. Distinct from few_assets, which keys off the absolute cross-section size. |

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -471,6 +471,11 @@ def quantile_spread_vw(
         )
         .group_by("date")
         .agg(
+            pl.col(factor_col).count().alias("_n_assets"),
+            pl.col(factor_col)
+            .filter(pl.col(factor_col).is_not_null())
+            .n_unique()
+            .alias("_n_unique"),
             (
                 pl.col("_wr").filter(pl.col("_group") == top_group).sum()
                 / pl.col(weight_col).filter(pl.col("_group") == top_group).sum()
@@ -481,7 +486,10 @@ def quantile_spread_vw(
             ).alias("bottom_return_vw"),
         )
         .with_columns(
-            (pl.col("top_return_vw") - pl.col("bottom_return_vw")).alias("spread_vw"),
+            pl.when((pl.col("_n_assets") > 0) & (pl.col("_n_unique") <= 1))
+            .then(pl.lit(0.0))
+            .otherwise(pl.col("top_return_vw") - pl.col("bottom_return_vw"))
+            .alias("spread_vw"),
         )
         .sort("date")
     )
@@ -503,9 +511,7 @@ def quantile_spread_vw(
     # n_groups buckets on per-date valid factor counts, then treat a constant
     # factor as no-signal — otherwise value weighting manufactures an
     # ordering-artifact spread (ordinal ties) or empty-bucket NaN (average).
-    per_date_assets = sampled.group_by("date").agg(
-        pl.col(factor_col).count().alias("_n")
-    )["_n"]
+    per_date_assets = vw_series["_n_assets"]
     if bool((per_date_assets < n_groups).all()):
         max_assets_value = per_date_assets.max()
         max_assets = 0 if max_assets_value is None else cast(int, max_assets_value)

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -278,6 +278,41 @@ class TestQuantileSpreadVW:
         assert result.metadata["signal_status"] == "no_signal_zero_variance_factor"
         assert result.metadata.get("reason") is None
 
+    @pytest.mark.parametrize("tie_policy", ["ordinal", "average"])
+    def test_mixed_constant_dates_contribute_zero_spread(self, tie_policy):
+        # Mixed panels should retain no-signal dates as zero spread. Dropping
+        # them overstates the mean; ranking them injects row-order artifacts.
+        n_dates, n_assets = 6, 10
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = []
+        for date_idx, date in enumerate(dates):
+            constant_date = date_idx % 2 == 0
+            for asset_idx in range(n_assets):
+                rows.append(
+                    {
+                        "date": date,
+                        "asset_id": f"s_{asset_idx}",
+                        "factor": 1.0 if constant_date else float(asset_idx),
+                        "forward_return": asset_idx / 100.0,
+                        "market_cap": 1.0,
+                    }
+                )
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        result = quantile_spread_vw(
+            panel,
+            forward_periods=1,
+            n_groups=5,
+            tie_policy=tie_policy,
+            lag_weights=False,
+        )
+
+        assert result.value == pytest.approx(0.04)
+        assert result.n_obs == n_dates
+        assert result.metadata.get("signal_status") is None
+        assert math.isfinite(result.value)
+        assert result.p_value is not None and math.isfinite(result.p_value)
+
     def test_per_date_assets_below_n_groups_short_circuits(self):
         # Three valid names per date cannot fill five quantile buckets.
         dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(8)]


### PR DESCRIPTION
## Summary
- Treat per-date zero-variance `quantile_spread_vw` observations as zero spread.
- Reuse the per-date asset count from the VW aggregation for the n_groups floor.
- Add regression coverage for mixed constant-date panels under both tie policies.

## Test plan
- [x] `python -m ruff check factrix\metrics\quantile.py tests\test_quantile.py`
- [x] `python -m pytest -q -p no:faulthandler tests\test_quantile.py`
- [x] `python -m pytest -q -p no:faulthandler`

Closes #708
