### PR TITLE
fix(stats): withhold the spanning alpha t and the Fisher z when they cannot be formed

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -75,6 +75,11 @@ def ols_alpha(
         reference the t is read against — see ``_stats.hac`` on why the
         full-count df is kept).
 
+    A fit that cannot be formed -- fewer than three observations, or a
+    rank-deficient design -- returns ``alpha`` and ``alpha_t`` as NaN.
+    Callers withhold the test rather than reporting the zeros an earlier
+    version returned, which claimed the factor added exactly nothing.
+
     Raises:
         ValueError: ``candidate`` or ``base_matrix`` holds a non-finite
             value. ``np.linalg.lstsq`` does not raise on NaN input — it
@@ -95,7 +100,7 @@ def ols_alpha(
 
     n_obs = len(candidate)
     if n_obs < 3:
-        return _OLSResult(alpha=0.0, alpha_t=0.0)
+        return _OLSResult(alpha=float("nan"), alpha_t=float("nan"))
 
     ones = np.ones((n_obs, 1))
     X = np.hstack([ones, base_matrix]) if base_matrix.shape[1] > 0 else ones
@@ -103,7 +108,11 @@ def ols_alpha(
     try:
         beta, _, _, _ = np.linalg.lstsq(X, candidate, rcond=None)
     except np.linalg.LinAlgError:
-        return _OLSResult(alpha=0.0, alpha_t=0.0)
+        # Rank-deficient design (collinear base factors, or a base factor
+        # equal to the candidate). The fit does not exist, so neither does
+        # alpha: NaN rather than 0.0, which would read as "this factor adds
+        # exactly nothing" -- a decisive claim from a failed computation.
+        return _OLSResult(alpha=float("nan"), alpha_t=float("nan"))
 
     alpha = float(beta[0])
     betas = [float(b) for b in beta[1:]]
@@ -117,12 +126,23 @@ def ols_alpha(
 
     dof = n_obs - X.shape[1]
     if dof <= 0:
-        return _OLSResult(alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared)
+        # No residual degrees of freedom: the design saturates the sample,
+        # so there is nothing left to estimate a standard error from.
+        return _OLSResult(
+            alpha=alpha, alpha_t=float("nan"), betas=betas, r_squared=r_squared
+        )
 
     sigma2 = ss_res / dof
     if sigma2 < EPSILON:
+        # Residuals vanished -- a perfect (typically rank-deficient) fit.
+        # ``lstsq`` does not raise there, it returns a minimum-norm
+        # solution, so this is the branch collinear designs actually reach.
         return _OLSResult(
-            alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
+            alpha=alpha,
+            alpha_t=float("nan"),
+            betas=betas,
+            r_squared=r_squared,
+            df_resid=dof,
         )
 
     # HAC covariance of the OLS coefficients; ``_ols_nw_multivariate`` returns
@@ -132,8 +152,17 @@ def ols_alpha(
     se_alpha = float(np.sqrt(max(v_hac[0, 0], 0.0)))
 
     if se_alpha < EPSILON:
+        # A collapsed HAC SE -- a perfect fit, or a design so nearly
+        # rank-deficient that the residuals vanish -- leaves no t. NaN, not
+        # 0.0: the alpha itself is real (a duplicated base column still
+        # yields an intercept), so reporting t = 0 turns a live estimate
+        # into a decisive "not significant". Same rule as ``_calc_t_stat``.
         return _OLSResult(
-            alpha=alpha, alpha_t=0.0, betas=betas, r_squared=r_squared, df_resid=dof
+            alpha=alpha,
+            alpha_t=float("nan"),
+            betas=betas,
+            r_squared=r_squared,
+            df_resid=dof,
         )
 
     return _OLSResult(

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -278,7 +278,15 @@ def event_ic(
     rho = float(rho)
     p = float(p)
 
-    z = np.arctanh(rho) * np.sqrt(n - 3) if abs(rho) < 1.0 - 1e-10 and n > 3 else 0.0
+    # Fisher z is undefined at |rho| = 1 (arctanh diverges) and needs n > 3.
+    # ``None`` rather than 0.0: a perfect rank correlation is maximal
+    # evidence, and reporting z = 0 beside scipy's p < 0.001 is an
+    # internally contradictory result. The p-value is scipy's and stands.
+    z: float | None = (
+        float(np.arctanh(rho) * np.sqrt(n - 3))
+        if abs(rho) < 1.0 - 1e-10 and n > 3
+        else None
+    )
 
     return MetricResult(
         p_value=p,

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -24,6 +24,7 @@ References:
 from __future__ import annotations
 
 import logging
+import math
 import warnings
 from dataclasses import dataclass, field
 
@@ -41,7 +42,11 @@ from factrix._ols import ols_alpha as _ols_alpha
 from factrix._results import MetricResult
 from factrix._stats import _p_value_from_t
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
+from factrix.metrics._helpers import (
+    _degenerate_test_fields,
+    _enforce_min_floor,
+    _short_circuit_output,
+)
 from factrix.metrics.quantile import compute_spread_series
 
 __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
@@ -302,22 +307,32 @@ def spanning_alpha(
     # single-sample n - 1: the alpha t-stat is built on the full design matrix.
     p = _p_value_from_t(ols.alpha_t, n_obs, dof=ols.df_resid)
 
+    metadata: dict = {
+        "stat_type": "t",
+        "h0": "alpha=0",
+        "method": "OLS spanning regression, Newey-West HAC SE",
+        "n_base_factors": base_matrix.shape[1],
+        "base_factors": base_names,
+        "betas": beta_dict,
+        "r_squared": ols.r_squared,
+    }
+    # A rank-deficient design (collinear base factors) leaves no fit, so
+    # ``alpha`` and its t are NaN: withhold the test rather than report the
+    # zeros that would read as "adds exactly nothing".
+    warning_codes: list[str] = []
+    stat, p_out, alternative = _degenerate_test_fields(
+        ols.alpha_t, p, "two-sided", metadata, warning_codes
+    )
+
     return MetricResult(
-        p_value=p,
-        alternative="two-sided",
+        p_value=p_out,
+        alternative=alternative,
         value=ols.alpha,
         n_obs=n_obs,
         n_obs_axis="periods",
-        stat=ols.alpha_t,
-        metadata={
-            "stat_type": "t",
-            "h0": "alpha=0",
-            "method": "OLS spanning regression, Newey-West HAC SE",
-            "n_base_factors": base_matrix.shape[1],
-            "base_factors": base_names,
-            "betas": beta_dict,
-            "r_squared": ols.r_squared,
-        },
+        stat=stat,
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
     )
 
 
@@ -561,7 +576,11 @@ def _backward_eliminate(
 
             ols = _ols_alpha(selected_arrays[name], base_matrix)
 
-            if abs(ols.alpha_t) < threshold:
+            # NaN t means the fit could not be formed on this subset
+            # (rank-deficient once the other selections are in the design).
+            # Drop rather than keep: an unevaluable factor has not earned
+            # its place, and ``NaN < threshold`` is False, which would.
+            if not math.isfinite(ols.alpha_t) or abs(ols.alpha_t) < threshold:
                 selected_names.remove(name)
                 del selected_arrays[name]
                 result.eliminated_factors.append(

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -102,9 +102,34 @@ class TestOLSAlpha:
         assert ols.betas[0] == pytest.approx(2.0, abs=0.1)
         assert ols.r_squared > 0.95
 
-    def test_insufficient_data(self):
+    def test_insufficient_data_is_not_computable(self):
+        """Too short to fit: NaN, not zero.
+
+        ``alpha = 0.0`` would read as "this factor adds exactly nothing",
+        a decisive claim from a fit that never ran.
+        """
+        import math
+
         ols = _ols_alpha(np.array([0.01, 0.02]), np.empty((2, 0)))
-        assert ols.alpha == 0.0 and ols.alpha_t == 0.0
+        assert math.isnan(ols.alpha) and math.isnan(ols.alpha_t)
+
+    def test_collapsed_se_withholds_the_t_not_the_alpha(self):
+        """A perfect fit leaves a real alpha and no t.
+
+        ``np.linalg.lstsq`` does not raise on a rank-deficient design -- it
+        returns a minimum-norm solution -- so the live path here is the
+        collapsed HAC SE, not the LinAlgError branch. A base column that
+        duplicates the intercept still produces an intercept estimate, so
+        the alpha survives while the t is withheld; reporting ``t = 0``
+        would turn that live estimate into a decisive "not significant".
+        """
+        import math
+
+        rng = np.random.default_rng(0)
+        candidate = rng.normal(size=40)
+        ols = _ols_alpha(candidate, np.ones((40, 1)))
+        assert math.isfinite(ols.alpha) and ols.alpha != 0.0
+        assert math.isnan(ols.alpha_t)
 
     def test_df_resid_excludes_base_regressors(self):
         rng = np.random.default_rng(42)


### PR DESCRIPTION
Closes #838.

Two sites the earlier sweeps missed — neither returns the literal `(0.0, 1.0)` tuple that sweep grepped for.

## `ols_alpha` reported `t = 0` on four distinct failures

Sample too short, design saturating the sample (no residual dof), residuals vanishing, and `LinAlgError`. Each produced `alpha_t = 0.0` → `p = 1.0` → *"this factor adds nothing over the base"*, from a fit that could not be evaluated. `alpha` feeds `spanning_alpha.value` and `alpha_t` feeds its `stat` and `p_value`.

**Correction to the issue as filed:** I attributed this to the `except LinAlgError` branch. That branch is nearly dead — `np.linalg.lstsq` does *not* raise on a rank-deficient design, it returns a minimum-norm solution. The reachable path is the vanishing-residual guard. Measured before the fix:

| input | alpha | t |
|---|---|---|
| duplicate intercept column | −0.0302 | **0.0** |
| collinear duplicate base | 0.0 | **0.0** |
| n = 2 | 0.0 | 0.0 |

The middle row is the one that matters: a **live alpha estimate** reported as decisively insignificant.

After:

| input | alpha | t |
|---|---|---|
| healthy base | −0.0838 | −0.6213 |
| duplicate intercept column | −0.0302 | **NaN** |
| collinear duplicate base | 0.0 | **NaN** |
| saturated (dof ≤ 0) | −1.8228 | **NaN** |
| n = 2 | NaN | NaN |

alpha and t fail separately, so they are treated separately: a duplicated base column still yields a real intercept, so only the t is withheld; where the fit itself does not exist, both are.

## Backward elimination needed an explicit branch

It drops a factor when `abs(t) < threshold`, and `NaN < threshold` is **False** — an unevaluable factor would have been *kept*. Forward selection needs no change: its condition is `abs(t) >= threshold`, which NaN already fails.

## `event_hit_rate`'s Fisher z — the mirror

At `|rho| = 1` arctanh diverges and z was set to `0.0`, so a perfect rank correlation (maximal evidence) was published as `z = 0` beside scipy's `p < 0.001` — an internally contradictory result. The p was always honest; only the statistic contradicted it. Now `None`.

## Verification

Healthy fits byte-identical. 2372 passed / 3 skipped, doctests 95, `ruff check` / `ruff format --check` / `mypy factrix` clean.