### PR TITLE
refactor(results)!: split hypothesis params from bookkeeping metadata

### DIFF
--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -19,10 +19,10 @@ from factrix.metrics import ic
 # "Which factor families have signal, and within those, which factors?"
 # evaluate() returns dict[str, EvaluationResult]; pull the single result
 # and stamp the family label onto it with dataclasses.replace so the
-# outer screen can group on context["family"].
-def stamp(panel, factor_col, **context):
+# outer screen can group on params["family"].
+def stamp(panel, factor_col, **params):
     res = fx.evaluate(panel, metrics={"ic": ic()}, factor_cols=[factor_col])[factor_col]
-    return dataclasses.replace(res, context=context)
+    return dataclasses.replace(res, params=params)
 
 results = [
     stamp(panel_mom_1m, "mom_1m", family="momentum"),
@@ -98,7 +98,7 @@ metric — the `_FdrResultBase` shape (`entries` / `survivors` / `adj_p` /
 | `group` | Context key naming the group axis (a single `str`) |
 | `n_tests` | Mapping `(group_value,) -> m_group` for **every** input group (covers dead families too, so "N of M families survived" claims are computable directly). Counter to `partial_conjunction`, which keeps surviving identities only. |
 
-Per-survivor group label: `survivor.context[result.group]`.
+Per-survivor group label: `survivor.params[result.group]`.
 
 ::: factrix.multi_factor.HierarchicalBhyResult
     options:
@@ -119,7 +119,7 @@ Per-survivor group label: `survivor.context[result.group]`.
 | Trigger | Outcome |
 |---|---|
 | `group` shadows an identity field (`factor` / `forward_periods`) | [`UserInputError`][factrix.UserInputError]. |
-| `group` key missing from a result's `context` | [`UserInputError`][factrix.UserInputError]. |
+| `group` key missing from a result's `params` | [`UserInputError`][factrix.UserInputError]. |
 | Only one distinct group value across input | [`UserInputError`][factrix.UserInputError] — points at [`bhy`](multi-factor.md). |
 | Every result is its own group at $n \ge 3$ (group axis near-unique) | [`UserInputError`][factrix.UserInputError] — pick a coarser categorical. |
 | Duplicate `(identity, group_value)` partition key | [`UserInputError`][factrix.UserInputError]. |

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -81,8 +81,11 @@ Two separate concerns, on two separate knobs:
 
 - **Identity** — `(factor, forward_periods, *params)`. It names *which
   hypothesis* this is. Every `EvaluationResult.params` entry joins it
-  automatically, so a swept knob (`base_tf`, `universe_id`, …) never has to be
-  encoded into the factor name to stay unique.
+  automatically, so a swept knob (`timeframe`, `universe_id`, …) never has to be
+  encoded into the factor name to stay unique. These knobs change the input
+  panel upstream of `evaluate()` — a different bar timeframe or universe is a
+  different panel — so `evaluate()` cannot infer them; the caller stamps them
+  on `params` after the fact.
 - **Family partition** — `expand_over` alone. It is a purely statistical
   declaration about which hypotheses compete with each other. It may name
   `params` keys or the built-in `"forward_periods"`, never the factor name.
@@ -108,12 +111,12 @@ control over later shopping across them.
 | User intent | Where the knob lives | API call | Family scope per step-up |
 |---|---|---|---|
 | "This study runs on `tw50` only" — a pre-registered scope, not a tested dimension | filter upstream; the knob need not be stamped at all | `bhy([r for r in results if …], metrics=["ic"])` | `factor × forward_periods` |
-| "Sweep `base_tf` ∈ {1h, 4h, 1d} and take the best" — a tested dimension, winner selected across it | `params` | `bhy(results, metrics=["ic"])` | `factor × forward_periods × base_tf`, **one** step-up over all of them |
+| "Sweep `timeframe` ∈ {1h, 4h, 1d} and take the best" — a tested dimension, winner selected across it | `params` | `bhy(results, metrics=["ic"])` | `factor × forward_periods × timeframe`, **one** step-up over all of them |
 | "Report predeclared `tw50` and `tw100` screens separately, with no cross-universe winner selection" | `params` + `expand_over` | `bhy(results, metrics=["ic"], expand_over=("universe_id",))` | one step-up per universe |
 | "Record which pipeline run produced this" — never affects inference | `metadata` | — | not applicable |
 
 The middle row is the one that used to require encoding the knob into the factor
-name. It no longer does: stamping `base_tf` on `params` makes each hypothesis
+name. It no longer does: stamping `timeframe` on `params` makes each hypothesis
 uniquely identified while leaving them all in a single family.
 
 ## See also

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -24,7 +24,7 @@ title: factrix.multi_factor.bhy
 
     ---
 
-    Pass `expand_over=(<context key>,)` to run one step-up per distinct
+    Pass `expand_over=(<params key>,)` to run one step-up per distinct
     bucket — for instance per `regime_id` or `universe_id` — under the
     Benjamini & Bogomolov (2014) selective-inference framing. Each
     bucket's `m`, threshold, and survivors stay self-contained.
@@ -72,47 +72,49 @@ when buckets are declared.
 | Kwarg | Default | Meaning |
 |-------|---------|---------|
 | `metrics` | (required) | `list[str]` of metric labels to run the FDR screen for. |
-| `expand_over` | `()` | Context keys whose distinct value tuples split the input into independent step-ups. Names must live in `EvaluationResult.context` (except for the built-in `"forward_periods"`). |
+| `expand_over` | `()` | Params keys whose distinct value tuples split the input into independent step-ups. Names must live in `EvaluationResult.params` (except for the built-in `"forward_periods"`). Naming a `metadata` key is rejected — bookkeeping does not define a family. |
 | `q` | `0.05` | Nominal false discovery rate target. The Benjamini–Yekutieli $c(m)$ correction is applied internally — pass the level you actually want; do not pre-divide. |
 
-### Identity vs context (anti-shopping defense)
+### Identity vs partition (anti-shopping defense)
 
-Identity = `(factor, forward_periods)` — names *which hypothesis*.
-Context = mutable dict of slicing conditions (`universe_id`,
-`regime_id`, …) — names *which slice* of the data the hypothesis was
-tested on. `expand_over` may only name context keys (or the built-in `"forward_periods"`), never the factor name.
+Two separate concerns, on two separate knobs:
 
-Concretely: if `expand_over=["factor"]` were allowed, every factor
-would land in its own size-1 family and pass its own step-up trivially
-— FDR control across the screening universe collapses.
+- **Identity** — `(factor, forward_periods, *params)`. It names *which
+  hypothesis* this is. Every `EvaluationResult.params` entry joins it
+  automatically, so a swept knob (`base_tf`, `universe_id`, …) never has to be
+  encoded into the factor name to stay unique.
+- **Family partition** — `expand_over` alone. It is a purely statistical
+  declaration about which hypotheses compete with each other. It may name
+  `params` keys or the built-in `"forward_periods"`, never the factor name.
 
-Different horizons of the same factor are distinct hypotheses because
-`forward_periods` is part of the base identity. With `expand_over=()`, all
-factor × horizon hypotheses enter one step-up; this is the correct family when
-the research process may choose the best horizon. Use
-`expand_over=("forward_periods",)` only when horizon-specific screens were
-predeclared and will be selected and reported separately. Separate buckets do
-not provide global control over later horizon shopping.
+`EvaluationResult.metadata` is bookkeeping (`run_id`, data vintage). It joins
+neither. Two results differing only in `metadata` are the *same* hypothesis and
+raise as a duplicate — that check exists to catch a hypothesis submitted twice,
+and a bookkeeping label must not defeat it.
 
-### Sample restriction vs hypothesis dimension
+Concretely: if `expand_over=["factor"]` were allowed, every factor would land in
+its own size-1 family and pass its own step-up trivially — FDR control across the
+screening universe collapses.
 
-A context key (`universe_id`, `regime_id`, …) can play one of two roles
-in a screening run:
+With `expand_over=()`, all hypotheses enter one step-up. Pooling makes the family
+larger and the per-rank threshold *stricter*, so it is the correct — and
+conservative — choice whenever the research process may select the winner across
+the swept knobs. Use `expand_over=(…)` only when the buckets were predeclared and
+will be selected and reported separately; separate buckets provide no global
+control over later shopping across them.
 
-- **Sample restriction** — you have *already* committed to a single slice
-  (e.g. "this study runs on `tw50` only"). The context value is a
-  pre-registered scope, not a tested dimension. Filter the input list
-  upstream and call `bhy` without naming that key. FDR is controlled over
-  the implied family.
-- **Separately reported family** — the context defines predeclared screens
-  whose discoveries will not compete across buckets. Pass it via
-  `expand_over=(<key>,)`; one independent step-up runs per distinct value
-  tuple. If selection later compares buckets, they belong in one family instead.
+### The three roles a knob can play
 
-| User intent | API call | Family scope per step-up |
-|---|---|---|
-| "Run BHY on the `tw50` universe only" | `bhy([r for r in results if r.context.get("universe_id") == "tw50"], metrics=["ic"])` | `factor × forward_periods` |
-| "Report predeclared `tw50` and `tw100` screens separately, with no cross-universe winner selection" | `bhy(results, metrics=["ic"], expand_over=("universe_id",))` | `factor × forward_periods × universe_id`, one step-up per universe |
+| User intent | Where the knob lives | API call | Family scope per step-up |
+|---|---|---|---|
+| "This study runs on `tw50` only" — a pre-registered scope, not a tested dimension | filter upstream; the knob need not be stamped at all | `bhy([r for r in results if …], metrics=["ic"])` | `factor × forward_periods` |
+| "Sweep `base_tf` ∈ {1h, 4h, 1d} and take the best" — a tested dimension, winner selected across it | `params` | `bhy(results, metrics=["ic"])` | `factor × forward_periods × base_tf`, **one** step-up over all of them |
+| "Report predeclared `tw50` and `tw100` screens separately, with no cross-universe winner selection" | `params` + `expand_over` | `bhy(results, metrics=["ic"], expand_over=("universe_id",))` | one step-up per universe |
+| "Record which pipeline run produced this" — never affects inference | `metadata` | — | not applicable |
+
+The middle row is the one that used to require encoding the knob into the factor
+name. It no longer does: stamping `base_tf` on `params` makes each hypothesis
+uniquely identified while leaving them all in a single family.
 
 ## See also
 

--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -39,7 +39,7 @@ The returned `pl.DataFrame` contains the following columns:
 
 - `factor`: The name of the evaluated factor.
 - `forward_periods`: The forward periods horizon.
-- Context keys: All context keys present across the evaluation results, ordered by first appearance.
+- Params keys: All `params` keys present across the evaluation results, ordered by first appearance.
 - `<metric_label>`: The metric value, where `metric_label` is the key in
   `EvaluationResult.metrics` and the string passed in `metrics=[...]` (e.g.
   `ic`).
@@ -54,7 +54,7 @@ The returned `pl.DataFrame` contains the following columns:
 | Kwarg | Default | Meaning |
 |-------|---------|---------|
 | `metrics` | (required) | `list[str]` of metric labels to include in the leaderboard. |
-| `sort_by` | `None` | Any output column produced before ranking: `factor`, `forward_periods`, context keys, metric value columns such as `ic`, or p-value columns such as `ic_p_value` / `<metric_label>_p_value`. `None` keeps the original list order. |
+| `sort_by` | `None` | Any output column produced before ranking: `factor`, `forward_periods`, `params` keys, metric value columns such as `ic`, or p-value columns such as `ic_p_value` / `<metric_label>_p_value`. `None` keeps the original list order. |
 | `descending` | `True` | Whether to sort in descending order (higher is better). Set to `False` for lower-is-better metrics. |
 
 `rank` is created after sorting, so it is not a valid `sort_by` key. To sort

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -81,7 +81,7 @@ Every `UserInputError` carries structured attributes (see [Reading a `UserInputE
 | Message hint | Trigger | Fix |
 |---|---|---|
 | `unknown metrics='...'` | Typo or metric not applicable to the data | `inspect_data(data).usable` enumerates the metrics applicable to the data shape. See [`list_metrics`](metrics/index.md#factrix.list_metrics) for the full catalog. |
-| `invalid expand_over=[...]` | One or more `expand_over` context keys missing on some results | The message lists every `(factor, missing_key)` pair in one pass. All results in the family must carry the key in `.context`; populate it consistently, or drop the key from `expand_over`. |
+| `invalid expand_over=[...]` | One or more `expand_over` keys missing on some results' `params` | The message lists every `(factor, missing_key)` pair in one pass. All results in the family must carry the key in `.params`; populate it consistently, or drop the key from `expand_over`. A key found on `.metadata` instead is called out separately — bookkeeping never partitions a family. |
 | `Expected: list[EvaluationResult], got ...` | Passing the wrong artifact type to a screening function | Screening (`bhy`, `partial_conjunction`, `bhy_hierarchical`) consumes `list[EvaluationResult]`. |
 
 ---

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -6,7 +6,7 @@ title: factrix.multi_factor
 
 Collection-level false-discovery-rate (FDR) control across a list of
 `EvaluationResult` objects. Use after `evaluate`
-has produced results for candidate factors (or per factor × context
+has produced results for candidate factors (or per factor × params
 combinations): the functions in this module adjust per-factor p-values
 for multiple testing under the dependence structure that factor pools
 exhibit by construction.

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -20,10 +20,10 @@ from factrix.metrics import ic
 # "Momentum is significant in BOTH large-cap AND small-cap universes"
 # evaluate() returns dict[str, EvaluationResult]; pull the single result
 # and stamp the universe label onto it with dataclasses.replace so
-# expand_over can split the family on context["universe_id"].
-def stamp(panel, factor_col, **context):
+# expand_over can split the family on params["universe_id"].
+def stamp(panel, factor_col, **params):
     res = fx.evaluate(panel, metrics={"ic": ic()}, factor_cols=[factor_col])[factor_col]
-    return dataclasses.replace(res, context=context)
+    return dataclasses.replace(res, params=params)
 
 results = [
     stamp(panel_large, "mom", universe_id="large_cap"),

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -132,7 +132,7 @@ per metric — the same `_FdrResultBase` shape as `bhy`'s
 | `pc_p_all` | Raw PC $p$-value (pre-BHY), aligned with `entries` |
 | `survivors` / `adj_p` | Surviving subset and its adjusted p-value (derived from `adj_p_all <= q`) |
 | `min_pass` | The $k$ you passed |
-| `n_tests` | Keyed by the single-element identity tuple `(factor,)` → condition count $m$ for that identity |
+| `n_tests` | Keyed by the identity tuple — `factor`, then `forward_periods` and `params` items not named by `expand_over` → condition count $m$ for that identity |
 | `n_passed_uncorr_all` | Per-identity count of raw $p < q$, aligned with `entries`. Descriptive — flags borderline (`n_passed_uncorr_all == min_pass`) and data-gap cases at a glance. **Cutoff is your `q`**, so the count moves with `q` — using it to override `adj_p` survivor selection is the anti-shopping failure mode this function exists to prevent. |
 
 `to_frame()` gives a `factor | adj_p | survived` DataFrame over every tested

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -137,7 +137,8 @@ class EvaluationResult:
     n_assets: int
     metrics: Mapping[str, MetricResult]
     plan: str
-    context: Mapping[str, Any] = field(default_factory=dict)
+    params: Mapping[str, Hashable] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
     warnings: list[Warning] = field(default_factory=list)
 ```
 
@@ -704,11 +705,11 @@ ones:
 For input `results: Sequence[EvaluationResult]`, `expand_over: Sequence[str] | None`,
 and `metric: str` (one resolved spec):
 
-1. `expand_over` names must be present in every result's `context`, except
+1. `expand_over` names must be present in every result's `params`, except
    the built-in `forward_periods`; `factor` is rejected because it is an
    identity dimension, not a family partition.
 2. hypothesis key per result = `(factor, forward_periods) +
-   tuple(context[k] for k in expand_over if k != "forward_periods")`
+   tuple(params[k] for k in expand_over if k != "forward_periods")`
    must be unique across the input. `EvaluationResult.__hash__ = None`, so dedup
    walks the tuple, not a hash.
 3. The specified `metric` must have a computed `p_value` that is non-NaN,
@@ -722,7 +723,7 @@ so fuzzy suggestions and docs links render uniformly.
 
 `expand_over` declares per-bucket independent families (Benjamini & Bogomolov
 2014, *Selective Inference on Multiple Families of Hypotheses*, JRSS-B). Each
-unique tuple of `context[k] for k in expand_over` is its own step-up batch —
+unique tuple of `params[k] for k in expand_over` is its own step-up batch —
 e.g. `expand_over=["regime_id"]` runs one BHY step-up per regime.
 
 ### Caller responsibilities
@@ -841,7 +842,7 @@ Hard constraints — violating these breaks the API contract:
 3. The metric-spec SSOT is the `@metric` registration in each `factrix/metrics/*.py`, resolved through `factrix._metric_index` (`spec_by_name` / `public_specs` / `list_metrics`); no parallel rule table. `@metric`-class registration feeds the index via `factrix.metrics._registry.register`. Slice-boundary warnings read `MetricSpec.slice_boundary_sensitive`; aggregation categories are not a proxy rule table.
 4. The DAG executor is the single dispatch path. `DagExecutor` topologically orders specs by `MetricSpec.requires` (raising `CycleError` on cycles), runs `batchable=True` producers once per factor batch and `batchable=False` consumers once per factor, and short-circuits a downstream consumer with a NaN `MetricResult` + `WarningCode.UPSTREAM_UNAVAILABLE` rather than invoking it on missing upstream data.
 5. `MetricResult.p_value` is the single canonical p-value read path — `EvaluationResult.to_frame()` / `to_dict()`, `compare`, and the BHY family resolver all read it; the p-value lives only on the field and is not duplicated into `metadata`. A formal p-value and `alternative` (`two-sided` / `greater` / `less`) must be present together; p-values are finite and in `[0, 1]`. `warnings` flag interpretation risk but never rebind it.
-6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over`. `_resolve_family` enforces (a) the hypothesis identity `(factor, forward_periods, *context_partition_values)` is unique across the input, (b) `expand_over` names come only from `EvaluationResult.context` (or the built-in `forward_periods`), never the factor, (c) `p_value` is populated everywhere before procedures read it. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
+6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over`. `_resolve_family` enforces (a) the hypothesis identity `(factor, forward_periods, *params)` is unique across the input — every `params` entry joins it automatically, while `metadata` never does, (b) `expand_over` names come only from `EvaluationResult.params` (or the built-in `forward_periods`), never the factor and never a `metadata` key, (c) `p_value` is populated everywhere before procedures read it. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
 7. `T < MIN_PERIODS_HARD` raises `InsufficientSampleError`; metrics never silently produce a result on under-sampled data. NW HAC lag selection on overlapping forward returns floors at `forward_periods - 1` (the Hansen-Hodrick floor) so serial correlation from overlap is not under-counted.
 
 For the user-facing field walk of `EvaluationResult` (and its

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -3,7 +3,7 @@
 Pure projection: stacks per-factor per-metric values into a wide
 ``pl.DataFrame`` for sorting and visual diff. No metric is recomputed.
 
-Heterogeneous context keys follow ``pl.concat(how="diagonal")`` —
+Heterogeneous ``params`` keys follow ``pl.concat(how="diagonal")`` —
 union + null-fill — so a result missing ``region`` surfaces as a
 ``null`` cell rather than a silent drop.
 """
@@ -44,7 +44,7 @@ def compare(
             ``metrics`` contract on ``fx.multi_factor.bhy`` so the
             whole multi-factor API surface uses one shape.
         sort_by: Optional :class:`str` naming any output column produced
-            before ranking: identity columns, context keys, metric value
+            before ranking: identity columns, params keys, metric value
             columns, or ``<metric_label>_p_value`` columns. ``None`` keeps
             input order and omits the ``rank`` column.
         descending: Sort direction applied to ``sort_by``. Default
@@ -59,7 +59,7 @@ def compare(
 
     Returns:
         ``pl.DataFrame`` with column order ``factor``,
-        ``forward_periods``, context keys (union across results,
+        ``forward_periods``, params keys (union across results,
         first-seen order), then ``<metric_label>`` /
         ``<metric_label>_p_value`` pairs
         in ``metrics`` order, then ``rank`` when ``sort_by`` is set.
@@ -84,15 +84,15 @@ def compare(
     """
     metric_list = _validate_metric_list(metrics, func_name="compare", field="metrics")
     _require_non_empty_results(results, func_name="compare")
-    context_keys = _ordered_keys(r.context for r in results)
+    param_keys = _ordered_keys(r.params for r in results)
     rows: list[dict[str, Any]] = []
     for r in results:
         row: dict[str, Any] = {
             "factor": r.factor,
             "forward_periods": r.forward_periods,
         }
-        for k in context_keys:
-            row[k] = r.context.get(k)
+        for k in param_keys:
+            row[k] = r.params.get(k)
         for spec in metric_list:
             if spec not in r.metrics:
                 raise UserInputError(

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -40,7 +40,7 @@ class FactrixError(Exception):
 class UserInputError(FactrixError, ValueError):
     """User-supplied input does not match expected names or types.
 
-    Raised for typos in named-set kwargs (metric / estimator / context key
+    Raised for typos in named-set kwargs (metric / estimator / params key
     / column name) or input-type mismatches. Multi-inherits from
     :class:`ValueError` so ecosystem code (`pytest.raises(ValueError)`,
     generic `except ValueError`) keeps working.

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -11,7 +11,7 @@ concerns and are kept on separate knobs:
 
 * **Identity** — ``(factor, forward_periods, *params)``. Every
   ``EvaluationResult.params`` entry joins the identifier automatically,
-  so a swept knob (``base_tf``, ``universe``) never has to be encoded
+  so a swept knob (``timeframe``, ``universe``) never has to be encoded
   into the factor name to stay unique. ``EvaluationResult.metadata`` is
   bookkeeping and never joins the identifier.
 * **Family partition** — ``expand_over`` alone, naming ``forward_periods``
@@ -128,7 +128,7 @@ def _partition(
                     f"{seen[identifier]}, again at {idx}. Two results that "
                     "differ only in `metadata` are the same hypothesis — "
                     "metadata is bookkeeping and never disambiguates. If the "
-                    "repeats are a swept knob (base_tf, universe, ...), stamp "
+                    "repeats are a swept knob (timeframe, universe, ...), stamp "
                     "it on `EvaluationResult.params`; it then joins the "
                     "identifier without partitioning the family"
                 ),

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -40,6 +40,24 @@ if TYPE_CHECKING:
 _BUILTIN_EXPAND_OVER_FIELDS: frozenset[str] = frozenset({"forward_periods"})
 
 
+def _hypothesis_identity(
+    result: EvaluationResult, *, exclude: tuple[str, ...] = ()
+) -> tuple[Any, ...]:
+    """Hypothesis identity: ``(factor, forward_periods, *sorted(params.items()))``.
+
+    ``exclude`` strips named components — ``partial_conjunction`` passes its
+    ``expand_over`` keys so results replicated along the condition axis
+    collapse into one aggregation identity while every other swept knob
+    keeps identities apart. Param keys ride along with their values so that
+    results carrying different key sets cannot collide on values alone.
+    """
+    parts: list[Any] = [result.factor]
+    if "forward_periods" not in exclude:
+        parts.append(result.forward_periods)
+    parts.extend(sorted((k, v) for k, v in result.params.items() if k not in exclude))
+    return tuple(parts)
+
+
 @dataclass(frozen=True, slots=True)
 class _FamilyEntry:
     """Flat record carrying one hypothesis through the family pipeline.
@@ -98,11 +116,7 @@ def _partition(
     seen: dict[tuple[Any, ...], int] = {}
     for idx, result in enumerate(results):
         values = _expand_over_values(result, keys=keys)
-        identifier = (
-            result.factor,
-            result.forward_periods,
-            *sorted(result.params.items()),
-        )
+        identifier = _hypothesis_identity(result)
         if identifier in seen:
             raise UserInputError(
                 func_name=func_name,

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -6,12 +6,19 @@ list of :class:`~factrix._results.EvaluationResult` into flat
 ``_FamilyEntry`` records ready for the procedure-specific step-up math.
 
 The invariants enforced here are the family-layer extension of the
-anti-shopping defense: the base hypothesis identity is
-``(factor, forward_periods)``. Context values named by ``expand_over``
-extend that identity while all ``expand_over`` values partition the family;
-``expand_over`` names are read
-from ``forward_periods`` (the lone non-context built-in slicing axis)
-or from ``EvaluationResult.context``. The estimator-override hook is
+anti-shopping defense. Identity and family partition are separate
+concerns and are kept on separate knobs:
+
+* **Identity** — ``(factor, forward_periods, *params)``. Every
+  ``EvaluationResult.params`` entry joins the identifier automatically,
+  so a swept knob (``base_tf``, ``universe``) never has to be encoded
+  into the factor name to stay unique. ``EvaluationResult.metadata`` is
+  bookkeeping and never joins the identifier.
+* **Family partition** — ``expand_over`` alone, naming ``forward_periods``
+  (the lone built-in) or ``params`` keys. It no longer doubles as an
+  identity knob, so partitioning is a pure statistical declaration.
+
+The estimator-override hook is
 gone — callers select inference at metric-construction time (e.g.
 ``ic(inference=fx.inference.NEWEY_WEST)``) and pick the result by
 passing the corresponding ``metric`` label.
@@ -43,9 +50,11 @@ class _FamilyEntry:
     ``p_value`` only after the attach stage, where it is always non-None.
 
     Attributes:
-        identifier: ``(factor, forward_periods, *context_partition_values)``
-            — the hypothesis key. ``forward_periods`` is always part of the
-            identity, even when it is also the family partition axis.
+        identifier: ``(factor, forward_periods, *sorted(params.items()))``
+            — the hypothesis key. ``forward_periods`` and every ``params``
+            entry always join the identity, independently of ``expand_over``.
+            Param keys ride along with their values so that results carrying
+            different key sets cannot collide on values alone.
         expand_over_values: ``tuple`` in caller-supplied key order;
             empty when ``expand_over`` is empty.
         result: Back-reference for survivor rendering; not read by the
@@ -79,35 +88,35 @@ def _partition(
                 func_name=func_name,
                 field="expand_over",
                 value=name,
-                expected="slicing axis, not the hypothesis identifier 'factor'",
+                expected="partition key, not the hypothesis identifier 'factor'",
                 docs_path=f"api/{func_name}#expand_over",
             )
 
-    _check_context_keys(results, keys=keys, func_name=func_name)
+    _check_param_keys(results, keys=keys, func_name=func_name)
 
     entries: list[_FamilyEntry] = []
     seen: dict[tuple[Any, ...], int] = {}
     for idx, result in enumerate(results):
         values = _expand_over_values(result, keys=keys)
-        context_values = tuple(
-            value
-            for name, value in zip(keys, values, strict=True)
-            if name not in _BUILTIN_EXPAND_OVER_FIELDS
+        identifier = (
+            result.factor,
+            result.forward_periods,
+            *sorted(result.params.items()),
         )
-        identifier = (result.factor, result.forward_periods, *context_values)
         if identifier in seen:
             raise UserInputError(
                 func_name=func_name,
                 field="results",
                 value=identifier,
                 expected=(
-                    "unique (factor, forward_periods, "
-                    "*context_partition_values) identifier across "
-                    f"input; duplicate first seen at index {seen[identifier]}, "
-                    f"again at {idx}. Either stamp a distinct factor column "
-                    "per evaluation, or pass `expand_over=[<context_key>]` "
-                    "when the repeated evaluation belongs to a predeclared "
-                    "context-specific family"
+                    "unique (factor, forward_periods, *params) identifier "
+                    f"across input; duplicate first seen at index "
+                    f"{seen[identifier]}, again at {idx}. Two results that "
+                    "differ only in `metadata` are the same hypothesis — "
+                    "metadata is bookkeeping and never disambiguates. If the "
+                    "repeats are a swept knob (base_tf, universe, ...), stamp "
+                    "it on `EvaluationResult.params`; it then joins the "
+                    "identifier without partitioning the family"
                 ),
                 docs_path=f"api/{func_name}#partition-key",
             )
@@ -170,12 +179,13 @@ def _resolve_family(
 
     Steps (raise on failure, in order):
 
-    1. ``expand_over`` names must exist either as a built-in slicing
-       field (``forward_periods``) or as a key in every result's
-       ``context``. ``factor`` is rejected (it is the hypothesis
-       identifier, not a slicing axis).
-    2. The hypothesis key ``(factor, forward_periods,
-       *context_partition_values)`` must be unique across the input.
+    1. ``expand_over`` names must exist either as a built-in field
+       (``forward_periods``) or as a key in every result's ``params``.
+       ``factor`` is rejected (it is the hypothesis identifier, not a
+       partition key); a ``metadata`` key is rejected (bookkeeping does
+       not define a family).
+    2. The hypothesis key ``(factor, forward_periods, *params)`` must be
+       unique across the input.
     3. Each result must produce the ``metric``'s p-value;
        the p must be present and non-NaN.
     """
@@ -183,7 +193,7 @@ def _resolve_family(
     return _attach_p_values(partition, func_name=func_name, metric=metric)
 
 
-def _check_context_keys(
+def _check_param_keys(
     results: Sequence[EvaluationResult],
     *,
     keys: list[str],
@@ -191,39 +201,52 @@ def _check_context_keys(
 ) -> None:
     """Raise once listing every ``(factor, missing_key)`` across the input.
 
-    Built-in slicing fields (``forward_periods``) are read off the result
-    and never missing; only ``context`` keys are checked. A single failed
-    result no longer short-circuits the whole screen — integrating results
-    from several sources surfaces all context gaps in one pass, matching
-    the aggregate-then-report idiom of ``evaluate``'s strict / column
-    guards. fail-loud is preserved: any gap still raises (silently
-    dropping a result would alter family composition and the FDR
-    denominator).
+    Built-in fields (``forward_periods``) are read off the result and never
+    missing; only ``params`` keys are checked. A single failed result does
+    not short-circuit the whole screen — integrating results from several
+    sources surfaces all gaps in one pass, matching the
+    aggregate-then-report idiom of ``evaluate``'s strict / column guards.
+    fail-loud is preserved: any gap still raises (silently dropping a result
+    would alter family composition and the FDR denominator).
+
+    A key that lives on ``metadata`` instead of ``params`` gets a targeted
+    message: it is present in the input, but bookkeeping labels do not
+    define a family, so partitioning on one is rejected rather than
+    silently honoured.
     """
-    context_keys = [k for k in keys if k not in _BUILTIN_EXPAND_OVER_FIELDS]
-    if not context_keys:
+    param_keys = [k for k in keys if k not in _BUILTIN_EXPAND_OVER_FIELDS]
+    if not param_keys:
         return
     missing = [
         (result.factor, name)
         for result in results
-        for name in context_keys
-        if name not in result.context
+        for name in param_keys
+        if name not in result.params
     ]
     if not missing:
         return
     missing_keys = sorted({k for _, k in missing})
-    available = sorted({k for result in results for k in result.context})
+    available = sorted({k for result in results for k in result.params})
+    on_metadata = sorted({k for k in missing_keys for r in results if k in r.metadata})
     detail = "; ".join(f"factor={factor!r} missing {key!r}" for factor, key in missing)
+    hint = (
+        (
+            f" Key(s) {on_metadata!r} live on `metadata`, which is bookkeeping "
+            f"and never partitions a family — move them to `params` if they "
+            f"are a swept knob."
+        )
+        if on_metadata
+        else ""
+    )
     raise UserInputError(
         func_name=func_name,
         field="expand_over",
         value=missing_keys,
         expected=(
             f"expand_over key(s) {missing_keys!r} present in every result's "
-            f"context. Missing — {detail}. Stamp the key on every "
-            f"EvaluationResult.context, or drop it from expand_over. "
-            f"Context keys seen across the input: "
-            f"{available or ['<none>']!r}"
+            f"params. Missing — {detail}.{hint} Stamp the key on every "
+            f"EvaluationResult.params, or drop it from expand_over. "
+            f"Param keys seen across the input: {available or ['<none>']!r}"
         ),
         docs_path=f"api/{func_name}#expand_over",
     )
@@ -236,13 +259,13 @@ def _expand_over_values(
 ) -> tuple[Any, ...]:
     """Read the ``expand_over`` value tuple off one result.
 
-    Presence of every context key is guaranteed by a prior
-    ``_check_context_keys`` sweep, so this reads without re-validating.
+    Presence of every param key is guaranteed by a prior
+    ``_check_param_keys`` sweep, so this reads without re-validating.
     """
     return tuple(
         getattr(result, name)
         if name in _BUILTIN_EXPAND_OVER_FIELDS
-        else result.context[name]
+        else result.params[name]
         for name in keys
     )
 

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -10,8 +10,9 @@ side).
 
 Family declaration is explicit: the input list *is* the family,
 optionally split per-bucket via ``expand_over``. The base hypothesis
-identifier is ``(factor, forward_periods)``; context partition values
-extend it. Family partitioning remains the caller's responsibility.
+identifier is ``(factor, forward_periods, *params)`` — every swept knob on
+``EvaluationResult.params`` joins it automatically. ``expand_over`` only
+partitions the family; ``metadata`` never touches either.
 """
 
 from __future__ import annotations
@@ -413,7 +414,7 @@ class HierarchicalBhyResult(_FdrResultBase):
 def _lookup_expand(result: EvaluationResult, key: str) -> Any:
     if key == "forward_periods":
         return result.forward_periods
-    return result.context.get(key)
+    return result.params.get(key)
 
 
 def bhy(
@@ -429,7 +430,7 @@ def bhy(
     is non-empty, one independent step-up runs per unique tuple of
     ``expand_over`` values (read from ``EvaluationResult.forward_periods``
     for that built-in slicing axis, otherwise from
-    ``EvaluationResult.context[k]``). Pooling horizons in one family is
+    ``EvaluationResult.params[k]``). Pooling horizons in one family is
     appropriate when selection may choose across horizons; partitioning by
     horizon is appropriate only for predeclared, separately reported screens.
 
@@ -444,7 +445,7 @@ def bhy(
         expand_over: Tuple of keys whose distinct value tuples split
             the input into independent BHY step-up buckets. Built-in
             field ``"forward_periods"`` is read off the result;
-            other keys are looked up on ``result.context``.
+            other keys are looked up on ``result.params``.
         q: Nominal FDR target. Must satisfy ``0 < q < 1``.
             Default ``0.05``.
 
@@ -453,10 +454,9 @@ def bhy(
 
     Raises:
         UserInputError: ``metrics`` not a non-empty ``list[str]``;
-            duplicate ``(factor, forward_periods,
-            *context_partition_values)`` identifier;
-            ``expand_over`` key missing from a result's context or
-            naming ``'factor'``; metric absent from a result's
+            duplicate ``(factor, forward_periods, *params)``
+            identifier; ``expand_over`` key missing from a result's
+            ``params`` or naming ``'factor'``; metric absent from a result's
             outputs or its ``p_value`` missing / NaN.
 
     Warns:
@@ -552,7 +552,7 @@ def partial_conjunction(
         metrics: ``list[str]`` — one PC screen runs per metric;
             return dict keyed by ``label``.
         min_pass: ``k`` in "k of m". Must be ``>= 2``.
-        expand_over: Non-empty tuple of context keys (or
+        expand_over: Non-empty tuple of ``params`` keys (or
             ``"forward_periods"``) defining the condition axis.
         n_conditions: Strict condition-count declaration. ``None`` lets ``m`` be
             inferred per identity; an ``int`` requires every identity
@@ -603,7 +603,7 @@ def partial_conjunction(
             field="expand_over",
             value=expand_over,
             expected=(
-                "non-empty tuple of context keys naming the condition "
+                "non-empty tuple of params keys naming the condition "
                 "axis (e.g. ('region',) for cross-region replication, "
                 "('forward_periods',) for cross-horizon replication). "
                 "partial_conjunction is undefined without a condition axis"
@@ -752,7 +752,7 @@ def bhy_hierarchical(
 
     Args:
         results: :class:`EvaluationResult` records. Each is assigned
-            to one group via ``result.context[group]`` (or via
+            to one group via ``result.params[group]`` (or via
             ``result.forward_periods`` if ``group == "forward_periods"``).
             Within a group, ``factor`` must be unique.
         metrics: ``list[str]`` — one hierarchical screen per

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -29,7 +29,12 @@ import numpy as np
 import polars as pl
 
 from factrix._errors import UserInputError
-from factrix._family import _attach_p_values, _partition, _resolve_family
+from factrix._family import (
+    _attach_p_values,
+    _hypothesis_identity,
+    _partition,
+    _resolve_family,
+)
 from factrix.stats.multiple_testing import (
     bhy_adjusted_p,
     partial_conjunction_p,
@@ -323,11 +328,13 @@ class PartialConjunctionResult(_FdrResultBase):
     ``n_tests`` with :class:`_FdrResultBase`. ``entries`` is one
     representative :class:`EvaluationResult` per identity; ``adj_p_all`` is
     the BHY-adjusted PC p-value; ``n_tests`` is the condition count per
-    identifier.
+    identity, keyed by the identifier with the ``expand_over`` components
+    stripped (``factor``, then ``forward_periods`` and ``params`` items not
+    named by ``expand_over``).
 
     Attributes:
         pc_p_all: Raw PC p-value aligned with ``entries``.
-        expand_over: Context keys defining the condition axis.
+        expand_over: ``params`` keys defining the condition axis.
         min_pass: ``k`` in the ``k`` of ``m`` partial conjunction test.
         n_passed_uncorr_all: Per-identity count of raw p-values strictly
             below ``q`` (descriptive — not used in inference), aligned
@@ -359,7 +366,11 @@ class PartialConjunctionResult(_FdrResultBase):
                 r.factor,
                 f"{float(pc):.4g}",
                 f"{float(adj):.4g}",
-                str(self.n_tests.get((r.factor,), 0)),
+                str(
+                    self.n_tests.get(
+                        _hypothesis_identity(r, exclude=self.expand_over), 0
+                    )
+                ),
                 str(int(n)),
             )
             for r, pc, adj, n, ok in zip(
@@ -387,7 +398,7 @@ class HierarchicalBhyResult(_FdrResultBase):
     ``(group_value,)`` — covering *all* input groups, not just survivors.
 
     Attributes:
-        group: Context key naming the group axis.
+        group: ``params`` key naming the group axis.
     """
 
     group: str
@@ -429,7 +440,7 @@ def bhy(
     The input list is treated as a single family. When ``expand_over``
     is non-empty, one independent step-up runs per unique tuple of
     ``expand_over`` values (read from ``EvaluationResult.forward_periods``
-    for that built-in slicing axis, otherwise from
+    for that built-in partition key, otherwise from
     ``EvaluationResult.params[k]``). Pooling horizons in one family is
     appropriate when selection may choose across horizons; partitioning by
     horizon is appropriate only for predeclared, separately reported screens.
@@ -545,10 +556,13 @@ def partial_conjunction(
     forbidden.
 
     Args:
-        results: :class:`EvaluationResult` records. Conditions per
-            identity come from ``expand_over``; multiple results
-            sharing the hypothesis identifier (``factor``) must differ
-            on at least one ``expand_over`` key.
+        results: :class:`EvaluationResult` records. The aggregation
+            identity is the hypothesis identifier minus the
+            ``expand_over`` components; results sharing an identity form
+            that identity's conditions and must differ on at least one
+            ``expand_over`` key. Any other swept knob (``params`` key or
+            ``forward_periods`` outside ``expand_over``) keeps
+            identities apart instead of inflating ``m``.
         metrics: ``list[str]`` — one PC screen runs per metric;
             return dict keyed by ``label``.
         min_pass: ``k`` in "k of m". Must be ``>= 2``.
@@ -654,23 +668,21 @@ def _partial_conjunction_one(
         expand_over=expand_over,
     )
 
-    entries_by_factor: dict[str, list[Any]] = defaultdict(list)
-    identifiers_ordered: list[str] = []
-    seen: set[str] = set()
+    entries_by_identity: dict[tuple[Any, ...], list[Any]] = defaultdict(list)
+    identities_ordered: list[tuple[Any, ...]] = []
     for entry in entries:
-        factor = entry.result.factor
-        entries_by_factor[factor].append(entry)
-        if factor not in seen:
-            seen.add(factor)
-            identifiers_ordered.append(factor)
+        identity = _hypothesis_identity(entry.result, exclude=expand_over)
+        if identity not in entries_by_identity:
+            identities_ordered.append(identity)
+        entries_by_identity[identity].append(entry)
 
-    pc_p_arr = np.empty(len(identifiers_ordered), dtype=np.float64)
-    n_passed_arr = np.empty(len(identifiers_ordered), dtype=np.int64)
+    pc_p_arr = np.empty(len(identities_ordered), dtype=np.float64)
+    n_passed_arr = np.empty(len(identities_ordered), dtype=np.int64)
     n_tests_per_id: dict[tuple[Any, ...], int] = {}
     rep_results: list[EvaluationResult] = []
 
-    for i, factor in enumerate(identifiers_ordered):
-        group = entries_by_factor[factor]
+    for i, identity in enumerate(identities_ordered):
+        group = entries_by_identity[identity]
         m = len(group)
 
         if n_conditions is not None and m != n_conditions:
@@ -679,10 +691,10 @@ def _partial_conjunction_one(
                 field="n_conditions",
                 value=n_conditions,
                 expected=(
-                    f"factor {factor!r} has {m} condition(s) in data but "
+                    f"identity {identity!r} has {m} condition(s) in data but "
                     f"n_conditions={n_conditions} declared. "
                     "Pass n_conditions=None for inferred condition counts, or fix the "
-                    f"input so every factor has exactly {n_conditions} "
+                    f"input so every identity has exactly {n_conditions} "
                     "conditions"
                 ),
                 docs_path="api/partial-conjunction#strict-vs-lenient",
@@ -692,11 +704,11 @@ def _partial_conjunction_one(
             raise UserInputError(
                 func_name="partial_conjunction",
                 field="results",
-                value=factor,
+                value=identity,
                 expected=(
-                    f"factor {factor!r} has only {m} condition(s) but "
+                    f"identity {identity!r} has only {m} condition(s) but "
                     f"min_pass={min_pass} requires at least that many. "
-                    "Either drop this factor from the input or lower min_pass"
+                    "Either drop this identity from the input or lower min_pass"
                 ),
                 docs_path="api/partial-conjunction#insufficient-conditions",
             )
@@ -704,7 +716,7 @@ def _partial_conjunction_one(
         ps = np.array([e.p_value for e in group], dtype=np.float64)
         pc_p_arr[i] = partial_conjunction_p(ps, min_pass=min_pass)
         n_passed_arr[i] = int(np.sum(ps < q))
-        n_tests_per_id[(factor,)] = m
+        n_tests_per_id[identity] = m
         rep_results.append(group[0].result)
 
     if n_conditions is None:
@@ -713,9 +725,9 @@ def _partial_conjunction_one(
             warnings.warn(
                 "partial_conjunction: inferred condition counts (n_conditions=None) "
                 f"is running with heterogeneous condition counts "
-                f"m={sorted(m_values)} across factors. PC p-values are "
-                "valid marginally but the k/m bar differs per factor. "
-                "For cross-factor comparability pass n_conditions=<int> "
+                f"m={sorted(m_values)} across identities. PC p-values are "
+                "valid marginally but the k/m bar differs per identity. "
+                "For cross-identity comparability pass n_conditions=<int> "
                 "(fixed condition count) or split the call.",
                 RuntimeWarning,
                 stacklevel=3,
@@ -730,7 +742,7 @@ def _partial_conjunction_one(
         q=q,
         expand_over=expand_over,
         min_pass=min_pass,
-        n_tests={(f,): n_tests_per_id[(f,)] for f in identifiers_ordered},
+        n_tests=n_tests_per_id,
         n_passed_uncorr_all=n_passed_arr,
     )
 
@@ -754,7 +766,9 @@ def bhy_hierarchical(
         results: :class:`EvaluationResult` records. Each is assigned
             to one group via ``result.params[group]`` (or via
             ``result.forward_periods`` if ``group == "forward_periods"``).
-            Within a group, ``factor`` must be unique.
+            Within a group, each member is one hypothesis of the inner
+            family; the ``(factor, forward_periods, *params)``
+            identifier must be unique across the input.
         metrics: ``list[str]`` — one hierarchical screen per
             metric; return dict keyed by ``label``.
         group: Single key naming the group axis.
@@ -768,7 +782,7 @@ def bhy_hierarchical(
         UserInputError: ``group == 'factor'`` (it is the identifier);
             only one distinct group value in the input (call ``bhy``
             instead); every result is its own group at ``n >= 3``;
-            duplicate ``(factor, group_value)`` identifier; any
+            duplicate ``(factor, forward_periods, *params)`` identifier; any
             ``_resolve_family`` invariant failure.
 
     Warns:

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import html
 import math
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -153,10 +153,17 @@ class EvaluationResult:
             Structural metrics (e.g. ``greedy_forward_selection``) carry
             their non-scalar payload in ``MetricResult.metadata`` — the
             value is still a :class:`MetricResult`.
-        context: Caller-supplied free-form labels (e.g.
-            ``{"region": "US"}``). Read by
-            ``bhy(expand_over=...)`` / ``partial_conjunction`` /
-            ``bhy_hierarchical`` to partition or aggregate inputs.
+        params: Caller-supplied hypothesis parameters — the sweep knobs
+            that decide *which* hypothesis this result is (e.g.
+            ``{"base_tf": "1h", "universe": "tw50"}``). Every value joins
+            the hypothesis identifier, so two results that differ only in
+            ``params`` are two distinct hypotheses. ``expand_over`` may
+            name these keys to partition a family.
+        metadata: Caller-supplied bookkeeping labels that do *not* define
+            the hypothesis (e.g. ``{"run_id": ..., "vintage": ...}``).
+            Never joins the identifier and never partitions a family, so
+            two results differing only in ``metadata`` still collide as a
+            duplicate hypothesis.
         warnings: Flat list of :class:`Warning` records. Per-metric
             entries carry ``source=label``; cross-metric or pre-dispatch
             entries carry ``source=None``.
@@ -172,7 +179,8 @@ class EvaluationResult:
     n_assets: int
     metrics: Mapping[str, MetricResult]
     plan: str
-    context: Mapping[str, Any] = field(default_factory=dict)
+    params: Mapping[str, Hashable] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
     warnings: list[Warning] = field(default_factory=list)
 
     def metric(self, label: str) -> MetricResult:
@@ -234,7 +242,7 @@ class EvaluationResult:
         Layout (top-level keys, stable order):
 
         - ``factor`` / ``cell`` / ``forward_periods`` / ``n_periods`` /
-          ``n_pairs`` / ``n_assets`` / ``context``
+          ``n_pairs`` / ``n_assets`` / ``params`` / ``metadata``
         - ``metrics``: ``label -> {value, p_value, alternative, stat, n_obs,
           n_obs_axis, is_applicable, reason, metadata}``
         - ``warnings``: list of ``{code, source, message}``
@@ -254,7 +262,8 @@ class EvaluationResult:
             "n_periods": self.n_periods,
             "n_pairs": self.n_pairs,
             "n_assets": self.n_assets,
-            "context": dict(self.context),
+            "params": dict(self.params),
+            "metadata": dict(self.metadata),
             "metrics": {
                 name: _metric_output_to_record(out)
                 for name, out in self.metrics.items()
@@ -281,8 +290,10 @@ class EvaluationResult:
             ("n_assets", self.n_assets),
             ("n_metrics", len(self.metrics)),
         ]
-        if self.context:
-            header_rows.append(("context", dict(self.context)))
+        if self.params:
+            header_rows.append(("params", dict(self.params)))
+        if self.metadata:
+            header_rows.append(("metadata", dict(self.metadata)))
         if self.warnings:
             header_rows.append(("n_warnings", len(self.warnings)))
         header_html = "".join(

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -155,7 +155,7 @@ class EvaluationResult:
             value is still a :class:`MetricResult`.
         params: Caller-supplied hypothesis parameters — the sweep knobs
             that decide *which* hypothesis this result is (e.g.
-            ``{"base_tf": "1h", "universe": "tw50"}``). Every value joins
+            ``{"timeframe": "1h", "universe": "tw50"}``). Every value joins
             the hypothesis identifier, so two results that differ only in
             ``params`` are two distinct hypotheses. ``expand_over`` may
             name these keys to partition a family.

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -416,7 +416,8 @@ Dataclass containing the evaluation outputs:
 - `n_assets`: Unique asset count.
 - `metrics`: read-only `Mapping[str, MetricResult]` holding metric results, keyed by user label.
 - `plan`: Execution plan string.
-- `context`: Free-form context dictionary.
+- `params`: Caller-supplied hypothesis parameters (the swept knobs — `base_tf`, `universe`, ...). Every entry joins the hypothesis identifier `(factor, forward_periods, *params)`, so a swept knob never has to be encoded into the factor name to stay unique. `expand_over` may name these keys to partition a multiple-testing family.
+- `metadata`: Caller-supplied bookkeeping labels (`run_id`, data vintage, ...). Never joins the identifier and never partitions a family — two results differing only in `metadata` are the same hypothesis and raise as a duplicate.
 - `warnings`: Attached `Warning` records.
 
 Methods:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -416,7 +416,7 @@ Dataclass containing the evaluation outputs:
 - `n_assets`: Unique asset count.
 - `metrics`: read-only `Mapping[str, MetricResult]` holding metric results, keyed by user label.
 - `plan`: Execution plan string.
-- `params`: Caller-supplied hypothesis parameters (the swept knobs — `base_tf`, `universe`, ...). Every entry joins the hypothesis identifier `(factor, forward_periods, *params)`, so a swept knob never has to be encoded into the factor name to stay unique. `expand_over` may name these keys to partition a multiple-testing family.
+- `params`: Caller-supplied hypothesis parameters (the swept knobs — `timeframe`, `universe`, ...). Every entry joins the hypothesis identifier `(factor, forward_periods, *params)`, so a swept knob never has to be encoded into the factor name to stay unique. `expand_over` may name these keys to partition a multiple-testing family.
 - `metadata`: Caller-supplied bookkeeping labels (`run_id`, data vintage, ...). Never joins the identifier and never partitions a family — two results differing only in `metadata` are the same hypothesis and raise as a duplicate.
 - `warnings`: Attached `Warning` records.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,13 +38,16 @@ def make_result(
     value: float = 0.05,
     metadata: dict[str, Any] | None = None,
     forward_periods: int = 5,
-    context: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+    result_metadata: dict[str, Any] | None = None,
     extra_outputs: dict[str, MetricResult] | None = None,
 ) -> EvaluationResult:
     """Build an :class:`EvaluationResult` for testing.
 
     ``metric`` names the metric label included in outputs. ``p=None``
-    simulates a metric with no p-value.
+    simulates a metric with no p-value. ``metadata`` seeds the
+    :class:`MetricResult` payload; ``result_metadata`` seeds the
+    bundle-level :class:`EvaluationResult` bookkeeping labels.
     """
     output_metadata: dict[str, Any] = {} if p is None else {"p_value": float(p)}
     if metadata:
@@ -69,7 +72,8 @@ def make_result(
         n_assets=25,
         metrics=MappingProxyType(outputs),
         plan="1. test [per-factor]",
-        context=context or {},
+        params=params or {},
+        metadata=result_metadata or {},
     )
 
 

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -144,13 +144,13 @@ def test_expand_over_forward_periods_partitions_by_horizon():
     assert survivor_factors == {"f0", "f1", "f2"}
 
 
-def test_expand_over_context_key():
+def test_expand_over_param_key():
     make_spec("ic")
     results = [
-        make_result(factor=f"f{i}", p=0.001, metric="ic", context={"region": "US"})
+        make_result(factor=f"f{i}", p=0.001, metric="ic", params={"region": "US"})
         for i in range(3)
     ] + [
-        make_result(factor=f"f{i}", p=0.9, metric="ic", context={"region": "EU"})
+        make_result(factor=f"f{i}", p=0.9, metric="ic", params={"region": "EU"})
         for i in range(3)
     ]
     out = bhy(results, metrics=["ic"], expand_over=("region",), q=0.05)
@@ -185,8 +185,8 @@ def test_same_factor_at_different_horizons_is_two_hypotheses():
 def test_singleton_buckets_warn():
     make_spec("ic")
     results = [
-        make_result(factor="f1", p=0.001, metric="ic", context={"region": "US"}),
-        make_result(factor="f2", p=0.001, metric="ic", context={"region": "EU"}),
+        make_result(factor="f1", p=0.001, metric="ic", params={"region": "US"}),
+        make_result(factor="f2", p=0.001, metric="ic", params={"region": "EU"}),
     ]
     with pytest.warns(RuntimeWarning, match="single result"):
         bhy(results, metrics=["ic"], expand_over=("region",), q=0.5)
@@ -254,19 +254,19 @@ def test_factor_as_expand_over_key_raises():
         bhy(results, metrics=["ic"], expand_over=("factor",))
 
 
-def test_missing_context_key_raises():
+def test_missing_param_key_raises():
     make_spec("ic")
-    results = [make_result(factor="f1", p=0.01, metric="ic", context={"region": "US"})]
+    results = [make_result(factor="f1", p=0.01, metric="ic", params={"region": "US"})]
     with pytest.raises(UserInputError, match="universe"):
         bhy(results, metrics=["ic"], expand_over=("universe",))
 
 
-def test_missing_context_key_aggregates_all_offenders():
+def test_missing_param_key_aggregates_all_offenders():
     make_spec("ic")
     results = [
-        make_result(factor="f1", p=0.01, metric="ic", context={"region": "US"}),
-        make_result(factor="f2", p=0.01, metric="ic", context={}),
-        make_result(factor="f3", p=0.01, metric="ic", context={"region": "EU"}),
+        make_result(factor="f1", p=0.01, metric="ic", params={"region": "US"}),
+        make_result(factor="f2", p=0.01, metric="ic", params={}),
+        make_result(factor="f3", p=0.01, metric="ic", params={"region": "EU"}),
     ]
     with pytest.raises(UserInputError) as excinfo:
         bhy(results, metrics=["ic"], expand_over=("region",))
@@ -277,11 +277,11 @@ def test_missing_context_key_aggregates_all_offenders():
     assert "factor='f3'" not in msg
 
 
-def test_missing_context_key_aggregates_multiple_keys():
+def test_missing_param_key_aggregates_multiple_keys():
     make_spec("ic")
     results = [
-        make_result(factor="f1", p=0.01, metric="ic", context={"region": "US"}),
-        make_result(factor="f2", p=0.01, metric="ic", context={"sector": "tech"}),
+        make_result(factor="f1", p=0.01, metric="ic", params={"region": "US"}),
+        make_result(factor="f2", p=0.01, metric="ic", params={"sector": "tech"}),
     ]
     with pytest.raises(UserInputError) as excinfo:
         bhy(results, metrics=["ic"], expand_over=("region", "sector"))
@@ -315,3 +315,60 @@ def test_bhy_result_repr_and_html():
     assert "f0" in text
     html = out._repr_html_()
     assert "<table" in html and "adj_p" in html
+
+
+def test_params_join_identity_so_swept_knob_pools_in_one_family():
+    """A knob swept in `params` disambiguates without splitting the family.
+
+    Before params joined the identity, the same factor evaluated across
+    several `base_tf` values collided on `(factor, forward_periods)` and the
+    only pooling-safe escape was encoding the knob into the factor name.
+    """
+    make_spec("ic")
+    results = [
+        make_result(factor="mom", p=0.001, metric="ic", params={"base_tf": tf})
+        for tf in ("1h", "4h", "1d")
+    ]
+    out = bhy(results, metrics=["ic"], q=0.05)
+
+    # One family of three — not three families, and not a duplicate-id raise.
+    assert out["ic"].expand_over == ()
+    assert out["ic"].n_tests == {(): 3}
+
+
+def test_metadata_does_not_disambiguate_a_duplicate_hypothesis():
+    """Bookkeeping labels must not rescue a genuinely duplicated hypothesis."""
+    make_spec("ic")
+    results = [
+        make_result(factor="mom", p=0.001, metric="ic", result_metadata={"run_id": run})
+        for run in ("a", "b")
+    ]
+    with pytest.raises(UserInputError, match="metadata is bookkeeping"):
+        bhy(results, metrics=["ic"], q=0.05)
+
+
+def test_expand_over_on_a_metadata_key_is_rejected():
+    """Partitioning a family on bookkeeping is a category error, not a lookup miss."""
+    make_spec("ic")
+    results = [
+        make_result(
+            factor=f"f{i}",
+            p=0.001,
+            metric="ic",
+            result_metadata={"run_id": "a"},
+        )
+        for i in range(3)
+    ]
+    with pytest.raises(UserInputError, match="never partitions a family"):
+        bhy(results, metrics=["ic"], expand_over=("run_id",), q=0.05)
+
+
+def test_params_keys_ride_along_so_distinct_axes_do_not_collide():
+    """Same value on different param keys must stay two hypotheses."""
+    make_spec("ic")
+    results = [
+        make_result(factor="mom", p=0.001, metric="ic", params={"base_tf": "1h"}),
+        make_result(factor="mom", p=0.002, metric="ic", params={"universe": "1h"}),
+    ]
+    out = bhy(results, metrics=["ic"], q=0.05)
+    assert out["ic"].n_tests[()] == 2

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -321,12 +321,12 @@ def test_params_join_identity_so_swept_knob_pools_in_one_family():
     """A knob swept in `params` disambiguates without splitting the family.
 
     Before params joined the identity, the same factor evaluated across
-    several `base_tf` values collided on `(factor, forward_periods)` and the
+    several `timeframe` values collided on `(factor, forward_periods)` and the
     only pooling-safe escape was encoding the knob into the factor name.
     """
     make_spec("ic")
     results = [
-        make_result(factor="mom", p=0.001, metric="ic", params={"base_tf": tf})
+        make_result(factor="mom", p=0.001, metric="ic", params={"timeframe": tf})
         for tf in ("1h", "4h", "1d")
     ]
     out = bhy(results, metrics=["ic"], q=0.05)
@@ -367,7 +367,7 @@ def test_params_keys_ride_along_so_distinct_axes_do_not_collide():
     """Same value on different param keys must stay two hypotheses."""
     make_spec("ic")
     results = [
-        make_result(factor="mom", p=0.001, metric="ic", params={"base_tf": "1h"}),
+        make_result(factor="mom", p=0.001, metric="ic", params={"timeframe": "1h"}),
         make_result(factor="mom", p=0.002, metric="ic", params={"universe": "1h"}),
     ]
     out = bhy(results, metrics=["ic"], q=0.05)

--- a/tests/test_bhy_hierarchical.py
+++ b/tests/test_bhy_hierarchical.py
@@ -11,7 +11,7 @@ from .conftest import make_result, make_spec
 
 def _grouped(p_by_factor: dict[str, float], group_value: str, primary):
     return [
-        make_result(factor=factor, p=p, metric=primary, context={"family": group_value})
+        make_result(factor=factor, p=p, metric=primary, params={"family": group_value})
         for factor, p in p_by_factor.items()
     ]
 
@@ -46,7 +46,7 @@ def test_single_group_raises():
 def test_every_result_own_group_raises():
     make_spec("ic")
     results = [
-        make_result(factor=f"f{i}", p=0.01, metric="ic", context={"family": f"g{i}"})
+        make_result(factor=f"f{i}", p=0.01, metric="ic", params={"family": f"g{i}"})
         for i in range(3)
     ]
     with pytest.raises(UserInputError, match="every result is its own group"):
@@ -99,7 +99,7 @@ def test_list_of_dict_keys_suggests_values():
     make_spec("ic")
     results = {
         "mom_1": make_result(
-            factor="mom_1", p=0.01, metric="ic", context={"family": "momentum"}
+            factor="mom_1", p=0.01, metric="ic", params={"family": "momentum"}
         )
     }
     mistaken: list[str] = []
@@ -124,10 +124,8 @@ def test_primary_must_be_list_of_str():
 def test_missing_group_key_aggregates_all_offenders():
     make_spec("ic")
     results = [
-        make_result(
-            factor="mom_1", p=0.01, metric="ic", context={"family": "momentum"}
-        ),
-        make_result(factor="mom_2", p=0.01, metric="ic", context={}),
+        make_result(factor="mom_1", p=0.01, metric="ic", params={"family": "momentum"}),
+        make_result(factor="mom_2", p=0.01, metric="ic", params={}),
     ]
     with pytest.raises(UserInputError) as excinfo:
         bhy_hierarchical(results, metrics=["ic"], group="family")

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -104,18 +104,18 @@ def test_sort_by_p_value_column():
     assert df["rank"].to_list() == [1, 2, 3]
 
 
-def test_sort_by_identity_and_context_columns():
+def test_sort_by_identity_and_param_columns():
     make_spec("ic")
     results = [
-        make_result(factor="b", p=0.1, metric="ic", context={"region": "US"}),
-        make_result(factor="a", p=0.1, metric="ic", context={"region": "EU"}),
+        make_result(factor="b", p=0.1, metric="ic", params={"region": "US"}),
+        make_result(factor="a", p=0.1, metric="ic", params={"region": "EU"}),
     ]
 
     by_factor = compare(results, metrics=["ic"], sort_by="factor", descending=False)
     assert by_factor["factor"].to_list() == ["a", "b"]
 
-    by_context = compare(results, metrics=["ic"], sort_by="region", descending=False)
-    assert by_context["region"].to_list() == ["EU", "US"]
+    by_params = compare(results, metrics=["ic"], sort_by="region", descending=False)
+    assert by_params["region"].to_list() == ["EU", "US"]
 
 
 def test_no_sort_keeps_input_order_omits_rank():
@@ -130,11 +130,11 @@ def test_no_sort_keeps_input_order_omits_rank():
     assert "rank" not in df.columns
 
 
-def test_context_keys_propagate_with_null_fill():
+def test_param_keys_propagate_with_null_fill():
     make_spec("ic")
     results = [
-        make_result(factor="a", p=0.1, metric="ic", context={"region": "US"}),
-        make_result(factor="b", p=0.1, metric="ic", context={"sector": "tech"}),
+        make_result(factor="a", p=0.1, metric="ic", params={"region": "US"}),
+        make_result(factor="b", p=0.1, metric="ic", params={"sector": "tech"}),
     ]
     df = compare(results, metrics=["ic"])
     assert set(df.columns) >= {"region", "sector"}

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -164,13 +164,13 @@ def test_missing_param_key_aggregates_all_offenders():
 def test_pc_non_condition_param_separates_identities():
     """A knob swept outside the condition axis must not inflate m.
 
-    With `base_tf` on `params`, the four results are two identities of two
+    With `timeframe` on `params`, the four results are two identities of two
     conditions each — not one identity with four mixed-axis "conditions".
     """
     make_spec("ic")
     results = [
         make_result(
-            factor="mom", p=p, metric="ic", params={"base_tf": tf, "region": rg}
+            factor="mom", p=p, metric="ic", params={"timeframe": tf, "region": rg}
         )
         for tf, rg, p in [
             ("1h", "US", 0.001),

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -11,7 +11,7 @@ from .conftest import make_result, make_spec
 
 def _replicate(factor: str, ps: list[float], primary, regions=("US", "EU", "JP")):
     return [
-        make_result(factor=factor, p=p, metric=primary, context={"region": region})
+        make_result(factor=factor, p=p, metric=primary, params={"region": region})
         for p, region in zip(ps, regions, strict=False)
     ]
 
@@ -78,7 +78,7 @@ def test_pc_list_of_dict_keys_suggests_values():
     make_spec("ic")
     results = {
         "alpha": make_result(
-            factor="alpha", p=0.01, metric="ic", context={"region": "US"}
+            factor="alpha", p=0.01, metric="ic", params={"region": "US"}
         )
     }
     mistaken: list[str] = []
@@ -115,8 +115,8 @@ def test_pc_insufficient_conditions_raises():
 def test_pc_duplicate_condition_raises():
     make_spec("ic")
     results = [
-        make_result(factor="alpha_1", p=0.01, metric="ic", context={"region": "US"}),
-        make_result(factor="alpha_1", p=0.02, metric="ic", context={"region": "US"}),
+        make_result(factor="alpha_1", p=0.01, metric="ic", params={"region": "US"}),
+        make_result(factor="alpha_1", p=0.02, metric="ic", params={"region": "US"}),
     ]
     with pytest.raises(UserInputError, match="unique"):
         partial_conjunction(
@@ -148,11 +148,11 @@ def test_pc_heterogeneous_m_warns_in_lenient_mode():
         )
 
 
-def test_missing_context_key_aggregates_all_offenders():
+def test_missing_param_key_aggregates_all_offenders():
     make_spec("ic")
     results = [
-        make_result(factor="alpha", p=0.01, metric="ic", context={"region": "US"}),
-        make_result(factor="alpha", p=0.01, metric="ic", context={}),
+        make_result(factor="alpha", p=0.01, metric="ic", params={"region": "US"}),
+        make_result(factor="alpha", p=0.01, metric="ic", params={}),
     ]
     with pytest.raises(UserInputError) as excinfo:
         partial_conjunction(

--- a/tests/test_partial_conjunction.py
+++ b/tests/test_partial_conjunction.py
@@ -159,3 +159,49 @@ def test_missing_param_key_aggregates_all_offenders():
             results, metrics=["ic"], min_pass=2, expand_over=("region",)
         )
     assert "factor='alpha' missing 'region'" in str(excinfo.value)
+
+
+def test_pc_non_condition_param_separates_identities():
+    """A knob swept outside the condition axis must not inflate m.
+
+    With `base_tf` on `params`, the four results are two identities of two
+    conditions each — not one identity with four mixed-axis "conditions".
+    """
+    make_spec("ic")
+    results = [
+        make_result(
+            factor="mom", p=p, metric="ic", params={"base_tf": tf, "region": rg}
+        )
+        for tf, rg, p in [
+            ("1h", "US", 0.001),
+            ("1h", "EU", 0.002),
+            ("4h", "US", 0.9),
+            ("4h", "EU", 0.8),
+        ]
+    ]
+    out = partial_conjunction(
+        results, metrics=["ic"], min_pass=2, expand_over=("region",), q=0.05
+    )
+    assert len(out["ic"].n_tests) == 2
+    assert set(out["ic"].n_tests.values()) == {2}
+
+
+def test_pc_mixed_horizons_outside_condition_axis_stay_distinct():
+    """`forward_periods` outside `expand_over` splits identities, not conditions."""
+    make_spec("ic")
+    results = [
+        make_result(
+            factor="mom",
+            p=0.001,
+            metric="ic",
+            forward_periods=fp,
+            params={"region": rg},
+        )
+        for fp in (5, 10)
+        for rg in ("US", "EU")
+    ]
+    out = partial_conjunction(
+        results, metrics=["ic"], min_pass=2, expand_over=("region",), q=0.05
+    )
+    assert len(out["ic"].n_tests) == 2
+    assert set(out["ic"].n_tests.values()) == {2}


### PR DESCRIPTION
## Summary

- replace `EvaluationResult.context` with `params` (hypothesis parameters) and `metadata` (bookkeeping labels)
- derive the hypothesis identifier as `(factor, forward_periods, *params)` so every swept knob joins it automatically
- leave `expand_over` as a pure family-partition knob; it rejects `metadata` keys with a targeted message
- carry param keys alongside their values in the identifier so results with different key sets cannot collide on values alone
- aggregate `partial_conjunction` by the full identity minus the `expand_over` components (previously by `factor` alone), sharing one identity helper with the duplicate guard; `PartialConjunctionResult.n_tests` is now keyed by that identity tuple instead of `(factor,)`

## Why it matters

Selecting the best cell of a `base_tf × horizon` sweep requires pooling every cell into one family. Before this change, repeats of a factor across `base_tf` collided on `(factor, forward_periods)`, and the only escapes were `expand_over=("base_tf",)` — which partitions the family and therefore stops controlling selection across `base_tf` — or encoding the knob into the factor name. Stamping `base_tf` on `params` now keeps each hypothesis uniquely identified while leaving them all in a single family.

`metadata` deliberately does not disambiguate: two results differing only in `run_id` remain a duplicate hypothesis, so the duplicate-identifier check still catches a hypothesis submitted twice.

The `partial_conjunction` aggregation change closes a hole the new contract would otherwise open: with `params` joining the identifier, the old duplicate check no longer blocked two results that share a factor and condition value but differ on another swept knob, and factor-only grouping would have silently counted them as extra conditions — inflating `m` along an axis the caller never declared. Grouping by identity-minus-condition-axis keeps `m` counted strictly along `expand_over`; results differing on horizons or params outside `expand_over` now form separate identities.

## Test plan

- [x] `pytest`: 1766 passed, 3 skipped (6 new tests covering cross-param pooling, metadata not disambiguating, `expand_over` on a metadata key, param keys riding along with values, and PC identity separation for non-condition params and mixed horizons)
- [x] `pytest --doctest-modules factrix/`: 95 passed, 1 skipped
- [x] `mypy factrix`: passed (84 source files)
- [x] `ruff check` / `ruff format --check`: passed
- [x] `mkdocs build --strict`: passed

Closes #781
