### PR TITLE
feat(inference): bootstrap consistency for series-mean inference

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -504,8 +504,9 @@ Only the series-mean family (`ic`, `quantile_spread`, `k_spread`) takes a
 selectable `inference=`; every other metric carries a fixed estimator by
 its statistical shape, so the absence of the knob is by design. The
 `factrix.inference` module docstring is the SSOT for the full rule — the
-per-family rationale, the closed-union policy, and why `HANSEN_HODRICK` is
-exported yet absent from the metric unions.
+per-family rationale, the closed-union policy, and why `HANSEN_HODRICK` and
+`STATIONARY_BOOTSTRAP` are each exported but not admitted into every
+metric's union.
 
 ### `individual_continuous(IC)` — cross-section first
 

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -58,29 +58,35 @@ The closed union is a type annotation, not a runtime gate, so every
 ``_check_applicable_inference``). A method outside the set raises
 :class:`~factrix.IncompatibleInferenceError` listing the allowed members,
 rather than running an unintended test or silently falling back to the
-default. ``ic`` / ``quantile_spread`` / ``k_spread`` all allow
-``{NON_OVERLAPPING, NEWEY_WEST}``; ``resolve_applicable_inference`` reads
-the set back for discovery.
+default. ``quantile_spread`` / ``k_spread`` allow
+``{NON_OVERLAPPING, NEWEY_WEST}``; ``ic`` additionally allows
+``STATIONARY_BOOTSTRAP`` (see below); ``resolve_applicable_inference``
+reads the set back for discovery.
 
-``HANSEN_HODRICK`` vs the metric allowlists
--------------------------------------------
-``HansenHodrick`` is a complete series-mean member (same ``compute``
-contract as the other two) and is exported for explicit / comparison use,
-but it is **not** in any metric's ``applicable_inference`` today, for
-reasons that differ per dispatch style:
+``HANSEN_HODRICK`` / ``STATIONARY_BOOTSTRAP`` vs the metric allowlists
+-----------------------------------------------------------------------
+``HansenHodrick`` and ``StationaryBootstrap`` are complete series-mean
+members (same ``compute`` contract as the others), but neither is in
+every metric's ``applicable_inference``, for reasons that differ per
+dispatch style:
 
 - ``ic`` dispatches **polymorphically** (``inference.compute(...)`` /
   ``inference.min_input_periods(...)``), so it could in principle run
   ``HANSEN_HODRICK`` — its allowlist is narrower than its capability. The
-  vetted pair is kept: ``NeweyWest`` (Bartlett kernel, PSD-guaranteed) is
+  vetted HAC pair is kept: ``NeweyWest`` (Bartlett kernel, PSD-guaranteed) is
   the recommended HAC, while ``HansenHodrick``'s rectangular kernel has no
   PSD guarantee (it can clamp a negative variance — see
-  ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``).
+  ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``). ``StationaryBootstrap``
+  runs through the same polymorphic path and *is* admitted — it makes no
+  asymptotic-variance assumption at all, so it is the recommended fallback
+  when the IC series is too short or too heavy-tailed for either HAC
+  member to be trusted.
 - ``quantile_spread`` / ``k_spread`` dispatch through
   ``_spread_significance_with_inference``, which hard-branches on
   ``isinstance(inference, NeweyWest)`` for the HAC path. The allowlist is
   **load-bearing** there: it admits exactly the two members that dispatch
-  handles, so widening it requires making that dispatch polymorphic first.
+  handles, so widening it to ``HANSEN_HODRICK`` or ``STATIONARY_BOOTSTRAP``
+  requires making that dispatch polymorphic first — not done here.
 """
 
 from __future__ import annotations
@@ -90,18 +96,22 @@ from factrix.inference.series_mean import (
     HANSEN_HODRICK,
     NEWEY_WEST,
     NON_OVERLAPPING,
+    STATIONARY_BOOTSTRAP,
     HansenHodrick,
     NeweyWest,
     NonOverlapping,
+    StationaryBootstrap,
 )
 
 __all__ = [
     "HANSEN_HODRICK",
     "NEWEY_WEST",
     "NON_OVERLAPPING",
+    "STATIONARY_BOOTSTRAP",
     "HansenHodrick",
     "Inference",
     "InferenceResult",
     "NeweyWest",
     "NonOverlapping",
+    "StationaryBootstrap",
 ]

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -10,8 +10,11 @@ one date-aware input contract::
 DataFrame). ``NonOverlapping`` strides the cleaned series at
 ``forward_periods`` (sub-sampling away the MA(h-1) overlap), while
 ``NeweyWest`` / ``HansenHodrick`` keep every observation and correct the
-SE via a HAC kernel. The lag / bandwidth is derived from the
-compute-time sample, so the dataclasses take no constructor knobs.
+SE via a HAC kernel. ``StationaryBootstrap`` also keeps every observation
+but replaces the analytic SE with a block-bootstrap empirical p, for
+series too short or non-normal for a HAC t-test to be trusted. The
+lag / bandwidth / block length is derived from the compute-time sample,
+so the dataclasses take no constructor knobs.
 
 These are metric-internal inference units: ``compute`` returns an
 ``InferenceResult`` whose ``stat`` / ``p_value`` feed a ``MetricResult``
@@ -191,6 +194,58 @@ class HansenHodrick:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class StationaryBootstrap:
+    r"""Stationary-bootstrap empirical-p inference on a series mean.
+
+    Resamples geometric-length blocks ([Politis-Romano 1994][politis-romano-1994])
+    from the series, centred under $H_0: \mathbb{E}[x] = 0$, and reports the
+    two-sided empirical p — the fraction of bootstrap means at least as
+    extreme as the observed one (Davison-Hinkley ``+1`` smoothing). No
+    normality or asymptotic-variance assumption, unlike ``NeweyWest`` /
+    ``HansenHodrick``: appropriate when the series is short relative to its
+    dependence horizon or heavy-tailed / skewed enough that a HAC t-test is
+    unreliable. Block length resolves automatically per
+    [Politis-White (2004)][politis-white-2004]; the resolved seed is
+    reported in ``metadata`` so the run is reproducible after the fact even
+    though the dataclass itself carries no seed knob.
+
+    Delegates to ``factrix._stats.bootstrap._block_bootstrap_diff_p`` —
+    the same kernel backing ``factrix.stats.BlockBootstrap`` — so the
+    empirical-p convention is one implementation, not a parallel one.
+    """
+
+    test: ClassVar[str] = "bootstrap-mean"
+    se: ClassVar[str | None] = "bootstrap"
+    summary: ClassVar[str] = "stationary-bootstrap empirical p-test"
+    min_periods: ClassVar[int] = MIN_PERIODS_WARN
+
+    def min_input_periods(self, forward_periods: int) -> int:
+        """Minimum input series length (periods); no overlap-specific floor."""
+        return MIN_PERIODS_HARD
+
+    def compute(
+        self, data: pl.DataFrame, *, value_col: str, forward_periods: int
+    ) -> InferenceResult:
+        from factrix._stats.bootstrap import _block_bootstrap_diff_p
+
+        vals = _clean_series(data, value_col).to_numpy()
+        n = len(vals)
+        p_value, boot_metadata = _block_bootstrap_diff_p(vals)
+
+        warnings: frozenset[WarningCode] = frozenset()
+        if 0 < n < self.min_periods:
+            warnings = frozenset({WarningCode.UNRELIABLE_SE_SHORT_PERIODS})
+
+        return InferenceResult(
+            stat=float(vals.mean()) if n else float("nan"),
+            p_value=p_value,
+            metadata=dict(boot_metadata),
+            warnings=warnings,
+        )
+
+
 NON_OVERLAPPING = NonOverlapping()
 NEWEY_WEST = NeweyWest()
 HANSEN_HODRICK = HansenHodrick()
+STATIONARY_BOOTSTRAP = StationaryBootstrap()

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -34,7 +34,7 @@ from factrix._codes import WarningCode, cross_section_tier
 from factrix._errors import IncompatibleInferenceError
 
 if TYPE_CHECKING:
-    from factrix.inference import NeweyWest, NonOverlapping
+    from factrix.inference import NeweyWest, NonOverlapping, StationaryBootstrap
     from factrix.metrics._base import MetricBase
 from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult, PValueAlternative
@@ -118,7 +118,7 @@ def _spread_significance(
 
 def _check_applicable_inference(
     inference: object,
-    applicable: frozenset[NonOverlapping | NeweyWest],
+    applicable: frozenset[NonOverlapping | NeweyWest | StationaryBootstrap],
     *,
     func_name: str,
 ) -> None:

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -36,7 +36,14 @@ from factrix._types import (
     MIN_IC_ASSETS_WARN,
     MIN_SERIES_PERIODS_HARD,
 )
-from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
+from factrix.inference import (
+    NEWEY_WEST,
+    NON_OVERLAPPING,
+    STATIONARY_BOOTSTRAP,
+    NeweyWest,
+    NonOverlapping,
+    StationaryBootstrap,
+)
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
@@ -72,11 +79,14 @@ min_assets_per_group: int | None = None
 per_date_series = per_date_series_rename("ic")
 
 # Inference allowlist: ``ic`` dispatches an ``Inference.compute`` polymorphically,
-# so it *could* run any series-mean member, but the vetted pair is the
-# non-overlap t-test and the Bartlett-kernel Newey-West HAC. ``HansenHodrick``
-# (rectangular kernel, no PSD guarantee) is deliberately excluded.
-applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
-    {NON_OVERLAPPING, NEWEY_WEST}
+# so it *could* run any series-mean member. The vetted set is the non-overlap
+# t-test, the Bartlett-kernel Newey-West HAC, and the stationary-bootstrap
+# empirical p (no asymptotic-variance assumption at all — the fallback when
+# the IC series is too short / heavy-tailed for either HAC path).
+# ``HansenHodrick`` (rectangular kernel, no PSD guarantee) is deliberately
+# excluded.
+applicable_inference: frozenset[NonOverlapping | NeweyWest | StationaryBootstrap] = (
+    frozenset({NON_OVERLAPPING, NEWEY_WEST, STATIONARY_BOOTSTRAP})
 )
 
 
@@ -203,7 +213,7 @@ def _ic_shortfall_is_asset_driven(ic_df: pl.DataFrame, raw_min: int) -> bool:
 def ic(
     ic_df: pl.DataFrame,
     forward_periods: int = 5,
-    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
+    inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
     r"""Information coefficient (IC) mean significance: is mean IC significantly different from zero?
@@ -220,8 +230,11 @@ def ic(
         inference: Significance-test method. ``fx.inference.NON_OVERLAPPING``
             (default) runs an OLS t-test on a non-overlapping stride
             subsample; ``fx.inference.NEWEY_WEST`` keeps every observation
-            and uses a Newey-West HAC standard error. Both test the same
-            $H_0: \mathbb{E}[\mathrm{IC}] = 0$.
+            and uses a Newey-West HAC standard error; ``fx.inference.STATIONARY_BOOTSTRAP``
+            also keeps every observation but replaces the HAC SE with a
+            block-bootstrap empirical p, for a series too short or
+            heavy-tailed for either t-test to be trusted. All three test the
+            same $H_0: \mathbb{E}[\mathrm{IC}] = 0$.
 
     Returns:
         MetricResult with value=mean IC and the inference method's t/p.
@@ -254,8 +267,12 @@ def ic(
         The guidance is one-directional: prefer ``NEWEY_WEST`` when the
         non-overlapping effective sample is too thin; there is no symmetric
         reason to switch back to non-overlapping once the sample is ample.
-        ``ic`` never changes ``inference`` for you — the choice stays
-        explicit.
+        ``STATIONARY_BOOTSTRAP`` drops the HAC asymptotic-variance
+        assumption entirely in favour of a block-bootstrap empirical p —
+        prefer it when the IC series is heavy-tailed / skewed enough that
+        a HAC t-test's normal-approximation p-value is itself suspect, not
+        only when the sample is short. ``ic`` never changes ``inference``
+        for you — the choice stays explicit.
 
     Examples:
         Chain from :func:`compute_ic` output:
@@ -324,7 +341,10 @@ def ic(
     metadata: dict[str, object] = {
         "n_periods": n,
         "forward_periods": forward_periods,
-        "stat_type": "t",
+        # stat / stat_type must reflect the test actually run — NonOverlapping
+        # / NeweyWest report a t-ratio, StationaryBootstrap reports the
+        # observed mean under an empirical (not t-distribution) p.
+        "stat_type": inference.test,
         "h0": "mu=0",
         "method": inference.summary,
         "tie_ratio": median_tie,

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -12,10 +12,11 @@ References:
     - [Politis & Romano (1994)][politis-romano-1994], "The Stationary
       Bootstrap."
     - [Politis & White (2004)][politis-white-2004], "Automatic Block-
-      Length Selection for the Dependent Bootstrap." Full procedure
-      requires spectral-density estimation; this module falls back to
-      the practical ``L = round(1.75 * T^(1/3))`` rule when
-      ``block_length=None``.
+      Length Selection for the Dependent Bootstrap." ``block_length=None``
+      runs the same spectral plug-in used by ``factrix.stats.BlockBootstrap``
+      (via ``factrix._stats.bootstrap._politis_white_block_length``), so
+      "auto" means one calibrated estimate everywhere in the library rather
+      than a cruder standalone default.
 """
 
 from __future__ import annotations
@@ -26,18 +27,27 @@ from numbers import Integral
 import numpy as np
 
 
-def _default_block_length(n: int) -> float:
-    """Practical fallback per [Politis-White (2004)][politis-white-2004] commentary.
+def _resolve_auto_block_length(values: np.ndarray) -> float:
+    """Politis-White (2004) block length, shared with ``BlockBootstrap``.
 
-    Full PW picks ``L`` from a plug-in of the spectral density; that
-    needs another set of choices we don't want to inherit here. The
-    ``1.75 * T^(1/3)`` rule is the widely-cited pragmatic compromise
-    (same cube-root cadence as [Newey-West (1994)][newey-west-1994], slightly larger constant
-    because the stationary bootstrap's kernel is different).
+    Matrix input resamples every column under one shared row-index draw
+    (see ``stationary_bootstrap_resamples``), so a single block length must
+    serve all columns. Taking the max of the per-column spectral estimates
+    is the conservative choice — under-blocking the most persistent column
+    would understate its dependence in the joint resample.
     """
-    if n < 2:
-        return 1.0
-    return max(1.0, 1.75 * (n ** (1.0 / 3.0)))
+    from factrix._stats.bootstrap import _politis_white_block_length
+
+    if values.ndim == 1:
+        return _politis_white_block_length(values, scheme="stationary")
+    if values.shape[1] == 0:
+        return _politis_white_block_length(
+            np.zeros(values.shape[0]), scheme="stationary"
+        )
+    return max(
+        _politis_white_block_length(values[:, j], scheme="stationary")
+        for j in range(values.shape[1])
+    )
 
 
 def stationary_bootstrap_resamples(
@@ -62,10 +72,11 @@ def stationary_bootstrap_resamples(
             function separately per column when cross-column dependence
             matters.
         n_bootstrap: Number of resamples to draw.
-        block_length: Mean geometric block length. Defaults to
-            ``1.75 * T^(1/3)`` ([Politis-White (2004)][politis-white-2004] practical rule).
-            Must be ``>= 1``; block_length=1 reduces to the ordinary
-            iid bootstrap (Efron).
+        block_length: Mean geometric block length. Defaults to the
+            [Politis-White (2004)][politis-white-2004] automatic spectral
+            plug-in (falling back to the practical ``1.75 * T^(1/3)`` rule
+            when the series is too short or degenerate). Must be ``>= 1``;
+            block_length=1 reduces to the ordinary iid bootstrap (Efron).
         seed: Seed for ``np.random.default_rng`` to make the resample
             reproducible.
 
@@ -80,8 +91,8 @@ def stationary_bootstrap_resamples(
           block lengths — the resampling scheme this function implements.
         - [Politis & White (2004)][politis-white-2004]. "Automatic Block-
           Length Selection for the Dependent Bootstrap." Econometric
-          Reviews, 23(1), 53–70. Source of the practical ``1.75 * T^(1/3)``
-          block-length default.
+          Reviews, 23(1), 53–70. Source of the spectral plug-in
+          ``block_length=None`` resolves to.
     """
     from factrix._stats.bootstrap import _stationary_block_indices
 
@@ -104,7 +115,7 @@ def stationary_bootstrap_resamples(
         return np.empty((n_bootstrap, *values.shape), dtype=float)
 
     if block_length is None:
-        block_length = _default_block_length(n)
+        block_length = _resolve_auto_block_length(values)
     if block_length < 1.0:
         raise ValueError(f"block_length must be >= 1.0, got {block_length!r}")
 

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -24,14 +24,17 @@ from factrix._stats import (
     _resolve_nw_lags,
     _t_stat_from_array,
 )
+from factrix._stats.bootstrap import _block_bootstrap_diff_p
 from factrix._stats.constants import MIN_PERIODS_WARN, auto_bartlett
 from factrix.inference import (
     NEWEY_WEST,
     NON_OVERLAPPING,
+    STATIONARY_BOOTSTRAP,
     HansenHodrick,
     Inference,
     NeweyWest,
     NonOverlapping,
+    StationaryBootstrap,
 )
 
 
@@ -44,7 +47,9 @@ def _series_df(values: np.ndarray) -> pl.DataFrame:
 
 
 class TestProtocolIdentity:
-    @pytest.mark.parametrize("member", [NON_OVERLAPPING, NEWEY_WEST, HansenHodrick()])
+    @pytest.mark.parametrize(
+        "member", [NON_OVERLAPPING, NEWEY_WEST, HansenHodrick(), STATIONARY_BOOTSTRAP]
+    )
     def test_satisfies_inference_protocol(self, member: object) -> None:
         assert isinstance(member, Inference)
 
@@ -53,10 +58,13 @@ class TestProtocolIdentity:
         assert NonOverlapping.se == "ols"
         assert NeweyWest.se == "hac"
         assert HansenHodrick.se == "hac"
+        assert StationaryBootstrap.test == "bootstrap-mean"
+        assert StationaryBootstrap.se == "bootstrap"
 
     def test_curated_instances_are_singletons_of_their_type(self) -> None:
         assert isinstance(NON_OVERLAPPING, NonOverlapping)
         assert isinstance(NEWEY_WEST, NeweyWest)
+        assert isinstance(STATIONARY_BOOTSTRAP, StationaryBootstrap)
 
 
 class TestNonOverlapping:
@@ -160,3 +168,40 @@ class TestHansenHodrick:
         )
         assert result.metadata["variance_clamped"] is True
         assert WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE in result.warnings
+
+
+class TestStationaryBootstrap:
+    def test_stat_is_observed_mean(self) -> None:
+        series = np.random.default_rng(0).standard_normal(80) + 0.2
+        result = STATIONARY_BOOTSTRAP.compute(
+            _series_df(series), value_col="ic", forward_periods=5
+        )
+        assert result.stat == pytest.approx(float(series.mean()))
+        assert 0.0 < result.p_value <= 1.0
+
+    def test_metadata_reports_reproducible_seed(self) -> None:
+        series = np.random.default_rng(1).standard_normal(80)
+        result = STATIONARY_BOOTSTRAP.compute(
+            _series_df(series), value_col="ic", forward_periods=5
+        )
+        assert set(result.metadata) == {
+            "block_length",
+            "n_resamples",
+            "scheme",
+            "rng_seed",
+        }
+        p_replay, _ = _block_bootstrap_diff_p(
+            series, rng_seed=result.metadata["rng_seed"]
+        )
+        assert result.p_value == p_replay
+
+    def test_short_sample_warns(self) -> None:
+        result = STATIONARY_BOOTSTRAP.compute(
+            _series_df(np.arange(10.0)), value_col="ic", forward_periods=1
+        )
+        assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in result.warnings
+
+    def test_min_input_periods_matches_newey_west(self) -> None:
+        assert STATIONARY_BOOTSTRAP.min_input_periods(
+            5
+        ) == NEWEY_WEST.min_input_periods(5)

--- a/tests/stats/test_bootstrap.py
+++ b/tests/stats/test_bootstrap.py
@@ -4,22 +4,40 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from factrix._stats.bootstrap import _politis_white_block_length
 from factrix.stats.bootstrap import (
-    _default_block_length,
+    _resolve_auto_block_length,
     bootstrap_mean_ci,
     stationary_bootstrap_resamples,
 )
 
 
-class TestDefaultBlockLength:
-    def test_grows_as_t_cuberoot(self):
-        # L ≈ 1.75 · T^(1/3): 1000 → ~17.5, 8000 → ~35
-        assert _default_block_length(1000) == pytest.approx(17.5, rel=0.01)
-        assert _default_block_length(8000) == pytest.approx(35.0, rel=0.01)
+class TestResolveAutoBlockLength:
+    def test_vector_matches_politis_white(self):
+        x = np.random.default_rng(0).standard_normal(200)
+        assert _resolve_auto_block_length(x) == _politis_white_block_length(
+            x, scheme="stationary"
+        )
 
-    def test_degenerate_small_n(self):
-        assert _default_block_length(1) == 1.0
-        assert _default_block_length(0) == 1.0
+    def test_matrix_takes_max_of_per_column_estimates(self):
+        rng = np.random.default_rng(0)
+        persistent = np.empty(300)
+        persistent[0] = rng.standard_normal()
+        for t in range(1, 300):
+            persistent[t] = 0.9 * persistent[t - 1] + rng.standard_normal()
+        iid = rng.standard_normal(300)
+        values = np.column_stack([iid, persistent])
+
+        expected = max(
+            _politis_white_block_length(iid, scheme="stationary"),
+            _politis_white_block_length(persistent, scheme="stationary"),
+        )
+        assert _resolve_auto_block_length(values) == expected
+
+    def test_zero_column_matrix_falls_back_like_degenerate_series(self):
+        assert _resolve_auto_block_length(
+            np.empty((10, 0))
+        ) == _politis_white_block_length(np.zeros(10), scheme="stationary")
 
 
 class TestStationaryBootstrapResamples:

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -420,7 +420,11 @@ class TestICInferenceAllowlist:
                 inference=fx.inference.HANSEN_HODRICK,
             )
         assert exc.value.func_name == "ic"
-        assert exc.value.applicable == ("NeweyWest", "NonOverlapping")
+        assert exc.value.applicable == (
+            "NeweyWest",
+            "NonOverlapping",
+            "StationaryBootstrap",
+        )
         assert "HansenHodrick" in str(exc.value)
 
     def test_non_inference_object_raises_cleanly(self):
@@ -432,7 +436,11 @@ class TestICInferenceAllowlist:
     def test_allowlisted_members_pass(self):
         import factrix as fx
 
-        for member in (fx.inference.NON_OVERLAPPING, fx.inference.NEWEY_WEST):
+        for member in (
+            fx.inference.NON_OVERLAPPING,
+            fx.inference.NEWEY_WEST,
+            fx.inference.STATIONARY_BOOTSTRAP,
+        ):
             result = ic(self._ic_series(40), forward_periods=1, inference=member)
             assert not math.isnan(result.value)
 
@@ -448,13 +456,25 @@ class TestApplicableInferenceDiscovery:
         from factrix.metrics.k_spread import k_spread
         from factrix.metrics.quantile import quantile_spread
 
-        for m in (ic, quantile_spread, k_spread):
+        # quantile_spread / k_spread dispatch through a hard isinstance(NeweyWest)
+        # branch, so their allowlist stays the original vetted pair.
+        for m in (quantile_spread, k_spread):
             allow = resolve_applicable_inference(m)
             assert allow is not None
             assert sorted(type(x).__name__ for x in allow) == [
                 "NeweyWest",
                 "NonOverlapping",
             ]
+
+        # ic dispatches polymorphically, so its allowlist additionally admits
+        # StationaryBootstrap.
+        ic_allow = resolve_applicable_inference(ic)
+        assert ic_allow is not None
+        assert sorted(type(x).__name__ for x in ic_allow) == [
+            "NeweyWest",
+            "NonOverlapping",
+            "StationaryBootstrap",
+        ]
 
     def test_singleton_inference_metric_returns_none(self):
         from factrix.metrics._metric_capabilities import resolve_applicable_inference


### PR DESCRIPTION
## Summary
- Unify the stationary-bootstrap "auto" block length: `stationary_bootstrap_resamples`/`bootstrap_mean_ci` now run the same Politis-White spectral plug-in `BlockBootstrap` already uses, instead of a cruder standalone `1.75*T^(1/3)` rule
- Add `StationaryBootstrap` to `factrix.inference`'s series-mean family and admit it into `ic`'s `inference=` allowlist, giving a block-bootstrap empirical-p option for IC series too short or heavy-tailed for a HAC t-test
- `quantile_spread` / `k_spread` are intentionally left out of scope — their dispatch hard-branches on `isinstance(inference, NeweyWest)` and would need to go polymorphic first before admitting a third member

## Test plan
- [x] `python -m pytest -q -p no:faulthandler` (1814 passed, 3 skipped)
- [x] `ruff check factrix tests`
- [x] `ruff format --check factrix tests`
- [x] `mypy factrix`
- [x] `mkdocs build --strict`