### PR TITLE
fix(metrics): forward expected_warnings to every drop-rate echo

### DIFF
--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -337,6 +337,7 @@ def common_beta_profile(
     common_betas_df: pl.DataFrame,
     *,
     neutral_epsilon: float = EPSILON,
+    expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
     """Descriptive sign and dispersion profile of per-asset common-factor betas.
 
@@ -411,7 +412,12 @@ def common_beta_profile(
 
     warning_codes: list[str] = []
     _surface_drop_stats(
-        common_betas_df, "common_beta_profile", metadata, warning_codes, axis="assets"
+        common_betas_df,
+        "common_beta_profile",
+        metadata,
+        warning_codes,
+        axis="assets",
+        expected_warnings=expected_warnings,
     )
     return MetricResult(
         value=spread,
@@ -437,7 +443,10 @@ def common_beta_profile(
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=1),
 )
-def common_beta_r_squared(common_betas_df: pl.DataFrame) -> MetricResult:
+def common_beta_r_squared(
+    common_betas_df: pl.DataFrame,
+    expected_warnings: tuple[str, ...] = (),
+) -> MetricResult:
     r"""Average $R^2$ across per-asset TS regressions — ``value`` $= \mathrm{mean}_i R^2_i$.
 
     $R^2_i$ comes from asset $i$'s regression
@@ -497,7 +506,12 @@ def common_beta_r_squared(common_betas_df: pl.DataFrame) -> MetricResult:
     }
     warning_codes: list[str] = []
     _surface_drop_stats(
-        common_betas_df, "common_beta_r_squared", metadata, warning_codes, axis="assets"
+        common_betas_df,
+        "common_beta_r_squared",
+        metadata,
+        warning_codes,
+        axis="assets",
+        expected_warnings=expected_warnings,
     )
     return MetricResult(
         value=float(np.mean(r2_vals)),
@@ -686,7 +700,10 @@ def compute_rolling_common_beta(
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=2),
 )
-def common_beta_sign_consistency(common_betas_df: pl.DataFrame) -> MetricResult:
+def common_beta_sign_consistency(
+    common_betas_df: pl.DataFrame,
+    expected_warnings: tuple[str, ...] = (),
+) -> MetricResult:
     """Symmetric sign-agreement across per-asset βs — `value = max(pos, 1−pos)` where `pos = mean_i 1{β_i > 0}`.
 
     Range [0.5, 1.0]: 0.5 = βs evenly split (no directional consensus);
@@ -755,6 +772,7 @@ def common_beta_sign_consistency(common_betas_df: pl.DataFrame) -> MetricResult:
         metadata,
         warning_codes,
         axis="assets",
+        expected_warnings=expected_warnings,
     )
     return MetricResult(
         value=consistency,

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -378,7 +378,9 @@ def fm_beta(
         warning_codes,
         expected_warnings=expected_warnings,
     )
-    _surface_drop_stats(beta_df, "fm_beta", metadata, warning_codes)
+    _surface_drop_stats(
+        beta_df, "fm_beta", metadata, warning_codes, expected_warnings=expected_warnings
+    )
     # A flat β series (or one whose Bartlett HAC SE collapses) admits no t;
     # ``mean_beta`` is still the premium estimate.
     stat, p_out, alternative = _degenerate_test_fields(
@@ -980,7 +982,13 @@ def fm_beta_sign_consistency(
         warning_codes,
         expected_warnings=expected_warnings,
     )
-    _surface_drop_stats(beta_df, "fm_beta_sign_consistency", metadata, warning_codes)
+    _surface_drop_stats(
+        beta_df,
+        "fm_beta_sign_consistency",
+        metadata,
+        warning_codes,
+        expected_warnings=expected_warnings,
+    )
     return MetricResult(
         value=consistent,
         n_obs=n,

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -372,7 +372,9 @@ def ic(
     _warn_if_few_ic_assets(
         ic_df, "ic", metadata, warning_codes, expected_warnings=expected_warnings
     )
-    _surface_drop_stats(ic_df, "ic", metadata, warning_codes)
+    _surface_drop_stats(
+        ic_df, "ic", metadata, warning_codes, expected_warnings=expected_warnings
+    )
     # Surface the inference method's own soft-floor signals (e.g. a thin
     # post-stride sample tripping UNRELIABLE_SE_SHORT_PERIODS); de-dup so a
     # code already raised by the drop-stats pass is not repeated.
@@ -493,7 +495,9 @@ def ic_ir(
     _warn_if_few_ic_assets(
         ic_df, "ic_ir", metadata, warning_codes, expected_warnings=expected_warnings
     )
-    _surface_drop_stats(ic_df, "ic_ir", metadata, warning_codes)
+    _surface_drop_stats(
+        ic_df, "ic_ir", metadata, warning_codes, expected_warnings=expected_warnings
+    )
     return MetricResult(
         value=ratio,
         n_obs=n,

--- a/tests/test_expected_warnings.py
+++ b/tests/test_expected_warnings.py
@@ -21,7 +21,7 @@ import polars as pl
 import pytest
 from factrix._codes import WarningCode
 from factrix._errors import UserInputError
-from factrix.metrics import ic, quantile_spread
+from factrix.metrics import ic, ic_ir, quantile_spread
 
 
 def _thin_panel(n_assets: int = 6, n_dates: int = 220) -> pl.DataFrame:
@@ -337,3 +337,82 @@ class TestEchoStopsForEveryMetric:
             # Inference is untouched by the declaration.
             for key in metrics:
                 assert quiet.metrics[key].p_value == plain.metrics[key].p_value, label
+
+
+def _drop_panel(
+    n_periods: int = 80, n_assets: int = 6, dropped: int = 16
+) -> pl.DataFrame:
+    """Thin cross-section whose first ``dropped`` periods carry no factor.
+
+    ``compute_ic`` drops those periods, so every consumer of the shared
+    primitive surfaces ``excessive_period_drops`` alongside ``few_assets``.
+    """
+    rng = np.random.default_rng(3)
+    factor = rng.normal(size=(n_periods, n_assets))
+    ret = 0.3 * factor + rng.normal(size=(n_periods, n_assets))
+    rows = [
+        {
+            "date": datetime(2020, 1, 1) + timedelta(days=period),
+            "asset_id": str(asset),
+            "factor": None if period < dropped else float(factor[period, asset]),
+            "forward_return": float(ret[period, asset]),
+        }
+        for period in range(n_periods)
+        for asset in range(n_assets)
+    ]
+    return pl.DataFrame(rows)
+
+
+_DROP_METRICS = {
+    "ic": ic(inference=fx.inference.NEWEY_WEST),
+    "ic_ir": ic_ir(),
+}
+
+
+class TestDropEchoFollowsDeclaration:
+    """Drop-rate echoes from a shared primitive obey the same contract."""
+
+    def test_undeclared_drop_rate_still_echoes(self):
+        with pytest.warns(UserWarning, match="of periods dropped"):
+            results = fx.evaluate(
+                _drop_panel(),
+                metrics=_DROP_METRICS,
+                factor_cols=["factor"],
+                forward_periods=1,
+                strict=False,
+            )
+        res = results["factor"]
+        codes = {w.code for w in res.warnings}
+        assert WarningCode.EXCESSIVE_PERIOD_DROPS in codes
+        assert all(not w.expected for w in res.warnings)
+
+    def test_mixed_declaration_silences_every_declared_echo(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            results = fx.evaluate(
+                _drop_panel(),
+                metrics=_DROP_METRICS,
+                factor_cols=["factor"],
+                forward_periods=1,
+                strict=False,
+                expected_warnings=("few_assets", "excessive_period_drops"),
+            )
+        assert not [w for w in caught if issubclass(w.category, UserWarning)], [
+            str(w.message) for w in caught
+        ]
+        res = results["factor"]
+        for name in _DROP_METRICS:
+            assert "excessive_period_drops" in res.metrics[name].warning_codes
+            assert "few_assets" in res.metrics[name].warning_codes
+        declared = [
+            w
+            for w in res.warnings
+            if w.code in (WarningCode.EXCESSIVE_PERIOD_DROPS, WarningCode.FEW_ASSETS)
+        ]
+        assert {w.source for w in declared} >= set(_DROP_METRICS)
+        assert all(w.expected for w in declared)
+        assert not [
+            w
+            for w in res.unexpected_warnings
+            if w.code in (WarningCode.EXCESSIVE_PERIOD_DROPS, WarningCode.FEW_ASSETS)
+        ]


### PR DESCRIPTION
> **TL;DR** — `expected_warnings` now silences the `excessive_period_drops` / `excessive_asset_drops` echo on every consumer of a shared primitive, not just `few_assets`. Records stay on the result with `expected=True`; inference untouched.

## Summary
- `ic`, `ic_ir`, `fm_beta`, `fm_beta_sign_consistency` forward the injected `expected_warnings` into `_surface_drop_stats` (the helper already honoured it; the call sites dropped it).
- `common_beta_profile`, `common_beta_r_squared`, `common_beta_sign_consistency` accept the injected declaration so the asset-axis drop echo follows the same contract.
- Regression test: mixed `("few_assets", "excessive_period_drops")` declaration on a panel where `compute_ic` feeds both `ic` and `ic_ir`; asserts zero `UserWarning`, both codes on both metrics' `warning_codes`, `expected=True` on the result, and the undeclared path still echoes.

## Test plan
- [x] `ruff check`, `ruff format --check`, `mypy factrix`
- [x] `pytest tests` — 2776 passed, 3 skipped
- [x] New test fails on `main`, passes on this branch

Closes #844
