### PR TITLE
ci: suppress link-check false positives from 404.html and doi.org

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,14 +1,11 @@
 name: link-check
 
 on:
-  # pull_request trigger held off: the `pr:` job (fail: true) red-builds on
-  # root-relative `/factrix/...` links in the built site (theme assets +
-  # mike version-prefixed internal links). lychee errors on these at the
-  # URL-build stage — before `.lycheeignore` filtering applies — because the
-  # local `site/` tree has no `factrix/` prefix to resolve them against.
-  # These internal links are already validated by `mkdocs build --strict`,
-  # so the daily scheduled run below is sufficient. Restore the PR trigger
-  # once the lychee root-relative false-positive is resolved.
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.lycheeignore'
   schedule:
     # Daily at 06:00 UTC (~14:00 Asia/Taipei) — outside GitHub Actions
     # peak hours, runner availability is best.
@@ -58,6 +55,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude-loopback
+            --exclude-path ./site/404.html
             './site/**/*.html'
             './README.md'
           fail: true
@@ -101,6 +99,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude-loopback
+            --exclude-path ./site/404.html
             './site/**/*.html'
             './README.md'
           output: ./lychee-report.md

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -44,16 +44,20 @@
 ^https://onlinelibrary\.wiley\.com/
 ^https://www\.tandfonline\.com/
 
-# Site-internal absolute paths rendered from `site_url` (e.g.
-# `/factrix/api/evaluate/`). Lychee scans the built HTML as local
-# files but cannot map a root-relative URL back to the local site
-# directory without a URL → filesystem rewrite — every such link
-# errors with "Cannot convert path '/factrix/...' to a URI". These
-# internal links are already validated by `mkdocs build --strict`
-# (broken nav / cross-references fail the docs build), so duplicating
-# the check at the lychee layer adds no signal. Revisit if lychee
-# gains first-class support for `site_url`-prefixed URL → local-dir
-# remapping.
+# doi.org returns 403 to bot user-agents (same reason as the academic
+# publishers above); DOI links redirect to the publisher page which is
+# already excluded. Add the resolver itself so lychee doesn't flag
+# DOI citations before the redirect.
+^https://doi\.org/
+
+# Site-internal root-relative paths (e.g. `/factrix/api/evaluate/`).
+# The main source of these was `site/404.html` (theme sitemap), which
+# is now excluded via `--exclude-path ./site/404.html` in the workflow.
+# This pattern remains as a safety net for any other page that may emit
+# root-relative hrefs — lychee errors on them at URL-build time (before
+# filtering), so `--exclude-path` is the primary fix; this entry only
+# catches anything that slips through as a text-based pattern match.
+# Internal links are already validated by `mkdocs build --strict`.
 ^/factrix/
 
 # pola.rs (Polars project home) intermittently fails TLS handshake


### PR DESCRIPTION
## Summary

- Exclude `site/404.html` from lychee scans via `--exclude-path ./site/404.html` (both `pr:` and `scheduled:` jobs). The 404 page is a theme-generated sitemap whose root-relative hrefs (e.g. `/factrix/api/`) fail at lychee's URL-build stage — before `.lycheeignore` filtering applies — producing 90+ spurious errors per daily run. `mkdocs build --strict` already validates these internal links.
- Add `^https://doi\.org/` to `.lycheeignore`. DOI resolver returns 403 to bot user-agents (same pattern as the existing `tandfonline`/`wiley`/`oup` exclusions).
- Restore the `pull_request` trigger (path-filtered to `docs/**`, `mkdocs.yml`, `.lycheeignore`) now that the root-relative false-positive source is removed.
- Update the `^/factrix/` comment in `.lycheeignore` to reflect that `--exclude-path` is now the primary fix.

Closes #729

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and confirm lychee reports 0 errors
- [ ] Merge and verify the next scheduled daily run closes issue #729