### PR TITLE
feat(multi-factor): add cross-metric FDR screens (#791)

### DIFF
--- a/docs/api/bhy-across-metrics.md
+++ b/docs/api/bhy-across-metrics.md
@@ -1,0 +1,63 @@
+---
+title: factrix.multi_factor.bhy_across_metrics
+---
+
+::: factrix.multi_factor.bhy_across_metrics
+
+<hr>
+
+## When to use it
+
+Use `bhy_across_metrics` when the research process may select any tested
+factor × metric cell. Unlike [`bhy`](bhy.md), which deliberately runs one
+screen per metric label, this function flattens all declared labels into one
+Benjamini-Hochberg-Yekutieli family.
+
+```python
+screen = fx.multi_factor.bhy_across_metrics(
+    results,
+    metrics=["ic", "spread"],
+    q=0.05,
+)
+
+screen.n_tests       # {(): n_results * 2}, less data-shortage cells
+screen.to_frame()    # factor | metric | p_value | adj_p | survived | active
+```
+
+The survivor unit is one `(EvaluationResult, metric label)` hypothesis. Taking
+the unique factor names afterward does **not** provide factor-level FDR control.
+For the claim that a factor works on at least `k` predeclared endpoints, use
+[`partial_conjunction_across_metrics`](partial-conjunction-across-metrics.md).
+
+## Family and audit contract
+
+- `metrics` must contain at least two unique inferential labels. A descriptive
+  output with `p_value=None` fails loudly.
+- Entry order is result-major, then caller-supplied metric order.
+- `expand_over` retains the existing `bhy` meaning: it partitions by a result
+  field or `params` key; metric labels remain pooled inside each bucket.
+- An `insufficient_*` cell stays in `entries` with `active=False` and
+  `adj_p=NaN`, but does not enter the active family or `n_tests`.
+- Other missing or invalid p-values raise rather than silently changing the
+  family.
+
+## Result fields
+
+| Field | Meaning |
+|---|---|
+| `entries` | Every traceable `MetricHypothesis`, including inactive and eliminated cells |
+| `adj_p_all` | BHY-adjusted p-values aligned with `entries`; NaN for inactive cells |
+| `survivors` / `adj_p` | Passing cell hypotheses and their adjusted p-values |
+| `metrics` | Metric labels in declared order |
+| `expand_over` | Keys partitioning separately reported families |
+| `n_tests` | Active factor × metric family size per bucket |
+
+::: factrix.multi_factor.CrossMetricBhyResult
+    options:
+      show_root_toc_entry: false
+      heading_level: 3
+
+::: factrix.multi_factor.MetricHypothesis
+    options:
+      show_root_toc_entry: false
+      heading_level: 3

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,7 +26,9 @@ flowchart TD
 
     subgraph Screen["FDR screening"]
         BHY[bhy]
+        XBHY[bhy across metrics]
         PC[partial conjunction]
+        XPC[partial conjunction across metrics]
         BHYH[hierarchical BHY]
     end
 
@@ -51,13 +53,18 @@ flowchart TD
     EVALP -.-> ST
     EVALP -.-> ID
     EV ==>|results| BHY
+    EV ==>|results| XBHY
     EV ==>|results| PC
+    EV ==>|results| XPC
     EV ==>|results| BHYH
     EV ==>|results| CMP
     EVH ==>|results| CMP
     EVH ==>|results| BHY
+    EVH ==>|results| XBHY
+    EVH ==>|results| XPC
     BHY ==>|survivors| CMP
     PC ==>|survivors| CMP
+    XPC ==>|survivors| CMP
     BHYH ==>|survivors| CMP
     LM -.-> EV
     MS -.-> EV
@@ -69,7 +76,9 @@ flowchart TD
     click BS "by-slice/" "by_slice API"
     click ST "slice-test/" "slice tests API"
     click BHY "multi-factor/" "bhy API"
+    click XBHY "bhy-across-metrics/" "bhy_across_metrics API"
     click PC "partial-conjunction/" "partial_conjunction API"
+    click XPC "partial-conjunction-across-metrics/" "partial_conjunction_across_metrics API"
     click BHYH "bhy-hierarchical/" "bhy_hierarchical API"
     click LM "metrics/#factrix.list_metrics" "list_metrics API"
     click MS "metrics/#factrix.metrics_summary" "metrics_summary API"
@@ -107,9 +116,9 @@ each requested horizon.
 - **Inference** produces a p-value for one hypothesis. `evaluate` and
   `evaluate_horizons` do this per factor; `slice_*_test` functions test across
   slices of one factor. None of these corrects for testing many candidates.
-- **Screening** starts after inference. `bhy`, `partial_conjunction`, and
-  `bhy_hierarchical` take `list[EvaluationResult]` and control false discoveries
-  across the declared family.
+- **Screening** starts after inference. The `multi_factor` procedures take
+  `list[EvaluationResult]` and control false discoveries across declared
+  factor, context, or metric families.
 - **Views** such as `by_slice` and `compare` arrange or rank results; they do
   not add another statistical test.
 
@@ -129,6 +138,8 @@ each requested horizon.
 | Metric catalog discovery, browse | `metrics_summary()` -> `pl.DataFrame` of `(family, metric, summary)` |
 | Per-panel applicability | `inspect_data(raw_or_panel)` -> `.usable` / `.degraded` / `.unusable` |
 | Multi-factor screening with FDR | `evaluate(...)` -> `multi_factor.bhy(list(results.values()), metrics=[...])` |
+| Cross-metric pooled FDR | `evaluate(...)` -> `multi_factor.bhy_across_metrics(list(results.values()), metrics=[...])` |
+| Factor confirmation across metrics | `evaluate(...)` -> `multi_factor.partial_conjunction_across_metrics(list(results.values()), metrics=[...], min_pass=k)` |
 | Cross-factor leaderboard | `compare(list(results.values()), metrics=[...])` -> `pl.DataFrame` |
 
 See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surface end-to-end.
@@ -145,7 +156,9 @@ See the [Slice analysis guide](../guides/slice-analysis.md) for the slice surfac
 | [`slice_*_test` family](slice-test.md) | Inference (across slices) | Pairwise / omnibus tests over date-aligned or date-disjoint slice families. | Testing whether slice means differ. |
 | [`multi_factor`](multi-factor.md) | Screening (FDR) | Module-level overview of collection-level FDR functions. | Multi-factor FDR screening overview. |
 | [`bhy`](bhy.md) | Screening (FDR) | Benjamini-Hochberg-Yekutieli step-up FDR. | Screening candidate factors. |
+| [`bhy_across_metrics`](bhy-across-metrics.md) | Screening (FDR) | One pooled BHY family over factor × metric cells. | Selection may choose across metric labels. |
 | [`partial_conjunction`](partial-conjunction.md) | Screening (FDR) | k-of-m partial conjunction screening. | "Factor passes in k of m contexts." |
+| [`partial_conjunction_across_metrics`](partial-conjunction-across-metrics.md) | Screening (FDR) | Factor-level k-of-m confirmation across metrics. | "Factor passes on k of m endpoints." |
 | [`bhy_hierarchical`](bhy-hierarchical.md) | Screening (FDR) | Two-stage hierarchical BHY FDR. | Grouped / nested-context screening. |
 | [`compare`](compare.md) | Descriptive view | Cross-factor leaderboard; stacks evaluation results into a `pl.DataFrame`. | Ranking candidate factors. |
 | [`list_metrics`](metrics/index.md#factrix.list_metrics) | Introspection | Family-grouped catalog of public metric specs. | Programmatic browsing over the metric catalog. |

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -7,9 +7,9 @@ title: factrix.multi_factor
 Collection-level false-discovery-rate (FDR) control across a list of
 `EvaluationResult` objects. Use after `evaluate`
 has produced results for candidate factors (or per factor × params
-combinations): the functions in this module adjust per-factor p-values
-for multiple testing under the dependence structure that factor pools
-exhibit by construction.
+combinations): the functions in this module adjust traceable
+factor/context/metric hypotheses for multiple testing under the dependence
+structure that factor pools exhibit by construction.
 
 This page is a module-level index. Each function has its own page
 covering call shape, parameters, the result containers,
@@ -20,12 +20,15 @@ and design rationale.
 | Question you are asking | Function | Page |
 |---|---|---|
 | "Which factors in this candidate pool survive FDR ≤ q under arbitrary dependence?" | `bhy` | [api/bhy](bhy.md) |
+| "Which factor × metric cells survive one pooled FDR family?" | `bhy_across_metrics` | [api/bhy-across-metrics](bhy-across-metrics.md) |
 | "Which factors are significant in at least `k` of `m` replication conditions?" | `partial_conjunction` | [api/partial-conjunction](partial-conjunction.md) |
+| "Which factors have signal on at least `k` of `m` predeclared metrics?" | `partial_conjunction_across_metrics` | [api/partial-conjunction-across-metrics](partial-conjunction-across-metrics.md) |
 | "Which factor *families* carry signal, and which factors within each surviving family survive?" | `bhy_hierarchical` | [api/bhy-hierarchical](bhy-hierarchical.md) |
 
-`bhy` is the canonical entry point — start there unless you have an
-explicit reason to claim partial-conjunction or hierarchical group
-structure.
+Start with `bhy` when one metric defines the screen. Use a cross-metric function
+only when the predeclared selection rule may choose among metric labels or
+requires confirmation on at least `k` endpoints; use the hierarchical function
+only for a predeclared group structure.
 
 ## See also
 

--- a/docs/api/partial-conjunction-across-metrics.md
+++ b/docs/api/partial-conjunction-across-metrics.md
@@ -1,0 +1,62 @@
+---
+title: factrix.multi_factor.partial_conjunction_across_metrics
+---
+
+::: factrix.multi_factor.partial_conjunction_across_metrics
+
+<hr>
+
+## When to use it
+
+Use this procedure for a predeclared factor-level claim such as "the factor has
+signal on at least two of IC, beta, and spread." Metric labels are the fixed
+condition axis: each factor identity receives one k-of-m partial-conjunction
+p-value, followed by BHY across identities.
+
+```python
+screen = fx.multi_factor.partial_conjunction_across_metrics(
+    results,
+    metrics=["ic", "beta", "spread"],
+    min_pass=2,
+    q=0.05,
+)
+
+screen.to_frame()
+# factor | pc_p | adj_p | survived | active
+#        | n_tests | n_active | n_passed_uncorr
+```
+
+This differs from [`bhy_across_metrics`](bhy-across-metrics.md): pooled BHY
+selects factor × metric cells, while partial conjunction returns factor
+identities supported by at least `k` endpoints.
+
+## Fixed-m data-shortage rule
+
+The declared metric list fixes `m`. An `insufficient_*` endpoint is retained in
+`hypotheses` and conservatively enters the k-of-m calculation as `p=1`; it is
+never deleted in a way that would lower the confirmation bar. If fewer than
+`min_pass` endpoints are active, that identity remains visible with
+`active=False` and empty PC/adjusted p-values, and does not enter the outer BHY
+family.
+
+Descriptive endpoints and other invalid p-values fail loudly. The function does
+not implement `min_pass=1` any-metric promotion.
+
+## Result fields
+
+| Field | Meaning |
+|---|---|
+| `entries` | Every tested factor identity, in input order |
+| `hypotheses` | Underlying result × metric cells retained for audit |
+| `pc_p_all` | Raw k-of-m p-value per identity; NaN when fewer than `k` endpoints are active |
+| `adj_p_all` | BHY-adjusted PC p-value per identity |
+| `survivors` / `adj_p` | Passing factor identities and their adjusted p-values |
+| `metrics` / `min_pass` | Declared m endpoints and required k |
+| `n_tests` | Fixed condition count m per identity |
+| `n_active` | Computable endpoint count per identity |
+| `n_identities` | Identities entering the outer BHY family |
+
+::: factrix.multi_factor.CrossMetricPartialConjunctionResult
+    options:
+      show_root_toc_entry: false
+      heading_level: 3

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -31,13 +31,13 @@ flowchart TD
     REG["Registry<br/>list[MetricSpec]"]
     DAG["DagExecutor<br/>computes dependency graph"]
     ER["EvaluationResult<br/>groups / metrics / warnings"]
-    BHY["multi_factor.bhy()<br/>BHY FDR correction"]
+    SCREEN["multi_factor<br/>FDR screening"]
 
     User -->|"evaluate(panel, metrics=[...])"| EVAL
     EVAL --> REG
     REG --> DAG
     DAG -->|"results"| ER
-    ER -->|"batch"| BHY
+    ER -->|"batch"| SCREEN
 ```
 
 The dispatch runs through a Directed Acyclic Graph (DAG) executor on a closed `list[MetricSpec]` rather than a registry-keyed procedure table.
@@ -46,12 +46,16 @@ The dispatch runs through a Directed Acyclic Graph (DAG) executor on a closed `l
 
 ## Public API surface
 
-Entry points, all in `factrix.__init__`:
+Primary public entry points:
 
 | Symbol | Purpose |
 |--------|---------|
 | `fx.evaluate(panel, metrics=...)` | Dispatch to the metrics applicable to the factor's cell |
 | `fx.multi_factor.bhy(results, *, metrics, expand_over=(), q=0.05)` | Benjamini-Hochberg-Yekutieli (BHY) false discovery rate (FDR) correction; one declared family per call (optionally split per-bucket via `expand_over`) |
+| `fx.multi_factor.bhy_across_metrics(results, *, metrics, expand_over=(), q=0.05)` | One pooled BHY family over factor × metric hypotheses, optionally partitioned by predeclared contexts |
+| `fx.multi_factor.partial_conjunction(results, *, metrics, min_pass, expand_over, ...)` | Factor confirmation in at least `min_pass` predeclared contexts |
+| `fx.multi_factor.partial_conjunction_across_metrics(results, *, metrics, min_pass, q=0.05)` | Factor confirmation on at least `min_pass` predeclared metric endpoints |
+| `fx.multi_factor.bhy_hierarchical(results, *, metrics, group, q=0.05)` | Two-stage FDR screening across and within predeclared groups |
 
 Plus introspection / error / enum re-exports:
 
@@ -684,10 +688,12 @@ producer owns calibration and records `alternative`; the family layer neither
 converts tails nor infers them from statistic signs. There is intentionally no
 generic one-sided-to-two-sided helper.
 
-EvaluationResult-based multiple-testing functions (`bhy`, `bhy_hierarchical`,
-and `partial_conjunction`) share a single internal pre-processing
-layer in `factrix/_family.py::_resolve_family`. Each function's procedure runs *after*
-the family-resolution invariants pass.
+`EvaluationResult`-based multiple-testing functions share partitioning and
+p-value resolution in `factrix/_family.py`. Single-metric procedures use
+`_resolve_family`; cross-metric procedures flatten the result × metric grid in
+`_multi_factor.py::_normalize_metric_hypotheses`, reusing `_partition` and
+`_attach_p_values`. Each procedure runs only after these family-resolution
+invariants pass.
 
 ### Two signature classes
 
@@ -697,10 +703,10 @@ ones:
 
 | Class | Functions | Signature shape |
 |-------|-------|-----------------|
-| Closed-form (p-value only) | `bhy` / `bhy_hierarchical` / `partial_conjunction` | `(results, *, metrics, expand_over, ...)` |
+| Closed-form (p-value only) | `bhy` / `bhy_across_metrics` / `bhy_hierarchical` / `partial_conjunction` / `partial_conjunction_across_metrics` | `(results, *, metrics, ...)`; `expand_over` is available only where the procedure supports separate context families |
 | Resampling-based | Not exposed at the `multi_factor` layer | Requires a future metric-specific panel and bootstrap contract; the low-level `stats.romano_wolf_adjusted_p` primitive is not this workflow |
 
-### `_resolve_family` four invariants
+### Family-resolution invariants
 
 For input `results: Sequence[EvaluationResult]`, `expand_over: Sequence[str] | None`,
 and `metric: str` (one resolved spec):
@@ -708,16 +714,23 @@ and `metric: str` (one resolved spec):
 1. `expand_over` names must be present in every result's `params`, except
    the built-in `forward_periods`; `factor` is rejected because it is an
    identity dimension, not a family partition.
-2. hypothesis key per result = `(factor, forward_periods) +
-   tuple(params[k] for k in expand_over if k != "forward_periods")`
-   must be unique across the input. `EvaluationResult.__hash__ = None`, so dedup
-   walks the tuple, not a hash.
+2. The hypothesis identity per result is `(factor, forward_periods,
+   *sorted(params.items()))` and must be unique across the input. Every declared
+   parameter therefore joins identity even when it does not partition the
+   family. `EvaluationResult.__hash__ = None`, so dedup walks the tuple, not a
+   result hash.
 3. The specified `metric` must have a computed `p_value` that is non-NaN,
    and must be populated on every result.
 4. Resolved `p_value` per entry: the p-value read from the specified `metric`.
 
-All three user-facing raises route through `factrix._errors.UserInputError`
-so fuzzy suggestions and docs links render uniformly.
+Cross-metric BHY adds the metric label to this identity. Cross-metric partial
+conjunction instead treats the predeclared metric list as a fixed condition
+axis: insufficient endpoints count as p=1 and do not reduce `m`; an identity
+with fewer than `min_pass` active endpoints remains auditable but does not enter
+the outer BHY family.
+
+All screening input errors route through `factrix._errors.UserInputError` so
+fuzzy suggestions and docs links render uniformly.
 
 ### `expand_over` semantics
 
@@ -810,8 +823,8 @@ factrix/
 ├── _results.py              # EvaluationResult / MetricResult / Warning dataclasses
 ├── _inspect.py              # inspect_data — typed data introspection with per-metric verdict
 ├── _compare.py              # compare — multi-metric leaderboard over EvaluationResult lists
-├── _family.py               # _resolve_family — shared family resolution for the FDR verbs
-├── _multi_factor.py         # bhy / partial_conjunction / bhy_hierarchical impls
+├── _family.py               # _partition / _attach_p_values / _resolve_family — shared FDR family resolution
+├── _multi_factor.py         # per-metric, cross-metric, partial-conjunction, and hierarchical FDR impls
 ├── multi_factor.py          # public namespace (re-exports the FDR verbs)
 ├── _data_input.py           # input-type gateway for public entry points
 ├── adapt.py                 # column-name adapter → factrix canonical names
@@ -842,7 +855,7 @@ Hard constraints — violating these breaks the API contract:
 3. The metric-spec SSOT is the `@metric` registration in each `factrix/metrics/*.py`, resolved through `factrix._metric_index` (`spec_by_name` / `public_specs` / `list_metrics`); no parallel rule table. `@metric`-class registration feeds the index via `factrix.metrics._registry.register`. Slice-boundary warnings read `MetricSpec.slice_boundary_sensitive`; aggregation categories are not a proxy rule table.
 4. The DAG executor is the single dispatch path. `DagExecutor` topologically orders specs by `MetricSpec.requires` (raising `CycleError` on cycles), runs `batchable=True` producers once per factor batch and `batchable=False` consumers once per factor, and short-circuits a downstream consumer with a NaN `MetricResult` + `WarningCode.UPSTREAM_UNAVAILABLE` rather than invoking it on missing upstream data.
 5. `MetricResult.p_value` is the single canonical p-value read path — `EvaluationResult.to_frame()` / `to_dict()`, `compare`, and the BHY family resolver all read it; the p-value lives only on the field and is not duplicated into `metadata`. A formal p-value and `alternative` (`two-sided` / `greater` / `less`) must be present together; p-values are finite and in `[0, 1]`. `warnings` flag interpretation risk but never rebind it.
-6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over`. `_resolve_family` enforces (a) the hypothesis identity `(factor, forward_periods, *params)` is unique across the input — every `params` entry joins it automatically, while `metadata` never does, (b) `expand_over` names come only from `EvaluationResult.params` (or the built-in `forward_periods`), never the factor and never a `metadata` key, (c) `p_value` is populated everywhere before procedures read it. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
+6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over` where the API supports it. Shared resolution enforces (a) the result identity `(factor, forward_periods, *sorted(params.items()))` is unique across the input — every `params` entry joins it automatically, while `metadata` never does, (b) `expand_over` names come only from `EvaluationResult.params` (or the built-in `forward_periods`), never the factor and never a `metadata` key, (c) formal p-values are populated before procedures read them. Cross-metric BHY adds the metric label to the hypothesis identity; cross-metric partial conjunction keeps the predeclared metric count fixed under insufficient endpoints. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
 7. `T < MIN_PERIODS_HARD` raises `InsufficientSampleError`; metrics never silently produce a result on under-sampled data. NW HAC lag selection on overlapping forward returns floors at `forward_periods - 1` (the Hansen-Hodrick floor) so serial correlation from overlap is not under-counted.
 
 For the user-facing field walk of `EvaluationResult` (and its

--- a/docs/guides/validating-allocation-signals.md
+++ b/docs/guides/validating-allocation-signals.md
@@ -110,11 +110,13 @@ select, not to every descriptive column in a report.
 | Select the best factor or horizon from a grid | Run `evaluate_horizons`, then call `bhy` without `expand_over`; keep factor × horizon hypotheses pooled |
 | Report predeclared horizon-specific screens without comparing them | `bhy(..., expand_over=("forward_periods",))` |
 | Require a factor to pass at least k of m horizons | `partial_conjunction(..., min_pass=k, expand_over=("forward_periods",))` |
+| Select factor × metric cells from one family | `bhy_across_metrics(...)`; the survivor unit remains a cell hypothesis |
+| Require a factor to pass at least k of m metrics | `partial_conjunction_across_metrics(..., min_pass=k)` |
 
-Do not run separate metric families and promote a factor when any one passes;
-that creates an uncorrected any-pass rule. Horizon suitability comes from the
-effective sample, overlap, and warning records—not a universal list of allowed
-horizon numbers.
+Do not deduplicate pooled cell survivors into factors and claim factor-level
+FDR; an any-metric-pass factor promotion is a different procedure. Horizon
+suitability comes from the effective sample, overlap, and warning records—not
+a universal list of allowed horizon numbers.
 
 With `strict=False`, data-shortage placeholders remain visible. `bhy` excludes
 outputs whose reason starts with `insufficient_` from the active test count and

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -16,6 +16,11 @@ _VALUE_REPR_CAP = 120
 _AVAILABLE_PREVIEW = 15
 
 
+def _api_docs_path(func_name: str, anchor: str) -> str:
+    """Return the deployed API path for a snake-case function name."""
+    return f"api/{func_name.replace('_', '-')}#{anchor}"
+
+
 def _truncate_repr(value: object) -> str:
     text = repr(value)
     if len(text) <= _VALUE_REPR_CAP:

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -31,7 +31,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from factrix._errors import UserInputError
+from factrix._errors import UserInputError, _api_docs_path
 
 if TYPE_CHECKING:
     from factrix._results import EvaluationResult
@@ -107,7 +107,7 @@ def _partition(
                 field="expand_over",
                 value=name,
                 expected="partition key, not the hypothesis identifier 'factor'",
-                docs_path=f"api/{func_name}#expand_over",
+                docs_path=_api_docs_path(func_name, "expand_over"),
             )
 
     _check_param_keys(results, keys=keys, func_name=func_name)
@@ -132,7 +132,7 @@ def _partition(
                     "it on `EvaluationResult.params`; it then joins the "
                     "identifier without partitioning the family"
                 ),
-                docs_path=f"api/{func_name}#partition-key",
+                docs_path=_api_docs_path(func_name, "partition-key"),
             )
         seen[identifier] = idx
         entries.append(
@@ -167,7 +167,7 @@ def _attach_p_values(
                     f"target metric {metric!r} has no p-values (all results returned None). "
                     "Descriptive metrics without formal hypothesis tests cannot be used for FDR control"
                 ),
-                docs_path=f"api/{func_name}#metrics",
+                docs_path=_api_docs_path(func_name, "metrics"),
             )
 
     return [
@@ -262,7 +262,7 @@ def _check_param_keys(
             f"EvaluationResult.params, or drop it from expand_over. "
             f"Param keys seen across the input: {available or ['<none>']!r}"
         ),
-        docs_path=f"api/{func_name}#expand_over",
+        docs_path=_api_docs_path(func_name, "expand_over"),
     )
 
 
@@ -302,7 +302,7 @@ def _resolve_p_value(
                 f"{metric!r}; missing on factor={result.factor!r}"
             ),
             candidates=sorted(result.metrics),
-            docs_path=f"api/{func_name}#metrics",
+            docs_path=_api_docs_path(func_name, "metrics"),
         ) from None
 
     p = out.p_value
@@ -316,7 +316,7 @@ def _resolve_p_value(
                 f"factor={result.factor!r} has no p-value for "
                 f"metric {metric!r}"
             ),
-            docs_path=f"api/{func_name}#metrics",
+            docs_path=_api_docs_path(func_name, "metrics"),
         )
 
     p_float = float(p)
@@ -330,6 +330,6 @@ def _resolve_p_value(
                 f"has NaN p for metric {metric!r} — drop the result "
                 "or pick a different metric"
             ),
-            docs_path=f"api/{func_name}#metrics",
+            docs_path=_api_docs_path(func_name, "metrics"),
         )
     return p_float

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -1,18 +1,20 @@
-"""Collection-level FDR-control functions (``bhy`` / ``partial_conjunction``
-/ ``bhy_hierarchical``).
+"""Collection-level FDR control for per-metric and cross-metric families.
 
-All three accept ``list[EvaluationResult]`` and a list of
-:class:`~factrix._metric_index.metric label` records; each function runs
-one independent screen per metric and returns a
-``dict[metric_name, *Result]`` keyed by ``label`` (a single
-metric still returns a dict — no isinstance dispatch on the caller
-side).
+The original ``bhy`` / ``partial_conjunction`` / ``bhy_hierarchical``
+procedures run one independent screen per metric and return a
+``dict[metric_name, *Result]``. Cross-metric procedures share the
+``list[EvaluationResult]`` input but return one result with an explicit
+cell-level or factor-level survivor unit.
 
 Family declaration is explicit: the input list *is* the family,
 optionally split per-bucket via ``expand_over``. The base hypothesis
 identifier is ``(factor, forward_periods, *params)`` — every swept knob on
 ``EvaluationResult.params`` joins it automatically. ``expand_over`` only
 partitions the family; ``metadata`` never touches either.
+
+``bhy_across_metrics`` extends that identity with a metric label;
+``partial_conjunction_across_metrics`` treats the declared labels as a fixed
+k-of-m condition axis and returns factor-level identities.
 """
 
 from __future__ import annotations
@@ -22,13 +24,13 @@ import warnings
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from numbers import Real
+from numbers import Integral, Real
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import polars as pl
 
-from factrix._errors import UserInputError
+from factrix._errors import UserInputError, _api_docs_path
 from factrix._family import (
     _attach_p_values,
     _hypothesis_identity,
@@ -57,7 +59,7 @@ def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str
     Used by ``bhy.metrics`` / ``compare.metrics`` so both surfaces give
     identical error messages for the same misuse.
     """
-    anchor = f"api/{func_name}#{field}"
+    anchor = _api_docs_path(func_name, field)
     if not isinstance(value, list):
         raise UserInputError(
             func_name=func_name,
@@ -86,6 +88,32 @@ def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str
     return list(value)
 
 
+def _validate_cross_metric_list(value: Any, *, func_name: str) -> list[str]:
+    """Validate the ordered, unique metric axis for cross-metric screens."""
+    metrics = _validate_metric_list(value, func_name=func_name, field="metrics")
+    duplicates = sorted({name for name in metrics if metrics.count(name) > 1})
+    if duplicates:
+        raise UserInputError(
+            func_name=func_name,
+            field="metrics",
+            value=duplicates,
+            expected="unique metric labels; duplicates would repeat one hypothesis",
+            docs_path=_api_docs_path(func_name, "metrics"),
+        )
+    if len(metrics) < 2:
+        raise UserInputError(
+            func_name=func_name,
+            field="metrics",
+            value=metrics,
+            expected=(
+                "at least 2 metric labels for a cross-metric family; "
+                "use bhy() for one metric"
+            ),
+            docs_path=_api_docs_path(func_name, "metrics"),
+        )
+    return metrics
+
+
 def _validate_q(value: Any, *, func_name: str) -> float:
     """Validate the nominal FDR target shared by screening procedures."""
     if isinstance(value, bool) or not isinstance(value, Real):
@@ -94,7 +122,7 @@ def _validate_q(value: Any, *, func_name: str) -> float:
             field="q",
             value=value,
             expected="float in the open interval (0, 1)",
-            docs_path=f"api/{func_name}#q",
+            docs_path=_api_docs_path(func_name, "q"),
         )
     q = float(value)
     if not np.isfinite(q) or not 0.0 < q < 1.0:
@@ -103,7 +131,7 @@ def _validate_q(value: Any, *, func_name: str) -> float:
             field="q",
             value=value,
             expected="float in the open interval (0, 1)",
-            docs_path=f"api/{func_name}#q",
+            docs_path=_api_docs_path(func_name, "q"),
         )
     return q
 
@@ -126,7 +154,7 @@ def _require_non_empty_results(
                 "list[EvaluationResult], not the dict returned by evaluate() — "
                 "pass list(results.values())"
             ),
-            docs_path=f"api/{func_name}#results",
+            docs_path=_api_docs_path(func_name, "results"),
         )
     if not results:
         raise UserInputError(
@@ -134,7 +162,7 @@ def _require_non_empty_results(
             field="results",
             value=results,
             expected="non-empty list[EvaluationResult]",
-            docs_path=f"api/{func_name}#results",
+            docs_path=_api_docs_path(func_name, "results"),
         )
     from factrix._results import EvaluationResult
 
@@ -149,7 +177,7 @@ def _require_non_empty_results(
                     "evaluate(), pass list(results.values()); do not extend "
                     "a list with the dict itself, because that appends keys"
                 ),
-                docs_path=f"api/{func_name}#results",
+                docs_path=_api_docs_path(func_name, "results"),
             )
 
 
@@ -320,6 +348,110 @@ class BhyResult(_FdrResultBase):
         return headers, rows
 
 
+@dataclass(frozen=True, slots=True)
+class MetricHypothesis:
+    """One traceable ``EvaluationResult`` x metric hypothesis.
+
+    ``is_active=False`` marks an ``insufficient_*`` data-shortage cell. The
+    record remains auditable but is excluded from the BHY denominator.
+    """
+
+    result: EvaluationResult
+    metric_name: str
+    p_value: float
+    identifier: tuple[Any, ...]
+    expand_over_values: tuple[Any, ...]
+    is_active: bool
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CrossMetricBhyResult:
+    """One BHY screen over a pooled factor x metric hypothesis family."""
+
+    entries: list[MetricHypothesis]
+    adj_p_all: np.ndarray
+    q: float
+    metrics: tuple[str, ...]
+    expand_over: tuple[str, ...]
+    n_tests: Mapping[tuple[Any, ...], int]
+
+    @property
+    def _survived(self) -> np.ndarray:
+        return self.adj_p_all <= self.q
+
+    @property
+    def survivors(self) -> list[MetricHypothesis]:
+        """Surviving factor x metric hypotheses in canonical order."""
+        return [e for e, ok in zip(self.entries, self._survived, strict=True) if ok]
+
+    @property
+    def adj_p(self) -> np.ndarray:
+        """Adjusted p-values aligned with :attr:`survivors`."""
+        return self.adj_p_all[self._survived]
+
+    def to_frame(self) -> pl.DataFrame:
+        """Return every tested cell, including inactive and eliminated rows."""
+        return pl.DataFrame(
+            {
+                "factor": [e.result.factor for e in self.entries],
+                "metric": [e.metric_name for e in self.entries],
+                "p_value": [e.p_value for e in self.entries],
+                "adj_p": self.adj_p_all,
+                "survived": self._survived,
+                "active": [e.is_active for e in self.entries],
+            }
+        )
+
+    def __len__(self) -> int:
+        return int(self._survived.sum())
+
+    def _header(self) -> str:
+        parts = [
+            f"metrics={list(self.metrics)!r}",
+            f"n={len(self.survivors)}",
+            f"q={self.q:g}",
+        ]
+        if self.expand_over:
+            parts.append(f"expand_over={list(self.expand_over)!r}")
+        return ", ".join(parts)
+
+    def _rows(self) -> tuple[tuple[str, ...], list[tuple[str, ...]]]:
+        if self.expand_over:
+            headers: tuple[str, ...] = (
+                "expand_over_values",
+                "factor",
+                "metric",
+                "adj_p",
+            )
+            rows: list[tuple[str, ...]] = [
+                (
+                    repr(entry.expand_over_values),
+                    entry.result.factor,
+                    entry.metric_name,
+                    f"{float(adj):.4g}",
+                )
+                for entry, adj in zip(self.survivors, self.adj_p, strict=True)
+            ]
+            return headers, rows
+        headers = ("factor", "metric", "adj_p")
+        rows = [
+            (entry.result.factor, entry.metric_name, f"{float(adj):.4g}")
+            for entry, adj in zip(self.survivors, self.adj_p, strict=True)
+        ]
+        return headers, rows
+
+    def __repr__(self) -> str:
+        head = f"{type(self).__name__}({self._header()})"
+        if not self.survivors:
+            return head
+        headers, rows = self._rows()
+        return f"{head}\n{_render_table(headers, rows)}"
+
+    def _repr_html_(self) -> str:
+        headers, rows = self._rows()
+        return _render_html(f"{type(self).__name__} ({self._header()})", headers, rows)
+
+
 @dataclass(frozen=True, slots=True, repr=False)
 class PartialConjunctionResult(_FdrResultBase):
     """Per-identity partial-conjunction survivors for one metric.
@@ -384,6 +516,105 @@ class PartialConjunctionResult(_FdrResultBase):
             if ok
         ]
         return headers, rows
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class CrossMetricPartialConjunctionResult:
+    """Factor-level k-of-m metric confirmation followed by BHY."""
+
+    entries: list[EvaluationResult]
+    hypotheses: list[MetricHypothesis]
+    adj_p_all: np.ndarray
+    pc_p_all: np.ndarray
+    q: float
+    metrics: tuple[str, ...]
+    min_pass: int
+    n_tests: Mapping[tuple[Any, ...], int]
+    n_active: Mapping[tuple[Any, ...], int]
+    n_identities: int
+    n_passed_uncorr_all: np.ndarray
+
+    @property
+    def _survived(self) -> np.ndarray:
+        return self.adj_p_all <= self.q
+
+    @property
+    def survivors(self) -> list[EvaluationResult]:
+        """Factor identities whose adjusted partial-conjunction p passes."""
+        return [e for e, ok in zip(self.entries, self._survived, strict=True) if ok]
+
+    @property
+    def adj_p(self) -> np.ndarray:
+        """Adjusted p-values aligned with :attr:`survivors`."""
+        return self.adj_p_all[self._survived]
+
+    def to_frame(self) -> pl.DataFrame:
+        """Return one row per factor identity, including ineligible rows."""
+        identities = [_hypothesis_identity(entry) for entry in self.entries]
+        return pl.DataFrame(
+            {
+                "factor": [entry.factor for entry in self.entries],
+                "pc_p": self.pc_p_all,
+                "adj_p": self.adj_p_all,
+                "survived": self._survived,
+                "active": [
+                    self.n_active[identity] >= self.min_pass for identity in identities
+                ],
+                "n_tests": [self.n_tests[identity] for identity in identities],
+                "n_active": [self.n_active[identity] for identity in identities],
+                "n_passed_uncorr": self.n_passed_uncorr_all,
+            }
+        )
+
+    def __len__(self) -> int:
+        return int(self._survived.sum())
+
+    def _header(self) -> str:
+        return (
+            f"metrics={list(self.metrics)!r}, n={len(self.survivors)}, "
+            f"q={self.q:g}, min_pass={self.min_pass}"
+        )
+
+    def _rows(self) -> tuple[tuple[str, ...], list[tuple[str, ...]]]:
+        identities = [_hypothesis_identity(entry) for entry in self.entries]
+        headers: tuple[str, ...] = (
+            "factor",
+            "pc_p",
+            "adj_p",
+            "n_tests",
+            "n_passed_uncorr",
+        )
+        rows: list[tuple[str, ...]] = [
+            (
+                entry.factor,
+                f"{float(pc):.4g}",
+                f"{float(adj):.4g}",
+                str(self.n_tests[identity]),
+                str(int(n_passed)),
+            )
+            for entry, identity, pc, adj, n_passed, ok in zip(
+                self.entries,
+                identities,
+                self.pc_p_all,
+                self.adj_p_all,
+                self.n_passed_uncorr_all,
+                self._survived,
+                strict=True,
+            )
+            if ok
+        ]
+        return headers, rows
+
+    def __repr__(self) -> str:
+        head = f"{type(self).__name__}({self._header()})"
+        if not self.survivors:
+            return head
+        headers, rows = self._rows()
+        return f"{head}\n{_render_table(headers, rows)}"
+
+    def _repr_html_(self) -> str:
+        headers, rows = self._rows()
+        return _render_html(f"{type(self).__name__} ({self._header()})", headers, rows)
 
 
 @dataclass(frozen=True, slots=True, repr=False)
@@ -481,7 +712,7 @@ def bhy(
     _require_non_empty_results(results, func_name="bhy")
     expand_over_tuple = tuple(expand_over)
 
-    _warn_on_mixed_horizons(results, expand_over=expand_over_tuple)
+    _warn_on_mixed_horizons(results, func_name="bhy", expand_over=expand_over_tuple)
 
     partition = _partition(results, func_name="bhy", expand_over=expand_over_tuple)
     buckets: dict[tuple[Any, ...], list[int]] = defaultdict(list)
@@ -530,6 +761,115 @@ def _is_insufficient_short_circuit(result: EvaluationResult, metric: str) -> boo
     """Return True when a metric output is a data-shortage placeholder."""
     reason = result.metrics[metric].metadata.get("reason")
     return isinstance(reason, str) and reason.startswith("insufficient_")
+
+
+def _normalize_metric_hypotheses(
+    results: Sequence[EvaluationResult],
+    *,
+    metrics: Sequence[str],
+    func_name: str,
+    expand_over: tuple[str, ...] = (),
+) -> list[MetricHypothesis]:
+    """Flatten results x metrics while preserving result-major order."""
+    partition = _partition(results, func_name=func_name, expand_over=expand_over)
+    attached = {
+        metric: _attach_p_values(partition, func_name=func_name, metric=metric)
+        for metric in metrics
+    }
+    hypotheses: list[MetricHypothesis] = []
+    for idx, partition_entry in enumerate(partition):
+        for metric in metrics:
+            p_value = attached[metric][idx].p_value
+            assert p_value is not None  # guaranteed by _attach_p_values
+            hypotheses.append(
+                MetricHypothesis(
+                    result=partition_entry.result,
+                    metric_name=metric,
+                    p_value=float(p_value),
+                    identifier=(*partition_entry.identifier, ("metric", metric)),
+                    expand_over_values=partition_entry.expand_over_values,
+                    is_active=not _is_insufficient_short_circuit(
+                        partition_entry.result, metric
+                    ),
+                )
+            )
+    return hypotheses
+
+
+def bhy_across_metrics(
+    results: list[EvaluationResult],
+    *,
+    metrics: list[str],
+    expand_over: tuple[str, ...] = (),
+    q: float = 0.05,
+) -> CrossMetricBhyResult:
+    """Pool factor x metric hypotheses into one BHY FDR family.
+
+    The survivor unit is one ``(EvaluationResult, metric label)`` cell. This
+    controls hypothesis-level FDR; deduplicating survivors by factor does not
+    create a factor-level FDR guarantee.
+
+    Args:
+        results: Unique :class:`EvaluationResult` hypotheses.
+        metrics: At least two unique inferential metric labels, in the desired
+            audit order.
+        expand_over: Result fields or ``params`` keys that partition the input
+            into separately reported families. Metrics stay pooled inside each
+            bucket.
+        q: Nominal FDR target in the open interval ``(0, 1)``.
+
+    Returns:
+        A :class:`CrossMetricBhyResult` containing every submitted cell.
+
+    Raises:
+        UserInputError: Inputs do not define a valid, traceable family or any
+            non-short-circuited metric cell has an invalid p-value.
+    """
+    metric_list = _validate_cross_metric_list(metrics, func_name="bhy_across_metrics")
+    q_target = _validate_q(q, func_name="bhy_across_metrics")
+    _require_non_empty_results(results, func_name="bhy_across_metrics")
+    expand_over_tuple = tuple(expand_over)
+    _warn_on_mixed_horizons(
+        results,
+        func_name="bhy_across_metrics",
+        expand_over=expand_over_tuple,
+    )
+
+    entries = _normalize_metric_hypotheses(
+        results,
+        metrics=metric_list,
+        func_name="bhy_across_metrics",
+        expand_over=expand_over_tuple,
+    )
+    buckets: dict[tuple[Any, ...], list[int]] = defaultdict(list)
+    for idx, entry in enumerate(entries):
+        if entry.is_active:
+            buckets[entry.expand_over_values].append(idx)
+
+    n_tests = {bucket_key: len(ix) for bucket_key, ix in buckets.items()}
+    singleton = sum(1 for ix in buckets.values() if len(ix) == 1)
+    if singleton and len(buckets) > 1:
+        warnings.warn(
+            f"bhy_across_metrics: {singleton} of {len(buckets)} expand_over "
+            "buckets contain a single active hypothesis; BHY on n=1 is "
+            "identical to a raw threshold and provides no FDR correction.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    adj_p_all = np.full(len(entries), np.nan, dtype=np.float64)
+    for ix in buckets.values():
+        p_array = np.array([entries[i].p_value for i in ix], dtype=np.float64)
+        adj_p_all[ix] = bhy_adjusted_p(p_array)
+
+    return CrossMetricBhyResult(
+        entries=entries,
+        adj_p_all=adj_p_all,
+        q=q_target,
+        metrics=tuple(metric_list),
+        expand_over=expand_over_tuple,
+        n_tests=n_tests,
+    )
 
 
 def partial_conjunction(
@@ -747,6 +1087,122 @@ def _partial_conjunction_one(
     )
 
 
+def partial_conjunction_across_metrics(
+    results: list[EvaluationResult],
+    *,
+    metrics: list[str],
+    min_pass: int,
+    q: float = 0.05,
+) -> CrossMetricPartialConjunctionResult:
+    """Test whether each factor identity passes at least k of m metrics.
+
+    Metric labels are the predeclared condition axis. For each result, the
+    Bonferroni-style partial-conjunction p-value is computed across the fixed
+    ``m=len(metrics)`` endpoints, then BHY runs across factor identities.
+    ``insufficient_*`` endpoints are conservatively assigned p=1 rather than
+    shrinking ``m``; identities with fewer than ``min_pass`` active endpoints
+    remain in the audit output but do not enter the outer BHY family.
+
+    Args:
+        results: Unique :class:`EvaluationResult` hypotheses. Horizon and all
+            ``params`` remain part of each factor identity.
+        metrics: At least two unique, predeclared inferential metric labels.
+        min_pass: ``k`` in the claim "at least k of m metrics carry signal".
+            Must satisfy ``2 <= min_pass <= len(metrics)``.
+        q: Nominal FDR target for BHY across factor identities.
+
+    Returns:
+        A :class:`CrossMetricPartialConjunctionResult` with factor-level
+        survivors and the underlying metric hypotheses retained for audit.
+
+    Raises:
+        UserInputError: Inputs, metric p-values, or ``min_pass`` violate the
+            declared k-of-m contract.
+    """
+    metric_list = _validate_cross_metric_list(
+        metrics, func_name="partial_conjunction_across_metrics"
+    )
+    if isinstance(min_pass, bool) or not isinstance(min_pass, Integral):
+        raise UserInputError(
+            func_name="partial_conjunction_across_metrics",
+            field="min_pass",
+            value=min_pass,
+            expected="integer satisfying 2 <= min_pass <= len(metrics)",
+            docs_path="api/partial-conjunction-across-metrics#min-pass",
+        )
+    min_pass_int = int(min_pass)
+    if not 2 <= min_pass_int <= len(metric_list):
+        raise UserInputError(
+            func_name="partial_conjunction_across_metrics",
+            field="min_pass",
+            value=min_pass,
+            expected=(
+                f"integer satisfying 2 <= min_pass <= len(metrics) ({len(metric_list)})"
+            ),
+            docs_path="api/partial-conjunction-across-metrics#min-pass",
+        )
+
+    q_target = _validate_q(q, func_name="partial_conjunction_across_metrics")
+    _require_non_empty_results(results, func_name="partial_conjunction_across_metrics")
+    _warn_on_mixed_horizons(
+        results,
+        func_name="partial_conjunction_across_metrics",
+        expand_over=(),
+        supports_expand_over=False,
+    )
+    hypotheses = _normalize_metric_hypotheses(
+        results,
+        metrics=metric_list,
+        func_name="partial_conjunction_across_metrics",
+    )
+
+    m = len(metric_list)
+    identifiers = [_hypothesis_identity(result) for result in results]
+    n_tests = {identity: m for identity in identifiers}
+    n_active: dict[tuple[Any, ...], int] = {}
+    pc_p_all = np.full(len(results), np.nan, dtype=np.float64)
+    n_passed = np.zeros(len(results), dtype=np.int64)
+    eligible: list[int] = []
+
+    for idx, identity in enumerate(identifiers):
+        conditions = hypotheses[idx * m : (idx + 1) * m]
+        active_count = sum(condition.is_active for condition in conditions)
+        n_active[identity] = active_count
+        n_passed[idx] = sum(
+            condition.is_active and condition.p_value < q_target
+            for condition in conditions
+        )
+        if active_count < min_pass_int:
+            continue
+        p_values = np.array(
+            [
+                condition.p_value if condition.is_active else 1.0
+                for condition in conditions
+            ],
+            dtype=np.float64,
+        )
+        pc_p_all[idx] = partial_conjunction_p(p_values, min_pass=min_pass_int)
+        eligible.append(idx)
+
+    adj_p_all = np.full(len(results), np.nan, dtype=np.float64)
+    if eligible:
+        adj_p_all[eligible] = bhy_adjusted_p(pc_p_all[eligible])
+
+    return CrossMetricPartialConjunctionResult(
+        entries=list(results),
+        hypotheses=hypotheses,
+        adj_p_all=adj_p_all,
+        pc_p_all=pc_p_all,
+        q=q_target,
+        metrics=tuple(metric_list),
+        min_pass=min_pass_int,
+        n_tests=n_tests,
+        n_active=n_active,
+        n_identities=len(eligible),
+        n_passed_uncorr_all=n_passed,
+    )
+
+
 def bhy_hierarchical(
     results: list[EvaluationResult],
     *,
@@ -894,19 +1350,30 @@ def _bhy_hierarchical_one(
 def _warn_on_mixed_horizons(
     results: Sequence[EvaluationResult],
     *,
+    func_name: str,
     expand_over: tuple[str, ...],
+    supports_expand_over: bool = True,
 ) -> None:
     if "forward_periods" in expand_over:
         return
     horizons = {r.forward_periods for r in results}
     if len(horizons) > 1:
+        hint = (
+            "Use expand_over=('forward_periods',) only when horizon screens "
+            "were predeclared and will be selected and reported separately; "
+            "it does not control global horizon shopping."
+            if supports_expand_over
+            else (
+                "For predeclared horizon-specific screens, filter the input by "
+                "horizon and call the function separately; separate calls do "
+                "not control later global horizon shopping."
+            )
+        )
         warnings.warn(
-            f"bhy: input mixes forward_periods={sorted(horizons)} but "
+            f"{func_name}: input mixes forward_periods={sorted(horizons)} but "
             "they are being pooled into one multiple-testing family. This is "
             "the correct choice when the research process may select across "
-            "horizons. Use expand_over=('forward_periods',) only when horizon "
-            "screens were predeclared and will be selected and reported "
-            "separately; it does not control global horizon shopping.",
+            f"horizons. {hint}",
             RuntimeWarning,
             stacklevel=3,
         )

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -296,6 +296,24 @@ buckets do not control later horizon shopping.
 - `q`: Target FDR.
 - `n_tests`: Partition sizes.
 
+### `multi_factor.bhy_across_metrics`
+
+```python
+def bhy_across_metrics(
+    results: list[EvaluationResult],
+    *,
+    metrics: list[str],
+    expand_over: tuple[str, ...] = (),
+    q: float = 0.05,
+) -> CrossMetricBhyResult:
+```
+
+Pools all declared factor × metric cells into one BHY family. The survivor unit
+is a `MetricHypothesis`, not a factor; deduplicating survivors by factor does
+not provide factor-level FDR control. `insufficient_*` cells remain auditable
+with `active=False` and empty adjusted p-values but do not enter `n_tests`.
+Other missing or invalid p-values fail loudly.
+
 For lower-level multiplicity adjustment, `factrix.stats.bhy_adjusted_p`
 controls FDR when retaining a batch, while
 `factrix.stats.holm_adjusted_p` controls FWER when a search selects one winner
@@ -358,6 +376,24 @@ def partial_conjunction(
 ```
 
 Partial-conjunction screening: keeps factors significant in at least `min_pass` of `expand_over` conditions.
+
+### `multi_factor.partial_conjunction_across_metrics`
+
+```python
+def partial_conjunction_across_metrics(
+    results: list[EvaluationResult],
+    *,
+    metrics: list[str],
+    min_pass: int,
+    q: float = 0.05,
+) -> CrossMetricPartialConjunctionResult:
+```
+
+Treats the predeclared metric list as the fixed condition axis, computes one
+k-of-m p-value per factor identity, then runs BHY across identities. An
+`insufficient_*` endpoint is conservatively assigned p=1 rather than lowering
+m; an identity with fewer than k active endpoints stays in the audit output but
+does not enter the outer BHY family. Descriptive endpoints fail loudly.
 
 ---
 

--- a/factrix/llms.txt
+++ b/factrix/llms.txt
@@ -15,7 +15,7 @@
 - [API — evaluate](https://awwesomeman.github.io/factrix/api/evaluate/): single-factor and multi-factor evaluation entry point
 - [API — Multi-horizon](https://awwesomeman.github.io/factrix/api/multi-horizon/): multi-horizon evaluation recipes using evaluate_horizons + bhy(expand_over=)
 - [API — EvaluationResult](https://awwesomeman.github.io/factrix/api/evaluation-results/): unified result schema, to_dict() / to_frame()
-- [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): bhy() / bhy_hierarchical() / partial_conjunction() — FDR-corrected screening
+- [API — multi_factor](https://awwesomeman.github.io/factrix/api/multi-factor/): per-metric, cross-metric, partial-conjunction, and hierarchical FDR screening
 - [API — stats](https://awwesomeman.github.io/factrix/api/stats/): BHY FDR plus Holm and Romano-Wolf FWER adjusted p-values, dependent-series bootstrap helpers
 - [Reference — warning codes](https://awwesomeman.github.io/factrix/reference/warning-codes/): WarningCode enum
 - [Reference — metric applicability](https://awwesomeman.github.io/factrix/reference/metric-applicability/): which metrics apply to which axis combinations

--- a/factrix/multi_factor.py
+++ b/factrix/multi_factor.py
@@ -1,25 +1,37 @@
 """Public ``multi_factor`` namespace — collection-level FDR control.
 
-One procedure-paired result dataclass per function
-(:class:`BhyResult`, :class:`PartialConjunctionResult`,
-:class:`HierarchicalBhyResult`); each function returns
-``dict[metric_name, *Result]`` keyed by ``MetricSpec.name``.
+The original per-metric procedures return one result container per metric
+label. Cross-metric procedures return one container whose survivor unit is
+explicitly either a factor-by-metric hypothesis or a factor identity.
+
+Cross-metric procedures return one result whose survivor unit is explicitly
+either a factor-by-metric hypothesis or a factor identity.
 """
 
 from factrix._multi_factor import (
     BhyResult,
+    CrossMetricBhyResult,
+    CrossMetricPartialConjunctionResult,
     HierarchicalBhyResult,
+    MetricHypothesis,
     PartialConjunctionResult,
     bhy,
+    bhy_across_metrics,
     bhy_hierarchical,
     partial_conjunction,
+    partial_conjunction_across_metrics,
 )
 
 __all__ = [
     "BhyResult",
+    "CrossMetricBhyResult",
+    "CrossMetricPartialConjunctionResult",
     "HierarchicalBhyResult",
+    "MetricHypothesis",
     "PartialConjunctionResult",
     "bhy",
+    "bhy_across_metrics",
     "bhy_hierarchical",
     "partial_conjunction",
+    "partial_conjunction_across_metrics",
 ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,7 +186,9 @@ nav:
           - Multi-factor:
               - Overview: api/multi-factor.md
               - bhy: api/bhy.md
+              - bhy_across_metrics: api/bhy-across-metrics.md
               - partial_conjunction: api/partial-conjunction.md
+              - partial_conjunction_across_metrics: api/partial-conjunction-across-metrics.md
               - bhy_hierarchical: api/bhy-hierarchical.md
           - Discovery:
               - metric_spec: api/metric-spec.md

--- a/tests/test_bhy_across_metrics.py
+++ b/tests/test_bhy_across_metrics.py
@@ -1,0 +1,173 @@
+"""Cross-metric pooled BHY on traceable ``EvaluationResult`` cells."""
+
+from __future__ import annotations
+
+import factrix as fx
+import numpy as np
+import pytest
+from factrix._errors import UserInputError
+from factrix._multi_factor import CrossMetricBhyResult, bhy_across_metrics
+from factrix._results import MetricResult
+from factrix.stats.multiple_testing import bhy_adjusted_p
+
+from .conftest import make_result, make_spec
+
+
+def _output(name: str, p: float, *, reason: str | None = None) -> MetricResult:
+    metadata: dict[str, object] = {"p_value": p}
+    if reason is not None:
+        metadata["reason"] = reason
+    return MetricResult(
+        value=float("nan") if reason else 0.1,
+        p_value=p,
+        alternative="two-sided",
+        n_obs=100,
+        name=name,
+        metadata=metadata,
+    )
+
+
+def _two_metric_result(factor: str, p_ic: float, p_spread: float, **kwargs):
+    return make_result(
+        factor=factor,
+        p=p_ic,
+        metric="ic",
+        extra_outputs={"spread": _output("spread", p_spread)},
+        **kwargs,
+    )
+
+
+def test_pools_factor_by_metric_cells_into_one_family():
+    make_spec("ic")
+    make_spec("spread")
+    results = [
+        _two_metric_result("f1", 0.001, 0.02),
+        _two_metric_result("f2", 0.03, 0.4),
+    ]
+
+    out = bhy_across_metrics(results, metrics=["ic", "spread"], q=0.05)
+
+    assert isinstance(out, CrossMetricBhyResult)
+    assert out.n_tests == {(): 4}
+    assert [(e.result.factor, e.metric_name) for e in out.entries] == [
+        ("f1", "ic"),
+        ("f1", "spread"),
+        ("f2", "ic"),
+        ("f2", "spread"),
+    ]
+    np.testing.assert_allclose(
+        out.adj_p_all,
+        bhy_adjusted_p(np.array([0.001, 0.02, 0.03, 0.4])),
+    )
+
+
+def test_public_multi_factor_namespace_exports_cross_metric_api():
+    assert fx.multi_factor.bhy_across_metrics is bhy_across_metrics
+    assert fx.multi_factor.CrossMetricBhyResult is CrossMetricBhyResult
+    assert fx.multi_factor.MetricHypothesis.__name__ == "MetricHypothesis"
+
+
+def test_to_frame_keeps_raw_p_metric_and_survival_identity():
+    results = [
+        _two_metric_result("f1", 0.001, 0.02),
+        _two_metric_result("f2", 0.03, 0.4),
+    ]
+    out = bhy_across_metrics(results, metrics=["ic", "spread"], q=0.5)
+
+    frame = out.to_frame()
+    assert frame.columns == [
+        "factor",
+        "metric",
+        "p_value",
+        "adj_p",
+        "survived",
+        "active",
+    ]
+    assert frame.height == 4
+    assert frame["metric"].to_list() == ["ic", "spread", "ic", "spread"]
+
+
+def test_insufficient_cell_stays_auditable_but_not_active():
+    valid = _two_metric_result("valid", 0.01, 0.02)
+    thin = make_result(
+        factor="thin",
+        p=0.03,
+        metric="ic",
+        extra_outputs={"spread": _output("spread", 1.0, reason="insufficient_assets")},
+    )
+
+    out = bhy_across_metrics([valid, thin], metrics=["ic", "spread"], q=0.5)
+    frame = out.to_frame()
+    inactive = frame.filter(~frame["active"])
+
+    assert out.n_tests == {(): 3}
+    assert inactive.height == 1
+    assert inactive["factor"].item() == "thin"
+    assert inactive["metric"].item() == "spread"
+    assert np.isnan(inactive["adj_p"].item())
+
+
+def test_expand_over_partitions_after_metric_flattening():
+    results = [
+        _two_metric_result("us", 0.01, 0.02, params={"region": "US"}),
+        _two_metric_result("eu", 0.03, 0.04, params={"region": "EU"}),
+    ]
+
+    out = bhy_across_metrics(
+        results,
+        metrics=["ic", "spread"],
+        expand_over=("region",),
+        q=0.5,
+    )
+
+    assert out.n_tests == {("US",): 2, ("EU",): 2}
+    assert out.expand_over == ("region",)
+
+
+def test_descriptive_metric_fails_loudly():
+    descriptive = MetricResult(value=0.1, p_value=None, name="shape")
+    results = [
+        make_result(
+            factor="f1",
+            p=0.01,
+            metric="ic",
+            extra_outputs={"shape": descriptive},
+        )
+    ]
+    with pytest.raises(UserInputError, match="FDR control") as excinfo:
+        bhy_across_metrics(results, metrics=["ic", "shape"])
+    assert "/api/bhy-across-metrics#metrics" in excinfo.value.docs_url
+
+
+@pytest.mark.parametrize("metrics", [["ic"], ["ic", "ic"]])
+def test_metric_axis_requires_two_unique_labels(metrics):
+    results = [_two_metric_result("f1", 0.01, 0.02)]
+    with pytest.raises(UserInputError, match="metric"):
+        bhy_across_metrics(results, metrics=metrics)
+
+
+def test_metric_container_error_links_to_deployed_page():
+    results = [_two_metric_result("f1", 0.01, 0.02)]
+    with pytest.raises(UserInputError) as excinfo:
+        bhy_across_metrics(results, metrics=("ic", "spread"))  # type: ignore[arg-type]
+    assert "/api/bhy-across-metrics#metrics" in excinfo.value.docs_url
+
+
+def test_mixed_horizons_warns_with_cross_metric_function_name():
+    results = [
+        _two_metric_result("f1", 0.01, 0.02, forward_periods=1),
+        _two_metric_result("f2", 0.03, 0.04, forward_periods=5),
+    ]
+    with pytest.warns(RuntimeWarning, match="bhy_across_metrics"):
+        bhy_across_metrics(results, metrics=["ic", "spread"], q=0.5)
+
+
+def test_repr_and_html_show_metric_identity():
+    out = bhy_across_metrics(
+        [_two_metric_result("f1", 0.001, 0.002)],
+        metrics=["ic", "spread"],
+        q=0.5,
+    )
+    assert "CrossMetricBhyResult" in repr(out)
+    assert "spread" in repr(out)
+    assert "<table" in out._repr_html_()

--- a/tests/test_partial_conjunction_across_metrics.py
+++ b/tests/test_partial_conjunction_across_metrics.py
@@ -1,0 +1,171 @@
+"""Factor-level partial conjunction across predeclared metric endpoints."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._errors import UserInputError
+from factrix._multi_factor import (
+    CrossMetricPartialConjunctionResult,
+    partial_conjunction_across_metrics,
+)
+from factrix._results import MetricResult
+
+from .conftest import make_result
+
+
+def _output(name: str, p: float, *, reason: str | None = None) -> MetricResult:
+    metadata: dict[str, object] = {"p_value": p}
+    if reason is not None:
+        metadata["reason"] = reason
+    return MetricResult(
+        value=float("nan") if reason else 0.1,
+        p_value=p,
+        alternative="two-sided",
+        n_obs=100,
+        name=name,
+        metadata=metadata,
+    )
+
+
+def _result(factor: str, ps: tuple[float, float, float], **kwargs):
+    return make_result(
+        factor=factor,
+        p=ps[0],
+        metric="ic",
+        extra_outputs={
+            "beta": _output("beta", ps[1]),
+            "spread": _output("spread", ps[2]),
+        },
+        **kwargs,
+    )
+
+
+def test_computes_metric_k_of_m_then_bhy_across_factor_identities():
+    results = [
+        _result("strong", (0.001, 0.002, 0.8)),
+        _result("weak", (0.1, 0.2, 0.3)),
+    ]
+
+    out = partial_conjunction_across_metrics(
+        results,
+        metrics=["ic", "beta", "spread"],
+        min_pass=2,
+        q=0.05,
+    )
+
+    assert isinstance(out, CrossMetricPartialConjunctionResult)
+    np.testing.assert_allclose(out.pc_p_all, [0.004, 0.4])
+    assert [entry.factor for entry in out.survivors] == ["strong"]
+    assert out.n_identities == 2
+    assert set(out.n_tests.values()) == {3}
+    assert len(out.hypotheses) == 6
+
+
+def test_insufficient_endpoint_keeps_fixed_m_and_ineligible_factor_is_audited():
+    fixed_m = make_result(
+        factor="fixed_m",
+        p=0.001,
+        metric="ic",
+        extra_outputs={
+            "beta": _output("beta", 0.002),
+            "spread": _output("spread", 1.0, reason="insufficient_assets"),
+        },
+    )
+    ineligible = make_result(
+        factor="ineligible",
+        p=0.001,
+        metric="ic",
+        extra_outputs={
+            "beta": _output("beta", 1.0, reason="insufficient_periods"),
+            "spread": _output("spread", 1.0, reason="insufficient_assets"),
+        },
+    )
+
+    out = partial_conjunction_across_metrics(
+        [fixed_m, ineligible],
+        metrics=["ic", "beta", "spread"],
+        min_pass=2,
+        q=0.5,
+    )
+    frame = out.to_frame()
+
+    # Fixed m=3 gives 2 * p_(2) = 0.004; silently shrinking to m=2 would
+    # incorrectly produce 0.002.
+    assert out.pc_p_all[0] == pytest.approx(0.004)
+    assert np.isnan(out.pc_p_all[1])
+    assert out.n_identities == 1
+    assert frame["active"].to_list() == [True, False]
+    assert frame["n_active"].to_list() == [2, 1]
+    assert frame["n_tests"].to_list() == [3, 3]
+
+
+def test_to_frame_reports_factor_level_contract():
+    out = partial_conjunction_across_metrics(
+        [_result("f1", (0.001, 0.002, 0.8))],
+        metrics=["ic", "beta", "spread"],
+        min_pass=2,
+        q=0.5,
+    )
+    assert out.to_frame().columns == [
+        "factor",
+        "pc_p",
+        "adj_p",
+        "survived",
+        "active",
+        "n_tests",
+        "n_active",
+        "n_passed_uncorr",
+    ]
+
+
+@pytest.mark.parametrize("min_pass", [True, 1, 4, 2.5])
+def test_min_pass_must_fit_declared_metric_count(min_pass):
+    with pytest.raises(UserInputError, match="min_pass"):
+        partial_conjunction_across_metrics(
+            [_result("f1", (0.01, 0.02, 0.03))],
+            metrics=["ic", "beta", "spread"],
+            min_pass=min_pass,
+        )
+
+
+def test_descriptive_endpoint_fails_loudly():
+    result = make_result(
+        factor="f1",
+        p=0.01,
+        metric="ic",
+        extra_outputs={"shape": MetricResult(value=0.1, name="shape")},
+    )
+    with pytest.raises(UserInputError, match="FDR control"):
+        partial_conjunction_across_metrics(
+            [result], metrics=["ic", "shape"], min_pass=2
+        )
+
+
+def test_mixed_horizons_warns_because_outer_bhy_pools_identities():
+    results = [
+        _result("f1", (0.01, 0.02, 0.03), forward_periods=1),
+        _result("f2", (0.01, 0.02, 0.03), forward_periods=5),
+    ]
+    with pytest.warns(
+        RuntimeWarning, match="partial_conjunction_across_metrics"
+    ) as warning_records:
+        partial_conjunction_across_metrics(
+            results,
+            metrics=["ic", "beta", "spread"],
+            min_pass=2,
+            q=0.5,
+        )
+    assert "filter the input by horizon" in str(warning_records[0].message)
+
+
+def test_repr_and_html_show_factor_level_screen():
+    out = partial_conjunction_across_metrics(
+        [_result("f1", (0.001, 0.002, 0.8))],
+        metrics=["ic", "beta", "spread"],
+        min_pass=2,
+        q=0.5,
+    )
+    assert "CrossMetricPartialConjunctionResult" in repr(out)
+    assert "f1" in repr(out)
+    assert "<table" in out._repr_html_()


### PR DESCRIPTION
## Summary
- add pooled BHY screening across factor x metric hypotheses
- add fixed-m partial-conjunction screening across predeclared metrics
- align API guides, architecture, MkDocs navigation, and LLM references

## Test plan
- [x] `python -m pytest -q -p no:faulthandler` (1807 passed, 3 skipped)
- [x] `ruff check factrix tests`
- [x] `mypy factrix`
- [x] `mkdocs build --strict`

Closes #791