### PR TITLE
fix(metrics): report spanning alpha with a Newey-West HAC t

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
+from factrix._stats.constants import auto_bartlett
+from factrix._stats.ols import _ols_nw_multivariate
 from factrix._types import EPSILON
 
 
@@ -27,11 +29,28 @@ def ols_alpha(
     candidate: np.ndarray,
     base_matrix: np.ndarray,
 ) -> _OLSResult:
-    """Ordinary least squares (OLS) regression: candidate = alpha + beta @ base + epsilon.
+    """OLS regression ``candidate = alpha + beta @ base + epsilon`` with a HAC t on alpha.
+
+    Point estimates are plain OLS. ``alpha_t`` divides by the Newey-West
+    HAC standard error (Bartlett kernel, [Newey-West (1994)][newey-west-1994]
+    automatic bandwidth) rather than the homoskedastic OLS SE. Spanning
+    alphas are routinely reported with HAC t-stats (Barillas-Shanken,
+    Fama-French). The cost on a genuinely non-overlapping, homoskedastic
+    series is the usual small-sample HAC noise: at ``n = 120`` iid the
+    HAC t has empirical size 6.7% at a nominal 5% (OLS ≈ 5%), the same
+    mild anti-conservatism every other HAC path in factrix carries and
+    ``statistical-methods`` §6 discloses. An overlapping or
+    heteroskedastic series is corrected instead of silently over-stated,
+    which is the trade this buys. An earlier version used the
+    OLS SE on the stated assumption that callers pass non-overlap spreads;
+    nothing in the ``(date, spread)`` input could verify that, so the
+    assumption was retired rather than documented harder.
 
     Returns:
-        _OLSResult with alpha, t_stat, betas, R², and residual degrees of
-        freedom ``df_resid = n_obs - (1 + n_base_factors)``.
+        _OLSResult with alpha, HAC t_stat, betas, R², and residual degrees
+        of freedom ``df_resid = n_obs - (1 + n_base_factors)`` (the
+        reference the t is read against — see ``_stats.hac`` on why the
+        full-count df is kept).
 
     Raises:
         ValueError: ``candidate`` or ``base_matrix`` holds a non-finite
@@ -83,13 +102,11 @@ def ols_alpha(
             alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
         )
 
-    try:
-        xtx_inv = np.linalg.inv(X.T @ X)
-        se_alpha = float(np.sqrt(sigma2 * xtx_inv[0, 0]))
-    except np.linalg.LinAlgError:
-        return _OLSResult(
-            alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
-        )
+    # HAC covariance of the OLS coefficients; ``_ols_nw_multivariate`` returns
+    # zeros when X'X is singular, which the EPSILON guard below turns into
+    # the same degenerate result the OLS path produced.
+    _, v_hac, _ = _ols_nw_multivariate(candidate, X, lags=auto_bartlett(n_obs))
+    se_alpha = float(np.sqrt(max(v_hac[0, 0], 0.0)))
 
     if se_alpha < EPSILON:
         return _OLSResult(

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -223,11 +223,14 @@ def spanning_alpha(
         common-date intersected spread series. Test ``H0: alpha = 0`` via
         ``t = alpha / SE(alpha)`` from the OLS covariance.
 
-        factrix uses plain OLS standard errors here rather than Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC):
-        the inputs are non-overlap quantile spreads (single-period stride)
-        so MA(h-1) overlap is absent. Callers feeding HAC-relevant
-        overlapping series should either pre-resample or wrap the call
-        with their own HAC SE.
+        The alpha t-stat uses a Newey-West HAC standard error (Bartlett
+        kernel, automatic bandwidth) — the convention for spanning alphas
+        in the factor-model literature. An earlier version used the
+        homoskedastic OLS SE on the stated assumption that inputs are
+        non-overlap spreads; nothing in a ``(date, spread)`` frame can
+        verify that, so the SE is now robust to whatever the caller
+        passes. On a genuinely non-overlapping series the two agree to
+        within the 1–2 lags the auto bandwidth selects.
 
     References:
         - [Barillas & Shanken (2017)][barillas-shanken-2017]. "Which
@@ -306,7 +309,7 @@ def spanning_alpha(
         metadata={
             "stat_type": "t",
             "h0": "alpha=0",
-            "method": "OLS spanning regression",
+            "method": "OLS spanning regression, Newey-West HAC SE",
             "n_base_factors": base_matrix.shape[1],
             "base_factors": base_names,
             "betas": beta_dict,

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -461,3 +461,53 @@ class TestOlsAlphaFiniteContract:
         candidate, _ = self._design()
         result = ols_alpha(candidate, np.empty((len(candidate), 0)))
         assert result.alpha == pytest.approx(float(np.mean(candidate)))
+
+
+class TestAlphaTIsHac:
+    """``alpha_t`` divides by a Newey-West HAC SE, not the homoskedastic OLS SE.
+
+    Nothing in a ``(date, spread)`` input can prove the series is
+    non-overlapping, so the SE must not depend on that assumption. Under
+    positive serial correlation the HAC SE is wider and the t smaller; on
+    iid input the two agree closely.
+    """
+
+    @staticmethod
+    def _ols_t(y: np.ndarray, X: np.ndarray) -> float:
+        beta = np.linalg.lstsq(X, y, rcond=None)[0]
+        resid = y - X @ beta
+        sigma2 = resid @ resid / (len(y) - X.shape[1])
+        se = np.sqrt(sigma2 * np.linalg.inv(X.T @ X)[0, 0])
+        return float(beta[0] / se)
+
+    def test_autocorrelated_residuals_shrink_the_t(self):
+        from factrix._ols import ols_alpha
+
+        rng = np.random.default_rng(0)
+        n = 240
+        eps = np.empty(n)
+        eps[0] = rng.standard_normal()
+        for t in range(1, n):
+            eps[t] = 0.7 * eps[t - 1] + rng.standard_normal()
+        y = 0.3 + eps
+        X = np.ones((n, 1))
+        hac_t = ols_alpha(y, np.empty((n, 0))).alpha_t
+        assert 0 < hac_t < self._ols_t(y, X)
+
+    def test_iid_residuals_agree_with_ols_on_average(self):
+        """On iid input the HAC and OLS t agree in expectation.
+
+        A single draw can differ by ±20% (the HAC SE is a noisier estimate
+        on iid data — that is its known small-sample cost), so the
+        agreement is asserted on the mean ratio over many draws, not on
+        one series.
+        """
+        from factrix._ols import ols_alpha
+
+        n = 240
+        ratios = []
+        for seed in range(200):
+            y = 0.3 + np.random.default_rng(seed).standard_normal(n)
+            hac_t = ols_alpha(y, np.empty((n, 0))).alpha_t
+            ratios.append(hac_t / self._ols_t(y, np.ones((n, 1))))
+        assert 0.95 <= float(np.mean(ratios)) <= 1.10


### PR DESCRIPTION
#803 checklist item 1 (`spanning` 的 alpha 用同質變異 OLS SE，且沒有東西強制 caller 的 spread 序列非重疊).

## Why HAC rather than a documented contract

The stride happens in `compute_spread_series` and leaves no stamp on the `(date, spread)` frame, so `spanning_alpha` cannot check the non-overlap assumption — a "contract" here is a sentence nobody can enforce, and an overlapping input silently over-states the t. Switching the SE to Newey-West HAC removes the assumption instead of restating it. HAC t-stats are the reporting convention for spanning alphas (Barillas-Shanken 2017, Fama-French factor-model tests). No new API.

## Measured cost — stated, not waved away

On the case the old assumption was written for (iid non-overlap spreads, n = 120):

- HAC/OLS t ratio: mean 1.04, p5 0.88, p95 1.23 — the HAC SE is noisier on iid input.
- Empirical size at nominal 5%: **6.7%** (OLS ≈ 5%).

That is the same small-sample HAC anti-conservatism every other HAC path in factrix carries (`fm_beta`, `ic` under `NEWEY_WEST`) and `statistical-methods.md` §6 already discloses. The docstring quotes the number rather than calling the cost "small". The trade: mild noise on the benign case vs. silent over-statement on the overlapping case.

## Change
- `_ols.py::ols_alpha`: `alpha_t` from `_ols_nw_multivariate`'s `V_hac[0,0]`, `auto_bartlett(n)` lags; point estimates unchanged; degenerate paths preserved.
- `spanning.py` docstring Notes rewritten; `method` → `"OLS spanning regression, Newey-West HAC SE"`.
- Tests: HAC t < OLS t under AR(0.7) residuals; mean HAC/OLS ratio over 200 iid draws within [0.95, 1.10] (a single-draw closeness test was wrong — p95 of the ratio is 1.23, which is the point).

## Breaking
All `spanning_alpha` / `greedy_forward_selection` t and p move.

2319 passed, 3 skipped; `ruff` / `mypy` clean.