### PR TITLE
fix(slicing): Welch F reference and observed-mean centring in the pairwise period test

### DIFF
--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -359,10 +359,13 @@ def slice_period_pairwise_test(
             # Two disjoint slices with their own HAC variances is the Welch
             # two-sample setting, so the finite-sample reference is
             # F_{1, ν} with the Welch-Satterthwaite ν rather than the
-            # asymptotic χ²₁ (which over-rejects at short slices: 6.8% at
-            # T = 8 for a nominal 5%, vs 4.8% here). Same F reference the
-            # cross-sectional sibling in ``slicing.inference`` uses; ν is
-            # per pair because the two slices differ in length.
+            # asymptotic χ²₁. At the smallest slice the metric floors
+            # admit (50 periods) the two are within simulation noise
+            # (6.4% vs 6.6% null size at nominal 5%); the F reference is
+            # kept for consistency with the cross-sectional sibling in
+            # ``slicing.inference`` and because the disclosed ν lets a
+            # reader recompute p from ``stat``. ν is per pair because the
+            # two slices differ in length.
             nu = _welch_df(
                 float(variances[i]), n_periods[i], float(variances[j]), n_periods[j]
             )
@@ -404,14 +407,23 @@ def _welch_df(var_a: float, n_a: int, var_b: float, n_b: int) -> float:
     """Welch-Satterthwaite denominator df for a two-sample mean contrast.
 
     ``var_*`` are the (HAC) variances *of the mean*, so the classic
-    ``s²/n`` terms are already folded in. Floors at 1.0 so a degenerate
-    pair cannot hand ``f.sf`` a zero df.
+    ``s²/n`` terms are already folded in. The ratio is computed on the
+    variance *shares* ``w = var / (var_a + var_b)`` so it is scale-free:
+    ``var_*`` shrinks like ``σ²/n`` and the raw ``Σ var²/(n-1)``
+    denominator like ``σ⁴/n³``, which for a per-period σ ≈ 0.1 drops
+    below any absolute tolerance from roughly n ≈ 60 and would pin ν at
+    the floor for perfectly healthy data. Floors at 1.0 so a degenerate
+    pair (both variances zero) cannot hand ``f.sf`` a zero df.
     """
-    num = (var_a + var_b) ** 2
-    den = (var_a**2) / max(n_a - 1, 1) + (var_b**2) / max(n_b - 1, 1)
-    if den <= EPSILON or not np.isfinite(num):
+    total = var_a + var_b
+    if not np.isfinite(total) or total <= 0.0:
         return 1.0
-    return max(float(num / den), 1.0)
+    w_a = var_a / total
+    w_b = var_b / total
+    den = (w_a**2) / max(n_a - 1, 1) + (w_b**2) / max(n_b - 1, 1)
+    if not np.isfinite(den) or den <= 0.0:
+        return 1.0
+    return max(1.0 / float(den), 1.0)
 
 
 def _analytic_slice_moments(

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -285,12 +285,14 @@ def slice_period_pairwise_test(
         reference_dist, df_num, df_denom, multiplicity)``; one row per
         ordered slice pair ``(a, b)``. ``n_periods_*`` are each slice's own
         date counts (disjoint spans differ in length). ``mean_diff`` is the
-        signed ``μ_a − μ_b``; ``stat`` the studentized contrast on a χ²₁
-        scale. The mechanism columns disclose the path (constant across
-        rows): ``stat_type="wald"``, ``df_num=1`` and ``df_denom=None``
-        (the disjoint-sample reference has no finite-cluster denominator);
-        ``reference_dist`` is ``"bootstrap_null"`` (``method="bootstrap"``)
-        or ``"chi2"`` (``method="analytic"``, asymptotic χ²₁); and
+        signed ``μ_a − μ_b``; ``stat`` the studentized contrast
+        ``(μ_a − μ_b)² / (v_a + v_b)``. The mechanism columns disclose the
+        path: ``stat_type="wald"``, ``df_num=1``; ``reference_dist`` is
+        ``"bootstrap_null"`` (``method="bootstrap"``, ``df_denom=None``) or
+        ``"f"`` (``method="analytic"``: ``F_{1, ν}`` with the per-pair
+        Welch-Satterthwaite ``ν`` in ``df_denom`` — two disjoint slices with
+        their own HAC variances is the Welch two-sample setting, and the
+        asymptotic χ²₁ used earlier over-rejected at short slices); and
         ``multiplicity`` the family-wise correction (``"romano_wolf"`` for
         ``"bootstrap"``, ``"holm"`` for ``"analytic"``).
 
@@ -329,7 +331,12 @@ def slice_period_pairwise_test(
                 col = np.zeros(_N_RESAMPLES)
             else:
                 t = diff_obs / se
-                col = (d - d.mean()) / se
+                # Centre on the OBSERVED difference, not the bootstrap mean:
+                # the studentised null draw is (θ* − θ̂) / se* (Efron-Tibshirani
+                # §16), and it is what ``_wald_bootstrap_omnibus`` already does
+                # via ``boot - obs_means``. Centring on ``d.mean()`` was an
+                # implicit bias correction the omnibus path did not apply.
+                col = (d - diff_obs) / se
             t_obs.append(t)
             boot_cols.append(col)
             mean_diffs.append(diff_obs)
@@ -345,22 +352,34 @@ def slice_period_pairwise_test(
         mean_diffs = []
         stats = []
         p_raw = []
+        df_denoms = []
         for i, j in pairs:
             diff_obs = float(means[i] - means[j])
             se2 = float(variances[i] + variances[j])
+            # Two disjoint slices with their own HAC variances is the Welch
+            # two-sample setting, so the finite-sample reference is
+            # F_{1, ν} with the Welch-Satterthwaite ν rather than the
+            # asymptotic χ²₁ (which over-rejects at short slices: 6.8% at
+            # T = 8 for a nominal 5%, vs 4.8% here). Same F reference the
+            # cross-sectional sibling in ``slicing.inference`` uses; ν is
+            # per pair because the two slices differ in length.
+            nu = _welch_df(
+                float(variances[i]), n_periods[i], float(variances[j]), n_periods[j]
+            )
             if se2 <= EPSILON:
                 chi = 0.0
                 p = 1.0
             else:
                 chi = diff_obs * diff_obs / se2
-                p = float(sp_stats.chi2.sf(chi, df=1))
+                p = float(sp_stats.f.sf(chi, dfn=1, dfd=nu))
             mean_diffs.append(diff_obs)
             stats.append(chi)
             p_raw.append(p)
+            df_denoms.append(nu)
         p_adj = holm_adjusted_p(p_raw)
 
     n_pairs = len(pairs)
-    reference_dist = "bootstrap_null" if method == "bootstrap" else "chi2"
+    reference_dist = "bootstrap_null" if method == "bootstrap" else "f"
     multiplicity = "romano_wolf" if method == "bootstrap" else "holm"
     return pl.DataFrame(
         {
@@ -375,10 +394,24 @@ def slice_period_pairwise_test(
             "stat_type": ["wald"] * n_pairs,
             "reference_dist": [reference_dist] * n_pairs,
             "df_num": [1] * n_pairs,
-            "df_denom": [None] * n_pairs,
+            "df_denom": ([None] * n_pairs if method == "bootstrap" else df_denoms),
             "multiplicity": [multiplicity] * n_pairs,
         }
     )
+
+
+def _welch_df(var_a: float, n_a: int, var_b: float, n_b: int) -> float:
+    """Welch-Satterthwaite denominator df for a two-sample mean contrast.
+
+    ``var_*`` are the (HAC) variances *of the mean*, so the classic
+    ``s²/n`` terms are already folded in. Floors at 1.0 so a degenerate
+    pair cannot hand ``f.sf`` a zero df.
+    """
+    num = (var_a + var_b) ** 2
+    den = (var_a**2) / max(n_a - 1, 1) + (var_b**2) / max(n_b - 1, 1)
+    if den <= EPSILON or not np.isfinite(num):
+        return 1.0
+    return max(float(num / den), 1.0)
 
 
 def _analytic_slice_moments(

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -50,12 +50,13 @@ def test_two_slice_returns_one_row(
     if method == "bootstrap":
         assert out["df_denom"][0] is None
     else:
-        # Welch-Satterthwaite ν: strictly between 1 and the pooled n_a+n_b-2.
+        # Welch-Satterthwaite ν: two equal-length slices of equal per-period
+        # variance give ν ≈ 2(n−1). A wide-but-open lower bound (``1.0 <=``)
+        # would silently accept the degenerate floor, so anchor at the
+        # theoretical value instead.
         nu = out["df_denom"][0]
-        assert (
-            nu is not None
-            and 1.0 <= nu <= out["n_periods_a"][0] + out["n_periods_b"][0] - 2
-        )
+        n_a, n_b = out["n_periods_a"][0], out["n_periods_b"][0]
+        assert nu is not None and nu == pytest.approx(n_a + n_b - 2, rel=0.1)
     assert out["multiplicity"][0] == multiplicity
 
 
@@ -63,9 +64,8 @@ def test_analytic_reference_is_welch_f() -> None:
     """The analytic p is ``F_{1, ν}`` on the disclosed ``df_denom``, not χ²₁.
 
     Two disjoint slices with their own HAC variances is the Welch two-sample
-    setting. The earlier asymptotic χ²₁ over-rejected at short slices (6.8%
-    at T=8 for nominal 5%; Welch F gives 4.8%), and the disclosed ``ν`` is
-    what lets a reader recompute the p from ``stat`` alone.
+    setting, and the disclosed ``ν`` is what lets a reader recompute the p
+    from ``stat`` alone.
     """
     from scipy import stats as sp_stats
 
@@ -79,6 +79,39 @@ def test_analytic_reference_is_welch_f() -> None:
     assert p == pytest.approx(float(sp_stats.f.sf(stat, dfn=1, dfd=nu)))
     # Unequal slice lengths must give a non-integer, pair-specific ν.
     assert nu != pytest.approx(round(nu))
+
+
+def test_welch_df_does_not_collapse_at_long_slices() -> None:
+    """ν must track 2(n−1) at long slices, not fall to the 1.0 floor.
+
+    The HAC variances of the mean shrink like σ²/n, so any absolute
+    tolerance on the raw Welch denominator (∝ σ⁴/n³) trips on healthy data
+    once the slices are long enough — pinning ν at 1.0 and turning the
+    reference into F₁,₁, which has essentially no power. Regression for
+    the scale-free share-based formula.
+    """
+    df = build_disjoint_period_panel(
+        seed=7,
+        spans={"a": (150, 0.1), "b": (150, 0.1), "c": (150, 0.1)},
+        label_col="regime",
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", method="analytic"
+    )
+    for nu in out["df_denom"].to_list():
+        assert nu == pytest.approx(298.0, rel=0.05)
+
+
+def test_welch_df_is_scale_free() -> None:
+    """Rescaling both variances by a constant leaves ν unchanged."""
+    from factrix.slicing.period_inference import _welch_df
+
+    base = _welch_df(2.0e-4, 60, 5.0e-4, 120)
+    assert base > 1.0
+    for scale in (1e-6, 1e-3, 1e3):
+        assert _welch_df(2.0e-4 * scale, 60, 5.0e-4 * scale, 120) == pytest.approx(base)
+    # Only a genuinely degenerate pair (both variances zero) hits the floor.
+    assert _welch_df(0.0, 60, 0.0, 120) == 1.0
 
 
 def test_three_slice_returns_three_rows() -> None:

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -31,7 +31,7 @@ _PAIRWISE_COLS = [
 
 @pytest.mark.parametrize(
     ("method", "reference_dist", "multiplicity"),
-    [("bootstrap", "bootstrap_null", "romano_wolf"), ("analytic", "chi2", "holm")],
+    [("bootstrap", "bootstrap_null", "romano_wolf"), ("analytic", "f", "holm")],
 )
 def test_two_slice_returns_one_row(
     method: str, reference_dist: str, multiplicity: str
@@ -47,8 +47,38 @@ def test_two_slice_returns_one_row(
     assert out["stat_type"][0] == "wald"
     assert out["reference_dist"][0] == reference_dist
     assert out["df_num"][0] == 1
-    assert out["df_denom"][0] is None
+    if method == "bootstrap":
+        assert out["df_denom"][0] is None
+    else:
+        # Welch-Satterthwaite ν: strictly between 1 and the pooled n_a+n_b-2.
+        nu = out["df_denom"][0]
+        assert (
+            nu is not None
+            and 1.0 <= nu <= out["n_periods_a"][0] + out["n_periods_b"][0] - 2
+        )
     assert out["multiplicity"][0] == multiplicity
+
+
+def test_analytic_reference_is_welch_f() -> None:
+    """The analytic p is ``F_{1, ν}`` on the disclosed ``df_denom``, not χ²₁.
+
+    Two disjoint slices with their own HAC variances is the Welch two-sample
+    setting. The earlier asymptotic χ²₁ over-rejected at short slices (6.8%
+    at T=8 for nominal 5%; Welch F gives 4.8%), and the disclosed ``ν`` is
+    what lets a reader recompute the p from ``stat`` alone.
+    """
+    from scipy import stats as sp_stats
+
+    df = build_disjoint_period_panel(
+        seed=4, spans={"a": (45, 0.1), "b": (90, 0.1)}, label_col="regime"
+    )
+    out = slice_period_pairwise_test(
+        df, ic(), by="regime", factor_col="factor", method="analytic"
+    )
+    stat, nu, p = out["stat"][0], out["df_denom"][0], out["p_raw"][0]
+    assert p == pytest.approx(float(sp_stats.f.sf(stat, dfn=1, dfd=nu)))
+    # Unequal slice lengths must give a non-integer, pair-specific ν.
+    assert nu != pytest.approx(round(nu))
 
 
 def test_three_slice_returns_three_rows() -> None:

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -70,7 +70,7 @@ def test_analytic_reference_is_welch_f() -> None:
     from scipy import stats as sp_stats
 
     df = build_disjoint_period_panel(
-        seed=4, spans={"a": (45, 0.1), "b": (90, 0.1)}, label_col="regime"
+        seed=4, spans={"a": (60, 0.1), "b": (120, 0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
         df, ic(), by="regime", factor_col="factor", method="analytic"


### PR DESCRIPTION
#803 checklist items 2a + 2b (`slicing/period_inference.py`).

## 2a — χ²₁ → F_{1, Welch ν}

Two slices with their own HAC variances is the Welch two-sample setting, so the reference is `F_{1, Welch ν}` (matching the cross-sectional sibling's F form) rather than the asymptotic χ²₁. `df_denom` now carries the per-pair ν (previously `None`), so a reader can recompute `p` from `stat` alone; `reference_dist` reads `"f"`.

**Calibration, measured at reachable sizes** (the metric floor makes T < 50 per slice unreachable through the public API, so the earlier T = 8–40 table was not evidence a user can hit). True null, three disjoint iid slices, σ = 0.1, 300 draws, nominal 5%:

| T / slice | χ²₁ (before) | F_{1,Welch} — first push | **F_{1,Welch} — after `fd754bb`** |
|---|---|---|---|
| 50 | 0.066 | 0.064 | 0.057 |
| 90 | 0.054 | 0.034 | 0.060 |
| 150 | 0.062 | **0.000** | 0.040 |

Review (thanks @factrix-13's independent rerun) caught that the first push's `_welch_df` guard compared a `Σ var²/(n−1)` denominator — which shrinks like σ⁴/n³ — against an absolute `EPSILON`, so it tripped on healthy data from ~60 periods and pinned ν at the 1.0 floor (F₁,₁ has essentially no power). `fd754bb` computes the ratio on the variance shares `var / (var_a + var_b)`, making it scale-free; ν is bit-identical where the old guard did not fire and returns to 2(n−1) where it did. Tests now anchor ν at 2(n−1) for equal slices instead of the `1.0 <= ν` bound that accepted the degenerate value, and add a 150-period regression plus a unit-level scale-invariance check.

At reachable T the F and χ²₁ sizes are within simulation noise — the F reference is kept for consistency with `slicing.inference` and for the disclosed ν, not for a size gain.

**Scope note**: the omnibus keeps χ²(K−1) — a multi-restriction Welch analogue has no clean form, and it is disclosed via `reference_dist`. Flag if you'd rather see it changed too.

## 2b — bootstrap centring aligned to the omnibus

Pairwise centred on the bootstrap mean; omnibus on the observed statistic. `(θ* − θ̂)/se*` is the studentised null draw (Efron-Tibshirani) and what Romano-Wolf expects; pairwise now matches. Measured effect: mean |Δp| = 0.002 on the 1/1000 grid — consistency, not a correction.

## Breaking
Analytic pairwise `p_raw` / `p_adj` move (toward calibrated at short slices); `df_denom` becomes a float on that path; `reference_dist` string changes. Bootstrap p moves negligibly.

2318 passed, 3 skipped; `ruff` / `mypy` clean.
