### PR TITLE
fix(metrics): tighten factor dtype docs and monotonicity edge case

### DIFF
--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -10,7 +10,7 @@ Single-source contract for every `factrix` entry point that consumes a panel. Ev
 |---|---|---|
 | `date` | `Date` (preferred) or `Datetime` | Observation timestamp. Sorted ascending per asset. Frequency-agnostic — factrix shifts rows, never calendar time. |
 | `asset_id` | `Utf8` / `Categorical` | Cross-section identifier. Identical for COMMON-scope factors (`df.group_by("date").agg(pl.col("factor").n_unique() == 1).all()` is `True`). |
-| `factor` | `Float64` | The signal value. Dense: real-valued exposure (z-score, IC-rankable). Sparse: zero-encoded `{0, R}` event trigger, where `0` marks non-events. |
+| `factor` | numeric (`Int*` / `Float*`) | The signal value. Dense: real-valued exposure (z-score, IC-rankable). Sparse: zero-encoded `{0, R}` event trigger, where `0` marks non-events. |
 | `forward_return` | `Float64` | Look-ahead return over the horizon used at evaluate time. Attach via [`compute_forward_return`](preprocess.md) so the horizon is explicit and aligned with `forward_periods`. |
 
 The minimal panel is therefore long-format `(date, asset_id, factor, forward_return)`. A 3-row preview:

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -14,15 +14,6 @@ Multi-factor function-name suffix taxonomy (project-wide convention):
   ``bootstrap_mean_ci`` (1-D);
   ``_assign_quantile_groups`` (single) + ``_assign_quantile_groups_batch``
   (batch).
-- **``_chunked``** — split-and-yield variant of an already-batch
-  function. Takes the same ``factor_cols`` input but splits into K
-  sub-batches and yields K results; per-chunk peak RSS is bounded.
-  Example: ``fx.run_metrics_chunked``.
-- **``_iter``** — per-factor streaming yield variant. Takes the same
-  input but yields ``(factor_id, result)`` one factor at a time so
-  callers can compose with per-bundle sinks. Cross-factor batch
-  dispatch is preserved internally; the streaming is at the result
-  granularity.
 
 ``_multi*`` is reserved for structural multivariate concepts (e.g.
 multivariate test statistics), not for "this function handles many

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -39,6 +39,7 @@ from factrix.metrics._helpers import (
     _enforce_scaled_floor,
     _sample_non_overlapping,
     _scaled_periods_threshold,
+    _short_circuit_output,
     _warn_high_tie_ratio,
 )
 
@@ -200,6 +201,20 @@ def monotonicity(
         )
         if sc is not None:
             results[f] = sc
+            continue
+        if len(mono_arr) == 0:
+            # n_raw_periods cleared the scaled floor above, but every
+            # sampled date had a null bucket mean for this factor (e.g. a
+            # sparse column), leaving nothing to correlate.
+            results[f] = _short_circuit_output(
+                "monotonicity",
+                "insufficient_monotonicity_periods",
+                n_obs=0,
+                n_obs_axis="periods",
+                n_groups=n_groups,
+                tie_ratio=tie_ratios[f],
+                tie_policy=tie_policy,
+            )
             continue
         avg_mono = float(np.mean(np.abs(mono_arr)))
         mean_mono = float(np.mean(mono_arr))

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -48,6 +48,32 @@ class TestComputeMonotonicity:
         assert math.isnan(result.value)
         assert result.p_value is None or result.p_value >= 0.10
 
+    def test_all_null_buckets_short_circuits_with_reason(self):
+        """Raw date count clears the scaled floor, but every sampled date's
+        bucket means are null (e.g. ``forward_return`` entirely missing), so
+        there is nothing left to correlate. Must short-circuit with a reason
+        rather than silently returning a degenerate NaN/t=0/p=1 triple.
+        """
+        from datetime import datetime, timedelta
+
+        import polars as pl
+
+        n_dates = 10
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n_dates)]
+        rows = [
+            {"date": d, "asset_id": aid, "factor": float(j), "forward_return": None}
+            for d in dates
+            for j, aid in enumerate(["A", "B", "C", "D"])
+        ]
+        df = pl.DataFrame(rows).with_columns(
+            pl.col("date").cast(pl.Datetime("ms")),
+            pl.col("forward_return").cast(pl.Float64),
+        )
+        result = monotonicity(df, forward_periods=1, n_groups=2)["factor"]
+
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_monotonicity_periods"
+
 
 class TestMonotonicityBatch:
     """Multi-factor path of ``monotonicity``."""


### PR DESCRIPTION
## Summary
- `data-schema.md` documented `factor` as `Float64`, but the actual gate (`_validate_factor_cols_numeric`) only requires `is_numeric()`; loosen the doc to match.
- Drop the `_helpers.py` suffix-taxonomy entries for `_chunked` / `_iter`, which pointed at `run_metrics_chunked` / `run_metrics_iter` — both already retired with no live replacement.
- `monotonicity` fell through to a degenerate `NaN`/`t=0`/`p=1` result with no `reason` when every sampled date's bucket means were null (e.g. `forward_return` entirely missing for a factor); short-circuit it like every other data-shortage path.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy factrix`
- [x] New `test_all_null_buckets_short_circuits_with_reason` regression test
- [x] Full suite: 1722 passed, 3 skipped

Resolves the remaining items tracked in #767.
