### PR TITLE
fix(docs): repair user input documentation links (#861)

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -96,7 +96,7 @@ Every user-facing raise that takes a named input renders the same three-part mes
 bhy(): unknown expand_over='univere_id'
   Did you mean: "universe_id"?
   Available: ['regime_id', 'sector', 'universe_id']
-  Docs: https://awwesomeman.github.io/factrix/api/bhy#expand_over
+  Docs: https://awwesomeman.github.io/factrix/api/bhy#factrix.multi_factor.bhy
 ```
 
 | Line | What to look at |

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -538,9 +538,9 @@ def _validate_forward_periods_sweep(forward_periods: object) -> list[int]:
     return list(forward_periods)
 
 
-_DOCS_METRICS = "api/evaluate#metrics"
-_DOCS_FACTOR_COLS = "api/evaluate#factor_cols"
-_DOCS_DATA = "api/evaluate#data"
+_DOCS_METRICS = "api/evaluate#factrix.evaluate"
+_DOCS_FACTOR_COLS = "api/evaluate#factrix.evaluate"
+_DOCS_DATA = "api/evaluate#factrix.evaluate"
 
 
 def _is_metrics_overview(metrics: object) -> bool:
@@ -568,7 +568,7 @@ def _validate_expected_warnings_arg(expected_warnings: object) -> tuple[str, ...
     existing code — the declaration marks records as expected, so a typo
     would silently mark nothing.
     """
-    docs = "api/evaluate#expected_warnings"
+    docs = "api/evaluate#factrix.evaluate"
     if isinstance(expected_warnings, str) or not isinstance(
         expected_warnings, (tuple, list)
     ):

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -104,7 +104,7 @@ def compare(
                         f"missing on factor={r.factor!r}"
                     ),
                     candidates=sorted(r.metrics),
-                    docs_path="api/compare#metrics",
+                    docs_path="api/compare#parameter-details",
                 )
             out = r.metrics[spec]
             row[spec] = _float_or_none(out.value)
@@ -121,7 +121,7 @@ def compare(
                 value=sort_by,
                 expected="one of the columns produced by compare()",
                 candidates=sort_candidates,
-                docs_path="api/compare#sort_by",
+                docs_path="api/compare#parameter-details",
             )
         data = data.sort(sort_by, descending=descending, nulls_last=True)
         data = data.with_columns(

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -96,8 +96,8 @@ def _read_overlap_periods_stamp(data: pl.DataFrame) -> int | None:
     return _read_int_stamp(data, _OVERLAP_PERIODS_COL)
 
 
-_DOCS_OVERLAP_PERIODS = "api/evaluate#overlap_periods"
-_DOCS_FORWARD_PERIODS = "api/evaluate#forward_periods"
+_DOCS_OVERLAP_PERIODS = "api/evaluate#forward_periods-and-overlap_periods"
+_DOCS_FORWARD_PERIODS = "api/evaluate#forward_periods-and-overlap_periods"
 
 
 def _validate_overlap_periods(declared: object, *, func_name: str) -> int:

--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -17,8 +17,16 @@ _AVAILABLE_PREVIEW = 15
 
 
 def _api_docs_path(func_name: str, anchor: str) -> str:
-    """Return the deployed API path for a snake-case function name."""
-    return f"api/{func_name.replace('_', '-')}#{anchor}"
+    """Return the deployed API path for a public function.
+
+    Mkdocstrings uses the fully qualified symbol as its heading id; parameter
+    names are not standalone anchors. ``anchor`` remains in the signature so
+    shared validators can report the field the caller supplied, but the link
+    targets the function contract that documents it.
+    """
+    del anchor
+    namespace = "factrix" if func_name == "compare" else "factrix.multi_factor"
+    return f"api/{func_name.replace('_', '-')}#{namespace}.{func_name}"
 
 
 def _truncate_repr(value: object) -> str:

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -925,7 +925,7 @@ def partial_conjunction(
             field="min_pass",
             value=min_pass,
             expected=expected,
-            docs_path="api/partial-conjunction#min-pass-must-be-at-least-2",
+            docs_path="api/partial-conjunction#validation-summary",
         )
 
     if not expand_over:
@@ -939,7 +939,7 @@ def partial_conjunction(
                 "('forward_periods',) for cross-horizon replication). "
                 "partial_conjunction is undefined without a condition axis"
             ),
-            docs_path="api/partial-conjunction#expand-over-required",
+            docs_path="api/partial-conjunction#validation-summary",
         )
 
     if n_conditions is not None and n_conditions < min_pass:
@@ -951,7 +951,7 @@ def partial_conjunction(
                 f"n_conditions >= min_pass ({min_pass}); requiring more "
                 "passes than total conditions is unsatisfiable"
             ),
-            docs_path="api/partial-conjunction#n-conditions",
+            docs_path="api/partial-conjunction#validation-summary",
         )
 
     expand_over_tuple = tuple(expand_over)
@@ -1014,7 +1014,7 @@ def _partial_conjunction_one(
                     f"input so every identity has exactly {n_conditions} "
                     "conditions"
                 ),
-                docs_path="api/partial-conjunction#strict-vs-lenient",
+                docs_path="api/partial-conjunction#strict-vs-lenient-mode",
             )
 
         if m < min_pass:
@@ -1027,7 +1027,7 @@ def _partial_conjunction_one(
                     f"min_pass={min_pass} requires at least that many. "
                     "Either drop this identity from the input or lower min_pass"
                 ),
-                docs_path="api/partial-conjunction#insufficient-conditions",
+                docs_path="api/partial-conjunction#validation-summary",
             )
 
         ps = np.array([e.p_value for e in group], dtype=np.float64)
@@ -1105,7 +1105,10 @@ def partial_conjunction_across_metrics(
             field="min_pass",
             value=min_pass,
             expected="integer satisfying 2 <= min_pass <= len(metrics)",
-            docs_path="api/partial-conjunction-across-metrics#min-pass",
+            docs_path=(
+                "api/partial-conjunction-across-metrics"
+                "#factrix.multi_factor.partial_conjunction_across_metrics"
+            ),
         )
     min_pass_int = int(min_pass)
     if not 2 <= min_pass_int <= len(metric_list):
@@ -1116,7 +1119,10 @@ def partial_conjunction_across_metrics(
             expected=(
                 f"integer satisfying 2 <= min_pass <= len(metrics) ({len(metric_list)})"
             ),
-            docs_path="api/partial-conjunction-across-metrics#min-pass",
+            docs_path=(
+                "api/partial-conjunction-across-metrics"
+                "#factrix.multi_factor.partial_conjunction_across_metrics"
+            ),
         )
 
     q_target = _validate_q(q, func_name="partial_conjunction_across_metrics")

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -225,7 +225,7 @@ def _validate_block_length(block_length: float, n: int, func_name: str) -> None:
                 f"a block length in [1, {b_max}] for a series of {n} "
                 f"observations (ceil(min(3*sqrt(n), n/3)))"
             ),
-            docs_path="api/stats#blockbootstrap",
+            docs_path="api/stats#factrix.stats.BlockBootstrap",
         )
 
 

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -138,7 +138,11 @@ class MetricMeta(type):
                 field=name,
                 value=supplied[name],
                 expected=expected_by_param[name],
-                docs_path=f"api/evaluate#{name}",
+                docs_path=(
+                    "api/evaluate#forward_periods-and-overlap_periods"
+                    if name == "overlap_periods"
+                    else "api/evaluate#factrix.evaluate"
+                ),
             )
 
 

--- a/factrix/preprocess/normalize.py
+++ b/factrix/preprocess/normalize.py
@@ -23,8 +23,8 @@ from factrix._types import (
 
 __all__ = ["cross_sectional_zscore", "mad_winsorize"]
 
-_DOCS_MAD_WINSORIZE = "api/preprocess#mad_winsorize"
-_DOCS_ZSCORE = "api/preprocess#cross_sectional_zscore"
+_DOCS_MAD_WINSORIZE = "api/preprocess#factrix.preprocess.mad_winsorize"
+_DOCS_ZSCORE = "api/preprocess#factrix.preprocess.cross_sectional_zscore"
 
 # Where the per-date centre is taken. ``"median"`` is the robust default;
 # ``"mean"`` buys an exactly mean-zero score at the cost of outlier

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -17,9 +17,11 @@ import polars as pl
 from factrix._codes import WarningCode
 from factrix._errors import UserInputError
 
-_DOCS_FORWARD_RETURN = "api/preprocess#compute_forward_return"
+_DOCS_FORWARD_RETURN = "api/preprocess#factrix.preprocess.compute_forward_return"
 _DOCS_EVALUATION_GRID = "api/preprocess#evaluating-on-a-coarser-grid"
-_DOCS_WINSORIZE_FORWARD_RETURN = "api/preprocess#winsorize_forward_return"
+_DOCS_WINSORIZE_FORWARD_RETURN = (
+    "api/preprocess#factrix.preprocess.winsorize_forward_return"
+)
 
 
 def _validate_forward_periods(forward_periods: object) -> int:

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -268,7 +268,7 @@ def bootstrap_mean_ci(
             field="ci",
             value=ci,
             expected="a coverage level strictly inside (0, 1)",
-            docs_path="api/stats#bootstrap_mean_ci",
+            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
     if method not in ("studentized", "percentile"):
         raise UserInputError(
@@ -276,7 +276,7 @@ def bootstrap_mean_ci(
             field="method",
             value=method,
             expected="'studentized' or 'percentile'",
-            docs_path="api/stats#bootstrap_mean_ci",
+            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
     values = np.asarray(values, dtype=float)
     if values.ndim != 1:
@@ -285,7 +285,7 @@ def bootstrap_mean_ci(
             field="values",
             value=values.shape,
             expected="a 1-D array of observations",
-            docs_path="api/stats#bootstrap_mean_ci",
+            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
     if len(values) < 2:
         raise UserInputError(
@@ -293,7 +293,7 @@ def bootstrap_mean_ci(
             field="values",
             value=len(values),
             expected="at least 2 observations to resample",
-            docs_path="api/stats#bootstrap_mean_ci",
+            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
     if n_bootstrap < _BOOTSTRAP_RESAMPLES_FLOOR:
         raise UserInputError(
@@ -304,7 +304,7 @@ def bootstrap_mean_ci(
                 f"at least {_BOOTSTRAP_RESAMPLES_FLOOR} resamples — below that "
                 f"the interval endpoints are resampling noise"
             ),
-            docs_path="api/stats#bootstrap_mean_ci",
+            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
     if statistic is not None and method == "studentized":
         raise UserInputError(
@@ -316,7 +316,7 @@ def bootstrap_mean_ci(
                 "studentized root needs a block SE of the statistic on every "
                 "resample, which is only available for the mean"
             ),
-            docs_path="api/stats#bootstrap_mean_ci",
+            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
 
     if block_length is None:

--- a/tests/test_bhy_across_metrics.py
+++ b/tests/test_bhy_across_metrics.py
@@ -136,7 +136,10 @@ def test_descriptive_metric_fails_loudly():
     ]
     with pytest.raises(UserInputError, match="FDR control") as excinfo:
         bhy_across_metrics(results, metrics=["ic", "shape"])
-    assert "/api/bhy-across-metrics#metrics" in excinfo.value.docs_url
+    assert (
+        "/api/bhy-across-metrics#factrix.multi_factor.bhy_across_metrics"
+        in excinfo.value.docs_url
+    )
 
 
 @pytest.mark.parametrize("metrics", [["ic"], ["ic", "ic"]])
@@ -150,7 +153,10 @@ def test_metric_container_error_links_to_deployed_page():
     results = [_two_metric_result("f1", 0.01, 0.02)]
     with pytest.raises(UserInputError) as excinfo:
         bhy_across_metrics(results, metrics=("ic", "spread"))  # type: ignore[arg-type]
-    assert "/api/bhy-across-metrics#metrics" in excinfo.value.docs_url
+    assert (
+        "/api/bhy-across-metrics#factrix.multi_factor.bhy_across_metrics"
+        in excinfo.value.docs_url
+    )
 
 
 def test_mixed_horizons_warns_with_cross_metric_function_name():

--- a/tests/test_docs_paths.py
+++ b/tests/test_docs_paths.py
@@ -1,0 +1,102 @@
+"""Validate every package ``docs_path`` against the rendered MkDocs site.
+
+Source-level checks cannot reproduce mkdocstrings' fully qualified ids or
+MkDocs' heading normalization reliably. Build the real site once, then verify
+that every literal API path in ``factrix/**/*.py`` resolves to a page and, when
+present, an HTML id. Dynamic multi-factor paths are generated through their
+shared helper and included explicitly.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.metadata
+import pathlib
+from html.parser import HTMLParser
+
+import pytest
+from factrix._errors import _api_docs_path
+
+pytest.importorskip("mkdocs", reason="docs-path validation requires the docs extra")
+try:
+    importlib.metadata.version("mkdocs-material")
+    importlib.metadata.version("mkdocstrings-python")
+except importlib.metadata.PackageNotFoundError:
+    pytest.skip("docs-path validation requires the docs extra", allow_module_level=True)
+build = pytest.importorskip("mkdocs.commands.build").build
+load_config = pytest.importorskip("mkdocs.config").load_config
+
+PACKAGE_ROOT = pathlib.Path("factrix")
+_DYNAMIC_DOCS_FUNCTIONS = (
+    "compare",
+    "bhy",
+    "bhy_across_metrics",
+    "partial_conjunction",
+    "partial_conjunction_across_metrics",
+    "bhy_hierarchical",
+)
+
+
+def _literal_docs_paths() -> set[str]:
+    paths: set[str] = set()
+    for source in PACKAGE_ROOT.rglob("*.py"):
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        paths.update(
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value.startswith("api/")
+            and "{" not in node.value
+        )
+    return paths
+
+
+DOCS_PATHS = sorted(
+    _literal_docs_paths()
+    | {_api_docs_path(name, "field") for name in _DYNAMIC_DOCS_FUNCTIONS}
+)
+
+
+class _IdCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del tag
+        self.ids.update(value for key, value in attrs if key == "id" and value)
+
+
+@pytest.fixture(scope="module")
+def built_site(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    site_dir = tmp_path_factory.mktemp("docs-path-site")
+    config = load_config(config_file="mkdocs.yml", site_dir=str(site_dir))
+    build(config)
+    return site_dir
+
+
+def test_docs_paths_found() -> None:
+    """Guard against a silently empty or over-narrow source sweep."""
+    assert len(DOCS_PATHS) >= 25
+    assert any("#" not in path for path in DOCS_PATHS)
+    assert any("#" in path for path in DOCS_PATHS)
+
+
+@pytest.mark.parametrize("docs_path", DOCS_PATHS)
+def test_docs_path_resolves_in_built_site(
+    docs_path: str, built_site: pathlib.Path
+) -> None:
+    """Every path resolves to a rendered page and optional HTML anchor."""
+    page_path, separator, anchor = docs_path.partition("#")
+    html_path = built_site / page_path / "index.html"
+    assert html_path.is_file(), f"{docs_path!r} points to missing page {html_path}"
+    if not separator:
+        return
+
+    parser = _IdCollector()
+    parser.feed(html_path.read_text(encoding="utf-8"))
+    assert anchor in parser.ids, (
+        f"{docs_path!r} points to a missing anchor; rendered ids include "
+        f"{sorted(parser.ids)}"
+    )


### PR DESCRIPTION
## Summary
- point UserInputError links at rendered headings or mkdocstrings symbol ids
- update the public error example to match the deployed URL
- build MkDocs in a regression test and validate anchorless and anchored paths

## Test plan
- [x] 352 targeted API, validation, bootstrap, preprocessing, and docs tests
- [x] Ruff check on all changed Python files

Closes #861