### PR TITLE
fix(stats): stop rounding the stationary scheme's auto block length

### DIFF
--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -238,9 +238,10 @@ def _block_bootstrap_diff_p(
         diff: 1-D paired-difference series (already date-aligned by
             caller — the bootstrap does not re-align).
         block_length: ``"auto"`` runs Politis-White; ``int >= 1`` uses
-            the supplied length unchanged. Stationary scheme uses the
-            mean of the geometric distribution; fixed scheme uses the
-            integer directly.
+            the supplied length unchanged. Under ``"stationary"`` the
+            resolved value is the *mean* of the geometric block-length
+            distribution and stays fractional; under ``"fixed"`` it is a
+            literal block size and is rounded to an integer.
         n_resamples: ``B``. [Politis-White (2004)][politis-white-2004] recommends ≥ 999 for two-sided
             5% tests; default matches.
         scheme: ``"fixed"`` (fixed-length circular blocks,
@@ -251,9 +252,11 @@ def _block_bootstrap_diff_p(
 
     Returns:
         ``(p_value, metadata)`` — p in ``[1/(B+1), 1]``; metadata
-        records the resolved block length, scheme, n_resamples, and the
-        actual seed used (so the run is reproducible from the logged
-        metadata even when the caller passed ``rng_seed=None``).
+        records the resolved block length (a float: fractional under
+        ``"stationary"``, integral under ``"fixed"``), scheme,
+        n_resamples, and the actual seed used (so the run is reproducible
+        from the logged metadata even when the caller passed
+        ``rng_seed=None``).
     """
     diff = np.asarray(diff, dtype=float)
     # A NaN would make ``centred`` all-NaN, every ``|boot| >= |obs|`` test
@@ -264,19 +267,28 @@ def _block_bootstrap_diff_p(
     n = len(diff)
     if n < 2:
         return 1.0, {
-            "block_length": 0,
+            "block_length": 0.0,
             "n_resamples": 0,
             "scheme": scheme,
             "rng_seed": rng_seed if rng_seed is not None else -1,
         }
 
+    L: float
     if block_length == "auto":
-        L_float = _politis_white_block_length(diff, scheme=scheme)
-        L = max(1, round(L_float))
+        L_auto = _politis_white_block_length(diff, scheme=scheme)
+        # Only the fixed scheme's L is a block *size* and has to be integral.
+        # The stationary scheme's is the MEAN of a geometric distribution —
+        # ``_stationary_block_indices`` only ever reads it as
+        # ``p_new = 1 / L`` — so rounding discretizes the renewal probability
+        # for nothing: L=3.4 turns p_new 0.294 into 0.333. It also put this
+        # function out of step with the other two consumers of the same
+        # estimate, ``stationary_bootstrap_resamples`` and
+        # ``slicing.period_inference``, which both pass the float through.
+        L = max(1.0, L_auto) if scheme == "stationary" else float(max(1, round(L_auto)))
     else:
-        L = int(block_length)
-        if L < 1:
-            raise ValueError(f"block_length must be >= 1; got {L!r}")
+        L = float(int(block_length))
+        if L < 1.0:
+            raise ValueError(f"block_length must be >= 1; got {block_length!r}")
 
     # Resolve seed up front so it can be reported back even when None.
     # `secrets.randbits(32)` is the purpose-built "give me a random int
@@ -288,9 +300,9 @@ def _block_bootstrap_diff_p(
     # Centre under H0 (mean=0) before resampling.
     centred = diff - float(np.mean(diff))
     if scheme == "stationary":
-        idx = _stationary_block_indices(n, n_resamples, float(L), rng)
+        idx = _stationary_block_indices(n, n_resamples, L, rng)
     else:
-        idx = _fixed_block_indices(n, n_resamples, L, rng)
+        idx = _fixed_block_indices(n, n_resamples, int(L), rng)
     resamples = centred[idx]
     boot_means = resamples.mean(axis=1)
 

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -166,6 +166,63 @@ class TestBlockBootstrapDiffP:
         assert m_fixed["scheme"] == "fixed"
         assert m_fixed["block_length"] == 5
 
+    def test_stationary_auto_block_length_is_not_discretized(self):
+        """The stationary L is a geometric MEAN, so it must stay fractional.
+
+        Rounding it discretizes the renewal probability ``p_new = 1 / L``
+        for no reason, and put this function out of step with the two other
+        consumers of the same estimate.
+        """
+        rng = np.random.default_rng(seed=7)
+        # AR(1): persistent enough that Politis-White lands off an integer.
+        x = np.empty(300)
+        x[0] = rng.standard_normal()
+        for t in range(1, 300):
+            x[t] = 0.6 * x[t - 1] + rng.standard_normal()
+
+        expected = _politis_white_block_length(x, scheme="stationary")
+        assert expected != round(expected), "fixture must exercise a fractional L"
+
+        _p, meta = _block_bootstrap_diff_p(x, n_resamples=199, rng_seed=0)
+        assert meta["block_length"] == pytest.approx(expected)
+
+    def test_stationary_auto_matches_period_inference(self):
+        """Both auto paths resolve the same series to the same block length.
+
+        ``slicing.period_inference`` passes the Politis-White float straight
+        to ``_stationary_block_indices``; before the fix this function
+        rounded it first, so the two re-sampled the same series with
+        different effective block lengths.
+        """
+        from factrix.slicing.period_inference import _SCHEME
+
+        rng = np.random.default_rng(seed=11)
+        x = np.empty(300)
+        x[0] = rng.standard_normal()
+        for t in range(1, 300):
+            x[t] = 0.6 * x[t - 1] + rng.standard_normal()
+
+        _p, meta = _block_bootstrap_diff_p(
+            x, n_resamples=199, rng_seed=0, scheme=_SCHEME
+        )
+        assert meta["block_length"] == pytest.approx(
+            _politis_white_block_length(x, scheme=_SCHEME)
+        )
+
+    def test_fixed_auto_block_length_stays_integral(self):
+        """The fixed scheme's L IS a block size, so rounding is correct there."""
+        rng = np.random.default_rng(seed=7)
+        x = np.empty(300)
+        x[0] = rng.standard_normal()
+        for t in range(1, 300):
+            x[t] = 0.6 * x[t - 1] + rng.standard_normal()
+
+        _p, meta = _block_bootstrap_diff_p(
+            x, n_resamples=199, rng_seed=0, scheme="fixed"
+        )
+        L = meta["block_length"]
+        assert int(L) == L
+
     def test_short_series_returns_one(self):
         p, meta = _block_bootstrap_diff_p(np.array([0.5]))
         assert p == 1.0


### PR DESCRIPTION
Closes #799

## Problem

`_block_bootstrap_diff_p` resolved `block_length="auto"` through `max(1, round(L_float))` and fed the result to *both* schemes:

```python
L = max(1, round(L_float))
...
if scheme == "stationary":
    idx = _stationary_block_indices(n, n_resamples, float(L), rng)
else:
    idx = _fixed_block_indices(n, n_resamples, L, rng)
```

Only the fixed (circular) scheme needs an integer — its `L` is a literal block size. The stationary scheme's `L` is the **mean** of a geometric distribution, and `_stationary_block_indices` reads it only as `p_new = 1 / L`. Rounding discretizes the renewal probability for nothing: `L = 3.4` turns `p_new` 0.294 into 0.333.

## The inconsistency was wider than the issue reported

The issue names `slicing/period_inference.py:235` as the un-rounded counterpart. There is a second one: the **public** `stationary_bootstrap_resamples` (`factrix/stats/bootstrap.py:127`) also passes the float straight through.

So of the three consumers of the same Politis-White estimate, `_block_bootstrap_diff_p` was the only one rounding — two auto paths resolved one series to the same `L_float` and then resampled it with different effective block lengths.

## Change

- `"stationary"` → `max(1.0, L_auto)`, no rounding. `"fixed"` → `float(max(1, round(L_auto)))`, unchanged behaviour.
- `metadata["block_length"]` is a float throughout (fractional under `"stationary"`, integral under `"fixed"`); the `n < 2` early return reports `0.0` to match. The declared return type already permitted float, and the two downstream readers (`_helpers.py:136`, `StationaryBootstrap` metadata) pass it through untyped.

## What I deliberately did NOT do

The issue's "順帶" item — aligning `_politis_white_block_length`'s upper clamp (`n / 2`) with arch's reported `min(3·sqrt(n), n/3)` — is **not** in this PR.

`arch` is not installed in this environment, so I could not verify its actual bound rather than taking the issue's transcription of it. Changing the clamp would move every auto p-value on a second, unrelated axis, and bundling an unverified numeric bound into a PR whose point is removing an unnecessary discretization would muddy the review. Worth a separate change once the reference bound is confirmed — it is a real inconsistency (the *lower* clamp's comment already says "as `arch` / Patton do", so only the upper one is out of step).

## Breaking changes

p-values from `BlockBootstrap(block_length="auto", scheme="stationary")` move wherever Politis-White resolves off an integer. Fine pre-v1; no deprecation shim per project convention.

## Verification

- 2140 passed, 3 skipped.
- `ruff check`, `ruff format --check`, `mypy factrix` clean.
- New tests: `test_stationary_auto_block_length_is_not_discretized`, `test_stationary_auto_matches_period_inference` (pins the cross-consumer agreement the issue asked for), `test_fixed_auto_block_length_stays_integral`.