### PR TITLE
fix(metrics): remove the small-cross-section bootstrap switch in spread metrics

### DIFF
--- a/docs/api/metrics/k_spread.md
+++ b/docs/api/metrics/k_spread.md
@@ -39,10 +39,11 @@ title: factrix.metrics.k_spread
 
     ---
 
-    The headline test follows the shared small-cross-section policy
-    (`_spread_significance`): with `n_assets < MIN_ASSETS_WARN` the per-date
-    spread is heavy-tailed (few names per leg), so the non-overlapping `t` is
-    replaced by a block-bootstrap CI; `metadata["method"]` records which ran.
+    The headline test is the non-overlapping `t` on the strided spread
+    series (`_spread_significance`); with `n_assets < MIN_ASSETS_WARN`
+    the metric attaches `few_assets` — the spread is a noisier estimate with
+    few names per leg — and changes nothing else. `metadata["method"]`
+    records the inference member that ran.
     Dates with fewer than `2·k` names are dropped; if none qualify the metric
     short-circuits with `max_assets_per_date`.
 
@@ -69,7 +70,7 @@ title: factrix.metrics.k_spread
 
     out = k_spread(panel, forward_periods=5, k=3)
     print(out.value, out.metadata["method"], out.metadata["cross_sectional_dispersion"])
-    # 0.0018  block-bootstrap CI  0.041   (approximate)
+    # 0.0018  non-overlapping t-test  0.041   (approximate)
     ```
 
 ## See also

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -21,11 +21,11 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 
 `n_assets` is never hard-blocked because the cross-asset t-test on E[β] is mathematically well-defined for `n_assets >= 2` — only its statistical power degrades. A hard block would force users to choose between "can't run" and "don't know there's a problem"; the warning provides the result while surfacing the issue.
 
-`FEW_ASSETS` does not imply one universal estimator switch. Spread metrics may
-switch from a cross-asset t-test to block bootstrap in the thin regime; IC,
-Fama–MacBeth, and common-beta paths retain their documented estimator and use
-the warning to flag thin ranks, low residual degrees of freedom, or unstable
-cross-asset aggregation. Read the metric metadata and method, not the warning
+`FEW_ASSETS` never changes the estimator. Spread metrics, IC, Fama–MacBeth
+and common-beta paths all retain their documented estimator and use the
+warning to flag thin ranks, low residual degrees of freedom, or unstable
+cross-asset aggregation (an earlier automatic switch of the spread metrics to
+a block bootstrap in the thin regime was removed after it measured worse). Read the metric metadata and method, not the warning
 code alone, to identify the inference path.
 
 ### Behaviour matrix by density and `n_assets`

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -59,8 +59,8 @@ contrasts, not a sidecar to a primary value.
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | none — descriptive | — | mean bars per event |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | none — descriptive | — | mean leakage score |
 | [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | cross-asset `t` on signed Spearman | `p_value` | mean \|Spearman\| |
-| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | NW HAC `t` on top-bottom spread (block-bootstrap CI when small cross-section) | `p_value` | mean(spread) |
-| [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (block-bootstrap CI when small cross-section) | `p_value` | mean(spread) |
+| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | non-overlapping `t` on top-bottom spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
+| [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
 | [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
 | [`top_concentration`][factrix.metrics.concentration.top_concentration] | one-sided `t` on diversity ratio | `p_value` | mean(eff_n) = mean(1/HHI) |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | none — descriptive | — | event-date Herfindahl-Hirschman index (HHI) |
@@ -326,9 +326,10 @@ consistency are read separately.
 #### `quantile_spread`
 
 - *primary*: `p_value` — non-overlapping `t`-test on the
-  (top − bottom) spread series. Small cross-sections
-  (`median_cross_section < MIN_ASSETS_WARN`) switch to a
-  block-bootstrap CI; see the shared small-N keys below.
+  (top − bottom) spread series (Newey-West HAC on the full series under
+  `inference=NEWEY_WEST`). Small cross-sections
+  (`median_cross_section < MIN_ASSETS_WARN`) attach `few_assets` and
+  change nothing else; see the shared small-N note below.
 - *secondary-test*: `long_alpha`, `long_stat`, `long_p_value` —
   long-leg attribution (mean excess and `t` / p-value), on
   `n_periods_long_leg` observations.
@@ -366,8 +367,7 @@ Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
 `quantile_spread`.
 
 - *primary*: `p_value` — non-overlapping `t`-test on the spread
-  series, or a block-bootstrap CI in the small-cross-section regime
-  (`method` records which).
+  series (`method` records the inference member that ran).
 - *descriptive*: `k` (names per leg), `cross_sectional_dispersion`
   (mean per-date cross-sectional return std), `top_return`,
   `bottom_return`, `n_periods` (**the sample the headline test ran on**,
@@ -382,18 +382,18 @@ Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
   but no cross-sectional variation. This is a valid `p_value = 1.0`
   result, not a short-circuit `reason`.
 
-#### Shared small-N significance keys
+#### Shared small-N note
 
-Both `quantile_spread` and `k_spread` switch the headline test to a
-block-bootstrap CI when the **median per-date** cross-section
-(`median_cross_section`) is below `MIN_ASSETS_WARN` — the heavy-tail
-rationale is per date, so a rotating universe with many lifetime
-`asset_id`s but few names quoted at a time still counts as thin. In that branch
-they additionally emit `p_value_t` (the parametric `t` p-value kept
-for reference), `bootstrap_block_length`, `bootstrap_n_resamples`,
-and `bootstrap_seed`. The switch is **not** silent: the single
-cross-section code (`few_assets`) is attached to `warning_codes`,
-so the method change surfaces as a `Warning` on the result.
+Both `quantile_spread` and `k_spread` attach `few_assets` when the
+**median per-date** cross-section (`median_cross_section`) is below
+`MIN_ASSETS_WARN` — how many names back a bucket mean is a per-date
+quantity, so a rotating universe with many lifetime `asset_id`s but few
+names quoted at a time still counts as thin. The warning is advisory; the
+headline test does not change. An earlier automatic switch to a
+block-bootstrap CI in this regime was removed after measurement: the
+bootstrap p rejected 8–20% at a nominal 5% against the `t`'s 7–9%, and
+its heavy-tail rationale had the size direction backwards (the `t` is
+size-robust to heavy tails; the small-`n` bootstrap is not).
 
 ### `concentration` (`factrix.metrics.concentration`)
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -186,9 +186,8 @@ def evaluate(
             ``expected=True`` (read the alert view via
             ``result.unexpected_warnings``), so nothing leaves the audit
             trail — the declaration says "this regime is expected", not
-            "pretend it is absent". Inference is untouched (e.g. the
-            small-cross-section block-bootstrap switch still fires and stays
-            readable in ``metadata["method"]``); only the human-facing
+            "pretend it is absent". Inference is untouched (the method that
+            ran stays readable in ``metadata["method"]``); only the human-facing
             channels go quiet — the per-run ``UserWarning`` echoes stop and
             repr emphasis moves to unexpected warnings. Unknown codes are
             rejected (typo guard). Default ``()`` — behavior is completely

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -42,7 +42,7 @@ class WarningCode(StrEnum):
     # bucket: each bucket mean rests on a handful of names, so the spread can be
     # dominated by individual assets. Advisory only — the spread is still
     # computed. Distinct from FEW_ASSETS (which keys off the absolute
-    # cross-section size driving the inference switch): a wide panel cut into
+    # cross-section size): a wide panel cut into
     # many buckets can trip this without tripping FEW_ASSETS.
     THIN_QUANTILE_GROUPS = "thin_quantile_groups"
     # Fired when a sparse ``factor`` column carries mixed signs but is

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
 from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult, PValueAlternative
 from factrix._stats import _calc_t_stat, _p_value_from_t
-from factrix._stats.constants import MIN_ASSETS_WARN
 from factrix._types import DDOF, EPSILON, KPSource, SampleAxis
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
@@ -58,12 +57,6 @@ DROP_RATE_WARN_THRESHOLD = 0.05
 # Internal diagnostic column a PANEL→SERIES primitive attaches to each per-factor
 # frame, carrying the canonical drop-stat struct from its ``.filter(...)`` step.
 _DROP_STATS_COL = "_drop_stats"
-
-# Fixed bootstrap seed for the small-cross-section significance path.
-# A spread metric's headline p must be reproducible run-to-run, so the
-# block-bootstrap branch draws from a fixed seed rather than system
-# entropy; the resolved seed is echoed into metadata for the record.
-_SPREAD_BOOTSTRAP_SEED = 0
 
 
 def _finite_expr(col: str) -> pl.Expr:
@@ -97,51 +90,38 @@ def _finite_values(series: pl.Series) -> pl.Series:
 def _spread_significance(
     spread: np.ndarray,
     n_assets: int,
-    *,
-    rng_seed: int = _SPREAD_BOOTSTRAP_SEED,
 ) -> tuple[float, float, str, dict[str, object], tuple[str, ...]]:
     """Headline significance for a per-date long-short spread series.
 
-    Returns ``(stat, p_value, method, extra_metadata, warning_codes)``.
+    Returns ``(stat, p_value, method, extra_metadata, warning_codes)`` —
+    the non-overlapping ``t`` on the strided series, with the single
+    cross-section code (``FEW_ASSETS``) attached when
+    ``n_assets < MIN_ASSETS_WARN``. The warning is advisory: a thin
+    cross-section means each leg's mean rests on a handful of names, so the
+    spread is a noisier *estimate*, not a differently-distributed one.
 
-    Small cross-sections (``n_assets < MIN_ASSETS_WARN``) switch the
-    headline test from the non-overlapping ``t`` to a block-bootstrap
-    CI: with few names per leg the per-date spread is heavy-tailed, so
-    the ``t``-test's normality assumption is unreliable while the
-    block bootstrap (Politis-Romano stationary scheme) is
-    distribution-free and preserves any residual serial dependence.
-    Larger cross-sections keep the cheaper ``t``-test. ``stat`` is the
-    ``t`` statistic in both branches as a descriptive standardised
-    effect size; in the bootstrap branch ``p_value`` comes from the
-    resampling (``extra_metadata["p_value_t"]`` keeps the parametric ``p``
-    for reference). The chosen path is named in the returned ``method``.
-
-    The switch fires exactly when :func:`cross_section_tier` flags the
-    cross-section (``n_assets < MIN_ASSETS_WARN``), so the returned
-    ``warning_codes`` carry the single ``FEW_ASSETS`` code. This
-    surfaces the method change as a :class:`Warning` on the result rather
-    than leaving it buried in metadata; severity is read from ``n_assets``.
+    An earlier version switched thin cross-sections to a block-bootstrap
+    CI on the grounds that few names per leg make the spread heavy-tailed
+    and the ``t`` unreliable. Measured, that was backwards on both counts.
+    The ``t``-test is size-robust to heavy tails — on t(3) input it rejects
+    3–4% at a nominal 5% — while the bootstrap p carries the usual small-n
+    distortion (iid input: 13.6% at ``n = 12``, 9.8% at 30, 7.4% at 60,
+    5.2% only by 120) and the strided spread series is short exactly when
+    ``forward_periods`` is large. Through the public path the bootstrap
+    branch rejected 8–20% against the ``t`` branch's 7–9%. And the switch
+    keyed on the cross-section while the bootstrap's validity depends on
+    the number of periods, so it was effectively random which estimator a
+    panel got. Removing it returns the plain ``t`` that spread metrics
+    conventionally report; whether a long-series bootstrap route is worth
+    offering is a separate, larger routing question.
     """
     n = len(spread)
     mean = float(np.mean(spread))
     std = float(np.std(spread, ddof=DDOF))
     t = _calc_t_stat(mean, std, n)
-
-    if n_assets >= MIN_ASSETS_WARN:
-        return t, _p_value_from_t(t, n), "non-overlapping t-test", {}, ()
-
-    from factrix._stats.bootstrap import _block_bootstrap_diff_p
-
-    p_boot, boot_meta = _block_bootstrap_diff_p(spread, rng_seed=rng_seed)
-    extra: dict[str, object] = {
-        "p_value_t": _p_value_from_t(t, n),
-        "bootstrap_block_length": boot_meta["block_length"],
-        "bootstrap_n_resamples": boot_meta["n_resamples"],
-        "bootstrap_seed": boot_meta["rng_seed"],
-    }
     tier: WarningCode | None = cross_section_tier(n_assets)
     codes = (tier.value,) if tier is not None else ()
-    return t, float(p_boot), "block-bootstrap CI", extra, codes
+    return t, _p_value_from_t(t, n), "non-overlapping t-test", {}, codes
 
 
 def _check_applicable_inference(
@@ -175,7 +155,6 @@ def _spread_significance_with_inference(
     full_spread: pl.DataFrame | None,
     forward_periods: int,
     n_assets: int,
-    rng_seed: int = _SPREAD_BOOTSTRAP_SEED,
 ) -> tuple[float, float, float, str, dict[str, object], tuple[str, ...]]:
     """Single headline-significance chokepoint shared by every spread metric.
 
@@ -184,46 +163,32 @@ def _spread_significance_with_inference(
     inference: the full-sample mean for the HAC path, the non-overlap mean
     otherwise.
 
-    Two deliberate layers — both ``quantile_spread`` and ``k_spread`` route
-    here so the policy lives in one place:
-
-    1. **Small-cross-section fallback (automatic, data-driven).** When the
-       cross-section is thin (``n_assets < MIN_ASSETS_WARN``) the per-date
-       spread is heavy-tailed, so the distribution-free block-bootstrap CI
-       overrides whatever ``inference`` was requested — HAC / OLS-t correct
-       *autocorrelation*, not tail thickness. The switch emits the
-       ``FEW_ASSETS`` tier code (never silent); a requested-but-overridden
-       HAC is additionally flagged ``inference_overridden``.
-    2. **Inference family (user-selected).** With an adequate cross-section
-       the requested member runs: ``NonOverlapping`` reproduces the
-       non-overlap t **bit-for-bit** (``_t_stat_from_array`` is the same
-       ``_calc_t_stat`` formula on the same strided values, so the default
-       stays byte-identical), while ``NeweyWest`` keeps the *full*
-       overlapping ``full_spread`` series and HAC-corrects the MA(h-1) SE.
+    Both ``quantile_spread`` and ``k_spread`` route here so the policy
+    lives in one place. The requested member runs: ``NonOverlapping``
+    reproduces the non-overlap t **bit-for-bit** (``_t_stat_from_array`` is
+    the same ``_calc_t_stat`` formula on the same strided values, so the
+    default stays byte-identical), while ``NeweyWest`` keeps the *full*
+    overlapping ``full_spread`` series and HAC-corrects the MA(h-1) SE. A
+    thin cross-section (``n_assets < MIN_ASSETS_WARN``) attaches
+    ``FEW_ASSETS`` on either path and changes nothing else — the automatic
+    block-bootstrap fallback that used to override the requested member
+    there was removed after measurement (see :func:`_spread_significance`).
 
     The two series inputs are a perf split, not duplicated logic: the cheap
     panel-stride feeds ``strided_spread`` for the common path; the full
     series is built (h× more bucketing) only when the HAC path needs it.
     ``full_spread`` is ``None`` off the HAC path; a missing one degrades to
-    the non-overlap path defensively. The block bootstrap is intentionally
-    *not* a family member — it is an automatic small-cross-section fallback,
-    not a blind-selectable method.
+    the non-overlap path defensively and is flagged ``inference_overridden``.
     """
     from factrix.inference import NeweyWest
 
     strided_mean = float(np.mean(strided_spread))
-    use_hac = (
-        isinstance(inference, NeweyWest)
-        and n_assets >= MIN_ASSETS_WARN
-        and full_spread is not None
-    )
+    use_hac = isinstance(inference, NeweyWest) and full_spread is not None
     if not use_hac:
-        t, p, method, extra, codes = _spread_significance(
-            strided_spread, n_assets, rng_seed=rng_seed
-        )
+        t, p, method, extra, codes = _spread_significance(strided_spread, n_assets)
         if isinstance(inference, NeweyWest):
-            # Requested HAC but the small-cross-section bootstrap (or a
-            # missing full series) took precedence — surface the override.
+            # Requested HAC but no full series was supplied — surface the
+            # degradation rather than report the non-overlap t as HAC.
             extra = {
                 **extra,
                 "inference_requested": inference.summary,
@@ -246,6 +211,9 @@ def _spread_significance_with_inference(
         "n_periods_tested": len(full_vals),
     }
     codes = tuple(code.value for code in res.warnings)
+    tier: WarningCode | None = cross_section_tier(n_assets)
+    if tier is not None and tier.value not in codes:
+        codes = (*codes, tier.value)
     return full_mean, res.stat, res.p_value, inference.summary, extra, codes
 
 

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -5,7 +5,7 @@ Notes:
     bottom ``k`` names by factor rank, take the mean-return difference
     (cross-section step), then test the per-date spread series across
     time. Small cross-sections switch the headline test to a
-    block-bootstrap CI.
+    ``FEW_ASSETS`` advisory.
 
     **Input.** DataFrame with ``date, asset_id, factor, forward_return``.
 
@@ -81,9 +81,9 @@ def _median_per_date_count(panel: pl.DataFrame) -> int:
     """Median per-date row count of the cleaned (finite factor+return) panel.
 
     The cross-section size that actually forms one date's legs. The
-    small-cross-section bootstrap switch keys on this rather than on
-    ``asset_id.n_unique()`` over the whole panel: the heavy-tail rationale is
-    per date (``k`` names per leg out of *today's* names), so a universe that
+    ``FEW_ASSETS`` advisory keys on this rather than on
+    ``asset_id.n_unique()`` over the whole panel: what matters is per date
+    (``k`` names per leg out of *today's* names), so a universe that
     rotated through many tickers but only ever lists a handful at a time must
     read as thin, not wide.
     """
@@ -179,7 +179,6 @@ def k_spread(
     k: int = 5,
     factor_col: str = "factor",
     return_col: str = "forward_return",
-    rng_seed: int = 0,
     inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
 ) -> MetricResult:
     r"""Fixed-K Top-K vs Bottom-K long-short spread.
@@ -199,8 +198,6 @@ def k_spread(
             disjoint legs — dates with fewer are dropped.
         factor_col: Ranking column (default ``"factor"``).
         return_col: Realised-return column (default ``"forward_return"``).
-        rng_seed: Seed for the small-N block-bootstrap branch
-            (reproducible by default).
         inference: Headline significance method. ``fx.inference.NON_OVERLAPPING``
             (default) runs the OLS t-test on the non-overlap stride;
             ``fx.inference.NEWEY_WEST`` keeps every date and HAC-corrects the
@@ -222,16 +219,15 @@ def k_spread(
         $$\text{spread}_t = \frac1k \sum_{i \in \mathrm{top}_k} r_{i,t}
         - \frac1k \sum_{i \in \mathrm{bot}_k} r_{i,t}.$$
 
-        ``value = mean_t spread_t``. The headline test follows the shared
-        small-cross-section policy: below ``MIN_ASSETS_WARN`` names the
-        per-date spread is heavy-tailed (few names per leg), so the
-        ``t``-test is replaced by a block-bootstrap CI; otherwise the
-        non-overlapping ``t`` applies. ``metadata["method"]`` records
-        which ran. The contemporaneous cross-sectional dispersion
-        $\mathrm{std}_i(r_{i,t})$ is averaged over dates and reported so
-        the spread can be judged against the period's return spread.
+        ``value = mean_t spread_t``. The headline test is the non-overlapping
+        ``t`` on the strided spread series (or Newey-West HAC on the full
+        series under ``inference=NEWEY_WEST``); a thin cross-section attaches
+        ``FEW_ASSETS`` and changes nothing else. The contemporaneous
+        cross-sectional dispersion $\mathrm{std}_i(r_{i,t})$ is averaged
+        over dates and reported so the spread can be judged against the
+        period's return spread.
 
-        **What "small" counts.** The switch reads the median *per-date*
+        **What "small" counts.** The advisory reads the median *per-date*
         number of usable names (``metadata["median_cross_section"]``), not
         the count of distinct ``asset_id`` values in the panel: the legs
         are formed date by date, so a universe listing 12 names at a time
@@ -375,7 +371,6 @@ def k_spread(
             full_spread=full_series,
             forward_periods=forward_periods,
             n_assets=median_xs,
-            rng_seed=rng_seed,
         )
     )
     # Sample the headline stat/p actually ran on: full overlapping series under

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -93,10 +93,10 @@ def _median_finite_cross_section(panel: pl.DataFrame, factor_col: str) -> int:
 
     The size of the cross-section that is actually ranked on a typical date
     — not ``asset_id.n_unique()`` over the whole panel, which counts every
-    name that ever appeared. The small-cross-section bootstrap switch keys
-    on this: the heavy-tail rationale is about how many names back a single
-    date's bucket mean, so a 12-name-per-date universe that rotated through
-    200 tickers over the sample is thin, not wide.
+    name that ever appeared. The ``FEW_ASSETS`` advisory keys on this: how
+    many names back a single date's bucket mean is a per-date quantity, so a
+    12-name-per-date universe that rotated through 200 tickers over the
+    sample is thin, not wide.
     """
     if panel.is_empty():
         return 0
@@ -180,9 +180,8 @@ def quantile_spread(
         heteroskedasticity-and-autocorrelation-consistent (HAC) route is
         the sibling that keeps the full overlapping series instead of
         striding — select it via ``inference=fx.inference.NEWEY_WEST``.
-        Because HAC corrects autocorrelation rather than heavy tails, the
-        small-cross-section block bootstrap still wins when it fires and the
-        requested HAC is flagged ``inference_overridden`` in metadata.
+        A thin cross-section (``median_cross_section < MIN_ASSETS_WARN``)
+        attaches ``FEW_ASSETS`` on either route and changes nothing else.
 
         Long/short alpha decomposition stays a descriptive OLS t-test on
         ``top_return - universe_return`` and ``universe_return -
@@ -369,13 +368,12 @@ def _quantile_spread_from_series(
         )
 
     arr = spread_vals.to_numpy()
-    # Headline test: ``inference`` selects non-overlap t vs Newey-West HAC;
-    # a thin cross-section switches either to a block-bootstrap CI (shared
-    # policy with k_spread). ``mean_spread`` is the full-sample mean under HAC,
-    # the non-overlap mean otherwise. The thin-cross-section switch keys on the
-    # median *per-date* finite-factor count, not the universe-wide unique asset
-    # count: the heavy-tail rationale is per-date (how many names back one
-    # bucket mean), so a rotating universe must not read as wide.
+    # Headline test: ``inference`` selects non-overlap t vs Newey-West HAC.
+    # ``mean_spread`` is the full-sample mean under HAC, the non-overlap mean
+    # otherwise. The FEW_ASSETS advisory keys on the median *per-date*
+    # finite-factor count, not the universe-wide unique asset count: how many
+    # names back one bucket mean is a per-date quantity, so a rotating
+    # universe must not read as wide.
     n_assets = _median_finite_cross_section(sampled, factor_col)
     # Non-finite spreads must not reach the HAC regression either — same reason
     # the strided array is cleaned above.

--- a/tests/test_expected_warnings.py
+++ b/tests/test_expected_warnings.py
@@ -116,7 +116,8 @@ class TestDeclaredStudy:
         other = [w for w in res.warnings if w.code is not WarningCode.FEW_ASSETS]
         assert all(not w.expected for w in other)
 
-    def test_inference_switch_stays_readable(self):
+    def test_thin_cross_section_keeps_the_t_test(self):
+        """Declaring the regime expected does not change the test that ran."""
         panel = _thin_panel()
         results = fx.evaluate(
             panel,
@@ -125,8 +126,8 @@ class TestDeclaredStudy:
             expected_warnings=("few_assets",),
         )
         meta = results["factor"].metrics["spread"].metadata
-        assert meta["method"] == "block-bootstrap CI"
-        assert "p_value_t" in meta
+        assert meta["method"] == "non-overlapping t-test"
+        assert "p_value_t" not in meta
 
     def test_p_value_identical_to_undeclared_run(self):
         """The declaration changes reporting only — never the inference."""

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -71,17 +71,22 @@ class TestSmallNSignificanceSwitch:
         assert result.metadata["method"] == "non-overlapping t-test"
         assert "p_value_t" not in result.metadata
 
-    def test_small_cross_section_uses_block_bootstrap(self):
+    def test_small_cross_section_keeps_the_t_test_and_warns(self):
+        """No automatic bootstrap switch: the t stays, FEW_ASSETS is attached.
+
+        The switch was removed after measurement — the bootstrap p rejected
+        8–20% at a nominal 5% on thin cross-sections against the t's 7–9%,
+        and its heavy-tail rationale had the size direction backwards.
+        """
         rng = np.random.default_rng(3)
         factor = np.arange(20, dtype=float)
         returns = rng.normal(0.001, 0.02, size=(40, 20))
         panel = _panel_from_matrix(factor, returns)
         result = k_spread(panel, forward_periods=1, k=5)
 
-        assert result.metadata["method"] == "block-bootstrap CI"
-        assert "p_value_t" in result.metadata  # parametric p retained for reference
-        assert result.metadata["bootstrap_seed"] == 0
-        # the method switch surfaces as a cross-section warning, not silently
+        assert result.metadata["method"] == "non-overlapping t-test"
+        assert "p_value_t" not in result.metadata
+        # the thin cross-section surfaces as a warning, not as a different test
         assert "few_assets" in result.warning_codes
         # reproducible run-to-run under the fixed seed
         again = k_spread(panel, forward_periods=1, k=5)
@@ -207,17 +212,19 @@ class TestUnderfilledDatesDropped:
 
 
 class TestQuantileSpreadSharesPolicy:
-    """The small-N bootstrap switch is shared with quantile_spread."""
+    """The small-N policy (warn, keep the t) is shared with quantile_spread."""
 
-    def test_quantile_spread_switches_on_small_cross_section(self):
+    def test_quantile_spread_warns_without_switching_on_small_cross_section(self):
+        from factrix._codes import WarningCode
+
         rng = np.random.default_rng(6)
         factor = np.arange(20, dtype=float)
         returns = rng.normal(0.001, 0.02, size=(40, 20))
         out = quantile_spread(
             _panel_from_matrix(factor, returns), forward_periods=1, n_groups=5
         )["factor"]
-        assert out.metadata["method"] == "block-bootstrap CI"
-        assert "p_value_t" in out.metadata
+        assert out.metadata["method"] == "non-overlapping t-test"
+        assert WarningCode.FEW_ASSETS.value in out.warning_codes
 
     def test_quantile_spread_keeps_t_test_on_large_cross_section(self):
         rng = np.random.default_rng(7)
@@ -265,15 +272,16 @@ class TestInference:
         assert nw.metadata["n_periods"] == nw.metadata["n_periods_full"]
         assert nw.n_obs == nw.metadata["n_periods_full"]
 
-    def test_small_cross_section_bootstrap_overrides_requested_hac(self):
+    def test_small_cross_section_keeps_requested_hac_and_warns(self):
         import factrix as fx
+        from factrix._codes import WarningCode
 
         raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=400, seed=4)
         panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
         nw = k_spread(panel, forward_periods=5, k=3, inference=fx.inference.NEWEY_WEST)
-        assert nw.metadata["method"] == "block-bootstrap CI"
-        assert nw.metadata["inference_overridden"] is True
-        assert nw.metadata["inference_requested"] == "Newey-West HAC t-test"
+        assert nw.metadata["method"] == "Newey-West HAC t-test"
+        assert "inference_overridden" not in nw.metadata
+        assert WarningCode.FEW_ASSETS.value in nw.warning_codes
 
     def test_unapplicable_inference_raises_not_silent_fallback(self):
         import factrix as fx
@@ -371,11 +379,13 @@ class TestNonFiniteFactors:
 
 class TestSmallCrossSectionKeying:
     def test_rotating_universe_still_counts_as_thin(self):
+        from factrix._codes import WarningCode
+
         """12 names per date, 720 distinct asset_ids over the sample.
 
-        The switch used to read ``asset_id.n_unique()`` over the whole panel
-        (720 -> "wide", parametric t); the heavy-tail rationale is per date,
-        where only 12 names back each leg.
+        The advisory used to read ``asset_id.n_unique()`` over the whole panel
+        (720 -> "wide", no warning); the thin-cross-section rationale is per
+        date, where only 12 names back each leg.
         """
         rng = np.random.default_rng(7)
         rows = []
@@ -393,4 +403,4 @@ class TestSmallCrossSectionKeying:
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = k_spread(panel, forward_periods=1, k=3)
         assert result.metadata["median_cross_section"] == 12
-        assert result.metadata["method"] == "block-bootstrap CI"
+        assert WarningCode.FEW_ASSETS.value in result.warning_codes

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -374,17 +374,18 @@ class TestQuantileSpreadInference:
         assert nw.metadata["n_periods"] == nw.metadata["n_periods_full"]
         assert nw.n_obs == nw.metadata["n_periods_full"]
 
-    def test_small_cross_section_bootstrap_overrides_requested_hac(self):
+    def test_small_cross_section_keeps_requested_hac_and_warns(self):
         import factrix as fx
+        from factrix._codes import WarningCode
 
         raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=400, seed=6)
         panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
         nw = quantile_spread(
             panel, forward_periods=5, n_groups=5, inference=fx.inference.NEWEY_WEST
         )["factor"]
-        assert nw.metadata["method"] == "block-bootstrap CI"
-        assert nw.metadata["inference_overridden"] is True
-        assert nw.metadata["inference_requested"] == "Newey-West HAC t-test"
+        assert nw.metadata["method"] == "Newey-West HAC t-test"
+        assert "inference_overridden" not in nw.metadata
+        assert WarningCode.FEW_ASSETS.value in nw.warning_codes
 
     def test_unapplicable_inference_raises_not_silent_fallback(self):
         import factrix as fx
@@ -675,15 +676,17 @@ class TestQuantileSpreadNonFiniteSeries:
 
 
 class TestSmallCrossSectionKeying:
-    """The bootstrap switch reads the per-date cross-section, not the panel."""
+    """The FEW_ASSETS advisory reads the per-date cross-section, not the panel."""
 
     def test_rotating_universe_still_counts_as_thin(self):
         """12 names per date, but 240 distinct asset_ids over the sample.
 
-        ``asset_id.n_unique()`` over the panel says 240 (wide, run the t-test);
-        the median per-date cross-section says 12 (thin, bootstrap it). The
-        heavy-tail rationale is per date, so the bootstrap must fire.
+        ``asset_id.n_unique()`` over the panel says 240 (wide, silent); the
+        median per-date cross-section says 12 (thin, warn). How many names
+        back a bucket mean is a per-date quantity, so the advisory must fire.
         """
+        from factrix._codes import WarningCode
+
         rng = np.random.default_rng(3)
 
         def build(d):
@@ -699,4 +702,38 @@ class TestSmallCrossSectionKeying:
         panel = _long_panel(build, n_dates=200)
         result = quantile_spread(panel, forward_periods=1, n_groups=3)["factor"]
         assert result.metadata["median_cross_section"] == 12
-        assert result.metadata["method"] == "block-bootstrap CI"
+        assert WarningCode.FEW_ASSETS.value in result.warning_codes
+
+
+class TestSmallCrossSectionSize:
+    """Realised size of the headline t on a thin cross-section (characterisation).
+
+    Measured through the public path on a true null (500 seeds): the t
+    branch sits at 7–9%, where the removed block-bootstrap branch sat at
+    8–20%. Band asserts the measured order of magnitude at 120 reps.
+    """
+
+    def test_thin_cross_section_t_is_roughly_calibrated(self):
+        import warnings
+
+        import factrix as fx
+        from factrix.preprocess import compute_forward_return
+
+        reps, rejected = 120, 0
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            for seed in range(reps):
+                panel = compute_forward_return(
+                    fx.datasets.make_cs_panel(
+                        n_assets=12,
+                        n_dates=157,
+                        ic_target=0.0,
+                        signal_horizon=5,
+                        seed=seed,
+                    ),
+                    forward_periods=5,
+                )
+                out = quantile_spread(panel, forward_periods=5, n_groups=2)["factor"]
+                assert out.metadata["method"] == "non-overlapping t-test"
+                rejected += out.p_value is not None and out.p_value < 0.05
+        assert 0.01 <= rejected / reps <= 0.16


### PR DESCRIPTION
> **TL;DR** — #821 §3a. The automatic switch to a block-bootstrap CI on thin cross-sections (`median_cross_section < MIN_ASSETS_WARN`) is removed: measured, it made calibration worse (8–20% vs the `t`'s 7–9% at nominal 5%), its heavy-tail rationale had the size direction backwards, and it keyed on the wrong axis. Thin cross-sections keep the requested inference member and get `few_assets` as an advisory. Moves numbers *toward* the plain `t` spread metrics conventionally report.

## Measured (public path, `quantile_spread`, true null, nominal 5%)

| n_assets | branch (before) | n_dates=60 | n_dates=150 |
|---|---|---|---|
| 8 / 12 / 20 / 29 | bootstrap | .164 / .168 / .160 / **.200** | .084 / .108 / .136 / .144 |
| 40 | t | .072 | .092 |

Kernel isolation (`_block_bootstrap_diff_p`, 500 reps): iid n = 12 / 30 / 60 / 120 → **13.6% / 9.8% / 7.4% / 5.2%** — the usual O(1/n) bootstrap distortion, and the strided spread series is short exactly when `forward_periods` is large. On heavy-tailed t(3) input — the case the switch existed for — plain `t` is *conservative* (3–4%) while the bootstrap is 6–14%: the `t` is size-robust to tails; the small-n bootstrap is not. The switch keyed on `n_assets` while the bootstrap's validity depends on `n_periods`.

## Why remove rather than re-gate on length
Gating on strided `n ≥ 120` (where the bootstrap is calibrated) would mean "long series switch to bootstrap for everyone" — a separate, larger routing decision needing per-metric / per-horizon measurement on real data. Not bundled. Reviewer concurred.

## Additivity line
Changes numbers, but to the plain `t` — the convention the literature reports — so it moves toward published numbers, not away. No user sign-off needed on that basis.

## Change
- `_spread_significance`: always the non-overlapping `t`; `FEW_ASSETS` tier attached.
- `_spread_significance_with_inference`: HAC no longer pre-empted by cross-section size; `FEW_ASSETS` attached on the HAC path too; `inference_overridden` only for a missing full series. `_SPREAD_BOOTSTRAP_SEED` gone.
- `k_spread` drops `rng_seed` (existed only for the removed branch). **Breaking signature** — pre-v1.
- Docstrings, `stat-keys-by-metric.md`, `k_spread.md`, `panel-timeseries.md`, `_codes.py` comments and the `evaluate` docstring updated; the removal and its measurement recorded in `_spread_significance`'s docstring.
- Tests re-targeted (switch tests → "keeps t and warns"); `TestSmallCrossSectionSize` pins the thin-cross-section `t` band through the public path.

2359 passed, 3 skipped; `ruff` / `mypy` clean.