### PR TITLE
fix(metrics): benchmark spread legs against the ranked universe only

### DIFF
--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -83,8 +83,9 @@ def compute_spread_series(
         missing (polars ``mean`` propagates NaN, so one bad print would
         otherwise NaN out the bucket mean and the spread); a null or NaN
         factor lands in no bucket and is excluded from ``_n_assets`` /
-        ``_n_unique`` too, so those diagnostics describe the cross-section
-        that was actually ranked.
+        ``_n_unique`` **and** ``universe_return``, so both the diagnostics
+        and the benchmark the long / short legs are measured against
+        describe the cross-section that was actually ranked.
 
     Examples:
         >>> import factrix as fx
@@ -142,16 +143,24 @@ def compute_spread_series(
     top_group = n_groups - 1
     bottom_group = 0
 
-    # Per-factor top / bottom means + a single shared universe mean.
-    agg_exprs: list[pl.Expr] = [
-        pl.col(return_col).mean().alias("universe_return"),
-    ]
+    # Per-factor top / bottom / universe means. The universe is per factor
+    # and restricted to rows whose factor is finite — the same cross-section
+    # the bucketing ranks. An earlier version shared one unfiltered mean
+    # across factors, which benchmarked the long / short legs against names
+    # the factor never ranked: with half the panel unranked and carrying a
+    # different return level, a leg with zero true excess reported the gap
+    # to the unranked names as alpha (the headline spread was unaffected —
+    # the universe cancels in ``long_alpha + short_alpha``).
+    agg_exprs: list[pl.Expr] = []
     for f in cols:
-        # Both counts are over *finite* factor values: ``count`` counts a NaN
-        # (it is not null) and ``n_unique`` would score NaN as a distinct
-        # value, so a NaN-poisoned date would look wider and more varied than
-        # the cross-section that actually gets bucketed.
+        # Counts and the universe are over *finite* factor values: ``count``
+        # counts a NaN (it is not null) and ``n_unique`` would score NaN as
+        # a distinct value, so a NaN-poisoned date would look wider and more
+        # varied than the cross-section that actually gets bucketed.
         finite_f = _finite_expr(f)
+        agg_exprs.append(
+            pl.col(return_col).filter(finite_f).mean().alias(f"_universe__{f}")
+        )
         agg_exprs.append(pl.col(f).filter(finite_f).n_unique().alias(f"_n_unique__{f}"))
         agg_exprs.append(pl.col(f).filter(finite_f).len().alias(f"_n_assets__{f}"))
         agg_exprs.append(
@@ -173,14 +182,14 @@ def compute_spread_series(
         f: wide.select(
             pl.col("date"),
             pl.when((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1))
-            .then(pl.col("universe_return"))
+            .then(pl.col(f"_universe__{f}"))
             .otherwise(pl.col(f"_top__{f}"))
             .alias("top_return"),
             pl.when((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1))
-            .then(pl.col("universe_return"))
+            .then(pl.col(f"_universe__{f}"))
             .otherwise(pl.col(f"_bot__{f}"))
             .alias("bottom_return"),
-            pl.col("universe_return"),
+            pl.col(f"_universe__{f}").alias("universe_return"),
             pl.when((pl.col(f"_n_assets__{f}") > 0) & (pl.col(f"_n_unique__{f}") <= 1))
             .then(pl.lit(0.0))
             .otherwise(pl.col(f"_top__{f}") - pl.col(f"_bot__{f}"))

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -570,6 +570,65 @@ class TestQuantileSpreadVWMissingReturns:
         assert result.metadata["n_periods"] == result.n_obs
 
 
+class TestUniverseReturnRankedOnly:
+    """``universe_return`` averages only the cross-section the factor ranked.
+
+    Rows whose factor is null / NaN land in no bucket, but an earlier
+    version still averaged their returns into the shared universe mean —
+    so ``long_alpha`` / ``short_alpha`` benchmarked the legs against names
+    the factor never saw. With half the panel unranked at a +5% return
+    level, a long leg with zero true excess reported ~-2.5% "alpha". The
+    headline spread was unaffected (the universe cancels in the sum),
+    which is why nothing else caught it.
+    """
+
+    @staticmethod
+    def _half_ranked_panel():
+        rng = np.random.default_rng(0)
+        rows = []
+        for d in range(120):
+            for a in range(20):
+                ranked = a < 10
+                rows.append(
+                    {
+                        "date": datetime(2024, 1, 1) + timedelta(days=d),
+                        "asset_id": f"A{a}",
+                        "factor": float(a) if ranked else None,
+                        # Unranked names sit at a very different return level:
+                        # if they leak into the universe they shift it ~+2.5%.
+                        "forward_return": float(
+                            rng.normal(0.0 if ranked else 0.05, 0.01)
+                        ),
+                    }
+                )
+        return pl.DataFrame(rows)
+
+    def test_unranked_names_do_not_shift_the_leg_benchmark(self):
+        result = quantile_spread(
+            self._half_ranked_panel(), forward_periods=1, n_groups=5
+        )["factor"]
+        md = result.metadata
+        # Ranked names all sit at ~0%: both excess legs are genuinely ~0.
+        assert abs(md["long_alpha"]) < 0.005
+        assert abs(md["short_alpha"]) < 0.005
+        # The decomposition identity must survive the universe change.
+        assert md["long_alpha"] + md["short_alpha"] == pytest.approx(result.value)
+
+    def test_series_universe_matches_ranked_mean(self):
+        from factrix.metrics.quantile import compute_spread_series
+
+        panel = self._half_ranked_panel()
+        series = compute_spread_series(panel, forward_periods=1, n_groups=5)["factor"]
+        expected = (
+            panel.filter(pl.col("factor").is_not_null())
+            .group_by("date")
+            .agg(pl.col("forward_return").mean().alias("ranked_mean"))
+            .sort("date")
+        )
+        joined = series.join(expected, on="date")
+        assert ((joined["universe_return"] - joined["ranked_mean"]).abs() < 1e-12).all()
+
+
 class TestQuantileSpreadNonFiniteSeries:
     def test_nan_spread_is_dropped_not_silently_zeroing_the_t_stat(self):
         """One NaN in the spread series must not reach the t-stat.


### PR DESCRIPTION
#803 checklist item 2 (`_spread_series` 的 `universe_return` 把 null-factor 名字也算進平均).

## Confirmed, with magnitude

The issue asked to "確認實際過濾時點". Confirmed at the source: `pl.col(return_col).mean()` with no factor filter, while bucketing (and the `_n_assets` / `_n_unique` diagnostics) exclude non-finite factors. Reproduction — half the panel unranked, sitting at a +5% return level, ranked names at ~0%:

```
before:  long_alpha = -2.45%   short_alpha = +2.61%   (true excess ≈ 0 for both)
after:   long_alpha = +0.05%   short_alpha = +0.10%
```

The headline spread / stat / p are untouched in both versions — the universe cancels in `long_alpha + short_alpha` — which is exactly why nothing else caught it. This is the "改分母" branch of the issue's either/or, chosen over "改述文件" because a decomposition benchmarked against never-ranked names is not a convention worth documenting: it reports level differences between coverage sets as leg alpha.

## Change

- `universe_return` is now **per factor**, filtered on the same `_finite_expr(f)` mask the bucketing uses. The shared column could not be kept correct: in the multi-factor batch each factor has its own finite mask, so one shared mean cannot be right for more than one factor.
- The degenerate constant-factor branch (`top = bottom = universe`, spread 0) substitutes the per-factor mean — a constant factor still reports 0 against its own ranked cross-section.
- Docstring's non-finite note now covers the universe alongside the diagnostics.

## Breaking

`long_alpha` / `short_alpha` metadata, degenerate-date top/bottom substitution values, and the public `compute_spread_series` `universe_return` column move on any panel with null-factor rows. Clean panels are bit-identical. Pre-1.0, no shim per convention.

## Verification

2287 passed, 3 skipped; `ruff` / `mypy` clean. New `TestUniverseReturnRankedOnly` pins the ~0 attribution, the decomposition identity, and the series-level ranked-mean equality.