### PR TITLE
docs: clarify inference follow-ups

### DIFF
--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -106,6 +106,19 @@ info = fx.inspect_data(panel)
 any `blockers` / `warnings`, accounting for the actual panel shape
 (`n_periods` / `n_assets` / `n_pairs`).
 
+### Inference selection
+
+Only metrics whose signature exposes `inference=` accept a selectable
+inference method. Today that surface is limited to the series-mean family:
+`ic`, `quantile_spread`, and `k_spread`. Each of those metrics validates the
+passed method against its own allowlist and raises
+`IncompatibleInferenceError` for anything outside it, instead of running an
+unvetted test or falling back silently.
+
+`factrix.inference.HANSEN_HODRICK` is available as a standalone series-mean
+inference member, but it is not currently in any metric's allowlist. The
+metric-supported choices are `NON_OVERLAPPING` and `NEWEY_WEST`.
+
 ## Cell vs. DataStructure
 
 factrix has **two orthogonal classifications**:

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -56,7 +56,8 @@ Plus introspection / error / enum re-exports:
 
 - `fx.FactorScope`, `fx.FactorDensity` — user-facing axes
 - `fx.WarningCode` — structured result codes
-- `fx.FactrixError`, `fx.IncompatibleAxisError`, `fx.InsufficientSampleError`, `fx.UserInputError` — exception hierarchy (see § Error UX contract)
+- `fx.FactrixError`, `fx.IncompatibleAxisError`, `fx.IncompatibleInferenceError`,
+  `fx.InsufficientSampleError`, `fx.UserInputError` — exception hierarchy (see § Error UX contract)
 
 `__version__` is sourced from `pyproject.toml` (Commitizen-managed).
 
@@ -797,8 +798,8 @@ factrix/
 │                            #   MIN_SERIES_PERIODS_HARD, MIN_EVENTS_HARD/WARN,
 │                            #   MIN_OOS_PERIODS_HARD, MIN_PORTFOLIO_PERIODS_HARD/WARN, ...
 ├── _stats/                  # numerics: hac, bootstrap, unit_root, wald, gmm, ols, diagnostics, constants
-├── stats/                   # public estimator surface (newey_west, hansen_hodrick, driscoll_kraay, gmm, ...)
-├── estimators/              # lowercase estimator callables
+├── inference/               # curated metric-internal inference members (series-mean dataclasses)
+├── stats/                   # public statistical helper surface (block_bootstrap, driscoll_kraay, ...)
 ├── metrics/                 # @metric callables (ic, fm_beta, common_beta, caar, ...) + _registry
 │                            # per-cell thresholds (MIN_FM_PERIODS_HARD/WARN, MIN_COMMON_BETA_PERIODS_HARD) live
 │                            # alongside the metrics that enforce them


### PR DESCRIPTION
## Summary
- Clarify metric inference selection and allowlist behavior in the metrics API docs.
- Update architecture docs for IncompatibleInferenceError and the current inference/stats layout.

## Test plan
- [x] python -m pytest -q tests/test_docs_llms.py tests/test_docs_matrix.py -p no:faulthandler

Refs #575
