### PR TITLE
fix(metrics): reject positional metric knobs instead of misbinding them

### DIFF
--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -63,11 +63,26 @@ class MetricMeta(type):
             remaining_args = args
 
         if has_first_param:
-            # Instantiate with the remaining fields, then run on the first argument
-            param_names = getattr(cls, "_param_names", ())
+            # Direct-call form takes the data positionally and every knob by
+            # keyword. Positional knobs are rejected rather than mapped: the
+            # old mapping followed ``_param_names`` order, which is NOT the
+            # body's signature order — dataclass field rules re-sort
+            # non-default fields first and ``forward_periods`` is removed as
+            # an injected param — so ``quantile_spread(df, 3)`` silently set
+            # ``n_groups=3`` where the signature promises
+            # ``forward_periods=3``. No repo-internal caller, doc, or test
+            # ever passed a second positional; failing loud costs nothing
+            # and ends the misalignment class outright.
+            if remaining_args:
+                raise TypeError(
+                    f"{cls.__name__}: pass metric parameters by keyword — "
+                    f"got {len(remaining_args)} extra positional "
+                    f"argument(s) after the data. Positional parameters "
+                    f"were previously matched against an internal field "
+                    f"order that differs from the signature, silently "
+                    f"binding values to the wrong parameter."
+                )
             resolved_kwargs = kwargs.copy()
-            for name, val in zip(param_names, remaining_args, strict=False):
-                resolved_kwargs[name] = val
             # A direct call may carry the injected horizon (``forward_periods``) —
             # it is not a constructor field, so route it to the call as the
             # per-invocation horizon rather than into ``cls(**...)``.

--- a/tests/test_metric_base.py
+++ b/tests/test_metric_base.py
@@ -254,3 +254,61 @@ def test_metric_parameter_ordering_and_reflection():
         from factrix._metric_index import _all_specs
 
         _all_specs.cache_clear()
+
+
+class TestPositionalKnobsRejected:
+    """Metric knobs are keyword-only past the data argument.
+
+    The old positional mapping followed ``_param_names`` order, which is not
+    the body's signature order: dataclass field rules re-sort non-default
+    fields first and ``forward_periods`` is removed as an injected param.
+    Concretely, ``quantile_spread(df, 3)`` — a call that reads as
+    ``forward_periods=3`` straight off the signature — silently bound
+    ``n_groups=3`` and reported numbers for the wrong configuration.
+    """
+
+    @staticmethod
+    def _panel():
+        import factrix as fx
+        from factrix.preprocess import compute_forward_return
+
+        return compute_forward_return(
+            fx.datasets.make_cs_panel(n_assets=30, n_dates=120, seed=0),
+            forward_periods=5,
+        )
+
+    def test_second_positional_raises(self):
+        from factrix.metrics.quantile import quantile_spread
+
+        with pytest.raises(TypeError, match="by keyword"):
+            quantile_spread(self._panel(), 3)
+
+    def test_scalar_metric_second_positional_raises(self):
+        # Scalar-shaped metrics (no DataFrame) go through the same wrapper.
+        from factrix.metrics.tradability import net_spread
+
+        with pytest.raises(TypeError, match="by keyword"):
+            net_spread(0.10, 0.5)
+
+    def test_keyword_call_is_unaffected(self):
+        import warnings
+
+        from factrix.metrics.quantile import quantile_spread
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = quantile_spread(self._panel(), forward_periods=3, n_groups=3)
+        assert result["factor"].n_obs is not None
+
+    def test_constructor_form_is_unaffected(self):
+        # ``metric(**knobs)`` then ``instance(data)`` — no data in args, so
+        # the guard must not fire on the plain constructor path.
+        import warnings
+
+        from factrix.metrics.quantile import quantile_spread
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            inst = quantile_spread(n_groups=3)
+            result = inst(self._panel())
+        assert result["factor"].n_obs is not None

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -214,12 +214,12 @@ class TestBreakevenCost:
         # rebalance): gross=0.10/period, turnover=0.5/rebalance, fp=1.
         # Traded notional per rebalance = 4*0.5 = 2 (2 legs x sell+buy), so
         # the breakeven one-way cost is 0.10*1/(4*0.5)*10000 = 500 bps.
-        result = breakeven_cost(0.10, 0.5, forward_periods=1)
+        result = breakeven_cost(0.10, turnover=0.5, forward_periods=1)
         assert result.value == pytest.approx(500.0)
         assert result.metadata["forward_periods"] == 1
 
     def test_zero_turnover(self):
-        result = breakeven_cost(0.10, 0.0, forward_periods=1)
+        result = breakeven_cost(0.10, turnover=0.0, forward_periods=1)
         assert result.value == float("inf")
 
     def test_forward_periods_scales_breakeven(self):
@@ -229,25 +229,29 @@ class TestBreakevenCost:
         same breakeven as the forward_periods=1 baseline — the trader earns the spread
         twice before paying the once-per-rebalance cost.
         """
-        baseline = breakeven_cost(0.10, 0.5, forward_periods=1).value
-        scaled = breakeven_cost(0.05, 0.5, forward_periods=2).value
+        baseline = breakeven_cost(0.10, turnover=0.5, forward_periods=1).value
+        scaled = breakeven_cost(0.05, turnover=0.5, forward_periods=2).value
         assert scaled == pytest.approx(baseline)
 
     def test_forward_periods_validation(self):
         with pytest.raises(ValueError, match="forward_periods"):
-            breakeven_cost(0.10, 0.5, forward_periods=0)
+            breakeven_cost(0.10, turnover=0.5, forward_periods=0)
 
 
 class TestNetSpread:
     def test_basic(self):
         # Notional turnover=0.5 (per leg); cost=30bps one-way; fp=1.
         # net = 0.10 - 4*(30/10000)*0.5/1 = 0.10 - 0.006 = 0.094
-        result = net_spread(0.10, 0.5, estimated_cost_bps=30, forward_periods=1)
+        result = net_spread(
+            0.10, turnover=0.5, estimated_cost_bps=30, forward_periods=1
+        )
         assert result.value == pytest.approx(0.094)
         assert result.metadata["forward_periods"] == 1
 
     def test_cost_exceeds_alpha(self):
-        result = net_spread(0.001, 0.5, estimated_cost_bps=100, forward_periods=1)
+        result = net_spread(
+            0.001, turnover=0.5, estimated_cost_bps=100, forward_periods=1
+        )
         assert result.value < 0
 
     def test_forward_periods_amortises_cost(self):
@@ -255,12 +259,16 @@ class TestNetSpread:
         cost drag must shrink by exactly 1/N. Asserting the ratio (rather
         than absolute values) pins the scaling invariant under any rescaling
         of inputs — which is the whole point of the fix."""
-        baseline = net_spread(0.10, 0.5, estimated_cost_bps=30, forward_periods=1)
-        scaled = net_spread(0.10, 0.5, estimated_cost_bps=30, forward_periods=5)
+        baseline = net_spread(
+            0.10, turnover=0.5, estimated_cost_bps=30, forward_periods=1
+        )
+        scaled = net_spread(
+            0.10, turnover=0.5, estimated_cost_bps=30, forward_periods=5
+        )
         assert scaled.metadata["cost_drag"] == pytest.approx(
             baseline.metadata["cost_drag"] / 5
         )
 
     def test_forward_periods_validation(self):
         with pytest.raises(ValueError, match="forward_periods"):
-            net_spread(0.10, 0.5, forward_periods=0)
+            net_spread(0.10, turnover=0.5, forward_periods=0)


### PR DESCRIPTION
#803 checklist item 3 (`metrics/_base.py:69` 的 `zip` / `strict=False`).

## Upgraded from latent to live

The issue filed this as a hazard ("目前所有 metric 的順序恰好正確，所以是潛在而非現行缺陷"). Measured, it is live today:

```python
quantile_spread(df, 3)      # signature: (data, forward_periods=5, n_groups=5, ...)
# → n_groups=3, forward_periods=5   — silently
```

`_param_names` for `quantile_spread` is `('n_groups', 'factor_cols', 'tie_policy', 'inference', '_precomputed_series')` — `forward_periods` is stripped as an injected param, so the second positional lands on `n_groups`. Verified: the positional call is value-identical to `n_groups=3` and differs from `forward_periods=3`. Wrong numbers, no error, no warning.

## Fix: reject, don't remap

A second positional argument now raises `TypeError` naming the metric and the reason. Between the issue's two options (keyword-only vs a consistency assertion), keyword-only wins because the mapping is **not fixable**: signature order is unrecoverable from the dataclass fields (the non-default-first re-sort exists because dataclass rules forbid a non-default field after a default one), so any repaired mapping stays one refactor away from the same silent misbinding. `strict=True` would only catch length mismatches, not order mismatches — useless against the actual failure.

Mainstream precedent: sklearn made estimator params keyword-only for exactly this reason. Every repo-internal caller, doc example and test already uses keywords — except eight `net_spread` / `breakeven_cost` tests whose positional bindings happened to be correct; converted.

The constructor form (`metric(**knobs)` then `instance(data)`) is untouched, pinned by test.

## Breaking

Any external caller passing a second positional argument gets a `TypeError` with instructions — previously they got silently wrong numbers, so the error is strictly an upgrade. Pre-1.0, no shim.

2285 passed, 3 skipped; `ruff` / `mypy` clean. `TestPositionalKnobsRejected` pins DataFrame-shaped, scalar-shaped, keyword and constructor paths.