### PR TITLE
ci(link-check): fix exclude-path not matching site/404.html

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -55,7 +55,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude-loopback
-            --exclude-path ./site/404.html
+            --exclude-path site/404.html
             './site/**/*.html'
             './README.md'
           fail: true
@@ -99,7 +99,7 @@ jobs:
             --cache
             --max-cache-age 1d
             --exclude-loopback
-            --exclude-path ./site/404.html
+            --exclude-path site/404.html
             './site/**/*.html'
             './README.md'
           output: ./lychee-report.md


### PR DESCRIPTION
## Summary
- `--exclude-path ./site/404.html` never matched: lychee normalizes scanned file paths without a leading `./` (`site/404.html`), so the exclude list entry was a silent no-op and 404.html's root-relative `/factrix/...` hrefs kept failing at the URL-build stage.
- Reproduced locally with the CI-identical lychee invocation: the leading `./` reproduces all 92 errors from #769; dropping it clears them to 0 errors on the same build.

## Test plan
- [x] Local `lychee` (installed via Homebrew) against `uv run mkdocs build` output, exact CI args — 92 errors with `./site/404.html`, 0 errors with `site/404.html`
- [ ] Scheduled/PR link-check workflow run green after merge

Fixes the exclude-path regression from #768 (tracked in #769).
