### PR TITLE
fix(slicing): F_{K−1, Satterthwaite ν} reference for the joint period test

### DIFF
--- a/factrix/_stats/wald.py
+++ b/factrix/_stats/wald.py
@@ -43,7 +43,7 @@ def _wald_p_linear(
     R: np.ndarray,
     q: np.ndarray | float = 0.0,
     *,
-    df_denom: int | None = None,
+    df_denom: float | None = None,
 ) -> tuple[float, float]:
     """Wald test of the linear restriction ``Rβ = q``.
 

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -415,8 +415,11 @@ def _satterthwaite_df(variances: np.ndarray, n_periods: np.ndarray) -> float:
     tolerance from roughly n ≈ 60 and would pin ν at the floor for
     perfectly healthy data. ``K = 2`` is the pairwise Welch df; ``K > 2``
     is the same Satterthwaite approximation on the diagonal Wald form the
-    omnibus uses (measured 5.4–5.8% at nominal 5% across K = 3–5 and
-    T = 20–150, vs 5.7–6.7% for χ²_{K-1}). Floors at 1.0 so a degenerate
+    omnibus uses. At the slice lengths the public API admits (``ic``
+    floors at 50 periods) ν lands in the hundreds, where ``F_{K-1, ν}``
+    and ``χ²_{K-1}`` are practically the same reference — the point of
+    using it is consistency with the pairwise path and disclosing ν, not
+    a size correction. Floors at 1.0 so a degenerate
     set (all variances zero) cannot hand ``f.sf`` a zero df.
     """
     v = np.asarray(variances, dtype=float)
@@ -578,8 +581,11 @@ def slice_period_joint_test(
         )
         # Same finite-sample reference the pairwise path uses, generalised
         # to K slices: F_{K-1, ν} with the Satterthwaite ν on the diagonal
-        # Wald form, instead of the asymptotic χ²_{K-1} that over-rejected
-        # at short slices (5.7–6.7% for a nominal 5%).
+        # Wald form. Consistency + disclosure, not a size fix: at reachable
+        # slice lengths ν is in the hundreds and F ≈ χ². The joint path's
+        # residual over-rejection (5.8–8.0% at nominal 5%, not converging
+        # in T) comes from understated HAC variances in
+        # ``_analytic_slice_moments``, tracked separately.
         nu = _satterthwaite_df(
             variances, np.array([len(series) for series in series_list])
         )

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -366,8 +366,9 @@ def slice_period_pairwise_test(
             # ``slicing.inference`` and because the disclosed ν lets a
             # reader recompute p from ``stat``. ν is per pair because the
             # two slices differ in length.
-            nu = _welch_df(
-                float(variances[i]), n_periods[i], float(variances[j]), n_periods[j]
+            nu = _satterthwaite_df(
+                np.array([variances[i], variances[j]]),
+                np.array([n_periods[i], n_periods[j]]),
             )
             if se2 <= EPSILON:
                 chi = 0.0
@@ -403,27 +404,31 @@ def slice_period_pairwise_test(
     )
 
 
-def _welch_df(var_a: float, n_a: int, var_b: float, n_b: int) -> float:
-    """Welch-Satterthwaite denominator df for a two-sample mean contrast.
+def _satterthwaite_df(variances: np.ndarray, n_periods: np.ndarray) -> float:
+    """Welch-Satterthwaite denominator df for a contrast of K slice means.
 
-    ``var_*`` are the (HAC) variances *of the mean*, so the classic
+    ``variances`` are the (HAC) variances *of the mean*, so the classic
     ``s²/n`` terms are already folded in. The ratio is computed on the
-    variance *shares* ``w = var / (var_a + var_b)`` so it is scale-free:
-    ``var_*`` shrinks like ``σ²/n`` and the raw ``Σ var²/(n-1)``
-    denominator like ``σ⁴/n³``, which for a per-period σ ≈ 0.1 drops
-    below any absolute tolerance from roughly n ≈ 60 and would pin ν at
-    the floor for perfectly healthy data. Floors at 1.0 so a degenerate
-    pair (both variances zero) cannot hand ``f.sf`` a zero df.
+    variance *shares* ``w = var / Σ var`` so it is scale-free: ``var_*``
+    shrinks like ``σ²/n`` and the raw ``Σ var²/(n-1)`` denominator like
+    ``σ⁴/n³``, which for a per-period σ ≈ 0.1 drops below any absolute
+    tolerance from roughly n ≈ 60 and would pin ν at the floor for
+    perfectly healthy data. ``K = 2`` is the pairwise Welch df; ``K > 2``
+    is the same Satterthwaite approximation on the diagonal Wald form the
+    omnibus uses (measured 5.4–5.8% at nominal 5% across K = 3–5 and
+    T = 20–150, vs 5.7–6.7% for χ²_{K-1}). Floors at 1.0 so a degenerate
+    set (all variances zero) cannot hand ``f.sf`` a zero df.
     """
-    total = var_a + var_b
+    v = np.asarray(variances, dtype=float)
+    n = np.asarray(n_periods, dtype=float)
+    total = float(v.sum())
     if not np.isfinite(total) or total <= 0.0:
         return 1.0
-    w_a = var_a / total
-    w_b = var_b / total
-    den = (w_a**2) / max(n_a - 1, 1) + (w_b**2) / max(n_b - 1, 1)
+    w = v / total
+    den = float(np.sum(w**2 / np.maximum(n - 1.0, 1.0)))
     if not np.isfinite(den) or den <= 0.0:
         return 1.0
-    return max(1.0 / float(den), 1.0)
+    return max(1.0 / den, 1.0)
 
 
 def _analytic_slice_moments(
@@ -538,11 +543,11 @@ def slice_period_joint_test(
         multiplicity)``. ``stat`` is the joint Wald statistic. The mechanism
         columns
         disclose the reference: ``stat_type="wald"``, ``df_num=K-1``
-        (restriction rank) and ``df_denom=None`` (disjoint samples have no
-        finite-cluster denominator); ``reference_dist`` is ``"chi2"`` —
-        ``p_value`` from the χ²_{K-1} survival function — for
-        ``method="analytic"``, or ``"bootstrap_null"`` for
-        ``method="bootstrap"``. ``multiplicity`` is ``None`` — a single
+        (restriction rank); ``reference_dist`` is ``"f"`` for
+        ``method="analytic"`` — ``p_value`` from ``F_{K-1, ν}`` with the
+        Satterthwaite ``ν`` in ``df_denom``, the K-slice form of the
+        pairwise Welch reference — or ``"bootstrap_null"`` (``df_denom``
+        ``None``) for ``method="bootstrap"``. ``multiplicity`` is ``None`` — a single
         omnibus has no family-internal correction.
 
     Raises:
@@ -571,7 +576,15 @@ def slice_period_joint_test(
         means, variances = _analytic_slice_moments(
             series_list, _read_forward_periods_stamp(data)
         )
-        stat, p = _wald_p_linear(means, np.diag(variances), restriction)
+        # Same finite-sample reference the pairwise path uses, generalised
+        # to K slices: F_{K-1, ν} with the Satterthwaite ν on the diagonal
+        # Wald form, instead of the asymptotic χ²_{K-1} that over-rejected
+        # at short slices (5.7–6.7% for a nominal 5%).
+        nu = _satterthwaite_df(
+            variances, np.array([len(series) for series in series_list])
+        )
+        stat, p = _wald_p_linear(means, np.diag(variances), restriction, df_denom=nu)
+        df_denom = nu
 
     return pl.DataFrame(
         {
@@ -579,9 +592,9 @@ def slice_period_joint_test(
             "stat": [stat],
             "p_value": [p],
             "stat_type": ["wald"],
-            "reference_dist": ["bootstrap_null" if method == "bootstrap" else "chi2"],
+            "reference_dist": ["bootstrap_null" if method == "bootstrap" else "f"],
             "df_num": [k - 1],
-            "df_denom": [None],
+            "df_denom": [None if method == "bootstrap" else df_denom],
             "multiplicity": [None],
         }
     )

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -37,10 +37,41 @@ def test_single_row_shape(method: str) -> None:
     assert out["df_num"][0] == 2
     assert out["stat_type"][0] == "wald"
     assert out["reference_dist"][0] == (
-        "bootstrap_null" if method == "bootstrap" else "chi2"
+        "bootstrap_null" if method == "bootstrap" else "f"
     )
-    assert out["df_denom"][0] is None
+    if method == "bootstrap":
+        assert out["df_denom"][0] is None
+    else:
+        # Satterthwaite ν on three 80-period slices: well above the 1.0
+        # floor (which is the degenerate value) and at most the pooled dof.
+        assert 50.0 < out["df_denom"][0] <= 3 * 80 - 3
     assert out["multiplicity"][0] is None
+
+
+def test_analytic_omnibus_reference_is_satterthwaite_f() -> None:
+    """The analytic omnibus p is ``F_{K-1, ν}`` on the disclosed ``df_denom``.
+
+    Same finite-sample reference as the pairwise path, generalised to K
+    slices; the earlier asymptotic χ²_{K-1} over-rejected at short slices.
+    """
+    from scipy import stats as sp_stats
+
+    df = build_disjoint_period_panel(
+        seed=5,
+        spans={"a": (60, 0.1), "b": (90, 0.1), "c": (120, 0.1)},
+        label_col="regime",
+    )
+    out = slice_period_joint_test(
+        df, ic(), by="regime", factor_col="factor", method="analytic"
+    )
+    k, stat, nu, p = (
+        out["k_slices"][0],
+        out["stat"][0],
+        out["df_denom"][0],
+        out["p_value"][0],
+    )
+    assert p == pytest.approx(float(sp_stats.f.sf(stat / (k - 1), dfn=k - 1, dfd=nu)))
+    assert nu != pytest.approx(round(nu))  # unequal slices → fractional ν
 
 
 @pytest.mark.parametrize("method", ["bootstrap", "analytic"])

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -102,16 +102,27 @@ def test_welch_df_does_not_collapse_at_long_slices() -> None:
         assert nu == pytest.approx(298.0, rel=0.05)
 
 
-def test_welch_df_is_scale_free() -> None:
-    """Rescaling both variances by a constant leaves ν unchanged."""
-    from factrix.slicing.period_inference import _welch_df
+def test_satterthwaite_df_is_scale_free() -> None:
+    """Rescaling all variances by a constant leaves ν unchanged.
 
-    base = _welch_df(2.0e-4, 60, 5.0e-4, 120)
+    The df is computed on variance *shares*, so there is no absolute
+    quantity to underflow against a tolerance — the defect that pinned
+    ν at 1.0 on larger slices before the shares form was adopted.
+    """
+    import numpy as np
+    from factrix.slicing.period_inference import _satterthwaite_df
+
+    v = np.array([2.0e-4, 5.0e-4])
+    n = np.array([60, 120])
+    base = _satterthwaite_df(v, n)
     assert base > 1.0
     for scale in (1e-6, 1e-3, 1e3):
-        assert _welch_df(2.0e-4 * scale, 60, 5.0e-4 * scale, 120) == pytest.approx(base)
-    # Only a genuinely degenerate pair (both variances zero) hits the floor.
-    assert _welch_df(0.0, 60, 0.0, 120) == 1.0
+        assert _satterthwaite_df(v * scale, n) == pytest.approx(base)
+    # Only a genuinely degenerate set (all variances zero) hits the floor.
+    assert _satterthwaite_df(np.zeros(2), n) == 1.0
+    # K = 3 is the same function the omnibus uses; still scale-free.
+    v3, n3 = np.array([1e-4, 2e-4, 3e-4]), np.array([60, 90, 120])
+    assert _satterthwaite_df(v3 * 1e-5, n3) == pytest.approx(_satterthwaite_df(v3, n3))
 
 
 def test_three_slice_returns_three_rows() -> None:


### PR DESCRIPTION
> **TL;DR** — Closes #817. The analytic joint omnibus moves from χ²(K−1) to `F_{K−1, ν}` with a Satterthwaite ν, **for consistency with the pairwise path and to disclose ν** — not as a size fix. At reachable slice lengths ν is in the hundreds and the two references agree to ≤ 0.006. The joint path's residual 5.8–8.0% over-rejection is a variance understatement in `_analytic_slice_moments`, tracked in #820.

## Rationale (revised after review)

The first version of this PR quoted a size improvement from a grid whose two most favourable cells (`T = 20`, `T = 30`) sit below `ic`'s 50-period floor and cannot be produced through the public API. Restricted to reachable cells the correction is inert. What remains true:

- `F_{K−1, ν}` with an estimated `V` is the more defensible finite-sample reference on principle, and it is what the pairwise path already uses since #813 — so the file no longer carries two conventions.
- `df_denom` now discloses ν on the analytic omnibus (was `None`), so a reader can recompute `p` from `stat`.

## Measured through the public path (reviewer's harness, real HAC variances, nominal 5%)

| K | T | χ² (main) | F (this PR) | ν |
|---|---|---|---|---|
| 3 | 50 | 0.080 | 0.074 | 138 |
| 3 | 90 | 0.058 | 0.058 | 257 |
| 3 | 150 | 0.060 | 0.060 | 434 |
| 5 | 50 | 0.078 | 0.076 | 227 |
| 5 | 150 | 0.080 | 0.080 | 720 |

**Unresolved and out of scope here**: the joint path sits at 5.8–8.0% under either reference and does not converge in T (K=5, T=150 still 0.080). With ν in the hundreds no denominator df can fix that — the Wald statistic itself is too large, i.e. the per-slice HAC variances are understated. → #820.

## Change
- `_welch_df` → `_satterthwaite_df(variances, n_periods)` (K-array, shares form); pairwise calls it with two slices — verified unchanged to one ULP over 20k draws.
- Omnibus analytic: `_wald_p_linear(..., df_denom=ν)`; `reference_dist="f"`, `df_denom=ν`. Bootstrap omnibus untouched.
- `_wald_p_linear.df_denom` typed `float | None`.
- #813's scale-free test renamed to the new helper and extended to K=3.

## Breaking
Analytic `slice_period_joint_test` mechanism columns change (`reference_dist`, `df_denom`); p-values move by ≤ 0.006 at reachable sizes.

2329 passed, 3 skipped; `ruff` / `mypy` clean.