### PR TITLE
fix(metrics)!: separate rebalance lag and holding periods

### DIFF
--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -36,6 +36,28 @@ rather than silently overriding the data. Both surface on the result —
 [Evaluating on a coarser grid](preprocess.md#evaluating-on-a-coarser-grid)
 for why the two are kept apart.
 
+### Two more period counts the tradability metrics declare
+
+On a full evaluation grid all four counts below are the same number, which is
+why one name used to carry all of them. They separate as soon as the
+evaluation grid is coarser than the return horizon.
+
+| Quantity | Question | Unit | Declared on |
+|---|---|---|---|
+| `forward_periods` | Economic horizon: over how many periods was the return measured? | Underlying period grid | `compute_forward_return`; stamped |
+| `overlap_periods` | Inference: how many adjacent evaluation observations share future periods? | Evaluation-grid observations | Derived and stamped; injected, never a metric knob |
+| `rebalance_lag` | Turnover: how far apart are the rankings / memberships compared? | Evaluation-grid observations | `rank_turnover()`, `notional_turnover()` |
+| `holding_periods` | Cost amortisation: how many return periods pass between paying trading cost? | Underlying period grid | `breakeven_cost()`, `net_spread()` |
+
+`rebalance_lag` defaults to the injected `overlap_periods` — horizon-aligned
+turnover, the historical behaviour. Pass `rebalance_lag=1` when the evaluation
+grid *is* the rebalance schedule. `holding_periods` has no default tie to the
+stamp: `gross_spread` is per underlying return period (`compute_forward_return`
+divides by `forward_periods`), so the cost must be amortised over underlying
+periods too. Substituting the derived evaluation-grid overlap there is a unit
+error, not a conservative choice — see the
+[tradability migration note](metrics/tradability.md#migration--the-holding_periods-rename).
+
 ## Use cases
 
 <div class="grid cards" markdown>

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -46,32 +46,94 @@ title: factrix.metrics.tradability
     **not** for cost arithmetic. Because $\rho \in [-1, +1]$, the value
     lies in $[0, 2]$ — not $[0, 1]$: a stable ranking gives 0, an
     independent re-draw gives $\approx 1$, a reversed ranking up to 2.
-    `n_obs` counts adjacent-period transitions (`n_obs_axis="periods"`).
+    `n_obs` counts transitions at the rebalance lag
+    (`n_obs_axis="periods"`).
 
 -   __Breakeven cost in bps__
 
     ---
 
-    `breakeven_cost = gross_spread \cdot h / (4 \cdot \tau) \cdot 10^4`.
-    If the venue's actual **one-way** cost is below this, the factor's
-    alpha survives. The `\cdot h` lift puts per-period spread onto the
-    per-rebalance scale of $\tau$. The $4\tau$ is two legs times two
-    trades (sell the leaver, buy the joiner) per unit of per-leg
-    turnover; halve a round-trip quote before comparing it to this
-    number. See the `breakeven_cost` Notes for the full derivation.
+    `breakeven_cost = gross_spread \cdot H / (4 \cdot \tau) \cdot 10^4`,
+    where $H$ is `holding_periods`. If the venue's actual **one-way**
+    cost is below this, the factor's alpha survives. The $\cdot H$ lift
+    puts the per-underlying-period spread onto the per-rebalance scale
+    of $\tau$. The $4\tau$ is two legs times two trades (sell the
+    leaver, buy the joiner) per unit of per-leg turnover; halve a
+    round-trip quote before comparing it to this number. See the
+    `breakeven_cost` Notes for the full derivation.
 
 -   __Net spread after estimated costs__
 
     ---
 
-    `net_spread = gross_spread - 4 \cdot (cost_{bps} / 10^4) \cdot \tau / h`,
+    `net_spread = gross_spread - 4 \cdot (cost_{bps} / 10^4) \cdot \tau / H`,
     with `cost_bps` quoted **one-way**. The cost is paid once per
-    $h$-period rebalance, so dividing by $h$ amortises it back to the
-    per-period scale of `gross_spread` — without that, any factor with
-    $h \geq 2$ would be artificially killed. `breakeven_cost` inverts
-    this same $4\tau$ coefficient, so the two stay consistent.
+    rebalance, i.e. once per $H$ underlying return periods, so dividing
+    by $H$ amortises it back to the scale of `gross_spread` — without
+    that, any multi-period holding would be artificially killed.
+    `breakeven_cost` inverts this same $4\tau$ coefficient, so the two
+    stay consistent.
 
 </div>
+
+## Four period counts, four questions
+
+The tradability surface touches all four of the period counts factrix keeps
+apart. They coincide on a full evaluation grid and come apart the moment
+`compute_forward_return(..., dates=)` puts the evaluation grid on a coarser
+spacing than the return horizon.
+
+| Quantity | Question it answers | Unit | Who declares it |
+|---|---|---|---|
+| `forward_periods` | Over how many periods was the return measured? | Underlying period grid | `compute_forward_return`; stamped |
+| `overlap_periods` | How many adjacent evaluation observations share future periods? | Evaluation-grid observations | Derived and stamped; injected into metrics |
+| `rebalance_lag` | How far apart are the rankings / memberships being compared? | Evaluation-grid observations | The user, on `rank_turnover` / `notional_turnover` |
+| `holding_periods` | How many return periods pass between paying trading cost? | Underlying period grid | The user, on `breakeven_cost` / `net_spread` |
+
+!!! warning "Do not substitute one for another"
+    `rebalance_lag` defaults to the injected `overlap_periods`, which
+    reproduces the horizon-aligned turnover the metrics have always reported.
+    Pass `rebalance_lag=1` when the evaluation grid *is* the rebalance
+    schedule. `holding_periods` has no such default relationship to the stamp:
+    it must be the rebalance interval measured in **underlying return
+    periods**, because `gross_spread` is normalised to that unit
+    (`compute_forward_return` divides by `forward_periods`).
+
+!!! example "Worked numbers — the 10x cost-drag error"
+    A signal holding 20 underlying return periods per rebalance, evaluated on
+    a coarse grid whose derived `overlap_periods` is 2. At
+    `gross_spread = 0.001`, `turnover = 0.20` and a one-way cost of 30 bps:
+
+    ```text
+    holding_periods=20  ->  drag = 4 * 0.003 * 0.20 / 20 = 0.00012, net =  0.00088
+    overlap_periods=2   ->  drag = 4 * 0.003 * 0.20 /  2 = 0.00120, net = -0.00020
+    ```
+
+    Breakeven is 250 bps at 20 underlying periods and 25 bps at overlap 2 —
+    a 10x error that flips the sign of the net spread.
+
+### Migration — the `holding_periods` rename
+
+`breakeven_cost` and `net_spread` take `holding_periods=`. The keyword was
+`forward_periods=` up to `v0.22.0` and `overlap_periods=` in `v0.23.0`; there
+is no deprecation shim, so a call using either older name raises `TypeError`.
+
+- **From `forward_periods=`** — pass the same number as `holding_periods=`.
+  The unit is unchanged: underlying return periods between rebalances.
+- **From `overlap_periods=`** — pass the rebalance interval in underlying
+  return periods, *not* the panel's derived evaluation-grid overlap. On a full
+  grid the two coincide and the number is the same; on a panel built with
+  `compute_forward_return(..., dates=)` they differ, and substituting the
+  derived overlap is exactly the unit error above.
+- **The stride pairing check is gone.** `breakeven_cost` / `net_spread` used
+  to reject a call whose keyword disagreed with the upstream producer's
+  `overlap_periods`. That check compared two different units once the
+  evaluation grid could differ from the horizon, so it is removed;
+  `holding_periods` is recorded in metadata instead. The `n_groups` bucketing
+  check is unchanged.
+- **`rank_turnover` / `notional_turnover` are unaffected by the rename.** They
+  keep the injected `overlap_periods` as their default stride and gain the
+  optional `rebalance_lag=`.
 
 ## Choosing a function
 
@@ -110,19 +172,21 @@ title: factrix.metrics.tradability
     # The scalar helpers take the gross spread positionally and every other
     # parameter by keyword. Pass the MetricResults, not their .value: the
     # helper then verifies the two describe the same portfolio.
-    be  = breakeven_cost(spread, turnover=tau, forward_periods=5)
+    # holding_periods is the rebalance interval in underlying return periods.
+    # On this full grid that is the forward_periods the return was built at.
+    be  = breakeven_cost(spread, turnover=tau, holding_periods=5)
     net = net_spread(spread, turnover=tau,
-                     estimated_cost_bps=30.0, forward_periods=5)
+                     estimated_cost_bps=30.0, holding_periods=5)
     print(be.value, net.value)
     # 36.0   0.00043   (approximate; one-way bps and per-period spread)
     ```
 
 !!! warning "The spread and the turnover must price the same portfolio"
     The cost algebra is a statement about *one* book, so a τ measured on
-    decile membership churn does not price a quintile spread, and a τ per bar
-    does not price a 5-period holding. `quantile_spread` and
+    decile membership churn does not price a quintile spread, and a τ per
+    period does not price a multi-period holding. `quantile_spread` and
     `notional_turnover` used to ship incompatible defaults (`n_groups` 5 vs
-    10, `forward_periods` 5 vs 1). On a 60-name, 400-period panel at
+    10, stride 5 vs 1). On a 60-name, 400-period panel at
     `gross_spread = 0.001`, the matched pair gives breakeven **15.7 bps** and
     net **−9.14 bps**; each function at its own default gave **2.8 bps** and
     **−98.02 bps** — breakeven understated 5.6×, drag overstated 10.7×.
@@ -130,10 +194,16 @@ title: factrix.metrics.tradability
     They now share one constant (`DEFAULT_N_GROUPS = 5`,
     `DEFAULT_FORWARD_PERIODS = 5`), so the defaults pair by construction. And
     when handed the producing `MetricResult`s rather than bare floats,
-    `breakeven_cost` / `net_spread` cross-check `n_groups` and
-    `forward_periods` and raise `UserInputError` on a mismatch, recording
-    `pairing_checked` in metadata otherwise. Bare floats carry no provenance,
-    so nothing can be verified — prefer passing the results.
+    `breakeven_cost` / `net_spread` cross-check `n_groups` and raise
+    `UserInputError` on a mismatch, recording `pairing_checked` in metadata
+    otherwise. Bare floats carry no provenance, so nothing can be verified —
+    prefer passing the results.
+
+    `holding_periods` is **not** cross-checked against the producers. It
+    describes the trading schedule in underlying return periods, which no
+    upstream metadata records; the stride a producer *does* record is an
+    evaluation-grid count, so equality between the two would not have been
+    evidence of a correctly paired book.
 
     `monotonicity` deliberately keeps its own `n_groups=10`: a decile curve is
     the shape it is calibrated to read, not a long-short leg.

--- a/docs/examples/stock_factor_evaluation.md
+++ b/docs/examples/stock_factor_evaluation.md
@@ -262,7 +262,7 @@ Read the diagnostics table before treating a low p-value as comparable across fa
 
 ## 8. Translate gross spread into net feasibility
 
-The `spread` metric is a gross per-period Q1/Q5 spread, and the `turnover` metric below is notional Q1/Q5 membership churn per rebalance because it came from `notional_turnover(n_groups=5)`. That pair can feed the scalar cost helpers. Keep this arithmetic outside `evaluate()`: it is a pre-strategy feasibility read, not an execution simulation.
+The `spread` metric is a gross per-period Q1/Q5 spread, and the `turnover` metric below is notional Q1/Q5 membership churn per rebalance because it came from `notional_turnover(n_groups=5)`. That pair can feed the scalar cost helpers. `holding_periods` is the rebalance interval in underlying return periods — the unit `gross_spread` is normalised to — which on this full evaluation grid is the horizon the return was built at. Keep this arithmetic outside `evaluate()`: it is a pre-strategy feasibility read, not an execution simulation.
 
 ```python
 cost_rows = []
@@ -277,13 +277,13 @@ for res in results.values():
             "breakeven_cost_bps": breakeven_cost(
                 gross_spread,
                 turnover=turnover,
-                forward_periods=res.forward_periods,
+                holding_periods=res.forward_periods,
             ).value,
             "net_spread_30bps": net_spread(
                 gross_spread,
                 turnover=turnover,
                 estimated_cost_bps=30.0,
-                forward_periods=res.forward_periods,
+                holding_periods=res.forward_periods,
             ).value,
         }
     )

--- a/docs/guides/validating-allocation-signals.md
+++ b/docs/guides/validating-allocation-signals.md
@@ -107,7 +107,12 @@ The built-in tradability helpers describe one specific proxy:
 | `net_spread` | Matching gross spread after that cost assumption |
 | `rank_turnover` | Rank stability only; not a position-turnover or cost input |
 
-Use the same `n_groups` and `forward_periods` for the spread and turnover.
+Use the same `n_groups` for the spread and the turnover. On an evaluation grid
+built with `compute_forward_return(..., dates=)`, pass `rebalance_lag=1` to the
+turnover metrics when that grid *is* the rebalance schedule, and give
+`breakeven_cost` / `net_spread` a `holding_periods` in **underlying return
+periods** — never the derived evaluation-grid `overlap_periods`.
+
 These helpers do not price a long-only or custom-weight allocation. Compute
 turnover, slippage, market impact, borrow, and capacity from the actual target
 weights downstream. See [Tradability](../api/metrics/tradability.md) for units

--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -82,7 +82,7 @@ Min sample*. `MIN_*` constants resolve to values in the
 
 | Metric | Sample axis | Min sample |
 |---|---|---|
-| [`rank_turnover`][factrix.metrics.tradability.rank_turnover] | `T` | `T >= 2*forward_periods + 1` |
+| [`rank_turnover`][factrix.metrics.tradability.rank_turnover] | `T` | `T >= 2*rebalance_lag + 1` |
 | [`notional_turnover`][factrix.metrics.tradability.notional_turnover] | `T` | `T >= 2` |
 | [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | scalar | `notional_turnover > 0` |
 | [`net_spread`][factrix.metrics.tradability.net_spread] | scalar | spread + cost provided |

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -882,26 +882,39 @@ inference.
 
 - *descriptive*: `mean_rank_autocorrelation`,
   `std_rank_autocorrelation`, `n_pairs`, `overlap_periods`,
-  `quantile`, `n_cross_section_mean`.
+  `rebalance_lag`, `quantile`, `n_cross_section_mean`.
 
 #### `notional_turnover`
 
 - *descriptive*: `n_rebalances`, `n_groups`, `overlap_periods`,
-  `mean_tail_size`.
+  `rebalance_lag`, `mean_tail_size`.
+
+Both turnover metrics report two strides. `overlap_periods` is the panel's
+evaluation-grid overlap stamp — an inference quantity, injected, never a user
+knob. `rebalance_lag` is the stride the metric actually paired consecutive
+observations at, counted in evaluation-grid observations; it equals
+`overlap_periods` unless the caller passed `rebalance_lag=`.
 
 #### `breakeven_cost`
 
 Scalar-input metric (consumes pre-aggregated scalars rather than a
 date-keyed DataFrame).
 
-- *descriptive*: `gross_spread`, `turnover`, `overlap_periods`.
+- *descriptive*: `gross_spread`, `turnover`, `holding_periods`.
 
 #### `net_spread`
 
 Scalar-input metric.
 
 - *descriptive*: `gross_spread`, `cost_drag`, `estimated_cost_bps`,
-  `turnover`, `overlap_periods`.
+  `turnover`, `holding_periods`.
+
+`holding_periods` is the cost-amortisation interval: the number of
+**underlying return periods** between rebalances, the same unit
+`compute_forward_return` normalises `gross_spread` to. It is neither the
+evaluation-grid `overlap_periods` nor the turnover metrics' `rebalance_lag`.
+Both helpers also record `n_groups` and `pairing_checked` when handed the
+producing `MetricResult`s rather than bare floats.
 
 ## Short-circuit envelope
 

--- a/examples/stock_factor_evaluation.ipynb
+++ b/examples/stock_factor_evaluation.ipynb
@@ -401,7 +401,7 @@
    "source": [
     "## 8. Translate gross spread into net feasibility\n",
     "\n",
-    "The `spread` metric is a gross per-period Q1/Q5 spread, and the `turnover` metric below is notional Q1/Q5 membership churn per rebalance because it came from `notional_turnover(n_groups=5)`. That pair can feed the scalar cost helpers. Keep this arithmetic outside `evaluate()`: it is a pre-strategy feasibility read, not an execution simulation.\n"
+    "The `spread` metric is a gross per-period Q1/Q5 spread, and the `turnover` metric below is notional Q1/Q5 membership churn per rebalance because it came from `notional_turnover(n_groups=5)`. That pair can feed the scalar cost helpers. `holding_periods` is the rebalance interval in underlying return periods — the unit `gross_spread` is normalised to — which on this full evaluation grid is the horizon the return was built at. Keep this arithmetic outside `evaluate()`: it is a pre-strategy feasibility read, not an execution simulation.\n"
    ]
   },
   {
@@ -423,13 +423,13 @@
     "            \"breakeven_cost_bps\": breakeven_cost(\n",
     "                gross_spread,\n",
     "                turnover=turnover,\n",
-    "                forward_periods=res.forward_periods,\n",
+    "                holding_periods=res.forward_periods,\n",
     "            ).value,\n",
     "            \"net_spread_30bps\": net_spread(\n",
     "                gross_spread,\n",
     "                turnover=turnover,\n",
     "                estimated_cost_bps=30.0,\n",
-    "                forward_periods=res.forward_periods,\n",
+    "                holding_periods=res.forward_periods,\n",
     "            ).value,\n",
     "        }\n",
     "    )\n",

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -182,6 +182,16 @@ Small cross-sections reduce power; they do not change the estimand. For an
   equal-weight top/bottom proxy. A long-only or custom-weight portfolio must
   compute turnover and execution costs from its actual weights downstream;
   `rank_turnover` is not a cost input.
+- Four period counts, identical on a full grid and distinct on a coarser one:
+  `forward_periods` (economic horizon, underlying period grid),
+  `overlap_periods` (inference, evaluation-grid observations, injected),
+  `rebalance_lag` (turnover comparison stride, evaluation-grid observations,
+  optional on `rank_turnover` / `notional_turnover`, defaults to the injected
+  overlap) and `holding_periods` (cost amortisation, underlying period grid,
+  required unit on `breakeven_cost` / `net_spread`). Never substitute the
+  derived `overlap_periods` for `holding_periods`: `gross_spread` is per
+  underlying return period, so that swap mis-states cost drag by the ratio of
+  the two.
 - Treat `by_slice`, `spanning_alpha`, and `pooled_beta` as follow-up robustness
   evidence, not an unregistered any-pass promotion gate.
 

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -191,6 +191,13 @@ class MetricBase(metaclass=MetricMeta):
     # can read ``self.overlap_periods`` — every metric that sub-samples carries it
     # as a dataclass field; metrics without it never resolve a stride-scaled floor.
     overlap_periods: int
+    # Rebalance stride the turnover metrics pair at, in evaluation-grid
+    # observations. Declared here for the same reason as ``overlap_periods``:
+    # a floor resolver typed ``Callable[[MetricBase], SampleThreshold]`` reads
+    # it off the instance. Unlike the horizon it is a user knob — ``None``
+    # means "fall back to the injected overlap" — and only the metrics that
+    # pair consecutive rebalances carry it as a field.
+    rebalance_lag: int | None
     _impl: ClassVar[Callable]
     _first_param_name: ClassVar[str | None]
     _param_names: ClassVar[tuple[str, ...]]

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -75,20 +75,45 @@ __all__ = [  # noqa: RUF022 (teaching order, see SSOT note)
 ]
 
 
-def _rank_turnover_min_dates(overlap_periods: int) -> int:
+def _resolve_rebalance_lag(rebalance_lag: int | None, overlap_periods: int) -> int:
+    """Stride the turnover metrics pair consecutive rebalances at.
+
+    WHY: ``overlap_periods`` is the panel's *inference* quantity — how many
+    adjacent evaluation observations share future periods — and ``evaluate``
+    injects it from the panel's stamp. It stopped being the rebalance schedule
+    once ``compute_forward_return(..., dates=)`` could put the evaluation grid
+    on a different spacing from the return horizon: the schedule a portfolio
+    trades on is a fact about the strategy, not about the return windows.
+    ``rebalance_lag`` states that fact in evaluation-grid observations;
+    ``None`` keeps the injected overlap, which on the full grid is the
+    horizon-aligned stride these metrics have always used.
+    """
+    return overlap_periods if rebalance_lag is None else rebalance_lag
+
+
+def _validate_rebalance_lag(rebalance_lag: int | None) -> None:
+    """``rebalance_lag`` is optional, but a supplied value is a positive count."""
+    if rebalance_lag is not None and rebalance_lag < 1:
+        raise ValueError(f"rebalance_lag must be ≥ 1, got {rebalance_lag!r}")
+
+
+def _rank_turnover_min_dates(rebalance_lag: int) -> int:
     """Raw-date floor for ``rank_turnover``: the non-overlap pair stride ``h`` needs
     >= 3 sampled dates (>= 2 non-overlapping pairs so ``std(rho)`` is defined),
     i.e. >= ``2*h + 1`` raw dates (Hansen & Hodrick 1980).
     """
-    return 2 * overlap_periods + 1
+    return 2 * rebalance_lag + 1
 
 
 def _rank_turnover_sample_threshold(self: MetricBase) -> SampleThreshold:
-    """Dynamic periods floor for ``rank_turnover``, scaling with ``overlap_periods``.
-    Delegates to the same ``_rank_turnover_min_dates`` the in-body short-circuit
-    reads, so the pre-flight and run-time floors agree.
+    """Dynamic periods floor for ``rank_turnover``, scaling with the *resolved*
+    rebalance lag. Reads the same ``_resolve_rebalance_lag`` /
+    ``_rank_turnover_min_dates`` pair the in-body short-circuit reads, so a
+    configured ``rebalance_lag`` moves the pre-flight floor and the run-time
+    floor together instead of leaving pre-flight on the injected overlap.
     """
-    return SampleThreshold(min_periods=_rank_turnover_min_dates(self.overlap_periods))
+    lag = _resolve_rebalance_lag(self.rebalance_lag, self.overlap_periods)
+    return SampleThreshold(min_periods=_rank_turnover_min_dates(lag))
 
 
 @metric(
@@ -101,20 +126,27 @@ def rank_turnover(
     data: pl.DataFrame,
     factor_col: str = "factor",
     overlap_periods: int = 1,
+    rebalance_lag: int | None = None,
     quantile: float | None = None,
 ) -> MetricResult:
     r"""Factor rank-stability via non-overlapping rank autocorrelation.
 
-    The periods floor is dynamic — the minimum date count is ``2*overlap_periods + 1`` — so it is declared as a resolver (a callable sample_threshold) rather than a constant, letting inspect_data pre-flight it.
+    The periods floor is dynamic — the minimum date count is ``2*rebalance_lag + 1`` — so it is declared as a resolver (a callable sample_threshold) rather than a constant, letting inspect_data pre-flight it.
 
     $\text{rank_turnover} = 1 - \mathrm{mean}(\bar\rho)$ where $\bar\rho$ is the mean rank autocorrelation
 
     **What this measures.** Sensitivity of the *full* cross-section rank
-    vector to reshuffling between ``t`` and ``t + overlap_periods``. Mid-rank
-    churn (names moving between e.g. Q4 ↔ Q5 in a 10-group split) counts
-    even though those names carry zero weight in a Q1/Qn long-short
-    portfolio. So this is a **rank-stability diagnostic**, *not* a notional
-    trading-fraction.
+    vector to reshuffling between ``t`` and ``t + lag``, where ``lag`` is the
+    resolved rebalance lag below. Mid-rank churn (names moving between e.g.
+    Q4 ↔ Q5 in a 10-group split) counts even though those names carry zero
+    weight in a Q1/Qn long-short portfolio. So this is a **rank-stability
+    diagnostic**, *not* a notional trading-fraction.
+
+    At ``rebalance_lag=None`` (the default) the metric measures
+    **horizon-aligned rank stability** — the stride is the panel's overlap,
+    which on the full grid is the return horizon. At ``rebalance_lag=1`` it
+    measures **adjacent-rebalance turnover**: how much the ranking moves from
+    one evaluation observation to the next.
 
     **When to use this vs ``notional_turnover``.** Feed a strategy-cost
     formula (breakeven_cost / net_spread) with ``notional_turnover``, not
@@ -123,17 +155,29 @@ def rank_turnover(
     does not provide. Keep this metric for ranking-stability comparisons
     across factors.
 
-    Rank autocorrelation is measured between dates ``t`` and ``t +
-    overlap_periods``, sub-sampled at stride ``overlap_periods`` (phase-0)
-    so each transition is a non-overlapping snapshot. This aligns the stability
-    window with the forward-return horizon used elsewhere in the profile.
+    Rank autocorrelation is measured between dates ``t`` and ``t + lag``,
+    sub-sampled at stride ``lag`` (phase-0) so each transition is a
+    non-overlapping snapshot.
 
     Args:
         data: Panel with ``date, asset_id, factor``.
         factor_col: Name of the factor column. Defaults to ``"factor"``.
-        overlap_periods: Sampling stride in periods — should match the
-            forward-return horizon the factor is being evaluated against.
-            ``1`` reproduces the lag-1 behaviour.
+        overlap_periods: The panel's evaluation-grid overlap. Injected by
+            ``evaluate`` from the ``compute_forward_return`` stamp, or read
+            from the stamp on a standalone call — not a user knob. Used only
+            as the fallback stride when ``rebalance_lag`` is not given.
+        rebalance_lag: Rebalance stride, counted in **evaluation-grid
+            observations** (periods of the panel handed to the metric). Must
+            be a positive ``int``. ``None`` (default) falls back to
+            ``overlap_periods``, reproducing the historical behaviour: on the
+            full grid that stamp equals the return horizon, i.e. the standard
+            holding-period-aligned turnover convention (Alphalens'
+            ``factor_rank_autocorrelation(period=holding)``). On a coarser
+            evaluation grid the stamp is the *derived* overlap, which equals
+            the horizon in evaluation observations only when that grid is
+            evenly spaced — the conservative max-count derivation inflates it
+            otherwise. Pass ``rebalance_lag=1`` when the evaluation grid *is*
+            the rebalance schedule.
         quantile: Optional tail filter in ``(0, 0.5)``. When set, restrict
             the Spearman ρ at each pair to assets whose rank at *either*
             endpoint lies in the top-q or bottom-q of that date's cross-
@@ -149,7 +193,8 @@ def rank_turnover(
     Returns:
         MetricResult with ``value = 1 − mean(ρ)`` and metadata
         carrying ``mean_rank_autocorrelation``, ``std_rank_autocorrelation``,
-        ``n_periods``, ``overlap_periods``, ``quantile``, and
+        ``n_periods``, ``overlap_periods`` (the panel's stamp, unchanged),
+        ``rebalance_lag`` (the stride actually paired at), ``quantile``, and
         ``n_cross_section_mean`` (mean assets-per-transition post-filter).
 
         The value lies in ``[0, 2]``, not ``[0, 1]``: ρ ranges over
@@ -191,7 +236,7 @@ def rank_turnover(
         >>> import factrix as fx
         >>> from factrix.metrics.tradability import rank_turnover
         >>> panel = fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0)
-        >>> result = rank_turnover(panel, overlap_periods=5)
+        >>> result = rank_turnover(panel, rebalance_lag=1)
         >>> result.name == ""
         True
     """
@@ -199,11 +244,13 @@ def rank_turnover(
         raise ValueError(f"quantile must be in (0, 0.5), got {quantile!r}")
     if overlap_periods < 1:
         raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
+    _validate_rebalance_lag(rebalance_lag)
+    lag = _resolve_rebalance_lag(rebalance_lag, overlap_periods)
 
     all_dates = data["date"].unique().sort()
     # Need ≥ 2 non-overlapping pairs so std(ρ) is defined; that requires
     # ≥ 3 sampled dates (Hansen & Hodrick 1980), i.e. ≥ 2·h + 1 raw dates.
-    min_required = _rank_turnover_min_dates(overlap_periods)
+    min_required = _rank_turnover_min_dates(lag)
     if len(all_dates) < min_required:
         return _short_circuit_output(
             "rank_turnover",
@@ -212,6 +259,7 @@ def rank_turnover(
             n_obs_axis="periods",
             min_required=min_required,
             overlap_periods=overlap_periods,
+            rebalance_lag=lag,
         )
 
     # WHY: polars ``rank()`` sorts NaN *last*, i.e. treats it as larger than
@@ -221,9 +269,7 @@ def rank_turnover(
     # outside the metric's own [0, 1] range — on a panel with 20% NaN factor
     # cells. Every other ranking site in the library filters first; this was
     # the last one that did not.
-    sampled_df = _sample_non_overlapping(data, overlap_periods).filter(
-        _finite_expr(factor_col)
-    )
+    sampled_df = _sample_non_overlapping(data, lag).filter(_finite_expr(factor_col))
 
     ranked = sampled_df.select(
         "date",
@@ -267,6 +313,7 @@ def rank_turnover(
             n_obs_axis="periods",
             min_required=2,
             overlap_periods=overlap_periods,
+            rebalance_lag=lag,
             quantile=quantile,
         )
 
@@ -286,6 +333,7 @@ def rank_turnover(
             "std_rank_autocorrelation": std_rc,
             "n_periods": rc_per_date.height,
             "overlap_periods": overlap_periods,
+            "rebalance_lag": lag,
             "quantile": quantile,
             "n_cross_section_mean": n_cs_mean,
         },
@@ -318,6 +366,7 @@ def notional_turnover(
     factor_col: str = "factor",
     *,
     n_groups: int = DEFAULT_N_GROUPS,
+    rebalance_lag: int | None = None,
     overlap_periods: int = DEFAULT_FORWARD_PERIODS,
 ) -> MetricResult:
     """Portfolio notional turnover via top/bottom quantile membership churn.
@@ -350,32 +399,48 @@ def notional_turnover(
             :data:`~factrix._types.DEFAULT_N_GROUPS` = 5 = quintiles, the
             same constant ``quantile_spread`` defaults to). Must be ≥ 3 so
             top and bottom are distinct buckets.
-        overlap_periods: Rebalance stride (default
-            :data:`~factrix._types.DEFAULT_FORWARD_PERIODS`). When ``> 1``,
-            sub-samples at stride ``h`` before pairing consecutive dates —
-            matches a holding-period-aligned rebalance schedule.
+        rebalance_lag: Rebalance stride, counted in **evaluation-grid
+            observations** (periods of the panel handed to the metric). Must
+            be a positive ``int``. When ``> 1``, sub-samples at that stride
+            before pairing consecutive dates. ``None`` (default) falls back to
+            ``overlap_periods``: on the full grid that stamp equals the return
+            horizon, giving the holding-period-aligned membership churn this
+            metric has always reported; on a coarser evaluation grid it is the
+            *derived* overlap, which matches the horizon in evaluation
+            observations only when that grid is evenly spaced. Pass
+            ``rebalance_lag=1`` when the evaluation grid *is* the rebalance
+            schedule — then the value is adjacent-rebalance membership churn.
+        overlap_periods: The panel's evaluation-grid overlap (default
+            :data:`~factrix._types.DEFAULT_FORWARD_PERIODS`). Injected by
+            ``evaluate`` from the ``compute_forward_return`` stamp, not a user
+            knob; used only as the fallback stride when ``rebalance_lag`` is
+            not given.
 
     Warning:
-        ``n_groups`` and ``overlap_periods`` must match the ``quantile_spread``
-        run whose spread is paired with this turnover. The cost algebra in
-        ``breakeven_cost`` / ``net_spread`` is a statement about *one*
-        portfolio, so a τ measured on decile membership churn does not price a
-        quintile spread, and a τ per bar does not price a 5-period holding.
-        The two used to ship incompatible defaults (10 / 1 here against 5 / 5
-        there); on a 60-name, 400-period panel at ``gross_spread = 0.001``, the
-        matched pair gave breakeven 15.7 bps and net −9.14 bps while each
-        function at its own default gave 2.8 bps and −98.02 bps — breakeven
-        understated 5.6x, drag overstated 10.7x. They now share one constant,
-        and the consumers cross-check the pairing when handed ``MetricResult``s
-        instead of bare floats.
+        ``n_groups`` must match the ``quantile_spread`` run whose spread is
+        paired with this turnover, and both must describe the same rebalance
+        schedule. The cost algebra in ``breakeven_cost`` / ``net_spread`` is a
+        statement about *one* portfolio, so a τ measured on decile membership
+        churn does not price a quintile spread, and a τ per period does not
+        price a multi-period holding. The two used to ship incompatible
+        defaults (10 / 1 here against 5 / 5 there); on a 60-name, 400-period
+        panel at ``gross_spread = 0.001``, the matched pair gave breakeven
+        15.7 bps and net −9.14 bps while each function at its own default gave
+        2.8 bps and −98.02 bps — breakeven understated 5.6x, drag overstated
+        10.7x. They now share one constant, and the consumers cross-check
+        ``n_groups`` when handed ``MetricResult``s instead of bare floats.
+        The cost amortisation itself is a separate declaration: pass
+        ``holding_periods`` — the rebalance interval in *underlying return
+        periods* — to ``breakeven_cost`` / ``net_spread``.
 
     Returns:
         MetricResult with ``value`` = mean per-rebalance turnover ∈ [0, 1].
         ``0`` = identical tail sets every rebalance; ``1`` = full rotation.
-        Metadata: ``n_rebalances``, ``n_groups``, ``overlap_periods``,
-        ``mean_tail_size`` (per-date average of ``(|Q_top| + |Q_bot|)/2``;
-        ≠ ``n_assets / n_groups`` signals unbalanced buckets from ties or
-        a short universe), ``method``.
+        Metadata: ``n_rebalances``, ``n_groups``, ``overlap_periods`` (the
+        panel's stamp, unchanged), ``rebalance_lag`` (the stride actually
+        sampled at), ``mean_tail_size`` (per-date average of
+        ``(|Q_top| + |Q_bot|)/2``; ≠ ``n_assets / n_groups`` signals
+        unbalanced buckets from ties or a short universe), ``method``.
 
     Notes:
         Per rebalance date ``t``::
@@ -403,19 +468,21 @@ def notional_turnover(
         >>> import factrix as fx
         >>> from factrix.metrics.tradability import notional_turnover
         >>> panel = fx.datasets.make_cs_panel(n_assets=80, n_dates=180, seed=0)
-        >>> result = notional_turnover(panel, n_groups=10, overlap_periods=5)
+        >>> result = notional_turnover(panel, n_groups=10, rebalance_lag=1)
         >>> result.name == ""
         True
     """
     if overlap_periods < 1:
         raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
+    _validate_rebalance_lag(rebalance_lag)
     if n_groups < 3:
         raise ValueError(
             f"n_groups must be ≥ 3 (need distinct top/bottom buckets), got {n_groups!r}"
         )
 
-    if overlap_periods > 1:
-        data = _sample_non_overlapping(data, overlap_periods)
+    lag = _resolve_rebalance_lag(rebalance_lag, overlap_periods)
+    if lag > 1:
+        data = _sample_non_overlapping(data, lag)
 
     dates = data["date"].unique().sort()
     sc = _enforce_min_floor(
@@ -424,6 +491,7 @@ def notional_turnover(
         len(dates),
         "insufficient_dates",
         overlap_periods=overlap_periods,
+        rebalance_lag=lag,
     )
     if sc is not None:
         return sc
@@ -492,6 +560,7 @@ def notional_turnover(
             min_required=n_groups,
             warning_codes=(WarningCode.THIN_QUANTILE_GROUPS.value,),
             overlap_periods=overlap_periods,
+            rebalance_lag=lag,
             n_groups=n_groups,
         )
 
@@ -512,6 +581,7 @@ def notional_turnover(
             "n_rebalances": int(per_date.height),
             "n_groups": n_groups,
             "overlap_periods": overlap_periods,
+            "rebalance_lag": lag,
             "mean_tail_size": mean_tail_size,
             "method": (
                 f"one-sided overlap on top/bottom {tail_pct:.0%} "
@@ -524,21 +594,20 @@ def notional_turnover(
 def _unpack_cost_inputs(
     gross_spread: float | MetricResult,
     turnover: float | MetricResult,
-    overlap_periods: int,
+    holding_periods: int,
 ) -> tuple[float, float, dict[str, object]]:
     """Resolve the two cost inputs and cross-check that they describe one book.
 
     ``breakeven_cost`` / ``net_spread`` take a spread and a turnover and solve
     a single portfolio's cost algebra. That algebra is only meaningful when the
-    two were computed on the *same* bucketing and the *same* rebalance stride —
-    a tau measured on decile membership churn does not price a quintile spread.
-    Bare floats carry no provenance, so nothing could be checked; when the
-    caller passes the producing ``MetricResult``s instead, the pairing is
-    verified here and recorded in the consumer's metadata.
+    two were computed on the *same* bucketing — a tau measured on decile
+    membership churn does not price a quintile spread. Bare floats carry no
+    provenance, so nothing could be checked; when the caller passes the
+    producing ``MetricResult``s instead, the bucketing is verified here and
+    recorded in the consumer's metadata.
 
     Raises:
-        UserInputError: the two results disagree on ``n_groups``, or either
-            disagrees with the ``overlap_periods`` this call was given.
+        UserInputError: the two results disagree on ``n_groups``.
     """
     checked: dict[str, object] = {}
     spread_meta = (
@@ -575,19 +644,19 @@ def _unpack_cost_inputs(
             spread_groups if spread_groups is not None else turnover_groups
         )
 
-    for label, meta in (("gross_spread", spread_meta), ("turnover", turnover_meta)):
-        upstream_h = meta.get("overlap_periods")
-        if upstream_h is not None and upstream_h != overlap_periods:
-            _mismatch(
-                "overlap_periods",
-                upstream_h if label == "gross_spread" else None,
-                upstream_h if label == "turnover" else None,
-                f"the {label} to have been computed at the same rebalance "
-                f"stride as this call's overlap_periods={overlap_periods}; got "
-                f"{upstream_h} upstream",
-            )
+    # WHY: there used to be a second check here, rejecting a call whose
+    # ``overlap_periods`` disagreed with the upstream ``overlap_periods`` in
+    # either producer's metadata. It no longer has a well-defined referent.
+    # The spread's ``overlap_periods`` is the panel's evaluation-grid overlap
+    # (an inference quantity), the turnover's ``rebalance_lag`` counts
+    # evaluation-grid observations, and this call's ``holding_periods`` counts
+    # underlying return periods between rebalances. Once the three units came
+    # apart, equality between any two of them stopped being evidence of a
+    # mis-paired book — the check would have rejected the *correct* call on
+    # every coarser evaluation grid. The bucketing check above is the pairing
+    # constraint that survives, so ``holding_periods`` is only recorded.
     if spread_meta or turnover_meta:
-        checked["overlap_periods"] = overlap_periods
+        checked["holding_periods"] = holding_periods
         checked["pairing_checked"] = True
 
     spread_value = (
@@ -611,13 +680,13 @@ def breakeven_cost(
     gross_spread: float | MetricResult,
     turnover: float | MetricResult,
     *,
-    overlap_periods: int = DEFAULT_FORWARD_PERIODS,
+    holding_periods: int = DEFAULT_FORWARD_PERIODS,
 ) -> MetricResult:
     """Breakeven single-leg trading cost in bps.
 
     No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because this is a scalar diagnostic function rather than a panel-based metric.
 
-    ``Breakeven = Gross_Spread × overlap_periods / (4 × Turnover)``
+    ``Breakeven = Gross_Spread × holding_periods / (4 × Turnover)``
 
     If the actual **one-way** trading cost is below this, the factor's
     alpha survives.
@@ -628,42 +697,62 @@ def breakeven_cost(
     (which is rank-stability, not position-change).
 
     Time-scale alignment: ``gross_spread`` from ``quantile_spread`` is
-    per-period (forward_return is divided by ``overlap_periods`` upstream), but ``turnover``
-    is per-rebalance (one rotation every ``overlap_periods`` periods). Multiplying spread
-    by ``overlap_periods`` puts both sides on the per-rebalance scale
-    before solving net=0 — without it, breakeven is understated by N×.
+    per **underlying return period** — ``compute_forward_return`` divides the
+    holding return by ``forward_periods`` — while ``turnover`` is
+    per-rebalance (one rotation every ``holding_periods`` underlying periods).
+    Multiplying the spread by ``holding_periods`` puts both sides on the
+    per-rebalance scale before solving net = 0; without it, breakeven is
+    understated by that factor.
 
     Args:
-        gross_spread: Per-period mean long-short spread. This is the
-            metric's *data* argument, so it is passed positionally and does
-            not appear on the generated ``__init__`` — the call shape is
-            ``breakeven_cost(gross_spread, turnover=..., overlap_periods=...)``
-            and a second positional argument raises ``TypeError``.
+        gross_spread: Mean long-short spread per underlying return period.
+            This is the metric's *data* argument, so it is passed positionally
+            and does not appear on the generated ``__init__`` — the call shape
+            is ``breakeven_cost(gross_spread, turnover=...,
+            holding_periods=...)`` and a second positional argument raises
+            ``TypeError``.
         turnover: Notional turnover ∈ [0, 1] from ``notional_turnover()``.
-        overlap_periods: Holding period matching the upstream
-            ``compute_forward_return`` and ``notional_turnover`` stride.
+        holding_periods: Number of **underlying return periods** between
+            rebalances — the same unit ``gross_spread`` is normalised to. Must
+            be ≥ 1. On the full grid this equals the ``forward_periods`` the
+            forward return was built at. On a coarser evaluation grid it is
+            the rebalance interval measured in underlying periods, which is
+            **not** the evaluation-grid ``overlap_periods`` and **not** the
+            turnover metrics' ``rebalance_lag``.
 
     Note:
         **Pass the ``MetricResult``s, not their ``.value``.** Both data
         arguments accept either a bare ``float`` or the producing
         ``MetricResult``. Given the results, this function verifies that the
-        spread and the turnover describe the *same* portfolio — same
-        ``n_groups``, same ``overlap_periods`` — and raises ``UserInputError``
-        when they do not, recording ``pairing_checked`` in metadata when they
-        do. Bare floats carry no provenance, so nothing can be checked: the
-        cost algebra silently prices a quintile spread with decile turnover if
-        that is what it is handed. With the pre-unification defaults that was
-        the *likely* outcome, not a corner case — breakeven came out 5.6x too
-        low and cost drag 10.7x too high.
+        spread and the turnover were bucketed the same way (same ``n_groups``)
+        and raises ``UserInputError`` when they were not, recording
+        ``pairing_checked`` in metadata when they were. Bare floats carry no
+        provenance, so nothing can be checked: the cost algebra silently
+        prices a quintile spread with decile turnover if that is what it is
+        handed. With the pre-unification defaults that was the *likely*
+        outcome, not a corner case — breakeven came out 5.6x too low and cost
+        drag 10.7x too high. ``holding_periods`` is not cross-checked against
+        the producers: it is a statement about the trading schedule, which no
+        upstream metadata records.
 
     Returns:
-        MetricResult with value = breakeven cost in bps.
+        MetricResult with value = breakeven cost in bps. Metadata carries
+        ``gross_spread``, ``turnover`` and ``holding_periods``.
 
     Notes:
-        ``breakeven_bps = (gross_spread × overlap_periods) /
-        (4 × turnover) × 1e4``. Multiplying spread by ``overlap_periods``
-        lifts the per-period spread to the per-rebalance scale matching
-        ``turnover``; ``× 1e4`` converts to bps.
+        ``breakeven_bps = (gross_spread × holding_periods) /
+        (4 × turnover) × 1e4``. Multiplying spread by ``holding_periods``
+        lifts the per-underlying-period spread to the per-rebalance scale
+        matching ``turnover``; ``× 1e4`` converts to bps.
+
+        **Example — the unit error this parameter name prevents.** A signal
+        evaluated on a coarse grid, holding 20 underlying return periods per
+        rebalance, on a panel whose derived evaluation-grid
+        ``overlap_periods`` is 2. At ``gross_spread = 0.001`` and
+        ``turnover = 0.20`` the breakeven is
+        ``0.001 × 20 / (4 × 0.20) × 1e4`` = 250 bps. Substituting the derived
+        overlap of 2 returns 25 bps — a 10x understatement of the cost the
+        alpha can bear.
 
         **Where the 4 comes from** (the mirror of ``net_spread``'s cost
         drag — the two must use the same coefficient or breakeven does not
@@ -698,15 +787,15 @@ def breakeven_cost(
     Examples:
         >>> from factrix.metrics.tradability import breakeven_cost
         >>> result = breakeven_cost(
-        ...     gross_spread=0.001, turnover=0.2, overlap_periods=5,
+        ...     gross_spread=0.001, turnover=0.2, holding_periods=5,
         ... )
         >>> result.name == ""
         True
     """
-    if overlap_periods < 1:
-        raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
+    if holding_periods < 1:
+        raise ValueError(f"holding_periods must be ≥ 1, got {holding_periods!r}")
     gross_spread, turnover, checked = _unpack_cost_inputs(
-        gross_spread, turnover, overlap_periods
+        gross_spread, turnover, holding_periods
     )
     if turnover < EPSILON:
         return MetricResult(
@@ -714,23 +803,23 @@ def breakeven_cost(
             metadata={
                 "gross_spread": gross_spread,
                 "turnover": turnover,
-                "overlap_periods": overlap_periods,
+                "holding_periods": holding_periods,
                 **checked,
             },
         )
 
     # WHY: ×4 = 2 legs × 2 trades (sell the leaver, buy the joiner) per unit of
-    # per-leg turnover; ×overlap_periods lifts the per-period spread to
-    # per-rebalance to align with turnover; ×10000 → bps. See Notes for the
+    # per-leg turnover; ×holding_periods lifts the per-underlying-period spread
+    # to per-rebalance to align with turnover; ×10000 → bps. See Notes for the
     # full derivation.
-    be_bps = (gross_spread * overlap_periods / (4 * turnover)) * 10000
+    be_bps = (gross_spread * holding_periods / (4 * turnover)) * 10000
 
     return MetricResult(
         value=be_bps,
         metadata={
             "gross_spread": gross_spread,
             "turnover": turnover,
-            "overlap_periods": overlap_periods,
+            "holding_periods": holding_periods,
             **checked,
         },
     )
@@ -747,13 +836,13 @@ def net_spread(
     turnover: float | MetricResult,
     estimated_cost_bps: float = 30.0,
     *,
-    overlap_periods: int = DEFAULT_FORWARD_PERIODS,
+    holding_periods: int = DEFAULT_FORWARD_PERIODS,
 ) -> MetricResult:
-    """Net spread after estimated trading costs (per-period).
+    """Net spread after estimated trading costs (per underlying return period).
 
     No static panel-shape thresholds are declared (sample_threshold=SampleThreshold()) because this is a scalar diagnostic function rather than a panel-based metric.
 
-    ``Net = Gross_Spread - 4 × cost_bps × Turnover / overlap_periods``
+    ``Net = Gross_Spread - 4 × cost_bps × Turnover / holding_periods``
 
     The ``4 ×`` is ``2 legs × 2 trades``: ``turnover`` is the mean
     **per-leg** fraction replaced per rebalance, each replacement is a
@@ -763,11 +852,12 @@ def net_spread(
     useful headline number; override with a venue-specific estimate
     when available.
 
-    Time-scale alignment: ``gross_spread`` is per-period (forward_return
-    is divided by ``overlap_periods`` upstream) but ``4 × cost × turnover`` is the cost paid
-    once per N-period rebalance. Dividing by ``overlap_periods`` amortises
-    that cost back to per-period. Without it, net is over-charged by N×
-    and any factor with h ≥ 2 is artificially killed.
+    Time-scale alignment: ``gross_spread`` is per **underlying return
+    period** — ``compute_forward_return`` divides the holding return by
+    ``forward_periods`` — but ``4 × cost × turnover`` is the cost paid once
+    per rebalance. Dividing by ``holding_periods`` amortises that cost back to
+    the per-underlying-period scale. Without it, net is over-charged by that
+    factor and any multi-period holding is artificially killed.
 
     Expects ``turnover`` to be a **notional** fraction ∈ [0, 1] — the
     share of the equal-weight Q1/Q_n portfolio replaced per rebalance.
@@ -775,35 +865,54 @@ def net_spread(
     (which is rank-stability, not position-change).
 
     Args:
-        gross_spread: Per-period mean long-short spread. This is the
-            metric's *data* argument, so it is passed positionally and does
-            not appear on the generated ``__init__`` — the call shape is
-            ``net_spread(gross_spread, turnover=..., estimated_cost_bps=...,
-            overlap_periods=...)`` and a second positional argument raises
-            ``TypeError``.
+        gross_spread: Mean long-short spread per underlying return period.
+            This is the metric's *data* argument, so it is passed positionally
+            and does not appear on the generated ``__init__`` — the call shape
+            is ``net_spread(gross_spread, turnover=...,
+            estimated_cost_bps=..., holding_periods=...)`` and a second
+            positional argument raises ``TypeError``.
         turnover: Notional turnover ∈ [0, 1] from ``notional_turnover()``.
         estimated_cost_bps: Estimated **one-way** (per-trade) trading cost
             in bps — what a single buy or a single sell costs, e.g.
             half-spread + impact. Halve a round-trip quote before passing
             it here.
-        overlap_periods: Holding period matching the upstream
-            ``compute_forward_return`` and ``notional_turnover`` stride.
+        holding_periods: Number of **underlying return periods** between
+            rebalances — the same unit ``gross_spread`` is normalised to. Must
+            be ≥ 1. On the full grid this equals the ``forward_periods`` the
+            forward return was built at. On a coarser evaluation grid it is
+            the rebalance interval measured in underlying periods, which is
+            **not** the evaluation-grid ``overlap_periods`` and **not** the
+            turnover metrics' ``rebalance_lag``.
 
     Note:
         ``gross_spread`` and ``turnover`` accept the producing
         ``MetricResult``s as well as bare floats; passing the results lets this
-        function verify that the two were computed on the same bucketing and
-        the same stride. See :func:`breakeven_cost`.
+        function verify that the two were bucketed the same way.
+        ``holding_periods`` is not cross-checked against them — it describes
+        the trading schedule, which no upstream metadata records. See
+        :func:`breakeven_cost`.
 
     Returns:
-        MetricResult with value = net spread (per-period).
+        MetricResult with value = net spread per underlying return period.
+        Metadata carries ``gross_spread``, ``cost_drag``,
+        ``estimated_cost_bps``, ``turnover`` and ``holding_periods``.
 
     Notes:
         ``net = gross_spread - 4 × (cost_bps / 1e4) × turnover /
-        overlap_periods``. Cost is incurred once per ``overlap_periods``-
-        period rebalance, so dividing by ``overlap_periods`` amortises it
-        back to the per-period scale of ``gross_spread``. Without the
-        amortisation any factor with ``h >= 2`` is over-charged by ``h x``.
+        holding_periods``. Cost is incurred once per rebalance, i.e. once per
+        ``holding_periods`` underlying return periods, so dividing by
+        ``holding_periods`` amortises it back to the scale of
+        ``gross_spread``. Without the amortisation any multi-period holding is
+        over-charged by exactly that factor.
+
+        **Example — the unit error this parameter name prevents.** A signal
+        evaluated on a coarse grid, holding 20 underlying return periods per
+        rebalance, on a panel whose derived evaluation-grid
+        ``overlap_periods`` is 2. At ``gross_spread = 0.001``,
+        ``turnover = 0.20`` and a one-way cost of 30 bps the drag is
+        ``4 × 0.003 × 0.20 / 20`` = 0.00012 and the net spread 0.00088.
+        Substituting the derived overlap of 2 gives a drag of 0.00120 and a
+        net of −0.00020 — a 10x over-charge that flips the sign of the answer.
 
         **Where the 4 comes from.** Each step of the accounting, in order:
 
@@ -844,20 +953,20 @@ def net_spread(
         >>> from factrix.metrics.tradability import net_spread
         >>> result = net_spread(
         ...     gross_spread=0.001, turnover=0.2,
-        ...     estimated_cost_bps=30.0, overlap_periods=5,
+        ...     estimated_cost_bps=30.0, holding_periods=5,
         ... )
         >>> result.name == ""
         True
     """
-    if overlap_periods < 1:
-        raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
+    if holding_periods < 1:
+        raise ValueError(f"holding_periods must be ≥ 1, got {holding_periods!r}")
     gross_spread, turnover, checked = _unpack_cost_inputs(
-        gross_spread, turnover, overlap_periods
+        gross_spread, turnover, holding_periods
     )
     # 4 × τ × c: τ is the mean per-leg replaced fraction, each replacement is a
     # sell plus a buy (2τ traded notional per leg) and the $1/$1 long-short
     # holds two legs. See Notes for the derivation.
-    cost_drag = 4 * (estimated_cost_bps / 10000) * turnover / overlap_periods
+    cost_drag = 4 * (estimated_cost_bps / 10000) * turnover / holding_periods
     net = gross_spread - cost_drag
 
     return MetricResult(
@@ -867,7 +976,7 @@ def net_spread(
             "cost_drag": cost_drag,
             "estimated_cost_bps": estimated_cost_bps,
             "turnover": turnover,
-            "overlap_periods": overlap_periods,
+            "holding_periods": holding_periods,
             **checked,
         },
     )

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -255,28 +255,28 @@ class TestBreakevenCost:
         # rebalance): gross=0.10/period, turnover=0.5/rebalance, fp=1.
         # Traded notional per rebalance = 4*0.5 = 2 (2 legs x sell+buy), so
         # the breakeven one-way cost is 0.10*1/(4*0.5)*10000 = 500 bps.
-        result = breakeven_cost(0.10, turnover=0.5, overlap_periods=1)
+        result = breakeven_cost(0.10, turnover=0.5, holding_periods=1)
         assert result.value == pytest.approx(500.0)
-        assert result.metadata["overlap_periods"] == 1
+        assert result.metadata["holding_periods"] == 1
 
     def test_zero_turnover(self):
-        result = breakeven_cost(0.10, turnover=0.0, overlap_periods=1)
+        result = breakeven_cost(0.10, turnover=0.0, holding_periods=1)
         assert result.value == float("inf")
 
     def test_forward_periods_scales_breakeven(self):
         """gross is per-period, turnover per-rebalance: breakeven scales by N.
 
-        Halving the per-period spread but holding for overlap_periods=2 should give the
-        same breakeven as the overlap_periods=1 baseline — the trader earns the spread
+        Halving the per-period spread but holding for holding_periods=2 should give the
+        same breakeven as the holding_periods=1 baseline — the trader earns the spread
         twice before paying the once-per-rebalance cost.
         """
-        baseline = breakeven_cost(0.10, turnover=0.5, overlap_periods=1).value
-        scaled = breakeven_cost(0.05, turnover=0.5, overlap_periods=2).value
+        baseline = breakeven_cost(0.10, turnover=0.5, holding_periods=1).value
+        scaled = breakeven_cost(0.05, turnover=0.5, holding_periods=2).value
         assert scaled == pytest.approx(baseline)
 
     def test_forward_periods_validation(self):
-        with pytest.raises(ValueError, match="overlap_periods"):
-            breakeven_cost(0.10, turnover=0.5, overlap_periods=0)
+        with pytest.raises(ValueError, match="holding_periods"):
+            breakeven_cost(0.10, turnover=0.5, holding_periods=0)
 
 
 class TestNetSpread:
@@ -284,14 +284,14 @@ class TestNetSpread:
         # Notional turnover=0.5 (per leg); cost=30bps one-way; fp=1.
         # net = 0.10 - 4*(30/10000)*0.5/1 = 0.10 - 0.006 = 0.094
         result = net_spread(
-            0.10, turnover=0.5, estimated_cost_bps=30, overlap_periods=1
+            0.10, turnover=0.5, estimated_cost_bps=30, holding_periods=1
         )
         assert result.value == pytest.approx(0.094)
-        assert result.metadata["overlap_periods"] == 1
+        assert result.metadata["holding_periods"] == 1
 
     def test_cost_exceeds_alpha(self):
         result = net_spread(
-            0.001, turnover=0.5, estimated_cost_bps=100, overlap_periods=1
+            0.001, turnover=0.5, estimated_cost_bps=100, holding_periods=1
         )
         assert result.value < 0
 
@@ -301,18 +301,18 @@ class TestNetSpread:
         than absolute values) pins the scaling invariant under any rescaling
         of inputs — which is the whole point of the fix."""
         baseline = net_spread(
-            0.10, turnover=0.5, estimated_cost_bps=30, overlap_periods=1
+            0.10, turnover=0.5, estimated_cost_bps=30, holding_periods=1
         )
         scaled = net_spread(
-            0.10, turnover=0.5, estimated_cost_bps=30, overlap_periods=5
+            0.10, turnover=0.5, estimated_cost_bps=30, holding_periods=5
         )
         assert scaled.metadata["cost_drag"] == pytest.approx(
             baseline.metadata["cost_drag"] / 5
         )
 
     def test_forward_periods_validation(self):
-        with pytest.raises(ValueError, match="overlap_periods"):
-            net_spread(0.10, turnover=0.5, overlap_periods=0)
+        with pytest.raises(ValueError, match="holding_periods"):
+            net_spread(0.10, turnover=0.5, holding_periods=0)
 
 
 class TestRankTurnoverIgnoresNonFiniteFactors:
@@ -383,11 +383,12 @@ class TestCostInputPairing:
         spread = quantile_spread(panel)["factor"]
         turnover = notional_turnover(panel)
         assert spread.metadata["n_groups"] == turnover.metadata["n_groups"]
-        assert turnover.metadata["overlap_periods"] == DEFAULT_FORWARD_PERIODS
-        # The pairing check passes silently and is recorded.
+        assert turnover.metadata["rebalance_lag"] == DEFAULT_FORWARD_PERIODS
+        # The bucketing check passes silently and is recorded.
         out = breakeven_cost(spread, turnover=turnover)
         assert out.metadata["pairing_checked"] is True
         assert out.metadata["n_groups"] == DEFAULT_N_GROUPS
+        assert out.metadata["holding_periods"] == DEFAULT_FORWARD_PERIODS
 
     def test_mismatched_bucketing_is_rejected(self):
         from factrix.metrics.quantile import quantile_spread
@@ -400,14 +401,21 @@ class TestCostInputPairing:
         with pytest.raises(UserInputError, match="n_groups"):
             net_spread(spread, turnover=turnover)
 
-    def test_mismatched_stride_is_rejected(self):
+    def test_stride_is_no_longer_cross_checked(self):
+        """The upstream stride and ``holding_periods`` measure different things.
+
+        A turnover striding the evaluation grid and a cost amortised over
+        underlying return periods are both correct and need not agree, so the
+        old equality check is gone; ``holding_periods`` is recorded instead.
+        """
         panel = self._panel()
-        turnover = notional_turnover(panel, overlap_periods=1)
-        with pytest.raises(UserInputError, match="overlap_periods"):
-            breakeven_cost(0.001, turnover=turnover, overlap_periods=5)
+        turnover = notional_turnover(panel, rebalance_lag=1)
+        out = breakeven_cost(0.001, turnover=turnover, holding_periods=5)
+        assert out.metadata["holding_periods"] == 5
+        assert out.metadata["pairing_checked"] is True
 
     def test_bare_floats_still_work_unchecked(self):
-        out = breakeven_cost(0.001, turnover=0.2, overlap_periods=5)
+        out = breakeven_cost(0.001, turnover=0.2, holding_periods=5)
         # gross * h / (4 * tau) * 1e4 = 0.001 * 5 / 0.8 * 1e4
         assert out.value == pytest.approx(62.5)
         assert "pairing_checked" not in out.metadata
@@ -422,6 +430,194 @@ class TestCostInputPairing:
             breakeven_cost(
                 spread.value,
                 turnover=turnover.value,
-                overlap_periods=DEFAULT_FORWARD_PERIODS,
+                holding_periods=DEFAULT_FORWARD_PERIODS,
             ).value
         )
+
+
+class TestRebalanceLagIsDistinctFromReturnOverlap:
+    """#872 — the turnover metrics pair at a rebalance lag, not the overlap.
+
+    ``overlap_periods`` is injected from the panel's stamp and answers an
+    inference question (how many adjacent evaluation observations share future
+    periods). ``rebalance_lag`` is the schedule the portfolio actually trades
+    on, counted in evaluation-grid observations.
+    """
+
+    @staticmethod
+    def _coarse_grid_panel():
+        """400-period panel evaluated on every 4th date at a 5-period horizon.
+
+        ``compute_forward_return`` derives ``overlap_periods = 2`` there: the
+        return is still measured over 5 periods of the underlying grid, but at
+        most one other evaluation date falls inside that window.
+        """
+        import factrix as fx
+
+        raw = fx.datasets.make_cs_panel(n_assets=30, n_dates=400, seed=0)
+        every_fourth = raw["date"].unique().sort()[::4]
+        return fx.preprocess.compute_forward_return(
+            raw, forward_periods=5, dates=list(every_fourth)
+        )
+
+    def test_evaluate_honours_rebalance_lag_without_falsifying_the_stamp(self):
+        import factrix as fx
+        from factrix.metrics import ic
+
+        panel = self._coarse_grid_panel()
+        n_dates = panel["date"].n_unique()
+        out = fx.evaluate(
+            panel,
+            metrics={
+                "rt": rank_turnover(rebalance_lag=1),
+                "nt": notional_turnover(rebalance_lag=1),
+                "ic": ic(),
+            },
+            factor_cols=["factor"],
+        )["factor"]
+
+        for label in ("rt", "nt"):
+            res = out.metrics[label]
+            # The panel's stamp is reported unchanged...
+            assert res.metadata["overlap_periods"] == 2
+            # ...and the lag the metric actually paired at sits beside it.
+            assert res.metadata["rebalance_lag"] == 1
+            # Adjacent transitions: every evaluation date but the first.
+            assert res.n_obs == n_dates - 1
+            assert res.n_obs_axis == "periods"
+
+        # An overlap-sensitive metric in the same call still gets the stamp.
+        assert out.metrics["ic"].metadata["overlap_periods"] == 2
+
+    def test_default_reproduces_the_stride_at_the_stamped_overlap(self):
+        import factrix as fx
+
+        panel = self._coarse_grid_panel()
+        default = fx.evaluate(
+            panel,
+            metrics={"rt": rank_turnover(), "nt": notional_turnover()},
+            factor_cols=["factor"],
+        )["factor"]
+        explicit = fx.evaluate(
+            panel,
+            metrics={
+                "rt": rank_turnover(rebalance_lag=2),
+                "nt": notional_turnover(rebalance_lag=2),
+            },
+            factor_cols=["factor"],
+        )["factor"]
+
+        for label in ("rt", "nt"):
+            assert default.metrics[label].metadata["rebalance_lag"] == 2
+            assert default.metrics[label].value == pytest.approx(
+                explicit.metrics[label].value
+            )
+            assert default.metrics[label].n_obs == explicit.metrics[label].n_obs
+
+    def test_standalone_call_honours_the_lag(self):
+        """Nine dates, ranking reversed on odd dates.
+
+        At lag 1 every transition is a full reversal (ρ = −1 → turnover 2); at
+        lag 2 only same-phase dates are compared (ρ = +1 → turnover 0).
+        """
+
+        def factor(t, a):
+            base = ord(a) - ord("A") + 1
+            return base if t % 2 == 0 else (4 - base)
+
+        df = _panel(9, ["A", "B", "C"], factor)
+        adjacent = rank_turnover(df, rebalance_lag=1)
+        strided = rank_turnover(df, overlap_periods=2)
+
+        assert adjacent.value == pytest.approx(2.0, abs=0.01)
+        assert adjacent.metadata["rebalance_lag"] == 1
+        assert adjacent.n_obs == 8
+        assert strided.value == pytest.approx(0.0, abs=0.01)
+        assert strided.metadata["rebalance_lag"] == 2
+
+    def test_lag_overrides_the_injected_overlap_in_a_standalone_call(self):
+        df = _panel(9, ["A", "B", "C"], lambda t, a: ord(a) + 0.1 * t)
+        out = rank_turnover(df, overlap_periods=4, rebalance_lag=1)
+        assert out.metadata["overlap_periods"] == 4
+        assert out.metadata["rebalance_lag"] == 1
+        assert out.n_obs == 8
+
+    def test_notional_turnover_lag_overrides_the_injected_overlap(self):
+        assets = [chr(ord("A") + i) for i in range(10)]
+        df = _panel(9, assets, lambda t, a: ord(a) + 0.1 * t)
+        out = notional_turnover(df, n_groups=5, overlap_periods=4, rebalance_lag=1)
+        assert out.metadata["overlap_periods"] == 4
+        assert out.metadata["rebalance_lag"] == 1
+        assert out.metadata["n_rebalances"] == 8
+
+    def test_sample_floor_follows_the_lag_not_the_overlap(self):
+        """Pre-flight and run-time must agree on the floor the lag implies."""
+        import factrix as fx
+
+        assert (
+            fx.sample_requirements(
+                rank_turnover(rebalance_lag=1), overlap_periods=5
+            ).min_periods
+            == 3
+        )
+        assert (
+            fx.sample_requirements(rank_turnover(), overlap_periods=5).min_periods == 11
+        )
+        assert (
+            fx.sample_requirements(
+                rank_turnover(rebalance_lag=4), overlap_periods=1
+            ).min_periods
+            == 9
+        )
+
+    def test_rebalance_lag_validation(self):
+        df = _panel(5, ["A", "B", "C"], lambda t, a: ord(a))
+        with pytest.raises(ValueError, match="rebalance_lag"):
+            rank_turnover(df, rebalance_lag=0)
+        with pytest.raises(ValueError, match="rebalance_lag"):
+            notional_turnover(df, rebalance_lag=0)
+
+
+class TestHoldingPeriodsAmortisesCost:
+    """#874 — cost is amortised over underlying return periods, not overlap."""
+
+    def test_net_spread_amortises_over_underlying_periods(self):
+        # 20 underlying return periods between rebalances; one-way cost 30 bps.
+        out = net_spread(
+            0.001, turnover=0.20, estimated_cost_bps=30, holding_periods=20
+        )
+        assert out.metadata["cost_drag"] == pytest.approx(4 * 0.003 * 0.20 / 20)
+        assert out.metadata["cost_drag"] == pytest.approx(0.00012)
+        assert out.value == pytest.approx(0.00088)
+        assert out.metadata["holding_periods"] == 20
+
+    def test_breakeven_cost_over_underlying_periods(self):
+        out = breakeven_cost(0.001, turnover=0.20, holding_periods=20)
+        assert out.value == pytest.approx(250.0)
+        assert out.metadata["holding_periods"] == 20
+
+    def test_derived_overlap_would_be_a_ten_x_unit_error(self):
+        """The quantity the old name invited: the evaluation-grid overlap."""
+        wrong = net_spread(
+            0.001, turnover=0.20, estimated_cost_bps=30, holding_periods=2
+        )
+        assert wrong.metadata["cost_drag"] == pytest.approx(0.00120)
+        assert wrong.value == pytest.approx(-0.00020)
+
+    def test_spread_carrying_an_overlap_stamp_is_accepted(self):
+        """A ``MetricResult`` whose metadata says ``overlap_periods=2`` no
+        longer collides with a ``holding_periods=20`` amortisation."""
+        from factrix._results import MetricResult
+
+        spread = MetricResult(
+            value=0.001, metadata={"n_groups": DEFAULT_N_GROUPS, "overlap_periods": 2}
+        )
+        out = net_spread(
+            spread, turnover=0.20, estimated_cost_bps=30, holding_periods=20
+        )
+        assert out.value == pytest.approx(0.00088)
+        assert out.metadata["holding_periods"] == 20
+        assert out.metadata["pairing_checked"] is True
+        assert breakeven_cost(
+            spread, turnover=0.20, holding_periods=20
+        ).value == pytest.approx(250.0)


### PR DESCRIPTION
## Problem

`compute_forward_return(..., dates=)` (#845) split the economic return horizon
from the evaluation-grid overlap. The tradability metrics never followed, so
`overlap_periods` was still carrying three different questions at once.

- **#872** — `rank_turnover` and `notional_turnover` (the issue omits the
  latter, but it has identical coupling and feeds the cost formulas) declare
  the injected `overlap_periods` and stride at it. Users cannot override it:
  `rank_turnover(overlap_periods=1)` raises `UserInputError` from
  `_reject_injected_params`. On a coarser evaluation grid with a derived
  overlap > 1 there was therefore **no way to measure adjacent-rebalance
  turnover through `evaluate`** — the metrics strided the evaluation grid by
  the inference overlap and kept only the phase-0 subsample.
- **#874** — `breakeven_cost` / `net_spread` used their `overlap_periods`
  argument as the cost amortisation divisor/multiplier. The correct quantity is
  the number of **underlying return periods between rebalances** — the unit
  `gross_spread` is normalised to by the `/ forward_periods` inside
  `compute_forward_return`. Since #845 that is not the evaluation-grid overlap.
  The name invited a 10x unit error and the docstrings said the wrong thing
  ("forward_return is divided by `overlap_periods` upstream"; it is divided by
  `forward_periods`).

## Change

**#872 — `rebalance_lag` on the two turnover metrics.**

- New keyword `rebalance_lag: int | None = None` on `rank_turnover` and
  `notional_turnover`. Resolution is
  `lag = rebalance_lag if rebalance_lag is not None else overlap_periods`; a
  supplied value must be a positive `int`. The injected `overlap_periods`
  parameter is unchanged and stays hidden from users.
- The lag is counted in **evaluation-grid observations**. `None` reproduces
  today's behaviour: on the full grid the stamp equals the horizon, i.e. the
  standard holding-period-aligned turnover convention. Users whose evaluation
  grid *is* the rebalance schedule pass `rebalance_lag=1`.
- The dynamic floor resolver `_rank_turnover_sample_threshold` now reads the
  resolved lag, so `inspect_data` / `sample_requirements` pre-flight and the
  in-body gate agree at any configuration.
- Metadata keeps `overlap_periods` (the stamp) and **adds** `rebalance_lag`
  (the stride actually used). Short-circuit outputs carry both.
  `n_obs` / `n_periods` semantics are unchanged: transitions at the lag.

**#874 — `holding_periods` on the two cost helpers.**

- `overlap_periods` is renamed to `holding_periods` on `breakeven_cost` and
  `net_spread`; the default stays `DEFAULT_FORWARD_PERIODS` and the value must
  be `>= 1`. Metadata key `holding_periods` replaces `overlap_periods`.
- Formulas, docstrings and comments now say what the quantity is: turnover and
  cost are incurred once per rebalance, `gross_spread` is per underlying return
  period, so the amortisation interval must be in underlying return periods
  too. On the full grid that is `forward_periods`; on a coarser grid it is the
  rebalance interval in underlying periods — not `overlap_periods` and not
  `rebalance_lag`.
- The stride pairing check inside `_unpack_cost_inputs` is removed. It compared
  the upstream `meta["overlap_periods"]` (evaluation-grid observations) against
  this call's argument (underlying periods), which stopped being comparable
  after #845 and would have rejected the correct call on every coarser grid.
  A comment records why. The `n_groups` bucketing check is unchanged;
  `holding_periods` and `pairing_checked` are still recorded in `checked`.

**Docs.** `docs/api/metrics/tradability.md` (formulas, the amortisation prose,
the pairing warning, a labelled worked example, a migration section),
`docs/api/evaluate.md` § `forward_periods=` and `overlap_periods=` (a table
distinguishing the four quantities), `docs/reference/stat-keys-by-metric.md`
(metadata keys for all four metrics), `docs/reference/metric-applicability.md`,
`docs/guides/validating-allocation-signals.md`, `factrix/llms-full.txt`, and the
`examples/stock_factor_evaluation.ipynb` cost recipe (which was still on the
pre-0.23 `forward_periods=` keyword) plus its generated page.

## Breaking notes

1. **`holding_periods` rename.** `breakeven_cost` / `net_spread` no longer
   accept `overlap_periods=` (nor the pre-0.23 `forward_periods=`); there is no
   deprecation shim, so an old call raises `TypeError`. Migrating from
   `forward_periods=`: pass the same number. Migrating from `overlap_periods=`:
   pass the rebalance interval in **underlying return periods** — do **not**
   substitute the panel's derived evaluation-grid overlap. Documented in
   `docs/api/metrics/tradability.md#migration--the-holding_periods-rename`.
2. **Stride pairing check removed.** A call whose `holding_periods` disagrees
   with an upstream producer's `overlap_periods` no longer raises. `n_groups`
   is still cross-checked.
3. **New `rebalance_lag` parameter** on `rank_turnover` / `notional_turnover`.
   Additive and defaulted to the previous behaviour, but the metrics' metadata
   gains a key and `rank_turnover`'s docstring floor is now stated in terms of
   `rebalance_lag`.

## Tests

`tests/test_tradability.py`:

- `TestRebalanceLagIsDistinctFromReturnOverlap` — builds the evaluation-grid
  panel from the issue (400 periods, every 4th date, `forward_periods=5` →
  stamp `_overlap_periods=2`), runs `evaluate` with
  `rank_turnover(rebalance_lag=1)` / `notional_turnover(rebalance_lag=1)` and
  asserts metadata reports `overlap_periods == 2` **and**
  `rebalance_lag == 1`, that `n_obs` is the adjacent-transition count
  (evaluation dates − 1), and that `ic` in the same call still receives
  `overlap_periods == 2`. A companion test asserts the default
  (`rebalance_lag=None`) reproduces the stride-2 result exactly. Further tests
  cover standalone calls, the lag overriding an explicit overlap, validation,
  and that `sample_requirements(rank_turnover(rebalance_lag=1),
  overlap_periods=5).min_periods == 3` (the lag, not the overlap).
- `TestHoldingPeriodsAmortisesCost` — the issue's worked numbers:
  `net_spread(0.001, turnover=0.20, estimated_cost_bps=30,
  holding_periods=20)` → `cost_drag == 0.00012`, `value == 0.00088`;
  `breakeven_cost(0.001, turnover=0.20, holding_periods=20).value == 250`;
  the overlap-2 substitution reproduced as the 10x error it is; and a
  `MetricResult` spread carrying `overlap_periods=2` in its metadata passing
  through both helpers without raising.
- `test_mismatched_stride_is_rejected` is converted to
  `test_stride_is_no_longer_cross_checked`; the remaining scalar-helper tests
  are updated for the renamed keyword and metadata key.

Verified locally: `uv run pytest -q` (2907 passed, 3 skipped),
`uv run pytest --doctest-modules factrix/ -q` (96 passed, 1 skipped),
`uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy factrix`,
and `uv run pre-commit run --hook-stage pre-push --all-files` (mypy +
`mkdocs build --strict` + CHANGELOG check) — all green.
