### PR TITLE
refactor(metrics): simplify warning append flow (#862)

### DIFF
--- a/factrix/metrics/directional_pair_accuracy.py
+++ b/factrix/metrics/directional_pair_accuracy.py
@@ -171,6 +171,7 @@ def directional_pair_accuracy(
     warning_codes: list[str] = []
     if n_usable_pairs < MIN_PAIR_ACCURACY_PAIRS_WARN:
         code = WarningCode.FEW_ORDERING_PAIRS.value
+        warning_codes.append(code)
         if code not in expected_warnings:
             warnings.warn(
                 f"directional_pair_accuracy: n_pairs={n_usable_pairs} below "
@@ -181,8 +182,6 @@ def directional_pair_accuracy(
                 UserWarning,
                 stacklevel=3,
             )
-        warning_codes.append(code)
-
     pooled_accuracy = n_correct_pairs / n_usable_pairs
     mean_per_date_accuracy = float(np.mean(per_date_accuracy))
     min_pairs = min(pairs_per_period) if pairs_per_period else 0

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -142,8 +142,7 @@ def _warn_if_high_ic_tie_ratio(
                 UserWarning,
                 stacklevel=2,
             )
-        if code not in warning_codes:
-            warning_codes.append(code)
+        warning_codes.append(code)
     return med
 
 
@@ -187,8 +186,7 @@ def _warn_if_few_ic_assets(
             UserWarning,
             stacklevel=2,
         )
-    if code not in warning_codes:
-        warning_codes.append(code)
+    warning_codes.append(code)
 
 
 def _ic_sample_threshold(self: MetricBase) -> SampleThreshold:


### PR DESCRIPTION
## Summary
- remove redundant warning-code membership checks in IC helpers
- record directional pair warnings before applying echo suppression
- leave uneven-grid calibration and slice overlap symmetry out of scope

## Test plan
- [x] 58 IC and directional-pair tests
- [x] Ruff check on both changed modules

Part of #862 (the two parked follow-ups remain tracked there; the tracker stays open).