### PR TITLE
docs(slicing): disclose the joint period test's short-slice over-rejection

### DIFF
--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -445,6 +445,24 @@ in the library and is a project rather than a patch. Read HAC $p$-values
 near the threshold as optimistic when the input is persistent — the
 `persistence` diagnostic in section 4 flags exactly that case.
 
+### Joint period test on short slices: known over-rejection
+
+`slice_period_joint_test` with `K ≥ 3` slices shorter than ~150 periods
+over-rejects on a true null — measured 8–9% at a nominal 5% for `K = 5`
+with 50–90-period slices, converging to ~5.5% by `T = 150`; `K = 2` is
+calibrated throughout. The cause is the per-slice Bartlett HAC variance
+estimate, whose effective degrees of freedom at `T = 50` are ≈ 21 rather
+than `T − 1`: with the *true* variances the same Wald statistic rejects
+3.8%, so neither the aggregation nor the `F` reference is at fault. The
+bootstrap path inherits the same noise (12% at `K = 5`, `T = 50`).
+Andrews-Monahan prewhitening, the Newey-West (1994) plug-in bandwidth, a
+Hotelling-style `F` on the HAC effective df, and a Satterthwaite ν on
+that df were each measured; none calibrates the iid short-slice case
+(prewhitening is the right tool for *autocorrelated* input — see the HAC
+size sweep tracker). The function warns in this regime and the
+characterisation test pins the measured band; pairwise contrasts on the
+same slices (5–6%) are the better-calibrated read.
+
 ## 7. Missing-value convention (null vs NaN)
 
 polars distinguishes `null` (missing) from float `NaN` (a value), and

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -59,6 +59,7 @@ Matrix-row: slice_period_pairwise_test, slice_period_joint_test | (*, *, *, *, *
 
 from __future__ import annotations
 
+import warnings
 from itertools import combinations
 from typing import Literal
 
@@ -92,6 +93,16 @@ Method = Literal["bootstrap", "analytic"]
 
 _N_RESAMPLES = 999
 _SCHEME: Scheme = "stationary"
+
+# Slice length below which the joint test's realised size exceeds ~1.5× its
+# nominal level on a true null with K >= 3 slices. Set from the measured
+# K × T grid (500 seeds each, iid per-date IC, nominal 5%): K=5 rejects 9.4% /
+# 8.2% / 5.4% / 5.6% and K=3 6.2% / 7.8% / 5.4% / 3.8% at T = 50 / 90 / 150 /
+# 250, while K=2 stays within 4.6–5.8% throughout. The excess is the
+# per-slice Bartlett HAC variance estimate's small-sample noise (effective
+# df ≈ 21 at T=50, not T-1) inverted across K-1 restrictions; the bootstrap
+# path shows the same 12% at K=5, T=50, so it is not a routing fix.
+_JOINT_SHORT_SLICE_PERIODS = 150
 
 
 def _validate_method(method: str, func_name: str) -> None:
@@ -519,8 +530,8 @@ def slice_period_joint_test(
     because the slices are independent samples, the cross-slice covariance
     is **block-diagonal** — ``Var(μ_k)`` on the diagonal, zero off it. Both
     methods share the same Wald quadratic form; they differ in how the null
-    is referenced, mirroring the pairwise path: ``"analytic"`` uses the
-    χ²_{K-1} asymptotic distribution, while ``"bootstrap"`` calibrates the
+    is referenced, mirroring the pairwise path: ``"analytic"`` uses an
+    ``F_{K-1, ν}`` reference with a Satterthwaite ``ν``, while ``"bootstrap"`` calibrates the
     statistic against its own block-bootstrap null (so a short-regime
     omnibus stays small-sample robust instead of leaning on χ²
     asymptotics). Useful for **regime analysis**: a single test of "does
@@ -561,12 +572,49 @@ def slice_period_joint_test(
             metric's own ``SampleThreshold`` floor (the size at which
             :func:`factrix.by_slice` short-circuits the metric to NaN).
         TypeError: Metric is not slice-test-eligible.
+
+    Warns:
+        UserWarning: ``K >= 3`` and the shortest slice has fewer than 150
+            periods. Measured size on a true null (iid per-date IC, nominal
+            5%, 500 seeds per cell), rows ``K``, columns ``T``::
+
+                K / T     50     90    150    250
+                2        .046   .058   .052   .046
+                3        .062   .078   .054   .038
+                5        .094   .082   .054   .056
+
+            The excess is not the reference distribution (``F`` and χ²
+            agree at these ν) and not the aggregation (with the true
+            variances the same statistic rejects 3.8%): each slice's
+            Bartlett HAC variance is a noisy small-sample estimate —
+            effective df ≈ 21 at ``T = 50`` rather than ``T - 1`` — and
+            inverting K-1 of them inflates the Wald. The bootstrap path
+            carries the same noise (12% at ``K=5, T=50``), so switching
+            method does not help; a longer slice does. Prewhitening,
+            plug-in bandwidths and finite-sample F references were each
+            measured and none calibrates this case. Pairwise contrasts on
+            the same slices sit at 5–6% and are the better-calibrated read.
     """
     _validate_metric_instance(metric, "slice_period_joint_test")
     _validate_method(method, "slice_period_joint_test")
     labels, series_list = _build_per_slice_series(
         data, metric, by, factor_col=factor_col, func_name="slice_period_joint_test"
     )
+    k = len(series_list)
+    shortest = min(len(series) for series in series_list)
+    if k >= 3 and shortest < _JOINT_SHORT_SLICE_PERIODS:
+        warnings.warn(
+            f"slice_period_joint_test: {k} slices with the shortest at "
+            f"{shortest} periods (< {_JOINT_SHORT_SLICE_PERIODS}). On a true "
+            f"null the joint test over-rejects here — measured 8–9% at a "
+            f"nominal 5% for K=5 with 50–90-period slices, under both "
+            f"methods — because each slice's HAC variance is a noisy "
+            f"small-sample estimate inverted across K-1 restrictions. Read "
+            f"the p-value as indicative; pairwise contrasts on the same "
+            f"slices are better calibrated.",
+            UserWarning,
+            stacklevel=2,
+        )
     k = len(labels)
     restriction = _equality_restriction(k)
 
@@ -583,8 +631,8 @@ def slice_period_joint_test(
         # to K slices: F_{K-1, ν} with the Satterthwaite ν on the diagonal
         # Wald form. Consistency + disclosure, not a size fix: at reachable
         # slice lengths ν is in the hundreds and F ≈ χ². The joint path's
-        # residual over-rejection (5.8–8.0% at nominal 5%, not converging
-        # in T) comes from understated HAC variances in
+        # residual over-rejection (up to ~9% at nominal 5% on short slices,
+        # converging by T ≈ 150) comes from understated HAC variances in
         # ``_analytic_slice_moments``, tracked separately.
         nu = _satterthwaite_df(
             variances, np.array([len(series) for series in series_list])

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -600,11 +600,10 @@ def slice_period_joint_test(
     labels, series_list = _build_per_slice_series(
         data, metric, by, factor_col=factor_col, func_name="slice_period_joint_test"
     )
-    k = len(series_list)
     shortest = min(len(series) for series in series_list)
-    if k >= 3 and shortest < _JOINT_SHORT_SLICE_PERIODS:
+    if len(series_list) >= 3 and shortest < _JOINT_SHORT_SLICE_PERIODS:
         warnings.warn(
-            f"slice_period_joint_test: {k} slices with the shortest at "
+            f"slice_period_joint_test: {len(series_list)} slices with the shortest at "
             f"{shortest} periods (< {_JOINT_SHORT_SLICE_PERIODS}). On a true "
             f"null the joint test over-rejects here — measured 8–9% at a "
             f"nominal 5% for K=5 with 50–90-period slices, under both "
@@ -632,8 +631,9 @@ def slice_period_joint_test(
         # Wald form. Consistency + disclosure, not a size fix: at reachable
         # slice lengths ν is in the hundreds and F ≈ χ². The joint path's
         # residual over-rejection (up to ~9% at nominal 5% on short slices,
-        # converging by T ≈ 150) comes from understated HAC variances in
-        # ``_analytic_slice_moments``, tracked separately.
+        # converging by T ≈ 150) comes from the *noise* of each slice's
+        # small-sample HAC variance estimate (effective df ≈ 21 at T = 50),
+        # not from bias — see the Warns block on ``slice_period_joint_test``.
         nu = _satterthwaite_df(
             variances, np.array([len(series) for series in series_list])
         )

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -210,9 +210,10 @@ class TestShortSliceDisclosure:
     """Short slices with K >= 3 warn, and the measured size band is pinned.
 
     The characterisation test asserts the *measured* band, not ``<= nominal``:
-    this path is known to over-reject on short slices, and the point of the
-    pin is that any future improvement (or regression) shows up as a
-    failure rather than being absorbed by a loose bound.
+    this path is known to over-reject on short slices. At 120 reps the band
+    is ~±2.5 SE wide, so it pins the order of magnitude and catches a large
+    regression (or a large improvement, which should prompt re-measuring
+    the grid) — it will not detect a shift of a percentage point or two.
     """
 
     @staticmethod

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -204,3 +204,70 @@ def test_raises_when_slice_below_metric_floor() -> None:
     )
     with pytest.raises(ValueError, match="sample floor"):
         slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=11)
+
+
+class TestShortSliceDisclosure:
+    """Short slices with K >= 3 warn, and the measured size band is pinned.
+
+    The characterisation test asserts the *measured* band, not ``<= nominal``:
+    this path is known to over-reject on short slices, and the point of the
+    pin is that any future improvement (or regression) shows up as a
+    failure rather than being absorbed by a loose bound.
+    """
+
+    @staticmethod
+    def _null_panel(seed: int, k: int, t: int):
+        return build_disjoint_period_panel(
+            seed=seed, spans={f"s{i}": (t, 0.1) for i in range(k)}, label_col="regime"
+        )
+
+    def test_short_slices_with_three_or_more_warn(self):
+        with pytest.warns(UserWarning, match="over-rejects"):
+            slice_period_joint_test(
+                self._null_panel(0, 3, 60),
+                ic(),
+                by="regime",
+                factor_col="factor",
+                method="analytic",
+            )
+
+    @pytest.mark.parametrize(("k", "t"), [(2, 60), (3, 150)])
+    def test_no_warning_outside_the_regime(self, k, t):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            slice_period_joint_test(
+                self._null_panel(0, k, t),
+                ic(),
+                by="regime",
+                factor_col="factor",
+                method="analytic",
+            )
+
+    @pytest.mark.parametrize(
+        ("k", "t", "low", "high"),
+        [
+            # measured 0.094 at 500 seeds; band is ~±2.5 SE at 120 reps
+            (5, 50, 0.04, 0.16),
+            # measured 0.052 at 500 seeds
+            (2, 150, 0.01, 0.11),
+        ],
+    )
+    def test_realised_size_band(self, k, t, low, high):
+        import warnings
+
+        reps = 120
+        rejected = 0
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for seed in range(reps):
+                out = slice_period_joint_test(
+                    self._null_panel(30000 + seed, k, t),
+                    ic(),
+                    by="regime",
+                    factor_col="factor",
+                    method="analytic",
+                )
+                rejected += out["p_value"][0] < 0.05
+        assert low <= rejected / reps <= high


### PR DESCRIPTION
> **TL;DR** — Closes #820 under its re-scoped acceptance (disclose + advisory warning + characterisation test). No numeric change. The over-rejection is real on short slices (K=5: 9.4% at T=50), converges by T≈150, and is isolated to per-slice HAC variance *noise* — not aggregation, not the reference, and not fixable by any of five candidate corrections including the bootstrap path.

## Measured grid (public path, iid true null, nominal 5%, 500 seeds/cell, SE 0.010)

| K / T | 50 | 90 | 150 | 250 |
|---|---|---|---|---|
| 2 | .046 | .058 | .052 | .046 |
| 3 | .062 | .078 | .054 | .038 |
| 5 | **.094** | **.082** | .054 | .056 |

Warning threshold `K ≥ 3 and min(T) < 150` is read off this grid (where it crosses ~1.5× nominal), per the review's requirement that it not be another unmeasured floor.

## Diagnosis (K=5, T=50, 600 seeds)

| denominator | reject | E[V̂]/V | sd(V̂/V) |
|---|---|---|---|
| shipped HAC, L=3 | 0.110 | 0.884 | 0.29 |
| sample variance, L=0 | 0.065 | 0.937 | 0.19 |
| true V (oracle) | 0.038 | 1 | 0 |

Oracle is fine → aggregation and the F reference are not at fault. The Bartlett estimate at L=3 on a ~50-period series has effective df ≈ 21 (measured 20.6), and inverting four of them is the 11%. Bias (−12%) is secondary.

**Tried and rejected**: NW1994 plug-in bandwidth (worse on iid), bootstrap routing (12.0% at K=5/T=50), Hotelling-F on effective df (over/under-corrects by K), Satterthwaite on effective df (inert), Andrews-Monahan prewhitening (neutral on iid — it is the tool for autocorrelated input, see #821).

## Change
- `warnings.warn` on the regime; `_JOINT_SHORT_SLICE_PERIODS = 150` with the grid in its comment.
- Docstring `Warns:` block carries the grid + diagnosis; also fixes the stale "analytic uses χ²" sentence and the "not converging in T" comment from #819.
- `statistical-methods.md` §6 subsection.
- `TestShortSliceDisclosure`: warning on/off by regime, and `test_realised_size_band` asserting the **measured** band (K=5/T=50 in [0.04, 0.16]; K=2/T=150 in [0.01, 0.11] at 120 reps) rather than `≤ nominal`.

2334 passed, 3 skipped; `ruff` / `mypy` clean.