### PR TITLE
docs(bhy): show the params stamp() pattern inline

### DIFF
--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -119,6 +119,35 @@ The middle row is the one that used to require encoding the knob into the factor
 name. It no longer does: stamping `timeframe` on `params` makes each hypothesis
 uniquely identified while leaving them all in a single family.
 
+`evaluate()` itself takes no `params=` kwarg — a swept knob changes the input
+panel *upstream* of `evaluate()` (a different timeframe is a different panel),
+so `evaluate()` has no way to know it. The caller stamps `params` on the
+returned `EvaluationResult` with `dataclasses.replace`, same pattern as
+[`bhy_hierarchical`](bhy-hierarchical.md) and
+[`partial_conjunction`](partial-conjunction.md):
+
+```python
+import dataclasses
+
+import factrix as fx
+from factrix.metrics import ic
+
+# "Sweep timeframe and let the winner be picked across all of them" —
+# evaluate() returns dict[str, EvaluationResult]; pull the single result
+# and stamp the timeframe label onto it with dataclasses.replace so the
+# identifier stays unique without splitting the family.
+def stamp(panel, factor_col, **params):
+    res = fx.evaluate(panel, metrics={"ic": ic()}, factor_cols=[factor_col])[factor_col]
+    return dataclasses.replace(res, params=params)
+
+results = [
+    stamp(panel_1h, "mom", timeframe="1h"),
+    stamp(panel_4h, "mom", timeframe="4h"),
+    stamp(panel_1d, "mom", timeframe="1d"),
+]
+survivors = fx.multi_factor.bhy(results, metrics=["ic"], q=0.05)  # one step-up over all three
+```
+
 ## See also
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary
- `docs/api/bhy.md` explained the identity-vs-partition split (`params` joining the hypothesis identifier vs. `expand_over` partitioning the family) in prose and a table, but never showed the actual `dataclasses.replace(res, params=...)` one-liner needed to use it — unlike its sibling pages `bhy-hierarchical.md` and `partial-conjunction.md`, which both demonstrate the same `stamp()` helper pattern inline.
- A reader who lands on `bhy.md` first (the most common entry point) had no runnable example for the "sweep a knob and let bhy pick the winner across it" case — the middle row of the existing "three roles a knob can play" table.

## Test plan
- [x] Ran the added snippet directly end-to-end (3 synthetic panels, 3 timeframes stamped via `dataclasses.replace`, fed to `fx.multi_factor.bhy`) — confirms one pooled family (`n_tests={(): 3}`), matching the documented behavior
- [x] `uv run mkdocs build` — no generated-file drift
- [x] `uv run pytest tests/test_docs_pages.py tests/test_docs_matrix.py tests/test_docs_stat_keys_by_metric.py -q` — 211 passed