### PR TITLE
refactor(errors): drop the unused anchor parameter from _api_docs_path

### DIFF
--- a/factrix/_errors.py
+++ b/factrix/_errors.py
@@ -16,15 +16,13 @@ _VALUE_REPR_CAP = 120
 _AVAILABLE_PREVIEW = 15
 
 
-def _api_docs_path(func_name: str, anchor: str) -> str:
-    """Return the deployed API path for a public function.
+def _api_docs_path(func_name: str) -> str:
+    """Return the deployed API path for a public multi-factor / compare function.
 
-    Mkdocstrings uses the fully qualified symbol as its heading id; parameter
-    names are not standalone anchors. ``anchor`` remains in the signature so
-    shared validators can report the field the caller supplied, but the link
-    targets the function contract that documents it.
+    Mkdocstrings uses the fully qualified symbol as the heading id and
+    parameter names are not standalone anchors, so every validator on one
+    function links to that function's contract.
     """
-    del anchor
     namespace = "factrix" if func_name == "compare" else "factrix.multi_factor"
     return f"api/{func_name.replace('_', '-')}#{namespace}.{func_name}"
 

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -114,7 +114,7 @@ def _partition(
                 field=field,
                 value=name,
                 expected="partition key, not the hypothesis identifier 'factor'",
-                docs_path=_api_docs_path(func_name, field),
+                docs_path=_api_docs_path(func_name),
             )
 
     _check_param_keys(results, keys=keys, func_name=func_name, field=field)
@@ -139,7 +139,7 @@ def _partition(
                     "it on `EvaluationResult.params`; it then joins the "
                     "identifier without partitioning the family"
                 ),
-                docs_path=_api_docs_path(func_name, "partition-key"),
+                docs_path=_api_docs_path(func_name),
             )
         seen[identifier] = idx
         entries.append(
@@ -174,7 +174,7 @@ def _attach_p_values(
                     f"target metric {metric!r} has no p-values (all results returned None). "
                     "Descriptive metrics without formal hypothesis tests cannot be used for FDR control"
                 ),
-                docs_path=_api_docs_path(func_name, "metrics"),
+                docs_path=_api_docs_path(func_name),
             )
 
     return [
@@ -275,7 +275,7 @@ def _check_param_keys(
             f"EvaluationResult.params, or drop it from {field}. "
             f"Param keys seen across the input: {available or ['<none>']!r}"
         ),
-        docs_path=_api_docs_path(func_name, field),
+        docs_path=_api_docs_path(func_name),
     )
 
 
@@ -315,7 +315,7 @@ def _resolve_p_value(
                 f"{metric!r}; missing on factor={result.factor!r}"
             ),
             candidates=sorted(result.metrics),
-            docs_path=_api_docs_path(func_name, "metrics"),
+            docs_path=_api_docs_path(func_name),
         ) from None
 
     p = out.p_value
@@ -337,7 +337,7 @@ def _resolve_p_value(
                 f"factor={result.factor!r} has no p-value for "
                 f"metric {metric!r}"
             ),
-            docs_path=_api_docs_path(func_name, "metrics"),
+            docs_path=_api_docs_path(func_name),
         )
 
     p_float = float(p)
@@ -351,6 +351,6 @@ def _resolve_p_value(
                 f"has NaN p for metric {metric!r} — drop the result "
                 "or pick a different metric"
             ),
-            docs_path=_api_docs_path(func_name, "metrics"),
+            docs_path=_api_docs_path(func_name),
         )
     return p_float

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -54,14 +54,14 @@ def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str
     Used by ``bhy.metrics`` / ``compare.metrics`` so both surfaces give
     identical error messages for the same misuse.
     """
-    anchor = _api_docs_path(func_name, field)
+    docs_path = _api_docs_path(func_name)
     if not isinstance(value, list):
         raise UserInputError(
             func_name=func_name,
             field=field,
             value=type(value).__name__,
             expected=(f"list[str] (always a list, even for a single {field})"),
-            docs_path=anchor,
+            docs_path=docs_path,
         )
     if not value:
         raise UserInputError(
@@ -69,7 +69,7 @@ def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str
             field=field,
             value=value,
             expected="non-empty list[str]",
-            docs_path=anchor,
+            docs_path=docs_path,
         )
     for i, spec in enumerate(value):
         if not isinstance(spec, str):
@@ -78,7 +78,7 @@ def _validate_metric_list(value: Any, *, func_name: str, field: str) -> list[str
                 field=f"{field}[{i}]",
                 value=type(spec).__name__,
                 expected="str metric label (e.g. 'ic')",
-                docs_path=anchor,
+                docs_path=docs_path,
             )
     return list(value)
 
@@ -93,7 +93,7 @@ def _validate_cross_metric_list(value: Any, *, func_name: str) -> list[str]:
             field="metrics",
             value=duplicates,
             expected="unique metric labels; duplicates would repeat one hypothesis",
-            docs_path=_api_docs_path(func_name, "metrics"),
+            docs_path=_api_docs_path(func_name),
         )
     if len(metrics) < 2:
         raise UserInputError(
@@ -104,7 +104,7 @@ def _validate_cross_metric_list(value: Any, *, func_name: str) -> list[str]:
                 "at least 2 metric labels for a cross-metric family; "
                 "use bhy() for one metric"
             ),
-            docs_path=_api_docs_path(func_name, "metrics"),
+            docs_path=_api_docs_path(func_name),
         )
     return metrics
 
@@ -117,7 +117,7 @@ def _validate_q(value: Any, *, func_name: str) -> float:
             field="q",
             value=value,
             expected="float in the open interval (0, 1)",
-            docs_path=_api_docs_path(func_name, "q"),
+            docs_path=_api_docs_path(func_name),
         )
     q = float(value)
     if not np.isfinite(q) or not 0.0 < q < 1.0:
@@ -126,7 +126,7 @@ def _validate_q(value: Any, *, func_name: str) -> float:
             field="q",
             value=value,
             expected="float in the open interval (0, 1)",
-            docs_path=_api_docs_path(func_name, "q"),
+            docs_path=_api_docs_path(func_name),
         )
     return q
 
@@ -149,7 +149,7 @@ def _require_non_empty_results(
                 "list[EvaluationResult], not the dict returned by evaluate() — "
                 "pass list(results.values())"
             ),
-            docs_path=_api_docs_path(func_name, "results"),
+            docs_path=_api_docs_path(func_name),
         )
     if not results:
         raise UserInputError(
@@ -157,7 +157,7 @@ def _require_non_empty_results(
             field="results",
             value=results,
             expected="non-empty list[EvaluationResult]",
-            docs_path=_api_docs_path(func_name, "results"),
+            docs_path=_api_docs_path(func_name),
         )
     from factrix._results import EvaluationResult
 
@@ -172,7 +172,7 @@ def _require_non_empty_results(
                     "evaluate(), pass list(results.values()); do not extend "
                     "a list with the dict itself, because that appends keys"
                 ),
-                docs_path=_api_docs_path(func_name, "results"),
+                docs_path=_api_docs_path(func_name),
             )
 
 

--- a/tests/test_docs_paths.py
+++ b/tests/test_docs_paths.py
@@ -53,8 +53,7 @@ def _literal_docs_paths() -> set[str]:
 
 
 DOCS_PATHS = sorted(
-    _literal_docs_paths()
-    | {_api_docs_path(name, "field") for name in _DYNAMIC_DOCS_FUNCTIONS}
+    _literal_docs_paths() | {_api_docs_path(name) for name in _DYNAMIC_DOCS_FUNCTIONS}
 )
 
 


### PR DESCRIPTION
## Summary
- `_api_docs_path` accepted an `anchor` argument and immediately discarded it (`del anchor`) since every validator on a multi-factor / compare function links to the function contract heading
- remove the parameter and update the 16 call sites (`_family.py`, `_multi_factor.py`, `tests/test_docs_paths.py`); rename the local in `_validate_metric_list` from `anchor` to `docs_path`

## Test plan
- [x] `tests/test_docs_paths.py` (built-site anchor guard), bhy / compare / partial-conjunction / errors tests — 165 passed
- [x] ruff check / format, mypy

Follow-up to #864.