### PR TITLE
docs: close the drift left by the warning-contract and routing-guide changes

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -184,7 +184,9 @@ Descriptive; no test.
   returns are negatively correlated and the test is conservative, which
   `ESTIMATION_WINDOW_CONTAMINATED` records; measured 4.7 / 2.3 / 5.0% size at
   h = 1 / 5 / 21 on 20 assets, 0.0% on one asset at h = 21),
-  `warning_codes` (conditional, e.g. `FEW_EVENTS`).
+  `warning_codes` (conditional, e.g. `FEW_EVENTS`; `SPARSE_MAGNITUDE_WEIGHTED`
+  when the sparse factor is mixed-sign and not a clean ±1 ternary;
+  `NON_FINITE_INPUT_DROPPED` when `compute_caar` dropped event rows).
 
 #### `bmp_z`
 
@@ -444,6 +446,8 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 - *descriptive*: `n_valid_periods`, `n_groups`, `tie_ratio`, `tie_policy`.
 
 ### `quantile` (`factrix.metrics.quantile`)
+- `warning_codes` (conditional): `HIGH_TIE_RATIO` under `tie_policy="ordinal"`
+  when the median per-period `tie_ratio` exceeds `TIE_RATIO_WARN_THRESHOLD`.
 
 #### `quantile_spread`
 
@@ -472,6 +476,10 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
   (`"no_signal_zero_variance_factor"`) when the factor has observations
   but no cross-sectional variation. This is a valid `p_value = 1.0`
   result, not a short-circuit `reason`.
+- `warning_codes` (conditional): `HIGH_TIE_RATIO` under `tie_policy="ordinal"`
+  when the median per-period `tie_ratio` exceeds `TIE_RATIO_WARN_THRESHOLD`;
+  `THIN_QUANTILE_GROUPS` when the median cross-section leaves fewer than
+  `MIN_GROUP_ASSETS` names per bucket.
 
 #### `quantile_spread_vw`
 
@@ -492,6 +500,8 @@ no-signal `signal_status` (`"no_signal_zero_variance_factor"`, a valid
 `p_value = 1.0` result) when the factor has no cross-sectional variation.
 
 ### `k_spread` (`factrix.metrics.k_spread`)
+- `warning_codes` (conditional): as `quantile_spread` — `HIGH_TIE_RATIO`,
+  `THIN_QUANTILE_GROUPS`.
 
 #### `k_spread`
 
@@ -518,6 +528,8 @@ Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
   (`"no_signal_zero_variance_factor"`) when the factor has observations
   but no cross-sectional variation. This is a valid `p_value = 1.0`
   result, not a short-circuit `reason`.
+- `warning_codes` (conditional): `HIGH_TIE_RATIO` under `tie_policy="ordinal"`
+  when the median per-period `tie_ratio` exceeds `TIE_RATIO_WARN_THRESHOLD`.
 
 #### Shared small-N note
 
@@ -863,6 +875,8 @@ Two complementary methods:
 All four are descriptive — `MetricResult.stat = None` and no
 `p_value` is emitted. They feed cost/benefit arithmetic, not
 inference.
+- `warning_codes` (conditional): `THIN_QUANTILE_PERIODS` when the historical
+  buckets average fewer than 5 periods each.
 
 #### `rank_turnover`
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -625,8 +625,8 @@ nominal 5%; sample sizes count periods on the evaluation grid after the
 |---|---|---|---|
 | Overlapping `forward_periods` panel, per-period series not persistent (the everyday case) | No warning | `NEWEY_WEST` 5–9% on real overlapping IC (h = 5, n = 240 / 480: 5.2% / 8.8%); `NON_OVERLAPPING` calibrated. | Keep the default member. |
 | Persistent per-period series (lag-1 φ ≥ 0.3 on the *tested* series) | `serial_correlation_detected` | No path is calibrated — NW 13–17%, stationary bootstrap 12–19%, plain *t* 32–34% at φ = 0.6 (table above). | Do **not** switch member; it moves the number without fixing it. Read the *t* against a raised hurdle (*t* > 3) or lengthen the sample. A coarser `overlap_periods` stride under `NON_OVERLAPPING` also helps mechanically — the strided sample sits at φ^h, and AR(0.6) strided at h = 21 measures 4.5%. |
-| Short strided series (fewer than ~120 periods after the stride) | `unreliable_se_short_periods`, or nothing on a moderately short series | The *t* / NW branch runs 7–9%. The bootstrap p is *worse* here — 13.6% at n = 12, 9.8% at 30, 7.4% at 60, reaching 5.2% only by 120 — and the strided series is short exactly when the horizon is long. | Stay on the analytic *t* / NW. Do not reach for the bootstrap to rescue a short sample; shorten the stride or lengthen the history instead. |
-| Long strided series (≥ ~120 periods) whose distribution is in doubt (heavy tails, skew) | No warning | At n ≥ 120 the bootstrap is at its nominal size (5.2%) while the analytic branch still carries its 7–9% baseline. | `STATIONARY_BOOTSTRAP` is the better-calibrated read on `ic`; the spread metrics keep `NON_OVERLAPPING` / `NEWEY_WEST` (their allowlist). This is a documented option, not a default — see §1. |
+| Short strided series (fewer than ~120 periods after the stride) | `unreliable_se_short_periods`, or nothing on a moderately short series | The *t* / NW branch runs 7–9%. A block-bootstrap p is *worse* here — the spread metrics' former bootstrap branch (`_block_bootstrap_diff_p`, kernel-isolated on iid input) measured 13.6% at n = 12, 9.8% at 30, 7.4% at 60, reaching 5.2% only by 120 — and the strided series is short exactly when the horizon is long. | Stay on the analytic *t* / NW. Do not reach for the bootstrap to rescue a short sample; shorten the stride or lengthen the history instead. |
+| Long strided series (≥ ~120 periods) whose distribution is in doubt (heavy tails, skew) | No warning | On iid input `STATIONARY_BOOTSTRAP` sits at the same 7–9% baseline as NW (φ = 0 row above) — it buys no *size*. Its case is distributional: it is the only member that does not assume asymptotic normality of the mean (§1). | Read `STATIONARY_BOOTSTRAP` on `ic` alongside the analytic p when tails or skew are the doubt; the spread metrics keep `NON_OVERLAPPING` / `NEWEY_WEST` (their allowlist). A documented option, not a default. |
 | Heavy-tailed *and* short | `unreliable_se_short_periods` | The *t* is size-robust to tails — 3–4% on t(3) input, i.e. conservative — while the small-n bootstrap is not (6–14%). | Keep the *t*. Tails are not a reason to bootstrap a short series. |
 | Thin cross-section (few names per leg) | `few_assets` | Each leg mean rests on a handful of names: a noisier estimate, not a differently-distributed one. The automatic bootstrap switch this once triggered rejected 8–20% against the *t*'s 7–9% and keyed on the wrong axis; it was removed. | Keep the requested member; read `n_assets` and treat the spread as fragile. |
 | Joint test on K ≥ 3 short slices | `slice_period_joint_test` warning | 8–9% for K = 5 on 50–90-period slices, converging by T ≈ 150; the bootstrap path inherits it (12%). K = 2 is calibrated throughout. | Read the pairwise contrasts on the same slices (5–6%) rather than the joint p, or lengthen the slices. |
@@ -638,9 +638,10 @@ a short sample is not fixed by changing the inference member — the
 analytic and bootstrap paths inherit the same small-sample distortion —
 so the honest response is a raised hurdle or more periods. A
 *distribution* problem on a long series is the one case where the
-bootstrap earns its cost, and it is offered there rather than routed to
-automatically because a default that silently moves a number is the line
-every other deviation in this library has stayed behind.
+bootstrap earns its cost — as a second read, not a better-sized one — and
+it is offered there rather than routed to automatically because a default
+that silently moves a number is the line every other deviation in this
+library has stayed behind.
 
 ---
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -239,6 +239,9 @@ class WarningCode(StrEnum):
     # bare DataFrame — there is no MetricResult to hang ``warning_codes`` on —
     # so these travel in the text of a ``UserWarning``. They exist because a
     # sample-regime-driven switch of estimator must never be silent.
+    # ``NON_FINITE_INPUT_DROPPED`` is also raised at one evaluation-side
+    # producer boundary (``compute_caar``), where ``caar`` attaches it to
+    # ``warning_codes`` like any metric code.
     #
     # The per-date MAD collapsed to zero (>50% ties at the median) and the
     # non-robust per-date sample standard deviation stood in as the scale.
@@ -255,10 +258,11 @@ class WarningCode(StrEnum):
     # no robust per-date scale exists; the date is left unscaled (z-score null,
     # clip skipped) rather than fabricating one.
     INSUFFICIENT_SCALE_ASSETS = "insufficient_scale_assets"
-    # NaN / +-Inf inputs were blanked to null. A non-finite tick is a data
-    # error, not an extreme value: clipping it into a winsorization band
-    # manufactures a plausible finite number that survives every downstream
-    # drop_nulls().drop_nans().
+    # NaN / +-Inf inputs were excluded at the producer boundary: the
+    # preprocess normalizers blank them to null, ``compute_caar`` drops the
+    # affected event rows. A non-finite tick is a data error, not an extreme
+    # value: clipping it into a winsorization band manufactures a plausible
+    # finite number that survives every downstream drop_nulls().drop_nans().
     NON_FINITE_INPUT_DROPPED = "non_finite_input_dropped"
 
     # Fired by ``orthogonalize_factor`` when a per-date cross-section clears the

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -578,7 +578,7 @@ All exceptions inherit from `FactrixError`:
 
 ## WarningCode reference
 
-The canonical glosses live in `factrix._codes.WarningCode.description` and are regenerated into `docs/reference/_generated_warning_codes.md`. The 28 evaluation-side codes (the preprocess and data-shape codes are in that generated reference):
+The canonical glosses live in `factrix._codes.WarningCode.description` and are regenerated into `docs/reference/_generated_warning_codes.md`. The 28 evaluation-side codes (the preprocess and data-shape codes are in that generated reference; of those, `non_finite_input_dropped` is also attached by `caar` when `compute_caar` drops non-finite event rows):
 
 | WarningCode | Description |
 |---|---|

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -180,7 +180,13 @@ def monotonicity(
         data: Panel with ``date, asset_id, factor, forward_return``.
         n_groups: Number of quantile groups (default 10 for a ~2000-name
             universe). Use 5 for ``n_assets < 1000``, 3 for ``n_assets < 200``.
-        tie_policy: Bucketing tie-break policy, see ``_assign_quantile_groups``.
+        tie_policy: Bucketing tie-break policy — the same knob and values as
+            ``quantile_spread`` / ``k_spread``, see ``_assign_quantile_groups``.
+            Under ``"ordinal"`` the realised per-period tie ratio is reported
+            in ``metadata["tie_ratio"]``; when its median exceeds
+            ``TIE_RATIO_WARN_THRESHOLD`` the result carries
+            ``WarningCode.HIGH_TIE_RATIO`` and echoes a ``UserWarning`` unless
+            the code is declared in ``expected_warnings``.
         direction: Which monotone pattern H1 asserts — ``"increasing"``
             (default) or ``"decreasing"`` in bucket index. Declare it from the
             factor's hypothesis; running both and reporting the smaller p is a


### PR DESCRIPTION
## Summary
Follow-up to an independent drift audit of yesterday's six merges.
- `statistical-methods` routing table: the 13.6% / 9.8% / 7.4% / 5.2% small-n sizes belong to the spread metrics' former bootstrap branch (`_block_bootstrap_diff_p`, as documented in `_helpers.py`); the long-series row wrongly extended that 5.2% to `STATIONARY_BOOTSTRAP`, whose iid size is the same 7–9% as NW (φ = 0 row) — rewritten to say the bootstrap buys a distributional second read, not size
- `_codes.py`: the preprocess block comment and the `NON_FINITE_INPUT_DROPPED` member comment now acknowledge that `caar` attaches the code; `llms-full.txt` intro clause likewise
- `stat-keys-by-metric`: `warning_codes` bullets for `caar` (two new codes), `common_quantile_spread`, `quantile_spread`, `quantile_spread_vw`, `k_spread`, `monotonicity`
- `monotonicity` docstring documents the tie-ratio advisory / `HIGH_TIE_RATIO` like `k_spread`

## Test plan
- [x] docs tests (`test_docs_stat_keys_by_metric`, `test_docs_pages`, `test_docs_llms`, `test_docs_matrix`, `test_docs_symbol_refs`) — 307 passed; monotonicity doctests
- [x] `mkdocs build` — no generated-file drift
- [x] ruff check / format, mypy