### PR TITLE
docs(stats): state the HAC trade both ways, and de-duplicate the one-signed warning

### DIFF
--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -426,6 +426,25 @@ gap matters. Distinct from the single-restriction NW-HAC **Wald** tests
 (`common_quantile_spread`, `common_asymmetry`), which *do* use a finite-sample
 $F_{r,\,T-k}$ reference.
 
+Measured on the `spanning_alpha` path (true null, one base factor, 4000
+draws), the anti-conservatism is mild on iid residuals and substantial on
+autocorrelated ones — empirical size at a nominal 5%:
+
+| residuals | $n=60$ | $n=120$ | $n=240$ |
+|---|---|---|---|
+| iid | 0.071 | 0.065 | 0.054 |
+| AR(0.6) | 0.185 | 0.135 | 0.115 |
+
+The iid column is the small-sample noise described above and shrinks
+normally. The AR column converges slowly enough to matter at realistic
+sample lengths, and is a property of the Bartlett kernel rather than of
+any one metric, so every HAC path listed here inherits it. It is
+disclosed rather than corrected: a finite-sample fix (fixed-$b$ critical
+values, or Andrews-Monahan prewhitening) would change every HAC $p$-value
+in the library and is a project rather than a patch. Read HAC $p$-values
+near the threshold as optimistic when the input is persistent — the
+`persistence` diagnostic in section 4 flags exactly that case.
+
 ## 7. Missing-value convention (null vs NaN)
 
 polars distinguishes `null` (missing) from float `NaN` (a value), and

--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -35,16 +35,39 @@ def ols_alpha(
     HAC standard error (Bartlett kernel, [Newey-West (1994)][newey-west-1994]
     automatic bandwidth) rather than the homoskedastic OLS SE. Spanning
     alphas are routinely reported with HAC t-stats (Barillas-Shanken,
-    Fama-French). The cost on a genuinely non-overlapping, homoskedastic
-    series is the usual small-sample HAC noise: at ``n = 120`` iid the
-    HAC t has empirical size 6.7% at a nominal 5% (OLS ≈ 5%), the same
-    mild anti-conservatism every other HAC path in factrix carries and
-    ``statistical-methods`` §6 discloses. An overlapping or
-    heteroskedastic series is corrected instead of silently over-stated,
-    which is the trade this buys. An earlier version used the
-    OLS SE on the stated assumption that callers pass non-overlap spreads;
-    nothing in the ``(date, spread)`` input could verify that, so the
-    assumption was retired rather than documented harder.
+    Fama-French).
+
+    **The trade, measured.** Empirical size at a nominal 5% under a true
+    null (``alpha = 0``, one base factor, 4000 draws, read against
+    ``t(n - k)``):
+
+    | residuals | OLS | HAC |
+    |---|---|---|
+    | iid, n=60 | 0.047 | 0.071 |
+    | iid, n=120 | 0.052 | 0.065 |
+    | iid, n=240 | 0.047 | 0.054 |
+    | AR(0.6), n=60 | 0.337 | 0.185 |
+    | AR(0.6), n=120 | 0.332 | 0.135 |
+    | AR(0.6), n=240 | 0.330 | 0.115 |
+
+    On the case the retired assumption was written for — iid, genuinely
+    non-overlapping — HAC costs 1–2 points of size, the usual small-sample
+    HAC noise every other HAC path in factrix carries and
+    ``statistical-methods`` §6 discloses. On the case the assumption was
+    silently covering, the OLS SE rejects at **33%** and does not improve
+    with more data, because it is estimating the wrong quantity: the
+    autocorrelation is in the residuals, and more of them does not help.
+    Trading ~1.5 points for ~20 is not a close call.
+
+    HAC is not itself well calibrated on the autocorrelated case (0.115 at
+    n=240 and converging slowly); it is merely far closer. That residual
+    gap is a Bartlett small-sample property shared by every HAC path here,
+    not something specific to spanning.
+
+    An earlier version used the OLS SE on the stated assumption that
+    callers pass non-overlap spreads; nothing in the ``(date, spread)``
+    input could verify that, so the assumption was retired rather than
+    documented harder.
 
     Returns:
         _OLSResult with alpha, HAC t_stat, betas, R², and residual degrees

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -255,19 +255,30 @@ def top_concentration(
         return sc
 
     warning_codes: list[str] = []
+    one_signed_meta: dict[str, int] = {}
     if weight_by == "abs_factor":
         finite_f = _finite_values(data[factor_col])
         n_pos = int((finite_f > 0).sum())
         n_neg = int((finite_f < 0).sum())
         if finite_f.len() and (n_pos == 0 or n_neg == 0):
             warning_codes.append(WarningCode.ONE_SIGNED_FACTOR.value)
+            one_signed_meta = {
+                "n_positive_factor_values": n_pos,
+                "n_negative_factor_values": n_neg,
+            }
+            # Constant message, counts in metadata: Python de-duplicates
+            # warnings per (text, category, module, lineno), so interpolating
+            # the counts made every call a distinct warning and a by_slice
+            # sweep or multi-factor evaluate emitted one per call instead of
+            # one per session.
             warnings.warn(
-                f"top_concentration: weight_by='abs_factor' on a factor that "
-                f"never changes sign ({n_pos} positive, {n_neg} negative finite "
-                f"values). |factor| is a density weight only when zero is the "
-                f"neutral point, and the HHI of |f| moves with an arbitrary "
-                f"level shift. Centre the factor (cross-sectional z-score) or "
-                f"use weight_by='alpha_contribution'.",
+                "top_concentration: weight_by='abs_factor' on a factor that "
+                "never changes sign. |factor| is a density weight only when "
+                "zero is the neutral point, and the HHI of |f| moves with an "
+                "arbitrary level shift. Centre the factor (cross-sectional "
+                "z-score) or use weight_by='alpha_contribution'. Counts are "
+                "in metadata['n_positive_factor_values'] / "
+                "['n_negative_factor_values'].",
                 UserWarning,
                 stacklevel=2,
             )
@@ -332,6 +343,8 @@ def top_concentration(
         # non-finite weight (both HHI and n_top exclude them).
         "n_top_members_selected": n_top_selected,
         "n_top_members_dropped": n_top_dropped,
+        # Present only when ONE_SIGNED_FACTOR fired; the sign split behind it.
+        **one_signed_meta,
     }
     # A uniform factor gives every date the same diversification ratio: the
     # ratio itself is still the answer, the one-sided t is not computable.

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -229,8 +229,11 @@ def spanning_alpha(
         homoskedastic OLS SE on the stated assumption that inputs are
         non-overlap spreads; nothing in a ``(date, spread)`` frame can
         verify that, so the SE is now robust to whatever the caller
-        passes. On a genuinely non-overlapping series the two agree to
-        within the 1–2 lags the auto bandwidth selects.
+        passes. On a genuinely non-overlapping iid series the HAC t costs
+        1–2 points of size (6.5% at ``n = 120`` against a nominal 5%); on
+        one with AR(0.6) residuals the OLS SE it replaces rejects at 33%
+        and does not improve with sample size. See
+        :func:`factrix._ols.ols_alpha` for the measured table.
 
     References:
         - [Barillas & Shanken (2017)][barillas-shanken-2017]. "Which

--- a/tests/test_concentration.py
+++ b/tests/test_concentration.py
@@ -232,7 +232,7 @@ class TestOneSignedFactorWarning:
     """
 
     @staticmethod
-    def _panel(shift: float):
+    def _panel(shift: float, n_assets: int = 30):
         from datetime import datetime, timedelta
 
         import numpy as np
@@ -241,8 +241,8 @@ class TestOneSignedFactorWarning:
         rng = np.random.default_rng(0)
         rows = []
         for d in range(40):
-            f = rng.standard_normal(30) + shift
-            for a in range(30):
+            f = rng.standard_normal(n_assets) + shift
+            for a in range(n_assets):
                 rows.append(
                     {
                         "date": datetime(2024, 1, 1) + timedelta(days=d),
@@ -262,6 +262,49 @@ class TestOneSignedFactorWarning:
             result = top_concentration(self._panel(shift=-10.0), forward_periods=1)
         assert WarningCode.ONE_SIGNED_FACTOR.value in result.warning_codes
         assert result.value is not None  # advisory only — metric still ran
+
+    def test_counts_land_in_metadata_and_the_message_is_constant(self):
+        """Counts belong in metadata so the warning text can de-duplicate.
+
+        Python keys its duplicate filter on (text, category, module, lineno).
+        Interpolating the sign counts made the text vary with the panel, so a
+        ``by_slice`` sweep or a multi-factor ``evaluate`` — where each call
+        sees a different number of values — emitted one warning per call
+        instead of one per session. Two panels of *different sizes* are what
+        exercises that; two identical calls de-duplicate either way.
+        """
+        import warnings as _warnings
+
+        from factrix._codes import WarningCode
+        from factrix.metrics.concentration import top_concentration
+
+        small = self._panel(shift=-10.0, n_assets=30)
+        large = self._panel(shift=-10.0, n_assets=45)
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("default")
+            first = top_concentration(small, forward_periods=1)
+            second = top_concentration(large, forward_periods=1)
+
+        one_signed = [w for w in caught if "never changes sign" in str(w.message)]
+        assert len(one_signed) == 1, (
+            "panels of different sizes must still produce one de-duplicated "
+            f"warning; got {[str(w.message) for w in one_signed]}"
+        )
+        assert not any(ch.isdigit() for ch in str(one_signed[0].message))
+
+        assert first.metadata["n_negative_factor_values"] == 30 * 40
+        assert second.metadata["n_negative_factor_values"] == 45 * 40
+        for result in (first, second):
+            assert WarningCode.ONE_SIGNED_FACTOR.value in result.warning_codes
+            assert result.metadata["n_positive_factor_values"] == 0
+
+    def test_counts_absent_when_the_factor_is_two_sided(self):
+        """The keys are conditional — they describe why the code fired."""
+        from factrix.metrics.concentration import top_concentration
+
+        result = top_concentration(self._panel(shift=0.0), forward_periods=1)
+        assert "n_positive_factor_values" not in result.metadata
+        assert "n_negative_factor_values" not in result.metadata
 
     def test_centred_factor_does_not_warn(self):
         from factrix._codes import WarningCode


### PR DESCRIPTION
Wrap-up of the two documentation items deferred out of the pre-1.0 review batch, per the convention that sub-issue PRs stay code-only and prose is batched to the epic close.

## The HAC rationale was one-sided

`spanning_alpha` moved from the homoskedastic OLS SE to a Newey-West HAC SE. The docstrings quantified only what that costs — 6.5% empirical size at a nominal 5% on iid `n = 120`, against OLS's ~5% — and never wrote down what it buys. A reader holding only that number has everything they need to argue for reverting.

Measured on the same harness (true null, `alpha = 0`, one base factor, 4000 draws, read against `t(n − k)`):

| residuals | OLS | HAC |
|---|---|---|
| iid, n=60 | 0.047 | 0.071 |
| iid, n=120 | 0.052 | 0.065 |
| iid, n=240 | 0.047 | 0.054 |
| AR(0.6), n=60 | **0.337** | 0.185 |
| AR(0.6), n=120 | **0.332** | 0.135 |
| AR(0.6), n=240 | **0.330** | 0.115 |

The OLS SE rejects at 33% under AR(0.6) residuals and does not improve with sample size — the autocorrelation is in the residuals, so more of them does not help. Trading ~1.5 points of size for ~20 is not a close call.

Both docstrings now carry the full table, and say plainly that HAC is not itself well calibrated on the autocorrelated case (0.115 at `n = 240`, converging slowly) — merely far closer.

`statistical-methods` §6 gains the same table, which is its proper home: the slow AR convergence is a Bartlett small-sample property, so every HAC path in the library inherits it rather than just spanning. The section states it is disclosed rather than corrected and names what a correction would take (fixed-$b$ critical values, Andrews-Monahan prewhitening), so that decision is legible instead of implicit.

## The one-signed warning could not de-duplicate

`top_concentration`'s `ONE_SIGNED_FACTOR` warning interpolated the positive and negative counts into its message. Python keys its duplicate filter on `(text, category, module, lineno)`, so a text that varies with the panel de-duplicates only against itself — a `by_slice` sweep or a multi-factor `evaluate`, where each call sees a different number of values, emitted one warning per call instead of one per session.

The message is now a constant string; the counts move to `metadata["n_positive_factor_values"]` / `["n_negative_factor_values"]`, present only when the code fires.

The regression test deliberately uses two panels of **different sizes**. Two identical calls de-duplicate under either implementation, so a same-panel test passes against the interpolated message and proves nothing — verified by mutation: the strengthened test fails against the old message, the first draft did not.

## Checks

2328 passed / 3 skipped, doctests 95 passed, `ruff check`, `ruff format --check`, `mypy factrix` all clean. No numeric behaviour change: the docstring edits are prose, and the warning change moves counts between fields without touching the metric's value, stat, or p.
