### PR TITLE
fix(metrics): sign pre-event returns; align stat-keys docs

### DIFF
--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -51,7 +51,7 @@ title: factrix.evaluate
     ---
 
     At `n_assets == 1` there is no cross-section, so any `DENSE` metric whose
-    cell is `PANEL` — `Individual × Continuous` (`ic`, `fm`) **and**
+    cell is `PANEL` — `Individual × Continuous` (`ic`, `fm_beta`) **and**
     `Common × Continuous` (`common_beta`, `common_quantile`, `common_asymmetry`) —
     raises `IncompatibleAxisError` (or NaN + `structure_mismatch` under
     `strict=False`). Single-asset data runs through the same entry point

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -21,7 +21,7 @@ Calling `inspect_data(data)` returns a `DataInspection` object. It detects data 
 
 ### 2. `evaluate` (DAG Evaluation)
 Once you select your metrics, you run the evaluation. 
-`evaluate()` takes your data, a dictionary of metric instances, and a list of factor columns. Under the hood, a **Directed Acyclic Graph (DAG) executor** resolves all metric dependencies, optimizes the execution sequence, and returns a list of `EvaluationResult` objects (one per factor).
+`evaluate()` takes your data, a dictionary of metric instances, and a list of factor columns. Under the hood, a **Directed Acyclic Graph (DAG) executor** resolves all metric dependencies, optimizes the execution sequence, and returns a `dict` of `EvaluationResult` objects keyed by factor column (one per factor).
 
 ### 3. `bhy` (FDR Screening)
 If you are screening multiple candidate factors, you must correct for multiple testing to control false discoveries.
@@ -66,4 +66,4 @@ nulls are missing values, not non-events. If missing upstream rows should
 mean "no event", fill them to `0`; if the research question is event-study
 shaped, map the event-of-interest into `{0, R}` before using sparse metrics.
 
-A metric's cell declares which `DataStructure` it applies to. A `PANEL`-cell metric needs a cross-section, so on `n_assets == 1` data — `Individual × Continuous` (`ic`, `fm`) or `Common × Continuous` (`common_beta`) — `evaluate` raises `IncompatibleAxisError` (or returns NaN + `structure_mismatch` under `strict=False`). Single-asset dense data uses `predictive_beta` for the direct HAC predictive-regression slope and `directional_hit_rate` for sign prediction. Single-asset sparse data is served by `(*, SPARSE, *)` metrics. Two-column diagnostics (`positive_rate`, `oos_decay`, `ic_trend`) remain standalone `(date, value)` tools, and in `evaluate()` they are layered on panel IC series rather than raw single-asset dense panels.
+A metric's cell declares which `DataStructure` it applies to. A `PANEL`-cell metric needs a cross-section, so on `n_assets == 1` data — `Individual × Continuous` (`ic`, `fm_beta`) or `Common × Continuous` (`common_beta`) — `evaluate` raises `IncompatibleAxisError` (or returns NaN + `structure_mismatch` under `strict=False`). Single-asset dense data uses `predictive_beta` for the direct HAC predictive-regression slope and `directional_hit_rate` for sign prediction. Single-asset sparse data is served by `(*, SPARSE, *)` metrics. Two-column diagnostics (`positive_rate`, `oos_decay`, `ic_trend`) remain standalone `(date, value)` tools, and in `evaluate()` they are layered on panel IC series rather than raw single-asset dense panels.

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -62,10 +62,10 @@ contrasts, not a sidecar to a primary value.
 | [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | NW HAC `t` on top-bottom spread (block-bootstrap CI when small cross-section) | `p_value` | mean(spread) |
 | [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (block-bootstrap CI when small cross-section) | `p_value` | mean(spread) |
 | [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
-| [`top_concentration`][factrix.metrics.concentration.top_concentration] | one-sided `t` on diversity ratio | `p_value` | mean(eff_n / n_top) |
+| [`top_concentration`][factrix.metrics.concentration.top_concentration] | one-sided `t` on diversity ratio | `p_value` | mean(eff_n) = mean(1/HHI) |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | none — descriptive | — | event-date Herfindahl-Hirschman index (HHI) |
 | [`mfe_mae`][factrix.metrics.mfe_mae.mfe_mae] | none — descriptive | — | MFE_p50 / \|MAE_p75\| |
-| [`oos_decay`][factrix.metrics.oos_decay.oos_decay] | none — descriptive | — | median(survival) |
+| [`oos_decay`][factrix.metrics.oos_decay.oos_decay] | none — descriptive | — | survival = \|mean_oos\| / \|mean_is\| |
 | [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | OLS `t` on α | `p_value` | spanning α |
 | [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | none — selection meta | — | (NaN; results in metadata) |
 | [`ic_trend`][factrix.metrics.trend.ic_trend] | Theil-Sen slope `t` (CI-based) | `p_value` | Theil-Sen slope |
@@ -386,8 +386,7 @@ Descriptive; period-axis concentration of event dates.
 
 Descriptive; no test.
 
-- *descriptive*: `mfe_p50`, `mae_p75`, `mae_p95`, `mfe_mae_ratio`,
-  `bars_to_mfe_mean`, `bars_to_mae_mean`, `n_events`.
+- *descriptive*: `mfe_p50`, `mae_p75`, `mfe_mae_ratio`, `n_events`.
 - *descriptive* (conditional, when σ-normalised inputs available):
   `mfe_z_p50`, `mae_z_p75`, `mfe_mae_ratio_z`, `n_events_z`.
 - `p_value` is `None` — descriptive metric, no hypothesis test.
@@ -399,9 +398,7 @@ Descriptive; no test.
 hypothesis test.
 
 - *descriptive*: `status` (`"PASS"` / `"VETOED"`), `sign_flipped`,
-  `per_split` (list of `{is_ratio, mean_is, mean_oos,
-  survival_ratio, sign_flipped}`), `survival_threshold`, `n_splits`,
-  `method`.
+  `is_ratio`, `mean_is`, `mean_oos`, `survival_threshold`.
 
 ### `spanning` (`factrix.metrics.spanning`)
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -66,14 +66,14 @@ with $h$ = `forward_periods`. The first term is the
 [Hansen-Hodrick 1980][hansen-hodrick-1980] overlap floor that ensures
 the kernel covers the MA(`h − 1`) structure of overlapping returns.
 factrix takes the maximum so the bandwidth is always at least large
-enough to absorb the overlap, with the Andrews term taking over once
+enough to absorb the overlap, with the Newey-West term taking over once
 `T` is large.
 
 Two choices factrix deliberately did not adopt:
 
 - The data-adaptive plug-in of [Newey-West 1994][newey-west-1994] is
   not used. Its sampling variability defeats the point of having a
-  reproducible reported SE; the deterministic Andrews rule is
+  reproducible reported SE; the deterministic Newey-West rule is
   adequate at typical research `T` and is auditable.
 - The prewhitening refinement of
   [Andrews-Monahan 1992][andrews-monahan-1992] is also not used.
@@ -270,7 +270,7 @@ returned; the caller decides whether to trust it.
 The ADF p-value is interpolated from
 [MacKinnon 1996][mackinnon-1996] response-surface critical values for
 the constant-only specification (`_adf_pvalue_interp`). The
-interpolation accuracy is ±0.03 — ample for the qualitative "is this
+interpolation accuracy is ~±0.02 — ample for the qualitative "is this
 a unit root" decision the threshold drives.
 
 Overlapping multi-period returns inherit MA(`h − 1`) autocorrelation

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -1,6 +1,6 @@
 """Input-type gateway for public entry points.
 
-factrix is polars-native: ``fx.evaluate`` and ``fx.run_metrics`` accept
+factrix is polars-native: ``fx.evaluate`` accepts
 ``pl.DataFrame`` (canonical) or ``pl.LazyFrame`` (collected immediately
 at the boundary — no projection or predicate pushdown applied by
 factrix, so call ``.select(...)`` / ``.filter(...)`` upstream for

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -7,7 +7,7 @@ Multi-factor function-name suffix taxonomy (project-wide convention):
 - **(no suffix)** — batch-native unified API. Function takes
   ``factor_cols: list[str]`` and returns ``dict[str, ResultT]``; no
   single-factor sibling. Examples: ``compute_ic``, ``quantile_spread``,
-  ``monotonicity``, ``fx.run_metrics``.
+  ``monotonicity``.
 - **``_batch``** — batch variant that coexists with a single-factor
   sibling. Use when keeping the single-factor signature stable matters
   (callable API, third-party callers). Examples:

--- a/factrix/metrics/_primitives/_event_returns.py
+++ b/factrix/metrics/_primitives/_event_returns.py
@@ -90,7 +90,8 @@ def compute_event_returns(
                     continue
                 if prices[prev_idx] < EPSILON:
                     continue
-                signed_ret = float(prices[bar_idx] / prices[prev_idx] - 1)
+                raw_ret = prices[bar_idx] / prices[prev_idx] - 1
+                signed_ret = float(direction * raw_ret)
 
             rows.append(
                 {

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -178,7 +178,7 @@ def common_quantile_spread(
     per_bucket_periods = n_periods // n_groups
     if per_bucket_periods < 5:
         warnings.warn(
-            f"common_quantile_spread: median {per_bucket_periods} periods per "
+            f"common_quantile_spread: avg {per_bucket_periods} periods per "
             f"bucket (T={n_periods}, n_groups={n_groups}). Each bucket mean "
             f"sits on a thin sample; consider reducing n_groups.",
             UserWarning,

--- a/tests/test_data_input.py
+++ b/tests/test_data_input.py
@@ -1,6 +1,6 @@
 """Tests for `_coerce_data`, the strict polars-native API gateway.
 
-`fx.evaluate` and `fx.run_metrics` accept `pl.DataFrame` (passes
+`fx.evaluate` accepts `pl.DataFrame` (passes
 through) and `pl.LazyFrame` (collected at the boundary). `pd.DataFrame`
 is rejected with a guiding `TypeError` that points to
 `factrix.adapt(df, ...)` or `pl.from_pandas(df)` as the documented

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -91,6 +91,35 @@ class TestComputeEventReturns:
         result = compute_event_returns(event_data, offsets=[12])
         assert result["signed_return"].mean() > 0
 
+    def test_pre_event_signed(self):
+        """Pre-event returns are direction-adjusted, so a directional
+        pre-event drift does not cancel across +/- events.
+
+        Two assets carry a consistent pre-event drift *in the direction of
+        the event*: the +1 event is preceded by a price rise, the -1 event
+        by a price fall. Raw (unsigned) pre-event returns would cancel to
+        ~0; direction-signed returns both read positive and add up.
+        """
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(6)]
+        # asset_up: prices rise before a +1 event on the last date
+        # asset_dn: prices fall before a -1 event on the last date
+        rows = []
+        for aid, prices, direction in [
+            ("asset_up", [100.0, 101.0, 102.0, 103.0, 104.0, 105.0], 1.0),
+            ("asset_dn", [100.0, 99.0, 98.0, 97.0, 96.0, 95.0], -1.0),
+        ]:
+            for i, (d, p) in enumerate(zip(dates, prices, strict=True)):
+                factor = direction if i == len(dates) - 1 else 0.0
+                rows.append({"date": d, "asset_id": aid, "factor": factor, "price": p})
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        result = compute_event_returns(panel, offsets=[-1])
+        signed = result["signed_return"].to_list()
+        # Both the up-event and down-event pre-returns are signed positive.
+        assert len(signed) == 2
+        assert all(s > 0 for s in signed)
+        assert result["signed_return"].mean() > 0
+
     def test_output_date_dtype_mirrors_input_us(self, event_data):
         df_us = event_data.with_columns(pl.col("date").cast(pl.Datetime("us")))
         result = compute_event_returns(df_us, offsets=[1, 6])


### PR DESCRIPTION
## Summary
- Sign pre-event returns in the event-window primitive so directional leakage no longer cancels across +/- events — `event_around_return` was under-reporting it (post-event was already signed; pre-event was raw).
- Align docs with implementation: `mfe_mae` / `oos_decay` / `top_concentration` stat keys, `evaluate` return type (dict, not list), Newey-West (1994) bandwidth attribution, ADF interpolation figure, and drop stale `run_metrics` references.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix`
- [x] `pytest` on touched modules (event_horizon, common_quantile, data_input, oos, mfe_mae, concentration) — 70 passed, 2 skipped
- [x] New regression test `test_pre_event_signed` (fails before the fix)

Remaining consistency/design follow-ups from the pre-release audit are tracked in #767.
