### PR TITLE
fix: preprocessing, ingestion contract, and cross-sectional diagnostics (user-test sweep, part 3/4)

### DIFF
--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -8,12 +8,29 @@ Single-source contract for every `factrix` entry point that consumes a panel. Ev
 
 | Column | dtype | Semantics |
 |---|---|---|
-| `date` | `Date` (preferred) or `Datetime` | Observation timestamp. Sorted ascending per asset. Frequency-agnostic — factrix shifts rows, never calendar time. |
+| `date` | `Date` or `Datetime` (**required** — a `String` or integer date is rejected) | Observation timestamp. Frequency-agnostic — the horizon is measured in periods of the panel's own distinct-date grid, never in calendar time. |
 | `asset_id` | `Utf8` / `Categorical` | Cross-section identifier. Identical for COMMON-scope factors (`df.group_by("date").agg((pl.col("factor").n_unique() == 1).alias("is_common"))["is_common"].all()` is `True`). |
 | `factor` | numeric (`Int*` / `Float*`) | The signal value. Dense: real-valued exposure (z-score, IC-rankable). Sparse: zero-encoded `{0, R}` event trigger, where `0` marks non-events. |
 | `forward_return` | `Float64` | Look-ahead return over the horizon used at evaluate time. Attach via [`compute_forward_return`](preprocess.md) so the horizon is explicit and aligned with `forward_periods`. |
 
 The minimal panel is therefore long-format `(date, asset_id, factor, forward_return)`. Two assets over three periods:
+
+## Ingestion contract
+
+Every entry point that consumes a panel (`evaluate`, `evaluate_horizons`,
+`inspect_data`, `by_slice`, `compute_forward_return`) normalises it once at
+the boundary. Three rules are enforced, and one rewrite is applied:
+
+| Rule | On violation |
+|---|---|
+| `date` is `Date` or `Datetime` | `UserInputError` — a `String` date sorts lexicographically and silently reorders any non-ISO format; parse it first (`pl.col("date").str.to_date(fmt)`). |
+| `(date, asset_id)` is unique | `UserInputError` — a duplicate makes the "next period" the same date's twin and fabricates a `0.0` forward return. |
+| Per-asset period grids agree | `ragged_period_grid` warning — an asset missing periods pairs `t+1` with `t+1+h` on *its own* grid, so its horizon differs from the others'. |
+| Non-finite float cells | `NaN` and `±inf` in every **float** column are rewritten to `null` (integer, boolean, `Decimal` and string columns are untouched). A `+inf` `price` therefore becomes a gap rather than a fabricated `-100 %` return; a `NaN` factor cell is a missing value like `null`. |
+
+The normalisation is idempotent and cheap (≈0.15 s on 3 M rows), so
+`compute_forward_return` followed by `evaluate` runs it twice without cost.
+
 
 For sparse factors, null factor cells are missing values, not non-events, and
 are excluded from sparse-ratio detection. Fill missing values to `0` only when

--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -19,6 +19,18 @@ title: factrix.metrics.caar
     factrix computes **CAR** (sum of per-period abnormal returns), not
     BHAR; see the same section for the distinction.
 
+!!! warning "`caar.value` is per period, not cumulative"
+    Despite the name, `caar.value` is `CAR / h`, not the cumulative abnormal
+    return of MacKinlay (1997) §4. `compute_forward_return` divides by
+    `forward_periods` to put every horizon on a common per-period scale, and
+    the event family reads that column, so the normalisation is inherited
+    rather than undone here. With μ = 0.0008 per period over `h = 5`, the
+    reported value is 0.001056 — the per-period average — not 5× that.
+
+    Multiply by `forward_periods` to recover the cumulative quantity the name
+    and the Brown-Warner / MacKinlay citations promise. Reading `caar.value`
+    directly as a 5-period event CAR is off by 5×.
+
 ## Use cases
 
 <div class="grid cards" markdown>

--- a/docs/api/metrics/monotonicity.md
+++ b/docs/api/metrics/monotonicity.md
@@ -14,25 +14,28 @@ title: factrix.metrics.monotonicity
 
 <div class="grid cards" markdown>
 
--   __Decile-curve direction test__
+-   __Decile-curve monotonicity test__
 
     ---
 
-    Per-date Spearman correlation between quantile-group index and
-    group mean return; cross-asset $t$ on the signed series asks
-    whether the bucket ordering is *consistently* increasing (or
-    decreasing) across dates — a stronger requirement than a positive
-    long-short spread.
+    The Patton-Timmermann (2010) MR test on the quantile-bucket return
+    curve: $J = \min_i \overline{\Delta}_i$ over the adjacent bucket
+    differences, with $H_0$ that the relation is *not* monotone and a
+    stationary-bootstrap p. A strictly increasing decile curve is a
+    stronger requirement than a positive long-short spread, which only
+    needs the two end buckets to separate.
 
--   __Magnitude vs direction separation__
+-   __Magnitude vs direction, as descriptive shape__
 
     ---
 
-    `value` is mean $|\text{Spearman}|$ (magnitude, $\geq 0$); `stat`
-    is a $t$ on the signed series. High `value` with insignificant
-    `stat` flags a factor that monotonically sorts returns but whose
-    direction flips across dates — Patton-Timmermann (2010) territory
-    that a single signed average would hide.
+    `metadata["mean_abs_spearman"]` (magnitude, $\geq 0$) and
+    `metadata["mean_signed"]` (direction consistency) still read
+    separately: high magnitude with a near-zero signed mean flags a
+    factor that sorts returns but flips direction across dates. They are
+    metadata, not the headline — $\mathbb{E}|\rho| > 0$ under $H_0$ by
+    Jensen, so mean $|\rho|$ has an `n_groups`-dependent noise floor
+    (0.67 / 0.42 / 0.27 at $K = 3 / 5 / 10$) that reads like evidence.
 
 </div>
 
@@ -58,12 +61,32 @@ title: factrix.metrics.monotonicity
     )
     panel = compute_forward_return(raw, forward_periods=5)
 
-    out = monotonicity(panel, forward_periods=5, n_groups=10)
-    print(out.value, out.stat,
-          out.metadata["mean_signed"], out.p_value)
-    # 0.41  5.62  0.39  2.1e-08   (approximate)
-    # value ≈ mean|Spearman|; mean_signed ≈ direction; stat t on signed series
+    out = monotonicity(panel, forward_periods=5, n_groups=10, seed=0)
+    print(out.value, out.p_value,
+          out.metadata["mr_adjacent_diffs"],
+          out.metadata["mean_abs_spearman"])
+    # value = stat = J, the smallest average adjacent bucket-return
+    # difference (return units); p_value is its bootstrap p under
+    # H0 "not monotonically increasing"; mr_adjacent_diffs shows which
+    # step binds; mean_abs_spearman is the descriptive magnitude.
     ```
+
+!!! warning "Declare the direction, do not search it"
+    `direction="increasing"` (default) or `"decreasing"` states what $H_1$
+    asserts. Running both and reporting the smaller p is a two-sided search
+    charged at a one-sided level. For a factor hypothesised to be negatively
+    related to returns, pass `direction="decreasing"` (or flip the factor's
+    sign upstream) rather than reading the increasing test and inverting it.
+
+!!! info "Deviation from the paper"
+    Patton-Timmermann bootstrap the raw (unstudentised) adjacent
+    differences, which is what runs here; their studentised variant is not
+    implemented. The bootstrap is the library's shared stationary
+    (Politis-Romano 1994) resampler with the Politis-White (2004) automatic
+    block length, applied to the whole $(T, K-1)$ difference matrix under
+    one row-index draw so within-period cross-bucket dependence is
+    preserved. Empirical p uses the Davison-Hinkley $+1$ smoothing shared
+    with the rest of the library, so p is never exactly 0.
 
 ## See also
 
@@ -98,8 +121,8 @@ title: factrix.metrics.monotonicity
 
     ---
 
-    Cross-asset $t$ on the per-date signed Spearman series, DDOF
-    convention.
+    The MR bootstrap, and the DDOF convention behind the descriptive
+    signed-Spearman $t$.
 
     [reference/statistical-methods →](../../reference/statistical-methods.md)
 

--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -44,6 +44,9 @@ title: factrix.metrics.quantile
     smaller than the EW spread, the alpha is concentrated in small
     names and may not survive capacity / liquidity constraints —
     Hou-Xue-Zhang (2020) found ~65% of factors disappear under VW.
+    It takes the same `inference=` knob and the same thin-cross-section
+    diagnostics as its equal-weighted sibling, so the comparison is
+    like-for-like rather than one leg being quietly less guarded.
 
 -   __Per-bucket mean returns for monotonicity charts__
 

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -108,18 +108,38 @@ title: factrix.metrics.tradability
     # 0.00258  0.897   (approximate)
 
     # The scalar helpers take the gross spread positionally and every other
-    # parameter by keyword.
-    be  = breakeven_cost(spread.value, turnover=tau.value, forward_periods=5)
-    net = net_spread(spread.value, turnover=tau.value,
+    # parameter by keyword. Pass the MetricResults, not their .value: the
+    # helper then verifies the two describe the same portfolio.
+    be  = breakeven_cost(spread, turnover=tau, forward_periods=5)
+    net = net_spread(spread, turnover=tau,
                      estimated_cost_bps=30.0, forward_periods=5)
     print(be.value, net.value)
     # 36.0   0.00043   (approximate; one-way bps and per-period spread)
     ```
 
+!!! warning "The spread and the turnover must price the same portfolio"
+    The cost algebra is a statement about *one* book, so a τ measured on
+    decile membership churn does not price a quintile spread, and a τ per bar
+    does not price a 5-period holding. `quantile_spread` and
+    `notional_turnover` used to ship incompatible defaults (`n_groups` 5 vs
+    10, `forward_periods` 5 vs 1). On a 60-name, 400-period panel at
+    `gross_spread = 0.001`, the matched pair gives breakeven **15.7 bps** and
+    net **−9.14 bps**; each function at its own default gave **2.8 bps** and
+    **−98.02 bps** — breakeven understated 5.6×, drag overstated 10.7×.
+
+    They now share one constant (`DEFAULT_N_GROUPS = 5`,
+    `DEFAULT_FORWARD_PERIODS = 5`), so the defaults pair by construction. And
+    when handed the producing `MetricResult`s rather than bare floats,
+    `breakeven_cost` / `net_spread` cross-check `n_groups` and
+    `forward_periods` and raise `UserInputError` on a mismatch, recording
+    `pairing_checked` in metadata otherwise. Bare floats carry no provenance,
+    so nothing can be verified — prefer passing the results.
+
+    `monotonicity` deliberately keeps its own `n_groups=10`: a decile curve is
+    the shape it is calibrated to read, not a long-short leg.
+
 `breakeven_cost` and `net_spread` are scalar post-processing helpers, not
-panel-evaluation metrics. Keep `n_groups`, `forward_periods`, and any weighting
-choice aligned between `quantile_spread` and `notional_turnover`, then pass their
-`.value` fields into the cost helper. Both helpers are `@metric` classes, so the
+panel-evaluation metrics. Both are `@metric` classes, so the
 gross spread is their call-time data argument and everything else must be passed
 by keyword — a second positional argument raises `TypeError`. `inspect_data()` marks these helpers as
 standalone so they are not included in `inspect_data().usable.to_metrics_dict()`.

--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -55,6 +55,54 @@ out-of-range values, non-numeric values, and `bool` bounds raise
 
 ## Factor normalization
 
+Both normalizers scale by the median absolute deviation (MAD). Three places
+where factrix departs from the most common implementation, and why:
+
+**Finite-sample MAD constant.** The standard scale is `1.4826 × MAD`, where
+`1.4826 = 1/Φ⁻¹(0.75)` is the *asymptotic* consistency constant — this is what
+R's `mad()` and `scipy.stats.median_abs_deviation` ship. factrix multiplies in
+the Croux-Rousseeuw (1992) finite-sample factor `b_n` as well (tabulated for
+`n ≤ 9`, `n/(n−0.8)` above), keyed on the per-date count of finite values,
+because this library targets cross-sections of 5–20 names where the asymptotic
+constant is materially biased. Measured on a standard-normal factor
+(true σ = 1), `E[1.4826 × MAD]` is 0.82 at n=5, 0.91 at n=10 and 0.96 at n=20,
+against 0.99–1.01 at every size with `b_n`. The bias matters twice over: the
+output of a function called "z-score" was not unit-scale, and because the bias
+is *n*-dependent, thin dates in an unbalanced panel (delistings, staggered
+entry, sparse event triggers) were handed systematically larger z-scores, so
+anything pooling or weighting by z over-weighted the noisiest cross-sections.
+Fewer than three finite values on a date leaves no estimable robust scale at
+all: the date comes back null rather than as a fabricated `0.0`.
+
+**Centring.** The textbook z-score subtracts the mean. `cross_sectional_zscore`
+defaults to `center="median"` to stay robust to the outliers the MAD scale is
+chosen for — with the consequence that the output is **not** mean-zero on a
+skewed factor, so `w ∝ z` carries a net long or short leg (measured: `+0.32`
+net exposure on a 2-of-20 sparse trigger column). Pass `center="mean"` when the
+weights must be dollar-neutral by construction; the scale stays the robust MAD
+either way.
+
+**Regime switches are announced.** When the per-date MAD collapses to zero
+(more than 50% ties at the median) the scale falls back to the non-robust
+per-date standard deviation. That is a data-driven change of estimator, so it
+raises a `UserWarning` carrying
+[`WarningCode.ZERO_MAD_STD_FALLBACK`](../reference/warning-codes.md) rather
+than mixing robust and non-robust dates into one column silently. On a sparse
+`{0, R}` trigger column `mad_winsorize` skips the clip entirely
+(`SPARSE_WINSORIZE_SKIPPED`): that column's standard deviation is produced *by
+the triggers*, so a 3-std band shrinks with the trigger rate and destroyed 58%
+of a unit event's magnitude at one trigger in fifty names.
+
+**Non-finite input.** NaN and ±Inf are blanked to **null** on output by both
+functions, not clipped into the band. A non-finite tick is a data error, not an
+extreme value; winsorizing it produced a plausible finite number that survived
+every downstream `drop_nulls().drop_nans()` and put that asset at the top of
+the date's ranking.
+
+`cross_sectional_zscore` names its output column after its input:
+`factor` → `factor_zscore`, `momentum` → `momentum_zscore`, so several factors
+can be standardized in one panel without colliding.
+
 ::: factrix.preprocess.mad_winsorize
 
 ::: factrix.preprocess.cross_sectional_zscore

--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -109,6 +109,36 @@ can be standardized in one panel without colliding.
 
 ## Orthogonalization
 
+`orthogonalize_factor` runs a per-date cross-sectional OLS and returns the
+residual. Two guards that the textbook formulation leaves to the analyst:
+
+**A degrees-of-freedom floor, not a solvability floor.** The regression is only
+fitted on dates leaving at least `min_residual_df` residual degrees of freedom
+(`n_assets − n_base − 1`, default 10 — the `N ≥ K + 10` form of the
+Fama-MacBeth convention). Raw R² is mechanically ≈ `K/(N − 1)` even when the
+true R² is zero, so on a six-name book regressed on four exposures the old
+one-df floor reported `mean_r_squared = 0.79` (adjusted: `−0.03`) after
+stripping 83% of the factor's variance — the factor reads as redundant when it
+is orthogonal by construction. Dates below the floor keep their original values,
+are counted in `n_dates_insufficient_df`, and raise
+`insufficient_regression_df`. `mean_adj_r_squared` is reported alongside the raw
+figure. Pass `min_residual_df=1` to restore the old behaviour.
+
+**Rank deficiency is detected, not assumed away.** An intercept is always
+prepended, so a full industry dummy set is exactly singular. `np.linalg.lstsq`
+does not raise on that — it returns the minimum-norm solution — so the residual
+is still exact (the projection onto the column space is unique) but `mean_betas`
+was an arbitrary point in the solution space. Rank is read from the singular
+values `lstsq` already computes, at `matrix_rank`'s tolerance so *near*-collinear
+designs are caught too; deficient dates are excluded from `mean_betas` and raise
+`rank_deficient_design`. Drop one dummy category as the reference level.
+
+**Residual scale.** The residual's dispersion is `sqrt(1 − R²)` times the
+input's, and R² varies by date, so the output scale varies by date. Rank-based
+metrics are unaffected; any magnitude-based use is otherwise quietly on a
+time-varying scale. Pass `restandardize=True` to rescale each date's residual
+back to the input's per-date dispersion.
+
 ::: factrix.preprocess.orthogonalize_factor
 
 ::: factrix.preprocess.OrthogonalizeResult

--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -30,17 +30,62 @@ forward returns are computed.
 
 ::: factrix.adapt.adapt
 
+## The panel contract
+
+Every public entry point — `evaluate`, `evaluate_horizons`, `inspect_data`,
+`compute_forward_return` — puts its input through one structural gate before
+anything else happens. Three things it enforces, each of which was previously
+left to individual producers and therefore missed by whichever path forgot it:
+
+- **`date` must be `Date` or `Datetime`.** Only column *names* were validated,
+  so a `String` date flowed through `sort` / `shift` / `over` / `group_by` as
+  text and was ordered lexicographically. With ISO-8601 strings that
+  accidentally works, which is what makes it dangerous — it passes every test
+  and every demo. With `MM/DD/YYYY` the panel is silently reordered and every
+  forward return is paired with the wrong neighbour. Parse first, e.g.
+  `pl.col("date").str.to_datetime("%m/%d/%Y")`.
+- **`(date, asset_id)` must be unique.** A duplicated row makes an asset's
+  "next period" that same date's twin, so `price / price - 1 = 0`: a four-row
+  panel concatenated with itself came back half fabricated zeros, biasing every
+  downstream mean toward zero with no error and no warning.
+- **NaN and ±Inf become `null`.** Applied to *inputs*, not to computed outputs.
+  This makes the whole class structurally unrepresentable downstream rather
+  than patching instances of it: polars ranks NaN as larger than every real
+  value, `pl.corr(method="spearman")` silently ranks it, and a `+Inf`
+  denominator makes `finite / inf` evaluate to `0.0` — a *finite* fabricated
+  −100% return that an output-side `is_finite()` filter cannot catch.
+
+The first two raise [`UserInputError`](errors.md); the third is a silent,
+deliberate normalization. `_finite_expr` remains in place inside the producers
+as defence in depth.
+
 ## Forward return
 
-`compute_forward_return` accepts `forward_periods` as a positive `int`
-row horizon. `0`, negative values, floats, strings, and `bool` values
-raise [`UserInputError`](errors.md). The function shifts by row count
-within each `asset_id`, computes the per-period normalized
-`forward_return`, then drops rows whose computed return is not finite
-(`null`, `NaN`, `+inf`, or `-inf`). If the horizon is too long for the
-panel, or price data leaves no finite forward returns after filtering,
-the function raises [`UserInputError`](errors.md) instead of returning
-an empty panel.
+`compute_forward_return` accepts `forward_periods` as a positive `int`.
+`0`, negative values, floats, strings, and `bool` values raise
+[`UserInputError`](errors.md).
+
+**The horizon is measured on the panel's own period grid** — the distinct
+sorted `date` values present in the panel, indexed 0, 1, 2, … Each asset's
+forward return pairs its row at period index `i + 1` with its row at
+`i + 1 + forward_periods`. This used to be a positional shift within each
+asset, which equals a time horizon only on a *complete* per-asset panel: with
+one asset missing 20 periods mid-sample, a "5-period" return silently spanned
+25 real periods, contaminating both the return and the overlap horizon stamped
+in `_forward_periods` that every downstream HAC inference reads. Suspensions,
+halts, delist-relist and staggered entry are ordinary in regional equity data,
+and sparse event panels are ragged by construction.
+
+A ragged grid raises `ragged_period_grid`. The pairing is correct for every
+asset either way; the point of the warning is that an asset with a gap has no
+observation to pair at the exit period and so contributes fewer rows than a
+complete one. Reindex onto a common grid if the horizons must be comparable
+across names.
+
+Rows whose computed return is not finite are dropped. If the horizon is too
+long for the panel, or price data leaves no finite forward returns after
+filtering, the function raises [`UserInputError`](errors.md) instead of
+returning an empty panel.
 
 `winsorize_forward_return` clips `forward_return` by per-date quantiles.
 Its bounds must satisfy `0 <= lower <= upper <= 1`; invalid ordering,

--- a/docs/examples/stock_factor_evaluation.md
+++ b/docs/examples/stock_factor_evaluation.md
@@ -86,7 +86,7 @@ panel = fprep.compute_forward_return(raw, forward_periods=5).with_columns(
 
 ## 5. Create sector and size neutral variants
 
-`orthogonalize_factor` residualizes one factor against a base exposure matrix using per-date cross-sectional OLS. Categorical exposures should be dummy encoded before they are passed in. Drop one sector dummy when an intercept is present; the helper uses `lstsq`, but a full dummy set adds no information.
+`orthogonalize_factor` residualizes one factor against a base exposure matrix using per-date cross-sectional OLS. Categorical exposures should be dummy encoded before they are passed in. **Drop one sector dummy as the reference level**: an intercept is always prepended, so a full dummy set is exactly singular. `lstsq` does not raise there — it returns the minimum-norm solution, so the residual stays correct but the reported betas are an arbitrary point in the solution space. The helper detects this, raises `rank_deficient_design`, and withholds `mean_betas` rather than reporting unidentified numbers.
 
 ```python
 sector_dummies = panel.select("date", "asset_id", "sector").to_dummies(

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -93,14 +93,17 @@ per-date boolean column, then reduce that `Series`, since `.all()` is a
 ## 2. Regular spacing per asset is load-bearing
 
 [`compute_forward_return`](../api/preprocess.md) sorts the input by
-`(asset_id, date)` itself, so an unsorted panel is fine. What it
-**does not** inspect is the calendar gap between successive rows —
-the function shifts by row count, not by date.
+`(asset_id, date)` itself, so an unsorted panel is fine, and it rejects
+duplicate `(date, asset_id)` rows and non-temporal `date` columns at the
+boundary (see the [ingestion contract](../api/data-schema.md#ingestion-contract)).
+The horizon is measured on the panel's distinct-date grid: period `i` is
+paired with periods `i+1` and `i+1+h` of that grid, never by row offset.
 
-If asset A has daily rows but asset B is missing two trading days in
-the middle, asset B's row-shift skips the gap silently and the forward
-return on the row before the gap measures the wrong horizon. Verify
-per-asset spacing before calling:
+If asset A has every period but asset B is missing two periods in the
+middle, asset B contributes rows only where both `i+1` and `i+1+h` exist
+for it, and `compute_forward_return` emits `ragged_period_grid` so the
+per-asset horizon mismatch is visible. Verify per-asset spacing before
+calling if the warning is unexpected:
 
 ```python
 gaps = raw.sort(["asset_id", "date"]).with_columns(
@@ -232,7 +235,7 @@ calls for a transformed signal.
 
 ## 5. Frequency alignment is the caller's job
 
-factrix is calendar-agnostic — it shifts rows, not calendar time.
+factrix is calendar-agnostic — it counts periods on the panel's own date grid, not calendar time.
 Three responsibilities sit upstream of `compute_forward_return`:
 
 - **Same date axis for factor and price source.** If the factor is
@@ -251,8 +254,8 @@ Three responsibilities sit upstream of `compute_forward_return`:
 
 | Source | factrix behaviour | Caller action |
 |---|---|---|
-| NaN in `factor` | Not auto-imputed; flows through to the procedure, where it depresses `n_obs` and may trip sample-size guards. | Drop or impute before optional factor preprocessing or `compute_forward_return`. |
-| NaN / inf in `price` | `compute_forward_return` drops rows whose computed `forward_return` is not finite (`null`, `NaN`, `+inf`, or `-inf`). Tail rows where `t + 1 + forward_periods` runs off the end of the series are dropped by the same filter. | If a daily NaN reflects a true gap (suspended trading, holiday), the drop is correct. If imputable (forward-fill from previous close), impute before calling. |
+| NaN in `factor` | Rewritten to `null` at ingestion, so it is a missing value like any other: it depresses `n_obs` and may trip sample-size guards, and never enters a rank. | Drop or impute before optional factor preprocessing or `compute_forward_return`. |
+| NaN / inf in `price` | Rewritten to `null` at ingestion *before* the return is formed, so a `+inf` price is a gap rather than a fabricated `-100 %` return; rows whose `forward_return` cannot be formed are dropped. Tail rows where `i + 1 + forward_periods` runs off the asset's grid are dropped by the same rule. | If a daily NaN reflects a true gap (suspended trading, holiday), the drop is correct. If imputable (forward-fill from previous close), impute before calling. |
 | `forward_periods <= 0`, non-`int`, or `bool` | Raises [`UserInputError`](../api/errors.md); the horizon must be a positive integer row count. | Pass an explicit row horizon such as `1`, `5`, or `20`. |
 | Horizon too long / no finite returns after filtering | Raises [`UserInputError`](../api/errors.md) instead of returning an empty panel. | Shorten the horizon, extend the panel, or clean price values before calling. |
 | Single-asset panel (`n_assets == 1`) | `DataStructure` auto-switches to `TIMESERIES`. Dense PANEL metrics (`individual_continuous` and `common_continuous`) raise [`IncompatibleAxisError`](../api/errors.md). | Use `predictive_beta` for dense predictive-regression slope inference, `directional_hit_rate` for sign prediction, or a sparse metric whose cell allows `TIMESERIES`. |

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -61,7 +61,7 @@ contrasts, not a sidecar to a primary value.
 | [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | Patton-Timmermann (2010) MR (stationary-bootstrap p) | `p_value` | `mr_min_diff` (min adjacent bucket-return difference) |
 | [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | non-overlapping `t` on top-bottom spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
 | [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
-| [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
+| [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | non-overlap `t` (default) or NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
 | [`top_concentration`][factrix.metrics.concentration.top_concentration] | one-sided `t` on diversity ratio | `p_value` | mean(eff_n) = mean(1/HHI) |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | none — descriptive | — | event-period Herfindahl-Hirschman index (HHI) |
 | [`mfe_mae`][factrix.metrics.mfe_mae.mfe_mae] | none — descriptive | — | MFE_p50 / \|MAE_p75\| |
@@ -462,9 +462,19 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 
 #### `quantile_spread_vw`
 
-Value-weighted variant. Same metadata shape as `quantile_spread`
-plus a `weights_lagged` flag indicating whether the weighting input
-was lagged before the join (descriptive). This includes the conditional
+Value-weighted variant. Same metadata shape as `quantile_spread` —
+including `median_cross_section`, `n_periods_strided` and whatever the
+selected inference member contributes — plus a `weights_lagged` flag
+indicating whether the weighting input was lagged before the join
+(descriptive). It takes the same `inference=` knob off the same
+allowlist as `quantile_spread`, so the equal-weighted / value-weighted
+pair is tested the same way on the same date set; under `NEWEY_WEST` the
+VW leg gives up the first date, whose lagged weight does not exist.
+It also carries the same thin-cross-section diagnostics — `few_assets`
+on the median per-period finite-factor count and `thin_quantile_groups`
+off the shared bucket threshold. Both were previously absent: the metric
+whose purpose is a capacity / robustness cross-check reported clean on a
+panel whose legs held a single name each. This includes the conditional
 no-signal `signal_status` (`"no_signal_zero_variance_factor"`, a valid
 `p_value = 1.0` result) when the factor has no cross-sectional variation.
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -487,7 +487,12 @@ Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
 
 - *primary*: `p_value` — non-overlapping `t`-test on the spread
   series (`method` records the inference member that ran).
-- *descriptive*: `k` (names per leg), `cross_sectional_dispersion`
+- *descriptive*: `k` (names per leg), `tie_ratio` / `tie_policy` (the
+  same tie diagnostics `quantile_spread` and `monotonicity` report —
+  the leg ranking used to be hard-coded `"ordinal"` with no tie ratio at
+  all, so a discrete signal's legs were filled by row order among tied
+  names and the arbitrary split was reported as a spread),
+  `cross_sectional_dispersion`
   (mean per-period cross-sectional return std), `top_return`,
   `bottom_return`, `n_periods` (**the sample the headline test ran on**,
   equal to `n_obs`: strided under `NON_OVERLAPPING`, full overlapping

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -47,7 +47,7 @@ contrasts, not a sidecar to a primary value.
 | [`fm_beta`][factrix.metrics.fm_beta.fm_beta] | NW HAC `t` on per-period λ | `p_value` | mean(β) |
 | [`pooled_beta`][factrix.metrics.fm_beta.pooled_beta] | clustered ordinary least squares (OLS) `t` (or `None` if G < 3) | `p_value` | pooled β |
 | [`fm_beta_sign_consistency`][factrix.metrics.fm_beta.fm_beta_sign_consistency] | none — descriptive | — | fraction with expected sign |
-| [`caar`][factrix.metrics.caar.caar] | non-overlapping `t` on event-period CAAR | `p_value` | mean(CAAR) |
+| [`caar`][factrix.metrics.caar.caar] | non-overlapping `t` on event-period CAAR | `p_value` | mean(CAAR) **per period** — `CAR / h`, not cumulative |
 | [`bmp_z`][factrix.metrics.caar.bmp_z] | BMP cross-sectional `z` on SAR | `p_value` | mean(SAR) |
 | [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] | nonparametric rank `z` on the event-period series (cluster-robust) | `p_value` | mean(per-period mean U × sign(factor)) |
 | [`positive_rate`][factrix.metrics.positive_rate.positive_rate] | binomial test (or normal `z`) | `p_value` | hit rate ∈ [0, 1] |
@@ -154,6 +154,10 @@ Descriptive; no test.
 - *primary*: `p_value` — non-overlapping `t` on per-event-period CAAR.
   `value`, `stat`, `p_value` and `n_obs` all describe the event-spaced
   subsample (`n_obs_axis = "events"`, the shared event-battery token).
+- **`value` is per period.** It is `CAR / h`, inherited from
+  `compute_forward_return`'s `/ forward_periods` normalisation, not the
+  cumulative abnormal return the name suggests. Multiply by
+  `forward_periods` for the cumulative quantity.
 - *descriptive*: `n_event_periods` (number of periods with an event),
   `total_events` (underlying events behind the portfolio),
   `n_event_periods_sampled`, `mean_caar_full` / `n_event_periods_full`

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -58,7 +58,7 @@ contrasts, not a sidecar to a primary value.
 | [`profit_factor`][factrix.metrics.event_quality.profit_factor] | none — descriptive | — | gains / \|losses\| |
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | none — descriptive | — | mean bars per event |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | none — descriptive | — | mean leakage score |
-| [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | cross-asset `t` on signed Spearman | `p_value` | mean \|Spearman\| |
+| [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | Patton-Timmermann (2010) MR (stationary-bootstrap p) | `p_value` | `mr_min_diff` (min adjacent bucket-return difference) |
 | [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | non-overlapping `t` on top-bottom spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
 | [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
 | [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
@@ -405,14 +405,30 @@ Pre/post-event return profile; descriptive.
 
 #### `monotonicity`
 
-`MetricResult.value` carries the *magnitude* (mean `|Spearman|`);
-`MetricResult.stat` carries the cross-asset `t` on the *signed*
-Spearman series. The split is intentional — magnitude and direction
-consistency are read separately.
+`MetricResult.value` and `MetricResult.stat` both carry the
+Patton-Timmermann (2010) MR statistic `mr_min_diff` — `J = min_i mean_t Δ_{i,t}`,
+the smallest average adjacent bucket-return difference, in return units.
+`p_value` is its stationary-bootstrap empirical p under
+`H₀: min_i E[Δ_i] ≤ 0` ("the relation is *not* monotone in the declared
+direction"), one-sided (`alternative="greater"`).
 
-- *primary*: `p_value` — cross-asset `t` (`H₀: μ = 0`).
-- *descriptive*: `mean_signed`, `n_valid_periods`, `n_groups`,
-  `tie_ratio`, `tie_policy`.
+The headline used to be `mean |Spearman|` with a cross-asset `t` on the
+signed series. That statistic has a large null floor that moves with
+`n_groups` — measured 0.67 / 0.42 / 0.27 at `n_groups` = 3 / 5 / 10 on
+panels where H₀ holds by construction, because `E|ρ| > 0` by Jensen — so a
+reader took the noise floor for MR evidence. The MR test's own rejection
+frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
+
+- *primary*: `p_value` — bootstrap p for the MR test.
+- *MR detail*: `mr_min_diff`, `mr_adjacent_diffs` (every `Δ̄_i`, so the
+  binding step is visible), `mr_direction`, `n_bootstrap`,
+  `bootstrap_seed` (resolved and reported when not supplied, so an
+  unseeded run is still reproducible after the fact).
+- *descriptive Spearman shape*: `mean_abs_spearman` (magnitude, ≥ 0),
+  `mean_signed` (direction consistency), `signed_spearman_t`,
+  `signed_spearman_p_value`. A high magnitude with a near-zero signed mean
+  still says the factor sorts returns but flips sign across dates.
+- *descriptive*: `n_valid_periods`, `n_groups`, `tie_ratio`, `tie_policy`.
 
 ### `quantile` (`factrix.metrics.quantile`)
 

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -165,7 +165,7 @@
    "source": [
     "## 5. Create sector and size neutral variants\n",
     "\n",
-    "`orthogonalize_factor` residualizes one factor against a base exposure matrix using per-date cross-sectional OLS. Categorical exposures should be dummy encoded before they are passed in. Drop one sector dummy when an intercept is present; the helper uses `lstsq`, but a full dummy set adds no information.\n"
+    "`orthogonalize_factor` residualizes one factor against a base exposure matrix using per-date cross-sectional OLS. Categorical exposures should be dummy encoded before they are passed in. **Drop one sector dummy as the reference level**: an intercept is always prepended, so a full dummy set is exactly singular. `lstsq` does not raise there \u2014 it returns the minimum-norm solution, so the residual stays correct but the reported betas are an arbitrary point in the solution space. The helper detects this, raises `rank_deficient_design`, and withholds `mean_betas` rather than reporting unidentified numbers.\n"
    ]
   },
   {

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -220,6 +220,52 @@ class WarningCode(StrEnum):
     # unchanged; the code says the null it is read against is conservative.
     ESTIMATION_WINDOW_CONTAMINATED = "estimation_window_contaminated"
 
+    # Preprocess scale-regime flags. ``factrix.preprocess.normalize`` returns a
+    # bare DataFrame — there is no MetricResult to hang ``warning_codes`` on —
+    # so these travel in the text of a ``UserWarning``. They exist because a
+    # sample-regime-driven switch of estimator must never be silent.
+    #
+    # The per-date MAD collapsed to zero (>50% ties at the median) and the
+    # non-robust per-date sample standard deviation stood in as the scale.
+    # Robust and non-robust dates then sit in one output column with nothing
+    # downstream able to tell them apart.
+    ZERO_MAD_STD_FALLBACK = "zero_mad_std_fallback"
+    # ``mad_winsorize`` left a date unwinsorized because the factor there is a
+    # sparse ``{0, R}`` trigger column (median 0, MAD 0). Its standard
+    # deviation is produced by the triggers themselves, so it shrinks with the
+    # trigger rate and the clip would destroy event magnitudes — 58% of a unit
+    # event at one trigger in fifty names.
+    SPARSE_WINSORIZE_SKIPPED = "sparse_winsorize_skipped"
+    # A date carries fewer than MIN_SCALE_ASSETS_HARD finite factor values, so
+    # no robust per-date scale exists; the date is left unscaled (z-score null,
+    # clip skipped) rather than fabricating one.
+    INSUFFICIENT_SCALE_ASSETS = "insufficient_scale_assets"
+    # NaN / +-Inf inputs were blanked to null. A non-finite tick is a data
+    # error, not an extreme value: clipping it into a winsorization band
+    # manufactures a plausible finite number that survives every downstream
+    # drop_nulls().drop_nans().
+    NON_FINITE_INPUT_DROPPED = "non_finite_input_dropped"
+
+    # Fired by ``orthogonalize_factor`` when a per-date cross-section clears the
+    # computability floor but leaves fewer than MIN_ORTHOGONALIZE_RESIDUAL_DF
+    # residual degrees of freedom. Those dates are skipped rather than fitted:
+    # raw R2 is mechanically ~K/(N-1) even at a true R2 of 0, so a 6-name
+    # cross-section on 4 regressors reported R2 = 0.79 while removing 83% of
+    # the factor's variance.
+    INSUFFICIENT_REGRESSION_DF = "insufficient_regression_df"
+    # Fired by ``orthogonalize_factor`` when the per-date design matrix is rank
+    # deficient (the classic full-dummy-set-plus-intercept trap). ``lstsq`` does
+    # not raise there — it returns the minimum-norm solution — so residuals stay
+    # correct but the reported betas are an arbitrary point in the solution
+    # space. ``mean_betas`` is suppressed rather than reported.
+    RANK_DEFICIENT_DESIGN = "rank_deficient_design"
+
+    # Fired by ``compute_forward_return`` when the per-asset date grids are
+    # ragged (an asset is missing periods other assets have). The horizon is a
+    # row shift within an asset, so on a ragged grid an h-period-ahead return
+    # spans a different number of real periods for different assets.
+    RAGGED_PERIOD_GRID = "ragged_period_grid"
+
     @property
     def description(self) -> str:
         return _WARNING_DESCRIPTIONS[self]
@@ -415,6 +461,50 @@ _WARNING_DESCRIPTIONS.update(
         "decomposed by period. Metrics that don't declare the flag and "
         "cross-sectional partitions (constant within an asset, e.g. sector) "
         "are unaffected and do not trigger.",
+        WarningCode.ZERO_MAD_STD_FALLBACK: "A preprocess scale estimator fell "
+        "back from the robust MAD to the non-robust per-date sample standard "
+        "deviation because >50% of the cross-section ties at the median "
+        "(bucketed / binary factors are the common case). The output column "
+        "then mixes robust and non-robust dates; the fallback keeps the factor "
+        "finite and rank-preserving but the scale is no longer outlier-proof.",
+        WarningCode.SPARSE_WINSORIZE_SKIPPED: "mad_winsorize left a date "
+        "unwinsorized: the factor is a sparse {0, R} trigger column whose "
+        "median and MAD are both 0, so the standard-deviation fallback is "
+        "driven by the triggers themselves and collapses as the trigger rate "
+        "falls (at 1 trigger in 50 names a 3-std band clipped a unit event to "
+        "0.42). Skipping preserves the event magnitudes the downstream "
+        "sparse-factor metrics measure.",
+        WarningCode.INSUFFICIENT_SCALE_ASSETS: "A date carries fewer than "
+        "MIN_SCALE_ASSETS_HARD (3) finite factor values, so no robust per-date "
+        "scale exists. cross_sectional_zscore returns null there and "
+        "mad_winsorize skips the clip, rather than fabricating a score (n=1 "
+        "used to yield 0.0, n=2 a constant +-0.6745 regardless of the values).",
+        WarningCode.NON_FINITE_INPUT_DROPPED: "NaN / +-Inf input values were "
+        "blanked to null. They are excluded from every per-date statistic and "
+        "from the output: a non-finite tick is a data error, not an extreme "
+        "value, and winsorizing it into the band would manufacture a plausible "
+        "finite number that survives every downstream "
+        "drop_nulls().drop_nans().",
+        WarningCode.INSUFFICIENT_REGRESSION_DF: "orthogonalize_factor skipped a "
+        "date whose cross-section left fewer than "
+        "MIN_ORTHOGONALIZE_RESIDUAL_DF residual degrees of freedom "
+        "(n_assets - n_base - 1). Raw R2 is mechanically ~K/(N-1) even at a "
+        "true R2 of 0, so fitting there reports noise as explanatory power "
+        "while removing most of the factor's variance. Skipped dates keep "
+        "their original values and are counted in n_dates_skipped.",
+        WarningCode.RANK_DEFICIENT_DESIGN: "orthogonalize_factor met a "
+        "rank-deficient per-date design matrix — most often a full industry "
+        "dummy set alongside the always-prepended intercept. np.linalg.lstsq "
+        "does not raise there; it returns the minimum-norm solution, so the "
+        "residual (a unique projection) stays correct but the betas are an "
+        "arbitrary point in the solution space. mean_betas is suppressed. Drop "
+        "one dummy category as the reference level.",
+        WarningCode.RAGGED_PERIOD_GRID: "compute_forward_return saw per-asset "
+        "date grids that do not agree: at least one asset is missing periods "
+        "that others have. The horizon is a shift along each asset's own "
+        "period index, so an h-period-ahead return then spans a different "
+        "number of panel periods for different assets. Reindex the panel onto "
+        "a common grid if the horizons must be comparable across names.",
     }
 )
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -247,7 +247,7 @@ class WarningCode(StrEnum):
     NON_FINITE_INPUT_DROPPED = "non_finite_input_dropped"
 
     # Fired by ``orthogonalize_factor`` when a per-date cross-section clears the
-    # computability floor but leaves fewer than MIN_ORTHOGONALIZE_RESIDUAL_DF
+    # computability floor but leaves fewer than MIN_ORTHOGONALIZE_RESIDUAL_ASSETS
     # residual degrees of freedom. Those dates are skipped rather than fitted:
     # raw R2 is mechanically ~K/(N-1) even at a true R2 of 0, so a 6-name
     # cross-section on 4 regressors reported R2 = 0.79 while removing 83% of
@@ -487,7 +487,7 @@ _WARNING_DESCRIPTIONS.update(
         "drop_nulls().drop_nans().",
         WarningCode.INSUFFICIENT_REGRESSION_DF: "orthogonalize_factor skipped a "
         "date whose cross-section left fewer than "
-        "MIN_ORTHOGONALIZE_RESIDUAL_DF residual degrees of freedom "
+        "MIN_ORTHOGONALIZE_RESIDUAL_ASSETS residual degrees of freedom "
         "(n_assets - n_base - 1). Raw R2 is mechanically ~K/(N-1) even at a "
         "true R2 of 0, so fitting there reports noise as explanatory power "
         "while removing most of the factor's variance. Skipped dates keep "

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -23,6 +23,9 @@ polars throughout) and avoids hiding the pd → pl copy inside every
 from __future__ import annotations
 
 import polars as pl
+import polars.selectors as cs
+
+from factrix._errors import UserInputError
 
 type DataInput = pl.DataFrame | pl.LazyFrame
 """Accepted panel input type for every data-consuming entry point.
@@ -70,22 +73,102 @@ def _read_forward_periods_stamp(data: pl.DataFrame) -> int | None:
     return int(data[_FORWARD_PERIODS_COL][0])
 
 
+_DOCS_DATA_SCHEMA = "api/data-schema"
+
+
+def _normalize_panel(data: pl.DataFrame) -> pl.DataFrame:
+    """Enforce the panel's structural contract once, at the boundary.
+
+    Three guards that were previously applied per producer — so a metric that
+    forgot one, or a path that predated it, diverged silently:
+
+    1. **``date`` must be temporal.** Only column *names* were ever validated,
+       so a ``String`` date flowed through ``sort`` / ``shift`` / ``over`` /
+       ``group_by`` as text and was ordered lexicographically. With ISO-8601
+       strings that accidentally works, which is exactly what makes it
+       dangerous — it passes every test and every demo. With ``MM/DD/YYYY`` the
+       panel is silently reordered and every forward return is computed against
+       the wrong neighbour.
+    2. **``(date, asset_id)`` must be unique.** The forward return is a
+       positional ``shift`` within an asset, so a duplicated row makes the
+       "next period" that same date's twin and manufactures a 0.0 return: a
+       four-row panel concatenated with itself came back half fabricated zeros,
+       with no error and no warning. A duplicated feed is an ordinary ingestion
+       accident, and it biases every downstream mean toward zero.
+    3. **Non-finite numerics become null.** NaN and ±Inf are structurally
+       unrepresentable downstream, which retires the whole class rather than
+       patching instances of it — polars ranks NaN as larger than every real
+       value, ``pl.corr(method="spearman")`` silently ranks it, and a ``+Inf``
+       denominator turns ``finite / inf`` into a *finite* fabricated return
+       that sails through an output-side ``is_finite()`` filter.
+
+    ``_finite_expr`` stays in place as defence in depth; it remains correct and
+    free once inputs are pre-normalised. Row order is deliberately **not**
+    changed here — the shift-based producers sort themselves, and reordering
+    every caller's frame at the gate would be a surprise that buys nothing.
+
+    Raises:
+        UserInputError: ``date`` is not a temporal dtype, or ``(date,
+            asset_id)`` is not unique.
+    """
+    columns = set(data.columns)
+
+    if "date" in columns:
+        dtype = data.schema["date"]
+        if not isinstance(dtype, pl.Date | pl.Datetime):
+            raise UserInputError(
+                func_name="factrix",
+                field="date",
+                value=str(dtype),
+                expected=(
+                    "a Date or Datetime column. A string date sorts "
+                    "lexicographically, which silently reorders the panel for "
+                    "any non-ISO format; parse it first, e.g. "
+                    "pl.col('date').str.to_datetime('%m/%d/%Y')"
+                ),
+                docs_path=_DOCS_DATA_SCHEMA,
+            )
+
+    if {"date", "asset_id"} <= columns:
+        keys = data.select("date", "asset_id")
+        n_duplicated = int(keys.is_duplicated().sum())
+        if n_duplicated:
+            raise UserInputError(
+                func_name="factrix",
+                field="(date, asset_id)",
+                value=f"{n_duplicated} duplicated row(s) of {data.height}",
+                expected=(
+                    "one row per (date, asset_id). The forward return shifts by "
+                    "row position within an asset, so a duplicate makes the "
+                    "'next period' the same date's twin and fabricates a 0.0 "
+                    "return. De-duplicate first, e.g. "
+                    "data.unique(subset=['date', 'asset_id'], keep='first')"
+                ),
+                docs_path=_DOCS_DATA_SCHEMA,
+            )
+
+    return data.with_columns(
+        pl.when(cs.numeric().is_finite()).then(cs.numeric()).otherwise(None)
+    )
+
+
 def _is_pandas_dataframe(obj: object) -> bool:
     """Detect ``pd.DataFrame`` without importing pandas (optional dep)."""
     return type(obj).__module__.split(".", 1)[0] == "pandas"
 
 
 def _coerce_data(data: DataInput) -> pl.DataFrame:
-    """Coerce ``DataInput`` to eager ``pl.DataFrame``.
+    """Coerce ``DataInput`` to eager ``pl.DataFrame`` and normalise it.
 
     ``pl.LazyFrame`` is collected immediately. ``pd.DataFrame`` is
     rejected with a ``TypeError`` that points to the documented
-    conversion paths.
+    conversion paths. The result passes through :func:`_normalize_panel`,
+    the single structural gate every public entry point shares.
     """
     if isinstance(data, pl.DataFrame):
-        return data
+        return _normalize_panel(data)
     if isinstance(data, pl.LazyFrame):
-        return data.collect()
+        return _normalize_panel(data.collect())
     if _is_pandas_dataframe(data):
         raise TypeError(
             "data must be pl.DataFrame or pl.LazyFrame; got pandas DataFrame. "

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -148,7 +148,11 @@ def _normalize_panel(data: pl.DataFrame) -> pl.DataFrame:
             )
 
     return data.with_columns(
-        pl.when(cs.numeric().is_finite()).then(cs.numeric()).otherwise(None)
+        # Float columns only: they are the only dtypes that can carry NaN /
+        # ±inf, and ``is_finite`` is undefined on ``Decimal`` (the default
+        # dtype for a DECIMAL / NUMERIC column read from Parquet or a
+        # warehouse), which ``cs.numeric()`` would include.
+        pl.when(cs.float().is_finite()).then(cs.float()).otherwise(None)
     )
 
 

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -41,7 +41,7 @@ import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope, InputShape, Tier
 from factrix._codes import WarningCode, cross_section_tier
-from factrix._data_input import _FORWARD_PERIODS_COL
+from factrix._data_input import _FORWARD_PERIODS_COL, _coerce_data
 from factrix._metric_index import MetricSpec, public_specs
 from factrix._results import Warning
 from factrix._types import MIN_IC_ASSETS_HARD, MIN_IC_ASSETS_WARN
@@ -602,6 +602,10 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
             f"factor_cols must be a list of column names, not a str; "
             f"did you mean factor_cols=[{factor_cols!r}]?"
         )
+    # Same structural gate evaluate goes through, so pre-flight and the run
+    # agree on what the panel is: a duplicated key or a string date must not
+    # pass inspection and then fail (or worse, silently mis-sort) at evaluate.
+    data = _coerce_data(data)
     if factor_cols is None:
         cols = [c for c in data.columns if c not in _INSPECT_RESERVED]
     else:

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -1226,6 +1226,19 @@ def bhy_hierarchical(
     flat :func:`bhy` is the higher-power alternative that also carries a
     theorem-backed guarantee.
 
+    **Dependence assumption — the outer layer is not
+    arbitrary-dependence-valid.** BHY itself holds under arbitrary
+    dependence, but each group enters the outer layer through
+    :func:`simes_p`, and Simes' combination is valid only
+    under independence or positive regression dependence (PRDS). Under
+    *negative* within-group dependence Simes is anti-conservative, so the
+    composite procedure inherits that limitation despite BHY's own
+    guarantee. Negative cross-regional correlation is not exotic. The
+    simulation evidence below covers positive equicorrelation only
+    (``rho`` in {0.5, 0.7, 0.9}); no negative-dependence cell was measured.
+    For a family with material negative dependence, prefer flat
+    :func:`bhy`, whose guarantee does not route through Simes.
+
     ``TestHierarchicalFdrControl`` pins realised FDR across group counts,
     sizes, sparsity, selected fraction down to ``R / G = 0.01``, and the
     small-correlated-group scan above.

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -156,3 +156,18 @@ ConcentrationWeight = Literal["abs_factor", "alpha_contribution"]
 # panel, so they must not share a token: a reader stacking ``to_frame`` across
 # metrics has only ``n_obs_axis`` to tell one from the other.
 SampleAxis = Literal["periods", "events", "pairs", "asset_pairs", "assets"]
+
+
+# Minimum surplus assets (n_assets - n_base - 1) a per-date cross-sectional OLS
+# must leave before ``orthogonalize_factor`` will fit it. On this axis one
+# surplus asset is exactly one residual degree of freedom, which is why the
+# public knob is spelled ``min_residual_df`` — the statistical term — while the
+# constant carries the ASSETS axis token the naming grammar requires.
+# The old floor was ``len(base_cols) + 2`` rows, i.e. a single residual df:
+# raw R2 is mechanically ~K/(N-1) even at a true R2 of 0, so a 6-name
+# cross-section on 4 regressors reported R2 = 0.79 while stripping 83% of the
+# factor's variance. Fama-MacBeth practice discards cross-sections with too few
+# names per regressor; 10 residual df is the ``N >= K + 10`` form of that rule
+# and is exposed as ``min_residual_df`` for callers who want the other
+# (``N >= 5K``) convention.
+MIN_ORTHOGONALIZE_RESIDUAL_ASSETS: int = 10

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -110,6 +110,16 @@ MIN_PORTFOLIO_PERIODS_WARN: int = 20
 
 MIN_MONOTONICITY_PERIODS_HARD: int = 5
 
+# Per-date cross-section floor (assets axis) for the robust-scale estimators in
+# ``factrix.preprocess.normalize``. Below three finite values a per-date median /
+# MAD pair carries no information about dispersion: at n=1 the chain used to
+# fall through to ``z = 0.0`` (an "average" fabricated from one observation) and
+# at n=2 the MAD-scaled z is ``+-0.6745`` whatever the two values are — a
+# constant that is indistinguishable downstream from a real score. Dates below
+# the floor are left unscaled (z null, clip skipped) and flagged with
+# ``WarningCode.INSUFFICIENT_SCALE_ASSETS``.
+MIN_SCALE_ASSETS_HARD: int = 3
+
 
 # Structural alias used by metric internals to mark "this float is a
 # p-value, not an effect-size".

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -171,3 +171,22 @@ SampleAxis = Literal["periods", "events", "pairs", "asset_pairs", "assets"]
 # and is exposed as ``min_residual_df`` for callers who want the other
 # (``N >= 5K``) convention.
 MIN_ORTHOGONALIZE_RESIDUAL_ASSETS: int = 10
+
+
+# ---------------------------------------------------------------------------
+# Shared bucketing / horizon defaults
+# ---------------------------------------------------------------------------
+#
+# One source of truth for the long-short bucketing and the rebalance stride,
+# shared by ``quantile_spread``, ``quantile_spread_vw`` and
+# ``notional_turnover``. These three are designed to be read together — the
+# spread is the gross alpha, the turnover is what it costs to hold — and the
+# cost algebra in ``breakeven_cost`` / ``net_spread`` is only valid when the
+# spread and the turnover were computed on the *same* bucketing and the *same*
+# stride. They previously carried incompatible defaults (n_groups 5 vs 10,
+# forward_periods 5 vs 1), so running each at its own default understated
+# breakeven by 5.6x and overstated cost drag by 10.7x on a 60-name panel.
+# ``monotonicity`` deliberately keeps its own ``n_groups=10``: a decile curve
+# is the shape it is calibrated to read, not a long-short leg.
+DEFAULT_N_GROUPS: int = 5
+DEFAULT_FORWARD_PERIODS: int = 5

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -1880,6 +1880,45 @@ def _median_universe_size(data: pl.DataFrame) -> int:
     )
 
 
+def _warn_thin_quantile_groups(
+    sampled: pl.DataFrame, n_groups: int, *, stacklevel: int = 3
+) -> bool:
+    """Emit the thin-bucket advisory and report whether it fired.
+
+    The ``UserWarning`` half of the dual-channel thin-group diagnostic whose
+    structured twin is :data:`WarningCode.THIN_QUANTILE_GROUPS`. Lives here
+    rather than inside ``compute_spread_series`` so every bucketing consumer
+    raises the *same* message off the *same* threshold — the value-weighted
+    spread built its buckets inline and so reported clean on a panel where
+    each leg was a single name.
+    """
+    if not _is_thin_quantile_groups(sampled, n_groups):
+        return False
+    median_n = _median_universe_size(sampled)
+    per_group = median_n // n_groups if n_groups > 0 else 0
+    if n_groups > 2:
+        # Coarsest split keeping ~5 assets per group (floored at the
+        # long-short minimum of 2): n_groups <= median_n // 5.
+        suggested = max(2, median_n // 5)
+        guidance = (
+            f"Reduce n_groups to ~{suggested} (≈5 assets per group), or "
+            f"treat this as a fragile small-cross-section diagnostic."
+        )
+    else:
+        guidance = (
+            "This is already the coarsest long-short split; treat the "
+            "spread as a fragile small-cross-section diagnostic."
+        )
+    warnings.warn(
+        f"Median {per_group} assets per group (n_assets={median_n}, "
+        f"n_groups={n_groups}). Spread may be dominated by "
+        f"individual assets. {guidance}",
+        UserWarning,
+        stacklevel=stacklevel,
+    )
+    return True
+
+
 def _is_thin_quantile_groups(sampled: pl.DataFrame, n_groups: int) -> bool:
     """True when the median cross-section split into ``n_groups`` buckets leaves
     fewer than :data:`MIN_GROUP_ASSETS` assets per bucket.

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 
 import polars as pl
@@ -17,11 +16,10 @@ from factrix._axis import (
 from factrix._metric_index import cell
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
-    MIN_GROUP_ASSETS,
     _assign_quantile_groups_batch,
     _finite_expr,
-    _median_universe_size,
     _sample_non_overlapping,
+    _warn_thin_quantile_groups,
 )
 
 
@@ -106,29 +104,7 @@ def compute_spread_series(
 
     sampled = _sample_non_overlapping(data, forward_periods)
 
-    median_n = _median_universe_size(sampled)
-    per_group = median_n // n_groups if n_groups > 0 else 0
-    if per_group < MIN_GROUP_ASSETS:
-        if n_groups > 2:
-            # Coarsest split keeping ~5 assets per group (floored at the
-            # long-short minimum of 2): n_groups <= median_n // 5.
-            suggested = max(2, median_n // 5)
-            guidance = (
-                f"Reduce n_groups to ~{suggested} (≈5 assets per group), or "
-                f"treat this as a fragile small-cross-section diagnostic."
-            )
-        else:
-            guidance = (
-                "This is already the coarsest long-short split; treat the "
-                "spread as a fragile small-cross-section diagnostic."
-            )
-        warnings.warn(
-            f"Median {per_group} assets per group (n_assets={median_n}, "
-            f"n_groups={n_groups}). Spread may be dominated by "
-            f"individual assets. {guidance}",
-            UserWarning,
-            stacklevel=2,
-        )
+    _warn_thin_quantile_groups(sampled, n_groups)
 
     # Neutralise non-finite returns at the producer boundary: polars ``mean``
     # propagates float NaN, so one NaN return would turn a whole bucket mean —

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -102,21 +102,31 @@ def _median_tie_ratio(ic_df: pl.DataFrame) -> float:
 def _warn_if_high_ic_tie_ratio(ic_df: pl.DataFrame, metric_name: str) -> float:
     """Emit ``UserWarning`` when median tie_ratio exceeds the global threshold.
 
-    Returns the median for caller to stash in metadata. The Spearman ρ on
-    average ranks is biased relative to the tie-corrected formula
-    (Kendall-Stuart §31) at high tie densities — a bucketed / categorical
-    factor will look like it has IC ≈ 0 even if the bucketing is
-    informative. Threshold reuses the global ``TIE_RATIO_WARN_THRESHOLD``
+    Returns the median for the caller to stash in metadata.
+
+    The caveat is **range attenuation**, not bias. The Pearson correlation of
+    mid-ranks *is* the tie-corrected Spearman coefficient (Kendall & Stuart;
+    it is exactly what ``scipy.stats.spearmanr`` computes), and
+    ``compute_ic`` computes precisely that — the uncorrected
+    ``1 - 6*sum(d^2)/(n^3-n)`` form appears nowhere in the library. The
+    warning used to call the corrected number biased and point users at "a
+    tie-corrected correlation", which is what they already had. What ties
+    actually do is shrink the attainable range of rho below ±1, so IC
+    magnitudes are not comparable across factors with different tie
+    densities. Threshold reuses the global ``TIE_RATIO_WARN_THRESHOLD``
     (0.3) shared with the quantile-bucketing diagnostics.
     """
     med = _median_tie_ratio(ic_df)
     if not math.isnan(med) and med > TIE_RATIO_WARN_THRESHOLD:
         _warnings.warn(
             f"{metric_name}: median tie_ratio={med:.3f} exceeds "
-            f"{TIE_RATIO_WARN_THRESHOLD:.2f}. Spearman ρ on average ranks is "
-            f"biased on bucketed / categorical factors; treat the IC "
-            f"magnitude as a lower bound and consider a tie-corrected "
-            f"correlation or a continuous transform of the factor.",
+            f"{TIE_RATIO_WARN_THRESHOLD:.2f}. The estimator is already the "
+            f"tie-corrected Spearman (Pearson on mid-ranks, identical to "
+            f"scipy.stats.spearmanr), so this is not a bias — but heavy ties "
+            f"shrink the attainable range of rho below ±1, so do not compare "
+            f"this IC magnitude against a factor with a different tie "
+            f"density. A continuous transform of the factor restores the "
+            f"full range.",
             UserWarning,
             stacklevel=2,
         )

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -44,6 +44,7 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _all_dates_degenerate,
     _check_applicable_inference,
+    _compute_tie_ratio,
     _degenerate_test_fields,
     _enforce_scaled_floor,
     _finite_expr,
@@ -54,6 +55,7 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _spread_significance_with_inference,
     _surface_null_drop,
+    _warn_high_tie_ratio,
 )
 
 __all__ = [
@@ -103,7 +105,11 @@ def _k_spread_threshold(self) -> SampleThreshold:
 
 
 def _build_k_spread_series(
-    panel: pl.DataFrame, k: int, factor_col: str, return_col: str
+    panel: pl.DataFrame,
+    k: int,
+    factor_col: str,
+    return_col: str,
+    tie_policy: str = "ordinal",
 ) -> tuple[pl.DataFrame | None, pl.DataFrame]:
     """Per-period Top-K/Bottom-K spread series from a (possibly sampled) panel.
 
@@ -136,9 +142,14 @@ def _build_k_spread_series(
             .sort("date")
         )
         return series, clean
+    # ``tie_policy`` is the caller's, not a hard-coded "ordinal". On a
+    # discrete signal — a 3-level CTA event score with k=5, say — ordinal
+    # tie-breaking fills the legs by row order among tied names and reports an
+    # arbitrary split as a spread. ``"average"`` gives tied names a shared rank
+    # so neither leg can be filled by sort artefacts; leg sizes then vary.
     ranked = clean.with_columns(
         pl.col(factor_col)
-        .rank(method="ordinal", descending=True)
+        .rank(method=tie_policy, descending=True)  # type: ignore[arg-type]
         .over("date")
         .alias("_rank"),
         pl.len().over("date").alias("_n_date"),
@@ -179,6 +190,7 @@ def k_spread(
     k: int = 5,
     factor_col: str = "factor",
     return_col: str = "forward_return",
+    tie_policy: str = "ordinal",
     inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
@@ -199,6 +211,25 @@ def k_spread(
             disjoint legs — dates with fewer are dropped.
         factor_col: Ranking column (default ``"factor"``).
         return_col: Realised-return column (default ``"forward_return"``).
+        tie_policy: Tie-break policy for the leg ranking — the same knob and
+            the same values as ``quantile_spread`` / ``quantile_spread_vw`` /
+            ``monotonicity``. ``"ordinal"`` (default) breaks ties by row order,
+            which keeps both legs exactly ``k`` names wide but fills them
+            arbitrarily among tied values; ``"average"`` gives tied names a
+            shared rank so a discrete signal cannot be split by sort artefacts.
+            Note what that means for a *fixed-k* leg: a tied block wider than
+            ``k`` puts no name inside the cutoff, so the leg is empty and the
+            date drops out (the drop-rate advisory reports it). That is the
+            honest answer — five names cannot be picked out of a ten-way tie
+            without an arbitrary rule — but it costs sample, so on a heavily
+            tied factor prefer ``quantile_spread`` with ``tie_policy="average"``,
+            whose legs are defined by rank *fraction* rather than count. The realised per-period tie
+            ratio is reported in ``metadata["tie_ratio"]`` and a median above
+            the shared threshold raises a ``UserWarning``. Only
+            ``_all_dates_degenerate`` used to guard this, and it fires only
+            when the factor is constant everywhere — a 3-level signal ranked
+            ordinally into fixed-``k`` legs reported an arbitrary split as a
+            spread with no tie diagnostic at all.
         inference: Headline significance method. ``fx.inference.NON_OVERLAPPING``
             (default) runs the OLS t-test on the non-overlap stride;
             ``fx.inference.NEWEY_WEST`` keeps every date and HAC-corrects the
@@ -290,7 +321,11 @@ def k_spread(
     # past the last real rank — silently shrinking or emptying the short leg.
     # forward_return is null on the last ``forward_periods`` rows per asset.
     sampled = _sample_non_overlapping(data, forward_periods)
-    series, clean = _build_k_spread_series(sampled, k, factor_col, return_col)
+    tie_ratio = _compute_tie_ratio(sampled, factor_col)
+    _warn_high_tie_ratio(tie_ratio, "k_spread", tie_policy)
+    series, clean = _build_k_spread_series(
+        sampled, k, factor_col, return_col, tie_policy
+    )
     n_assets = clean["asset_id"].n_unique()
     # Real per-period asset count (not the universe-wide unique count): both
     # insufficient-assets short-circuits report it under the same reason.
@@ -358,7 +393,9 @@ def k_spread(
     # before the HAC regression for the same reason ``arr`` is cleaned.
     full_series: pl.DataFrame | None = None
     if isinstance(inference, NeweyWest):
-        full_series, _ = _build_k_spread_series(data, k, factor_col, return_col)
+        full_series, _ = _build_k_spread_series(
+            data, k, factor_col, return_col, tie_policy
+        )
         if full_series is not None:
             full_series = full_series.filter(_finite_expr("spread"))
     # Thin-cross-section switch keys on the median per-period count of usable
@@ -395,6 +432,8 @@ def k_spread(
         "n_periods_strided": n_strided,
         "median_cross_section": median_xs,
         "k": k,
+        "tie_ratio": tie_ratio,
+        "tie_policy": tie_policy,
         "stat_type": "t",
         "h0": "mu=0",
         "method": sig_method,

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -342,6 +342,8 @@ def k_spread(
             k=k,
             min_required=2 * k,
             max_assets_per_date=max_per_date,
+            tie_ratio=tie_ratio,
+            tie_policy=tie_policy,
         )
 
     if series is None:
@@ -353,6 +355,8 @@ def k_spread(
             k=k,
             min_required=2 * k,
             max_assets_per_date=max_per_date,
+            tie_ratio=tie_ratio,
+            tie_policy=tie_policy,
         )
 
     spread_vals = _finite_values(series["spread"])
@@ -364,6 +368,8 @@ def k_spread(
         forward_periods,
         "insufficient_portfolio_periods",
         k=k,
+        tie_ratio=tie_ratio,
+        tie_policy=tie_policy,
     )
     if sc is not None:
         return sc
@@ -385,6 +391,8 @@ def k_spread(
             n_obs_axis="periods",
             k=k,
             n_periods_in=series.height,
+            tie_ratio=tie_ratio,
+            tie_policy=tie_policy,
         )
 
     arr = spread_vals.to_numpy()

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -15,6 +15,7 @@ Notes:
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 import polars as pl
@@ -37,8 +38,8 @@ from factrix._types import (
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups_batch,
-    _degenerate_test_fields,
     _enforce_scaled_floor,
+    _finite_expr,
     _median_universe_size,
     _sample_non_overlapping,
     _scaled_periods_threshold,
@@ -90,6 +91,64 @@ def _monotonicity_sample_threshold(self) -> SampleThreshold:
     )
 
 
+# Patton-Timmermann (2010) monotonic-relationship (MR) test. ``direction`` is
+# declared by the caller, not read off the data: running both and reporting the
+# better one is a two-sided search reported at a one-sided level.
+MRDirection = Literal["increasing", "decreasing"]
+
+
+def _mr_test(
+    bucket_means: np.ndarray,
+    *,
+    direction: MRDirection,
+    n_bootstrap: int,
+    seed: int | None,
+) -> tuple[float, float, dict[str, object]]:
+    """Patton-Timmermann (2010) MR test on a ``(n_periods, n_groups)`` block.
+
+    Returns ``(J, p_value, metadata)`` where ``J = min_i mean_t Delta_{i,t}`` is
+    the smallest average adjacent bucket-return difference, in return units.
+
+    H0 is "the pattern is **not** monotonically increasing", i.e.
+    ``min_i E[Delta_i] <= 0``; H1 is that every adjacent step is positive. The
+    null distribution is obtained by recentring the per-period difference matrix
+    at zero (the least-favourable configuration under H0) and resampling whole
+    blocks of periods with the stationary bootstrap, so cross-bucket dependence
+    within a period and serial dependence across periods are both preserved —
+    the differences are resampled jointly under one row-index draw, never
+    column by column.
+
+    ``p = (1 + #{J* >= J}) / (B + 1)`` — the Davison-Hinkley ``+1`` smoothing
+    the rest of the library's empirical-p paths use, so the p can never be
+    exactly 0.
+    """
+    from factrix.stats import stationary_bootstrap_resamples
+
+    diffs = np.diff(bucket_means, axis=1)
+    if direction == "decreasing":
+        diffs = -diffs
+    delta_bar = diffs.mean(axis=0)
+    j_stat = float(delta_bar.min())
+
+    if seed is None:
+        # Mirror ``StationaryBootstrap``: resolve a seed and report it, so a run
+        # is reproducible after the fact without a mandatory knob.
+        seed = int(np.random.default_rng().integers(0, 2**31 - 1))
+    resamples = stationary_bootstrap_resamples(diffs, n_bootstrap, seed=seed)
+    # (B, T, K-1) -> (B, K-1) bootstrap means, recentred under H0.
+    j_star = (resamples.mean(axis=1) - delta_bar).min(axis=1)
+    p_value = float((1 + int(np.count_nonzero(j_star >= j_stat))) / (n_bootstrap + 1))
+
+    metadata: dict[str, object] = {
+        "mr_direction": direction,
+        "mr_min_diff": j_stat,
+        "mr_adjacent_diffs": [float(v) for v in delta_bar],
+        "n_bootstrap": n_bootstrap,
+        "bootstrap_seed": seed,
+    }
+    return j_stat, p_value, metadata
+
+
 @metric(
     cell=cell(
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
@@ -105,36 +164,65 @@ def monotonicity(
     factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
+    direction: MRDirection = "increasing",
+    n_bootstrap: int = 1000,
+    seed: int | None = None,
 ) -> dict[str, MetricResult]:
-    """Quantile return monotonicity (Spearman correlation).
+    """Quantile return monotonicity — Patton-Timmermann (2010) MR test.
 
-    ``value`` = mean |Spearman| — magnitude of monotonicity (always ≥ 0).
-    ``t_stat`` = t-test on signed Spearman — whether direction is consistent.
-
-    A high ``value`` with insignificant ``t_stat`` means the factor has
-    strong monotonicity but the direction flips across dates.
+    ``value`` / ``stat`` = the MR statistic ``J = min_i mean_t Delta_{i,t}``,
+    the smallest average adjacent bucket-return difference, in return units.
+    ``p_value`` is its stationary-bootstrap p.
 
     Args:
         data: Panel with ``date, asset_id, factor, forward_return``.
-        n_groups: Number of quantile groups (default 10 for Taiwan ~2000 stocks).
-            Use 5 for ``n_assets < 1000``, 3 for ``n_assets < 200``.
+        n_groups: Number of quantile groups (default 10 for a ~2000-name
+            universe). Use 5 for ``n_assets < 1000``, 3 for ``n_assets < 200``.
         tie_policy: Bucketing tie-break policy, see ``_assign_quantile_groups``.
+        direction: Which monotone pattern H1 asserts — ``"increasing"``
+            (default) or ``"decreasing"`` in bucket index. Declare it from the
+            factor's hypothesis; running both and reporting the smaller p is a
+            two-sided search charged at a one-sided level.
+        n_bootstrap: Bootstrap resamples for the MR null distribution.
+        seed: Bootstrap seed. ``None`` resolves one and reports it in
+            ``metadata["bootstrap_seed"]``, so a run stays reproducible after
+            the fact.
 
     Returns:
-        MetricResult with value = mean |Spearman(group_idx, group_return)|.
+        MetricResult with ``value`` = ``stat`` = the MR statistic and
+        ``p_value`` from the bootstrap. The descriptive Spearman summaries
+        stay in metadata.
 
     Notes:
-        Per non-overlap date ``t``, bucket assets into ``n_groups`` by
-        factor rank and compute ``mono_t = Spearman(group_idx,
-        group_mean_return)``. ``value = mean_t |mono_t|`` (magnitude of
-        monotonicity, ≥ 0); ``t-stat = mean(mono) / (std(mono) /
-        sqrt(n))`` on the signed series tests directional consistency.
+        Per non-overlap date ``t``, assets are bucketed into ``n_groups`` by
+        factor rank and each bucket's mean return is taken. The MR test then
+        works on the adjacent differences ``Delta_{i,t} = mu_{i,t} -
+        mu_{i-1,t}``: ``J = min_i mean_t Delta_{i,t}``, with
+        ``H0: min_i E[Delta_i] <= 0`` ("the relation is *not* monotonically
+        increasing") against ``H1: min_i E[Delta_i] > 0``. The null
+        distribution comes from recentring the per-period difference matrix at
+        zero — the least-favourable configuration under H0 — and resampling
+        whole blocks of periods with the stationary bootstrap, which keeps both
+        the within-period cross-bucket dependence and the serial dependence
+        across periods. This is the test Patton-Timmermann (2010) actually
+        propose, and the one this metric previously cited without implementing.
 
-        factrix splits magnitude (``value``) and direction (``stat``)
-        deliberately: a high ``value`` paired with insignificant ``t``
-        means the factor monotonically discriminates returns but its sign
-        flips across dates — useful information that a single signed
-        average would hide.
+        **Why the headline is no longer mean |Spearman|.** ``mean_t |rho_t|``
+        has a large null floor that depends on ``n_groups``: on a factor drawn
+        independently of returns (T=400, N=100) it reads 0.66 at
+        ``n_groups=3``, 0.43 at 5 and 0.27 at 10, because ``E|rho| > 0`` under
+        H0 by Jensen's inequality. A reader seeing "value = 0.43,
+        Patton-Timmermann (2010)" took it as MR evidence when it was the noise
+        floor for five buckets. The Spearman summaries remain in metadata as
+        descriptive shape statistics —
+        ``mean_abs_spearman`` (magnitude, always >= 0) and ``mean_signed``
+        (direction consistency) — where a high magnitude with a near-zero
+        signed mean still tells the useful story that the factor sorts returns
+        but flips sign across dates.
+
+        **Deviation from the paper.** Patton-Timmermann bootstrap the raw
+        (unstudentised) differences, which is what runs here. Their studentised
+        variant is not implemented.
 
     Examples:
         >>> import factrix as fx
@@ -144,7 +232,9 @@ def monotonicity(
         ...     fx.datasets.make_cs_panel(n_assets=200, n_dates=180, seed=0),
         ...     forward_periods=5,
         ... )
-        >>> result = monotonicity(panel, forward_periods=5, n_groups=5)
+        >>> result = monotonicity(
+        ...     panel, forward_periods=5, n_groups=5, n_bootstrap=200, seed=0
+        ... )
         >>> result["factor"].name == ""
         True
     """
@@ -251,37 +341,46 @@ def monotonicity(
                 tie_policy=tie_policy,
             )
             continue
+        # Headline: the MR test on the same bucket means the Spearman
+        # summaries describe. ``mat`` is already restricted to periods with a
+        # finite mean in every bucket, so the difference matrix is finite.
+        j_stat, p_mr, mr_metadata = _mr_test(
+            mat,
+            direction=direction,
+            n_bootstrap=n_bootstrap,
+            seed=seed,
+        )
+        # Descriptive shape statistics, kept because magnitude and direction
+        # consistency read separately (see Notes) — not the headline.
         avg_mono = float(np.mean(np.abs(mono_arr)))
         mean_mono = float(np.mean(mono_arr))
         std_mono = float(np.std(mono_arr, ddof=DDOF))
-        t = _calc_t_stat(mean_mono, std_mono, len(mono_arr))
-        p = _p_value_from_t(t, len(mono_arr))
+        t_signed = _calc_t_stat(mean_mono, std_mono, len(mono_arr))
         metadata: dict[str, object] = {
-            "method": "t-test on per-period signed monotonicity",
-            "stat_type": "t",
-            "h0": "mu=0",
+            "method": (
+                "Patton-Timmermann (2010) MR test; stationary-bootstrap "
+                "empirical p on the min adjacent bucket-return difference"
+            ),
+            "stat_type": "mr",
+            "h0": f"min_i E[delta_i] <= 0 ({direction})",
+            "mean_abs_spearman": avg_mono,
             "mean_signed": mean_mono,
+            "signed_spearman_t": t_signed,
+            "signed_spearman_p_value": _p_value_from_t(t_signed, len(mono_arr)),
             "n_valid_periods": len(mono_arr),
             "n_groups": n_groups,
             "tie_ratio": tie_ratios[f],
             "tie_policy": tie_policy,
+            **mr_metadata,
         }
-        # An identical signed monotonicity on every period (a perfectly
-        # ordered factor, say) leaves no dispersion to test — ``avg_mono``
-        # still describes it, the t does not exist.
-        warning_codes: list[str] = []
-        stat, p_out, alternative = _degenerate_test_fields(
-            t, p, "two-sided", metadata, warning_codes
-        )
         results[f] = MetricResult(
-            p_value=p_out,
-            alternative=alternative,
-            value=avg_mono,
-            n_obs=len(mono_arr),
+            p_value=p_mr,
+            alternative="greater",
+            value=j_stat,
+            n_obs=mat.shape[0],
             n_obs_axis="periods",
-            stat=stat,
+            stat=j_stat,
             metadata=metadata,
-            warning_codes=tuple(warning_codes),
         )
 
     return results
@@ -295,23 +394,33 @@ def _compute_tie_ratios_batch(
     The single-factor :func:`_compute_tie_ratio` runs a separate polars
     aggregation per factor; this batches them into one ``group_by("date")`` so
     the sampled panel is scanned once for any number of factors. The tie ratio
-    is **per period** then median-reduced — the same statistic the single-factor
-    helper returns. Computing it globally (``n_unique`` / ``len`` over the whole
+    is **per period** over the *finite* values then median-reduced — the same
+    statistic the single-factor helper returns. Computing it globally (``n_unique`` / ``len`` over the whole
     frame) would conflate cross-sectional ties with values merely repeating
     across dates, inflating the ratio toward 1 and tripping spurious
     high-tie-ratio warnings on a continuous factor.
     """
     if not factor_cols:
         return {}
+    # Count only finite values, exactly as the single-factor
+    # :func:`_compute_tie_ratio` does. A bare ``pl.len()`` / ``n_unique()``
+    # counts nulls and NaNs as a tied level, so a cross-regional panel with 5
+    # of 10 names missing on a date read 0.4 on a factor with **zero** ties —
+    # over the 0.3 threshold, so the metric emitted a spurious
+    # "consider tie_policy='average'" advisory and stamped the wrong tie_ratio
+    # into metadata, while quantile_spread on the same panel reported 0.0.
     per_period = data.group_by("date").agg(
-        pl.len().alias("_n"),
-        *[pl.col(f).n_unique().alias(f"_u__{f}") for f in factor_cols],
+        *[_finite_expr(f).sum().alias(f"_n__{f}") for f in factor_cols],
+        *[
+            pl.col(f).filter(_finite_expr(f)).n_unique().alias(f"_u__{f}")
+            for f in factor_cols
+        ],
     )
     # ``median`` over the (possibly empty) per-period ratio yields ``None`` on an
     # empty frame, which maps to ``nan`` below — the same empty-panel contract as
     # the single-factor :func:`_compute_tie_ratio`, no separate guard needed.
     medians = per_period.select(
-        (1.0 - pl.col(f"_u__{f}") / pl.col("_n")).median().alias(f"_tr__{f}")
+        (1.0 - pl.col(f"_u__{f}") / pl.col(f"_n__{f}")).median().alias(f"_tr__{f}")
         for f in factor_cols
     ).row(0, named=True)
     return {

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -28,6 +28,7 @@ from factrix._axis import (
     FactorScope,
 )
 from factrix._codes import WarningCode
+from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
@@ -238,6 +239,23 @@ def monotonicity(
         >>> result["factor"].name == ""
         True
     """
+    if direction not in ("increasing", "decreasing"):
+        # A typo must not silently run the opposite one-sided test.
+        raise UserInputError(
+            func_name="monotonicity",
+            field="direction",
+            value=direction,
+            expected="'increasing' (default) or 'decreasing'",
+            docs_path="api/metrics/monotonicity",
+        )
+    if n_bootstrap < 1:
+        raise UserInputError(
+            func_name="monotonicity",
+            field="n_bootstrap",
+            value=n_bootstrap,
+            expected="a positive integer number of bootstrap resamples",
+            docs_path="api/metrics/monotonicity",
+        )
     cols = list(factor_cols)
     if not cols:
         raise ValueError("factor_cols must be non-empty")

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -54,6 +54,7 @@ from factrix.metrics._helpers import (
     _spread_significance_with_inference,
     _surface_null_drop,
     _warn_high_tie_ratio,
+    _warn_thin_quantile_groups,
 )
 from factrix.metrics._primitives import (
     compute_group_returns,
@@ -468,6 +469,78 @@ def _quantile_spread_from_series(
     )
 
 
+def _vw_spread_series(
+    panel: pl.DataFrame,
+    *,
+    factor_col: str,
+    return_col: str,
+    weight_col: str,
+    n_groups: int,
+    tie_policy: str,
+) -> pl.DataFrame:
+    """Per-period value-weighted top-minus-bottom spread for ``panel``.
+
+    Returns ``date, _n_assets, _n_unique, top_return_vw, bottom_return_vw,
+    spread_vw``. Split out of the metric body so the non-overlap path (strided
+    panel) and the HAC path (full overlapping panel) build the series the same
+    way, exactly as ``compute_spread_series`` serves both paths of the
+    equal-weighted sibling.
+    """
+    grouped = _assign_quantile_groups(
+        panel,
+        factor_col,
+        n_groups,
+        tie_policy=tie_policy,
+    )
+
+    top_group = n_groups - 1
+    bottom_group = 0
+
+    # A weighted mean is ``sum(w·r) / sum(w)``, and the two sums must run over
+    # the *same* names. A name with a missing return contributes nothing to the
+    # numerator (polars ``sum`` skips nulls) but its weight would still sit in
+    # the denominator, shrinking the bucket return toward 0 in proportion to how
+    # much of the bucket is missing. Masking the weight to null wherever the
+    # return (or the weight itself) is non-finite keeps both sums on the same
+    # sample.
+    finite_return = _finite_expr(return_col)
+    finite_weight = _finite_expr(weight_col)
+    finite_factor = _finite_expr(factor_col)
+
+    def _bucket_vw(group: int) -> pl.Expr:
+        """Weighted bucket return, null when no name in it carries a weight."""
+        in_bucket = pl.col("_group") == group
+        w_sum = pl.col("_w").filter(in_bucket).sum()
+        wr_sum = pl.col("_wr").filter(in_bucket).sum()
+        # ``sum()`` of an all-null column is 0, not null, so an empty or
+        # fully-missing bucket would otherwise divide 0/0 -> NaN, or (worse)
+        # surface as a manufactured 0.0 return. Emit null instead: no
+        # observation, not a zero return.
+        return pl.when(w_sum.is_not_null() & (w_sum != 0)).then(wr_sum / w_sum)
+
+    # WHY: per-period weighted mean for top and bottom buckets
+    return (
+        grouped.with_columns(
+            pl.when(finite_return & finite_weight).then(pl.col(weight_col)).alias("_w"),
+        )
+        .with_columns((pl.col(return_col) * pl.col("_w")).alias("_wr"))
+        .group_by("date")
+        .agg(
+            pl.col(factor_col).filter(finite_factor).len().alias("_n_assets"),
+            pl.col(factor_col).filter(finite_factor).n_unique().alias("_n_unique"),
+            _bucket_vw(top_group).alias("top_return_vw"),
+            _bucket_vw(bottom_group).alias("bottom_return_vw"),
+        )
+        .with_columns(
+            pl.when((pl.col("_n_assets") > 0) & (pl.col("_n_unique") <= 1))
+            .then(pl.lit(0.0))
+            .otherwise(pl.col("top_return_vw") - pl.col("bottom_return_vw"))
+            .alias("spread_vw"),
+        )
+        .sort("date")
+    )
+
+
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
@@ -481,6 +554,7 @@ def quantile_spread_vw(
     return_col: str = "forward_return",
     weight_col: str = "market_cap",
     tie_policy: str = "ordinal",
+    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
     lag_weights: bool = True,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
@@ -515,6 +589,13 @@ def quantile_spread_vw(
         data: Panel with ``date, asset_id, factor, forward_return,
             market_cap`` (or whatever ``weight_col`` names).
         weight_col: Column for value weighting (default ``market_cap``).
+        inference: Headline significance method on the per-period spread —
+            the same knob, allowlist and default as ``quantile_spread``, so
+            the equal-weighted / value-weighted pair is tested the same way on
+            the same date set. ``fx.inference.NON_OVERLAPPING`` (default) runs
+            the OLS t-test on the non-overlap stride subsample;
+            ``fx.inference.NEWEY_WEST`` keeps every date and absorbs the
+            MA(h-1) overlap in a HAC SE.
         lag_weights: When True (default), shift ``weight_col`` by 1
             period per asset (on the non-overlap-sampled frame) before
             weighting. When False, use weights as supplied.
@@ -533,7 +614,10 @@ def quantile_spread_vw(
             value = mean_t spread[t];  t = sqrt(n) * value / std(spread)
 
         factrix lags weights by one **sampled** period per asset by default
-        (not one raw bar) so the lag aligns with the rebalance stride;
+        (not one raw bar) so the lag aligns with the rebalance stride. Under
+        ``inference=NEWEY_WEST`` there is no stride — every date is its own
+        rebalance — so the lag is one bar there, and the first date drops out
+        for want of a lagged weight;
         contemporaneous ``weight × forward_return`` would embed look-ahead
         bias from market-cap moves that the forward return has not yet
         realized.
@@ -558,6 +642,18 @@ def quantile_spread_vw(
         the unguarded ratio would manufacture a ``0.0`` spread on a fully
         missing date and count it as a real observation, biasing both the
         mean and the t-stat toward zero.
+
+        **Thin-cross-section diagnostics.** This path used to build its
+        buckets inline and call the t-test directly, so it emitted none of
+        the diagnostics its equal-weighted sibling does: on an 8-name panel
+        cut into 5 buckets — 1.6 names per leg — ``quantile_spread``
+        reported ``('few_assets', 'thin_quantile_groups')`` and a
+        ``UserWarning``, while ``quantile_spread_vw`` reported clean. That
+        is exactly backwards for the metric whose purpose is a capacity /
+        robustness cross-check. It now routes through the same headline
+        chokepoint (``FEW_ASSETS`` on the median per-period finite-factor
+        count) and raises the same thin-bucket advisory and
+        ``THIN_QUANTILE_GROUPS`` code off the same threshold.
 
     References:
         [Hou-Xue-Zhang (2020)][hou-xue-zhang-2020]: ~65% of anomalies
@@ -584,64 +680,28 @@ def quantile_spread_vw(
             missing_column=weight_col,
         )
 
+    _check_applicable_inference(
+        inference, applicable_inference, func_name="quantile_spread_vw"
+    )
+
     sampled = _sample_non_overlapping(data, forward_periods)
     if lag_weights:
         sampled = _lag_within_asset(sampled, weight_col)
     tie_ratio = _compute_tie_ratio(sampled, factor_col)
     _warn_high_tie_ratio(tie_ratio, "quantile_spread_vw", tie_policy)
+    # Same dual-channel thin-bucket advisory the equal-weighted sibling gets,
+    # off the same threshold: this metric exists as a capacity / robustness
+    # cross-check, so it must not be the one that reports clean on a panel
+    # whose legs hold a single name each.
+    _warn_thin_quantile_groups(sampled, n_groups)
 
-    grouped = _assign_quantile_groups(
+    vw_series = _vw_spread_series(
         sampled,
-        factor_col,
-        n_groups,
+        factor_col=factor_col,
+        return_col=return_col,
+        weight_col=weight_col,
+        n_groups=n_groups,
         tie_policy=tie_policy,
-    )
-
-    top_group = n_groups - 1
-    bottom_group = 0
-
-    # A weighted mean is ``sum(w·r) / sum(w)``, and the two sums must run over
-    # the *same* names. A name with a missing return contributes nothing to the
-    # numerator (polars ``sum`` skips nulls) but its weight would still sit in
-    # the denominator, shrinking the bucket return toward 0 in proportion to how
-    # much of the bucket is missing. Masking the weight to null wherever the
-    # return (or the weight itself) is non-finite keeps both sums on the same
-    # sample.
-    finite_return = _finite_expr(return_col)
-    finite_weight = _finite_expr(weight_col)
-    finite_factor = _finite_expr(factor_col)
-
-    def _bucket_vw(group: int) -> pl.Expr:
-        """Weighted bucket return, null when no name in it carries a weight."""
-        in_bucket = pl.col("_group") == group
-        w_sum = pl.col("_w").filter(in_bucket).sum()
-        wr_sum = pl.col("_wr").filter(in_bucket).sum()
-        # ``sum()`` of an all-null column is 0, not null, so an empty or
-        # fully-missing bucket would otherwise divide 0/0 -> NaN, or (worse)
-        # surface as a manufactured 0.0 return. Emit null instead: no
-        # observation, not a zero return.
-        return pl.when(w_sum.is_not_null() & (w_sum != 0)).then(wr_sum / w_sum)
-
-    # WHY: per-period weighted mean for top and bottom buckets
-    vw_series = (
-        grouped.with_columns(
-            pl.when(finite_return & finite_weight).then(pl.col(weight_col)).alias("_w"),
-        )
-        .with_columns((pl.col(return_col) * pl.col("_w")).alias("_wr"))
-        .group_by("date")
-        .agg(
-            pl.col(factor_col).filter(finite_factor).len().alias("_n_assets"),
-            pl.col(factor_col).filter(finite_factor).n_unique().alias("_n_unique"),
-            _bucket_vw(top_group).alias("top_return_vw"),
-            _bucket_vw(bottom_group).alias("bottom_return_vw"),
-        )
-        .with_columns(
-            pl.when((pl.col("_n_assets") > 0) & (pl.col("_n_unique") <= 1))
-            .then(pl.lit(0.0))
-            .otherwise(pl.col("top_return_vw") - pl.col("bottom_return_vw"))
-            .alias("spread_vw"),
-        )
-        .sort("date")
     )
 
     spread_vals = _finite_values(vw_series["spread_vw"])
@@ -698,21 +758,58 @@ def quantile_spread_vw(
         )
 
     arr = spread_vals.to_numpy()
-    mean_spread = float(np.mean(arr))
-    std_spread = float(np.std(arr, ddof=DDOF))
-    t = _calc_t_stat(mean_spread, std_spread, n)
+    # Same headline chokepoint as the equal-weighted sibling, so the pair is
+    # tested the same way on the same date set: ``NON_OVERLAPPING`` reproduces
+    # the previous strided t bit-for-bit, ``NEWEY_WEST`` keeps every date and
+    # HAC-corrects the MA(h-1) overlap. The FEW_ASSETS advisory rides along on
+    # the median per-period finite-factor count.
+    n_assets = _median_finite_cross_section(sampled, factor_col)
+    full_series = None
+    if isinstance(inference, NeweyWest):
+        full_panel = _lag_within_asset(data, weight_col) if lag_weights else data
+        full_series = _vw_spread_series(
+            full_panel,
+            factor_col=factor_col,
+            return_col=return_col,
+            weight_col=weight_col,
+            n_groups=n_groups,
+            tie_policy=tie_policy,
+        ).select("date", pl.col("spread_vw").alias("spread"))
+        full_series = full_series.filter(_finite_expr("spread"))
 
-    p = _p_value_from_t(t, n)
+    mean_spread, t, p, sig_method, sig_extra, sig_codes = (
+        _spread_significance_with_inference(
+            inference,
+            strided_spread=arr,
+            full_spread=full_series,
+            forward_periods=forward_periods,
+            n_assets=n_assets,
+        )
+    )
+    n_tested = int(
+        cast(
+            int,
+            sig_extra.get("n_periods_tested", sig_extra.get("n_periods_full", n)),
+        )
+    )
     metadata: dict[str, object] = {
-        "n_periods": n,
-        "method": "non-overlapping t-test",
+        "n_periods": n_tested,
+        "n_periods_strided": n,
+        "median_cross_section": n_assets,
+        "method": sig_method,
         "stat_type": "t",
         "h0": "mu=0",
         "tie_ratio": tie_ratio,
         "tie_policy": tie_policy,
         "weights_lagged": lag_weights,
+        **sig_extra,
     }
-    warning_codes: list[str] = []
+    warning_codes = list(sig_codes)
+    # Structured twin of the thin-bucket advisory raised above.
+    if _is_thin_quantile_groups(sampled, n_groups):
+        warning_codes.append(WarningCode.THIN_QUANTILE_GROUPS.value)
+    # Drop stats describe the strided series this consumer collapsed, whatever
+    # sample the headline test ended up running on.
     _surface_null_drop(
         n_periods_in=vw_series.height,
         n_periods_out=n,
@@ -731,7 +828,7 @@ def quantile_spread_vw(
         p_value=p_out,
         alternative=alternative,
         value=mean_spread,
-        n_obs=n,
+        n_obs=n_tested,
         n_obs_axis="periods",
         stat=stat,
         metadata=metadata,

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -32,6 +32,8 @@ from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t, _significance_marker
 from factrix._types import (
     DDOF,
+    DEFAULT_FORWARD_PERIODS,
+    DEFAULT_N_GROUPS,
     MIN_PORTFOLIO_PERIODS_HARD,
 )
 from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
@@ -148,8 +150,8 @@ def _quantile_groups_threshold(self) -> SampleThreshold:
 )
 def quantile_spread(
     data: pl.DataFrame,
-    forward_periods: int = 5,
-    n_groups: int = 5,
+    forward_periods: int = DEFAULT_FORWARD_PERIODS,
+    n_groups: int = DEFAULT_N_GROUPS,
     factor_cols: Sequence[str] = ("factor",),
     tie_policy: str = "ordinal",
     inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
@@ -422,6 +424,8 @@ def _quantile_spread_from_series(
         "n_periods_long_leg": int(long_arr.size),
         "n_periods_short_leg": int(short_arr.size),
         "median_cross_section": n_assets,
+        "n_groups": n_groups,
+        "forward_periods": forward_periods,
         "stat_type": "t",
         "h0": "mu=0",
         "method": sig_method,
@@ -548,8 +552,8 @@ def _vw_spread_series(
 )
 def quantile_spread_vw(
     data: pl.DataFrame,
-    forward_periods: int = 5,
-    n_groups: int = 5,
+    forward_periods: int = DEFAULT_FORWARD_PERIODS,
+    n_groups: int = DEFAULT_N_GROUPS,
     factor_col: str = "factor",
     return_col: str = "forward_return",
     weight_col: str = "market_cap",
@@ -796,6 +800,8 @@ def quantile_spread_vw(
         "n_periods": n_tested,
         "n_periods_strided": n,
         "median_cross_section": n_assets,
+        "n_groups": n_groups,
+        "forward_periods": forward_periods,
         "method": sig_method,
         "stat_type": "t",
         "h0": "mu=0",

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -36,18 +36,27 @@ from factrix._axis import (
     InputShape,
 )
 from factrix._codes import WarningCode
+from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._types import DDOF, EPSILON
+from factrix._types import (
+    DDOF,
+    DEFAULT_FORWARD_PERIODS,
+    DEFAULT_N_GROUPS,
+    EPSILON,
+)
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
     _enforce_min_floor,
+    _finite_expr,
     _median_universe_size,
     _sample_non_overlapping,
     _short_circuit_output,
 )
+
+_DOCS_TRADABILITY = "api/metrics/tradability"
 
 _TR_CELL = cell(
     FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
@@ -204,7 +213,16 @@ def rank_turnover(
             forward_periods=forward_periods,
         )
 
-    sampled_df = _sample_non_overlapping(data, forward_periods)
+    # WHY: polars ``rank()`` sorts NaN *last*, i.e. treats it as larger than
+    # every real value, so a missing factor landed in the top tail; and
+    # ``pl.len()`` counted those rows, giving the wrong denominator for the
+    # tail cutoffs below. Together they pushed rank turnover to 1.0047 —
+    # outside the metric's own [0, 1] range — on a panel with 20% NaN factor
+    # cells. Every other ranking site in the library filters first; this was
+    # the last one that did not.
+    sampled_df = _sample_non_overlapping(data, forward_periods).filter(
+        _finite_expr(factor_col)
+    )
 
     ranked = sampled_df.select(
         "date",
@@ -298,8 +316,8 @@ def notional_turnover(
     data: pl.DataFrame,
     factor_col: str = "factor",
     *,
-    n_groups: int = 10,
-    forward_periods: int = 1,
+    n_groups: int = DEFAULT_N_GROUPS,
+    forward_periods: int = DEFAULT_FORWARD_PERIODS,
 ) -> MetricResult:
     """Portfolio notional turnover via top/bottom quantile membership churn.
 
@@ -327,11 +345,28 @@ def notional_turnover(
     Args:
         data: Panel with ``date, asset_id, factor``.
         factor_col: Name of the factor column.
-        n_groups: Number of quantile groups (default ``10`` = deciles).
-            Must be ≥ 3 so top and bottom are distinct buckets.
-        forward_periods: Rebalance stride. When ``> 1``, sub-samples at
-            stride ``h`` before pairing consecutive dates — matches a
-            holding-period-aligned rebalance schedule.
+        n_groups: Number of quantile groups (default
+            :data:`~factrix._types.DEFAULT_N_GROUPS` = 5 = quintiles, the
+            same constant ``quantile_spread`` defaults to). Must be ≥ 3 so
+            top and bottom are distinct buckets.
+        forward_periods: Rebalance stride (default
+            :data:`~factrix._types.DEFAULT_FORWARD_PERIODS`). When ``> 1``,
+            sub-samples at stride ``h`` before pairing consecutive dates —
+            matches a holding-period-aligned rebalance schedule.
+
+    Warning:
+        ``n_groups`` and ``forward_periods`` must match the ``quantile_spread``
+        run whose spread is paired with this turnover. The cost algebra in
+        ``breakeven_cost`` / ``net_spread`` is a statement about *one*
+        portfolio, so a τ measured on decile membership churn does not price a
+        quintile spread, and a τ per bar does not price a 5-period holding.
+        The two used to ship incompatible defaults (10 / 1 here against 5 / 5
+        there); on a 60-name, 400-period panel at ``gross_spread = 0.001``, the
+        matched pair gave breakeven 15.7 bps and net −9.14 bps while each
+        function at its own default gave 2.8 bps and −98.02 bps — breakeven
+        understated 5.6x, drag overstated 10.7x. They now share one constant,
+        and the consumers cross-check the pairing when handed ``MetricResult``s
+        instead of bare floats.
 
     Returns:
         MetricResult with ``value`` = mean per-rebalance turnover ∈ [0, 1].
@@ -485,6 +520,86 @@ def notional_turnover(
     )
 
 
+def _unpack_cost_inputs(
+    gross_spread: float | MetricResult,
+    turnover: float | MetricResult,
+    forward_periods: int,
+) -> tuple[float, float, dict[str, object]]:
+    """Resolve the two cost inputs and cross-check that they describe one book.
+
+    ``breakeven_cost`` / ``net_spread`` take a spread and a turnover and solve
+    a single portfolio's cost algebra. That algebra is only meaningful when the
+    two were computed on the *same* bucketing and the *same* rebalance stride —
+    a tau measured on decile membership churn does not price a quintile spread.
+    Bare floats carry no provenance, so nothing could be checked; when the
+    caller passes the producing ``MetricResult``s instead, the pairing is
+    verified here and recorded in the consumer's metadata.
+
+    Raises:
+        UserInputError: the two results disagree on ``n_groups``, or either
+            disagrees with the ``forward_periods`` this call was given.
+    """
+    checked: dict[str, object] = {}
+    spread_meta = (
+        gross_spread.metadata if isinstance(gross_spread, MetricResult) else {}
+    )
+    turnover_meta = turnover.metadata if isinstance(turnover, MetricResult) else {}
+
+    def _mismatch(field: str, left: object, right: object, detail: str) -> None:
+        raise UserInputError(
+            func_name="breakeven_cost / net_spread",
+            field=field,
+            value={"gross_spread": left, "turnover": right},
+            expected=detail,
+            docs_path=_DOCS_TRADABILITY,
+        )
+
+    spread_groups = spread_meta.get("n_groups")
+    turnover_groups = turnover_meta.get("n_groups")
+    if (
+        spread_groups is not None
+        and turnover_groups is not None
+        and spread_groups != turnover_groups
+    ):
+        _mismatch(
+            "n_groups",
+            spread_groups,
+            turnover_groups,
+            "the spread and the turnover to be computed on the same bucketing; "
+            "recompute one of them so both use the same n_groups (the shared "
+            "default is DEFAULT_N_GROUPS)",
+        )
+    if spread_groups is not None or turnover_groups is not None:
+        checked["n_groups"] = (
+            spread_groups if spread_groups is not None else turnover_groups
+        )
+
+    for label, meta in (("gross_spread", spread_meta), ("turnover", turnover_meta)):
+        upstream_h = meta.get("forward_periods")
+        if upstream_h is not None and upstream_h != forward_periods:
+            _mismatch(
+                "forward_periods",
+                upstream_h if label == "gross_spread" else None,
+                upstream_h if label == "turnover" else None,
+                f"the {label} to have been computed at the same rebalance "
+                f"stride as this call's forward_periods={forward_periods}; got "
+                f"{upstream_h} upstream",
+            )
+    if spread_meta or turnover_meta:
+        checked["forward_periods"] = forward_periods
+        checked["pairing_checked"] = True
+
+    spread_value = (
+        gross_spread.value
+        if isinstance(gross_spread, MetricResult)
+        else float(gross_spread)
+    )
+    turnover_value = (
+        turnover.value if isinstance(turnover, MetricResult) else float(turnover)
+    )
+    return float(spread_value), float(turnover_value), checked
+
+
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
@@ -492,10 +607,10 @@ def notional_turnover(
     sample_threshold=SampleThreshold(),
 )
 def breakeven_cost(
-    gross_spread: float,
-    turnover: float,
+    gross_spread: float | MetricResult,
+    turnover: float | MetricResult,
     *,
-    forward_periods: int = 1,
+    forward_periods: int = DEFAULT_FORWARD_PERIODS,
 ) -> MetricResult:
     """Breakeven single-leg trading cost in bps.
 
@@ -526,6 +641,19 @@ def breakeven_cost(
         turnover: Notional turnover ∈ [0, 1] from ``notional_turnover()``.
         forward_periods: Holding period matching the upstream
             ``compute_forward_return`` and ``notional_turnover`` stride.
+
+    Note:
+        **Pass the ``MetricResult``s, not their ``.value``.** Both data
+        arguments accept either a bare ``float`` or the producing
+        ``MetricResult``. Given the results, this function verifies that the
+        spread and the turnover describe the *same* portfolio — same
+        ``n_groups``, same ``forward_periods`` — and raises ``UserInputError``
+        when they do not, recording ``pairing_checked`` in metadata when they
+        do. Bare floats carry no provenance, so nothing can be checked: the
+        cost algebra silently prices a quintile spread with decile turnover if
+        that is what it is handed. With the pre-unification defaults that was
+        the *likely* outcome, not a corner case — breakeven came out 5.6x too
+        low and cost drag 10.7x too high.
 
     Returns:
         MetricResult with value = breakeven cost in bps.
@@ -576,6 +704,9 @@ def breakeven_cost(
     """
     if forward_periods < 1:
         raise ValueError(f"forward_periods must be ≥ 1, got {forward_periods!r}")
+    gross_spread, turnover, checked = _unpack_cost_inputs(
+        gross_spread, turnover, forward_periods
+    )
     if turnover < EPSILON:
         return MetricResult(
             value=float("inf"),
@@ -583,6 +714,7 @@ def breakeven_cost(
                 "gross_spread": gross_spread,
                 "turnover": turnover,
                 "forward_periods": forward_periods,
+                **checked,
             },
         )
 
@@ -598,6 +730,7 @@ def breakeven_cost(
             "gross_spread": gross_spread,
             "turnover": turnover,
             "forward_periods": forward_periods,
+            **checked,
         },
     )
 
@@ -609,11 +742,11 @@ def breakeven_cost(
     sample_threshold=SampleThreshold(),
 )
 def net_spread(
-    gross_spread: float,
-    turnover: float,
+    gross_spread: float | MetricResult,
+    turnover: float | MetricResult,
     estimated_cost_bps: float = 30.0,
     *,
-    forward_periods: int = 1,
+    forward_periods: int = DEFAULT_FORWARD_PERIODS,
 ) -> MetricResult:
     """Net spread after estimated trading costs (per-period).
 
@@ -654,6 +787,12 @@ def net_spread(
             it here.
         forward_periods: Holding period matching the upstream
             ``compute_forward_return`` and ``notional_turnover`` stride.
+
+    Note:
+        ``gross_spread`` and ``turnover`` accept the producing
+        ``MetricResult``s as well as bare floats; passing the results lets this
+        function verify that the two were computed on the same bucketing and
+        the same stride. See :func:`breakeven_cost`.
 
     Returns:
         MetricResult with value = net spread (per-period).
@@ -711,6 +850,9 @@ def net_spread(
     """
     if forward_periods < 1:
         raise ValueError(f"forward_periods must be ≥ 1, got {forward_periods!r}")
+    gross_spread, turnover, checked = _unpack_cost_inputs(
+        gross_spread, turnover, forward_periods
+    )
     # 4 × τ × c: τ is the mean per-leg replaced fraction, each replacement is a
     # sell plus a buy (2τ traded notional per leg) and the $1/$1 long-short
     # holds two legs. See Notes for the derivation.
@@ -725,5 +867,6 @@ def net_spread(
             "estimated_cost_bps": estimated_cost_bps,
             "turnover": turnover,
             "forward_periods": forward_periods,
+            **checked,
         },
     )

--- a/factrix/preprocess/normalize.py
+++ b/factrix/preprocess/normalize.py
@@ -418,7 +418,14 @@ def cross_sectional_zscore(
         n=10 — and, worse, the inflation is ``n``-dependent, so on an
         unbalanced panel thin dates produce systematically larger z and
         every pooled or z-weighted statistic over-weights the noisiest
-        cross-sections. See :func:`mad_winsorize`.
+        cross-sections. ``b_n`` removes the bias in the *scale estimator*
+        (``E[b_n · 1.4826 · MAD] = σ`` to within 1% at every ``n >= 3``),
+        which brings the expected ``sd(z)`` to 1.38 at n=5 and 1.08 at
+        n=10; the residual excess is Jensen curvature in ``E[σ̂ / scale]``
+        and no fixed constant removes it. The constant targets the
+        *normal-consistent* scale: on heavier tails it overstates the
+        distribution's own MAD-implied scale (about +12% at n=3 on a
+        t(5), under +1% by n=50). See :func:`mad_winsorize`.
 
         **Zero-MAD fallback.** With more than 50% ties on a date the MAD is
         exactly 0, so the naive ratio is ``+-inf`` for every non-median

--- a/factrix/preprocess/normalize.py
+++ b/factrix/preprocess/normalize.py
@@ -6,13 +6,93 @@ Step 5 — Cross-sectional Z-score: MAD-based robust standardization
 All functions expect canonical column names (date, asset_id).
 """
 
+from __future__ import annotations
+
+import warnings
+from typing import Any, Literal, cast
+
 import polars as pl
 
-from factrix._types import EPSILON, MAD_CONSISTENCY_CONSTANT
+from factrix._codes import WarningCode
+from factrix._errors import UserInputError
+from factrix._types import (
+    EPSILON,
+    MAD_CONSISTENCY_CONSTANT,
+    MIN_SCALE_ASSETS_HARD,
+)
+
+__all__ = ["cross_sectional_zscore", "mad_winsorize"]
+
+_DOCS_MAD_WINSORIZE = "api/preprocess#mad_winsorize"
+_DOCS_ZSCORE = "api/preprocess#cross_sectional_zscore"
+
+# Where the per-date centre is taken. ``"median"`` is the robust default;
+# ``"mean"`` buys an exactly mean-zero score at the cost of outlier
+# sensitivity (see :func:`cross_sectional_zscore` Notes).
+Center = Literal["median", "mean"]
+
+# Croux-Rousseeuw (1992) finite-sample correction factors ``b_n`` for the
+# MAD scale estimator. ``1.4826`` is the *asymptotic* consistency constant
+# (1/Phi^-1(0.75)); at finite ``n`` the MAD is biased low, and the bias is
+# ``n``-dependent — 18% at n=5, 9% at n=10, 4% at n=20. Left uncorrected,
+# an unbalanced panel (delistings, staggered entry, event-triggered sparse
+# dates) hands thin cross-sections systematically larger z-scores, so
+# anything that pools or weights by z over-weights the thinnest, noisiest
+# dates. The tabulated factors cover ``n <= 9``; above that the authors'
+# asymptotic expansion ``n / (n - 0.8)`` is accurate to well under 1%.
+_CR_SMALL_SAMPLE_FACTORS: dict[int, float] = {
+    3: 1.495,
+    4: 1.363,
+    5: 1.206,
+    6: 1.200,
+    7: 1.140,
+    8: 1.129,
+    9: 1.107,
+}
+
+
+def _validate_n_mad(n_mad: object) -> float:
+    """``n_mad`` must be a finite non-negative number.
+
+    ``float("nan")`` used to pass the bare ``n_mad <= 0`` guard, produce NaN
+    clip bounds, and be treated by polars as a no-op — winsorization silently
+    skipped with no trace in the output. Validate in the style of
+    ``_validate_forward_periods`` / ``_validate_winsorize_bounds``.
+    """
+    if isinstance(n_mad, bool) or not isinstance(n_mad, int | float):
+        raise UserInputError(
+            func_name="mad_winsorize",
+            field="n_mad",
+            value=n_mad,
+            expected="a finite non-negative number of MAD units, e.g. 3.0",
+            docs_path=_DOCS_MAD_WINSORIZE,
+        )
+    value = float(n_mad)
+    if value != value or value in (float("inf"), float("-inf")) or value < 0.0:
+        raise UserInputError(
+            func_name="mad_winsorize",
+            field="n_mad",
+            value=n_mad,
+            expected="a finite number >= 0 (0 disables winsorization)",
+            docs_path=_DOCS_MAD_WINSORIZE,
+        )
+    return value
+
+
+def _validate_center(center: object, func_name: str, docs_path: str) -> Center:
+    if center not in ("median", "mean"):
+        raise UserInputError(
+            func_name=func_name,
+            field="center",
+            value=center,
+            expected="'median' (robust, default) or 'mean' (mean-zero output)",
+            docs_path=docs_path,
+        )
+    return center
 
 
 def _finite(factor_col: str) -> pl.Expr:
-    """``factor_col`` with non-finite entries (NaN / ±Inf) blanked to null.
+    """``factor_col`` with non-finite entries (NaN / +-Inf) blanked to null.
 
     polars aggregations skip nulls but *propagate* float NaN, so a single
     NaN on a date would otherwise poison that date's median / MAD / std and
@@ -25,70 +105,242 @@ def _finite(factor_col: str) -> pl.Expr:
     return pl.when(col.is_finite()).then(col).otherwise(None)
 
 
-def _scale_expressions(factor_col: str) -> tuple[pl.Expr, pl.Expr]:
-    """Per-date centre and dispersion expressions for a factor column.
+def _mad_correction_expr(n_col: str) -> pl.Expr:
+    """Croux-Rousseeuw (1992) ``b_n`` keyed on the per-date finite count."""
+    n = pl.col(n_col)
+    expr: Any = pl.when(n >= 10).then(n / (n - 0.8))
+    for size, factor in _CR_SMALL_SAMPLE_FACTORS.items():
+        expr = expr.when(n == size).then(pl.lit(factor))
+    return cast(pl.Expr, expr.otherwise(pl.lit(None, dtype=pl.Float64)))
 
-    Returns:
-        ``(median_expr, scale_expr)`` — both per-date window expressions.
-        ``scale_expr`` is ``1.4826 × MAD`` when the MAD is non-degenerate,
-        the per-date sample standard deviation (``ddof=1``) when the MAD
-        collapses to zero, and ``0.0`` when the cross-section carries no
-        dispersion at all.
+
+def _per_date_scale(
+    data: pl.DataFrame, factor_col: str, center: Center
+) -> pl.DataFrame:
+    """Per-date centre / scale / regime table for ``factor_col``.
+
+    Columns: ``date``, ``_n_finite``, ``_center``, ``_scale``,
+    ``_scale_method``, ``_sparse_zero``. ``_scale_method`` names which branch
+    of the ladder produced ``_scale`` so every regime-driven switch is visible
+    to the caller instead of being folded into one number:
+
+    ``"mad"``
+        ``b_n * 1.4826 * MAD`` — the robust, small-sample-consistent scale.
+    ``"std"``
+        The MAD collapsed to 0 (>50% ties at the median) and the per-date
+        sample standard deviation (``ddof=1``) stood in for it.
+    ``"constant"``
+        No dispersion at all; ``_scale`` is ``0.0``.
+    ``"insufficient_assets"``
+        Fewer than ``MIN_SCALE_ASSETS_HARD`` finite values on the date —
+        no robust scale exists, ``_scale`` is null.
+
+    The MAD is always taken about the **median**, whatever ``center`` is:
+    it is a dispersion about the median by definition, and its consistency
+    constant is calibrated for that.
     """
     clean = _finite(factor_col)
-    median_expr = clean.median().over("date")
-    mad_expr = (clean - median_expr).abs().median().over("date")
-    std_expr = clean.std(ddof=1).over("date")
+    medians = data.group_by("date").agg(
+        clean.count().alias("_n_finite"),
+        clean.median().alias("_median"),
+        (clean.mean() if center == "mean" else clean.median()).alias("_center"),
+        clean.std(ddof=1).alias("_std"),
+        (clean == 0).sum().alias("_n_zero"),
+    )
+    mad = (
+        data.join(medians.select("date", "_median"), on="date", how="left")
+        .group_by("date")
+        .agg((clean - pl.col("_median")).abs().median().alias("_mad"))
+    )
+    stats = medians.join(mad, on="date", how="left")
 
-    scale_expr = (
-        pl.when(mad_expr > EPSILON)
-        .then(mad_expr * MAD_CONSISTENCY_CONSTANT)
-        .when(std_expr > EPSILON)
-        .then(std_expr)
+    scale = (
+        pl.when(pl.col("_n_finite") < MIN_SCALE_ASSETS_HARD)
+        .then(pl.lit(None, dtype=pl.Float64))
+        .when(pl.col("_mad") > EPSILON)
+        .then(
+            pl.col("_mad")
+            * MAD_CONSISTENCY_CONSTANT
+            * _mad_correction_expr("_n_finite")
+        )
+        .when(pl.col("_std") > EPSILON)
+        .then(pl.col("_std"))
         .otherwise(pl.lit(0.0))
     )
-    return median_expr, scale_expr
+    method = (
+        pl.when(pl.col("_n_finite") < MIN_SCALE_ASSETS_HARD)
+        .then(pl.lit("insufficient_assets"))
+        .when(pl.col("_mad") > EPSILON)
+        .then(pl.lit("mad"))
+        .when(pl.col("_std") > EPSILON)
+        .then(pl.lit("std"))
+        .otherwise(pl.lit("constant"))
+    )
+    # A ``{0, R}`` sparse trigger column: the median is 0 and the MAD is 0 by
+    # construction once fewer than half the assets fire, so the std fallback
+    # is driven *by the triggers themselves* and collapses toward zero as the
+    # trigger rate falls.
+    sparse_zero = (
+        (pl.col("_median") == 0)
+        & (pl.col("_mad") <= EPSILON)
+        & (pl.col("_n_zero") > 0)
+        & (pl.col("_n_zero") < pl.col("_n_finite"))
+    )
+    return stats.select(
+        "date",
+        "_n_finite",
+        pl.col("_center"),
+        scale.alias("_scale"),
+        method.alias("_scale_method"),
+        sparse_zero.alias("_sparse_zero"),
+    )
+
+
+def _warn_scale_regimes(
+    stats: pl.DataFrame, func_name: str, *, sparse_skipped: bool
+) -> None:
+    """Emit one ``UserWarning`` per regime-driven scale switch seen in ``stats``.
+
+    The project convention is that a sample-regime-driven switch of estimator
+    never happens silently. These functions return a bare DataFrame (there is
+    no ``MetricResult`` to hang ``warning_codes`` on), so the
+    :class:`~factrix._codes.WarningCode` value is carried in the warning text.
+    """
+    n_dates = stats.height
+    if not n_dates:
+        return
+    counts: dict[str, int] = {}
+    for method in stats["_scale_method"].to_list():
+        counts[method] = counts.get(method, 0) + 1
+
+    n_std = counts.get("std", 0)
+    n_sparse = int(stats["_sparse_zero"].sum()) if sparse_skipped else 0
+    n_std_non_sparse = n_std - n_sparse
+    if n_sparse:
+        warnings.warn(
+            f"{func_name}: {WarningCode.SPARSE_WINSORIZE_SKIPPED.value} — "
+            f"{n_sparse}/{n_dates} dates carry a sparse {{0, R}} factor whose "
+            "median and MAD are both 0. The standard-deviation fallback there "
+            "is driven by the triggers themselves and shrinks with the trigger "
+            "rate, so clipping would destroy event magnitudes; those dates are "
+            "left unwinsorized.",
+            UserWarning,
+            stacklevel=3,
+        )
+    if n_std_non_sparse > 0:
+        warnings.warn(
+            f"{func_name}: {WarningCode.ZERO_MAD_STD_FALLBACK.value} — "
+            f"{n_std_non_sparse}/{n_dates} dates had a zero MAD (>50% ties at "
+            "the median) and fell back to the non-robust per-date standard "
+            "deviation (ddof=1). Robust and non-robust dates are mixed in one "
+            "output column.",
+            UserWarning,
+            stacklevel=3,
+        )
+    n_thin = counts.get("insufficient_assets", 0)
+    if n_thin:
+        warnings.warn(
+            f"{func_name}: {WarningCode.INSUFFICIENT_SCALE_ASSETS.value} — "
+            f"{n_thin}/{n_dates} dates carry fewer than {MIN_SCALE_ASSETS_HARD} "
+            "finite factor values; no robust scale exists there, so those dates "
+            "are left unscaled (z-score null, clip skipped).",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
+def _warn_non_finite(data: pl.DataFrame, factor_col: str, func_name: str) -> None:
+    """Report the count of NaN / +-Inf inputs blanked to null."""
+    n_bad = int(
+        data.select(
+            (pl.col(factor_col).is_not_null() & ~pl.col(factor_col).is_finite()).sum()
+        ).item()
+    )
+    if n_bad:
+        warnings.warn(
+            f"{func_name}: {WarningCode.NON_FINITE_INPUT_DROPPED.value} — "
+            f"{n_bad} row(s) carry NaN / +-Inf in {factor_col!r} and come back "
+            "null. A non-finite tick is a data error, not an extreme value: "
+            "clipping it into the band would manufacture a plausible-looking "
+            "number that survives every downstream drop_nulls().drop_nans().",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 def mad_winsorize(
     data: pl.DataFrame,
     factor_col: str = "factor",
     n_mad: float = 3.0,
+    *,
+    center: Center = "median",
 ) -> pl.DataFrame:
     """Step 4: Per-date MAD-based winsorization on factor values.
 
-    Clips factor values to ``[median ± n_mad × 1.4826 × MAD]`` within each
-    cross-section.
+    Clips factor values to ``[centre +- n_mad * b_n * 1.4826 * MAD]`` within
+    each cross-section, where ``b_n`` is the Croux-Rousseeuw (1992)
+    finite-sample correction for the per-date finite count.
 
     Args:
-        n_mad: Number of MAD units for clipping (default 3.0).
-            Set to 0 to disable.
+        factor_col: Column to winsorize in place.
+        n_mad: Number of MAD units for clipping (default 3.0). Must be a
+            finite number ``>= 0``; ``0`` disables the step.
+        center: Where the clip band is centred — ``"median"`` (default,
+            robust) or ``"mean"``. The MAD itself is always taken about the
+            median.
+
+    Raises:
+        UserInputError: ``n_mad`` is not a finite number ``>= 0``, or
+            ``center`` is not ``"median"`` / ``"mean"``.
 
     Returns:
-        DataFrame with ``factor_col`` clipped in-place.
+        DataFrame with ``factor_col`` clipped in-place. Non-finite inputs
+        come back **null**.
 
     Notes:
-        **Zero-MAD fallback.** More than 50% ties on a date (bucketed,
-        binary or heavily discretised factors are the common case) drive
-        the MAD to exactly 0, which collapses the clip interval to
-        ``[median, median]`` and flattens the entire cross-section to its
-        median — the factor is destroyed rather than winsorised. When the
-        MAD is 0 we fall back to the per-date sample standard deviation
-        (``ddof=1``) as the scale; the MAD branch already carries the
-        1.4826 consistency constant precisely so the two scales are
-        comparable at the Gaussian. Mainstream robust-scale implementations
-        (statsmodels ``mad``, scipy ``median_abs_deviation``) leave the
-        zero-MAD case to the caller — the alternatives are an IQR fallback
-        (still zero for a two-bucket factor) or returning NaN (drops the
-        date). We prefer the std fallback because it keeps a bucketed
-        factor finite and rank-preserving. A cross-section with no
-        dispersion at all (every value identical) has ``scale = 0`` and is
-        left untouched by the clip.
+        **Small-sample MAD scaling.** ``1.4826`` is the asymptotic
+        consistency constant; at finite ``n`` it under-estimates sigma by
+        18% at n=5 and 9% at n=10, which makes ``n_mad=3.0`` an effective
+        2.46 sigma clip on a five-name cross-section — over-winsorizing
+        exactly the tail a factor's signal lives in. The Croux-Rousseeuw
+        (1992) factors (tabulated for ``n <= 9``, ``n/(n-0.8)`` above)
+        restore ``n_mad`` to its nominal sigma meaning at every
+        cross-section size, so an unbalanced panel is clipped consistently
+        across thin and wide dates.
 
-        **Non-finite input.** NaN / ±Inf values are excluded from the
-        per-date median / MAD / std (polars aggregations do not skip float
-        NaN on their own), so one bad tick no longer voids the date. They
-        are still clipped like any other value.
+        **Zero-MAD dates.** More than 50% ties on a date drives the MAD to
+        exactly 0. Two sub-regimes are handled differently, and both raise a
+        ``UserWarning``:
+
+        - A sparse ``{0, R}`` trigger column (median 0, MAD 0) is **left
+          unwinsorized** (``WarningCode.SPARSE_WINSORIZE_SKIPPED``). Its
+          standard deviation is produced *by the triggers*, so
+          ``3 * std`` collapses as the trigger rate falls — at one trigger
+          in fifty names a unit event was clipped to 0.42, destroying 58%
+          of the magnitude the metric downstream is trying to measure.
+        - Any other zero-MAD date (a bucketed or binary factor) falls back
+          to the per-date sample standard deviation (``ddof=1``), which
+          keeps the factor finite and rank-preserving
+          (``WarningCode.ZERO_MAD_STD_FALLBACK``).
+
+        A cross-section with no dispersion at all has ``scale = 0`` and is
+        left untouched by the clip. A date with fewer than
+        ``MIN_SCALE_ASSETS_HARD`` finite values has no estimable robust
+        scale and is left untouched too
+        (``WarningCode.INSUFFICIENT_SCALE_ASSETS``).
+
+        **Non-finite input.** NaN / +-Inf values are excluded from the
+        per-date statistics *and blanked to null in the output*, matching
+        :func:`cross_sectional_zscore`. Clipping them into the band (the
+        previous behaviour) turned a hard data error into a plausible
+        finite extreme that survived every downstream
+        ``drop_nulls().drop_nans()`` and put the asset at the top of that
+        date's ranking.
+
+    References:
+        - Croux, C. & Rousseeuw, P. J. (1992). "Time-Efficient Algorithms
+          for Two Highly Robust Estimators of Scale." Finite-sample
+          correction factors for the MAD.
 
     Examples:
         >>> import factrix as fx
@@ -100,53 +352,97 @@ def mad_winsorize(
         >>> clipped.height == raw.height
         True
     """
-    if n_mad <= 0:
+    n_mad = _validate_n_mad(n_mad)
+    center = _validate_center(center, "mad_winsorize", _DOCS_MAD_WINSORIZE)
+    if n_mad == 0.0:
         return data
 
-    median_expr, scale_expr = _scale_expressions(factor_col)
-    half_width = scale_expr * n_mad
+    _warn_non_finite(data, factor_col, "mad_winsorize")
+    stats = _per_date_scale(data, factor_col, center)
+    _warn_scale_regimes(stats, "mad_winsorize", sparse_skipped=True)
 
-    return data.with_columns(
-        pl.when(scale_expr > EPSILON)
-        .then(
-            pl.col(factor_col).clip(median_expr - half_width, median_expr + half_width)
+    clean = _finite(factor_col)
+    half_width = pl.col("_scale") * n_mad
+    clipped = (
+        pl.when(pl.col("_sparse_zero") | (pl.col("_scale").fill_null(0.0) <= EPSILON))
+        .then(clean)
+        .otherwise(
+            clean.clip(pl.col("_center") - half_width, pl.col("_center") + half_width)
         )
-        .otherwise(pl.col(factor_col))
         .alias(factor_col)
+    )
+    return (
+        data.join(stats, on="date", how="left", maintain_order="left")
+        .with_columns(clipped)
+        .drop(stats.columns[1:])
     )
 
 
 def cross_sectional_zscore(
     data: pl.DataFrame,
     factor_col: str = "factor",
+    *,
+    center: Center = "median",
 ) -> pl.DataFrame:
     """Step 5: MAD-robust z-score within each cross-section (date).
 
-    ``z = (x - median(x)) / (1.4826 × MAD(x))``
+    ``z = (x - centre(x)) / (b_n * 1.4826 * MAD(x))``
+
+    Args:
+        factor_col: Column to standardize.
+        center: Where the score is centred.
+
+            - ``"median"`` (default) — robust to outliers, but **not
+              mean-zero**. For any skewed factor (sparse event triggers,
+              log-scaled fundamentals) ``mean(z) != 0``, so weights
+              ``w ~ z`` carry a persistent net long or short leg and the
+              book is charged market beta the caller did not intend. On a
+              2-of-20 sparse trigger column the net exposure is ``+0.32``.
+            - ``"mean"`` — subtracts the per-date mean instead, so the
+              output is exactly mean-zero and ``w ~ z`` is dollar-neutral
+              by construction, at the cost of a centre that a single
+              outlier can move. The **scale** stays the robust MAD either
+              way.
 
     Returns:
-        DataFrame with ``factor_zscore`` column appended.
+        DataFrame with a ``f"{factor_col}_zscore"`` column appended (so
+        standardizing several factors in one panel no longer collides on a
+        single hard-coded name).
 
     Notes:
-        **Zero-MAD fallback.** With more than 50% ties on a date the MAD is
-        exactly 0, so the naive ratio is ``±inf`` for every non-median value
-        (and ``0/0 = NaN`` at the median). We fall back to the per-date
-        sample standard deviation (``ddof=1``) as the scale, matching
-        :func:`mad_winsorize`. The alternative conventions are to return NaN
-        for the date (drops bucketed factors entirely) or to fall back to a
-        scaled IQR (still zero for a two-bucket factor); the std fallback
-        keeps the z finite and rank-preserving, which is what the downstream
-        rank-based metrics need. When the cross-section is fully constant
-        there is genuinely no dispersion: every non-null value gets ``0.0``,
-        an honest "no spread", rather than ``inf`` or NaN.
+        **Small-sample MAD scaling.** The scale carries the Croux-Rousseeuw
+        (1992) finite-sample factor ``b_n`` on top of the asymptotic
+        ``1.4826``. Without it the output of a function called
+        "z-score" is not unit-scale at small ``n`` — its expected
+        cross-sectional standard deviation is 1.67 at n=5 and 1.18 at
+        n=10 — and, worse, the inflation is ``n``-dependent, so on an
+        unbalanced panel thin dates produce systematically larger z and
+        every pooled or z-weighted statistic over-weights the noisiest
+        cross-sections. See :func:`mad_winsorize`.
 
-        **Nulls stay null.** The previous implementation ended with
-        ``fill_nan(0.0).fill_null(0.0)``, which imputed every missing factor
-        to *exactly the cross-sectional median* — a silent, maximally
-        "average" fabrication that inflated coverage. Per the library
-        convention (producers never impute; consumers drop with
-        ``drop_nulls().drop_nans()``), a null input now yields a null
-        z-score, and so does a non-finite (NaN / ±Inf) input.
+        **Zero-MAD fallback.** With more than 50% ties on a date the MAD is
+        exactly 0, so the naive ratio is ``+-inf`` for every non-median
+        value (and ``0/0 = NaN`` at the median). We fall back to the
+        per-date sample standard deviation (``ddof=1``) as the scale, which
+        keeps the z finite and rank-preserving — and raise a
+        ``UserWarning`` carrying ``WarningCode.ZERO_MAD_STD_FALLBACK``,
+        because robust and non-robust dates otherwise end up mixed into one
+        column and one downstream statistic with no way to tell them apart.
+
+        **Thin cross-sections.** A date with fewer than
+        ``MIN_SCALE_ASSETS_HARD`` finite values yields **null**, not
+        ``0.0``. At n=1 the old chain fell through to ``0.0`` — an
+        "average" fabricated from a single observation — and at n=2 it
+        returned ``+-0.6745`` whatever the two values were, a constant
+        carrying no information but indistinguishable downstream from a
+        real score. ``WarningCode.INSUFFICIENT_SCALE_ASSETS`` is raised.
+        A fully constant cross-section of at least that size does have a
+        genuine "no spread" reading and still maps to ``0.0``.
+
+        **Nulls stay null.** Per the library convention (producers never
+        impute; consumers drop with ``drop_nulls().drop_nans()``), a null
+        input yields a null z-score, and so does a non-finite (NaN / +-Inf)
+        input.
 
     Examples:
         >>> import factrix as fx
@@ -156,15 +452,21 @@ def cross_sectional_zscore(
         >>> "factor_zscore" in standardized.columns
         True
     """
-    clean = _finite(factor_col)
-    median_expr, scale_expr = _scale_expressions(factor_col)
+    center = _validate_center(center, "cross_sectional_zscore", _DOCS_ZSCORE)
+    _warn_non_finite(data, factor_col, "cross_sectional_zscore")
+    stats = _per_date_scale(data, factor_col, center)
+    _warn_scale_regimes(stats, "cross_sectional_zscore", sparse_skipped=False)
 
+    clean = _finite(factor_col)
     zscore = (
-        pl.when(clean.is_null())
+        pl.when(clean.is_null() | pl.col("_scale").is_null())
         .then(pl.lit(None, dtype=pl.Float64))
-        .when(scale_expr > EPSILON)
-        .then((clean - median_expr) / scale_expr)
+        .when(pl.col("_scale") > EPSILON)
+        .then((clean - pl.col("_center")) / pl.col("_scale"))
         .otherwise(pl.lit(0.0))
     )
-
-    return data.with_columns(zscore.alias("factor_zscore"))
+    return (
+        data.join(stats, on="date", how="left", maintain_order="left")
+        .with_columns(zscore.alias(f"{factor_col}_zscore"))
+        .drop(stats.columns[1:])
+    )

--- a/factrix/preprocess/orthogonalize.py
+++ b/factrix/preprocess/orthogonalize.py
@@ -13,12 +13,14 @@ This module is independently usable for any analysis that requires
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 
 import numpy as np
 import polars as pl
 
-from factrix._types import EPSILON
+from factrix._codes import WarningCode
+from factrix._types import EPSILON, MIN_ORTHOGONALIZE_RESIDUAL_ASSETS
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +32,17 @@ class OrthogonalizeResult:
     Attributes:
         data: ``factor_df`` with ``factor_col`` replaced by the residual and
             ``factor_pre_ortho`` preserving the original value.
-        mean_betas: Average beta per base factor across regressed dates.
-        mean_r_squared: Average R² across regressed dates.
+        mean_betas: Average beta per base factor across regressed dates whose
+            design matrix had full column rank. Empty when every regressed
+            date was rank deficient — the betas are not identified there, so
+            reporting an average of arbitrary minimum-norm solutions would be
+            worse than reporting nothing (see ``n_dates_rank_deficient``).
+        mean_r_squared: Average raw R² across regressed dates.
+        mean_adj_r_squared: Average degrees-of-freedom-adjusted R²,
+            ``1 - (1 - R²)(N - 1)/(N - K - 1)``. Raw R² is mechanically
+            ≈ ``K/(N - 1)`` even when the true R² is 0, so on a thin
+            cross-section the adjusted figure is the one that answers "is the
+            factor actually spanned by the base set?".
         n_dates: Number of per-date cross-sections seen after the join.
         coverage: Fraction of input rows that carry an actual residual —
             rows dropped by the join, rows on a skipped date, and rows with
@@ -40,19 +51,51 @@ class OrthogonalizeResult:
         n_rows_non_finite: Rows whose factor or base values were null / NaN /
             ±Inf on an otherwise regressed date. These rows are excluded from
             the regression and their residual is **null** in ``data``.
-        n_dates_skipped: Dates left un-orthogonalised because too few finite
-            rows remained (``< len(base_cols) + 2``) or ``lstsq`` failed.
+        n_dates_skipped: Dates left un-orthogonalised, for any reason.
             Original factor values are kept for those dates.
+        n_dates_insufficient_df: Subset of ``n_dates_skipped`` skipped because
+            the cross-section left fewer than ``min_residual_df`` residual
+            degrees of freedom.
+        n_dates_rank_deficient: Dates that were regressed but whose design
+            matrix was rank deficient. The residual is still exact (the
+            projection is unique) but the betas are not identified, so those
+            dates are excluded from ``mean_betas``.
+        restandardized: Whether the residual was rescaled to the per-date
+            dispersion of the input factor.
+        warning_codes: :class:`~factrix._codes.WarningCode` values raised by
+            this run, as strings — the structured twin of the ``UserWarning``
+            echoes, for callers that inspect the result rather than trap
+            warnings.
     """
 
     data: pl.DataFrame
     mean_betas: dict[str, float] = field(default_factory=dict)
     mean_r_squared: float = 0.0
+    mean_adj_r_squared: float = 0.0
     n_dates: int = 0
     coverage: float = 0.0
     n_base: int = 0
     n_rows_non_finite: int = 0
     n_dates_skipped: int = 0
+    n_dates_insufficient_df: int = 0
+    n_dates_rank_deficient: int = 0
+    restandardized: bool = False
+    warning_codes: tuple[str, ...] = ()
+
+
+def _is_rank_deficient(design: np.ndarray, singular_values: np.ndarray) -> bool:
+    """Whether ``design`` is (near-)rank deficient, from ``lstsq``'s own SVD.
+
+    ``np.linalg.lstsq`` returns the singular values it already computed, so
+    the rank test costs nothing extra. The tolerance is ``np.linalg.matrix_rank``'s
+    default — ``max(M, N) * eps * s_max`` — deliberately looser than lstsq's own
+    ``rcond=None`` machine-precision cutoff, which reports full rank for a
+    *near*-collinear design and hands back huge unstable betas instead.
+    """
+    if singular_values.size == 0:
+        return design.shape[1] > 0
+    tol = max(design.shape) * float(np.finfo(float).eps) * float(singular_values[0])
+    return int(np.count_nonzero(singular_values > tol)) < design.shape[1]
 
 
 def orthogonalize_factor(
@@ -60,6 +103,9 @@ def orthogonalize_factor(
     base_factors: pl.DataFrame,
     factor_col: str = "factor",
     base_cols: list[str] | None = None,
+    *,
+    min_residual_df: int = MIN_ORTHOGONALIZE_RESIDUAL_ASSETS,
+    restandardize: bool = False,
 ) -> OrthogonalizeResult:
     """Orthogonalize factor against base factors via per-date ordinary least squares (OLS).
 
@@ -67,22 +113,73 @@ def orthogonalize_factor(
         factor_df: Panel with ``date, asset_id, {factor_col}``.
             factor_col should already be z-scored (Step 5 output).
         base_factors: Panel with ``date, asset_id`` and base factor columns.
-            Industry dummies should be pre-encoded as 0/1 columns.
+            Industry dummies must be pre-encoded as 0/1 columns **with one
+            category dropped as the reference level**: an intercept is always
+            prepended, so a full dummy set is exactly singular (the classic
+            dummy trap). See the rank-deficiency note below for what happens
+            if it is not.
         factor_col: Column name of the factor to orthogonalize.
         base_cols: List of column names in ``base_factors`` to regress on.
             If None, uses all columns except ``date`` and ``asset_id``.
+        min_residual_df: Minimum residual degrees of freedom
+            (``n_finite - len(base_cols) - 1``) a date must leave to be
+            regressed. Defaults to
+            :data:`~factrix._types.MIN_ORTHOGONALIZE_RESIDUAL_ASSETS` (10), the
+            ``N >= K + 10`` form of the Fama-MacBeth convention; pass
+            ``4 * len(base_cols)`` for the ``N >= 5K`` form, or ``1`` to
+            restore the old behaviour of fitting anything that is
+            arithmetically solvable.
+        restandardize: Rescale the residual to the per-date dispersion of the
+            input factor. ``False`` (default) returns the raw residual, whose
+            scale is ``sqrt(1 - R²)`` times the input — and since R² varies by
+            date, so does the output scale. Rank metrics are unaffected; any
+            magnitude-based use (weights ``w ~ f``, a spread in factor units)
+            is otherwise quietly running on a time-varying scale.
 
     Returns:
         OrthogonalizeResult with: ``data`` (factor_df with ``factor_col``
         replaced by the residual and ``factor_pre_ortho`` preserving the
         original value), ``mean_betas`` (average beta per base factor
-        across dates), and ``mean_r_squared`` (average R² across dates).
+        across full-rank dates), ``mean_r_squared`` and
+        ``mean_adj_r_squared``, plus the per-reason skip counts and
+        ``warning_codes``.
 
     Raises:
         ValueError: ``base_factors`` carries duplicate ``(date, asset_id)``
             keys, which would fan the inner join out and duplicate rows.
 
     Notes:
+        **Minimum residual degrees of freedom.** A cross-sectional OLS needs
+        residual df to mean anything. The old floor was ``len(base_cols) + 2``
+        rows — a single residual df — and raw R² is mechanically ≈
+        ``K/(N - 1)`` even when the true R² is zero, so a regional book of six
+        names regressed on size / value / momentum plus an industry dummy
+        passed the guard, fitted noise, and came back with
+        ``mean_r_squared = 0.79`` (adjusted: ``-0.03``) after removing 83% of
+        the factor's variance — the user concludes the factor is redundant
+        when it is orthogonal by construction. Dates below ``min_residual_df``
+        are now skipped, counted in ``n_dates_insufficient_df``, and flagged
+        with ``WarningCode.INSUFFICIENT_REGRESSION_DF``.
+        ``mean_adj_r_squared`` is reported alongside the raw figure for the
+        same reason.
+
+        **Rank deficiency.** ``np.linalg.lstsq`` does **not** raise on a
+        rank-deficient design — it returns the minimum-norm solution — so the
+        ``except LinAlgError`` branch never fired for the dummy trap. The
+        residual stays correct either way (the projection onto the column
+        space is unique), but ``mean_betas`` was an arbitrary point in the
+        solution space, reported without qualification: on a 4-dummy panel
+        the full set gave ``{ind0: 0.008, ind1: -0.007, ...}`` and dropping one
+        category gave ``{ind1: -0.015, ...}``, with identical residuals.
+        Rank is now read from the singular values ``lstsq`` already computes
+        (the ``matrix_rank`` tolerance, so *near*-collinear designs are caught
+        too, not only exactly singular ones); deficient dates are counted in
+        ``n_dates_rank_deficient``, excluded from ``mean_betas``, and flagged
+        with ``WarningCode.RANK_DEFICIENT_DESIGN``.
+
+        **Residual scale.** See ``restandardize`` above; the default leaves
+        the residual on its own per-date scale rather than the input's.
+
         **Non-finite rows.** A single null / NaN / ±Inf in ``factor_col`` or
         in any base column used to make ``np.linalg.lstsq`` return all-NaN
         betas, which turned *every* asset on that date into NaN while the
@@ -93,12 +190,11 @@ def orthogonalize_factor(
         inside one column — a silent, unrecoverable contamination. Their
         count is reported as ``n_rows_non_finite`` and logged.
 
-        **Skipped dates.** A date with fewer than ``len(base_cols) + 2``
-        finite rows (or one where ``lstsq`` raises) cannot support the
-        regression; the original values are kept for that date, as before
-        for ``lstsq`` failures, and the date is counted in
-        ``n_dates_skipped``. Such dates are excluded from ``coverage``,
-        ``mean_betas`` and ``mean_r_squared``.
+        **Skipped dates.** A date that leaves fewer than ``min_residual_df``
+        residual degrees of freedom (or one where ``lstsq`` raises) cannot
+        support the regression; the original values are kept for that date and
+        it is counted in ``n_dates_skipped``. Such dates are excluded from
+        ``coverage``, ``mean_betas`` and both R² figures.
 
         **Duplicate keys.** ``base_factors`` must be unique on
         ``(date, asset_id)``. A duplicated key silently fans the inner join
@@ -160,10 +256,16 @@ def orthogonalize_factor(
     residuals_list: list[pl.DataFrame] = []
     all_betas: list[np.ndarray] = []
     all_r2: list[float] = []
+    all_adj_r2: list[float] = []
     n_rows_non_finite = 0
     n_dates_skipped = 0
+    n_dates_insufficient_df = 0
+    n_dates_rank_deficient = 0
     n_rows_orthogonalized = 0
-    min_rows = len(base_cols) + 2
+    n_params = len(base_cols) + 1  # base columns + the prepended intercept
+    # WHY: residual df, not a bare row count. ``len(base_cols) + 2`` rows left
+    # exactly one residual df, where raw R2 is ~K/(N-1) at a true R2 of 0.
+    min_rows = n_params + max(int(min_residual_df), 1)
 
     # partition_by groups rows by date value; no pre-sort needed (the
     # earlier `.sort("date")` was dead weight at O(D×N log N)).
@@ -192,30 +294,53 @@ def orthogonalize_factor(
         if n_finite < min_rows:
             dt = chunk["date"][0]
             logger.warning(
-                "orthogonalize: date %s has %d finite rows (< %d required for "
-                "%d base factors + intercept), keeping original values",
+                "orthogonalize: date %s has %d finite rows, leaving %d residual "
+                "df for %d base factors + intercept (min_residual_df=%d); "
+                "keeping original values",
                 dt,
                 n_finite,
-                min_rows,
+                max(n_finite - n_params, 0),
                 len(base_cols),
+                min_residual_df,
             )
             residual = y
             orthogonalized = False
             n_dates_skipped += 1
+            n_dates_insufficient_df += 1
         else:
             X_fit = X_with_intercept[finite]
             y_fit = y[finite]
             # WHY: handle collinearity or all-zero columns (e.g. a sector with
             # no observations on that date).
             try:
-                beta, _, _, _ = np.linalg.lstsq(X_fit, y_fit, rcond=None)
+                beta, _, _, sv = np.linalg.lstsq(X_fit, y_fit, rcond=None)
                 residual_fit = y_fit - X_fit @ beta
                 residual[finite] = residual_fit
-                all_betas.append(beta[1:])  # exclude intercept
+                # WHY: lstsq does not raise on a rank-deficient design — it
+                # returns the minimum-norm solution — so the residual is exact
+                # but the betas are an arbitrary point in the solution space
+                # (the dummy trap). Read the rank off the singular values
+                # lstsq already computed, at the ``matrix_rank`` tolerance so
+                # near-collinear designs are caught too, and keep those betas
+                # out of the attribution average rather than reporting them.
+                if _is_rank_deficient(X_fit, sv):
+                    n_dates_rank_deficient += 1
+                else:
+                    all_betas.append(beta[1:])  # exclude intercept
                 ss_res = float(np.dot(residual_fit, residual_fit))
                 centered = y_fit - np.mean(y_fit)
                 ss_tot = float(np.dot(centered, centered))
-                all_r2.append(1.0 - ss_res / ss_tot if ss_tot > EPSILON else 0.0)
+                r2 = 1.0 - ss_res / ss_tot if ss_tot > EPSILON else 0.0
+                all_r2.append(r2)
+                # Raw R2 is mechanically ~K/(N-1) even at a true R2 of 0; the
+                # df-adjusted figure is the one that answers "is the factor
+                # spanned?" on a thin cross-section.
+                df_resid = n_finite - n_params
+                all_adj_r2.append(
+                    1.0 - (1.0 - r2) * (n_finite - 1) / df_resid
+                    if df_resid > 0
+                    else float("nan")
+                )
                 n_rows_orthogonalized += n_finite
             except np.linalg.LinAlgError:
                 dt = chunk["date"][0]
@@ -258,6 +383,20 @@ def orthogonalize_factor(
         .drop("_residual", "_orthogonalized")
     )
 
+    if restandardize:
+        # The raw residual's scale is sqrt(1 - R2) times the input's, and R2
+        # varies by date, so the output scale varies by date too. Rescale each
+        # regressed date's residual back to the pre-orthogonalisation
+        # dispersion; skipped dates already carry the original values.
+        pre_std = pl.col("factor_pre_ortho").std(ddof=1).over("date")
+        post_std = pl.col(factor_col).std(ddof=1).over("date")
+        result = result.with_columns(
+            pl.when(post_std > EPSILON)
+            .then(pl.col(factor_col) * pre_std / post_std)
+            .otherwise(pl.col(factor_col))
+            .alias(factor_col)
+        )
+
     n_total = len(factor_df)
     n_ortho = n_rows_orthogonalized
     n_base = len(base_cols)
@@ -290,22 +429,62 @@ def orthogonalize_factor(
         100 - drop_pct,
     )
 
-    # Attribution: average betas and R² across dates
+    # Attribution: average betas across full-rank dates, R² across all fitted
+    # ones. A rank-deficient date still contributes a valid residual and R²;
+    # only its betas are unidentified.
     mean_betas: dict[str, float] = {}
     mean_r2 = 0.0
+    mean_adj_r2 = 0.0
     if all_betas:
         beta_matrix = np.array(all_betas)
         for i, col in enumerate(base_cols):
             mean_betas[col] = float(np.mean(beta_matrix[:, i]))
+    if all_r2:
         mean_r2 = float(np.mean(all_r2))
+        mean_adj_r2 = float(np.nanmean(all_adj_r2))
+
+    warning_codes: list[str] = []
+    if n_dates_insufficient_df:
+        warning_codes.append(WarningCode.INSUFFICIENT_REGRESSION_DF.value)
+        warnings.warn(
+            f"orthogonalize_factor: "
+            f"{WarningCode.INSUFFICIENT_REGRESSION_DF.value} — "
+            f"{n_dates_insufficient_df}/{n_dates} dates left fewer than "
+            f"{min_residual_df} residual degrees of freedom for {n_base} base "
+            "factors + intercept and were skipped (original values kept). Raw "
+            "R2 is mechanically ~K/(N-1) at a true R2 of 0, so fitting there "
+            "reports noise as explanatory power while stripping most of the "
+            "factor's variance. Reduce base_cols, or lower min_residual_df if "
+            "the thin fit is wanted anyway.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if n_dates_rank_deficient:
+        warning_codes.append(WarningCode.RANK_DEFICIENT_DESIGN.value)
+        warnings.warn(
+            f"orthogonalize_factor: {WarningCode.RANK_DEFICIENT_DESIGN.value} "
+            f"— {n_dates_rank_deficient}/{n_dates} dates had a rank-deficient "
+            "design matrix. The residual is still exact (the projection is "
+            "unique) but the betas are not identified there, so those dates "
+            "are excluded from mean_betas. The usual cause is a full industry "
+            "dummy set alongside the always-prepended intercept — drop one "
+            "category as the reference level.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     return OrthogonalizeResult(
         data=result,
         mean_betas=mean_betas,
         mean_r_squared=mean_r2,
+        mean_adj_r_squared=mean_adj_r2,
         n_dates=n_dates,
         coverage=(n_ortho / n_total) if n_total else 0.0,
         n_base=n_base,
         n_rows_non_finite=n_rows_non_finite,
         n_dates_skipped=n_dates_skipped,
+        n_dates_insufficient_df=n_dates_insufficient_df,
+        n_dates_rank_deficient=n_dates_rank_deficient,
+        restandardized=restandardize,
+        warning_codes=tuple(warning_codes),
     )

--- a/factrix/preprocess/orthogonalize.py
+++ b/factrix/preprocess/orthogonalize.py
@@ -293,7 +293,9 @@ def orthogonalize_factor(
 
         if n_finite < min_rows:
             dt = chunk["date"][0]
-            logger.warning(
+            # Per-date detail at debug; the aggregate UserWarning below
+            # carries the count.
+            logger.debug(
                 "orthogonalize: date %s has %d finite rows, leaving %d residual "
                 "df for %d base factors + intercept (min_residual_df=%d); "
                 "keeping original values",
@@ -432,9 +434,11 @@ def orthogonalize_factor(
     # Attribution: average betas across full-rank dates, R² across all fitted
     # ones. A rank-deficient date still contributes a valid residual and R²;
     # only its betas are unidentified.
+    # NaN, not 0.0, when no date was fitted: a reported R² of 0.00 would read
+    # as "perfectly unspanned" when the truth is that no regression ran.
     mean_betas: dict[str, float] = {}
-    mean_r2 = 0.0
-    mean_adj_r2 = 0.0
+    mean_r2 = float("nan")
+    mean_adj_r2 = float("nan")
     if all_betas:
         beta_matrix = np.array(all_betas)
         for i, col in enumerate(base_cols):

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -8,8 +8,11 @@ All functions expect canonical column names (date, asset_id, price).
 Use ``adapt()`` to rename before calling.
 """
 
+import warnings
+
 import polars as pl
 
+from factrix._codes import WarningCode
 from factrix._errors import UserInputError
 
 _DOCS_FORWARD_RETURN = "api/preprocess#compute_forward_return"
@@ -63,6 +66,33 @@ def _validate_winsorize_bounds(lower: object, upper: object) -> tuple[float, flo
     return lower_f, upper_f
 
 
+def _warn_if_ragged(indexed: pl.DataFrame, n_periods: int) -> None:
+    """Flag per-asset date grids that disagree with the panel's own grid.
+
+    The horizon is a step along each asset's period index, so a gap is no
+    longer able to stretch one asset's window past another's — but the asset
+    with the gap has no observation to pair at ``i + 1 + h`` and simply
+    contributes fewer rows. Callers comparing horizons across names need to
+    know their grids differ.
+    """
+    per_asset = indexed.group_by("asset_id").agg(
+        pl.col("_period_index").n_unique().alias("_n_periods")
+    )
+    n_ragged = int((per_asset["_n_periods"] < n_periods).sum())
+    if n_ragged:
+        warnings.warn(
+            f"compute_forward_return: {WarningCode.RAGGED_PERIOD_GRID.value} — "
+            f"{n_ragged} of {per_asset.height} assets are missing periods that "
+            f"others have (panel grid: {n_periods} periods). The horizon is "
+            "measured on the panel's period grid, so those assets simply have "
+            "no observation to pair at the exit period rather than a stretched "
+            "window; reindex onto a common grid if the horizons must be "
+            "comparable across names.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
 def compute_forward_return(
     data: pl.DataFrame,
     forward_periods: int = 5,
@@ -90,13 +120,15 @@ def compute_forward_return(
     (see Notes for the scope boundary).
 
     Args:
-        data: Must contain ``date``, ``asset_id``, ``price``. Must already
-            be sorted with **regular spacing per asset** on the time axis;
-            this function shifts by row count and does not inspect ``date``.
-        forward_periods: Holding horizon in **rows** of the time axis,
-            not calendar time (default 5). On a daily panel this is 5
-            trading days; on a weekly panel, 5 weeks; on 1-min bars,
-            5 minutes. Frequency is the caller's responsibility.
+        data: Must contain ``date``, ``asset_id``, ``price``, with one row per
+            ``(date, asset_id)`` and a temporal ``date`` column. Both are
+            enforced (see Raises); neither used to be.
+        forward_periods: Holding horizon in **periods of the panel's own
+            grid** — the distinct sorted ``date`` values present in the panel,
+            not calendar time and not row position within an asset (default
+            5). On a daily panel this is 5 trading days; on a weekly panel, 5
+            weeks; on 1-min bars, 5 minutes. Which frequency those periods
+            represent is the caller's responsibility.
         overwrite: Allow recomputation when ``data`` already carries a
             ``forward_return`` column. ``False`` (default) raises rather
             than silently overwrite — the function is **not idempotent**:
@@ -108,9 +140,11 @@ def compute_forward_return(
 
     Raises:
         UserInputError: ``forward_periods`` is not a positive ``int``;
-            ``data`` already has a ``forward_return`` column and
-            ``overwrite`` is ``False``; or the row horizon / price data
-            leaves no finite forward returns after filtering.
+            ``data`` carries duplicate ``(date, asset_id)`` rows or a
+            non-temporal ``date`` column; ``data`` already has a
+            ``forward_return`` column and ``overwrite`` is ``False``; or the
+            horizon / price data leaves no finite forward returns after
+            filtering.
 
     Returns:
         Input DataFrame with ``forward_return`` column appended and the
@@ -121,6 +155,32 @@ def compute_forward_return(
         are dropped.
 
     Notes:
+        **The horizon is measured on the panel's period grid.** The distinct
+        sorted ``date`` values in the panel are indexed 0, 1, 2, ..., and each
+        asset's forward return pairs its row at period index ``i + 1`` with its
+        row at ``i + 1 + forward_periods``. This used to be a positional
+        ``shift`` within each asset, which equals a time horizon only on a
+        complete per-asset panel: with asset A missing 20 periods mid-sample, a
+        "5-period" return silently spanned 25 real periods, contaminating both
+        the return and the overlap horizon stamped in ``_forward_periods`` that
+        every downstream HAC inference reads. Suspensions, halts,
+        delist-relist and staggered entry are ordinary in regional equity data,
+        and sparse event panels are ragged by construction.
+
+        A ragged grid (an asset missing periods that others have) raises
+        ``WarningCode.RAGGED_PERIOD_GRID``: the pairing is now correct for
+        every asset, but an asset with a gap simply has no observation at
+        ``i + 1 + h``, so it contributes fewer rows than a complete one.
+        Reindex onto a common grid if the horizons must be comparable across
+        names.
+
+        **Non-finite prices are blanked before the division, not after.** The
+        filter used to be applied to the *quotient*: with a ``+Inf``
+        denominator, ``finite / inf`` is ``0.0``, so the result was a perfectly
+        finite fabricated ``-100%`` return that sailed straight through
+        ``is_finite()``. (An ``inf`` numerator gives ``inf`` and was correctly
+        dropped — the leak was asymmetric, and so easy to miss.)
+
         The ``/ forward_periods`` per-period normalization is a *scale* choice with
         three caveats the caller should know:
 
@@ -203,20 +263,59 @@ def compute_forward_return(
             )
         data = data.drop("forward_return")
 
-    from factrix._data_input import _stamp_forward_periods
+    from factrix._data_input import _normalize_panel, _stamp_forward_periods
 
+    # One structural gate: temporal ``date``, unique ``(date, asset_id)``, and
+    # non-finite numerics blanked to null *before* any arithmetic. A duplicated
+    # key made the "next period" the same date's twin and manufactured a 0.0
+    # return; a +Inf denominator made ``finite / inf = 0`` and manufactured a
+    # finite -100% return that an output-side is_finite() filter cannot catch.
+    data = _normalize_panel(data)
+
+    # Period index on the panel's own grid, shared by every asset. Shifting by
+    # row position within an asset only equals a time horizon on a complete
+    # panel — see Notes.
+    grid = (
+        data.select("date")
+        .unique()
+        .sort("date")
+        .with_row_index("_period_index")
+        .with_columns(pl.col("_period_index").cast(pl.Int64))
+    )
+    n_periods = grid.height
+    indexed = data.join(grid, on="date", how="left")
+
+    _warn_if_ragged(indexed, n_periods)
+
+    # Entry at period i+1, exit at period i+1+h, both looked up by index rather
+    # than by row offset, so a gap in one asset's history cannot stretch its
+    # horizon.
+    prices = indexed.select(
+        "asset_id",
+        pl.col("_period_index"),
+        pl.col("price").alias("_price_at"),
+    )
     out = (
-        data.sort(["asset_id", "date"])
-        .with_columns(
-            (
-                (
-                    pl.col("price").shift(-(forward_periods + 1)).over("asset_id")
-                    / pl.col("price").shift(-1).over("asset_id")
-                    - 1
-                )
-                / forward_periods
-            ).alias("forward_return")
+        indexed.with_columns(
+            (pl.col("_period_index") + 1).alias("_entry_index"),
+            (pl.col("_period_index") + 1 + forward_periods).alias("_exit_index"),
         )
+        .join(
+            prices.rename({"_period_index": "_entry_index", "_price_at": "_entry"}),
+            on=["asset_id", "_entry_index"],
+            how="left",
+        )
+        .join(
+            prices.rename({"_period_index": "_exit_index", "_price_at": "_exit"}),
+            on=["asset_id", "_exit_index"],
+            how="left",
+        )
+        .with_columns(
+            ((pl.col("_exit") / pl.col("_entry") - 1) / forward_periods).alias(
+                "forward_return"
+            )
+        )
+        .drop("_period_index", "_entry_index", "_exit_index", "_entry", "_exit")
         .filter(pl.col("forward_return").is_finite())
     )
     if out.is_empty():

--- a/tests/test_data_input.py
+++ b/tests/test_data_input.py
@@ -22,9 +22,14 @@ def data_pl() -> pl.DataFrame:
     return compute_forward_return(raw, forward_periods=5)
 
 
-def test_coerce_polars_dataframe_passthrough(data_pl: pl.DataFrame) -> None:
+def test_coerce_polars_dataframe_normalizes(data_pl: pl.DataFrame) -> None:
+    """No longer an identity passthrough: the frame goes through the gate.
+
+    A clean panel comes back equal in value; what changes is that NaN / ±Inf
+    are now structurally absent downstream (see test_normalize_panel.py).
+    """
     out = _coerce_data(data_pl)
-    assert out is data_pl
+    assert out.equals(data_pl)
 
 
 def test_coerce_lazyframe_collects(data_pl: pl.DataFrame) -> None:

--- a/tests/test_helpers_finite.py
+++ b/tests/test_helpers_finite.py
@@ -60,18 +60,21 @@ def test_aggregate_to_per_date_skips_nan():
 def _nan_vs_null_panels(n_periods: int = 30, n_assets: int = 20):
     """Two identical panels; one marks half the factor cells NaN, the other null."""
     import random
+    from datetime import datetime, timedelta
 
     rng = random.Random(0)
     dates, assets, factor, ret = [], [], [], []
     for d in range(n_periods):
         for a in range(n_assets):
-            dates.append(d)
+            # Real dates: the boundary gate rejects a non-temporal `date`,
+            # because a string / integer axis is sorted lexicographically.
+            dates.append(datetime(2024, 1, 1) + timedelta(days=d))
             assets.append(f"a{a}")
             factor.append(None if a % 2 == 0 else rng.gauss(0.0, 1.0))
             ret.append(rng.gauss(0.0, 0.02))
     null_panel = pl.DataFrame(
         {"date": dates, "asset_id": assets, "factor": factor, "forward_return": ret}
-    )
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
     nan_panel = null_panel.with_columns(pl.col("factor").fill_null(float("nan")))
     return nan_panel, null_panel
 

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -776,3 +776,59 @@ class TestEffectiveSampleFloor:
         assert not math.isnan(result.value)
         assert result.n_obs == 13
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in result.warning_codes
+
+
+class TestTieWarningWording:
+    """The estimator IS the tie-corrected Spearman; the caveat is range."""
+
+    @staticmethod
+    def _tied_panel(n_dates=40, n_assets=12, seed=0):
+        from datetime import datetime, timedelta
+
+        import numpy as np
+
+        rng = np.random.default_rng(seed)
+        rows = n_dates * n_assets
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                "factor": rng.integers(0, 3, rows).astype(float),
+                "forward_return": rng.standard_normal(rows) * 0.01,
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_estimator_matches_scipy_spearmanr_exactly(self):
+        """The premise of the old warning was false: this IS the corrected form."""
+        import numpy as np
+        import scipy.stats as scipy_stats
+        from factrix.metrics._primitives._ic import compute_ic
+
+        panel = self._tied_panel()
+        ic_df = compute_ic(panel)["factor"].sort("date")
+        for date, lib_ic in zip(
+            ic_df["date"].to_list(), ic_df["ic"].to_list(), strict=True
+        ):
+            day = panel.filter(pl.col("date") == date)
+            reference = scipy_stats.spearmanr(
+                day["factor"].to_numpy(), day["forward_return"].to_numpy()
+            ).statistic
+            assert lib_ic == pytest.approx(reference, abs=1e-12)
+            assert np.isfinite(lib_ic)
+
+    def test_warning_names_range_attenuation_not_bias(self):
+        from factrix.metrics._primitives._ic import compute_ic
+
+        panel = self._tied_panel()
+        with pytest.warns(UserWarning) as record:
+            ic(compute_ic(panel)["factor"], forward_periods=1)
+        text = " ".join(str(w.message) for w in record)
+        assert "range" in text
+        assert "spearmanr" in text
+        # The two false claims the warning used to make.
+        assert "lower bound" not in text
+        assert "consider a tie-corrected correlation" not in text

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -499,11 +499,12 @@ class TestApplicableInferenceDiscovery:
     def test_inference_metrics_expose_allowlist(self):
         from factrix.metrics._metric_capabilities import resolve_applicable_inference
         from factrix.metrics.k_spread import k_spread
-        from factrix.metrics.quantile import quantile_spread
+        from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
 
-        # quantile_spread / k_spread dispatch through a hard isinstance(NeweyWest)
-        # branch, so their allowlist stays the original vetted pair.
-        for m in (quantile_spread, k_spread):
+        # quantile_spread / quantile_spread_vw / k_spread dispatch through a
+        # hard isinstance(NeweyWest) branch, so their allowlist stays the
+        # original vetted pair.
+        for m in (quantile_spread, quantile_spread_vw, k_spread):
             allow = resolve_applicable_inference(m)
             assert allow is not None
             assert sorted(type(x).__name__ for x in allow) == [
@@ -524,11 +525,8 @@ class TestApplicableInferenceDiscovery:
     def test_singleton_inference_metric_returns_none(self):
         from factrix.metrics._metric_capabilities import resolve_applicable_inference
         from factrix.metrics.positive_rate import positive_rate
-        from factrix.metrics.quantile import quantile_spread_vw
 
-        # quantile_spread_vw shares its module with quantile_spread but has no
-        # inference= knob; positive_rate is in a module with no allowlist at all.
-        assert resolve_applicable_inference(quantile_spread_vw) is None
+        # positive_rate is in a module with no allowlist at all.
         assert resolve_applicable_inference(positive_rate) is None
 
 

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -404,3 +404,61 @@ class TestSmallCrossSectionKeying:
         result = k_spread(panel, forward_periods=1, k=3)
         assert result.metadata["median_cross_section"] == 12
         assert WarningCode.FEW_ASSETS.value in result.warning_codes
+
+
+class TestKSpreadTiePolicy:
+    """A discrete signal must not be split into legs by row order alone."""
+
+    @staticmethod
+    def _ternary_panel(n_dates=60, n_assets=30, seed=0):
+        from datetime import datetime, timedelta
+
+        import numpy as np
+
+        rng = np.random.default_rng(seed)
+        rows = n_dates * n_assets
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                # Three levels: every leg of size k=5 is filled from a tied block.
+                "factor": rng.integers(-1, 2, rows).astype(float),
+                "forward_return": rng.standard_normal(rows) * 0.01,
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_tie_ratio_is_reported(self):
+        panel = self._ternary_panel()
+        with pytest.warns(UserWarning, match="tie_ratio"):
+            out = k_spread(panel, forward_periods=1, k=5)
+        assert out.metadata["tie_ratio"] > 0.8
+        assert out.metadata["tie_policy"] == "ordinal"
+
+    def test_average_policy_refuses_to_invent_a_split(self):
+        """A 10-way tie cannot yield a 5-name leg without an arbitrary rule.
+
+        Under ``"average"`` every name in a tied block shares one rank, so a
+        block wider than ``k`` puts no name inside the leg cutoff and the date
+        drops out — surfaced by the existing drop-rate advisory. That is the
+        honest answer; ``"ordinal"`` returns a number for the same date by
+        filling the leg in row order.
+        """
+        import warnings
+
+        panel = self._ternary_panel()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ordinal = k_spread(panel, forward_periods=1, k=5)
+            average = k_spread(panel, forward_periods=1, k=5, tie_policy="average")
+        assert average.metadata["tie_policy"] == "average"
+        assert ordinal.value != average.value
+        assert average.n_obs < ordinal.n_obs
+
+    def test_continuous_factor_does_not_warn(self, noisy_panel):
+        out = k_spread(noisy_panel, forward_periods=1, k=5)
+        assert out.metadata["tie_ratio"] == pytest.approx(0.0)
+        assert out.metadata["tie_policy"] == "ordinal"

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -2,6 +2,7 @@
 
 import math
 
+import factrix as fx
 import pytest
 from factrix.metrics.monotonicity import monotonicity
 
@@ -459,3 +460,26 @@ class TestTieRatioCountsFiniteValuesOnly:
                 panel, forward_periods=1, n_groups=3, n_bootstrap=50, seed=0
             )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.8)
+
+
+class TestMRArgumentValidation:
+    @staticmethod
+    def _panel():
+        return fx.preprocess.compute_forward_return(
+            fx.datasets.make_cs_panel(n_assets=40, n_dates=120, seed=3),
+            forward_periods=1,
+        )
+
+    def test_direction_typo_is_rejected(self):
+        from factrix._errors import UserInputError
+        from factrix.metrics.monotonicity import monotonicity
+
+        with pytest.raises(UserInputError, match="direction"):
+            monotonicity(self._panel(), n_bootstrap=50, seed=0, direction="decrease")
+
+    def test_non_positive_n_bootstrap_is_rejected(self):
+        from factrix._errors import UserInputError
+        from factrix.metrics.monotonicity import monotonicity
+
+        with pytest.raises(UserInputError, match="n_bootstrap"):
+            monotonicity(self._panel(), n_bootstrap=0, seed=0)

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -7,41 +7,52 @@ from factrix.metrics.monotonicity import monotonicity
 
 
 class TestComputeMonotonicity:
+    @staticmethod
+    def _perfect(panel):
+        import polars as pl
+
+        return panel.with_columns(
+            pl.col("factor").rank(method="average").over("date").alias("forward_return")
+        )
+
     def test_perfect_monotonic(self, noisy_panel):
-        # WHY: tiny_panel only has 3 dates, < MIN_MONOTONICITY_PERIODS_HARD after sampling
-        # Use noisy_panel (20 dates × 30 assets) with perfect factor-return alignment
-        import polars as pl
-
-        perfect = noisy_panel.with_columns(
-            pl.col("factor").rank(method="average").over("date").alias("forward_return")
-        )
-        result = monotonicity(perfect, forward_periods=1, n_groups=5)["factor"]
-        assert result.value == pytest.approx(1.0)
-
-    def test_perfect_monotonicity_keeps_its_value_and_withholds_the_test(
-        self, noisy_panel
-    ):
-        """+1 on every period is maximal evidence, and has no t.
-
-        The measurement (avg monotonicity = 1.0) survives; the hypothesis
-        test does not, because a constant series has no dispersion to form
-        an SE from. What must never appear is the old t=0 / p=1, which read
-        a perfectly ordered factor as "no signal".
-        """
-        import polars as pl
-        from factrix._codes import WarningCode
-
-        perfect = noisy_panel.with_columns(
-            pl.col("factor").rank(method="average").over("date").alias("forward_return")
-        )
-        result = monotonicity(perfect, forward_periods=1, n_groups=5)["factor"]
-        assert result.value == pytest.approx(1.0)
+        # WHY: tiny_panel only has 3 dates, < MIN_MONOTONICITY_PERIODS_HARD after
+        # sampling. Use noisy_panel (20 dates × 30 assets) with perfect
+        # factor-return alignment.
+        result = monotonicity(
+            self._perfect(noisy_panel), forward_periods=1, n_groups=5, seed=0
+        )["factor"]
+        # Every adjacent bucket step is strictly positive and identical across
+        # periods, so the MR statistic is the (positive) common step.
+        assert result.value > 0
+        assert result.metadata["mean_abs_spearman"] == pytest.approx(1.0)
         assert result.metadata["mean_signed"] == pytest.approx(1.0)
-        assert result.stat is None
-        assert result.p_value is None
-        assert result.alternative is None
-        assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
-        assert result.metadata["signal_status"] == "degenerate_zero_variance"
+
+    def test_perfect_monotonicity_is_maximal_evidence(self, noisy_panel):
+        """A perfectly ordered factor gets the smallest attainable p.
+
+        The old headline reported ``value = mean|Spearman| = 1.0`` with the t
+        withheld — a constant signed series has no dispersion to form an SE
+        from. The MR test has no such hole: the recentred bootstrap puts every
+        draw at 0 while the observed J sits above it, so p is the floor
+        ``1 / (B + 1)``.
+        """
+        n_bootstrap = 200
+        result = monotonicity(
+            self._perfect(noisy_panel),
+            forward_periods=1,
+            n_groups=5,
+            n_bootstrap=n_bootstrap,
+            seed=0,
+        )["factor"]
+        assert result.p_value == pytest.approx(1 / (n_bootstrap + 1))
+        assert result.alternative == "greater"
+        assert result.stat == result.value
+        assert result.metadata["stat_type"] == "mr"
+        assert result.warning_codes == ()
+        # The descriptive Spearman pair is preserved, not the headline.
+        assert result.metadata["mean_abs_spearman"] == pytest.approx(1.0)
+        assert result.metadata["mean_signed"] == pytest.approx(1.0)
 
     def test_inverse_monotonic(self, noisy_panel):
         import polars as pl
@@ -51,9 +62,33 @@ class TestComputeMonotonicity:
                 "forward_return"
             )
         )
-        result = monotonicity(inverted, forward_periods=1, n_groups=5)["factor"]
-        assert result.value == pytest.approx(1.0)
+        result = monotonicity(inverted, forward_periods=1, n_groups=5, seed=0)["factor"]
+        # H1 is "increasing" by default, so a perfectly decreasing pattern is
+        # the furthest thing from it: J < 0 and the p is at its ceiling.
+        assert result.value < 0
+        assert result.p_value == pytest.approx(1.0)
+        assert result.metadata["mean_abs_spearman"] == pytest.approx(1.0)
         assert result.metadata["mean_signed"] == pytest.approx(-1.0)
+
+    def test_direction_declares_the_alternative(self, noisy_panel):
+        import polars as pl
+
+        inverted = noisy_panel.with_columns(
+            (-pl.col("factor").rank(method="average").over("date")).alias(
+                "forward_return"
+            )
+        )
+        result = monotonicity(
+            inverted,
+            forward_periods=1,
+            n_groups=5,
+            direction="decreasing",
+            n_bootstrap=200,
+            seed=0,
+        )["factor"]
+        assert result.value > 0
+        assert result.p_value == pytest.approx(1 / 201)
+        assert result.metadata["mr_direction"] == "decreasing"
 
     def test_insufficient_periods(self):
         from datetime import datetime
@@ -240,3 +275,187 @@ class TestBatchTieRatio:
             },
         )
         assert math.isnan(_compute_tie_ratios_batch(empty, ["factor"])["factor"])
+
+
+class TestPattonTimmermannMRTest:
+    """The headline is the MR test, not a statistic with a null floor."""
+
+    @staticmethod
+    def _null_panel(n_dates=400, n_assets=100, seed=0):
+        """Factor drawn independently of returns — H0 true by construction."""
+        from datetime import datetime, timedelta
+
+        import numpy as np
+        import polars as pl
+
+        rng = np.random.default_rng(seed)
+        rows = n_dates * n_assets
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                "factor": rng.standard_normal(rows),
+                "forward_return": rng.standard_normal(rows) * 0.02,
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    @pytest.mark.parametrize("n_groups", [3, 5, 10])
+    def test_headline_no_longer_carries_an_n_groups_null_floor(self, n_groups):
+        """mean|rho| read 0.66 / 0.43 / 0.27 at K = 3 / 5 / 10 under H0.
+
+        E|rho| > 0 by Jensen, so the old headline was a noise floor a reader
+        took for MR evidence, and the floor moved with n_groups. Measure the
+        MR test's rejection frequency on panels where H0 holds by construction:
+        it sits at or below nominal at every K, while the descriptive
+        statistic's floor is still plainly there (in metadata, labelled as a
+        shape statistic rather than as evidence).
+        """
+        n_reps = 20
+        rejections = 0
+        floors = []
+        for rep in range(n_reps):
+            panel = self._null_panel(n_dates=120, n_assets=40, seed=100 + rep)
+            result = monotonicity(
+                panel,
+                forward_periods=1,
+                n_groups=n_groups,
+                n_bootstrap=99,
+                seed=rep,
+            )["factor"]
+            rejections += result.p_value < 0.05
+            floors.append(result.metadata["mean_abs_spearman"])
+        assert rejections / n_reps <= 0.15
+        assert min(floors) > 0.15
+
+    def test_mr_statistic_is_the_min_adjacent_difference(self):
+        """Hand computation against the reported bucket means."""
+        import numpy as np
+
+        panel = self._null_panel(n_dates=60, n_assets=20, seed=3)
+        result = monotonicity(
+            panel, forward_periods=1, n_groups=4, n_bootstrap=100, seed=2
+        )["factor"]
+        diffs = np.asarray(result.metadata["mr_adjacent_diffs"])
+        assert len(diffs) == 3  # n_groups - 1 adjacent steps
+        assert result.value == pytest.approx(float(diffs.min()))
+        assert result.metadata["mr_min_diff"] == pytest.approx(result.value)
+
+    def test_bootstrap_is_reproducible_and_reports_its_seed(self):
+        panel = self._null_panel(n_dates=60, n_assets=20, seed=4)
+        kwargs = {"forward_periods": 1, "n_groups": 4, "n_bootstrap": 100}
+        a = monotonicity(panel, seed=7, **kwargs)["factor"]
+        b = monotonicity(panel, seed=7, **kwargs)["factor"]
+        assert a.p_value == b.p_value
+        assert a.metadata["bootstrap_seed"] == 7
+        # An unseeded run resolves one and reports it, so the run stays
+        # reproducible after the fact.
+        c = monotonicity(panel, **kwargs)["factor"]
+        assert isinstance(c.metadata["bootstrap_seed"], int)
+
+    def test_monotone_signal_is_detected(self):
+        from datetime import datetime, timedelta
+
+        import numpy as np
+        import polars as pl
+
+        rng = np.random.default_rng(9)
+        n_dates, n_assets = 200, 60
+        rows = n_dates * n_assets
+        factor = rng.standard_normal(rows)
+        panel = pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                "factor": factor,
+                "forward_return": 0.01 * factor + 0.005 * rng.standard_normal(rows),
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = monotonicity(
+            panel, forward_periods=1, n_groups=5, n_bootstrap=200, seed=5
+        )["factor"]
+        assert result.value > 0
+        assert result.p_value < 0.05
+
+
+class TestTieRatioCountsFiniteValuesOnly:
+    def test_nulls_are_not_counted_as_a_tied_level(self):
+        """5 of 10 names null, the other 5 all distinct: the tie ratio is 0."""
+        from datetime import datetime, timedelta
+
+        import polars as pl
+
+        n_dates = 40
+        rows = []
+        for d in range(n_dates):
+            date = datetime(2024, 1, 1) + timedelta(days=d)
+            for i in range(10):
+                rows.append(
+                    {
+                        "date": date,
+                        "asset_id": f"A{i}",
+                        "factor": None if i >= 5 else float(i) + d * 0.01,
+                        "forward_return": 0.001 * i,
+                    }
+                )
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = monotonicity(
+            panel, forward_periods=1, n_groups=3, n_bootstrap=50, seed=0
+        )["factor"]
+        assert result.metadata["tie_ratio"] == pytest.approx(0.0)
+
+    def test_nan_is_not_counted_either(self):
+        from datetime import datetime, timedelta
+
+        import polars as pl
+
+        n_dates = 40
+        rows = []
+        for d in range(n_dates):
+            date = datetime(2024, 1, 1) + timedelta(days=d)
+            for i in range(10):
+                rows.append(
+                    {
+                        "date": date,
+                        "asset_id": f"A{i}",
+                        "factor": float("nan") if i >= 5 else float(i) + d * 0.01,
+                        "forward_return": 0.001 * i,
+                    }
+                )
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        result = monotonicity(
+            panel, forward_periods=1, n_groups=3, n_bootstrap=50, seed=0
+        )["factor"]
+        assert result.metadata["tie_ratio"] == pytest.approx(0.0)
+
+    def test_real_ties_are_still_reported(self):
+        from datetime import datetime, timedelta
+
+        import polars as pl
+
+        n_dates = 40
+        rows = []
+        for d in range(n_dates):
+            date = datetime(2024, 1, 1) + timedelta(days=d)
+            for i in range(10):
+                rows.append(
+                    {
+                        "date": date,
+                        "asset_id": f"A{i}",
+                        "factor": float(i // 5),  # two distinct levels
+                        "forward_return": 0.001 * i,
+                    }
+                )
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        with pytest.warns(UserWarning, match="tie_ratio"):
+            result = monotonicity(
+                panel, forward_periods=1, n_groups=3, n_bootstrap=50, seed=0
+            )["factor"]
+        assert result.metadata["tie_ratio"] == pytest.approx(0.8)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -3,8 +3,10 @@
 import math
 from datetime import datetime
 
+import numpy as np
 import polars as pl
 import pytest
+from factrix._errors import UserInputError
 from factrix.preprocess.normalize import cross_sectional_zscore, mad_winsorize
 
 
@@ -142,3 +144,168 @@ class TestZeroMADFallback:
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         out = mad_winsorize(df, n_mad=3.0)["factor"].to_list()
         assert max(out) < 100.0
+
+
+def _one_date(values, name="factor"):
+    return pl.DataFrame(
+        {
+            "date": [datetime(2024, 1, 1)] * len(values),
+            "asset_id": [str(i) for i in range(len(values))],
+            name: values,
+        }
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+class TestSmallSampleMADScaling:
+    """Croux-Rousseeuw (1992) finite-sample correction on the MAD scale."""
+
+    def test_scale_carries_b_n_at_n_five(self):
+        # median([1,2,3,4,5]) = 3; MAD = median([2,1,0,1,2]) = 1.
+        # scale = b_5 * 1.4826 * 1 = 1.206 * 1.4826 = 1.78802...
+        z = cross_sectional_zscore(_one_date([1.0, 2.0, 3.0, 4.0, 5.0]))
+        scale = 1.206 * 1.4826
+        assert z["factor_zscore"].to_list() == pytest.approx(
+            [(v - 3.0) / scale for v in (1.0, 2.0, 3.0, 4.0, 5.0)]
+        )
+
+    def test_scale_uses_asymptotic_expansion_above_the_table(self):
+        values = [float(v) for v in range(1, 12)]  # n = 11, median 6, MAD 3
+        z = cross_sectional_zscore(_one_date(values))
+        scale = (11 / (11 - 0.8)) * 1.4826 * 3.0
+        assert z["factor_zscore"][-1] == pytest.approx((11.0 - 6.0) / scale)
+
+    @pytest.mark.parametrize(
+        ("n_assets", "uncorrected"), [(5, 0.821), (10, 0.913), (20, 0.959)]
+    )
+    def test_scale_is_unbiased_for_sigma_at_every_cross_section_size(
+        self, n_assets, uncorrected
+    ):
+        """The bias is N-dependent, so thin dates were handed larger z-scores.
+
+        Monte-Carlo on a standard-normal factor (true sigma = 1): the bare
+        1.4826 constant under-estimates sigma by 18% at n=5, 9% at n=10 and 4%
+        at n=20, while ``b_n * 1.4826 * MAD`` is unbiased at all three. In an
+        unbalanced panel that difference is exactly what makes anything pooling
+        or weighting by z over-weight the thinnest cross-sections.
+        """
+        rng = np.random.default_rng(7)
+        n_dates = 4000
+        x = rng.standard_normal((n_dates, n_assets))
+        df = pl.DataFrame(
+            {
+                "date": np.repeat(np.arange(n_dates), n_assets),
+                "asset_id": np.tile(np.arange(n_assets), n_dates),
+                "factor": x.ravel(),
+            }
+        )
+        z = cross_sectional_zscore(df).sort("date", "asset_id")["factor_zscore"]
+        # scale = value / z, recovered from any non-centre name.
+        centred = (x - np.median(x, axis=1, keepdims=True)).ravel()
+        off_centre = np.abs(centred) > 1e-9
+        mean_scale = float(np.mean(centred[off_centre] / z.to_numpy()[off_centre]))
+        assert mean_scale == pytest.approx(1.0, abs=0.02)
+        # ... and materially better than the uncorrected asymptotic constant.
+        assert abs(mean_scale - 1.0) < abs(uncorrected - 1.0)
+
+    def test_n_mad_is_a_nominal_sigma_clip_at_small_n(self):
+        """3 MAD units must not be an effective 2.46 sigma band at n=5."""
+        # spread [-2,-1,0,1,2]: MAD = 1, corrected scale 1.78802, band +-5.364.
+        out = mad_winsorize(_one_date([-2.0, -1.0, 0.0, 1.0, 6.0]), n_mad=3.0)
+        assert out["factor"].to_list()[-1] == pytest.approx(3.0 * 1.206 * 1.4826)
+
+
+class TestCenterChoice:
+    def test_median_centred_output_is_not_mean_zero(self):
+        """Documented consequence: w ~ z carries a net long leg on a skewed factor."""
+        sparse = [0.0] * 18 + [1.0, 1.0]
+        with pytest.warns(UserWarning, match="sparse_winsorize_skipped|zero_mad"):
+            z = cross_sectional_zscore(_one_date(sparse))["factor_zscore"]
+        assert float(z.mean()) > 0.3
+
+    def test_mean_centre_is_exactly_mean_zero(self):
+        sparse = [0.0] * 18 + [1.0, 1.0]
+        with pytest.warns(UserWarning, match="zero_mad_std_fallback"):
+            z = cross_sectional_zscore(_one_date(sparse), center="mean")[
+                "factor_zscore"
+            ]
+        assert float(z.mean()) == pytest.approx(0.0, abs=1e-12)
+
+    def test_rejects_unknown_centre(self):
+        with pytest.raises(UserInputError):
+            cross_sectional_zscore(_one_date([1.0, 2.0, 3.0]), center="mode")
+
+
+class TestScaleMethodSwitchIsAnnounced:
+    def test_std_fallback_emits_the_code(self):
+        with pytest.warns(UserWarning, match="zero_mad_std_fallback"):
+            cross_sectional_zscore(_one_date([1.0, 1.0, 1.0, 1.0, 2.0]))
+
+    def test_thin_cross_section_yields_null_not_a_fabricated_zero(self):
+        with pytest.warns(UserWarning, match="insufficient_scale_assets"):
+            z = cross_sectional_zscore(_one_date([7.0]))["factor_zscore"].to_list()
+        assert z == [None]
+
+    def test_two_asset_date_no_longer_returns_a_constant(self):
+        with pytest.warns(UserWarning, match="insufficient_scale_assets"):
+            z = cross_sectional_zscore(_one_date([1.0, 9.0]))["factor_zscore"].to_list()
+        assert z == [None, None]
+
+    def test_thin_date_is_left_unwinsorized(self):
+        with pytest.warns(UserWarning, match="insufficient_scale_assets"):
+            out = mad_winsorize(_one_date([1.0, 500.0]), n_mad=3.0)
+        assert out["factor"].to_list() == [1.0, 500.0]
+
+
+class TestSparseWinsorize:
+    def test_sparse_trigger_magnitude_is_preserved(self):
+        """1 trigger / 50 assets used to lose 58% of its magnitude to 3 x std."""
+        with pytest.warns(UserWarning, match="sparse_winsorize_skipped"):
+            out = mad_winsorize(_one_date([0.0] * 49 + [1.0]), n_mad=3.0)
+        assert out["factor"].to_list()[-1] == 1.0
+
+    def test_bucketed_non_sparse_factor_still_uses_the_std_fallback(self):
+        with pytest.warns(UserWarning, match="zero_mad_std_fallback"):
+            out = mad_winsorize(_one_date([1.0] * 10 + [2.0, 100.0]), n_mad=3.0)
+        assert max(out["factor"].to_list()) < 100.0
+
+
+class TestNonFiniteHandling:
+    def test_infinity_becomes_null_not_a_fabricated_finite_value(self):
+        with pytest.warns(UserWarning, match="non_finite_input_dropped"):
+            out = mad_winsorize(
+                _one_date([1.0, 2.0, 3.0, 4.0, float("inf")]), n_mad=3.0
+            )
+        assert out["factor"].to_list() == [1.0, 2.0, 3.0, 4.0, None]
+
+    def test_nan_becomes_null_in_winsorize_too(self):
+        with pytest.warns(UserWarning, match="non_finite_input_dropped"):
+            out = mad_winsorize(
+                _one_date([1.0, 2.0, 3.0, 4.0, float("nan")]), n_mad=3.0
+            )
+        assert out["factor"].to_list()[-1] is None
+
+
+class TestNMadValidation:
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), -1.0, "3", None, True])
+    def test_rejects_non_finite_or_non_numeric(self, bad):
+        with pytest.raises(UserInputError):
+            mad_winsorize(_one_date([1.0, 2.0, 3.0]), n_mad=bad)
+
+    def test_zero_still_disables(self):
+        df = _one_date([1.0, 2.0, 300.0])
+        assert mad_winsorize(df, n_mad=0.0)["factor"].to_list() == [1.0, 2.0, 300.0]
+
+
+class TestZScoreOutputColumnName:
+    def test_column_name_derives_from_factor_col(self):
+        df = _one_date([1.0, 2.0, 3.0, 4.0, 5.0], name="value_raw")
+        out = cross_sectional_zscore(df, factor_col="value_raw")
+        assert "value_raw_zscore" in out.columns
+        assert "factor_zscore" not in out.columns
+
+    def test_two_factors_do_not_collide(self):
+        df = _one_date([1.0, 2.0, 3.0, 4.0, 5.0]).with_columns(
+            pl.col("factor").alias("momentum")
+        )
+        out = cross_sectional_zscore(cross_sectional_zscore(df), factor_col="momentum")
+        assert {"factor_zscore", "momentum_zscore"} <= set(out.columns)

--- a/tests/test_orthogonalize.py
+++ b/tests/test_orthogonalize.py
@@ -1,10 +1,12 @@
 """Tests for factrix.preprocess.orthogonalize."""
 
+import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
 import polars as pl
 import pytest
+from factrix._codes import WarningCode
 from factrix.preprocess.orthogonalize import orthogonalize_factor
 
 
@@ -96,7 +98,9 @@ class TestDuplicateBaseKeys:
 
     def test_unique_keys_keep_height_and_coverage(self):
         factor_df, base_df = _make_ortho_data(n_dates=3, n_assets=5)
-        ortho = orthogonalize_factor(factor_df, base_df)
+        # min_residual_df=1 keeps this a coverage test: 5 names on 2 base
+        # columns is far below the default df floor.
+        ortho = orthogonalize_factor(factor_df, base_df, min_residual_df=1)
         assert ortho.data.height == factor_df.height
         assert ortho.coverage == pytest.approx(1.0)
 
@@ -158,9 +162,10 @@ class TestNonFiniteRows:
         assert row["factor"][0] is None
 
     def test_too_few_finite_rows_skips_the_date(self):
-        """Below len(base_cols) + 2 finite rows the date keeps its raw values."""
-        # 2 base cols + intercept → 4 finite rows required. The first date is
-        # one short once A0 goes non-finite; the second date clears the bar.
+        """Below the residual-df floor the date keeps its raw values."""
+        # 2 base cols + intercept → 4 finite rows required at
+        # min_residual_df=1. The first date is one short once A0 goes
+        # non-finite; the second date clears the bar.
         factor_df, base_df = _make_ortho_data(n_dates=2, n_assets=4)
         first_date = factor_df["date"][0]
         dirty = factor_df.with_columns(
@@ -169,11 +174,191 @@ class TestNonFiniteRows:
             .otherwise(pl.col("factor"))
             .alias("factor")
         )
-        ortho = orthogonalize_factor(dirty, base_df)
+        ortho = orthogonalize_factor(dirty, base_df, min_residual_df=1)
         assert ortho.n_dates_skipped == 1
 
         kept = ortho.data.filter(pl.col("date") == first_date).sort("asset_id")
         original = dirty.filter(pl.col("date") == first_date).sort("asset_id")
         np.testing.assert_array_equal(
             kept["factor"].to_numpy(), original["factor"].to_numpy()
+        )
+
+
+class TestResidualDegreesOfFreedom:
+    """A df floor, not a bare row count (finding: R2 0.79 at a true R2 of 0)."""
+
+    @staticmethod
+    def _independent_panel(n_dates: int, n_assets: int, n_base: int, seed: int = 0):
+        """factor drawn independently of the base set — true R2 is exactly 0."""
+        rng = np.random.default_rng(seed)
+        dates = [datetime(2024, 1, 1) + timedelta(days=d) for d in range(n_dates)]
+        rows = n_dates * n_assets
+        base_names = [f"b{i}" for i in range(n_base)]
+        keys = {
+            "date": [d for d in dates for _ in range(n_assets)],
+            "asset_id": [f"A{i}" for _ in dates for i in range(n_assets)],
+        }
+        factor_df = pl.DataFrame({**keys, "factor": rng.standard_normal(rows)})
+        base_df = pl.DataFrame(
+            {**keys, **{c: rng.standard_normal(rows) for c in base_names}}
+        )
+        return factor_df, base_df, base_names
+
+    def test_thin_cross_section_is_skipped_not_fitted(self):
+        factor_df, base_df, base_names = self._independent_panel(
+            n_dates=200, n_assets=6, n_base=4
+        )
+        with pytest.warns(UserWarning, match="insufficient_regression_df"):
+            ortho = orthogonalize_factor(factor_df, base_df, base_cols=base_names)
+        assert ortho.n_dates_insufficient_df == 200
+        assert ortho.n_dates_skipped == 200
+        assert ortho.coverage == 0.0
+        assert WarningCode.INSUFFICIENT_REGRESSION_DF.value in ortho.warning_codes
+        # The factor survives intact rather than being residualised into noise.
+        np.testing.assert_allclose(
+            ortho.data.sort(["date", "asset_id"])["factor"].to_numpy(),
+            factor_df.sort(["date", "asset_id"])["factor"].to_numpy(),
+        )
+
+    def test_old_floor_reported_noise_as_explanatory_power(self):
+        """min_residual_df=1 reproduces the defect the floor exists to stop."""
+        factor_df, base_df, base_names = self._independent_panel(
+            n_dates=200, n_assets=6, n_base=4
+        )
+        ortho = orthogonalize_factor(
+            factor_df, base_df, base_cols=base_names, min_residual_df=1
+        )
+        # Raw R2 ~ K/(N-1) = 4/5 even though the true R2 is 0 ...
+        assert ortho.mean_r_squared > 0.7
+        # ... and the adjusted figure says so.
+        assert abs(ortho.mean_adj_r_squared) < 0.2
+        assert ortho.mean_adj_r_squared < ortho.mean_r_squared
+
+    def test_wide_cross_section_still_fits(self):
+        factor_df, base_df, base_names = self._independent_panel(
+            n_dates=30, n_assets=40, n_base=3
+        )
+        ortho = orthogonalize_factor(factor_df, base_df, base_cols=base_names)
+        assert ortho.n_dates_insufficient_df == 0
+        assert ortho.coverage == pytest.approx(1.0)
+        assert ortho.warning_codes == ()
+
+    def test_floor_is_residual_df_not_row_count(self):
+        """n_assets = n_base + 1 + min_residual_df is the exact boundary."""
+        for n_assets, expect_skip in ((13, True), (14, False)):
+            factor_df, base_df, base_names = self._independent_panel(
+                n_dates=5, n_assets=n_assets, n_base=3
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ortho = orthogonalize_factor(
+                    factor_df, base_df, base_cols=base_names, min_residual_df=10
+                )
+            assert (ortho.n_dates_insufficient_df == 5) is expect_skip
+
+
+class TestRankDeficiency:
+    """lstsq does not raise on a singular design; it returns min-norm betas."""
+
+    @staticmethod
+    def _dummy_panel(*, drop_reference: bool, n_dates: int = 50, n_assets: int = 20):
+        rng = np.random.default_rng(3)
+        dates = [datetime(2024, 1, 1) + timedelta(days=d) for d in range(n_dates)]
+        keys = {
+            "date": [d for d in dates for _ in range(n_assets)],
+            "asset_id": [f"A{i}" for _ in dates for i in range(n_assets)],
+        }
+        rows = n_dates * n_assets
+        industry = np.tile(np.arange(n_assets) % 4, n_dates)
+        cols = {f"ind{k}": (industry == k).astype(float) for k in range(4)}
+        base_df = pl.DataFrame({**keys, **cols})
+        factor_df = pl.DataFrame({**keys, "factor": rng.standard_normal(rows)})
+        names = sorted(cols)
+        return factor_df, base_df, names[1:] if drop_reference else names
+
+    def test_full_dummy_set_is_detected(self):
+        factor_df, base_df, base_names = self._dummy_panel(drop_reference=False)
+        with pytest.warns(UserWarning, match="rank_deficient_design"):
+            ortho = orthogonalize_factor(factor_df, base_df, base_cols=base_names)
+        assert ortho.n_dates_rank_deficient == 50
+        assert WarningCode.RANK_DEFICIENT_DESIGN.value in ortho.warning_codes
+        # Unidentified betas are withheld rather than reported as attribution.
+        assert ortho.mean_betas == {}
+
+    def test_duplicated_column_is_detected(self):
+        factor_df, base_df, base_names = self._dummy_panel(drop_reference=True)
+        base_df = base_df.with_columns(pl.col(base_names[0]).alias("copy"))
+        with pytest.warns(UserWarning, match="rank_deficient_design"):
+            ortho = orthogonalize_factor(
+                factor_df, base_df, base_cols=[*base_names, "copy"]
+            )
+        assert ortho.n_dates_rank_deficient == 50
+        assert ortho.mean_betas == {}
+
+    def test_reference_level_dropped_gives_identified_betas(self):
+        factor_df, base_df, base_names = self._dummy_panel(drop_reference=True)
+        ortho = orthogonalize_factor(factor_df, base_df, base_cols=base_names)
+        assert ortho.n_dates_rank_deficient == 0
+        assert set(ortho.mean_betas) == set(base_names)
+        assert ortho.warning_codes == ()
+
+    def test_residuals_are_identical_either_way(self):
+        """The projection is unique; only the betas were arbitrary."""
+        factor_df, base_df, full = self._dummy_panel(drop_reference=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            deficient = orthogonalize_factor(factor_df, base_df, base_cols=full)
+        reduced = orthogonalize_factor(factor_df, base_df, base_cols=full[1:])
+        np.testing.assert_allclose(
+            deficient.data.sort(["date", "asset_id"])["factor"].to_numpy(),
+            reduced.data.sort(["date", "asset_id"])["factor"].to_numpy(),
+            atol=1e-10,
+        )
+
+
+class TestRestandardize:
+    def test_default_leaves_the_residual_on_its_own_scale(self):
+        rng = np.random.default_rng(11)
+        n_dates, n_assets = 40, 40
+        dates = [datetime(2024, 1, 1) + timedelta(days=d) for d in range(n_dates)]
+        keys = {
+            "date": [d for d in dates for _ in range(n_assets)],
+            "asset_id": [f"A{i}" for _ in dates for i in range(n_assets)],
+        }
+        rows = n_dates * n_assets
+        size = rng.standard_normal(rows)
+        factor = size + rng.standard_normal(rows)
+        factor_df = pl.DataFrame({**keys, "factor": factor})
+        base_df = pl.DataFrame({**keys, "size": size})
+
+        raw = orthogonalize_factor(factor_df, base_df, base_cols=["size"])
+        pre = float(factor_df["factor"].std(ddof=1))
+        post = float(raw.data["factor"].std(ddof=1))
+        # sd(post) ~ sd(pre) * sqrt(1 - R2)
+        assert post == pytest.approx(pre * (1 - raw.mean_r_squared) ** 0.5, rel=0.1)
+        assert raw.restandardized is False
+
+    def test_restandardize_restores_the_per_date_input_dispersion(self):
+        rng = np.random.default_rng(12)
+        n_dates, n_assets = 40, 40
+        dates = [datetime(2024, 1, 1) + timedelta(days=d) for d in range(n_dates)]
+        keys = {
+            "date": [d for d in dates for _ in range(n_assets)],
+            "asset_id": [f"A{i}" for _ in dates for i in range(n_assets)],
+        }
+        rows = n_dates * n_assets
+        size = rng.standard_normal(rows)
+        factor_df = pl.DataFrame({**keys, "factor": size + rng.standard_normal(rows)})
+        base_df = pl.DataFrame({**keys, "size": size})
+
+        out = orthogonalize_factor(
+            factor_df, base_df, base_cols=["size"], restandardize=True
+        )
+        assert out.restandardized is True
+        per_date = out.data.group_by("date").agg(
+            pl.col("factor").std(ddof=1).alias("post"),
+            pl.col("factor_pre_ortho").std(ddof=1).alias("pre"),
+        )
+        np.testing.assert_allclose(
+            per_date["post"].to_numpy(), per_date["pre"].to_numpy(), rtol=1e-9
         )

--- a/tests/test_panel_ingestion_gate.py
+++ b/tests/test_panel_ingestion_gate.py
@@ -188,3 +188,27 @@ def warnings_as_errors():
             yield
 
     return _ctx()
+
+
+class TestNonFloatColumnsUntouched:
+    """Only float dtypes can carry NaN / ±inf; every other dtype passes through."""
+
+    def test_decimal_column_passes_through(self):
+        from decimal import Decimal
+
+        df = pl.DataFrame(
+            {
+                "date": [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+                "asset_id": ["A", "A"],
+                "market_cap": pl.Series(
+                    [Decimal("1.50"), Decimal("2.25")], dtype=pl.Decimal(10, 2)
+                ),
+                "n": pl.Series([1, 2], dtype=pl.Int64),
+                "flag": [True, False],
+            }
+        )
+        out = _normalize_panel(df)
+        assert out.schema["market_cap"] == pl.Decimal(10, 2)
+        assert out["market_cap"].to_list() == df["market_cap"].to_list()
+        assert out["n"].to_list() == [1, 2]
+        assert out["flag"].to_list() == [True, False]

--- a/tests/test_panel_ingestion_gate.py
+++ b/tests/test_panel_ingestion_gate.py
@@ -1,0 +1,190 @@
+"""The structural contract every public entry point shares.
+
+`_normalize_panel` enforces three things that were previously left to each
+producer: a temporal `date`, unique `(date, asset_id)` keys, and non-finite
+numerics blanked to null *before* any arithmetic. Each of the cases below is a
+number the library used to return without error or warning.
+"""
+
+from datetime import datetime, timedelta
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._codes import WarningCode
+from factrix._data_input import _normalize_panel
+from factrix._errors import UserInputError
+from factrix.preprocess import compute_forward_return
+
+
+def _panel(prices, dates=None, asset="A"):
+    dates = dates or [
+        datetime(2024, 1, 1) + timedelta(days=i) for i in range(len(prices))
+    ]
+    return pl.DataFrame(
+        {
+            "date": dates,
+            "asset_id": [asset] * len(prices),
+            "price": prices,
+        }
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+class TestDateDtypeContract:
+    def test_string_date_is_rejected(self):
+        """Lexicographic ordering silently reorders any non-ISO format."""
+        df = pl.DataFrame(
+            {
+                "date": ["01/02/2024", "02/01/2024", "03/01/2024"],
+                "asset_id": ["A", "A", "A"],
+                "price": [110.0, 120.0, 100.0],
+            }
+        )
+        with pytest.raises(UserInputError, match="date"):
+            _normalize_panel(df)
+        with pytest.raises(UserInputError, match="date"):
+            compute_forward_return(df, forward_periods=1)
+
+    def test_integer_date_is_rejected(self):
+        df = pl.DataFrame(
+            {"date": [0, 1, 2], "asset_id": ["A"] * 3, "price": [1.0, 2.0, 3.0]}
+        )
+        with pytest.raises(UserInputError, match="date"):
+            _normalize_panel(df)
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [pl.Date, pl.Datetime("ms"), pl.Datetime("ns"), pl.Datetime("us", "UTC")],
+    )
+    def test_temporal_dtypes_pass(self, dtype):
+        df = _panel([1.0, 2.0, 3.0]).with_columns(pl.col("date").cast(dtype))
+        assert _normalize_panel(df).height == 3
+
+
+class TestKeyUniqueness:
+    def test_duplicate_keys_are_rejected(self):
+        """A duplicate makes the 'next period' the same date's twin."""
+        clean = _panel([100.0, 101.0, 102.0, 103.0])
+        dup = pl.concat([clean, clean])
+        with pytest.raises(UserInputError, match=r"\(date, asset_id\)"):
+            _normalize_panel(dup)
+        with pytest.raises(UserInputError, match=r"\(date, asset_id\)"):
+            compute_forward_return(dup, forward_periods=1)
+
+    def test_duplicates_used_to_fabricate_zero_returns(self):
+        """Half the surviving panel was 0.0 returns, silently."""
+        clean = _panel([100.0, 101.0, 102.0, 103.0])
+        out = compute_forward_return(clean, forward_periods=1)
+        assert 0.0 not in out["forward_return"].to_list()
+
+    def test_unique_keys_across_assets_are_fine(self):
+        a = _panel([100.0, 101.0, 102.0], asset="A")
+        b = _panel([100.0, 101.0, 102.0], asset="B")
+        assert _normalize_panel(pl.concat([a, b])).height == 6
+
+
+class TestNonFiniteNumerics:
+    def test_inf_price_no_longer_fabricates_a_minus_one_return(self):
+        """`finite / inf` is 0.0, so the quotient was a finite -100% return."""
+        with_inf = _panel([100.0, 101.0, float("inf"), 103.0, 104.0, 105.0])
+        null_twin = _panel([100.0, 101.0, None, 103.0, 104.0, 105.0])
+        out = compute_forward_return(with_inf, forward_periods=1)
+        twin = compute_forward_return(null_twin, forward_periods=1)
+        assert -1.0 not in out["forward_return"].to_list()
+        assert out["forward_return"].to_list() == pytest.approx(
+            twin["forward_return"].to_list()
+        )
+
+    def test_nan_and_inf_become_null(self):
+        df = _panel([1.0, float("nan"), float("-inf"), 4.0])
+        out = _normalize_panel(df)
+        assert out["price"].to_list() == [1.0, None, None, 4.0]
+
+    def test_non_numeric_columns_are_untouched(self):
+        df = _panel([1.0, 2.0, 3.0]).with_columns(
+            pl.lit("tech").alias("sector"),
+        )
+        out = _normalize_panel(df)
+        assert out["sector"].to_list() == ["tech"] * 3
+
+
+class TestHorizonIsMeasuredOnThePeriodGrid:
+    @staticmethod
+    def _ragged_panel():
+        """Asset A is missing periods 10-29; asset B is complete."""
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(40)]
+        rows = []
+        for i, d in enumerate(dates):
+            for asset in ("A", "B"):
+                if asset == "A" and 10 <= i < 30:
+                    continue
+                rows.append({"date": d, "asset_id": asset, "price": 100.0 * (1.01**i)})
+        return pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_gap_no_longer_stretches_the_window(self):
+        """A "5-period" return used to span 25 real periods across the gap."""
+        panel = self._ragged_panel()
+        with pytest.warns(UserWarning, match="ragged_period_grid"):
+            out = compute_forward_return(panel, forward_periods=5)
+        # Every surviving return is the same 5-period compounded move, whichever
+        # asset it came from — the row-shift version gave asset A a 25-period
+        # return at the gap boundary.
+        returns = out["forward_return"].to_list()
+        expected = (1.01**5 - 1) / 5
+        assert returns == pytest.approx([expected] * len(returns))
+
+    def test_asset_with_a_gap_contributes_no_row_across_it(self):
+        panel = self._ragged_panel()
+        with pytest.warns(UserWarning, match="ragged_period_grid"):
+            out = compute_forward_return(panel, forward_periods=5)
+        a_dates = out.filter(pl.col("asset_id") == "A")["date"].to_list()
+        # Period index 4 would exit at index 10, which asset A does not have.
+        assert datetime(2024, 1, 5) not in a_dates
+
+    def test_complete_panel_does_not_warn(self):
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(30)]
+        rows = [
+            {"date": d, "asset_id": a, "price": 100.0 + i}
+            for i, d in enumerate(dates)
+            for a in ("A", "B")
+        ]
+        panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        with warnings_as_errors():
+            compute_forward_return(panel, forward_periods=5)
+
+    def test_ragged_grid_code_is_documented(self):
+        assert WarningCode.RAGGED_PERIOD_GRID.description
+
+
+class TestGateReachesEveryEntryPoint:
+    def test_evaluate_rejects_duplicate_keys(self):
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=40, seed=0)
+        panel = compute_forward_return(raw, forward_periods=1)
+        dup = pl.concat([panel, panel.head(1)])
+        with pytest.raises(UserInputError, match=r"\(date, asset_id\)"):
+            fx.evaluate(
+                dup,
+                factor_cols=["factor"],
+                metrics={"ic": fx.metrics.ic()},
+                forward_periods=1,
+            )
+
+    def test_inspect_data_rejects_duplicate_keys(self):
+        raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=40, seed=0)
+        panel = compute_forward_return(raw, forward_periods=1)
+        dup = pl.concat([panel, panel.head(1)])
+        with pytest.raises(UserInputError, match=r"\(date, asset_id\)"):
+            fx.inspect_data(dup)
+
+
+def warnings_as_errors():
+    import warnings as _w
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        with _w.catch_warnings():
+            _w.simplefilter("error", UserWarning)
+            yield
+
+    return _ctx()

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -6,6 +6,9 @@ from datetime import datetime, timedelta
 import numpy as np
 import polars as pl
 import pytest
+from factrix._codes import WarningCode
+from factrix._errors import IncompatibleInferenceError
+from factrix.inference import HANSEN_HODRICK, NEWEY_WEST
 from factrix.metrics.quantile import (
     compute_spread_series,
     quantile_spread,
@@ -793,3 +796,111 @@ class TestQuantileSpreadVwThroughEvaluate:
         info_w = fx.inspect_data(self._panel())
         entry_w = next(m for m in info_w.metrics if m.name == "quantile_spread_vw")
         assert not any("market_cap" in b for b in entry_w.blockers)
+
+
+class TestValueWeightedThinDiagnostics:
+    """The capacity cross-check must not be the one that reports clean."""
+
+    @staticmethod
+    def _thin_panel(n_assets=8, n_dates=60, seed=0):
+        from datetime import datetime, timedelta
+
+        import numpy as np
+
+        rng = np.random.default_rng(seed)
+        rows = n_dates * n_assets
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                "factor": rng.standard_normal(rows),
+                "forward_return": rng.standard_normal(rows) * 0.01,
+                "market_cap": rng.uniform(1e8, 1e10, rows),
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_vw_matches_ew_diagnostics_on_the_same_panel(self):
+        panel = self._thin_panel()
+        with pytest.warns(UserWarning, match="assets per group"):
+            ew = quantile_spread(panel, forward_periods=1, n_groups=5)["factor"]
+        with pytest.warns(UserWarning, match="assets per group"):
+            vw = quantile_spread_vw(panel, forward_periods=1, n_groups=5)
+        assert WarningCode.THIN_QUANTILE_GROUPS.value in vw.warning_codes
+        assert WarningCode.FEW_ASSETS.value in vw.warning_codes
+        assert set(ew.warning_codes) == set(vw.warning_codes)
+
+    def test_wide_panel_stays_clean(self):
+        panel = self._thin_panel(n_assets=60, n_dates=80)
+        vw = quantile_spread_vw(panel, forward_periods=1, n_groups=5)
+        assert vw.warning_codes == ()
+        assert vw.metadata["median_cross_section"] == 60
+
+
+class TestValueWeightedInference:
+    @staticmethod
+    def _panel(n_assets=50, n_dates=200, seed=1):
+        from datetime import datetime, timedelta
+
+        import numpy as np
+
+        rng = np.random.default_rng(seed)
+        rows = n_dates * n_assets
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                "factor": rng.standard_normal(rows),
+                "forward_return": rng.standard_normal(rows) * 0.01,
+                "market_cap": rng.uniform(1e8, 1e10, rows),
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_default_reproduces_the_previous_non_overlap_t(self):
+        panel = self._panel()
+        out = quantile_spread_vw(panel, forward_periods=5, n_groups=5)
+        assert out.metadata["method"] == "non-overlapping t-test"
+        assert out.n_obs == out.metadata["n_periods_strided"]
+
+    def test_newey_west_keeps_every_date(self):
+        panel = self._panel()
+        strided = quantile_spread_vw(panel, forward_periods=5, n_groups=5)
+        hac = quantile_spread_vw(
+            panel, forward_periods=5, n_groups=5, inference=NEWEY_WEST
+        )
+        assert hac.n_obs > strided.n_obs
+        # 200 dates less the first, whose lagged weight is null by
+        # construction — on the HAC path every date is its own rebalance, so
+        # the weight lag is one bar rather than one stride.
+        assert hac.n_obs == 199
+        assert hac.metadata["method"] == NEWEY_WEST.summary
+        # value is the full-sample mean on the HAC path, the strided mean
+        # otherwise — both describe the sample the headline ran on.
+        assert hac.metadata["n_periods_tested"] == hac.n_obs
+
+    def test_pair_shares_the_inference_allowlist(self):
+        panel = self._panel()
+        ew = quantile_spread(
+            panel, forward_periods=5, n_groups=5, inference=NEWEY_WEST
+        )["factor"]
+        vw = quantile_spread_vw(
+            panel, forward_periods=5, n_groups=5, inference=NEWEY_WEST
+        )
+        # Same date set and same inference member, so the pair is comparable;
+        # the VW leg gives up the first date to the weight lag.
+        assert vw.n_obs == ew.n_obs - 1
+        assert ew.metadata["method"] == vw.metadata["method"]
+
+    def test_rejects_an_inference_outside_the_allowlist(self):
+        panel = self._panel(n_assets=20, n_dates=60)
+        with pytest.raises(IncompatibleInferenceError):
+            quantile_spread_vw(
+                panel, forward_periods=5, n_groups=5, inference=HANSEN_HODRICK
+            )

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -6,6 +6,8 @@ from typing import ClassVar
 
 import polars as pl
 import pytest
+from factrix._errors import UserInputError
+from factrix._types import DEFAULT_FORWARD_PERIODS, DEFAULT_N_GROUPS
 from factrix.metrics.tradability import (
     breakeven_cost,
     net_spread,
@@ -117,7 +119,7 @@ class TestNotionalTurnover:
     def test_static_factor(self):
         """Same tail sets every day → notional turnover = 0."""
         df = _panel(5, self.TEN_ASSETS, lambda t, a: ord(a))
-        result = notional_turnover(df, n_groups=5)
+        result = notional_turnover(df, n_groups=5, forward_periods=1)
         assert result.value == pytest.approx(0.0)
         assert result.metadata["n_rebalances"] == 4
         assert result.metadata["n_groups"] == 5
@@ -126,25 +128,25 @@ class TestNotionalTurnover:
         assert result.n_obs == 4
 
     def test_small_universe_names_the_assets_axis(self):
-        """Default n_groups=10 on an 8-name universe empties every date however
+        """The default n_groups on a 4-name universe empties every date however
         long the panel — an assets-axis failure, reported as one."""
         from factrix._codes import WarningCode
 
-        assets = [chr(ord("A") + i) for i in range(8)]
+        assets = [chr(ord("A") + i) for i in range(4)]
         df = _panel(200, assets, lambda t, a: ord(a) + t)
         result = notional_turnover(df)
         assert math.isnan(result.value)
         assert result.metadata["reason"] == "insufficient_assets_for_quantile_groups"
         assert result.n_obs_axis == "assets"
-        assert result.n_obs == 8
-        assert result.metadata["min_required"] == 10
+        assert result.n_obs == 4
+        assert result.metadata["min_required"] == DEFAULT_N_GROUPS
         assert WarningCode.THIN_QUANTILE_GROUPS.value in result.warning_codes
 
     def test_declared_assets_floor_tracks_n_groups(self):
         from factrix.metrics import notional_turnover as nt
 
         cls = type(nt())
-        assert cls._resolve_sample_threshold(nt()).min_assets == 10
+        assert cls._resolve_sample_threshold(nt()).min_assets == DEFAULT_N_GROUPS
         assert cls._resolve_sample_threshold(nt(n_groups=3)).min_assets == 3
 
     def test_downscaled_n_groups_runs_on_the_same_panel(self):
@@ -161,7 +163,7 @@ class TestNotionalTurnover:
             return base if t % 2 == 0 else (9 - base)
 
         df = _panel(5, self.TEN_ASSETS, factor)
-        result = notional_turnover(df, n_groups=5)
+        result = notional_turnover(df, n_groups=5, forward_periods=1)
         assert result.value == pytest.approx(1.0)
 
     def test_middle_shuffle_does_not_count(self):
@@ -311,3 +313,115 @@ class TestNetSpread:
     def test_forward_periods_validation(self):
         with pytest.raises(ValueError, match="forward_periods"):
             net_spread(0.10, turnover=0.5, forward_periods=0)
+
+
+class TestRankTurnoverIgnoresNonFiniteFactors:
+    """polars ranks NaN last, i.e. as larger than every real value."""
+
+    @staticmethod
+    def _panel_with(mask_value):
+        import numpy as np
+
+        rng = np.random.default_rng(0)
+        n_dates, assets = 60, [f"A{i}" for i in range(20)]
+        rows = []
+        poison = rng.random((n_dates, len(assets))) < 0.2
+        for t in range(n_dates):
+            for j, a in enumerate(assets):
+                rows.append(
+                    {
+                        "date": datetime(2024, 1, 1) + timedelta(days=t),
+                        "asset_id": a,
+                        "factor": mask_value if poison[t, j] else float(rng.normal()),
+                    }
+                )
+        return pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_nan_and_null_agree(self):
+        nan_value = rank_turnover(self._panel_with(float("nan")), forward_periods=1)
+        null_value = rank_turnover(self._panel_with(None), forward_periods=1)
+        assert nan_value.value == pytest.approx(null_value.value)
+
+    def test_poisoned_rows_leave_the_denominator_too(self):
+        """``pl.len().over(date)`` counted the NaN rows, so the tail cutoffs
+        used the wrong cross-section size on top of ranking NaN as largest."""
+        out = rank_turnover(self._panel_with(float("nan")), forward_periods=1)
+        clean = rank_turnover(self._panel_with(None), forward_periods=1)
+        assert out.metadata["n_cross_section_mean"] == pytest.approx(
+            clean.metadata["n_cross_section_mean"]
+        )
+        assert out.metadata["n_cross_section_mean"] < 20
+
+
+class TestCostInputPairing:
+    """The cost algebra prices one portfolio; the two inputs must describe it."""
+
+    @staticmethod
+    def _panel(n_assets=60, n_dates=200, seed=0):
+        import numpy as np
+
+        rng = np.random.default_rng(seed)
+        rows = n_dates * n_assets
+        return pl.DataFrame(
+            {
+                "date": [
+                    datetime(2024, 1, 1) + timedelta(days=d)
+                    for d in range(n_dates)
+                    for _ in range(n_assets)
+                ],
+                "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+                "factor": rng.standard_normal(rows),
+                "forward_return": rng.standard_normal(rows) * 0.01,
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+    def test_defaults_now_pair_by_construction(self):
+        """Each function at its own default used to price a different book."""
+        from factrix.metrics.quantile import quantile_spread
+
+        panel = self._panel()
+        spread = quantile_spread(panel)["factor"]
+        turnover = notional_turnover(panel)
+        assert spread.metadata["n_groups"] == turnover.metadata["n_groups"]
+        assert turnover.metadata["forward_periods"] == DEFAULT_FORWARD_PERIODS
+        # The pairing check passes silently and is recorded.
+        out = breakeven_cost(spread, turnover=turnover)
+        assert out.metadata["pairing_checked"] is True
+        assert out.metadata["n_groups"] == DEFAULT_N_GROUPS
+
+    def test_mismatched_bucketing_is_rejected(self):
+        from factrix.metrics.quantile import quantile_spread
+
+        panel = self._panel()
+        spread = quantile_spread(panel, n_groups=5)["factor"]
+        turnover = notional_turnover(panel, n_groups=10)
+        with pytest.raises(UserInputError, match="n_groups"):
+            breakeven_cost(spread, turnover=turnover)
+        with pytest.raises(UserInputError, match="n_groups"):
+            net_spread(spread, turnover=turnover)
+
+    def test_mismatched_stride_is_rejected(self):
+        panel = self._panel()
+        turnover = notional_turnover(panel, forward_periods=1)
+        with pytest.raises(UserInputError, match="forward_periods"):
+            breakeven_cost(0.001, turnover=turnover, forward_periods=5)
+
+    def test_bare_floats_still_work_unchecked(self):
+        out = breakeven_cost(0.001, turnover=0.2, forward_periods=5)
+        # gross * h / (4 * tau) * 1e4 = 0.001 * 5 / 0.8 * 1e4
+        assert out.value == pytest.approx(62.5)
+        assert "pairing_checked" not in out.metadata
+
+    def test_metric_result_and_float_agree_on_the_number(self):
+        from factrix.metrics.quantile import quantile_spread
+
+        panel = self._panel()
+        spread = quantile_spread(panel)["factor"]
+        turnover = notional_turnover(panel)
+        assert breakeven_cost(spread, turnover=turnover).value == pytest.approx(
+            breakeven_cost(
+                spread.value,
+                turnover=turnover.value,
+                forward_periods=DEFAULT_FORWARD_PERIODS,
+            ).value
+        )


### PR DESCRIPTION
> **TL;DR** — Part 3 of 4. The preprocessing layer is made small-sample correct for regional panels of 5–20 assets, the panel gets one enforced ingestion contract so engine defaults (NaN-as-value, string dates, duplicate keys) can no longer produce wrong numbers silently, and `monotonicity` reports the Patton-Timmermann (2010) test it cites. Every deviation from the textbook form driven by a repo convention is stated in the docstring Notes and the docs page.

## Main changes

**Ingestion contract (`_data_input`)** — one normalisation gate shared by `evaluate`, `evaluate_horizons`, `inspect_data`, `by_slice`, `compute_forward_return`:
- `date` must be `Date`/`Datetime` (a `String` date sorted lexicographically and silently reordered any non-ISO format); `(date, asset_id)` must be unique (a duplicate fabricated `0.0` forward returns); `NaN`/`±inf` in **float** columns → `null` (integer / boolean / `Decimal` / string columns untouched). A `+inf` price previously produced a finite `−100 %` return.
- `compute_forward_return` measures the horizon on the panel's distinct-date grid (period `i` → `i+1`, `i+1+h`), not by row offset; a ragged per-asset grid emits `ragged_period_grid`. Documented in `data-schema.md` § Ingestion contract.

**Small-sample scale (`cross_sectional_zscore`, `mad_winsorize`)**
- Croux-Rousseeuw (1992) finite-sample factor `b_n` on the MAD (bias in the scale estimator −18 % at n=5 → <1 % at every n ≥ 3; verified by MC). This is a deliberate deviation from the bare 1.4826 that R / scipy / Barra-style z-scoring use, and the docs say so, including what it does *not* fix (Jensen curvature in `sd(z)`).
- Every scale-method switch emits a `WarningCode`; n=1 / n=2 → `null`, not `0.0` / `±0.6745`; `±inf` → `null`; sparse `{0, R}` winsorize is skipped rather than destroying the event magnitude; output column derives from `factor_col`.

**`orthogonalize_factor`** — residual-df floor (N=6 on K=4 previously reported R² 0.79 while stripping 83 % of the variance at true R²=0), rank-deficiency detection with `mean_betas={}` (dummy trap), adjusted R², NaN rather than `0.0` when no date was fitted, per-date skips at debug level.

**`monotonicity`** — the headline was `mean|ρ|`, which sits at 0.43–0.66 under the null; it now reports the Patton-Timmermann MR test (min adjacent bucket difference, stationary bootstrap, Davison-Hinkley p; null size 4–5 %, power 0.94 at T=240). `direction` / `n_bootstrap` validated. Tie ratio counts finite values only.

**Cross-sectional diagnostics** — `quantile_spread_vw` gets the thin-bucket / `FEW_ASSETS` diagnostics and the `inference=` knob its sibling has (bit-identical to `quantile_spread` on equal weights); `rank_turnover` ranks finite values only (was > 1 with NaN cells); `k_spread` exposes `tie_policy` and carries `tie_ratio` into its short-circuits; `notional_turnover` / `breakeven_cost` / `net_spread` share one default `n_groups` / `forward_periods` and cross-check provenance.

**Docs** — `ic` tie warning wording (the estimator equals `scipy.stats.spearmanr`), `caar` per-period naming, `bhy_hierarchical` PRDS assumption.

## Breaking (pre-1.0)
Ingestion errors on string dates and duplicate keys; `cross_sectional_zscore` output column name; `monotonicity` value/p semantics; `notional_turnover` default `n_groups` 10 → 5 and `forward_periods` 1 → 5; `breakeven_cost` / `net_spread` default `forward_periods` 1 → 5.

## Verification
GitHub Actions is in a major outage at the time of this PR; verified locally instead: `ruff check`, `ruff format --check`, `mypy factrix`, `pytest` (2681 passed) and doctests on polars 1.40 / numpy 2.4 / py3.14, plus the full suite on the declared floor (polars 1.38.1 / numpy 2.0.2 / scipy 1.13.1 / py3.12). The three-OS matrix runs on `main` once Actions recovers.