### PR TITLE
fix(metrics): use one-sided p-value in corrado_rank

### DIFF
--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -100,7 +100,7 @@ Min sample*. `MIN_*` constants resolve to values in the
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | per-offset `K` | `K ≥ MIN_EVENTS_HARD` |
 | [`mfe_mae`][factrix.metrics.mfe_mae.mfe_mae] | `K` | `K ≥ MIN_EVENTS_HARD`; `price` column required |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | `K`, `n_assets` | `n_assets >= 2`; `K >= MIN_EVENTS_HARD` |
-| [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] | `K` × estimation window | `K ≥ MIN_EVENTS_HARD`; per-asset `T ≥ 30` |
+| [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] | `K` | `K ≥ MIN_EVENTS_HARD` |
 
 ### TS-β family — Cell: Common × Continuous
 
@@ -316,20 +316,19 @@ metric. Two implications:
 ### `estimation_window`
 
 The estimation window is the per-asset pre-event sample used to fit
-the abnormal-return baseline. factrix uses it in two places:
-
-- [`bmp_z`][factrix.metrics.caar.bmp_z]: standardises each
-  event's abnormal return by the event's own pre-event SE, computed
-  over the estimation window.
-- [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank]:
-  ranks the abnormal return against the per-asset distribution drawn
-  from the estimation window.
+the abnormal-return baseline. factrix uses it in
+[`bmp_z`][factrix.metrics.caar.bmp_z], which standardises each
+event's abnormal return by the event's own pre-event SE, computed
+over the estimation window.
+[`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] ranks
+each asset's *full* return sample (event + non-event rows) rather
+than an estimation-window slice — see the per-row primitive table
+above — so the conventions below apply to `bmp_z` only.
 
 Conventions:
 
 - **Length**: per-asset `T ≥ 30` non-event observations is the
-  literature default (Brown-Warner 1985 §2.B). factrix enforces
-  this floor at the `corrado_rank` per-asset gate.
+  literature default (Brown-Warner 1985 §2.B).
 - **Alignment**: ends one period before the event date; gap-before
   -event of zero (no skip period). Users running a skip-period
   convention must pre-shift the panel.

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
+from scipy import stats as sp_stats
 
 from factrix._axis import (
     Aggregation,
@@ -16,7 +17,7 @@ from factrix._axis import (
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._stats import _calc_t_stat, _p_value_from_z
+from factrix._stats import _calc_t_stat
 from factrix._types import EPSILON, MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
@@ -56,6 +57,10 @@ def corrado_rank(
         form $U_{\text{event,signed}} = U_{\text{event}} \cdot \mathrm{sign}(\text{factor})$.
         Test statistic
         $z = \mathrm{mean}(U_{\text{event,signed}}) / (\mathrm{std}(U_{\text{all}}) / \sqrt{N_{\text{events}}})$.
+        ``p_value`` is **one-sided** (``H0: mean_u <= 0``): the direction
+        adjustment already folds sign into $z$, so a factor that
+        anti-predicts returns a negative $z$ rather than a small two-sided
+        $p$ — mirroring :func:`~factrix.metrics.directional_hit_rate.directional_hit_rate`.
 
     Args:
         data: Full panel with ``date, asset_id, factor, forward_return``.
@@ -134,7 +139,10 @@ def corrado_rank(
 
     mean_u = float(np.mean(u_event))
     z = _calc_t_stat(mean_u, std_u, n_events)
-    p = _p_value_from_z(z)
+    # One-sided: u_event is already direction-adjusted by sign(factor), so
+    # z > 0 signals genuine directional skill and z < 0 signals a factor that
+    # anti-predicts — a two-sided p would read the latter as "significant".
+    p = float(sp_stats.norm.sf(z))
 
     return MetricResult(
         p_value=p,
@@ -146,7 +154,7 @@ def corrado_rank(
             "n_events": n_events,
             "n_total_obs": len(ranked),
             "stat_type": "z",
-            "h0": "mu_rank=0",
+            "h0": "mu_rank<=0",
             "method": "Corrado (1989) rank test",
         },
     )

--- a/tests/test_corrado_rank.py
+++ b/tests/test_corrado_rank.py
@@ -1,0 +1,81 @@
+"""Tests for factrix.metrics.corrado_rank."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+from factrix.metrics.corrado_rank import corrado_rank
+
+
+def _panel(returns: np.ndarray, factor: np.ndarray) -> pl.DataFrame:
+    n = len(returns)
+    dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame(
+        {
+            "date": dates,
+            "asset_id": ["A"] * n,
+            "factor": factor,
+            "forward_return": returns,
+        }
+    )
+
+
+def _directional_panel(sign: float, n: int = 300, seed: int = 0) -> pl.DataFrame:
+    """Baseline noise returns with a handful of events whose own return is
+    shifted well into the tail in the direction ``sign * factor``, so the
+    event ranks are genuinely extreme rather than incidentally so.
+    """
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(size=n)
+    factor = np.zeros(n)
+    event_idx = np.arange(10, n, 30)
+    factor[event_idx] = sign
+    returns[event_idx] = sign * 5.0  # push into the extreme tail
+    return _panel(returns, factor)
+
+
+class TestOneSidedPValue:
+    def test_anti_predictive_factor_is_not_significant(self):
+        """Events sit at the top of the return distribution (rank ≈ +0.5)
+        while ``factor`` points the wrong way (-1), so the direction-signed
+        rank is negative: z < 0, and a one-sided p should be large.
+        """
+        rng = np.random.default_rng(0)
+        n = 300
+        returns = rng.normal(size=n)
+        factor = np.zeros(n)
+        event_idx = np.arange(10, n, 30)
+        returns[event_idx] = 5.0  # events are the largest returns...
+        factor[event_idx] = -1.0  # ...but the factor calls them down
+
+        result = corrado_rank(_panel(returns, factor))
+
+        assert result.stat < 0
+        assert result.p_value > 0.5
+
+    def test_predictive_factor_is_significant(self):
+        """Mirror case: factor direction matches the extreme rank at each
+        event, so z > 0 and the one-sided p should be small.
+        """
+        result = corrado_rank(_directional_panel(sign=1.0))
+
+        assert result.stat > 0
+        assert result.p_value < 0.05
+
+    def test_p_value_is_one_sided_sf(self):
+        """p should equal the upper-tail normal survival function of z,
+        not the two-sided 2*sf(|z|)."""
+        from scipy import stats as sp_stats
+
+        rng = np.random.default_rng(1)
+        n = 150
+        returns = rng.normal(size=n)
+        factor = np.zeros(n)
+        event_idx = np.arange(5, n, 15)
+        factor[event_idx] = rng.choice([-1.0, 1.0], size=len(event_idx))
+
+        result = corrado_rank(_panel(returns, factor))
+
+        assert result.p_value == sp_stats.norm.sf(result.stat)


### PR DESCRIPTION
## Summary
- `corrado_rank`'s rank statistic is already direction-adjusted by `sign(factor)`, so a two-sided p-value read an anti-predictive factor (z < 0) as significant instead of non-significant — inconsistent with the one-sided `directional_hit_rate` sibling.
- Switch to a one-sided p (`norm.sf(z)`, `H0: mu_rank<=0`) and align `metric-applicability.md`'s estimation-window / sample-floor claims with what the implementation actually does (full-sample ranking, no per-asset T-gate).

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix`
- [x] New `tests/test_corrado_rank.py` — anti-predictive vs. predictive factor sidedness, and exact `norm.sf` equivalence
- [x] Full suite: 1721 passed, 3 skipped

Related follow-ups tracked in #767 (not closed by this PR).
