### PR TITLE
test(docs): check symbol references inside the package, fix two residues

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -1187,4 +1187,5 @@ __all__ = [
     # Metric registration surface
     "MetricSpec",
     "metric_spec",
+    "spec_by_name",
 ]

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -59,8 +59,8 @@ _METRICS_DIR = _REPO_ROOT / "factrix" / "metrics"
 # :func:`docs_anchor_for`: docs-root-relative path +
 # mkdocstrings symbol fragment. Centralised here so a future docs URL
 # change touches one literal — external prose in
-# ``factrix._describe.list_metrics`` and ``docs/api/metric-output.md``
-# cite this constant by name rather than restating the string.
+# ``docs/api/metric-output.md`` cites this constant by name rather than
+# restating the string.
 DOCS_ANCHOR_FMT: str = "api/metrics/{module}.md#factrix.metrics.{module}.{name}"
 
 # ---------------------------------------------------------------------------

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -48,12 +48,6 @@ if TYPE_CHECKING:
     from factrix._results import EvaluationResult
 
 
-_NOT_METRICSPEC_EXPECTED = (
-    "metric label instance (str / Callable not accepted — pick the spec from "
-    "fx.metrics.spec_by_name())"
-)
-
-
 def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str]:
     """Shared validator: ``list[str]`` canonical form.
 

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -454,6 +454,17 @@ def custom_ic(panel):
 fx.metrics.register(custom_ic)
 ```
 
+Resolve a registered spec by its label with `fx.spec_by_name()`, which
+returns the full `dict[str, MetricSpec]` registry keyed by metric name —
+the lookup the DAG executor itself uses, and the way to inspect a custom
+metric's declared cell after registration:
+
+```python
+specs = fx.spec_by_name()
+specs["custom_ic"].cell        # the declared analysis cell
+sorted(specs)                  # every metric label factrix knows
+```
+
 ---
 
 ### Preprocessing

--- a/tests/_doc_validation.py
+++ b/tests/_doc_validation.py
@@ -14,7 +14,9 @@ as a test module.
 from __future__ import annotations
 
 import importlib
+import pathlib
 import re
+from collections.abc import Iterable
 
 import factrix
 
@@ -88,6 +90,54 @@ def imports(text: str) -> list[tuple[str, str | None]]:
     for m in BARE_IMPORT_RE.finditer(text):
         out.append((m.group(1), None))
     return out
+
+
+# Logger names live in the ``factrix.*`` string namespace but are NOT symbol
+# paths — ``logging.getLogger("factrix.dag")`` names a node in the logging
+# hierarchy, and no ``factrix.dag`` module exists or should. They appear in
+# three shapes: a literal ``getLogger`` argument, an f-string one
+# (``f"factrix.metric.{name}"``, truncated at the brace below), and a
+# ``*_LOGGER_NAME`` constant. Prose in ``_logging.py`` also names them.
+#
+# These are discovered from the source rather than kept as an allowlist, so a
+# newly added logger is exempt automatically instead of failing the symbol
+# check until someone edits a list in the tests.
+LOGGER_GETLOGGER_RE = re.compile(r'getLogger\(\s*f?"(factrix[^"{]*)')
+LOGGER_CONST_RE = re.compile(r'_LOGGER_NAME\s*=\s*"(factrix[^"]*)"')
+
+
+def logger_namespaces(paths: Iterable[pathlib.Path]) -> set[str]:
+    """Return the ``factrix.*`` logging-hierarchy names used in ``paths``.
+
+    A name ending in ``.`` came from an f-string truncated at its first
+    placeholder (``factrix.metric.``) and matches by prefix; the rest match
+    exactly. Both are stripped of the leading ``factrix.`` so they compare
+    against the chains :func:`referenced_chains` produces.
+    """
+    names: set[str] = set()
+    for path in paths:
+        text = path.read_text()
+        names.update(LOGGER_GETLOGGER_RE.findall(text))
+        names.update(LOGGER_CONST_RE.findall(text))
+    return {n.removeprefix("factrix.") for n in names if n != "factrix."}
+
+
+def is_logger_name(chain: tuple[str, ...], namespaces: set[str]) -> bool:
+    """True when ``chain`` names a logger rather than a symbol.
+
+    A truncated (f-string) namespace matches both its own stem and anything
+    beneath it: ``getLogger(f"factrix.metric.{name}")`` yields the namespace
+    ``metric.``, while the reference scanner stops at the brace and produces
+    the chain ``metric`` — so the stem has to match too.
+    """
+    dotted = ".".join(chain)
+    for ns in namespaces:
+        if ns.endswith("."):
+            if dotted == ns.rstrip(".") or dotted.startswith(ns):
+                return True
+        elif dotted == ns:
+            return True
+    return False
 
 
 def resolves(chain: tuple[str, ...]) -> bool:

--- a/tests/test_docs_symbol_refs.py
+++ b/tests/test_docs_symbol_refs.py
@@ -1,0 +1,91 @@
+"""Validates that ``factrix.X.Y`` symbol references inside the package resolve.
+
+Docstrings and comments in ``factrix/**/*.py`` name symbols the same way
+docs pages do, and nothing checked them. The layers that exist cover
+neighbouring surfaces:
+
+* ``ruff``'s ``D`` rules check docstring *structure*, not the truth of
+  what a docstring says.
+* ``mkdocs build --strict`` + autorefs resolve cross-references, but only
+  for symbols mkdocstrings actually renders. Every ``::: factrix.X`` block
+  in ``docs/api/**`` targets a public symbol (sole exception:
+  ``factrix._axis.SpecRole``), so mkdocstrings never opens
+  ``factrix/_stats/**``, ``factrix/metrics/_helpers.py`` or
+  ``factrix/_multi_factor.py`` — their symbol references are plain text
+  nobody validates.
+* ``test_docs_pages.py`` and ``test_docs_llms.py`` run this same check, but
+  over ``docs/**/*.md`` and the llms snapshots respectively.
+* ``test_docs_bibliography.py`` walks ``factrix/**/*.py`` already, but for
+  *citation anchors* — the other half of the same problem.
+
+This file closes the remaining gap: symbol chains in package source.
+Roughly 178 of the package's distinct ``factrix.X.Y`` chains live in
+modules that are never rendered.
+
+**Why mechanical rather than another manual pass.** #321 was a manual
+citation-accuracy review whose stated scope included ``factrix/**/*.py``
+References blocks. A misattribution of the circular block bootstrap to
+Künsch (1989) sat inside that scope and survived it, only surfacing in the
+v0.20.0 pre-release review. Manual passes miss; a test does not.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from tests._doc_validation import (
+    is_logger_name,
+    logger_namespaces,
+    referenced_chains,
+    resolves,
+)
+
+PACKAGE_ROOT = pathlib.Path("factrix")
+SOURCE_FILES = sorted(PACKAGE_ROOT.rglob("*.py"))
+LOGGER_NAMESPACES = logger_namespaces(SOURCE_FILES)
+
+
+def test_source_files_found():
+    """Guard against a silently empty sweep (a bad glob passes everything)."""
+    assert len(SOURCE_FILES) > 50
+
+
+@pytest.mark.parametrize("path", SOURCE_FILES, ids=lambda p: str(p))
+def test_symbol_references_resolve(path: pathlib.Path):
+    """Every ``factrix.X.Y`` chain in the file resolves against the package."""
+    unresolved = sorted(
+        ".".join(chain)
+        for chain in referenced_chains(path.read_text())
+        if not is_logger_name(chain, LOGGER_NAMESPACES) and not resolves(chain)
+    )
+    assert not unresolved, (
+        f"{path}: docstring/comment references that do not resolve: "
+        f"{unresolved}. Either the symbol moved and the prose is stale, or "
+        f"the name is a logging-hierarchy node (add it via getLogger / a "
+        f"*_LOGGER_NAME constant so logger_namespaces() picks it up)."
+    )
+
+
+class TestLoggerNamespaceExemption:
+    """The exemption must be narrow enough to still catch real breakage."""
+
+    def test_discovered_from_source_not_hardcoded(self):
+        """Every known logger namespace comes out of the sweep."""
+        assert {"dag", "evaluation", "metrics"} <= LOGGER_NAMESPACES
+        # f-string form is truncated at the placeholder and matches by prefix.
+        assert "metric." in LOGGER_NAMESPACES
+
+    def test_prefix_form_does_not_swallow_siblings(self):
+        """``metric.`` must not exempt ``metrics.<anything>``."""
+        assert is_logger_name(("metric", "ic"), LOGGER_NAMESPACES)
+        # The scanner stops at the f-string brace, so the bare stem appears too.
+        assert is_logger_name(("metric",), LOGGER_NAMESPACES)
+        assert not is_logger_name(("metrics", "nonexistent"), LOGGER_NAMESPACES)
+
+    def test_a_real_broken_chain_is_not_exempt(self):
+        """The two residues this test was written to catch."""
+        for chain in (("_describe", "list_metrics"), ("metrics", "spec_by_name")):
+            assert not is_logger_name(chain, LOGGER_NAMESPACES)
+            assert not resolves(chain)


### PR DESCRIPTION
Closes #802

## The gap

`factrix.X.Y` chains in `factrix/**/*.py` had **no** check. The neighbouring layers each cover something else:

| layer | covers | misses |
|---|---|---|
| `ruff` `D` | docstring structure, all of `factrix/**` | whether what it says is true |
| `mkdocs --strict` + autorefs | rendered symbols only | private modules — mkdocstrings never opens them |
| `test_docs_pages.py` | `docs/**/*.md` | package source |
| `test_docs_bibliography.py` | `factrix/**/*.py` **citation anchors** | symbol chains |

Every `::: factrix.X` block in `docs/api/**` targets a public symbol (sole exception `factrix._axis.SpecRole`), so `_stats/**`, `metrics/_helpers.py` and `_multi_factor.py` are plain text nobody validated. ~178 distinct chains live there.

## The check

`tests/test_docs_symbol_refs.py` reuses the existing `referenced_chains()` + `resolves()` pair, parametrised per file so a failure names the file. It is the symbol half of what `test_docs_bibliography.py` already does for citations.

**Logger names, not an allowlist.** `getLogger("factrix.dag")` names a node in the logging hierarchy, not a module. The exempt set is *scanned out of the source* (`getLogger` literals, f-string forms, `*_LOGGER_NAME` constants) rather than hardcoded, so a newly added logger is exempt automatically instead of failing the check until someone edits a list in the tests. Discovered set: `{dag, evaluation, metric., metrics}` — exactly the four false positives the issue predicted.

The f-string form truncates at its placeholder (`f"factrix.metric.{name}"` → namespace `metric.`) while the scanner stops at the brace and emits the chain `metric`, so a truncated namespace matches both its own stem and anything beneath it. `TestLoggerNamespaceExemption` pins that the prefix form does not swallow `metrics.<anything>`.

**Verified by mutation**, not just by passing: injecting `factrix._stats.nonexistent_module.helper` into `_stats/core.py` fails the new test; reverting restores green.

## Residues fixed

1. `_multi_factor.py::_NOT_METRICSPEC_EXPECTED` — dead (defined, never referenced anywhere in `factrix/`, `tests/` or `docs/`) and its text pointed at `fx.metrics.spec_by_name()`, which does not exist. **Deleted** rather than corrected, as the issue recommends.
2. `_metric_index.py:62` — cited `factrix._describe.list_metrics`; that module is gone. Comment rewritten.

## `spec_by_name` publicness

**Resolved as: make it public.** Of the five APIs the package docstring recommends in one sentence — `spec_by_name`, `metric_spec`, `evaluate`, `inspect_data`, `multi_factor` — it was the only one missing from `__all__`. That is an omission, not a decision to keep it private, so `__all__` follows the documentation rather than the documentation dropping its recommendation.

Adding it tripped the existing rule that every public symbol appears in `llms-full.txt`, so both copies gained a worked example. The example is executed, not guessed: `fx.spec_by_name()` returns a 48-entry `dict[str, MetricSpec]` and `.cell` exists.

## Verification

2243 passed, 3 skipped. `ruff check`, `ruff format --check`, `mypy factrix` clean.