### PR TITLE
chore(stats): guard the OLS HAC kernels, pin the multiple-testing guards

### DIFF
--- a/factrix/_stats/ols.py
+++ b/factrix/_stats/ols.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import numpy as np
 from scipy import stats as sp_stats
 
+from factrix._stats.hac import _require_finite
 from factrix._types import EPSILON
 
 
@@ -30,7 +31,17 @@ def _ols_nw_slope_t(
 
     Returns ``(0.0, 0.0, 1.0, np.zeros(n))`` for n < 3 or degenerate
     inputs (``Var(x) ≈ 0``).
+
+    Raises:
+        ValueError: ``y`` or ``x`` holds a non-finite value. A NaN flows
+            through ``np.mean`` / ``np.dot`` and slips past the
+            ``sxx < EPSILON`` degeneracy guard (every comparison with NaN
+            is False), surfacing as a NaN β / t far from the cause. Same
+            contract as ``_newey_west_se``; callers drop or impute
+            upstream.
     """
+    y = _require_finite(y, "_ols_nw_slope_t")
+    x = _require_finite(x, "_ols_nw_slope_t")
     n = len(y)
     if n < 3 or len(x) != n:
         return 0.0, 0.0, 1.0, np.zeros(n)
@@ -82,7 +93,15 @@ def _ols_nw_multivariate(
 
     Returns ``(zeros(k), zeros((k,k)), zeros(n))`` if ``X'X`` is singular
     (e.g. perfectly collinear columns) or ``n < k + 1``.
+
+    Raises:
+        ValueError: ``y`` or ``X`` holds a non-finite value. ``np.linalg.inv``
+            does not raise on a NaN-bearing matrix — it returns a NaN inverse,
+            so the singularity branch never fires and a NaN β / V_hac is
+            returned silently. Same contract as ``_newey_west_se``.
     """
+    y = _require_finite(y, "_ols_nw_multivariate")
+    X = _require_finite(X, "_ols_nw_multivariate")
     n, k = X.shape
     if len(y) != n or n < k + 1:
         return np.zeros(k), np.zeros((k, k)), np.zeros(n)

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -445,8 +445,15 @@ class TestNonFiniteRejectedByEveryKernel:
 
     @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
     def test_clean_input_still_works(self, name, kernel):
-        """The guard must not reject the boundary values 0 and 1."""
-        assert kernel(np.array([0.0, 0.5, 1.0])) is not None
+        """The guard must not reject the boundary values 0 and 1.
+
+        Asserting finiteness rather than merely "returned something": the
+        defect this class guards against is a NaN travelling through a
+        kernel, so a test that accepts a NaN return would not notice the
+        guard being removed and the NaN reappearing.
+        """
+        out = np.asarray(kernel(np.array([0.0, 0.5, 1.0])), dtype=float)
+        assert np.all(np.isfinite(out))
 
     def test_romano_wolf_guards_both_arguments(self):
         """Romano-Wolf takes statistics, not p-values, so it carries its own

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -408,3 +408,60 @@ class TestSimesP:
     def test_empty_raises(self):
         with pytest.raises(ValueError, match="non-empty"):
             simes_p([])
+
+
+class TestNonFiniteRejectedByEveryKernel:
+    """Every multiple-testing kernel refuses non-finite p-values.
+
+    ``_multi_factor.py`` reaches these through five call sites (``bhy``,
+    ``bhy_across_metrics``, both partial-conjunction paths, and
+    ``_bhy_hierarchical_one``) and carries no non-finite check of its own
+    beyond ``_validate_q``. That is fine *because* the guard lives in the
+    kernel — the v0.20.0 convention — but nothing pinned it: the existing
+    coverage only exercised out-of-range values on ``bhy_adjust``, so
+    dropping ``_validate_p_values`` from any of the other three would have
+    gone unnoticed and returned a NaN adjusted p instead of raising.
+    """
+
+    KERNELS = (
+        ("simes_p", simes_p),
+        ("bhy_adjusted_p", bhy_adjusted_p),
+        ("bhy_adjust", bhy_adjust),
+        ("holm_adjusted_p", holm_adjusted_p),
+        ("partial_conjunction_p", lambda a: partial_conjunction_p(a, min_pass=2)),
+    )
+
+    @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_raises(self, name, kernel, bad):
+        with pytest.raises(ValueError, match="must all lie in"):
+            kernel(np.array([0.1, bad, 0.3]))
+
+    @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
+    @pytest.mark.parametrize("bad", [-0.1, 1.5])
+    def test_out_of_range_raises(self, name, kernel, bad):
+        with pytest.raises(ValueError, match="must all lie in"):
+            kernel(np.array([0.1, bad, 0.3]))
+
+    @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
+    def test_clean_input_still_works(self, name, kernel):
+        """The guard must not reject the boundary values 0 and 1."""
+        assert kernel(np.array([0.0, 0.5, 1.0])) is not None
+
+    def test_romano_wolf_guards_both_arguments(self):
+        """Romano-Wolf takes statistics, not p-values, so it carries its own
+        guard rather than ``_validate_p_values`` — pinned here so the family
+        is covered end to end."""
+        rng = np.random.default_rng(0)
+        statistics = np.array([2.5, 1.0, 3.0])
+        bootstrap = rng.normal(size=(200, 3))
+
+        bad_stats = statistics.copy()
+        bad_stats[1] = float("nan")
+        with pytest.raises(ValueError, match="statistics must be finite"):
+            romano_wolf_adjusted_p(bad_stats, bootstrap)
+
+        bad_boot = bootstrap.copy()
+        bad_boot[5, 1] = float("inf")
+        with pytest.raises(ValueError, match="bootstrap_statistics must be finite"):
+            romano_wolf_adjusted_p(statistics, bad_boot)

--- a/tests/stats/test_ols_nonfinite.py
+++ b/tests/stats/test_ols_nonfinite.py
@@ -1,0 +1,82 @@
+"""Non-finite contract for the Newey-West OLS kernels in ``factrix._stats.ols``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._stats.ols import _ols_nw_multivariate, _ols_nw_slope_t
+
+
+class TestNonFiniteContract:
+    """Both kernels refuse non-finite input rather than returning NaN.
+
+    Neither degeneracy branch catches a NaN. ``_ols_nw_slope_t`` guards on
+    ``sxx < EPSILON``, and every comparison with NaN is False, so a NaN x
+    walks straight past it. ``_ols_nw_multivariate`` relies on
+    ``np.linalg.inv`` raising ``LinAlgError`` on a singular ``X'X``, but inv
+    does not raise on a NaN-bearing matrix — it returns a NaN inverse, so
+    the singularity branch never fires. Both returned a silent NaN.
+
+    Protection previously lived at the call sites; ``predictive_beta.py:115``
+    even carries a comment explaining that a NaN "would flow into
+    ``_ols_nw_slope_t``". That makes it a property of those callers rather
+    than of the kernels. Same fail-loud contract as ``_newey_west_se``.
+    """
+
+    @staticmethod
+    def _design(n: int = 30):
+        rng = np.random.default_rng(0)
+        x = np.arange(float(n))
+        return x * 0.5 + rng.normal(size=n), x
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_slope_t_rejects_non_finite_x(self, bad):
+        y, x = self._design()
+        x = x.copy()
+        x[3] = bad
+        with pytest.raises(ValueError, match="_ols_nw_slope_t: values must be finite"):
+            _ols_nw_slope_t(y, x, lags=2)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_slope_t_rejects_non_finite_y(self, bad):
+        y, x = self._design()
+        y = y.copy()
+        y[7] = bad
+        with pytest.raises(ValueError, match="_ols_nw_slope_t: values must be finite"):
+            _ols_nw_slope_t(y, x, lags=2)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_multivariate_rejects_non_finite_design(self, bad):
+        y, x = self._design()
+        X = np.column_stack([np.ones(len(x)), x])
+        X[5, 1] = bad
+        with pytest.raises(
+            ValueError, match="_ols_nw_multivariate: values must be finite"
+        ):
+            _ols_nw_multivariate(y, X, lags=2)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_multivariate_rejects_non_finite_y(self, bad):
+        y, x = self._design()
+        y = y.copy()
+        y[2] = bad
+        X = np.column_stack([np.ones(len(x)), x])
+        with pytest.raises(
+            ValueError, match="_ols_nw_multivariate: values must be finite"
+        ):
+            _ols_nw_multivariate(y, X, lags=2)
+
+    def test_clean_input_is_unaffected(self):
+        y, x = self._design()
+        beta, t_stat, p_value, resid = _ols_nw_slope_t(y, x, lags=2)
+        assert beta == pytest.approx(0.5, abs=0.1)
+        assert np.isfinite([t_stat, p_value]).all()
+        assert np.isfinite(resid).all()
+
+    def test_short_sample_path_still_returns_the_degenerate_tuple(self):
+        """The n<3 early return must sit AFTER the guard, not be bypassed."""
+        beta, t_stat, p_value, resid = _ols_nw_slope_t(
+            np.array([1.0, 2.0]), np.array([1.0, 2.0]), lags=1
+        )
+        assert (beta, t_stat, p_value) == (0.0, 0.0, 1.0)
+        assert resid.shape == (2,)


### PR DESCRIPTION
Completes #801 (§2 and §4). Together with #807 (§1 and §3) this closes the issue — **#807 should merge first**; both touch `_multi_factor.py`, though in different places.

## §2 — already compliant; the gap was coverage

Measured rather than assumed. Every kernel `_multi_factor.py` reaches (five call sites: `bhy`, `bhy_across_metrics`, both partial-conjunction paths, `_bhy_hierarchical_one`) already refuses non-finite input:

| kernel | guard |
|---|---|
| `simes_p` | `_validate_p_values` |
| `bhy_adjusted_p` | `_validate_p_values` |
| `bhy_adjust` | `_validate_p_values` |
| `holm_adjusted_p` | `_validate_p_values` |
| `romano_wolf_adjusted_p` | own guard, both arguments |

So the v0.20.0 kernel-raise convention already holds and **no code changed**. The issue's concern reads the caller layer; the protection is one level down.

**What was actually missing was the test.** Existing coverage exercised only out-of-range values, and only on `bhy_adjust` — dropping `_validate_p_values` from any of the other three would have returned a NaN adjusted p with nothing failing. `TestNonFiniteRejectedByEveryKernel` now covers NaN / ±inf / out-of-range across the family, plus the boundary values `0` and `1` so a future tightening cannot start rejecting legitimate p-values.

## §4 — five modules clean, one real defect

The five orchestration modules the issue lists contain **zero** numeric operations:

```
_inspect.py: 0   _metric_index.py: 0   _dag.py: 0   _family.py: 0   _compare.py: 0
```

(scanned for `np.{mean,std,dot,sqrt,log,exp,var,linalg}` / `scipy` / `sp_stats.`)

The issue's guess that they are orchestration rather than statistical kernels is confirmed by measurement. Left alone.

**`_stats/ols.py` was the exception**, and it carried the same defect just fixed in `_ols.py`. Neither degeneracy branch catches a NaN:

- `_ols_nw_slope_t` guards on `sxx < EPSILON`, and every comparison with NaN is False — a NaN walks straight past it.
- `_ols_nw_multivariate` relies on `np.linalg.inv` raising `LinAlgError` on a singular `X'X`, but **inv does not raise on a NaN-bearing matrix** — it returns a NaN inverse, so the singularity branch never fires.

Both returned a silent NaN β / t. Confirmed empirically before fixing:

```
clean: (0.4967, 34.2606, 0.0)
NaN x: (nan, nan, nan)   <-- no raise
NaN X multivariate beta: [nan nan]   <-- no raise
```

Both now call `_require_finite` on each argument, same contract as `_newey_west_se`.

Protection had again been living at the call sites — `predictive_beta.py:115` carries a comment explaining that a NaN "would flow into `_ols_nw_slope_t`" — making it a property of those callers rather than of the kernels. That is the third instance of this pattern in the review (`ols_alpha` in #807 was the second).

**No call site depended on the silent behaviour**: the suite passes unchanged apart from the new tests.

## Verification

2197 passed, 3 skipped. `ruff check`, `ruff format --check`, `mypy factrix` clean.