### PR TITLE
feat(metrics): resolve a configured metric's sample floor at the panel horizon

### DIFF
--- a/docs/api/inspect-data.md
+++ b/docs/api/inspect-data.md
@@ -21,6 +21,25 @@ the upstream diagnostics first and call the helper directly.
 
 <hr>
 
+## Resolved floor for a configured metric
+
+The tiers above read each metric's **default-configuration** `sample_threshold`
+(as do `list_metrics` / `metrics_summary`). The floor a run gates on can differ:
+the configuration changes it (`ic(inference=NEWEY_WEST)` needs 20 periods, the
+default non-overlapping t-test 50), and stride-scaled floors follow the panel's
+`forward_periods` (`positive_rate()` needs 10 periods at `forward_periods=1`, 50
+at 5). `sample_requirements` resolves the floor for an instance at a horizon —
+the same resolution `evaluate` and the `slice_period_*` tests apply — so a
+coverage audit (regime slices, IS/OOS splits) can be planned against the
+number the run will actually use. `evaluate(strict=True)` raises on a hard
+`min_*` breach; `strict=False` short-circuits the metric to NaN with a
+`metric_unavailable` warning; the soft `warn_*` tier always returns a value
+and attaches the axis' degraded-tier warning code.
+
+::: factrix.sample_requirements
+
+<hr>
+
 ## Result structure
 
 `inspect_data` returns a `DataInspection` carrying the detected data

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -83,6 +83,15 @@ covariance. A two-valued `method` flag selects the estimator:
 | `"bootstrap"` (default) | Independent stationary block bootstrap (Politis-White automatic block length) | Romano-Wolf step-down | Short regimes (T ≈ 30-80); never invalid |
 | `"analytic"` | Per-slice Newey-West HAC, Welch-style pairwise contrast | Holm step-down | Long spans (T ≳ 100); fast, deterministic |
 
+Each slice's per-period series must clear the metric's own sample floor,
+resolved at the panel's stamped `forward_periods` — the same floor
+`by_slice` short-circuits on — otherwise the test raises `ValueError`
+rather than return an uncalibrated contrast. Plan the partition against
+[`sample_requirements`](inspect-data.md#resolved-floor-for-a-configured-metric)
+(e.g. `positive_rate()` needs 10 periods per slice at `forward_periods=1`,
+50 at the default 5). An unstamped panel resolves the floor at the metric's
+default horizon.
+
 Pairwise output is `(slice_a, slice_b, n_periods_a, n_periods_b,
 mean_diff, stat, p_raw, p_adj, stat_type, reference_dist, df_num,
 df_denom, multiplicity)` — per-slice `n_periods_*` because disjoint spans

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -261,7 +261,7 @@ def evaluate(
         label: (
             _dataclasses.replace(
                 type(inst).spec(),
-                sample_threshold=type(inst)._resolve_sample_threshold(inst),
+                sample_threshold=inst._resolved_sample_threshold(fp),
             )
             if isinstance(inst, MetricBase)
             else inst.__metric_spec__
@@ -674,6 +674,77 @@ def _validate_metrics_arg(metrics: object) -> None:
                 ),
                 docs_path=_DOCS_METRICS,
             )
+
+
+def sample_requirements(
+    metric: _Any,
+    *,
+    data: _pl.DataFrame | None = None,
+    forward_periods: int | None = None,
+) -> SampleThreshold:
+    """Resolve a configured metric's sample floor at a panel's overlap horizon.
+
+    The floor a metric gates on depends on its configuration (e.g.
+    ``ic(inference=NeweyWest())`` needs fewer periods than the default
+    non-overlapping t-test) and, for metrics that sub-sample at the overlap
+    stride, on the panel's ``forward_periods``. ``list_metrics`` /
+    ``metrics_summary`` / ``inspect_data`` report the default-configuration
+    floor; this is the run-time one — the same resolution :func:`evaluate`
+    and the ``slice_period_*`` tests apply.
+
+    Args:
+        metric: A metric **instance** (``ic()``, ``positive_rate()``, …).
+        data: Panel whose stamped horizon (set by
+            :func:`factrix.preprocess.compute_forward_return`) resolves the
+            floor. Resolved exactly as :func:`evaluate` does: an explicit
+            ``forward_periods`` must agree with the stamp; an unstamped panel
+            requires it.
+        forward_periods: The overlap horizon, when no panel is at hand (or
+            the panel is unstamped). With neither ``data`` nor
+            ``forward_periods`` the floor is resolved at the metric's default
+            horizon — the same value ``metric.spec().sample_threshold`` carries.
+
+    Returns:
+        :class:`SampleThreshold` with the hard ``min_*`` and soft ``warn_*``
+        floors per axis. ``evaluate(strict=True)`` raises on a hard-floor
+        breach; ``strict=False`` short-circuits the metric to NaN with a
+        ``metric_unavailable`` warning; the soft tier always returns a value
+        and attaches the axis' degraded-tier warning code.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.metrics import ic, positive_rate
+        >>> fx.sample_requirements(ic()).min_periods
+        50
+        >>> fx.sample_requirements(ic(inference=fx.inference.NEWEY_WEST)).min_periods
+        20
+        >>> fx.sample_requirements(positive_rate(), forward_periods=1).min_periods
+        10
+        >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+        >>> panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+        >>> fx.sample_requirements(positive_rate(), data=panel).min_periods
+        50
+    """
+    from factrix.metrics._base import MetricBase
+
+    if not isinstance(metric, MetricBase):
+        raise UserInputError(
+            func_name="sample_requirements",
+            field="metric",
+            value=(
+                f"{metric.__name__} (the class)"
+                if isinstance(metric, type)
+                else type(metric).__name__
+            ),
+            expected="a metric instance, e.g. ic() or positive_rate()",
+            docs_path="api/inspect-data",
+        )
+    fp = (
+        _resolve_forward_periods(data, forward_periods)
+        if data is not None
+        else forward_periods
+    )
+    return metric._resolved_sample_threshold(fp)
 
 
 def _resolve_forward_periods(data: _pl.DataFrame, declared: int | None) -> int:
@@ -1268,6 +1339,7 @@ __all__ = [
     "inspect_data",
     "list_metrics",
     "metrics_summary",
+    "sample_requirements",
     # Slicing dispatcher + cross-slice inference functions
     "by_slice",
     "slice_joint_test",

--- a/factrix/_metric_index.py
+++ b/factrix/_metric_index.py
@@ -162,7 +162,9 @@ class SampleThreshold:
 
     The same constants are read by the metric's own short-circuit
     logic at run time — single source of truth for what counts as
-    "thin sample" per metric.
+    "thin sample" per metric. The spec carries the floor at the metric's
+    default configuration; :func:`factrix.sample_requirements` resolves it
+    for a configured instance at the panel's ``forward_periods``.
 
     Per axis the ``min_*`` floor must not exceed the ``warn_*`` floor:
     a metric is unusable below ``min``, degraded between ``min`` and
@@ -650,6 +652,10 @@ def list_metrics() -> dict[str, list[MetricSpec]]:
     cell filter is retired; ``inspect_data`` subsumes it with a
     structure-aware, sample-floor-aware verdict.)
 
+    Each spec's ``sample_threshold`` is the floor at the metric's **default
+    configuration**; the floor a configured instance gates on at a panel's
+    ``forward_periods`` comes from :func:`factrix.sample_requirements`.
+
     Source of truth is the registered ``@metric`` classes in each
     ``factrix/metrics/*.py`` module, loaded by :mod:`factrix._metric_index`.
 
@@ -672,9 +678,11 @@ def metrics_summary() -> pl.DataFrame:
     ``(family, metric)``.
 
     Use this to *browse* the catalog; reach for :func:`list_metrics` when you
-    need the full ``MetricSpec`` (cell, aggregation, sample thresholds) for
-    programmatic filtering, and :func:`factrix.inspect_data` for which metrics
-    actually run on a given panel.
+    need the full ``MetricSpec`` (cell, aggregation, default-configuration
+    sample thresholds) for programmatic filtering, :func:`factrix.inspect_data`
+    for which metrics actually run on a given panel, and
+    :func:`factrix.sample_requirements` for a configured instance's floor at
+    the panel's ``forward_periods``.
 
     Examples:
         >>> import factrix as fx

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -258,6 +258,22 @@ Typed pre-flight introspection that combines axis detection with a per-metric us
   - `unusable` (`MetricApplicabilityGroup` / `Tier.UNUSABLE`): Metrics that will short-circuit to NaN.
 - The usability tier classification is determined using the metric's `SampleThreshold`.
 - `.to_metrics_dict()` on a group returns the `{label: instance}` dictionary that `evaluate(metrics=...)` expects.
+- The verdict reads each metric's **default-configuration** floor. For the floor a configured instance gates on at run time, use `sample_requirements`.
+
+---
+
+### `sample_requirements`
+
+```python
+def sample_requirements(
+    metric: Metric,
+    *,
+    data: pl.DataFrame | None = None,
+    forward_periods: int | None = None,
+) -> SampleThreshold:
+```
+
+Resolves a configured metric instance's `SampleThreshold` (hard `min_*` / soft `warn_*` per axis) at the panel's overlap horizon — the same floor `evaluate` and the `slice_period_*` tests apply. `data=` reads the stamped horizon exactly as `evaluate` does (an explicit `forward_periods` must agree; an unstamped panel needs it); `forward_periods=` alone resolves at that horizon; neither resolves the default horizon (what `list_metrics` / `metrics_summary` / `inspect_data` report). E.g. `ic()` → `min_periods=50`, `ic(inference=NEWEY_WEST)` → `20`, `positive_rate()` at `forward_periods=1` → `10`, at `5` → `50`.
 
 ---
 

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 import logging
 from collections.abc import Callable, Sequence
 from typing import Any, ClassVar
@@ -228,6 +229,28 @@ class MetricBase(metaclass=MetricMeta):
     def _params(self) -> dict[str, Any]:
         """Configured parameter values, pulled from the instance's slots."""
         return {name: getattr(self, name) for name in self._param_names}
+
+    def _resolved_sample_threshold(
+        self, forward_periods: int | None = None
+    ) -> SampleThreshold:
+        """Resolve this instance's floor at the panel's overlap horizon.
+
+        ``forward_periods`` is injected from the data at dispatch, never
+        configured, so the instance always carries the body's signature
+        default; a stride-scaled floor resolved against the bare instance is
+        the default-horizon floor, not the one the in-body gate applies at
+        run time. Pass the panel's horizon (its stamp, or the caller's
+        explicit declaration) to resolve the floor the run will actually
+        gate on; ``None`` (or a metric that takes no injected horizon)
+        resolves the instance as configured.
+        """
+        inst: MetricBase = self
+        if forward_periods is not None and "forward_periods" in (
+            self._injected_param_names
+        ):
+            inst = copy.copy(self)
+            object.__setattr__(inst, "forward_periods", forward_periods)
+        return type(self)._resolve_sample_threshold(inst)
 
     @staticmethod
     def _stamped_forward_periods(data: Any) -> int | None:

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -69,7 +69,6 @@ from scipy import stats as sp_stats
 
 from factrix._data_input import _read_forward_periods_stamp
 from factrix._errors import UserInputError
-from factrix._metric_index import SampleThreshold
 from factrix._stats.bootstrap import (
     Scheme,
     _politis_white_block_length,
@@ -116,23 +115,12 @@ def _validate_method(method: str, func_name: str) -> None:
         )
 
 
-def _resolve_sample_threshold(metric: MetricBase) -> SampleThreshold:
-    """Resolve the metric instance's ``SampleThreshold`` for its actual config.
-
-    Calls the metric's normalized floor resolver against the **actual
-    instance** (not a default-built one), so a metric whose floor scales with a
-    non-default ``forward_periods`` (e.g. ``caar``) reports the floor for its own
-    horizon rather than the default-config floor baked into
-    ``cls.sample_threshold``.
-    """
-    return type(metric)._resolve_sample_threshold(metric)
-
-
 def _require_slice_floor(
     metric: MetricBase,
     labels: list[str],
     series_list: list[np.ndarray],
     *,
+    forward_periods: int | None,
     func_name: str,
 ) -> None:
     """Raise when any slice's per-period series is below the metric's own floor.
@@ -140,16 +128,18 @@ def _require_slice_floor(
     ``by_slice`` short-circuits a thin metric to NaN via the metric body; the
     date-disjoint slice tests build each slice's per-period series directly and
     would otherwise return a calibrated-looking p-value on a sub-floor regime.
-    Reuse the metric's own :class:`SampleThreshold` — the single source of
-    truth both paths read — so they agree on what counts as a thin sample, and
-    refuse (rather than emit) the contrast at that size: the inferential path
-    must be at least as protective as the descriptive one. The per-period series
-    length is the slice's time-axis sample, so only the time-series floors
-    (``min_periods`` / ``min_events``) bind — the cross-section floors
-    (``min_assets`` / ``min_pairs``) describe within-period width, which the
-    series has already collapsed.
+    Reuse the metric's own :class:`SampleThreshold`, resolved at the panel's
+    stamped ``forward_periods`` — the single source of truth both paths read —
+    so they agree on what counts as a thin sample, and refuse (rather than
+    emit) the contrast at that size: the inferential path must be at least as
+    protective as the descriptive one. An unstamped panel resolves the floor at
+    the metric's default horizon. The per-period series length is the slice's
+    time-axis sample, so only the time-series floors (``min_periods`` /
+    ``min_events``) bind — the cross-section floors (``min_assets`` /
+    ``min_pairs``) describe within-period width, which the series has already
+    collapsed.
     """
-    threshold = _resolve_sample_threshold(metric)
+    threshold = metric._resolved_sample_threshold(forward_periods)
     floor = max(
         (f for f in (threshold.min_periods, threshold.min_events) if f is not None),
         default=None,
@@ -164,12 +154,18 @@ def _require_slice_floor(
     if not thin:
         return
     detail = ", ".join(f"{lbl!r} (n_periods={n})" for lbl, n in thin)
+    horizon = (
+        f"the panel's stamped forward_periods={forward_periods}"
+        if forward_periods is not None
+        else "the metric's default horizon (panel carries no stamp)"
+    )
     raise ValueError(
         f"{func_name}: slice(s) {detail} fall below {type(metric).__name__!r}'s "
-        f"minimum sample floor ({floor}); by_slice short-circuits this metric "
-        f"to NaN at that size, so the date-disjoint tests refuse to return a "
-        f"contrast that is not calibrated. Use coarser regimes (each ≥{floor} "
-        f"periods) or a metric with a lower sample floor."
+        f"minimum sample floor ({floor}, resolved at {horizon}); "
+        f"by_slice short-circuits this metric to NaN at that size, "
+        f"so the date-disjoint tests refuse to return a contrast that is not "
+        f"calibrated. Use coarser regimes (each ≥{floor} periods) or a metric "
+        f"with a lower sample floor."
     )
 
 
@@ -220,7 +216,13 @@ def _build_per_slice_series(
                 f"within-slice variance estimate."
             )
         series_list.append(np.asarray(s, dtype=float))
-    _require_slice_floor(metric, labels, series_list, func_name=func_name)
+    _require_slice_floor(
+        metric,
+        labels,
+        series_list,
+        forward_periods=_read_forward_periods_stamp(data),
+        func_name=func_name,
+    )
     return labels, series_list
 
 
@@ -312,8 +314,11 @@ def slice_period_pairwise_test(
             is absent, or ``method`` is invalid.
         ValueError: Fewer than two slice values, any slice with fewer than
             two dates, or any slice whose per-period series is below the
-            metric's own ``SampleThreshold`` floor (the size at which
-            :func:`factrix.by_slice` short-circuits the metric to NaN).
+            metric's own ``SampleThreshold`` floor resolved at the panel's
+            stamped ``forward_periods`` (the size at which
+            :func:`factrix.by_slice` short-circuits the metric to NaN; see
+            :func:`factrix.sample_requirements`). An unstamped panel resolves
+            the floor at the metric's default horizon.
         TypeError: Metric is not slice-test-eligible (no ``per_date_series``
             capability / no producer).
     """
@@ -592,8 +597,11 @@ def slice_period_joint_test(
             is absent, or ``method`` is invalid.
         ValueError: Fewer than two slice values, any slice with fewer than
             two dates, or any slice whose per-period series is below the
-            metric's own ``SampleThreshold`` floor (the size at which
-            :func:`factrix.by_slice` short-circuits the metric to NaN).
+            metric's own ``SampleThreshold`` floor resolved at the panel's
+            stamped ``forward_periods`` (the size at which
+            :func:`factrix.by_slice` short-circuits the metric to NaN; see
+            :func:`factrix.sample_requirements`). An unstamped panel resolves
+            the floor at the metric's default horizon.
         TypeError: Metric is not slice-test-eligible.
 
     Warns:

--- a/tests/test_sample_requirements.py
+++ b/tests/test_sample_requirements.py
@@ -1,0 +1,80 @@
+"""``sample_requirements``: a configured metric's floor at the panel's horizon.
+
+The catalog surfaces (``list_metrics`` / ``metrics_summary`` /
+``spec().sample_threshold``) report the default-configuration floor;
+``evaluate`` gates in-body on the injected ``forward_periods``. This public
+resolver returns the run-time floor for the instance as configured, at the
+stamped or declared horizon, so a coverage audit can be planned against the
+number the run will actually apply.
+"""
+
+from __future__ import annotations
+
+import factrix as fx
+import pytest
+from factrix._errors import UserInputError
+from factrix.metrics import ic, positive_rate
+
+
+def _stamped(forward_periods: int):
+    raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120, seed=3)
+    return fx.preprocess.compute_forward_return(raw, forward_periods=forward_periods)
+
+
+class TestConfiguration:
+    def test_ic_default_inference_is_stride_scaled(self):
+        assert fx.sample_requirements(ic()).min_periods == 50
+        assert fx.sample_requirements(ic(), forward_periods=1).min_periods == 10
+
+    def test_ic_newey_west_is_a_fixed_hac_bound(self):
+        nw = ic(inference=fx.inference.NEWEY_WEST)
+        assert fx.sample_requirements(nw).min_periods == 20
+        assert fx.sample_requirements(nw, forward_periods=1).min_periods == 20
+
+    def test_positive_rate_scales_with_horizon(self):
+        assert (
+            fx.sample_requirements(positive_rate(), forward_periods=1).min_periods == 10
+        )
+        assert (
+            fx.sample_requirements(positive_rate(), forward_periods=5).min_periods == 50
+        )
+
+    def test_default_matches_spec_threshold(self):
+        for m in (ic(), positive_rate()):
+            assert fx.sample_requirements(m) == type(m).spec().sample_threshold
+
+
+class TestHorizonResolution:
+    def test_reads_panel_stamp(self):
+        assert (
+            fx.sample_requirements(positive_rate(), data=_stamped(1)).min_periods == 10
+        )
+        assert (
+            fx.sample_requirements(positive_rate(), data=_stamped(5)).min_periods == 50
+        )
+
+    def test_explicit_horizon_must_match_stamp(self):
+        with pytest.raises(UserInputError, match="stamped overlap horizon"):
+            fx.sample_requirements(positive_rate(), data=_stamped(5), forward_periods=1)
+
+    def test_unstamped_panel_requires_explicit_horizon(self):
+        raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120, seed=3)
+        with pytest.raises(UserInputError, match="forward_periods"):
+            fx.sample_requirements(positive_rate(), data=raw)
+        assert (
+            fx.sample_requirements(
+                positive_rate(), data=raw, forward_periods=2
+            ).min_periods
+            == 20
+        )
+
+    def test_rejects_class_and_non_metric(self):
+        with pytest.raises(UserInputError, match="metric instance"):
+            fx.sample_requirements(positive_rate)
+        with pytest.raises(UserInputError, match="metric instance"):
+            fx.sample_requirements("ic")
+
+    def test_instance_is_not_mutated(self):
+        m = positive_rate()
+        fx.sample_requirements(m, forward_periods=1)
+        assert m.forward_periods == 5

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import factrix as fx
+import polars as pl
 import pytest
-from factrix import slice_period_joint_test
+from factrix import slice_period_joint_test, slice_period_pairwise_test
 from factrix._errors import UserInputError
-from factrix.metrics import ic, monotonicity
+from factrix.metrics import ic, monotonicity, positive_rate
 
 from tests._slice_panel import build_disjoint_period_panel
 
@@ -272,3 +274,47 @@ class TestShortSliceDisclosure:
                 )
                 rejected += out["p_value"][0] < 0.05
         assert low <= rejected / reps <= high
+
+
+class TestFloorFollowsPanelStamp:
+    """The slice-test floor is resolved at the panel's stamped horizon — the
+    same floor ``by_slice`` gates on — not at the metric's default horizon."""
+
+    @staticmethod
+    def _panel(forward_periods: int) -> pl.DataFrame:
+        df = build_disjoint_period_panel(
+            seed=7, spans={"a": (20, 0.02), "b": (20, 0.02)}, label_col="regime"
+        )
+        return df.with_columns(pl.lit(forward_periods).alias("_forward_periods"))
+
+    def test_stamp_one_admits_twenty_period_slices(self) -> None:
+        panel = self._panel(1)
+        per_slice = fx.by_slice(
+            panel, positive_rate(), by="regime", factor_col="factor", strict=False
+        )
+        assert all(r.metrics["positive_rate"].n_obs == 20 for r in per_slice.values())
+        joint = slice_period_joint_test(
+            panel, positive_rate(), by="regime", factor_col="factor", rng_seed=1
+        )
+        assert joint["k_slices"].item() == 2
+        pairwise = slice_period_pairwise_test(
+            panel, positive_rate(), by="regime", factor_col="factor", rng_seed=1
+        )
+        assert pairwise.select("n_periods_a", "n_periods_b").row(0) == (20, 20)
+
+    def test_stamp_five_refuses_and_names_the_horizon(self) -> None:
+        with pytest.raises(
+            ValueError, match=r"floor \(50, resolved at .*forward_periods=5"
+        ):
+            slice_period_joint_test(
+                self._panel(5), positive_rate(), by="regime", factor_col="factor"
+            )
+
+    def test_unstamped_panel_falls_back_to_default_horizon(self) -> None:
+        with pytest.raises(ValueError, match="default horizon"):
+            slice_period_pairwise_test(
+                self._panel(1).drop("_forward_periods"),
+                positive_rate(),
+                by="regime",
+                factor_col="factor",
+            )


### PR DESCRIPTION
> **TL;DR** — One resolver for "what floor does this configured metric gate on at this panel's `forward_periods`", exposed as `fx.sample_requirements(metric, data=… | forward_periods=…)`, and used by `evaluate`'s pre-flight and the `slice_period_*` tests so they agree with `by_slice`.

## Summary
- `MetricBase._resolved_sample_threshold(forward_periods)` — resolves the instance's floor at a horizon (shallow copy carrying the injected horizon; the instance itself is never mutated). `evaluate`'s per-label spec now resolves at the stamped horizon.
- `fx.sample_requirements(metric, *, data=None, forward_periods=None)` — public entry: `data=` reads the stamp with `evaluate`'s exact rules (explicit must agree, unstamped needs explicit); `forward_periods=` alone resolves at that horizon; neither → default horizon (what `list_metrics` / `metrics_summary` / `inspect_data` report). `ic()` → 50, `ic(NEWEY_WEST)` → 20, `positive_rate()` at h=1 → 10, h=5 → 50.
- `slice_period_pairwise_test` / `slice_period_joint_test` gate on the floor resolved at the panel stamp; the `ValueError` names the resolved floor and the horizon; unstamped panels fall back to the default horizon (documented).
- Docs: `inspect-data` page gains a "Resolved floor for a configured metric" section, `slice-test` page states the floor rule, `list_metrics` / `metrics_summary` / `SampleThreshold` docstrings say "default configuration", `llms-full.txt` entry added. No CHANGELOG entry (pre-1.0 policy).

## Test plan
- [x] `tests/test_sample_requirements.py` — configuration × horizon matrix, stamp read, stamp/explicit mismatch, unstamped rejection, class/non-metric rejection, no mutation
- [x] `tests/test_slice_period_joint_test.py::TestFloorFollowsPanelStamp` — stamp=1 admits 20-period slices (matching `by_slice`), stamp=5 refuses and names the horizon, unstamped falls back
- [x] `ruff check`, `ruff format --check`, `mypy factrix`, `mkdocs build --strict`, `pytest tests` — 2786 passed, 3 skipped

Closes #846
Closes #847
