### PR TITLE
fix(metrics): align predictive_beta diagnostics with corrected fit

### DIFF
--- a/docs/api/metrics/predictive_beta.md
+++ b/docs/api/metrics/predictive_beta.md
@@ -57,17 +57,20 @@ title: factrix.metrics.predictive_beta
     of draws while the test rejects 13% (`h = 1`) / 35% (`h = 21`) at a
     nominal 5%; at `T = 2500` the ADF test can reject the unit root, the flag
     goes silent (~0% of draws) and the test still rejects 9% / 14%. A silent
-    flag is not evidence of an unbiased slope, and factrix applies no
-    Stambaugh correction.
+    flag is not evidence of an unbiased slope. The Stambaugh bias itself is
+    corrected unconditionally, so the flag is about the *regressor*, not
+    about whether `value` still carries the bias.
 
 -   __Overlap and residual persistence__
 
     ---
 
     Two further screens read the sample the standard error actually has.
-    `WarningCode.SERIAL_CORRELATION_DETECTED` fires when the regression
-    residuals' lag-1 autocorrelation exceeds `PERSISTENT_SERIES_AUTOCORR`
-    (0.3) — the same rule `fm_beta` and the series-mean inference members
+    `WarningCode.SERIAL_CORRELATION_DETECTED` fires when the **reported**
+    model's residuals — `y - alpha - value * factor` over the `n_obs` rows,
+    so the bias-corrected fit's residuals whenever the correction applies —
+    have a lag-1 autocorrelation above `PERSISTENT_SERIES_AUTOCORR` (0.3) —
+    the same rule `fm_beta` and the series-mean inference members
     apply. `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` reads
     `n_periods_effective = n_periods // forward_periods`, not the raw row
     count: `n` overlapping rows carry about `n / h` independent observations
@@ -162,7 +165,7 @@ windows share observations.
                 "beta": result.value,
                 "t_stat": result.stat,
                 "n_periods": result.metadata["n_periods"],
-                "r_squared": result.metadata["r_squared"],
+                "r_squared_ols": result.metadata["r_squared_ols_uncorrected"],
             }
         )
 

--- a/docs/api/metrics/predictive_beta.md
+++ b/docs/api/metrics/predictive_beta.md
@@ -35,7 +35,7 @@ title: factrix.metrics.predictive_beta
     ---
 
     The slope test uses Newey-West HAC covariance. The lag defaults to
-    the Newey-West automatic bandwidth, floored at `forward_periods - 1`
+    the Newey-West automatic bandwidth, floored at `overlap_periods - 1`
     so overlapping forward-return windows do not understate standard
     errors.
 
@@ -72,7 +72,7 @@ title: factrix.metrics.predictive_beta
     have a lag-1 autocorrelation above `PERSISTENT_SERIES_AUTOCORR` (0.3) —
     the same rule `fm_beta` and the series-mean inference members
     apply. `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` reads
-    `n_periods_effective = n_periods // forward_periods`, not the raw row
+    `n_periods_effective = n_periods // overlap_periods`, not the raw row
     count: `n` overlapping rows carry about `n / h` independent observations
     while the HAC lag floor rises with `h`. At `T = 120`, `h = 21` the
     regression runs on 98 rows with a Bartlett lag of 20 and rejects 17.5% of
@@ -144,8 +144,8 @@ windows share observations.
         forward_periods=5,
     )
 
-    full = predictive_beta(panel, forward_periods=5)
-    hit = directional_hit_rate(panel, forward_periods=5)
+    full = predictive_beta(panel, overlap_periods=5)
+    hit = directional_hit_rate(panel, overlap_periods=5)
 
     dates = panel.select("date").unique().sort("date")["date"].to_list()
     window_periods = 60
@@ -156,7 +156,7 @@ windows share observations.
         window = panel.filter(
             pl.col("date").is_between(window_dates[0], window_dates[-1])
         )
-        result = predictive_beta(window, forward_periods=5)
+        result = predictive_beta(window, overlap_periods=5)
         rows.append(
             {
                 "date": window_dates[-1],

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -745,14 +745,35 @@ own bias: at `T = 60, phi = 0.95, rho = -0.9` the corrected test rejects
 90.7%). At `rho = 0`, where OLS is unbiased, the gap is small (63.2%
 against 70.5% at `T = 60`).
 
+Every key names the fit it belongs to. `alpha`, `residual_lag1_autocorr`,
+`n_obs`, `n_periods` and `n_periods_effective` describe the **corrected**
+fit — the model `value` came from, on the rows it was estimated on.
+`beta_ols_uncorrected` and `r_squared_ols_uncorrected` are the
+pre-correction OLS reference on the full finite-pair sample
+(`n_periods_finite`). There is deliberately no corrected `r_squared`: the
+Amihud-Hurvich slope does not minimise the sum of squares, so `1 - SSR/SST`
+off its residual can go negative and has no standing in this literature,
+which reports `R²` for the OLS regression.
+
 - *primary*: `p_value` — two-sided bias-corrected slope test.
-- *descriptive*: `n_periods`, `n_periods_effective`
-  (`n_periods // overlap_periods` — the non-overlapping observations the
-  short-sample gate reads), `residual_lag1_autocorr`, `newey_west_lags`,
+- *primary sample*: `n_obs` — the rows the headline test ran on, which is
+  `n_periods_finite - overlap_periods` whenever the correction applies. The
+  augmented design spends the first observation on the AR(1) lag and, at
+  `overlap_periods > 1`, the last `overlap_periods - 1` windows on the
+  horizon-summed innovation proxy. When the sample is too short for that
+  design and `value` falls back to the plain OLS slope, `n_obs` is the
+  finite-pair count again — the reported model is then the OLS one.
+- *descriptive*: `n_periods` (= `n_obs`), `n_periods_finite` (the finite
+  `(factor, return)` pairs available before the augmented design trimmed its
+  rows), `n_periods_effective` (`n_periods // overlap_periods` — the
+  non-overlapping observations the short-sample gate reads),
+  `residual_lag1_autocorr` (lag-1 autocorrelation of the reported model's
+  residuals, strided at `overlap_periods`), `newey_west_lags`,
   `overlap_periods`, `har_lags` (the HAR bandwidth the corrected slope test
   uses; `newey_west_lags` stays the narrow rule the reported uncorrected OLS
-  slope is fitted with), `alpha`, `r_squared`, `factor_std`, `adf_stat`, `adf_p`,
-  `adf_threshold`, `unit_root_suspected`.
+  slope is fitted with), `alpha` (the intercept the corrected slope implies
+  on the `n_obs` rows), `r_squared_ols_uncorrected`, `factor_std`,
+  `adf_stat`, `adf_p`, `adf_threshold`, `unit_root_suspected`.
 - *descriptive* (Stambaugh correction): `stambaugh_adjusted` (False only
   when the sample is too short for the augmented design, in which case
   `value` falls back to the plain OLS slope), `beta_ols_uncorrected`,
@@ -777,13 +798,18 @@ against 70.5% at `T = 60`).
   oversized in this regime", not "beta may carry Stambaugh bias" — the bias
   is corrected. It is about the *regressor*: the `h > 1` over-rejection
   above fires no code of its own.
-- *warning*: `WarningCode.SERIAL_CORRELATION_DETECTED` when the regression
-  residuals' lag-1 autocorrelation exceeds `PERSISTENT_SERIES_AUTOCORR`.
+- *warning*: `WarningCode.SERIAL_CORRELATION_DETECTED` when the **reported**
+  model's residuals — `y - alpha - value * factor` over the `n_obs` rows,
+  strided at `overlap_periods` — have a lag-1 autocorrelation above
+  `PERSISTENT_SERIES_AUTOCORR`. Reading the uncorrected OLS residuals here
+  flipped the verdict on draws where the two slopes are far apart.
 - *warning*: `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` when
   `n_periods_effective` is below `MIN_PERIODS_WARN`.
 - *short-circuit*: `reason` `insufficient_predictive_periods`,
   `degenerate_factor_variance`, `no_factor_column`, or
-  `no_return_column`.
+  `no_return_column`. The `insufficient_predictive_periods` floor is a
+  pre-flight gate on `n_periods_finite`, before the augmented design trims
+  its rows.
 
 ### `common_beta` (`factrix.metrics.common_beta`)
 

--- a/factrix/_stats/ols.py
+++ b/factrix/_stats/ols.py
@@ -215,7 +215,18 @@ def _ols_homoskedastic(
 
 
 class AmihudHurvichFit(NamedTuple):
-    """Reduced-bias predictive-regression fit. See :func:`_amihud_hurvich_beta`."""
+    """Reduced-bias predictive-regression fit. See :func:`_amihud_hurvich_beta`.
+
+    ``alpha``, ``n_used`` and ``resid`` describe the **reported structural
+    model** ``y = alpha + beta·x + e`` on the rows the augmented design kept,
+    so a caller can report diagnostics for the fit it actually publishes
+    rather than for the OLS regression that preceded it. ``alpha`` is *not*
+    the augmented regression's intercept: that one absorbs the innovation
+    proxy and is not the intercept implied by ``beta``.
+
+    A not-computable fit fills every float with NaN, ``n_used`` with ``0``
+    and ``resid`` with an empty array.
+    """
 
     beta: float
     t_stat: float
@@ -225,6 +236,9 @@ class AmihudHurvichFit(NamedTuple):
     phi: float
     phi_corrected: float
     innovation_corr: float
+    alpha: float
+    n_used: int
+    resid: np.ndarray
 
 
 def _amihud_hurvich_beta(
@@ -359,14 +373,21 @@ def _amihud_hurvich_beta(
         overlap_periods: Overlap horizon ``h`` of ``y``.
 
     Returns:
-        :class:`AmihudHurvichFit`. Every field is NaN when the sample is too
-        short (``n < 5``) or the predictor is degenerate.
+        :class:`AmihudHurvichFit`. ``n_used`` is the row count the augmented
+        design ran on — ``n - h``, the first observation going to the AR(1)
+        lag and the last ``h - 1`` windows to the horizon-summed proxy — and
+        ``alpha`` / ``resid`` are the intercept and residual of the reported
+        structural model ``y = alpha + beta·x + e`` on exactly those rows.
+        Every field is NaN (``n_used = 0``, ``resid`` empty) when the sample
+        is too short (``n < 5``) or the predictor is degenerate.
     """
     y = _require_finite(y, "_amihud_hurvich_beta")
     x = _require_finite(x, "_amihud_hurvich_beta")
     n = len(y)
     nan = float("nan")
-    not_computable = AmihudHurvichFit(nan, nan, nan, nan, nan, nan, nan, nan)
+    not_computable = AmihudHurvichFit(
+        nan, nan, nan, nan, nan, nan, nan, nan, nan, 0, np.empty(0)
+    )
     if n < 5 or len(x) != n:
         return not_computable
 
@@ -437,16 +458,26 @@ def _amihud_hurvich_beta(
 
     se = float(np.sqrt(se_aug**2 + (gamma * se_phi * loading) ** 2))
     beta = float(beta_vec[1])
+    # The intercept the REPORTED model implies, on the rows this design used.
+    # It is not ``beta_vec[0]``: the augmented intercept is fitted alongside
+    # the innovation proxy and absorbs its (non-zero) mean, so it does not
+    # close the structural equation ``y = alpha + beta x + e``. The two differ
+    # by the constant ``gamma * mean(proxy)`` only.
+    alpha = float(np.mean(y[:m]) - beta * np.mean(x[:m]))
     # rho is the correlation between the PREDICTIVE residual and the AR
     # innovation - the Stambaugh channel itself. It must be measured off the
     # structural residual ``y - alpha - beta x``, NOT the augmented fit's
     # residual: the latter has the proxy projected out of it by construction,
     # so it is orthogonal to ``innovation`` and would report rho = 0 always.
-    resid_e = y[:m] - beta_vec[0] - beta_vec[1] * x[:m]
+    # The same series is handed back on the fit so callers can screen the
+    # residuals of the model they report; a constant shift leaves rho alone.
+    resid_e = y[:m] - alpha - beta * x[:m]
     corr_matrix = np.corrcoef(resid_e, innovation[:m])
     rho = float(corr_matrix[0, 1]) if np.isfinite(corr_matrix[0, 1]) else nan
     if se < EPSILON:
-        return AmihudHurvichFit(beta, nan, nan, se, gamma, phi, phi_c, rho)
+        return AmihudHurvichFit(
+            beta, nan, nan, se, gamma, phi, phi_c, rho, alpha, m, resid_e
+        )
 
     t_stat = beta / se
     # h = 1: the textbook residual df of the augmented regression. h > 1: the
@@ -456,4 +487,6 @@ def _amihud_hurvich_beta(
     # multivariate paths on the narrow rule does not apply to it.
     dof = float(max(m - 3, 1)) if h == 1 else _har_dof(m, lags, h)
     p_value = float(2 * sp_stats.t.sf(abs(t_stat), df=dof))
-    return AmihudHurvichFit(beta, t_stat, p_value, se, gamma, phi, phi_c, rho)
+    return AmihudHurvichFit(
+        beta, t_stat, p_value, se, gamma, phi, phi_c, rho, alpha, m, resid_e
+    )

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -152,6 +152,20 @@ def predictive_beta(
         (``stat`` / ``p_value`` are ``None`` under
         ``WarningCode.DEGENERATE_VARIANCE``) while keeping ``value``.
 
+        Every metadata key names the fit it belongs to.
+        ``metadata["alpha"]``, ``metadata["residual_lag1_autocorr"]``,
+        ``n_obs``, ``metadata["n_periods"]`` and
+        ``metadata["n_periods_effective"]`` describe the **corrected** fit —
+        the model ``value`` came from, on the rows it was estimated on.
+        ``metadata["beta_ols_uncorrected"]`` and
+        ``metadata["r_squared_ols_uncorrected"]`` are the pre-correction OLS
+        reference, on the full finite-pair sample
+        (``metadata["n_periods_finite"]``). There is deliberately no
+        corrected $R^2$: the Amihud-Hurvich slope does not minimise the sum
+        of squares, so ``1 - SSR/SST`` off its residual can go negative and
+        has no standing in this literature, which reports $R^2$ for the OLS
+        regression.
+
     Notes:
         This is **not** a ``common_beta`` fallback. ``common_beta`` tests the
         cross-asset mean of per-asset betas and therefore remains a PANEL
@@ -164,7 +178,18 @@ def predictive_beta(
         the missing marker), and a single ``NaN`` reaching the Newey-West
         slope routine either raises or yields a ``NaN`` beta that
         ``MetricResult`` rejects — one bad cell would fail the whole series.
-        ``n_obs`` counts the finite pairs actually regressed.
+        ``metadata["n_periods_finite"]`` counts those pairs.
+
+        ``n_obs`` counts the rows the **headline** test ran on, which is
+        ``n_periods_finite - overlap_periods`` whenever the correction
+        applies: the augmented design spends the first observation on the
+        AR(1) lag and, at ``overlap_periods > 1``, the last
+        ``overlap_periods - 1`` windows on the horizon-summed innovation
+        proxy (a zero-padded truncated sum is a different regressor from the
+        one every other row carries). When the sample is too short for the
+        augmented design and ``value`` falls back to the plain OLS slope,
+        ``n_obs`` is the finite-pair count again — the reported model is then
+        the OLS one.
 
         **What the persistence flags do and do not say.**
         ``PERSISTENT_REGRESSOR`` is an ADF verdict on the *regressor*: the
@@ -177,12 +202,16 @@ def predictive_beta(
         5%; at $T = 2500$ the ADF test has the power to reject the unit root,
         the flag falls silent (0.0-0.3% of draws) and the test still rejects
         9% / 14%. Read it as "this slope carries persistent-regressor risk",
-        never as "no bias here" when it is absent, and note that factrix
-        applies no Stambaugh correction.
+        never as "no bias here" when it is absent. The Stambaugh bias itself
+        is corrected unconditionally — this flag is about the *regressor*,
+        not about whether ``value`` still carries the bias.
 
         ``SERIAL_CORRELATION_DETECTED`` is the complementary screen, on the
-        residuals this regression actually produced, read at stride
-        ``overlap_periods``: above ``PERSISTENT_SERIES_AUTOCORR`` no HAC or
+        residuals of the **reported** model — ``y - alpha - value * factor``
+        over the ``n_obs`` rows, so the corrected fit's residuals whenever
+        the correction applies and the plain OLS ones when it falls back —
+        read at stride ``overlap_periods``: above
+        ``PERSISTENT_SERIES_AUTOCORR`` no HAC or
         bootstrap path in the library is calibrated, which is the same rule
         ``fm_beta`` and the series-mean inference members apply to their own
         tested series. The stride matters — overlapping forward returns give
@@ -269,17 +298,37 @@ def predictive_beta(
     fit = _amihud_hurvich_beta(y, x, lags=har_lags, overlap_periods=overlap_periods)
     if math.isnan(fit.beta):
         # Too short / degenerate for the augmented design; fall back to the
-        # plain slope so the metric still reports what it can.
+        # plain slope so the metric still reports what it can. The reported
+        # model IS the OLS one here, so every diagnostic below stays on its
+        # residuals and on the full finite-pair count.
         beta, t_stat, p_value = beta_ols, t_ols, p_ols
         stambaugh_applied = False
+        alpha = float(np.mean(y) - beta * np.mean(x))
+        model_resid = resid
+        n_used = n
     else:
         beta, t_stat, p_value = fit.beta, fit.t_stat, fit.p_value
         stambaugh_applied = True
-    alpha = float(np.mean(y) - beta * np.mean(x))
+        # Diagnostics describe the model that is REPORTED, on the rows that
+        # produced it. The augmented design spends the first observation on
+        # the AR(1) lag and, at h > 1, the last h - 1 windows on the
+        # horizon-summed innovation proxy, so ``alpha``, the residual screen
+        # and every sample count read ``fit``'s own rows - not the n finite
+        # pairs the uncorrected OLS reference was fitted on. Reporting a
+        # corrected slope next to an intercept and a residual autocorrelation
+        # taken off the uncorrected fit described a model no caller was shown.
+        alpha = fit.alpha
+        model_resid = fit.resid
+        n_used = fit.n_used
+    # R-squared stays an OLS quantity and is named for it. A "corrected R²"
+    # is not a least-squares object: the AH slope does not minimise the sum
+    # of squares on these rows, so 1 - SSR/SST off the corrected residual can
+    # go negative and has no standing in the Stambaugh / AH literature, which
+    # reports R² for the OLS regression. Labelling beats inventing.
     ss_res = float(np.dot(resid, resid))
     y_c = y - float(np.mean(y))
     ss_tot = float(np.dot(y_c, y_c))
-    r_squared = 0.0 if ss_tot < EPSILON else max(0.0, 1.0 - ss_res / ss_tot)
+    r_squared_ols = 0.0 if ss_tot < EPSILON else max(0.0, 1.0 - ss_res / ss_tot)
 
     adf_metadata: dict[str, float | bool] = {}
     unit_root_suspected = False
@@ -328,18 +377,19 @@ def predictive_beta(
     # PERSISTENT_SERIES_AUTOCORR no HAC or bootstrap path here is calibrated,
     # so the response is a raised hurdle or a longer sample, not a different
     # estimator.
-    resid_autocorr = _lag1_autocorr(resid[:: max(overlap_periods, 1)])
+    resid_autocorr = _lag1_autocorr(model_resid[:: max(overlap_periods, 1)])
     if resid_autocorr > PERSISTENT_SERIES_AUTOCORR:
         warning_codes.append(WarningCode.SERIAL_CORRELATION_DETECTED.value)
     # Effective sample, not raw rows: overlapping forward returns leave about
     # n / h independent observations while the HAC lag floor grows with h, so
     # the short-sample gate has to read the same axis the standard error does.
     # h = 1 leaves this identical to the raw count.
-    n_effective = n // max(overlap_periods, 1)
+    n_effective = n_used // max(overlap_periods, 1)
     warn_code = _warn_below_floor(
         predictive_beta,
         n_effective,
-        f"predictive_beta: n_periods={n} at overlap_periods={overlap_periods} "
+        f"predictive_beta: n_periods={n_used} at "
+        f"overlap_periods={overlap_periods} "
         f"leaves an effective sample of {n_effective} non-overlapping "
         f"observations, below MIN_PERIODS_WARN={MIN_PERIODS_WARN}; Newey-West "
         f"HAC inference is not calibrated there (measured 17.5% rejection at a "
@@ -355,14 +405,18 @@ def predictive_beta(
         "stat_type": "t",
         "h0": "beta=0",
         "method": "single-asset predictive regression + Newey-West",
-        "n_periods": n,
+        "n_periods": n_used,
         "n_periods_effective": n_effective,
+        # The finite pairs available before the augmented design trimmed its
+        # rows: the two counts differ by ``overlap_periods`` whenever the
+        # correction applies, and both have to stay auditable.
+        "n_periods_finite": n,
         "residual_lag1_autocorr": resid_autocorr,
         "newey_west_lags": lags,
         "har_lags": har_lags,
         "overlap_periods": overlap_periods,
         "alpha": alpha,
-        "r_squared": r_squared,
+        "r_squared_ols_uncorrected": r_squared_ols,
         "factor_std": x_std,
         "stambaugh_adjusted": stambaugh_applied,
         "beta_ols_uncorrected": beta_ols,
@@ -384,7 +438,7 @@ def predictive_beta(
         value=beta,
         p_value=p_out,
         alternative=alternative,
-        n_obs=n,
+        n_obs=n_used,
         n_obs_axis="periods",
         stat=stat,
         warning_codes=tuple(warning_codes),

--- a/tests/test_predictive_beta.py
+++ b/tests/test_predictive_beta.py
@@ -39,7 +39,13 @@ class TestPredictiveBetaStatistic:
         assert result.metadata["stambaugh_adjusted"] is True
         assert result.stat > 0
         assert result.p_value < 0.01
-        assert result.n_obs == 240
+        # 240 finite pairs, 235 rows in the corrected fit: the Amihud-Hurvich
+        # design needs a lagged predictor and a horizon-summed innovation
+        # proxy, so it drops ``overlap_periods`` rows. ``n_obs`` reports the
+        # rows the headline test actually ran on; the pair count stays
+        # auditable in ``n_periods_finite``.
+        assert result.n_obs == 240 - 5
+        assert result.metadata["n_periods_finite"] == 240
         assert result.n_obs_axis == "periods"
         assert result.metadata["h0"] == "beta=0"
         assert result.metadata["newey_west_lags"] == _resolve_nw_lags(240, None, 5)
@@ -95,7 +101,10 @@ class TestPredictiveBetaStatistic:
         )
 
         result = predictive_beta(panel, overlap_periods=1)
-        assert result.n_obs == 72
+        # 72 finite pairs; the corrected fit spends the first one on the AR(1)
+        # lag, so the reported sample is 71.
+        assert result.metadata["n_periods_finite"] == 72
+        assert result.n_obs == 71
 
 
 class TestPredictiveBetaShortCircuits:
@@ -209,7 +218,10 @@ class TestPredictiveBetaNonFinite:
         result = predictive_beta(poisoned)
         assert np.isfinite(result.value)
         assert np.isfinite(result.stat)
-        assert result.n_obs == data.height - 1
+        # One poisoned cell leaves 119 finite pairs; the corrected fit at the
+        # default ``overlap_periods=5`` runs on 114 of them.
+        assert result.metadata["n_periods_finite"] == data.height - 1
+        assert result.n_obs == data.height - 1 - 5
 
     def test_nan_factor_cell_is_dropped(self):
         data = self._series()
@@ -221,7 +233,8 @@ class TestPredictiveBetaNonFinite:
         )
         result = predictive_beta(poisoned)
         assert np.isfinite(result.value)
-        assert result.n_obs == data.height - 1
+        assert result.metadata["n_periods_finite"] == data.height - 1
+        assert result.n_obs == data.height - 1 - 5
 
     def test_matches_manually_pruned_input(self):
         data = self._series()
@@ -234,6 +247,35 @@ class TestPredictiveBetaNonFinite:
         pruned = data.with_row_index("_i").filter(pl.col("_i") != 7).drop("_i")
         assert predictive_beta(poisoned).value == pytest.approx(
             predictive_beta(pruned).value
+        )
+
+
+class TestPredictiveBetaReportedSample:
+    """REGRESSION (#873): the reported counts are the corrected fit's rows.
+
+    ``n_obs`` / ``n_periods`` used to report the finite-pair count while the
+    headline slope came from the Amihud-Hurvich augmented design, which spends
+    the first observation on the AR(1) lag and, at ``h > 1``, the last
+    ``h - 1`` windows on the horizon-summed innovation proxy. The two counts
+    are both auditable now: ``n_periods_finite`` is the pre-fit pair count.
+    """
+
+    @pytest.mark.parametrize("overlap_periods", [1, 2, 5, 21])
+    def test_n_obs_counts_the_rows_the_headline_test_used(
+        self, overlap_periods: int
+    ) -> None:
+        rng = np.random.default_rng(9)
+        n_finite = 200
+        result = predictive_beta(
+            _ts_panel(rng.normal(size=n_finite), rng.normal(size=n_finite)),
+            overlap_periods=overlap_periods,
+        )
+        assert result.metadata["stambaugh_adjusted"] is True
+        assert result.metadata["n_periods_finite"] == n_finite
+        assert result.n_obs == n_finite - overlap_periods
+        assert result.metadata["n_periods"] == result.n_obs
+        assert result.metadata["n_periods_effective"] == (
+            result.n_obs // overlap_periods
         )
 
 
@@ -250,19 +292,23 @@ class TestPredictiveBetaOverlapAndPersistenceScreens:
         y = rng.normal(size=n)
         with pytest.warns(UserWarning, match="effective sample"):
             result = predictive_beta(_ts_panel(x, y), overlap_periods=21)
-        assert result.metadata["n_periods"] == n
-        assert result.metadata["n_periods_effective"] == n // 21
+        # The corrected fit drops ``overlap_periods`` rows, so the effective
+        # count reads 99 // 21, not 120 // 21.
+        assert result.metadata["n_periods_finite"] == n
+        assert result.metadata["n_periods"] == n - 21
+        assert result.metadata["n_periods_effective"] == (n - 21) // 21
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value in result.warning_codes
 
     def test_same_length_at_horizon_one_stays_clean(self):
-        # h = 1 makes the effective and raw counts identical, so the gate is
-        # exactly the pre-existing one.
+        # h = 1 makes the effective and reported counts identical, so the gate
+        # is exactly the pre-existing one. Both sit one below the finite-pair
+        # count, which the AR(1) lag consumes.
         rng = np.random.default_rng(4)
         n = 120
         result = predictive_beta(
             _ts_panel(rng.normal(size=n), rng.normal(size=n)), overlap_periods=1
         )
-        assert result.metadata["n_periods_effective"] == n
+        assert result.metadata["n_periods_effective"] == n - 1
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value not in result.warning_codes
 
     def test_persistent_residuals_flag_serial_correlation(self):

--- a/tests/test_stambaugh_bias.py
+++ b/tests/test_stambaugh_bias.py
@@ -15,6 +15,8 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix._codes import WarningCode
+from factrix._stats import _lag1_autocorr
+from factrix._stats.constants import PERSISTENT_SERIES_AUTOCORR
 from factrix._stats.ols import _amihud_hurvich_beta
 from factrix.metrics.predictive_beta import (
     _STAMBAUGH_CHANNEL_WARN,
@@ -75,9 +77,39 @@ class TestAugmentedRegressionEstimator:
         assert fit.phi_corrected > fit.phi
 
     def test_short_or_degenerate_sample_is_not_computable(self):
-        assert np.isnan(_amihud_hurvich_beta(np.arange(3.0), np.arange(3.0), lags=1))[0]
+        # Read field by field rather than ``np.isnan`` over the whole tuple:
+        # the fit now carries an array field (``resid``), so the tuple is no
+        # longer a flat float vector numpy can test elementwise.
+        too_short = _amihud_hurvich_beta(np.arange(3.0), np.arange(3.0), lags=1)
+        assert np.isnan(too_short.beta)
+        assert np.isnan(too_short.alpha)
+        assert too_short.n_used == 0
+        assert too_short.resid.size == 0
         constant = np.full(40, 2.0)
         assert np.isnan(_amihud_hurvich_beta(np.arange(40.0), constant, lags=1).beta)
+
+    def test_reports_the_rows_and_structural_residual_of_its_own_design(self):
+        """The fit exposes the sample it actually used, not the caller's ``n``.
+
+        The augmented design drops the first observation at ``h = 1`` and the
+        last ``h - 1`` windows on top of that at ``h > 1``, and its residual
+        is the STRUCTURAL one — ``y - alpha_c - beta_c x`` — not the augmented
+        regression's, which has the innovation proxy projected out of it.
+        """
+        rng = np.random.default_rng(21)
+        x, y = _stambaugh_draw(120, 0.95, -0.9, 5, rng)
+        fit = _amihud_hurvich_beta(y, x, lags=4, overlap_periods=5)
+
+        assert fit.n_used == 120 - 5
+        assert fit.resid.shape == (fit.n_used,)
+        m = fit.n_used
+        assert fit.alpha == pytest.approx(
+            float(np.mean(y[:m]) - fit.beta * np.mean(x[:m]))
+        )
+        assert fit.resid == pytest.approx(y[:m] - fit.alpha - fit.beta * x[:m])
+        # The structural residual is centred by construction; the augmented
+        # regression's own residual is not (the proxy carries a non-zero mean).
+        assert float(np.mean(fit.resid)) == pytest.approx(0.0, abs=1e-10)
 
     def test_generated_regressor_term_widens_the_standard_error(self):
         """Without it the proxy absorbs the correlated part of e and the
@@ -171,3 +203,101 @@ class TestBiasChannelWarning:
             result.metadata["beta_ols_uncorrected"] - result.value
         )
         assert result.metadata["innovation_corr"] < 0.0
+
+
+class TestCorrectedFitDiagnostics:
+    """REGRESSION (#873): every headline diagnostic describes the fit that
+    produced ``value``.
+
+    The metric used to report the corrected slope alongside an ``alpha``, an
+    ``r_squared`` and a residual screen taken off the preceding UNCORRECTED
+    OLS fit, on the full pair count rather than the rows the augmented design
+    kept. In the Stambaugh regime the two coefficients differ materially, so
+    those diagnostics described a model the caller was never shown.
+    """
+
+    @staticmethod
+    def _ols_residual(x: np.ndarray, y: np.ndarray, beta_ols: float) -> np.ndarray:
+        """OLS residual on the full sample, rebuilt from the reported slope."""
+        alpha_ols = float(np.mean(y) - beta_ols * np.mean(x))
+        return y - alpha_ols - beta_ols * x
+
+    def test_alpha_and_r_squared_name_the_fit_they_belong_to(self):
+        rng = np.random.default_rng(0)
+        x, y = _stambaugh_draw(60, 0.95, -0.9, 1, rng)
+        result = predictive_beta(_panel(x, y), overlap_periods=1, adf_threshold=None)
+
+        assert result.metadata["stambaugh_adjusted"] is True
+        beta_ols = result.metadata["beta_ols_uncorrected"]
+        # The whole point of the cell: the two slopes are materially apart, so
+        # a diagnostic taken off the wrong one is visibly wrong.
+        assert abs(result.value - beta_ols) > 0.02
+
+        # ``alpha`` closes over the corrected slope on the fit's own rows.
+        m = result.n_obs
+        assert m == len(x) - 1
+        assert result.metadata["alpha"] == pytest.approx(
+            float(np.mean(y[:m]) - result.value * np.mean(x[:m]))
+        )
+
+        # R-squared stays an OLS quantity and says so in its name. A
+        # "corrected R-squared" is not a least-squares object at all - it can
+        # go negative - so the key is labelled rather than recomputed.
+        resid_ols = self._ols_residual(x, y, beta_ols)
+        y_c = y - float(np.mean(y))
+        expected_r2 = 1.0 - float(resid_ols @ resid_ols) / float(y_c @ y_c)
+        assert result.metadata["r_squared_ols_uncorrected"] == pytest.approx(
+            expected_r2
+        )
+        assert "r_squared" not in result.metadata
+
+    def test_residual_screen_reads_the_corrected_models_residuals(self):
+        rng = np.random.default_rng(0)
+        x, y = _stambaugh_draw(60, 0.95, -0.9, 1, rng)
+        result = predictive_beta(_panel(x, y), overlap_periods=1, adf_threshold=None)
+
+        m = result.n_obs
+        corrected_resid = y[:m] - result.metadata["alpha"] - result.value * x[:m]
+        assert result.metadata["residual_lag1_autocorr"] == pytest.approx(
+            _lag1_autocorr(corrected_resid)
+        )
+
+    def test_serial_correlation_verdict_follows_the_corrected_residuals(self):
+        """A draw where the two residual series straddle the threshold.
+
+        Seed 57 of this DGP puts the uncorrected OLS residual at 0.322 and the
+        corrected model's at 0.292, either side of
+        ``PERSISTENT_SERIES_AUTOCORR`` = 0.3: the metric used to flag serial
+        correlation for a residual series it did not report.
+        """
+        rng = np.random.default_rng(57)
+        x, y = _stambaugh_draw(60, 0.95, -0.9, 1, rng)
+        result = predictive_beta(_panel(x, y), overlap_periods=1, adf_threshold=None)
+
+        beta_ols = result.metadata["beta_ols_uncorrected"]
+        ols_autocorr = _lag1_autocorr(self._ols_residual(x, y, beta_ols))
+        assert ols_autocorr > PERSISTENT_SERIES_AUTOCORR
+
+        assert result.metadata["residual_lag1_autocorr"] <= PERSISTENT_SERIES_AUTOCORR
+        assert WarningCode.SERIAL_CORRELATION_DETECTED.value not in result.warning_codes
+
+    def test_fallback_to_plain_ols_keeps_every_diagnostic_on_the_ols_fit(self):
+        """Too short for the augmented design: the reported model IS the OLS
+        one, so ``alpha``, the residual screen and the counts stay on it."""
+        rng = np.random.default_rng(31)
+        n = 24
+        x, y = _stambaugh_draw(n, 0.5, 0.0, 20, rng)
+        with pytest.warns(UserWarning, match="effective sample"):
+            result = predictive_beta(
+                _panel(x, y), overlap_periods=20, adf_threshold=None
+            )
+
+        assert result.metadata["stambaugh_adjusted"] is False
+        assert result.n_obs == n
+        assert result.metadata["n_periods_finite"] == n
+        assert result.metadata["alpha"] == pytest.approx(
+            float(np.mean(y) - result.value * np.mean(x))
+        )
+        assert result.metadata["residual_lag1_autocorr"] == pytest.approx(
+            _lag1_autocorr(self._ols_residual(x, y, result.value)[::20])
+        )


### PR DESCRIPTION
## Problem

`predictive_beta` reports the Amihud-Hurvich bias-corrected slope as `value`,
but several diagnostics were still taken off the preceding **uncorrected** OLS
fit, on a different row sample:

1. `metadata["r_squared"]` came from the OLS residual while `value` / `alpha`
   described the corrected slope. At `T=60, phi=0.95, rho=-0.9` the reported
   `r_squared` was `0.0029` while the same quantity recomputed from the
   reported `alpha` and `value` was `-0.052` — a different coefficient, not
   rounding.
2. `metadata["residual_lag1_autocorr"]` and the `SERIAL_CORRELATION_DETECTED`
   verdict read the OLS residuals. On draws where the two slopes are far
   apart this flips the warning: seed 57 of the reporter's design puts the
   OLS residual at `0.322` and the corrected model's at `0.292`, either side
   of the `0.3` threshold.
3. `alpha` closed over `mean(y) - beta_c * mean(x)` on all `n` finite pairs,
   while the augmented design fits `n - overlap_periods` rows. `n_obs`,
   `n_periods` and `n_periods_effective` all reported `n`, so the
   `UNRELIABLE_SE_SHORT_PERIODS` gate read a sample the test never had.
4. The Notes still said "factrix applies no Stambaugh correction" —
   contradicting the headline, in the docstring and on the docs page.

Closes #873.

## Change

`AmihudHurvichFit` now carries what the caller needs to describe its own fit:
`alpha` (the intercept the corrected slope implies on the fitted rows —
*not* the augmented regression's intercept, which absorbs the innovation
proxy), `n_used` (the `n - h` rows the design ran on) and `resid` (the
structural residual `y - alpha - beta*x` on those rows). `resid` is the
quantity the estimator already computed for `rho`; it is now centred on the
structural intercept rather than the augmented one, which is a constant shift
and leaves `rho` unchanged.

In `predictive_beta`, when the correction applies:

- `alpha` ← `fit.alpha`
- `residual_lag1_autocorr` and the serial-correlation screen ←
  `_lag1_autocorr(fit.resid[::overlap_periods])`
- `n_obs`, `n_periods` ← `fit.n_used`; `n_periods_effective` ←
  `fit.n_used // overlap_periods`, which is what the short-sample gate reads
- new `n_periods_finite` = the finite-pair count before the design trimmed
  its rows, so both counts stay auditable

When the sample is too short for the augmented design and `value` falls back
to plain OLS, every diagnostic stays on the OLS quantities and on `n` —
the reported model *is* the OLS one there. The pre-flight
`insufficient_predictive_periods` floor still gates on the finite-pair count,
since it runs before the fit.

R-squared is **renamed**, not recomputed. A "corrected R²" is not a
least-squares object: the AH slope does not minimise the sum of squares, so
`1 - SSR/SST` off its residual can go negative, and the Stambaugh/AH
literature reports R² for the OLS regression. `r_squared` becomes
`r_squared_ols_uncorrected`, the same family as the existing
`beta_ols_uncorrected`.

## Breaking notes

- `metadata["r_squared"]` is **removed**; use
  `metadata["r_squared_ols_uncorrected"]`. It is the same number — it is now
  labelled with the fit it belongs to.
- `n_obs` and `metadata["n_periods"]` shrink by `overlap_periods` whenever
  the correction applies (`n_finite - 1` at `overlap_periods = 1`).
  `metadata["n_periods_finite"]` carries the old value.
- `n_periods_effective` falls with it, so a run sitting just above
  `MIN_PERIODS_WARN` on the old count can now raise
  `UNRELIABLE_SE_SHORT_PERIODS`. That is the point: the gate now reads the
  sample the standard error actually has.

## Tests

New coverage in `tests/test_stambaugh_bias.py`:

- `test_alpha_and_r_squared_name_the_fit_they_belong_to` — Stambaugh design
  (`T=60, phi=0.95, rho=-0.9`, seed 0) where the two slopes differ
  materially; asserts `alpha == mean(y_used) - value*mean(x_used)` on the
  fit's rows, that `r_squared_ols_uncorrected` equals the OLS R² recomputed
  from `beta_ols_uncorrected`, and that the bare `r_squared` key is gone.
- `test_residual_screen_reads_the_corrected_models_residuals` — recomputes
  the lag-1 autocorrelation independently from `value`, `alpha` and the row
  sample.
- `test_serial_correlation_verdict_follows_the_corrected_residuals` — seed 57
  of the same design, where the OLS residual crosses `0.3` and the corrected
  one does not; asserts the warning does not fire.
- `test_fallback_to_plain_ols_keeps_every_diagnostic_on_the_ols_fit`.
- `test_reports_the_rows_and_structural_residual_of_its_own_design` on the
  estimator itself.

New in `tests/test_predictive_beta.py`:
`TestPredictiveBetaReportedSample` parametrises `overlap_periods` over
`{1, 2, 5, 21}` and asserts `n_obs == n_finite - overlap_periods` and
`n_periods_effective == n_obs // overlap_periods`.

Existing count assertions were updated to the new contract with an inline
note explaining why each shifted.

Commands run, all green:

```
uv run pytest tests/test_predictive_beta.py tests/test_stambaugh_bias.py -q
    44 passed
uv run pytest -q
    2905 passed, 3 skipped in 137.70s
uv run ruff check . && uv run ruff format --check .
uv run mypy factrix
uv run pre-commit run --hook-stage pre-push --all-files
```
