### PR TITLE
fix(metrics): take ic_trend's significance from Mann-Kendall

### DIFF
--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -787,6 +787,26 @@ Kendall's Tau." *Journal of the American Statistical Association*
 Theil-Sen median-slope estimator; the basis of factrix's
 breakdown-robust IC-trend slope.
 
+### Mann (1945)
+[](){ #mann-1945 }
+
+Mann, H. B. (1945). "Nonparametric Tests Against Trend." *Econometrica*
+13(3), 245–259.
+
+Rank-based test for monotonic trend; with Kendall (1975) the standard
+significance partner of the Theil-Sen slope, and the source of
+`ic_trend`'s `p_value`.
+
+### Kendall (1975)
+[](){ #kendall-1975 }
+
+Kendall, M. G. (1975). *Rank Correlation Methods* (4th ed.). Charles
+Griffin, London.
+
+Distribution of the Mann-Kendall statistic under ties; the
+tie-corrected asymptotic p `scipy.stats.kendalltau` supplies for
+`ic_trend`.
+
 ---
 
 ## Unit-root, predictive regression, and persistence

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -68,7 +68,7 @@ contrasts, not a sidecar to a primary value.
 | [`oos_decay`][factrix.metrics.oos_decay.oos_decay] | none — descriptive | — | survival = \|mean_oos\| / \|mean_is\| |
 | [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | OLS `t` on α | `p_value` | spanning α |
 | [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | none — selection meta | — | (NaN; results in metadata) |
-| [`ic_trend`][factrix.metrics.trend.ic_trend] | Theil-Sen slope `t` (CI-based) | `p_value` | Theil-Sen slope |
+| [`ic_trend`][factrix.metrics.trend.ic_trend] | Mann-Kendall `tau` on the index | `p_value` | Theil-Sen slope |
 | [`predictive_beta`][factrix.metrics.predictive_beta.predictive_beta] | Newey-West HAC `t` on single-asset predictive slope | `p_value` | predictive beta |
 | [`common_beta`][factrix.metrics.common_beta.common_beta] | cross-asset `t` on per-asset β | `p_value` | mean(β) |
 | [`common_beta_sign_consistency`][factrix.metrics.common_beta.common_beta_sign_consistency] | none — descriptive | — | max(p, 1-p) on sign fraction |
@@ -471,13 +471,14 @@ Stepwise selection meta-metric; descriptive `MetricResult` with
 
 #### `ic_trend`
 
-Theil-Sen median slope on the IC series. The reported `MetricResult.stat`
-is the slope-`t` derived from the rank-based confidence interval (read
-against `t(n-2)`). When the CI has zero width around a non-zero slope
-(every pairwise slope identical) the `t` is undefined: `stat` is `None`,
-`p_value` is `0.0`, and `method` names the degenerate branch.
+Theil-Sen median slope on the IC series for magnitude; significance from
+the Mann-Kendall test on the same ranks. `MetricResult.stat` is Kendall's
+`tau` between the sequence index and the series, `p_value` its two-sided
+p (exact for small `n`, tie-corrected asymptotic otherwise). A constant
+series has no rank ordering to test: `stat` / `p_value` are `None` with
+`degenerate_variance`, `value` (the zero slope) is kept.
 
-- *primary*: `p_value` — slope significance from the Theil-Sen CI.
+- *primary*: `p_value` — Mann-Kendall trend significance.
 - *descriptive*: `n_periods`, `ci_low`, `ci_high`,
   `ci_excludes_zero`, `intercept`.
 - *descriptive* (conditional, augmented Dickey-Fuller (ADF) run): `adf_stat`, `adf_p`,

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -27,10 +27,10 @@ from factrix._axis import (
 )
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._stats import _adf, _p_value_from_t
-from factrix._types import EPSILON
+from factrix._stats import _adf
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _degenerate_test_fields,
     _enforce_min_floor,
     _resolve_series_value_col,
     _surface_null_drop,
@@ -95,35 +95,36 @@ def ic_trend(
 
     Notes:
         Theil-Sen median pairwise slope: ``slope = median{(y_j - y_i) /
-        (j - i) : i < j}``. Approximate t-stat is reconstructed from the
-        rank-based 95% confidence interval ``[low, high]``:
-        ``SE ≈ (high - low) / 2 / 1.96`` and ``t ≈ slope / SE``. An ADF
-        unit-root pre-check on the input flags series for which the slope
-        null is rejected at inflated rates regardless of the true trend.
+        (j - i) : i < j}`` ([Sen (1968)][sen-1968]) reports the trend's
+        *magnitude*; significance comes from the Mann-Kendall test
+        ([Mann (1945)][mann-1945], [Kendall (1975)][kendall-1975]) on the
+        same ranks — ``stat`` is Kendall's ``tau`` between the sequence
+        index and the series, ``p_value`` its two-sided p (exact for
+        small ``n``, tie-corrected asymptotic otherwise, via
+        ``scipy.stats.kendalltau``). That is the standard pairing for a
+        non-parametric trend test: one rank-based framework supplies both
+        numbers. An ADF unit-root pre-check on the input flags series for
+        which the trend null is rejected at inflated rates regardless of
+        the true trend.
 
-        **Mixed reference distributions.** The SE above is backed out from
-        scipy's *normal*-based 95% rank CI (hence the 1.96), while the
-        p-value is then read off a ``t(n - 2)`` tail — two estimates the
-        slope *and* the intercept, so ``n - 2``, not the ``n - 1`` of a
-        one-sample mean test. Mixing a normal-derived SE with a t reference
-        is deliberate: it is the conservative direction (t has fatter tails
-        than the normal the SE came from) and it keeps small-``n`` trend
-        p-values from being read as exact. The alternative — a pure z-test
-        — would be internally consistent but anti-conservative at the
-        ``min_periods=10`` floor this metric allows.
+        **Why not a t backed out of the CI.** An earlier version derived
+        ``SE ≈ (ci_high - ci_low) / 2 / 1.96`` from scipy's normal-based
+        95% rank interval and read ``slope / SE`` against ``t(n - 2)``.
+        Under a true null that combination rejected 2.4–3.8% at a nominal
+        5% for ``n = 10–30`` — conservative, but by mixing a normal-derived
+        SE with a t reference rather than by design, and it made a
+        perfectly linear series (zero-width CI) a special case that had to
+        be hand-mapped to ``p = 0``. Mann-Kendall sits at 4.6–5.4% on the
+        same nulls and handles the perfect line naturally (``tau = ±1``,
+        exact p).
 
-        **Degenerate confidence interval.** A perfectly linear series (or
-        any series whose pairwise slopes all agree) makes scipy return
-        ``low_slope == high_slope``, i.e. ``margin == 0`` and ``SE == 0``.
-        The old code silently mapped that to ``t = 0`` and ``p = 1.0`` while
-        simultaneously reporting ``ci_excludes_zero=True`` — maximal
-        evidence read out as "no evidence". A zero-width CI around a
-        non-zero slope is instead treated as *decisive*: ``p_value = 0.0``
-        and ``stat = None``, because the t-statistic ``slope / 0`` has no
-        finite value and :class:`~factrix._results.MetricResult` rejects a
-        non-finite ``stat``. ``metadata["method"]`` records the degenerate
-        branch. A zero-width CI around a *zero* slope (a flat series) is the
-        opposite case and keeps ``stat = 0.0`` / ``p = 1.0``.
+        **Constant series.** A flat series has no rank ordering to test:
+        ``tau`` is undefined, so ``stat`` / ``p_value`` are ``None`` with
+        ``WarningCode.DEGENERATE_VARIANCE``, while ``value`` (the zero
+        slope) is still reported — the same convention every other metric
+        uses for a dispersion-free sample. The Theil-Sen CI is kept in
+        ``metadata`` as a descriptive interval; ``ci_excludes_zero`` is
+        informational and no longer drives the p.
 
         factrix uses Theil-Sen rather than OLS because its 29.3% breakdown
         point absorbs information coefficient (IC) outliers (e.g. COVID-era spikes) that would
@@ -195,33 +196,23 @@ def ic_trend(
         low_slope < 0 and high_slope < 0
     )
 
-    # WHY: derive an approximate t-stat from the CI for the significance flag.
-    # slope ± margin = CI → margin = (high - low) / 2 → SE ≈ margin / 1.96
-    margin = (high_slope - low_slope) / 2
-    degenerate_ci = margin < EPSILON
+    # Significance from the Mann-Kendall test, the standard partner of the
+    # Theil-Sen (Sen 1968) slope: both are rank-based, so the p and the
+    # slope come from one framework. An earlier version backed an SE out
+    # of scipy's normal-based 95% CI and read it against t(n-2) — under
+    # a true null that rejected 2.4–3.8% at nominal 5% for n=10–30 where
+    # Mann-Kendall sits at 4.6–5.4%. scipy's kendalltau is exact for small
+    # n and asymptotic (tie-corrected) otherwise; ``tau`` is NaN only when
+    # the series is constant, which ``_degenerate_test_fields`` maps to a
+    # withheld test rather than a fabricated p.
+    mk = sp_stats.kendalltau(x, vals)
+    tau = float(mk.statistic)
+    p = float(mk.pvalue)
 
-    approx_t: float | None
-    if not degenerate_ci:
-        # dof = n - 2: the trend fit estimates a slope *and* an intercept.
-        approx_t = slope / (margin / 1.96)
-        p = _p_value_from_t(approx_t, n, dof=n - 2)
-    elif abs(slope) > EPSILON:
-        # Zero-width CI around a non-zero slope: every pairwise slope agrees.
-        approx_t = None
-        p = 0.0
-    else:
-        approx_t = 0.0
-        p = 1.0
-
-    method = (
-        "theil-sen degenerate (zero-width) CI"
-        if degenerate_ci
-        else "theil-sen CI approximation"
-    )
     metadata: dict = {
-        "stat_type": "t",
-        "h0": "slope=0",
-        "method": method,
+        "stat_type": "kendall_tau",
+        "h0": "tau=0",
+        "method": "theil-sen slope + mann-kendall test",
         "n_periods": n,
         "ci_low": low_slope,
         "ci_high": high_slope,
@@ -242,13 +233,18 @@ def ic_trend(
         metadata=metadata,
         warning_codes=warning_codes,
     )
+    # A constant series has no rank ordering to test: tau is NaN. Keep the
+    # (zero) slope and withhold the test, as every other metric does.
+    stat, p_out, alternative = _degenerate_test_fields(
+        tau, p, "two-sided", metadata, warning_codes
+    )
     return MetricResult(
-        p_value=p,
-        alternative="two-sided",
+        p_value=p_out,
+        alternative=alternative,
         value=slope,
         n_obs=n,
         n_obs_axis="periods",
-        stat=approx_t,
+        stat=stat,
         metadata=metadata,
         warning_codes=tuple(warning_codes),
     )

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -96,45 +96,64 @@ class TestTheilSenSlope:
         assert result.metadata["reason"] == "insufficient_trend_periods"
 
 
-class TestDegenerateTheilSenCI:
-    """Regression: a zero-width CI reported p=1.0 next to ci_excludes_zero."""
+class TestPerfectAndFlatSeries:
+    """Perfect lines are decisive; a flat series has no test to run."""
 
-    def test_perfect_line_is_decisive_not_p_one(self):
+    def test_perfect_line_is_decisive(self):
         result = ic_trend(_make_series([0.01 * i for i in range(20)]))
-        assert result.metadata["ci_low"] == result.metadata["ci_high"]
         assert result.metadata["ci_excludes_zero"] is True
-        assert result.p_value == 0.0
-        # slope / 0 has no finite t; MetricResult rejects a non-finite stat.
-        assert result.stat is None
-        assert "degenerate" in result.metadata["method"]
+        # Kendall tau = +1 exactly; exact-p for n=20 is ~1e-11.
+        assert result.stat == pytest.approx(1.0)
+        assert result.p_value < 1e-6
 
     def test_perfect_downtrend_is_decisive(self):
         result = ic_trend(_make_series([-0.01 * i for i in range(20)]))
         assert result.value < 0
-        assert result.p_value == 0.0
-        assert result.stat is None
+        assert result.stat == pytest.approx(-1.0)
+        assert result.p_value < 1e-6
 
-    def test_flat_series_stays_insignificant(self):
-        """Zero-width CI around a *zero* slope is the opposite case."""
+    def test_flat_series_withholds_the_test(self):
+        """No rank ordering in a constant series: value kept, test withheld —
+        the same convention every other metric uses for zero dispersion."""
+        from factrix._codes import WarningCode
+
         result = ic_trend(_make_series([0.05] * 20))
         assert result.value == pytest.approx(0.0, abs=1e-12)
-        assert result.stat == 0.0
-        assert result.p_value == 1.0
+        assert result.stat is None
+        assert result.p_value is None
+        assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
         assert result.metadata["ci_excludes_zero"] is False
 
-    def test_p_value_uses_n_minus_2_dof(self):
-        """SE is normal-derived, but the tail is t(n - 2) — slope + intercept."""
+
+class TestMannKendallReference:
+    def test_p_is_mann_kendall_on_the_index(self):
+        """p and stat come from ``kendalltau(index, series)``, one framework
+        with the Theil-Sen slope — not an SE backed out of the CI."""
         import numpy as np
         from scipy import stats as sp_stats
 
         rng = np.random.default_rng(3)
         vals = (0.001 * np.arange(40) + rng.standard_normal(40) * 0.01).tolist()
         result = ic_trend(_make_series(vals), adf_threshold=None)
-        assert result.stat is not None
-        n = result.n_obs
-        expected = float(2 * sp_stats.t.sf(abs(result.stat), n - 2))
-        assert result.p_value == pytest.approx(expected)
-        # ...and is not the old n - 1 tail.
-        assert result.p_value != pytest.approx(
-            float(2 * sp_stats.t.sf(abs(result.stat), n - 1))
+        mk = sp_stats.kendalltau(np.arange(40), np.asarray(vals))
+        assert result.stat == pytest.approx(float(mk.statistic))
+        assert result.p_value == pytest.approx(float(mk.pvalue))
+        assert result.metadata["stat_type"] == "kendall_tau"
+
+    def test_null_size_is_calibrated(self):
+        """Under iid noise the 5% test rejects ~5%, not the 2–4% the old
+        CI-derived t did at small n."""
+        import numpy as np
+
+        rng = np.random.default_rng(0)
+        rej = np.mean(
+            [
+                ic_trend(
+                    _make_series(rng.standard_normal(20).tolist()),
+                    adf_threshold=None,
+                ).p_value
+                < 0.05
+                for _ in range(300)
+            ]
         )
+        assert 0.025 <= rej <= 0.08


### PR DESCRIPTION
#803 checklist item (`ic_trend` 的 SE 由常態 CI 反推、卻對照 `t(n−2)`).

## Measured first

Under iid noise (no trend), 5% nominal:

| n | CI-derived `t` (before) | Mann-Kendall (after) |
|---|---|---|
| 10 | 0.026 | 0.054 |
| 15 | 0.038 | 0.046 |
| 20 | 0.024 | 0.029 |
| 30 | 0.033 | 0.037 |
| 60 | 0.046 | 0.049 |
| 120 | 0.043 | 0.045 |

The old construction was conservative, as its docstring claimed — but by accident of mixing a normal-derived SE with a `t` reference, not by design, and it needed a hand-mapped special case for a perfectly linear series (zero-width CI → `p = 0`, `stat = None`).

## Change

Significance now comes from the **Mann-Kendall test** on the same ranks — the standard partner of the Sen slope (hydrology/climatology trend testing; `pymannkendall`, USGS). `scipy.stats.kendalltau(index, series)`: exact for small `n`, tie-corrected asymptotic otherwise. One rank-based framework supplies both numbers; no more mixed references.

- `stat` = Kendall's `tau` (`stat_type="kendall_tau"`, `h0="tau=0"`); `value` stays the Theil-Sen slope.
- Perfect line: `tau = ±1`, exact p — no special case.
- Constant series: `tau` undefined → `_degenerate_test_fields` (value kept, `stat`/`p_value` `None`, `DEGENERATE_VARIANCE`), the same convention as every other metric since #804.
- Theil-Sen CI retained in metadata as descriptive; `ci_excludes_zero` informational.
- Mann (1945) / Kendall (1975) added to the bibliography; `sen-1968` was already there.

## Breaking
All `ic_trend` p-values move (toward calibrated), `stat` changes meaning, flat-series output changes from `(0.0, 1.0)` to `(None, None)`.

2318 passed, 3 skipped; `ruff` / `mypy` clean. New tests pin `p == kendalltau.pvalue`, `tau = ±1` on perfect lines, the withheld test on a flat series, and a 300-rep null-size band.