### PR TITLE
docs(readme): add a prominent top-of-page docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 
 <h3 align="center"><b>Tests one factor. Screens a thousand.</b></h3>
 
+<p align="center"><a href="https://awwesomeman.github.io/factrix/latest/"><b>📖 Full documentation</b></a></p>
+
 ## Where factrix fits
 
 **Does this factor possess predictive edge?**


### PR DESCRIPTION
## Summary
- The only link to the mkdocs site was one of six small badges stacked in a row near the top, and the organized `## Documentation` section (Get Started / User Guide / API Reference / Development / Release Notes) only appeared at the very bottom, after every code example.
- Added a single, visually distinct link right under the tagline pointing to the docs homepage. Deliberately not duplicating the bottom section's categorized breakdown — this is just a more discoverable entry point to the same destination the badge already linked to.

## Test plan
- [x] Rendered the markdown locally to confirm the link and layout