### PR TITLE
fix(ci): pass root-dir to lychee for root-relative doc links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -56,6 +56,7 @@ jobs:
             --max-cache-age 1d
             --exclude-loopback
             --exclude-path site/404.html
+            --root-dir "$GITHUB_WORKSPACE/site"
             './site/**/*.html'
             './README.md'
           fail: true
@@ -100,6 +101,7 @@ jobs:
             --max-cache-age 1d
             --exclude-loopback
             --exclude-path site/404.html
+            --root-dir "$GITHUB_WORKSPACE/site"
             './site/**/*.html'
             './README.md'
           output: ./lychee-report.md


### PR DESCRIPTION
## Summary
- The scheduled `link-check` workflow flagged 92 broken-link errors, all of the form `Cannot convert path '/factrix/...' to a URI: To resolve root-relative links in local files, provide a root dir`.
- mkdocs builds pages with root-relative hrefs (e.g. `/factrix/api/...`) matching `site_url`'s base path; lychee needs `--root-dir` to resolve those against the local `site/` checkout when scanning local HTML files.
- Added `--root-dir "$GITHUB_WORKSPACE/site"` to both the PR and scheduled lychee jobs.

## Test plan
- [x] Built docs locally (`uv run mkdocs build`) and ran `lychee` with the same args before/after: 92 errors → 0 errors.
- [x] `ruff check` / `ruff format --check` pass (YAML-only change, no Python touched).

Closes #769