### PR TITLE
fix(metrics): normalize pooled beta short circuits (#835)

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -128,13 +128,16 @@ is emitted.
 
 - *primary*: `p_value` — single- or two-way clustered OLS `t`. When
   the cluster count G < 3 the test is short-circuited with `stat =
-  None` and `p_value = 1.0`.
+  None`, `value = NaN`, and `p_value = 1.0`; the algebraic slope is not
+  exposed as a usable pooled beta when its declared covariance estimator
+  cannot be formed.
 - Sample size: `MetricResult.n_obs` (row count entering the test).
 - *descriptive*: `n_clusters` (one-way) or `n_clusters_a`,
   `n_clusters_b`, `n_clusters_intersection` (two-way).
 - *descriptive* (conditional, short-circuit): `reason =
   "insufficient_clusters"`, `n_clusters` (smallest G — first-class
-  `n_obs` carries the row count), `min_required` (always 3).
+  `n_obs` carries the row count), `min_required` (always 3), plus
+  `metric_unavailable` in `warning_codes`.
 - *descriptive* (conditional): `variance_non_psd_fallback` — names
   the fallback path when the meat matrix is non-PSD.
 - *descriptive* (Driscoll-Kraay path, `driscoll_kraay=True`):
@@ -142,7 +145,8 @@ is emitted.
   cross-sectional score-sum series), and `driscoll_kraay_lags` (the
   Bartlett bandwidth used). The DK path uses `df = n_periods − 1`,
   emits `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` below 30 periods, and
-  short-circuits with `reason = "insufficient_periods"` below 3.
+  short-circuits to `value = NaN` with `reason = "insufficient_periods"`
+  below 3.
 
 #### `fm_beta_sign_consistency`
 

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -465,8 +465,9 @@ def _pooled_beta_driscoll_kraay(
     (``factrix._stats.hac._driscoll_kraay_cov``): per-observation scores summed
     cross-sectionally per period, Bartlett-HAC'd over the period series,
     sandwiched with ``(X'X)⁻¹``. ``df = T_periods - 1``. Short-circuits
-    with ``stat=None`` / ``p=1.0`` below ``_MIN_DK_PERIODS_HARD`` periods (HAC
-    undefined), mirroring the clustered ``G < 3`` guard.
+    with ``value=NaN`` / ``stat=None`` / ``p=1.0`` below
+    ``_MIN_DK_PERIODS_HARD`` periods (HAC undefined), mirroring the clustered
+    ``G < 3`` guard.
     """
     if two_way_cluster_col is not None:
         raise ValueError(
@@ -491,18 +492,13 @@ def _pooled_beta_driscoll_kraay(
 
     n_periods = int(dk_meta["n_periods"])
     if n_periods < _MIN_DK_PERIODS_HARD:
-        return MetricResult(
-            p_value=1.0,
-            alternative="two-sided",
-            value=slope,
+        return _short_circuit_output(
+            "pooled_beta",
+            "insufficient_periods",
             n_obs=n_obs,
             n_obs_axis="pairs",
-            stat=None,
-            metadata={
-                "reason": "insufficient_periods",
-                "n_periods": n_periods,
-                "min_required": _MIN_DK_PERIODS_HARD,
-            },
+            n_periods=n_periods,
+            min_required=_MIN_DK_PERIODS_HARD,
         )
 
     se_slope = float(np.sqrt(max(float(cov[1, 1]), 0.0)))
@@ -597,10 +593,13 @@ def pooled_beta(
     ``method`` string). ``driscoll_kraay=True`` is mutually exclusive
     with ``two_way_cluster_col`` (raises ``ValueError``).
 
-    Short-circuits when ``n_obs < 10`` (no regression), returns ``stat=None``
-    with $p=1.0$ when the effective $G < 3$ (SE undefined with < 3
-    clusters) — or, on the DK path, when fewer than 3 distinct periods
-    leave the cross-sectional HAC undefined.
+    Short-circuits to ``value=NaN`` / ``stat=None`` / $p=1.0$ when
+    ``n_obs < 10`` (no regression), when the effective $G < 3$ (clustered SE
+    undefined), or, on the DK path, when fewer than 3 distinct periods leave
+    the cross-sectional HAC undefined. The slope computed before an SE floor
+    fails is not exposed as the headline value: without a valid covariance
+    estimate, downstream aggregation cannot distinguish it from a fully
+    inferential pooled beta.
 
     Formula:
         Point estimate:
@@ -670,11 +669,14 @@ def pooled_beta(
         slope that ``MetricResult`` rejects outright, turning one bad cell
         into a hard failure of the whole panel.
 
-        factrix reports ``stat = None`` (rather than 0) when ``G < 3``
-        because the cluster-robust variance is undefined with too few
-        clusters; falling back to a homoskedastic SE in that regime
-        would silently break the panel-correlation guarantee that
-        motivated using clustered SE in the first place.
+        factrix reports ``value = NaN`` and ``stat = None`` (rather than a
+        finite slope and zero statistic) when ``G < 3`` because the
+        cluster-robust variance is undefined with too few clusters. Retaining
+        the algebraic OLS slope in the headline field would let downstream
+        aggregation treat an inference-unavailable cell as a valid pooled
+        beta; falling back to a homoskedastic SE would silently break the
+        panel-correlation guarantee that motivated using clustered SE in the
+        first place.
 
     References:
         - [Petersen (2009)][petersen-2009]. "Estimating Standard Errors
@@ -769,18 +771,13 @@ def pooled_beta(
 
     if two_way_cluster_col is None:
         if g_a < 3:
-            return MetricResult(
-                p_value=1.0,
-                alternative="two-sided",
-                value=slope,
+            return _short_circuit_output(
+                "pooled_beta",
+                "insufficient_clusters",
                 n_obs=n_obs,
                 n_obs_axis="pairs",
-                stat=None,
-                metadata={
-                    "reason": "insufficient_clusters",
-                    "n_clusters": g_a,
-                    "min_required": 3,
-                },
+                n_clusters=g_a,
+                min_required=3,
             )
         effective_meat = (g_a / (g_a - 1)) * meat_a
         df_t = g_a
@@ -797,20 +794,15 @@ def pooled_beta(
         inter_ids = ids_a.astype(np.int64) * (int(ids_b.max()) + 1) + ids_b
         meat_i, g_i = _cluster_meat(X, resid, inter_ids)
         if min(g_a, g_b) < 3:
-            return MetricResult(
-                p_value=1.0,
-                alternative="two-sided",
-                value=slope,
+            return _short_circuit_output(
+                "pooled_beta",
+                "insufficient_clusters",
                 n_obs=n_obs,
                 n_obs_axis="pairs",
-                stat=None,
-                metadata={
-                    "reason": "insufficient_clusters",
-                    "n_clusters": min(g_a, g_b),
-                    "min_required": 3,
-                    "n_clusters_a": g_a,
-                    "n_clusters_b": g_b,
-                },
+                n_clusters=min(g_a, g_b),
+                min_required=3,
+                n_clusters_a=g_a,
+                n_clusters_b=g_b,
             )
         effective_meat = (
             (g_a / (g_a - 1)) * meat_a

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -444,6 +444,18 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert out.p_value == pytest.approx(float(p_ref))
         assert out.metadata["n_clusters"] == g
 
+    def test_one_way_too_few_clusters_hides_the_slope(self):
+        panel = self._panel(n_dates=2, n_assets=15)
+
+        out = pooled_beta(panel)
+
+        assert np.isnan(out.value)
+        assert out.stat is None
+        assert out.p_value == 1.0
+        assert out.metadata["reason"] == "insufficient_clusters"
+        assert out.metadata["n_clusters"] == 2
+        assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
+
     def test_two_way_is_the_cgm_sum_and_thompson_df(self):
         from factrix.metrics.fm_beta import _cluster_meat, pooled_beta
         from scipy import stats as sp_stats
@@ -482,3 +494,17 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert out.p_value == pytest.approx(float(2 * sp_stats.t.sf(abs(t_ref), df)))
         assert out.metadata["n_clusters_a"] == g_a
         assert out.metadata["n_clusters_b"] == g_b
+
+    def test_two_way_too_few_clusters_hides_the_slope(self):
+        panel = self._panel(n_dates=10, n_assets=2)
+
+        out = pooled_beta(panel, two_way_cluster_col="asset_id")
+
+        assert np.isnan(out.value)
+        assert out.stat is None
+        assert out.p_value == 1.0
+        assert out.metadata["reason"] == "insufficient_clusters"
+        assert out.metadata["n_clusters"] == 2
+        assert out.metadata["n_clusters_a"] == 10
+        assert out.metadata["n_clusters_b"] == 2
+        assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -92,9 +92,12 @@ class TestDriscollKraayPath:
         # < 3 distinct periods → cross-sectional HAC undefined.
         df = _common_factor_panel(n_dates=2, n_assets=30, rho=0.0)
         res = pooled_beta(df, driscoll_kraay=True)
+        assert np.isnan(res.value)
         assert res.stat is None
         assert res.metadata["reason"] == "insufficient_periods"
+        assert res.metadata["n_periods"] == 2
         assert res.p_value == 1.0
+        assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
 
     def test_mutually_exclusive_with_two_way_cluster(self):
         df = _common_factor_panel(n_dates=40, n_assets=10, rho=0.2)


### PR DESCRIPTION
## Summary
- route all three pooled-beta hard floors through the canonical unavailable-result contract
- prevent an algebraic slope from looking usable when clustered or Driscoll-Kraay covariance cannot be formed
- preserve insufficient-sample metadata, `METRIC_UNAVAILABLE` observability, and BHY exclusion

## Test plan
- [x] 2,857 tests passed; 1 skipped
- [x] 96 doctests passed; 1 skipped
- [x] 215 documentation contract tests passed
- [x] Ruff check and format check passed

Closes #835