### PR TITLE
feat(results)!: declare p-value and family contracts

### DIFF
--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -86,6 +86,14 @@ Concretely: if `expand_over=["factor"]` were allowed, every factor
 would land in its own size-1 family and pass its own step-up trivially
 — FDR control across the screening universe collapses.
 
+Different horizons of the same factor are distinct hypotheses because
+`forward_periods` is part of the base identity. With `expand_over=()`, all
+factor × horizon hypotheses enter one step-up; this is the correct family when
+the research process may choose the best horizon. Use
+`expand_over=("forward_periods",)` only when horizon-specific screens were
+predeclared and will be selected and reported separately. Separate buckets do
+not provide global control over later horizon shopping.
+
 ### Sample restriction vs hypothesis dimension
 
 A context key (`universe_id`, `regime_id`, …) can play one of two roles
@@ -96,16 +104,15 @@ in a screening run:
   pre-registered scope, not a tested dimension. Filter the input list
   upstream and call `bhy` without naming that key. FDR is controlled over
   the implied family.
-- **Hypothesis dimension** — you want to ask "across these
-  contexts, which factor / context combinations survive?" The context
-  value is part of the hypothesis identity at the family level. Pass it
-  via `expand_over=(<key>,)`; one independent step-up runs per distinct
-  value tuple.
+- **Separately reported family** — the context defines predeclared screens
+  whose discoveries will not compete across buckets. Pass it via
+  `expand_over=(<key>,)`; one independent step-up runs per distinct value
+  tuple. If selection later compares buckets, they belong in one family instead.
 
 | User intent | API call | Family scope per step-up |
 |---|---|---|
 | "Run BHY on the `tw50` universe only" | `bhy([r for r in results if r.context.get("universe_id") == "tw50"], metrics=["ic"])` | `factor × forward_periods` |
-| "Test the same factors on `tw50` *and* `tw100`, treating universe as a tested dimension" | `bhy(results, metrics=["ic"], expand_over=("universe_id",))` | `factor × forward_periods × universe_id`, one step-up per universe |
+| "Report predeclared `tw50` and `tw100` screens separately, with no cross-universe winner selection" | `bhy(results, metrics=["ic"], expand_over=("universe_id",))` | `factor × forward_periods × universe_id`, one step-up per universe |
 
 ## See also
 

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -41,15 +41,17 @@ own rows. The consequence depends on the slicing axis:
   constant within an asset): each slice is an independent universe with
   intact per-asset history. This is the primary intent.
 - **Date-axis partition** (year, regime; the value varies within an asset
-  over time): a metric whose aggregation looks across dates —
+  over time): a metric declaring boundary sensitivity —
   rolling-window betas, per-asset time-series regressions, event windows
   (`common_beta`, `mfe_mae`, `oos_decay`) — sees **truncated history** at
   slice boundaries, so its per-slice value differs from the full-sample
   value decomposed by period. Per-date metrics (`ic`, `fm_beta`,
-  `quantile`, `positive_rate`) are unaffected.
+  `quantile`) are unaffected. `positive_rate` is sensitive because each
+  slice resets its non-overlap sampling phase.
 
 `by_slice` emits a `WarningCode.SLICE_BOUNDARY_TRUNCATION` warning when a
-cross-date metric is sliced on a date axis. If you want the full-sample
+metric whose `MetricSpec.slice_boundary_sensitive` capability is true is
+sliced on a date axis. If you want the full-sample
 metric decomposed by period instead, compute it once on the whole panel
 and group the per-date output yourself.
 
@@ -70,7 +72,7 @@ pl.concat([
     r.to_frame().with_columns(pl.lit(k).alias("slice"))
     for k, r in result.items()
 ]).sort("slice")
-# columns: slice, factor, n_assets, metric_name, value, p_value, stat, n_obs, warning_codes
+# columns include: slice, factor, n_assets, metric_name, value, p_value, alternative, stat, n_obs, warning_codes
 ```
 
 Each `EvaluationResult` carries per-slice `n_periods` / `n_assets`, so
@@ -80,8 +82,8 @@ sample-size differences across slices are visible directly.
 
     Each slice's `p_value` tests that slice alone against its own null
     (e.g. `ic` mean = 0). Filtering across K parallel slices inflates the
-    family-wise error rate (FWER) — under H0, K=10 sectors yields ≈ 0.4
-    expected "significant" slices by pure chance. `by_slice` is for
+    family-wise error rate (FWER) — under independent nulls, K=10 sectors
+    gives about a 40% chance of at least one false positive. `by_slice` is for
     **exploration**; for inference claims with FWER / false discovery rate
     (FDR) control, use
     [`slice_pairwise_test`](slice-test.md#factrix.slice_pairwise_test)

--- a/docs/api/evaluation-results.md
+++ b/docs/api/evaluation-results.md
@@ -19,6 +19,7 @@ Converts the metric results into a stable, long-form Polars `pl.DataFrame`. This
 - `metric_name` (`str`): The metric identifier.
 - `value` (`f64` | `null`): The calculated metric value (NaN/Inf are normalized to `null`).
 - `p_value` (`f64` | `null`): The p-value, if applicable.
+- `alternative` (`str` | `null`): The tested alternative (`two-sided`, `greater`, or `less`), present exactly when `p_value` is present.
 - `stat` (`f64` | `null`): The underlying test statistic, if applicable.
 - `n_obs` (`i64` | `null`): Effective sample size the metric's estimator used. `null` only where a single integer count is not meaningful (e.g. a multi-window CAAR series).
 - `n_obs_axis` (`str` | `null`): The dimension `n_obs` counts along — `periods` / `events` / `pairs` / `assets`. A bare count is uninterpretable without it (a Fama-MacBeth `n_obs` is `periods`; a pooled-OLS one is `(date, asset)` `pairs`). `null` exactly when `n_obs` is.
@@ -50,7 +51,8 @@ Converts the result into a JSON-friendly nested dictionary. It normalizes floats
 `MetricResult` represents the outcome of a single metric calculation. Its primary fields are:
 
 - **`value`** (`float`): The calculated numeric output of the metric.
-- **`p_value`** (`float` | `None`): The statistical p-value.
+- **`p_value`** (`float` | `None`): The calibrated statistical p-value. It must be finite and in `[0, 1]`.
+- **`alternative`** (`str` | `None`): The corresponding alternative hypothesis (`two-sided`, `greater`, or `less`). `p_value` and `alternative` must either both be present or both be `None`.
     > [!IMPORTANT]
     > `p_value` is the canonical field for metric p-values.
 - **`stat`** (`float` | `None`): The test statistic (e.g. t-statistic, z-statistic).

--- a/docs/api/multi-horizon.md
+++ b/docs/api/multi-horizon.md
@@ -21,9 +21,10 @@ problems:
    horizon shopping explicit at the false discovery rate (FDR) layer; an
    in-metric horizon loop would collapse `k` horizons into one identity
    entry, defeating that defense.
-3. **Two Benjamini-Hochberg-Yekutieli (BHY) paths.** The family-function
-   layer ([`multi_factor.bhy`][bhy] with `expand_over=("forward_periods",)`)
-   is the single source of truth for FDR control across horizons.
+3. **One Benjamini-Hochberg-Yekutieli (BHY) path.** The family-function
+   layer ([`multi_factor.bhy`][bhy]) is the single source of truth for FDR
+   control. The caller declares whether horizons compete in one family or are
+   predeclared, separately reported buckets.
 
 The dispatcher framing also lets descriptive metrics (`mfe_mae`,
 `caar`, `oos`, `monotonicity`, ...) inherit horizon-sweep support
@@ -64,11 +65,12 @@ results = fx.evaluate_horizons(
 table = pl.concat([r.to_frame() for r in results])  # long-form: horizon x metric
 ```
 
-### Inferential sweep — FDR-controlled across horizons
+### Inferential sweep — FDR-controlled across factors and horizons
 
-Feed the swept list to [`multi_factor.bhy`][bhy] with
-`expand_over=("forward_periods",)`. The family-function layer partitions
-the BHY null per horizon so the step-up threshold is correct.
+Feed the swept list to [`multi_factor.bhy`][bhy] without `expand_over` when the
+research process may select any factor × horizon combination. This pools every
+searched hypothesis into the controlled family. A runtime warning makes that
+choice visible; it is informational, not an error.
 
 ```python
 import factrix as fx
@@ -86,13 +88,16 @@ results = fx.evaluate_horizons(
 fdr_res = fx.multi_factor.bhy(
     results,
     metrics=["ic"],
-    expand_over=("forward_periods",),
 )
 
 bhy_ic = fdr_res["ic"]
 survivors = bhy_ic.survivors
 adj_p = bhy_ic.adj_p
 ```
+
+Use `expand_over=("forward_periods",)` only for horizon-specific screens that
+were predeclared and will be selected and reported separately. It runs one
+step-up per horizon and does not control a later choice of the best horizon.
 
 Cross-horizon comparability is a scale alignment only: the `/ forward_periods` in
 `compute_forward_return` makes rank-IC comparable across horizons, but

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -27,3 +27,14 @@ The selection-only estimator classes under `factrix.stats`:
 - **`romano_wolf_adjusted_p(statistics, bootstrap_statistics, *, one_sided=False)`**: Dependence-aware step-down max-t FWER-adjusted p-values. This expert primitive requires every searched hypothesis and each bootstrap row to be a joint, null-centred draw with the same studentization as the observed statistics; independently resampled or omitted columns are invalid. Its empirical p-value resolution is `1 / (B + 1)`. Use Holm when a valid joint bootstrap family is unavailable.
 - **`stationary_bootstrap_resamples(values, n_bootstrap, ...)`**: Politis-Romano (1994) bootstrap resamples. An aligned `(T, m)` per-period statistic matrix is resampled with common row indices and returns `(B, T, m)`, preserving cross-hypothesis dependence for Romano-Wolf; separate per-column calls do not.
 - **`bootstrap_mean_ci(values, *, n_bootstrap, ci, ...)`**: Stationary-bootstrap CI for a statistic.
+
+Holm and BHY consume already calibrated p-values, so a declared family may
+contain a documented mix of `two-sided`, `greater`, and `less` alternatives;
+the procedures do not reinterpret tails. Factrix intentionally provides no
+generic one-sided-to-two-sided conversion because that conversion depends on
+the null distribution and producer contract.
+
+`romano_wolf_adjusted_p` remains an expert primitive: the caller must provide
+the complete joint, H0-centred, correctly studentized `(B, m)` matrix. Factrix
+does not currently expose a `multi_factor.romano_wolf` or panel-aware bootstrap
+workflow; use Holm unless that joint bootstrap contract is available.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -10,7 +10,8 @@ Current-state snapshot of the public API surface and internal layout.
 
 **factrix is a Factor FactorDensity Validator, not a backtest engine.**
 
-The library produces a single canonical p-value (`MetricResult.p_value`) per
+The library produces a single canonical p-value (`MetricResult.p_value`) and
+its explicit tested tail (`MetricResult.alternative`) per
 factor per `(scope, density, structure)` cell from the cell's mainstream
 metric (information coefficient (IC) / FM-λ / CAAR / TS-β). Dense
 time-series mainstream metrics use Newey-West (NW)
@@ -660,7 +661,8 @@ Failure modes:
 
 ## Family functions and the resolution layer
 
-The low-level public adjusted-p primitives under `factrix.stats` are distinct
+The low-level public adjusted-p primitives under the explicitly exported
+`factrix.stats` namespace are distinct
 from the family verbs in this section. `holm_adjusted_p` accepts a p-value
 vector; `romano_wolf_adjusted_p` accepts observed statistics plus a caller-
 supplied joint, null-centred, consistently studentized `(B, m)` bootstrap
@@ -675,8 +677,14 @@ horizons. It must not reconstruct a different estimand silently from scalar
 `EvaluationResult` fields; that higher-level workflow remains separate from
 the adjusted-p primitive.
 
-Multiple-testing functions (`bhy` today; `bhy_hierarchical` / `partial_conjunction` /
-`bonferroni` / `holm` / `romano_wolf` planned) share a single internal pre-processing
+Closed-form Holm/BHY procedures accept calibrated p-values and therefore do
+not require every hypothesis in a family to share the same alternative. The
+producer owns calibration and records `alternative`; the family layer neither
+converts tails nor infers them from statistic signs. There is intentionally no
+generic one-sided-to-two-sided helper.
+
+EvaluationResult-based multiple-testing functions (`bhy`, `bhy_hierarchical`,
+and `partial_conjunction`) share a single internal pre-processing
 layer in `factrix/_family.py::_resolve_family`. Each function's procedure runs *after*
 the family-resolution invariants pass.
 
@@ -688,19 +696,19 @@ ones:
 
 | Class | Functions | Signature shape |
 |-------|-------|-----------------|
-| Closed-form (p-value only) | `bhy` / `bhy_hierarchical` / `partial_conjunction` / `bonferroni` / `holm` | `(results, *, metrics, expand_over, ...)` |
-| Resampling-based | `romano_wolf` (planned) | `(results, panel, *, metrics, expand_over, n_bootstrap, ...)` — needs raw return panel for bootstrap step-down |
+| Closed-form (p-value only) | `bhy` / `bhy_hierarchical` / `partial_conjunction` | `(results, *, metrics, expand_over, ...)` |
+| Resampling-based | Not exposed at the `multi_factor` layer | Requires a future metric-specific panel and bootstrap contract; the low-level `stats.romano_wolf_adjusted_p` primitive is not this workflow |
 
 ### `_resolve_family` four invariants
 
 For input `results: Sequence[EvaluationResult]`, `expand_over: Sequence[str] | None`,
 and `metric: str` (one resolved spec):
 
-1. `expand_over` names must be present in every result's `context` and must
-   not collide with identity dimensions (`factor` / `forward_periods`) —
-   identity names *the hypothesis*, context names *the slicing condition*;
-   the family layer rejects confusing the two as an anti-shopping defense.
-2. partition key per result = `identity + tuple(context[k] for k in expand_over)`
+1. `expand_over` names must be present in every result's `context`, except
+   the built-in `forward_periods`; `factor` is rejected because it is an
+   identity dimension, not a family partition.
+2. hypothesis key per result = `(factor, forward_periods) +
+   tuple(context[k] for k in expand_over if k != "forward_periods")`
    must be unique across the input. `EvaluationResult.__hash__ = None`, so dedup
    walks the tuple, not a hash.
 3. The specified `metric` must have a computed `p_value` that is non-NaN,
@@ -724,11 +732,10 @@ e.g. `expand_over=["regime_id"]` runs one BHY step-up per regime.
 - Mixing cells without a distinct `factor` raises `UserInputError`
   (duplicate identity). Set `factor` per candidate, or use `expand_over`
   if results legitimately share identity.
-- Mixing `forward_periods` without `expand_over` emits a `RuntimeWarning` —
-  different horizons carry different null distributions, and pooling them
-  dilutes the per-rank threshold `q × k / N`.
-- Cross-family aggregation (horizon-shopping correction) remains the
-  user's responsibility — see the [BHY screening](../api/bhy.md) reference page.
+- Mixing `forward_periods` without a horizon partition emits an informational
+  `RuntimeWarning`. Pooling is correct when selection may choose across
+  horizons; `expand_over=("forward_periods",)` is only for predeclared,
+  separately reported horizon screens and does not control later horizon shopping.
 
 ---
 
@@ -831,10 +838,10 @@ Hard constraints — violating these breaks the API contract:
 
 1. `MetricSpec` is `frozen=True, slots=True`; every construction path runs `__post_init__`, which enforces the field invariants (e.g. `role=METRIC → output_shape=SCALAR`).
 2. All result dataclasses — `EvaluationResult`, `MetricResult`, `Warning` — are `frozen=True, slots=True`; `EvaluationResult.metrics` is a `MappingProxyType` for read-only per-metric outputs. One unified `EvaluationResult` — no per-cell subclass.
-3. The metric-spec SSOT is the `@metric` registration in each `factrix/metrics/*.py`, resolved through `factrix._metric_index` (`spec_by_name` / `public_specs` / `list_metrics`); no parallel rule table. `@metric`-class registration feeds the index via `factrix.metrics._registry.register`.
+3. The metric-spec SSOT is the `@metric` registration in each `factrix/metrics/*.py`, resolved through `factrix._metric_index` (`spec_by_name` / `public_specs` / `list_metrics`); no parallel rule table. `@metric`-class registration feeds the index via `factrix.metrics._registry.register`. Slice-boundary warnings read `MetricSpec.slice_boundary_sensitive`; aggregation categories are not a proxy rule table.
 4. The DAG executor is the single dispatch path. `DagExecutor` topologically orders specs by `MetricSpec.requires` (raising `CycleError` on cycles), runs `batchable=True` producers once per factor batch and `batchable=False` consumers once per factor, and short-circuits a downstream consumer with a NaN `MetricResult` + `WarningCode.UPSTREAM_UNAVAILABLE` rather than invoking it on missing upstream data.
-5. `MetricResult.p_value` is the single canonical p-value read path — `EvaluationResult.to_frame()` / `to_dict()`, `compare`, and the BHY family resolver all read it; the p-value lives only on the field and is not duplicated into `metadata`. `warnings` flag interpretation risk but never rebind it.
-6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over`. `_resolve_family` enforces (a) the hypothesis identity `(factor, *expand_over_values)` is unique across the input, (b) `expand_over` names come only from `EvaluationResult.context` (or the built-in `forward_periods`), never the factor, (c) `p_value` is populated everywhere before procedures read it. Cell / horizon partitioning is the caller's responsibility; mixed `forward_periods` without `expand_over` warns.
+5. `MetricResult.p_value` is the single canonical p-value read path — `EvaluationResult.to_frame()` / `to_dict()`, `compare`, and the BHY family resolver all read it; the p-value lives only on the field and is not duplicated into `metadata`. A formal p-value and `alternative` (`two-sided` / `greater` / `less`) must be present together; p-values are finite and in `[0, 1]`. `warnings` flag interpretation risk but never rebind it.
+6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over`. `_resolve_family` enforces (a) the hypothesis identity `(factor, forward_periods, *context_partition_values)` is unique across the input, (b) `expand_over` names come only from `EvaluationResult.context` (or the built-in `forward_periods`), never the factor, (c) `p_value` is populated everywhere before procedures read it. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
 7. `T < MIN_PERIODS_HARD` raises `InsufficientSampleError`; metrics never silently produce a result on under-sampled data. NW HAC lag selection on overlapping forward returns floors at `forward_periods - 1` (the Hansen-Hodrick floor) so serial correlation from overlap is not under-counted.
 
 For the user-facing field walk of `EvaluationResult` (and its

--- a/docs/examples/multi_factor_screening.md
+++ b/docs/examples/multi_factor_screening.md
@@ -14,7 +14,7 @@ This recipe uses `multi_factor.bhy(...)` over a list of `EvaluationResult` objec
 
 The input list is the family. Each result must carry a unique identity `(factor, forward_periods)`. The recommended path is to name the factor column distinctly per candidate panel and pass it via `factor_cols=[...]`; `evaluate` stamps the `factor` name onto each returned `EvaluationResult`.
 
-Pass `expand_over=("forward_periods",)` to declare per-horizon independent step-ups. Mixing `forward_periods` without `expand_over` emits a `RuntimeWarning` because different horizons carry different null distributions.
+Pooling horizons without `expand_over` controls the full factor × horizon search and emits an informational `RuntimeWarning`. Pass `expand_over=("forward_periods",)` only for predeclared horizon-specific screens that will be selected and reported separately; it does not control later horizon shopping.
 
 ## Use this when
 

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -21,6 +21,13 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 
 `n_assets` is never hard-blocked because the cross-asset t-test on E[β] is mathematically well-defined for `n_assets >= 2` — only its statistical power degrades. A hard block would force users to choose between "can't run" and "don't know there's a problem"; the warning provides the result while surfacing the issue.
 
+`FEW_ASSETS` does not imply one universal estimator switch. Spread metrics may
+switch from a cross-asset t-test to block bootstrap in the thin regime; IC,
+Fama–MacBeth, and common-beta paths retain their documented estimator and use
+the warning to flag thin ranks, low residual degrees of freedom, or unstable
+cross-asset aggregation. Read the metric metadata and method, not the warning
+code alone, to identify the inference path.
+
 ### Behaviour matrix by density and `n_assets`
 
 | Density / Scope | `n_assets == 1` | `n_assets = 2..9` | `n_assets = 10..29` | `n_assets >= 30` |

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -46,7 +46,8 @@ The `metrics` attribute is a read-only `Mapping[str, MetricResult]` mapping the 
 For a specific metric `key`, `result.metrics[key]` exposes:
 
 - **`value`**: Raw metric value (e.g. mean IC).
-- **`p_value`**: Promoted two-sided p-value for the metric's test (when applicable, or `None`).
+- **`p_value`**: Calibrated p-value for the metric's test (when applicable, or `None`).
+- **`alternative`**: The tested tail (`two-sided`, `greater`, or `less`), present exactly when `p_value` is present. Never infer the tail from the sign of `stat`.
 - **`stat`**: Test statistic (t, z, W, chi2, ...).
 - **`n_obs`**: Observations seen by this specific metric's estimator.
 - **`warning_codes`**: Advisory warnings attached by the metric (e.g. `FEW_EVENTS`).

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "The input list is the family. Each result must carry a unique identity `(factor, forward_periods)`. The recommended path is to name the factor column distinctly per candidate panel and pass it via `factor_cols=[...]`; `evaluate` stamps the `factor` name onto each returned `EvaluationResult`.\n",
     "\n",
-    "Pass `expand_over=(\"forward_periods\",)` to declare per-horizon independent step-ups. Mixing `forward_periods` without `expand_over` emits a `RuntimeWarning` because different horizons carry different null distributions.\n"
+    "Pooling horizons without `expand_over` controls the full factor × horizon search and emits an informational `RuntimeWarning`. Pass `expand_over=(\"forward_periods\",)` only for predeclared horizon-specific screens that will be selected and reported separately; it does not control later horizon shopping.\n"
    ]
   },
   {

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -50,7 +50,7 @@ import polars as pl
 if TYPE_CHECKING:
     from factrix.metrics._base import MetricBase
 
-from factrix import datasets, inference, multi_factor, preprocess
+from factrix import datasets, inference, multi_factor, preprocess, stats
 from factrix._axis import (  # DataStructure used by the structure pre-flight; re-exported for namespace access, intentionally not in __all__
     DataStructure,
     FactorDensity,
@@ -143,8 +143,8 @@ def evaluate(
             quantile_spread(n_groups=10)}`` — via by-value DAG dedup; shared
             upstream producers are computed once per distinct config.
             ``forward_periods`` is **not** a metric knob: every metric runs at
-            the data's single overlap horizon. To compare horizons, build two
-            panels and evaluate each.
+            the data's single overlap horizon. To compare horizons, use
+            :func:`evaluate_horizons` on the clean raw panel.
             Scalar-input helpers (for example ``breakeven_cost`` /
             ``net_spread``) are post-processing utilities, not
             panel-evaluation metrics; compute their upstream diagnostics first
@@ -346,8 +346,10 @@ def evaluate_horizons(
     horizon. ``factor`` and ``forward_periods`` are existing native
     attributes of :class:`EvaluationResult`; the list feeds straight into
     :func:`compare` and into
-    ``bhy(..., expand_over=('forward_periods',))``, which partitions each
-    horizon into its own step-up family.
+    :func:`factrix.multi_factor.bhy`. Pool all horizons when selection may
+    choose across them; use ``expand_over=('forward_periods',)`` only for
+    predeclared horizon-specific screens that are selected and reported
+    separately.
 
     Args:
         data: A **raw** panel carrying ``date``, ``asset_id``, ``price`` and
@@ -1095,6 +1097,8 @@ __all__ = [
     "preprocess",
     # Curated statistical inference methods (e.g. ic(inference=...))
     "inference",
+    # Low-level statistical primitives and estimator classes
+    "stats",
     # Metric registration surface
     "MetricSpec",
     "metric_spec",

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -6,8 +6,10 @@ list of :class:`~factrix._results.EvaluationResult` into flat
 ``_FamilyEntry`` records ready for the procedure-specific step-up math.
 
 The invariants enforced here are the family-layer extension of the
-anti-shopping defense: the hypothesis identity is
-``(factor, *expand_over_values)``; ``expand_over`` names are read
+anti-shopping defense: the base hypothesis identity is
+``(factor, forward_periods)``. Context values named by ``expand_over``
+extend that identity while all ``expand_over`` values partition the family;
+``expand_over`` names are read
 from ``forward_periods`` (the lone non-context built-in slicing axis)
 or from ``EvaluationResult.context``. The estimator-override hook is
 gone — callers select inference at metric-construction time (e.g.
@@ -41,8 +43,9 @@ class _FamilyEntry:
     ``p_value`` only after the attach stage, where it is always non-None.
 
     Attributes:
-        identifier: ``(factor, *expand_over_values)`` — the hypothesis
-            key. With no ``expand_over``, collapses to ``(factor,)``.
+        identifier: ``(factor, forward_periods, *context_partition_values)``
+            — the hypothesis key. ``forward_periods`` is always part of the
+            identity, even when it is also the family partition axis.
         expand_over_values: ``tuple`` in caller-supplied key order;
             empty when ``expand_over`` is empty.
         result: Back-reference for survivor rendering; not read by the
@@ -86,19 +89,25 @@ def _partition(
     seen: dict[tuple[Any, ...], int] = {}
     for idx, result in enumerate(results):
         values = _expand_over_values(result, keys=keys)
-        identifier = (result.factor, *values)
+        context_values = tuple(
+            value
+            for name, value in zip(keys, values, strict=True)
+            if name not in _BUILTIN_EXPAND_OVER_FIELDS
+        )
+        identifier = (result.factor, result.forward_periods, *context_values)
         if identifier in seen:
             raise UserInputError(
                 func_name=func_name,
                 field="results",
                 value=identifier,
                 expected=(
-                    "unique (factor, *expand_over_values) identifier across "
+                    "unique (factor, forward_periods, "
+                    "*context_partition_values) identifier across "
                     f"input; duplicate first seen at index {seen[identifier]}, "
                     f"again at {idx}. Either stamp a distinct factor column "
-                    "per evaluation, or pass `expand_over=[<key>]` to declare "
-                    "per-bucket families (e.g. `expand_over=('forward_periods',)` "
-                    "for multi-horizon screening)"
+                    "per evaluation, or pass `expand_over=[<context_key>]` "
+                    "when the repeated evaluation belongs to a predeclared "
+                    "context-specific family"
                 ),
                 docs_path=f"api/{func_name}#partition-key",
             )
@@ -165,8 +174,8 @@ def _resolve_family(
        field (``forward_periods``) or as a key in every result's
        ``context``. ``factor`` is rejected (it is the hypothesis
        identifier, not a slicing axis).
-    2. The partition key ``(factor, *expand_over_values)`` must be
-       unique across the input.
+    2. The hypothesis key ``(factor, forward_periods,
+       *context_partition_values)`` must be unique across the input.
     3. Each result must produce the ``metric``'s p-value;
        the p must be present and non-NaN.
     """

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -273,6 +273,10 @@ class MetricSpec:
       :func:`inspect_data` blocks it on a discrete ±k signal, matching the
       metric's run-time ``not_applicable_discrete_signal`` short-circuit.
       Defaults to ``False``.
+    - ``slice_boundary_sensitive``: ``True`` when evaluating independently on
+      date-axis slices changes the computation by truncating ordered history,
+      resetting a sampling phase, or refitting a time-series model. This is a
+      capability of the estimator, not an inference from ``aggregation``.
     """
 
     name: str
@@ -288,6 +292,7 @@ class MetricSpec:
     # factor (``|factor|`` varies across events). ``inspect_data`` blocks it on a
     # discrete ±k signal, matching the metric's run-time short-circuit.
     requires_continuous_magnitude: bool = False
+    slice_boundary_sensitive: bool = False
 
     def __post_init__(self) -> None:
         if self.role is SpecRole.METRIC and self.output_shape is not OutputShape.SCALAR:

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -9,9 +9,9 @@ metric still returns a dict — no isinstance dispatch on the caller
 side).
 
 Family declaration is explicit: the input list *is* the family,
-optionally split per-bucket via ``expand_over``. Hypothesis identifier
-is ``(factor, *expand_over_values)``. Cell / horizon partitioning is
-the caller's responsibility.
+optionally split per-bucket via ``expand_over``. The base hypothesis
+identifier is ``(factor, forward_periods)``; context partition values
+extend it. Family partitioning remains the caller's responsibility.
 """
 
 from __future__ import annotations
@@ -429,8 +429,9 @@ def bhy(
     is non-empty, one independent step-up runs per unique tuple of
     ``expand_over`` values (read from ``EvaluationResult.forward_periods``
     for that built-in slicing axis, otherwise from
-    ``EvaluationResult.context[k]``). Cell / horizon partitioning is
-    the caller's responsibility.
+    ``EvaluationResult.context[k]``). Pooling horizons in one family is
+    appropriate when selection may choose across horizons; partitioning by
+    horizon is appropriate only for predeclared, separately reported screens.
 
     Args:
         results: :class:`EvaluationResult` records. The full input is
@@ -452,15 +453,16 @@ def bhy(
 
     Raises:
         UserInputError: ``metrics`` not a non-empty ``list[str]``;
-            duplicate ``(factor, *expand_over_values)`` identifier;
+            duplicate ``(factor, forward_periods,
+            *context_partition_values)`` identifier;
             ``expand_over`` key missing from a result's context or
             naming ``'factor'``; metric absent from a result's
             outputs or its ``p_value`` missing / NaN.
 
     Warns:
-        RuntimeWarning: Input mixes ``forward_periods`` with
-            ``expand_over`` empty (pooling horizons dilutes the
-            per-rank threshold). Or most ``expand_over`` buckets are
+        RuntimeWarning: Input pools multiple ``forward_periods`` in the same
+            family, reminding callers to match the family to their selection
+            rule. Or most ``expand_over`` buckets are
             singletons (BHY on n=1 provides no FDR correction).
     """
     metric_list = _validate_metric_list(metrics, func_name="bhy", field="metrics")
@@ -880,19 +882,17 @@ def _warn_on_mixed_horizons(
     *,
     expand_over: tuple[str, ...],
 ) -> None:
-    if expand_over:
+    if "forward_periods" in expand_over:
         return
     horizons = {r.forward_periods for r in results}
     if len(horizons) > 1:
         warnings.warn(
             f"bhy: input mixes forward_periods={sorted(horizons)} but "
-            "expand_over is empty — different horizons have different "
-            "null distributions; pooling them in one step-up dilutes "
-            "the per-rank threshold and silently inflates FDR. Either "
-            "split the call per horizon, or set "
-            "expand_over=('forward_periods',) to declare per-bucket "
-            "families — the latter is the intended companion to an "
-            "evaluate_horizons sweep.",
+            "they are being pooled into one multiple-testing family. This is "
+            "the correct choice when the research process may select across "
+            "horizons. Use expand_over=('forward_periods',) only when horizon "
+            "screens were predeclared and will be selected and reported "
+            "separately; it does not control global horizon shopping.",
             RuntimeWarning,
             stacklevel=3,
         )

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -11,13 +11,15 @@ import html
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope
 from factrix._codes import WarningCode
 from factrix._types import SampleAxis
+
+PValueAlternative = Literal["two-sided", "greater", "less"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,8 +28,10 @@ class MetricResult:
 
     Attributes:
         value: Raw metric value.
-        p_value: Two-sided p-value for the metric's hypothesis test.
-            ``None`` for descriptive metrics that carry no formal test.
+        p_value: P-value for the metric's hypothesis test. ``None`` for
+            descriptive metrics that carry no formal test.
+        alternative: Alternative-hypothesis direction used to construct
+            ``p_value``. Present exactly when ``p_value`` is present.
         n_obs: Effective sample size the estimator actually used
             (e.g. number of non-overlapping IC periods, number of
             events, number of bootstrap windows). ``None`` where a
@@ -51,6 +55,7 @@ class MetricResult:
 
     value: float
     p_value: float | None = None
+    alternative: PValueAlternative | None = None
     n_obs: int | None = None
     n_obs_axis: SampleAxis | None = None
     stat: float | None = None
@@ -58,11 +63,26 @@ class MetricResult:
     warning_codes: tuple[str, ...] = ()
     name: str = ""
 
+    def __post_init__(self) -> None:
+        if (self.p_value is None) != (self.alternative is None):
+            raise ValueError(
+                "MetricResult: p_value and alternative must either both be "
+                "provided or both be None."
+            )
+        if self.p_value is not None and (
+            not math.isfinite(self.p_value) or not 0.0 <= self.p_value <= 1.0
+        ):
+            raise ValueError(
+                "MetricResult: p_value must be finite and lie in [0, 1]; "
+                f"got {self.p_value!r}."
+            )
+
     def __repr__(self) -> str:
         name = self.name or "?"
         parts = [f"{name}={self.value:.4f}"]
         if self.p_value is not None:
             parts.append(f"p_value={self.p_value:.4g}")
+            parts.append(f"alternative={self.alternative}")
         if self.n_obs is not None:
             axis = f" {self.n_obs_axis}" if self.n_obs_axis else ""
             parts.append(f"n_obs={self.n_obs}{axis}")
@@ -182,6 +202,7 @@ class EvaluationResult:
         | ``metric_name`` | str | ``MetricResult.name`` |
         | ``value`` | f64 \| null | ``MetricResult.value`` |
         | ``p_value`` | f64 \| null | ``MetricResult.p_value`` |
+        | ``alternative`` | str \| null | ``MetricResult.alternative`` |
         | ``stat`` | f64 \| null | ``MetricResult.stat`` |
         | ``n_obs`` | i64 \| null | ``MetricResult.n_obs`` — estimator effective sample size |
         | ``n_obs_axis`` | str \| null | ``MetricResult.n_obs_axis`` — axis ``n_obs`` counts along (``periods`` / ``events`` / ``pairs`` / ``assets``) |
@@ -214,7 +235,7 @@ class EvaluationResult:
 
         - ``factor`` / ``cell`` / ``forward_periods`` / ``n_periods`` /
           ``n_pairs`` / ``n_assets`` / ``context``
-        - ``metrics``: ``label -> {value, p_value, stat, n_obs,
+        - ``metrics``: ``label -> {value, p_value, alternative, stat, n_obs,
           n_obs_axis, is_applicable, reason, metadata}``
         - ``warnings``: list of ``{code, source, message}``
         - ``plan``
@@ -274,14 +295,16 @@ class EvaluationResult:
         for name, out in sorted(self.metrics.items()):
             val_repr = "null" if math.isnan(out.value) else f"{out.value:.4g}"
             p_repr = f"{out.p_value:.4g}" if isinstance(out.p_value, float) else ""
+            alternative = out.alternative or ""
             metric_rows.append(
                 f"<tr><td>{html.escape(name)}</td>"
                 f"<td style='text-align:right'>{val_repr}</td>"
-                f"<td style='text-align:right'>{p_repr}</td></tr>"
+                f"<td style='text-align:right'>{p_repr}</td>"
+                f"<td>{html.escape(alternative)}</td></tr>"
             )
         metric_table = (
             "<table><thead><tr><th>metric</th><th>value</th>"
-            "<th>p</th></tr></thead>"
+            "<th>p</th><th>alternative</th></tr></thead>"
             f"<tbody>{''.join(metric_rows)}</tbody></table>"
         )
 
@@ -322,6 +345,7 @@ _TO_FRAME_SCHEMA: dict[str, pl.DataType | type[pl.DataType]] = {
     "metric_name": pl.Utf8,
     "value": pl.Float64,
     "p_value": pl.Float64,
+    "alternative": pl.Utf8,
     "stat": pl.Float64,
     "n_obs": pl.Int64,
     "n_obs_axis": pl.Utf8,
@@ -341,6 +365,7 @@ def _output_row(
         "metric_name": label,
         "value": _float_or_none(out.value),
         "p_value": _float_or_none(out.p_value),
+        "alternative": out.alternative,
         "stat": _float_or_none(out.stat),
         "n_obs": out.n_obs,
         "n_obs_axis": out.n_obs_axis,
@@ -364,6 +389,7 @@ def _metric_output_to_record(out: MetricResult) -> dict[str, Any]:
     return {
         "value": _float_or_none(out.value),
         "p_value": _float_or_none(out.p_value),
+        "alternative": out.alternative,
         "stat": _float_or_none(out.stat),
         "n_obs": out.n_obs,
         "n_obs_axis": out.n_obs_axis,

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -202,7 +202,7 @@ Thin sweep that runs `evaluate` across several overlap horizons of one **raw** p
 
 - `data` is a raw price panel (`date`, `asset_id`, `price`, factor columns). Only forward-return is computed; winsorize / abnormal-return are out of scope.
 - `forward_periods` is a non-empty `list[int]` of distinct positive horizons (e.g. `[5, 20, 60]`); duplicates and non-positive values are rejected.
-- Returns a flat `list[EvaluationResult]` grouped by horizon then `factor_cols` order — one entry per `(factor, forward_periods)`. The list feeds straight into `compare(...)` and `bhy(..., expand_over=("forward_periods",))`, which partitions each horizon into its own step-up family.
+- Returns a flat `list[EvaluationResult]` grouped by horizon then `factor_cols` order — one entry per `(factor, forward_periods)`. The list feeds straight into `compare(...)` and `bhy(...)`. Pool horizons when selection may choose across them; use `expand_over=("forward_periods",)` only for predeclared, separately reported horizon screens.
 - Comparability across horizons is a scale alignment (the `/ forward_periods` in `compute_forward_return` makes rank-IC comparable); signed-return-mean metrics carry a compounding bias that grows with `forward_periods`, so treat those sweeps as descriptive.
 
 ---
@@ -250,6 +250,12 @@ def bhy(
 
 Benjamini-Hochberg-Yekutieli step-up FDR within a declared family. Returns a dictionary of `BhyResult` objects keyed by the metric labels.
 
+The base hypothesis identity is `(factor, forward_periods)`. With no
+`expand_over`, all factor × horizon hypotheses are pooled, which is required
+when the research process may select the best horizon. Partition by
+`forward_periods` only for predeclared horizon-specific screens; separate
+buckets do not control later horizon shopping.
+
 `BhyResult` contains:
 - `metric_name`: Metric label under test.
 - `survivors`: Surviving `EvaluationResult` records.
@@ -278,6 +284,13 @@ per-period statistic matrix and applies common block indices to all columns,
 returning `(B, T, m)`. This preserves joint dependence before the caller
 centres and studentizes each bootstrap statistic for
 `romano_wolf_adjusted_p`; separate calls per column are not equivalent.
+
+Holm and BHY consume calibrated p-values and may combine documented one- and
+two-sided alternatives; they do not reinterpret tails. There is no generic
+tail-conversion helper. Factrix also does not expose a high-level
+`multi_factor.romano_wolf` or panel-aware bootstrap workflow: callers of the
+low-level primitive must supply the complete joint, H0-centred, correctly
+studentized `(B, m)` matrix.
 
 ---
 
@@ -421,7 +434,8 @@ Flat warning representation containing:
 
 Dataclass for a single metric's output:
 - `value`: Raw scalar result.
-- `p_value`: Two-sided p-value for the metric's hypothesis test.
+- `p_value`: Calibrated p-value for the metric's hypothesis test, or `None` for descriptive outputs.
+- `alternative`: Tested tail (`two-sided`, `greater`, or `less`), present exactly when `p_value` is present.
 - `n_obs`: Effective sample size the estimator actually used (single source of truth for sample size).
 - `n_obs_axis`: The sample dimension `n_obs` counts along (`periods` / `pairs` / `events` / ...), or `None`.
 - `stat`: Test statistic value (t, z, W, chi2, ...), when applicable.

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -139,6 +139,10 @@ class MetricBase(metaclass=MetricMeta):
     # ``inspect_data`` blocks it pre-flight. Default ``False`` — most metrics
     # accept any cardinality.
     requires_continuous_magnitude: ClassVar[bool] = False
+    # Declares that independent date-axis slices alter ordered-history,
+    # sampling-phase, or time-series-model semantics. ``by_slice`` reads this
+    # capability directly instead of guessing from the aggregation category.
+    slice_boundary_sensitive: ClassVar[bool] = False
 
     # Canonical injected horizon. Declared here (not a real attribute on the
     # base) so a floor resolver typed ``Callable[[MetricBase], SampleThreshold]``
@@ -183,6 +187,7 @@ class MetricBase(metaclass=MetricMeta):
             batchable=cls.batchable,
             sample_threshold=cls.sample_threshold,
             requires_continuous_magnitude=cls.requires_continuous_magnitude,
+            slice_boundary_sensitive=cls.slice_boundary_sensitive,
         )
 
     def _params(self) -> dict[str, Any]:

--- a/factrix/metrics/_decorators.py
+++ b/factrix/metrics/_decorators.py
@@ -61,6 +61,7 @@ def metric(
     | Callable[[MetricBase], SampleThreshold]
     | None = None,
     requires_continuous_magnitude: bool = False,
+    slice_boundary_sensitive: bool = False,
 ) -> Callable[[_F], _F]:
     """Decorator to define a Metric class from a function definition.
 
@@ -135,6 +136,7 @@ def metric(
             "batchable": batchable,
             "_resolve_sample_threshold": staticmethod(resolver),
             "requires_continuous_magnitude": requires_continuous_magnitude,
+            "slice_boundary_sensitive": slice_boundary_sensitive,
             "_impl": fn,
             "_first_param_name": first_param_name,
             "_param_names": user_param_names,

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from factrix.inference import NeweyWest, NonOverlapping
     from factrix.metrics._base import MetricBase
 from factrix._metric_index import SampleThreshold
-from factrix._results import MetricResult
+from factrix._results import MetricResult, PValueAlternative
 from factrix._stats import _calc_t_stat, _p_value_from_t
 from factrix._stats.constants import MIN_ASSETS_WARN
 from factrix._types import DDOF, EPSILON, KPSource, SampleAxis
@@ -250,6 +250,7 @@ def _short_circuit_output(
     n_obs: int | None = None,
     n_obs_axis: SampleAxis | None = None,
     descriptive: bool = False,
+    alternative: PValueAlternative = "two-sided",
     **extra_metadata: object,
 ) -> MetricResult:
     """Canonical short-circuit ``MetricResult`` for "cannot compute".
@@ -290,6 +291,7 @@ def _short_circuit_output(
     return MetricResult(
         value=float("nan"),
         p_value=p,
+        alternative=None if descriptive else alternative,
         n_obs=n_obs,
         n_obs_axis=n_obs_axis,
         stat=None,
@@ -333,6 +335,7 @@ def _no_signal_zero_variance(n_periods: int, **extra: object) -> MetricResult:
     return MetricResult(
         value=0.0,
         p_value=1.0,
+        alternative="two-sided",
         n_obs=n_periods,
         n_obs_axis="periods",
         stat=0.0,
@@ -355,6 +358,7 @@ def _enforce_min_floor(
     *,
     axis: SampleAxis = "periods",
     descriptive: bool = False,
+    alternative: PValueAlternative = "two-sided",
     **extra: object,
 ) -> MetricResult | None:
     """Short-circuit when ``n`` falls below the metric's declared ``min_<axis>``.
@@ -391,6 +395,7 @@ def _enforce_min_floor(
             n_obs_axis=axis,
             min_required=floor,
             descriptive=descriptive,
+            alternative=alternative,
             **extra,
         )
     return None
@@ -402,6 +407,7 @@ def _enforce_scaled_floor(
     base: int,
     forward_periods: int,
     reason: str,
+    alternative: PValueAlternative = "two-sided",
     **extra: object,
 ) -> MetricResult | None:
     """Short-circuit when the *raw* (pre-sampling) date count is below the
@@ -428,6 +434,7 @@ def _enforce_scaled_floor(
             n_obs_axis="periods",
             min_required=floor,
             descriptive=False,  # every stride-sampling metric runs a hypothesis test
+            alternative=alternative,
             **extra,
         )
     return None

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -251,6 +251,7 @@ def caar(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=mean_caar,
         n_obs=n_sampled,
         n_obs_axis="events",
@@ -519,6 +520,7 @@ def bmp_z(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=mean_sar,
         n_obs=n_valid,
         n_obs_axis="events",

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -95,6 +95,7 @@ def _caar_sample_threshold(self: MetricBase) -> SampleThreshold:
 @metric(
     cell=_CAAR_CELL,
     aggregation=Aggregation.EVENT_TIME,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"caar_df": compute_caar},
     sample_threshold=_caar_sample_threshold,
@@ -264,6 +265,7 @@ def caar(
 @metric(
     cell=_CAAR_CELL,
     aggregation=Aggregation.EVENT_TIME,
+    slice_boundary_sensitive=True,
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def bmp_z(

--- a/factrix/metrics/common_asymmetry.py
+++ b/factrix/metrics/common_asymmetry.py
@@ -258,6 +258,7 @@ def common_asymmetry(
 
     return MetricResult(
         p_value=p_a,
+        alternative="two-sided",
         value=asym_value,
         n_obs=n_periods,
         n_obs_axis="periods",

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -64,6 +64,7 @@ _COMMON_BETA_CELL = cell(
 @metric(
     cell=_COMMON_BETA_CELL,
     aggregation=Aggregation.TS_THEN_CS,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=3),
@@ -157,6 +158,7 @@ def common_beta(common_betas_df: pl.DataFrame) -> MetricResult:
 @metric(
     cell=_COMMON_BETA_CELL,
     aggregation=Aggregation.TS_THEN_CS,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=1),
@@ -260,6 +262,7 @@ def common_beta_profile(
 @metric(
     cell=_COMMON_BETA_CELL,
     aggregation=Aggregation.TS_THEN_CS,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=1),
@@ -343,6 +346,7 @@ def common_beta_r_squared(common_betas_df: pl.DataFrame) -> MetricResult:
 @metric(
     cell=_COMMON_BETA_CELL,
     aggregation=Aggregation.TS_THEN_CS,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
@@ -479,6 +483,7 @@ def compute_rolling_common_beta(
 @metric(
     cell=_COMMON_BETA_CELL,
     aggregation=Aggregation.TS_THEN_CS,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=2),

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -139,6 +139,7 @@ def common_beta(common_betas_df: pl.DataFrame) -> MetricResult:
     )
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=mean_b,
         n_obs=n,
         n_obs_axis="assets",

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -225,6 +225,7 @@ def common_quantile_spread(
 
     return MetricResult(
         p_value=p_spread,
+        alternative="two-sided",
         value=spread_value,
         n_obs=n_periods,
         n_obs_axis="periods",

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -133,6 +133,7 @@ def top_concentration(
         return _short_circuit_output(
             "top_concentration",
             "no_return_column",
+            alternative="less",
             missing_column=return_col,
             weight_by=weight_by,
         )
@@ -229,6 +230,7 @@ def top_concentration(
     }
     return MetricResult(
         p_value=p,
+        alternative="less",
         value=mean_eff_n,
         n_obs=n,
         n_obs_axis="periods",

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -120,7 +120,12 @@ def corrado_rank(
     n_events = len(events)
 
     sc = _enforce_min_floor(
-        corrado_rank, "corrado_rank", n_events, "insufficient_events", axis="events"
+        corrado_rank,
+        "corrado_rank",
+        n_events,
+        "insufficient_events",
+        axis="events",
+        alternative="greater",
     )
     if sc is not None:
         return sc
@@ -134,6 +139,7 @@ def corrado_rank(
         return _short_circuit_output(
             "corrado_rank",
             "degenerate_rank_variance",
+            alternative="greater",
             std_u=std_u,
         )
 
@@ -146,6 +152,7 @@ def corrado_rank(
 
     return MetricResult(
         p_value=p,
+        alternative="greater",
         value=mean_u,
         n_obs=n_events,
         n_obs_axis="events",

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -33,6 +33,7 @@ __all__ = [
     # floor guards thin samples.
     cell=cell(None, FactorDensity.SPARSE, structure=None),
     aggregation=Aggregation.EVENT_TIME,
+    slice_boundary_sensitive=True,
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
 def corrado_rank(

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -160,6 +160,7 @@ def directional_hit_rate(
         return _short_circuit_output(
             "directional_hit_rate",
             "no_return_column",
+            alternative="greater",
             missing_column=return_col,
         )
 
@@ -189,6 +190,7 @@ def directional_hit_rate(
         n,
         "insufficient_directional_samples",
         axis="pairs",
+        alternative="greater",
     )
     if sc is not None:
         return sc
@@ -215,6 +217,7 @@ def directional_hit_rate(
         return _short_circuit_output(
             "directional_hit_rate",
             "degenerate_directional_variance",
+            alternative="greater",
             n_obs=n,
             n_obs_axis="pairs",
             p_correct=p_correct,
@@ -282,6 +285,7 @@ def directional_hit_rate(
     return MetricResult(
         value=p_correct,
         p_value=p,
+        alternative="greater",
         n_obs=n,
         n_obs_axis="pairs",
         stat=float(s_stat),

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -54,6 +54,7 @@ __all__ = [
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=None),
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.PANEL,
     sample_threshold=SampleThreshold(
         min_pairs=MIN_DIRECTIONAL_PAIRS_HARD,

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -44,6 +44,7 @@ _EH_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 @metric(
     cell=_EH_CELL,
     aggregation=Aggregation.EVENT_TIME,
+    slice_boundary_sensitive=True,
     sample_threshold=SampleThreshold(),
 )
 def event_around_return(

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -125,6 +125,7 @@ def event_hit_rate(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=rate,
         n_obs=n,
         n_obs_axis="events",
@@ -229,6 +230,7 @@ def event_ic(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=rho,
         n_obs=n,
         n_obs_axis="events",
@@ -410,6 +412,7 @@ def event_skewness(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=skew,
         n_obs=n,
         n_obs_axis="events",

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -335,6 +335,7 @@ def fm_beta(
     _surface_drop_stats(beta_df, "fm_beta", metadata, warning_codes)
     return MetricResult(
         p_value=p_final,
+        alternative="two-sided",
         value=mean_beta,
         n_obs=n,
         n_obs_axis="periods",
@@ -420,6 +421,7 @@ def _pooled_beta_driscoll_kraay(
     if n_periods < _MIN_DK_PERIODS_HARD:
         return MetricResult(
             p_value=1.0,
+            alternative="two-sided",
             value=slope,
             n_obs=n_obs,
             n_obs_axis="pairs",
@@ -458,6 +460,7 @@ def _pooled_beta_driscoll_kraay(
     }
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=slope,
         n_obs=n_obs,
         n_obs_axis="pairs",
@@ -671,6 +674,7 @@ def pooled_beta(
         if g_a < 3:
             return MetricResult(
                 p_value=1.0,
+                alternative="two-sided",
                 value=slope,
                 n_obs=n_obs,
                 n_obs_axis="pairs",
@@ -698,6 +702,7 @@ def pooled_beta(
         if min(g_a, g_b) < 3:
             return MetricResult(
                 p_value=1.0,
+                alternative="two-sided",
                 value=slope,
                 n_obs=n_obs,
                 n_obs_axis="pairs",
@@ -765,6 +770,7 @@ def pooled_beta(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=slope,
         n_obs=n_obs,
         n_obs_axis="pairs",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -329,6 +329,7 @@ def ic(
             warning_codes.append(code.value)
     return MetricResult(
         p_value=result.p_value,
+        alternative="two-sided",
         value=mean_ic,
         n_obs=n,
         n_obs_axis="periods",

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -333,6 +333,7 @@ def k_spread(
     return MetricResult(
         value=mean_spread,
         p_value=p,
+        alternative="two-sided",
         n_obs=n,
         n_obs_axis="periods",
         stat=t,

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -45,6 +45,7 @@ _MFE_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 @metric(
     cell=_MFE_CELL,
     aggregation=Aggregation.EVENT_TIME,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"mfe_mae_df": compute_mfe_mae},
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -223,6 +223,7 @@ def monotonicity(
         p = _p_value_from_t(t, len(mono_arr))
         results[f] = MetricResult(
             p_value=p,
+            alternative="two-sided",
             value=avg_mono,
             n_obs=len(mono_arr),
             n_obs_axis="periods",

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -50,6 +50,7 @@ GateStatus = Literal["PASS", "VETOED"]
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     sample_threshold=SampleThreshold(min_periods=MIN_OOS_PERIODS_HARD * 2),

--- a/factrix/metrics/positive_rate.py
+++ b/factrix/metrics/positive_rate.py
@@ -75,6 +75,7 @@ def per_date_series(series: pl.DataFrame) -> pl.DataFrame:
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     # Periods floor scales with the non-overlap stride: the binomial runs on the

--- a/factrix/metrics/positive_rate.py
+++ b/factrix/metrics/positive_rate.py
@@ -188,6 +188,7 @@ def positive_rate(
     )
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=rate,
         n_obs=n,
         n_obs_axis="periods",

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -37,6 +37,7 @@ __all__ = ["predictive_beta"]
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=DataStructure.TIMESERIES),
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.PANEL,
     sample_threshold=SampleThreshold(
         min_periods=MIN_PERIODS_HARD,

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -166,6 +166,7 @@ def predictive_beta(
     return MetricResult(
         value=beta,
         p_value=p_value,
+        alternative="two-sided",
         n_obs=n,
         n_obs_axis="periods",
         stat=t_stat,

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -345,6 +345,7 @@ def _quantile_spread_from_series(
     )
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=mean_spread,
         n_obs=n,
         n_obs_axis="periods",
@@ -559,6 +560,7 @@ def quantile_spread_vw(
     )
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=mean_spread,
         n_obs=n,
         n_obs_axis="periods",

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -162,6 +162,7 @@ def _align_spread_series(
 @metric(
     cell=_SPANNING_CELL,
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"factor_spread": compute_spread_series},
     sample_threshold=SampleThreshold(min_periods=10),
@@ -283,6 +284,7 @@ def spanning_alpha(
 @metric(
     cell=_SPANNING_CELL,
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     batchable=True,
     requires={"factor_spreads": compute_spread_series},

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -258,6 +258,7 @@ def spanning_alpha(
 
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=ols.alpha,
         n_obs=n_obs,
         n_obs_axis="periods",

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -83,6 +83,7 @@ def _rank_turnover_sample_threshold(self: MetricBase) -> SampleThreshold:
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     sample_threshold=_rank_turnover_sample_threshold,
 )
 def rank_turnover(

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -46,6 +46,7 @@ __all__ = [
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
     ),
     aggregation=Aggregation.TS_ONLY,
+    slice_boundary_sensitive=True,
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     sample_threshold=SampleThreshold(min_periods=10),

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -201,6 +201,7 @@ def ic_trend(
     )
     return MetricResult(
         p_value=p,
+        alternative="two-sided",
         value=slope,
         n_obs=n,
         n_obs_axis="periods",

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -138,8 +138,8 @@ def compute_forward_return(
            horizons — it does *not* address the inference problem.
            Overlap is handled by heteroskedasticity-and-autocorrelation-consistent (HAC) (see
            :class:`factrix.inference.NeweyWest`); across-horizon
-           selection is handled by the family-wise error rate (FWER) correction in
-           :func:`factrix.multi_factor.bhy`. The three concerns
+           selection is handled by a declared multiple-testing family in
+           :func:`factrix.multi_factor.bhy` (BHY controls FDR, not FWER). The three concerns
            (scale, overlap, cross-horizon selection) are addressed
            at separate layers; overlap and across-horizon dependence
            share a common source in the persistent regressor, but

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -17,28 +17,12 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-from factrix._axis import Aggregation
 from factrix._codes import WarningCode
 from factrix.slicing._primitive import _slice_by
 
 if TYPE_CHECKING:
     from factrix._results import EvaluationResult
     from factrix.metrics._base import MetricBase
-
-# Aggregations whose computation looks across dates per asset — a rolling
-# window, per-asset time-series regression, or event window. Slicing the
-# panel on a date axis truncates that history at slice boundaries (see
-# WarningCode.SLICE_BOUNDARY_TRUNCATION). The complement
-# (CS_THEN_TS / CS_SNAPSHOT) is per-date independent, so a date-axis slice
-# is exactly the intended period decomposition and does not warn.
-_CROSS_DATE_AGGREGATIONS = frozenset(
-    {
-        Aggregation.TS_ONLY,
-        Aggregation.TS_THEN_CS,
-        Aggregation.EVENT_TIME,
-        Aggregation.RETURN_SPANNING,
-    }
-)
 
 # Single-metric label used inside the per-slice evaluate call.
 _METRIC_LABEL = "metric"
@@ -73,7 +57,7 @@ def by_slice(
     windows (``common_beta``, ``mfe_mae``, ``oos_decay``, …) — sees truncated
     history at slice boundaries, so its per-slice value differs from the
     full-sample value decomposed by period. Per-date metrics (``ic``,
-    ``fm_beta``, ``quantile``, ``positive_rate``) are unaffected. A
+    ``fm_beta``, ``quantile``) are unaffected. A
     :class:`~factrix._codes.WarningCode.SLICE_BOUNDARY_TRUNCATION` warning
     is emitted when a cross-date metric is sliced on a date axis.
 
@@ -168,17 +152,17 @@ def _warn_date_axis_truncation(data: pl.DataFrame, metric: MetricBase, by: str) 
     """Warn when a cross-date metric is sliced on a date axis.
 
     Emits :class:`~factrix._codes.WarningCode.SLICE_BOUNDARY_TRUNCATION`
-    only when both hold: (1) the metric's aggregation looks across dates
-    (``_CROSS_DATE_AGGREGATIONS``); (2) ``by`` is a date-axis partition —
+    only when both hold: (1) the metric declares
+    ``MetricSpec.slice_boundary_sensitive``; (2) ``by`` is a date-axis partition —
     its value varies within an asset over time, so partitioning truncates
     each asset's history. A cross-sectional ``by`` (constant within an
     asset) keeps history intact and does not warn.
     """
     try:
-        aggregation = type(metric).spec().aggregation
+        spec = type(metric).spec()
     except (AttributeError, TypeError):
         return  # not a metric instance; evaluate raises the canonical error
-    if aggregation not in _CROSS_DATE_AGGREGATIONS:
+    if not spec.slice_boundary_sensitive:
         return
     if "asset_id" not in data.columns:
         return  # cannot classify the axis without an asset dimension
@@ -186,9 +170,9 @@ def _warn_date_axis_truncation(data: pl.DataFrame, metric: MetricBase, by: str) 
     n_asset_by_pairs = data.select("asset_id", by).n_unique()
     if n_asset_by_pairs <= n_assets:
         return  # by is constant within each asset → cross-sectional
-    name = type(metric).spec().name
+    name = spec.name
     warnings.warn(
-        f"by_slice: {name!r} aggregates across dates ({aggregation.value}), "
+        f"by_slice: {name!r} depends on intact date ordering, "
         f"but {by!r} is a date-axis partition (its value varies within an "
         f"asset over time). Each slice is evaluated on its own rows only, so "
         f"rolling windows / per-asset time-series regressions / event windows "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,12 @@ def make_result(
     if metadata:
         output_metadata.update(metadata)
     primary_out = MetricResult(
-        value=value, p_value=p, n_obs=100, name=metric, metadata=output_metadata
+        value=value,
+        p_value=p,
+        alternative=None if p is None else "two-sided",
+        n_obs=100,
+        name=metric,
+        metadata=output_metadata,
     )
     outputs = {metric: primary_out}
     if extra_outputs:

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import factrix as fx
 import numpy as np
 import pytest
 from factrix.stats import (
@@ -18,6 +19,12 @@ from factrix.stats.multiple_testing import (
     romano_wolf_adjusted_p,
     simes_p,
 )
+
+
+def test_stats_is_explicit_namespace_without_top_level_bhy() -> None:
+    assert "stats" in fx.__all__
+    assert fx.stats.bhy_adjusted_p is bhy_adjusted_p
+    assert not hasattr(fx, "bhy")
 
 
 class TestBhyAdjust:

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -35,6 +35,7 @@ def test_multi_primary_runs_independent_screens():
                 "ic_ir": MetricResult(
                     value=0.4,
                     p_value=0.5,
+                    alternative="two-sided",
                     n_obs=100,
                     name="ic_ir",
                     metadata={"p_value": 0.5},
@@ -208,15 +209,6 @@ def test_missing_primary_metric_raises():
     results = [make_result(factor="f1", p=0.01, metric="ic")]
     with pytest.raises(UserInputError, match="other"):
         bhy(results, metrics=["other"])
-
-
-def test_nan_p_raises():
-    make_spec("ic")
-    results = [
-        make_result(factor="f1", p=float("nan"), metric="ic"),
-    ]
-    with pytest.raises(UserInputError, match="NaN"):
-        bhy(results, metrics=["ic"])
 
 
 def test_descriptive_metric_all_none_p_raises():

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -167,6 +167,21 @@ def test_mixed_horizons_without_expand_over_warns():
         bhy(results, metrics=["ic"], q=0.5)
 
 
+def test_same_factor_at_different_horizons_is_two_hypotheses():
+    make_spec("ic")
+    results = [
+        make_result(factor="f1", p=0.01, metric="ic", forward_periods=1),
+        make_result(factor="f1", p=0.02, metric="ic", forward_periods=5),
+    ]
+    with pytest.warns(RuntimeWarning, match="pooled"):
+        out = bhy(results, metrics=["ic"], q=0.5)["ic"]
+    assert out.n_tests == {(): 2}
+    assert [(r.factor, r.forward_periods) for r in out.survivors] == [
+        ("f1", 1),
+        ("f1", 5),
+    ]
+
+
 def test_singleton_buckets_warn():
     make_spec("ic")
     results = [
@@ -193,7 +208,7 @@ def test_primary_element_must_be_str():
         bhy([], metrics=[123])  # type: ignore[list-item]
 
 
-def test_duplicate_factor_without_expand_over_raises():
+def test_duplicate_factor_and_horizon_without_expand_over_raises():
     make_spec("ic")
     results = [
         make_result(factor="f1", p=0.01, metric="ic"),

--- a/tests/test_by_slice.py
+++ b/tests/test_by_slice.py
@@ -9,7 +9,7 @@ import pytest
 from factrix import by_slice
 from factrix._codes import WarningCode
 from factrix._results import EvaluationResult
-from factrix.metrics import caar, ic
+from factrix.metrics import caar, event_hit_rate, ic, positive_rate
 from factrix.preprocess import compute_forward_return
 from factrix.slicing._primitive import _slice_by
 from factrix.slicing.dispatcher import _warn_date_axis_truncation
@@ -171,3 +171,18 @@ class TestDateAxisTruncationWarning:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             _warn_date_axis_truncation(panel, ic(), "year")  # CS_THEN_TS: no warn
+
+    def test_sampling_phase_metric_on_date_axis_warns(self):
+        panel = _sector_panel(n_dates=600)
+        with pytest.warns(
+            UserWarning, match=WarningCode.SLICE_BOUNDARY_TRUNCATION.value
+        ):
+            _warn_date_axis_truncation(panel, positive_rate(), "year")
+
+    def test_boundary_insensitive_event_metric_on_date_axis_silent(self):
+        panel = _sector_panel(n_dates=600)
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_date_axis_truncation(panel, event_hit_rate(), "year")

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -20,6 +20,7 @@ def _with_extra(factor: str, ic_value: float, sharpe_value: float):
             "sharpe": MetricResult(
                 value=sharpe_value,
                 p_value=0.2,
+                alternative="two-sided",
                 n_obs=100,
                 name="sharpe",
                 metadata={"p_value": 0.2},

--- a/tests/test_docs_stat_keys_by_metric.py
+++ b/tests/test_docs_stat_keys_by_metric.py
@@ -22,7 +22,7 @@ _COMMON_KEYS: frozenset[str] = frozenset(
 # Explicit-keyword params of ``_short_circuit_output`` — control flags that
 # do not surface as ``MetricResult.metadata`` keys at runtime.
 _HELPER_CONTROL_KWARGS: frozenset[str] = frozenset(
-    {"n_obs", "n_obs_axis", "descriptive"}
+    {"n_obs", "n_obs_axis", "descriptive", "alternative"}
 )
 
 # Inner keys of nested dict / list-of-dict metadata payloads. Documented

--- a/tests/test_evaluate_horizons.py
+++ b/tests/test_evaluate_horizons.py
@@ -110,16 +110,16 @@ class TestFeedsAggregationLayer:
             )
         assert "ic" in screens
 
-    def test_flatten_without_expand_over_raises_duplicate_identity(self):
-        # Same factor at two horizons -> duplicate (factor,) identity in bhy.
+    def test_flatten_without_expand_over_pools_factor_horizon_hypotheses(self):
         results = fx.evaluate_horizons(
             _raw(),
             metrics={"ic": ic()},
             factor_cols=["factor"],
             forward_periods=[5, 10],
         )
-        with pytest.raises(UserInputError):
-            fx.multi_factor.bhy(results, metrics=["ic"])
+        with pytest.warns(RuntimeWarning, match="pooled"):
+            screen = fx.multi_factor.bhy(results, metrics=["ic"])["ic"]
+        assert screen.n_tests == {(): 2}
 
 
 class TestStrictForwarded:

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -21,6 +21,7 @@ def _sample_group() -> Mapping[str, MetricResult]:
     ic_out = MetricResult(
         value=0.05,
         p_value=0.012,
+        alternative="two-sided",
         n_obs=100,
         stat=2.5,
         metadata={"p_value": 0.012},
@@ -92,6 +93,7 @@ class TestEvaluationResultToFrame:
             "metric_name",
             "value",
             "p_value",
+            "alternative",
             "stat",
             "n_obs",
             "n_obs_axis",
@@ -101,6 +103,7 @@ class TestEvaluationResultToFrame:
         ]
         assert df.schema["value"] == pl.Float64
         assert df.schema["p_value"] == pl.Float64
+        assert df.schema["alternative"] == pl.Utf8
         assert df.schema["n_obs"] == pl.Int64
         assert df.schema["n_obs_axis"] == pl.Utf8
         assert df.schema["is_applicable"] == pl.Boolean
@@ -123,6 +126,7 @@ class TestEvaluationResultToFrame:
         row = df.row(0, named=True)
         assert row["value"] is None
         assert row["p_value"] is None
+        assert row["alternative"] is None
 
     def test_short_circuit_marks_metric_inapplicable(self):
         bad = MetricResult(
@@ -182,6 +186,7 @@ class TestEvaluationResultToDict:
         assert "n_obs" not in back
         assert "metrics_partition" not in back
         assert back["metrics"]["ic"]["p_value"] == 0.012
+        assert back["metrics"]["ic"]["alternative"] == "two-sided"
         assert back["metrics"]["ic"]["is_applicable"] is True
         assert back["metrics"]["ic"]["reason"] is None
         assert back["warnings"][0]["code"] == WarningCode.FEW_ASSETS.value
@@ -190,7 +195,6 @@ class TestEvaluationResultToDict:
     def test_nonfinite_floats_become_null(self):
         bad = MetricResult(
             value=float("nan"),
-            p_value=float("nan"),
             stat=float("inf"),
             metadata={"p_value": float("nan")},
             name="ic",
@@ -201,6 +205,25 @@ class TestEvaluationResultToDict:
         assert d["metrics"]["ic"]["stat"] is None
         assert d["metrics"]["ic"]["p_value"] is None
         json.dumps(d)
+
+
+class TestMetricResultPValueContract:
+    @pytest.mark.parametrize("p_value", [float("nan"), float("inf"), -0.1, 1.1])
+    def test_rejects_invalid_p_value(self, p_value: float):
+        with pytest.raises(ValueError, match=r"finite.*\[0, 1\]"):
+            MetricResult(
+                value=0.0,
+                p_value=p_value,
+                alternative="two-sided",
+            )
+
+    def test_rejects_p_value_without_alternative(self):
+        with pytest.raises(ValueError, match="both be provided"):
+            MetricResult(value=0.0, p_value=0.5)
+
+    def test_rejects_alternative_without_p_value(self):
+        with pytest.raises(ValueError, match="both be provided"):
+            MetricResult(value=0.0, alternative="greater")
 
 
 class TestReprHtml:


### PR DESCRIPTION
## Summary

- require every formal `MetricResult.p_value` to declare its tested alternative
- treat `(factor, forward_periods)` as the base hypothesis identity while keeping `expand_over` as an explicit family partition
- drive date-axis slice warnings from a `MetricSpec` capability instead of aggregation categories
- explicitly export `factrix.stats` and align API, architecture, notebook, and LLM documentation

## Quant research contract

- Pool factor x horizon hypotheses when the research process may select across horizons.
- Use horizon buckets only for predeclared, separately selected and reported screens.
- Allow documented mixed-tail calibrated p-values in closed-form Holm/BHY procedures.
- Keep Romano-Wolf as a low-level expert primitive requiring a complete joint, H0-centred, correctly studentized `(B, m)` matrix; no high-level panel workflow is added.

## Validation

- `pytest`: 1760 passed, 3 skipped
- `pytest --doctest-modules factrix/`: 95 passed, 1 skipped
- `ruff check`: passed
- `ruff format --check`: passed
- `mypy factrix`: passed (84 source files)
- `mkdocs build --strict`: passed
- project consistency, correctness, and no-overdesign review: passed

Closes #777
