### PR TITLE
docs(api): document inspect data group helpers

### DIFF
--- a/docs/api/inspect-data.md
+++ b/docs/api/inspect-data.md
@@ -29,6 +29,10 @@ properties (`properties`), the per-metric applicability verdicts
 any data-level `warnings`. Each entry in the metrics group is a
 `MetricApplicability`.
 
+The tier groups are `MetricApplicabilityGroup` objects: they expose `.names`
+and `.to_metrics_dict()`, and slicing or concatenating them with `+` preserves
+those helpers.
+
 ::: factrix.DataInspection
 
 ---


### PR DESCRIPTION
## Summary
- Document MetricApplicabilityGroup helper access on inspect_data tier groups.
- Note that slicing and `+` concatenation preserve `.names` and `.to_metrics_dict()`.

## Test plan
- [x] `.\.venv\Scripts\mkdocs.exe build --strict`
- [x] `git diff --exit-code -- docs\examples\multi_factor_screening.md docs\examples\stock_factor_evaluation.md docs\reference\_generated_metric_matrix.md docs\reference\_generated_metric_name_index.md docs\reference\_generated_warning_codes.md docs\llms.txt docs\llms-full.txt`

Refs #515
