### PR TITLE
docs(architecture): state the period-grid principle once and link every mention to it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# factrix — project conventions for agents
+
+## Period grid, not calendar (first-order principle)
+
+factrix never reads the calendar. `date` is an ordering/alignment key only;
+every horizon, window, lag, stride and sample floor is a count of **periods on
+the panel's own distinct-date grid** — never calendar time, never row position
+within an asset. The evaluation grid may be unevenly spaced in periods; nothing
+may assume a constant stride or a bar frequency.
+
+Wording rule for code, docstrings, warnings, docs, issues and PRs: say
+**periods**. Never days / trading days / weeks / month-ends in a contract-level
+statement; concrete cadences appear only in explicitly labelled examples.
+Source of truth: `docs/development/architecture.md` § "Period grid, not calendar".

--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -8,7 +8,7 @@ Single-source contract for every `factrix` entry point that consumes a panel. Ev
 
 | Column | dtype | Semantics |
 |---|---|---|
-| `date` | `Date` or `Datetime` (**required** — a `String` or integer date is rejected) | Observation timestamp. Frequency-agnostic — the horizon is measured in periods of the panel's own distinct-date grid, never in calendar time. |
+| `date` | `Date` or `Datetime` (**required** — a `String` or integer date is rejected) | Observation timestamp. Ordering key only — the horizon is measured in periods of the panel's own distinct-date grid, never in calendar time ([Period grid, not calendar](../development/architecture.md#period-grid-not-calendar)). |
 | `asset_id` | `Utf8` / `Categorical` | Cross-section identifier. Identical for COMMON-scope factors (`df.group_by("date").agg((pl.col("factor").n_unique() == 1).alias("is_common"))["is_common"].all()` is `True`). |
 | `factor` | numeric (`Int*` / `Float*`) | The signal value. Dense: real-valued exposure (z-score, IC-rankable). Sparse: zero-encoded `{0, R}` event trigger, where `0` marks non-events. |
 | `forward_return` | `Float64` | Look-ahead return over the horizon used at evaluate time. Attach via [`compute_forward_return`](preprocess.md) so the horizon is explicit and aligned with `forward_periods`. |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -16,9 +16,41 @@ factor per `(scope, density, structure)` cell from the cell's mainstream
 metric (information coefficient (IC) / FM-λ / CAAR / TS-β). Dense
 time-series mainstream metrics use Newey-West (NW)
 heteroskedasticity-and-autocorrelation-consistent (HAC) inference; CAAR uses
-calendar-aware non-overlap sampling on the event-period series. Realistic execution simulation,
+event-period-indexed non-overlap sampling on the event-period series. Realistic execution simulation,
 tradability proxies, and portfolio construction are out of scope — feed
 screened factors into Zipline / Backtrader / `vectorbt` downstream.
+
+---
+
+## Period grid, not calendar
+
+**factrix never reads the calendar.** This is a first-order design principle,
+not an implementation detail, and every other page that mentions frequency
+links here.
+
+- `date` is an ordering and alignment key. Its granularity — minutes, days,
+  weeks, months — is never inspected; a `Date` or `Datetime` dtype is required
+  only so ordering is unambiguous.
+- Every horizon, window, lag, stride and sample floor is a **count of periods
+  on the panel's own grid** — the distinct sorted `date` values present in the
+  panel — never calendar time and never row position within an asset.
+  `forward_periods=5` is five periods of whatever one row represents.
+- There is no annualisation factor, no trading-day constant, no
+  business-day calendar and no date arithmetic anywhere in the library.
+- The evaluation grid may be spaced unevenly in periods (a caller-chosen
+  rebalance grid on a finer price grid). Nothing assumes a constant stride;
+  quantities that depend on spacing (overlap, non-overlapping stride) are
+  derived from period indices, never from dates.
+- Which real-world cadence a period represents, and aligning the factor and
+  price sources onto one grid, is the caller's responsibility
+  ([Preparing data §5](../guides/preparing-data.md#5-frequency-alignment-is-the-callers-job)).
+
+**Wording rule.** Documentation, docstrings, warning messages and code
+comments say *periods*. They do not say days, trading days, weeks,
+month-ends or any other calendar unit, and examples that need a concrete
+cadence say so explicitly ("on a daily panel, five periods is five days")
+rather than baking it into the contract. A reviewer who finds calendar
+vocabulary in a contract-level statement should treat it as a defect.
 
 ---
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,11 +2,13 @@
 title: Quickstart
 ---
 
-!!! warning "`forward_periods` counts rows, not calendar time"
-    factrix is frequency-agnostic — it only shifts row indices.
-    `forward_periods=5` on a daily panel means 5 trading days; on a
-    weekly panel, 5 weeks. The caller is responsible for ensuring the
-    panel is sorted per asset and has regular time spacing.
+!!! warning "`forward_periods` counts periods, not calendar time"
+    factrix never reads the calendar: every horizon, window and lag is a
+    count of periods on the panel's own date grid. `forward_periods=5` is
+    five periods of whatever one row represents — five days on a daily
+    panel, five weeks on a weekly one. Aligning the factor and price sources
+    onto one grid is the caller's job. See
+    [Period grid, not calendar](../development/architecture.md#period-grid-not-calendar).
 
 ## 30-second smoke test
 

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -235,16 +235,18 @@ calls for a transformed signal.
 
 ## 5. Frequency alignment is the caller's job
 
-factrix is calendar-agnostic — it counts periods on the panel's own date grid, not calendar time.
+factrix never reads the calendar — it counts periods on the panel's own
+date grid, not calendar time (the principle is stated once in
+[Period grid, not calendar](../development/architecture.md#period-grid-not-calendar)).
 Three responsibilities sit upstream of `compute_forward_return`:
 
 - **Same date axis for factor and price source.** If the factor is
   monthly and the price source is daily, downsample (or upsample) one
   side before joining. A frequency mismatch will not raise; it will
   silently mean the wrong thing.
-- **Same `forward_periods` interpretation.** Five rows on a daily panel
-  is one week of trading days; five rows on a monthly panel is five
-  months. Pick the horizon against your panel's actual cadence.
+- **Same `forward_periods` interpretation.** Five periods on a daily
+  panel is five days; five periods on a monthly panel is five months.
+  Pick the horizon against your panel's actual cadence.
 - **Slice / regime labels aligned by date.** If you attach a
   `regime_id` or `universe` column for downstream slicing, align it on
   the same date axis the panel uses; mismatched labels propagate

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -35,7 +35,8 @@ The five sections are the only first-class disciplines in factrix:
    BMP-style standardised AR, Corrado rank.
 
 !!! note "Every estimator here is frequency-agnostic"
-    No estimator in factrix reads the calendar. `date` is only an ordering
+    No estimator in factrix reads the calendar (the library-wide principle:
+    [Period grid, not calendar](../development/architecture.md#period-grid-not-calendar)). `date` is only an ordering
     key, and every window, lag, horizon and stride (`forward_periods`,
     `estimation_window`, `window`, Bartlett lags, block lengths) is a count
     of **panel rows**, i.e. of whatever period one row represents. There is

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -31,6 +31,8 @@ An evaluation cell is defined by three orthogonal axes that specify the dataset 
 
 Each metric spec is registered to run on a specific `(FactorScope, FactorDensity, DataStructure)` cell (or wildcard subset thereof).
 
+**Period grid, not calendar** — factrix never reads the calendar. `date` is an ordering key; every horizon, window, lag, stride and sample floor (`forward_periods`, estimation windows, Bartlett lags, block lengths, `min_periods`) is a count of periods on the panel's own distinct-date grid, never calendar time. No annualisation, no trading-day constant, no date arithmetic. Say "periods", never days / trading days / month-ends, when describing any contract.
+
 ---
 
 ## Canonical panel schema


### PR DESCRIPTION
> **TL;DR** — "factrix never reads the calendar" was implemented everywhere and stated in four places with three different words and two calendar-vocabulary examples, but never as a first-order principle. This adds one SSOT section to `architecture.md`, links every existing mention to it, fixes the wording that contradicted it, and adds a `CLAUDE.md` so agents see the rule at session start.

## Summary
- `docs/development/architecture.md` — new section **Period grid, not calendar** (ordering-key-only `date`; every horizon / window / lag / stride / floor is a period count on the panel's own grid; no annualisation / trading-day constant / date arithmetic; the evaluation grid may be unevenly spaced in periods; wording rule). `Positioning` no longer calls CAAR's sampling "calendar-aware".
- `quickstart.md` warning rewritten: drops "5 trading days" and the "regular time spacing" obligation (which the grid may not satisfy), links to the SSOT.
- `preparing-data.md` §5, `statistical-methods.md` note, `data-schema.md` `date` row: one sentence + link each; "one week of trading days" → periods.
- `llms-full.txt` Core concept gains the principle (agents read this).
- New `CLAUDE.md` with the principle and the wording rule.

## Test plan
- [x] `mkdocs build --strict`
- [x] `pytest tests/test_docs_pages.py tests/test_docs_llms.py tests/test_docs_symbol_refs.py` — 258 passed
