### PR TITLE
chore: drop stale post-removal prose and compat leftovers

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -120,14 +120,13 @@ python scripts/setup_dev.py
 ```
 
 The script runs `pre-commit install` for the `pre-commit`, `commit-msg`
-and `pre-push` stages, and unsets a leftover `core.hooksPath` from the
-pre-framework setup (it would shadow the installed hooks). Idempotent —
-re-running just rewrites the same shims; aborts (non-zero exit) if
-`core.hooksPath` points at some other path, so a contributor's
-dotfiles-managed hook surface is not silently overwritten. The
-installation is per-clone and local; it does not propagate across
-machines, so every clone / new machine must run the script once. `git
-worktree` instances share `.git/hooks` with their primary clone, so one
+and `pre-push` stages. Idempotent — re-running just rewrites the same
+shims; aborts (non-zero exit) if `core.hooksPath` is set at all, since it
+would shadow the installed hooks and a contributor's dotfiles-managed hook
+surface must not be silently overwritten. The installation is per-clone
+and local; it does not propagate across machines, so every clone / new
+machine must run the script once. `git worktree` instances share
+`.git/hooks` with their primary clone, so one
 run at the primary clone covers every worktree under it.
 
 `pre-commit` — when staged changes include `*.py` / `*.ipynb`, runs
@@ -544,9 +543,11 @@ meaning, leave it to release-train review.
 Before running a release bump (see §9), run this checklist on `main`:
 
 ```bash
-# 1. Search for known-deprecated symbol names that may have leaked back in.
-#    Extend the pattern per release with names retired since the last tag.
-git grep -nE 'q1_q5_spread'
+# 1. Search for symbols retired this release cycle that may have leaked back in.
+#    Build PATTERN from the breaking changes since the last tag (the `!`-marked
+#    commits and the CHANGELOG's breaking entries). It is rebuilt every cycle,
+#    not inherited — a pattern that survives past its removal only adds noise.
+git grep -nE "$PATTERN"
 
 # 2. Sync the release-check toolchain from locked project metadata.
 uv sync --frozen --extra dev --extra docs
@@ -866,7 +867,6 @@ The slicing subsystem is the worked example of the rule:
 | `Layer-A` / first-layer dispatcher | **slice dispatcher** — describes partitioning by label + applying a metric per slice (`by_slice`) |
 | `Layer-B` / second-layer / curated wrapper (inference path) | **slice-test function** / **inference function** — describes the cross-slice estimator + multiple-testing pipeline (`slice_pairwise_test` / `slice_joint_test`) |
 | `Layer-B` Estimator | **slice-test Estimator** — Estimators consumed by the slice-test functions (`WaldNWCluster` / `WaldTwoWayCluster` / `BlockBootstrap`) |
-| metric-specific `regime_<metric>` curated wrapper | **legacy metric-specific wrapper** (when describing removed surface area); for the current path, name `by_slice` + the inference function directly |
 | `EvaluationResult.to_frame()` renderer layer | **renderer** — result-side method; no separate tier implied |
 
 The rule is functional, not lexical — `dispatcher`, `function`, and `wrapper` are fine on their own when they describe what the function does. It is the **pairing** as a tier label (`dispatcher` vs `curated wrapper` as the two levels of the slicing system) that drifts; the same word as a behavioural noun is stable. Describe the specification by its content when a docstring needs to point at one, rather than `Layer-B (#NNN)` — the `Layer-B` tier label drifts, and an issue number does not belong in source either.
@@ -989,13 +989,13 @@ newlines as `<br>`, so source-level wrapping leaks into the rendered output.
 
 ### BC change reminders
 
-Example: `q1_q5_spread → long_short_spread` (this rename actually
-occurred in workspace history). This kind of rename is a BC change.
-When using `cz commit`, the developer must select Breaking Change and
-**explicitly write the migration path** in the prompt (old → new
-names, affected fields). The Pre-1.0 version guide above defines where that
-upgrade text lives before `v1.0.0`; from `v1.0.0` onward, carry it into the
-maintained changelog entry.
+Example: `breakeven_cost` / `net_spread` took `overlap_periods` up to
+`v0.23.0` and take `holding_periods` from the next release (#876). This
+kind of rename is a BC change. When using `cz commit`, the developer must
+select Breaking Change and **explicitly write the migration path** in the
+prompt (old → new names, affected fields). The Pre-1.0 version guide
+above defines where that upgrade text lives before `v1.0.0`; from
+`v1.0.0` onward, carry it into the maintained changelog entry.
 
 ### Workspace pins to tags, not main
 

--- a/docs/guides/large-scale-evaluation.md
+++ b/docs/guides/large-scale-evaluation.md
@@ -4,17 +4,17 @@ title: Large-scale evaluation and memory protection
 
 When evaluating hundreds or thousands of factors over large historical datasets, memory protection becomes a key design requirement.
 
-This guide explains how to structure your factor screens using a **user-side batched loop** with Polars LazyFrames. This approach replaces the retired built-in streaming/chunking APIs (`run_metrics_iter`, `run_metrics_chunked`, `evaluate_iter`, and `evaluate_chunked`).
+This guide explains how to structure your factor screens using a **user-side batched loop** with Polars LazyFrames.
 
-## Design trade-off: why built-in streaming was removed
+## Design trade-off: why factrix has no built-in batch API
 
-In earlier versions, `factrix` attempted to manage chunked evaluation and iterator streaming internally. However, this introduced several drawbacks:
+`factrix` exposes no chunked-evaluation or iterator-streaming API. Owning that internally costs more than it buys:
 
-- **Complex internal state**: Managing execution state, lazy-to-eager evaluation boundaries, and memory disposal internally added significant complexity to the DAG executor.
-- **Redundant memory pressure**: Stashing intermediate chunks in memory before returning them often defeated the purpose of streaming.
-- **Loss of control**: Callers could not easily control the file scanning, projection pushdown, or GC behavior of the under-the-hood engine.
+- **Complex internal state**: execution state, lazy-to-eager evaluation boundaries, and memory disposal all have to be tracked inside the DAG executor.
+- **Redundant memory pressure**: stashing intermediate chunks in memory before returning them defeats the purpose of streaming.
+- **Loss of control**: callers cannot easily steer the file scanning, projection pushdown, or GC behavior of an under-the-hood engine.
 
-By removing the built-in batch/streaming APIs, the library's API surface was simplified. Evaluating large-scale panels is now delegated to a user-side loop. This design lets Polars do what it does best: optimize column reads using projection pushdown, while allowing Python's garbage collector to immediately reclaim memory when a chunk's results fall out of scope.
+Delegating large-scale panels to a user-side loop keeps the API surface small and lets Polars do what it does best: optimize column reads using projection pushdown, while allowing Python's garbage collector to immediately reclaim memory when a chunk's results fall out of scope.
 
 ## The pattern: user-side batched loop
 

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -47,9 +47,10 @@ Time-series length `n_periods` and asset count `n_assets` are gated **independen
 `FEW_ASSETS` never changes the estimator. Spread metrics, IC, Fama–MacBeth
 and common-beta paths all retain their documented estimator and use the
 warning to flag thin ranks, low residual degrees of freedom, or unstable
-cross-asset aggregation (an earlier automatic switch of the spread metrics to
-a block bootstrap in the thin regime was removed after it measured worse). Read the metric metadata and method, not the warning
-code alone, to identify the inference path.
+cross-asset aggregation — see the [shared small-N note](../reference/stat-keys-by-metric.md#shared-small-n-note)
+for the measured sizes behind that choice on the spread metrics. Read the
+metric metadata and method, not the warning code alone, to identify the
+inference path.
 
 ### Behaviour matrix by density and `n_assets`
 

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -15,7 +15,7 @@ The **inference** functions are not. Cross-slice testing splits on a statistical
 
 Picking the wrong pair is not a tuning choice — it is the wrong statistical assumption, so the two are **separate, explicitly-named** functions rather than one auto-routing surface.
 
-factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs. The legacy regime-specific surface (`by_regime`, `regime_ic`) has been removed; use `by_slice` for descriptive per-slice results and the `slice_*_test` functions for calibrated cross-slice inference.
+factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs.
 
 ## The two roles
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -444,8 +444,7 @@ between/total ratio $\operatorname{Var}(\bar x_d) / (\operatorname{Var}(\bar x_d
 \hat\sigma^2_w)$; because $\mathbb{E}[\operatorname{Var}(\bar x_d)] = \sigma^2_b +
 \sigma^2_w / n$, that ratio converges to $1/(n+1)$ under **independence** and
 the deflator fired at full strength on unclustered data (empirical size
-$\approx 1\%$ at nominal 5%). This was previously described here as a
-conservative simplification; it was a mis-sized test and has been replaced.
+$\approx 1\%$ at nominal 5%).
 
 The deflator itself is the Kish design effect $1/\sqrt{1 + (n_0 - 1)\hat r}$,
 i.e. [Kolari-Pynnönen 2010][kolari-pynnonen-2010] **without** the $(1 - \bar r)$

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -43,8 +43,7 @@ typical usage patterns in a single fetch. Two access paths::
 
 # Underscore aliases: ``import factrix; dir(factrix)`` otherwise offers
 # ``math``, ``pl``, ``Any``, ``dataclasses``, ``MappingProxyType``,
-# ``TYPE_CHECKING`` and ``NoReturn`` alongside the real API, and
-# ``from factrix import *`` used to be the only thing ``__all__`` protected.
+# ``TYPE_CHECKING`` and ``NoReturn`` alongside the real API.
 import dataclasses as _dataclasses
 import math as _math
 from collections.abc import Iterable as _Iterable

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -15,13 +15,13 @@ concerns and are kept on separate knobs:
   into the factor name to stay unique. ``EvaluationResult.metadata`` is
   bookkeeping and never joins the identifier.
 * **Family partition** — ``expand_over`` alone, naming ``forward_periods``
-  (the lone built-in) or ``params`` keys. It no longer doubles as an
-  identity knob, so partitioning is a pure statistical declaration.
+  (the lone built-in) or ``params`` keys. It declares how to partition the
+  family and nothing else, so partitioning stays a pure statistical
+  declaration and never perturbs identity.
 
-The estimator-override hook is
-gone — callers select inference at metric-construction time (e.g.
-``ic(inference=fx.inference.NEWEY_WEST)``) and pick the result by
-passing the corresponding ``metric`` label.
+Inference is selected at metric-construction time (e.g.
+``ic(inference=fx.inference.NEWEY_WEST)``); this layer picks the matching
+result by ``metric`` label rather than overriding an estimator itself.
 """
 
 from __future__ import annotations

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -40,9 +40,13 @@ MAD_CONSISTENCY_CONSTANT: float = 1.4826
 
 # Two-tier per-date asset-count guard for ``compute_ic`` (cross-sectional
 # axis). ``MIN_IC_ASSETS_HARD`` is the true computability floor: Spearman IC is
-# undefined below two pairwise-complete names. ``MIN_IC_ASSETS_WARN`` preserves
-# the legacy reliability floor; dates in ``[HARD, WARN)`` are retained but
-# surfaced as thin cross-sections by IC consumers and ``inspect_data``.
+# undefined below two pairwise-complete names. ``MIN_IC_ASSETS_WARN`` is its
+# warn-tier counterpart and guards reliability rather than computability: a
+# per-period rank correlation over a single-digit cross-section is dominated by
+# tie-breaking and sampling noise, so the number is well-defined but carries
+# almost no signal. The exact value is a judgement floor, not a simulated one.
+# Dates in ``[HARD, WARN)`` are retained but surfaced as thin cross-sections by
+# IC consumers and ``inspect_data``.
 MIN_IC_ASSETS_HARD: int = 2
 MIN_IC_ASSETS_WARN: int = 10
 

--- a/factrix/adapt.py
+++ b/factrix/adapt.py
@@ -6,8 +6,9 @@ Canonical names used throughout factrix:
     - ``price``: price column (close, adj close, VWAP, etc.)
 
 Optional OHLCV canonicals (renamed when a source column is provided):
-    ``open``, ``high``, ``low``, ``volume`` — required by some factor
-    generators (``factors.technical``, ``factors.liquidity``).
+    ``open``, ``high``, ``low``, ``volume`` — nothing in factrix reads
+    these; ``adapt`` canonicalises them so your own factor construction
+    can rely on stable names.
 
 Other columns (market_cap, industry, etc.) pass through unchanged;
 factrix does not prescribe names for those.
@@ -19,7 +20,7 @@ Usage::
     # Minimal: just price panel
     raw = adapt(data, date="date", asset_id="ticker", price="close_adj")
 
-    # Full OHLCV — unlocks technical / liquidity factor generators
+    # Full OHLCV — canonical open/high/low/volume for your own factors
     raw = adapt(
         data,
         date="date", asset_id="ticker", price="close_adj",
@@ -82,17 +83,23 @@ def adapt(
     Args:
         data: Input frame — ``pl.DataFrame``, ``pl.LazyFrame``, or
             ``pd.DataFrame``.
-        date: User's date column name.
-        asset_id: User's asset identifier column name.
-        price: User's price column name.
-        open: User's open column name. If set, renamed to ``open``.
-            Required by ``factors.technical.generate_overnight_return``.
-        high: User's high column name. Renamed to ``high``. Required
-            by ``generate_52w_high_ratio`` / ``generate_intraday_range``.
-        low: User's low column name. Renamed to ``low``. Required by
-            ``generate_intraday_range``.
-        volume: User's volume column name. Renamed to ``volume``.
-            Required by ``generate_amihud`` / ``generate_volume_price_trend``.
+        date: User's date column name. Renamed to ``date`` — the panel's
+            ordering and alignment key; every factrix horizon, window and
+            lag counts periods on its distinct-date grid.
+        asset_id: User's asset identifier column name. Renamed to
+            ``asset_id`` — the cross-sectional key every metric groups by.
+        price: User's price column name. Renamed to ``price`` — the level
+            series ``compute_forward_return`` differences into
+            ``forward_return``, and the volatility source the event-study
+            metrics (``caar``, ``event_horizon``) prefer when present.
+        open: User's opening-price column name. Renamed to ``open``.
+            Not read by factrix; passed through for downstream use.
+        high: User's period-high price column name. Renamed to ``high``.
+            Not read by factrix; passed through for downstream use.
+        low: User's period-low price column name. Renamed to ``low``.
+            Not read by factrix; passed through for downstream use.
+        volume: User's traded-volume column name. Renamed to ``volume``.
+            Not read by factrix; passed through for downstream use.
         fill_forward: If True, map every non-finite value (NaN and
             ±inf) to null, then forward-fill all numeric columns per
             asset. Useful for raw OHLCV data that may contain sporadic
@@ -141,8 +148,8 @@ def adapt(
         data = data.rename(mapping)
 
     # Promote pl.Date → pl.Datetime("ms") losslessly so downstream joins
-    # (regime_labels / spanning_base_spreads / user panels) can share a
-    # common datetime dtype without the user writing an explicit cast.
+    # against other user panels share a common datetime dtype without the
+    # user writing an explicit cast.
     # Other Datetime variants (any time_unit, any TZ) pass through — the
     # library is TZ-agnostic and trusts the caller's precision choice.
     if schema.get(date) == pl.Date:

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -7,7 +7,7 @@ flat global ``list()`` — the contextual question "which methods does this
 metric accept?" is answered per-metric (e.g. ``ic`` accepts
 ``NON_OVERLAPPING`` / ``NEWEY_WEST``).
 
-This release scopes the namespace to the **series-mean** family
+The namespace is scoped to the **series-mean** family
 (``compute(data, *, value_col, overlap_periods)``). Slice / panel methods
 keep their multivariate compute in ``factrix.slicing`` until they move
 onto the same ``metric(inference=...)`` path; they are deliberately not

--- a/factrix/metrics/_registry.py
+++ b/factrix/metrics/_registry.py
@@ -35,22 +35,23 @@ def register(cls: type[MetricBase]) -> None:
         setattr(_metrics_pkg, name, cls)
 
     # Proactively clear caches in discovery index and DAG modules
-    try:
-        import factrix._metric_index as _index
+    import factrix._metric_index as _index
 
-        if hasattr(_index._all_specs, "cache_clear"):
-            _index._all_specs.cache_clear()
-        if hasattr(_index.public_specs, "cache_clear"):
-            _index.public_specs.cache_clear()
-        if hasattr(_index._first_party_spec_by_name, "cache_clear"):
-            _index._first_party_spec_by_name.cache_clear()
-    except (ImportError, AttributeError):
-        pass
+    _index._all_specs.cache_clear()
+    _index.public_specs.cache_clear()
+    _index._first_party_spec_by_name.cache_clear()
 
+    # WHY the guard here but not above: ``factrix._dag`` imports
+    # ``factrix.metrics._helpers`` near the top of its module body, which pulls
+    # in every metric module, whose ``@metric`` decorators call this function —
+    # all while ``_dag`` is still executing and ``_registry_callable_table``
+    # (defined much further down) does not exist yet. AttributeError on that
+    # partially-initialised module is expected and safe to swallow: a module
+    # that has not finished importing has no populated cache to clear.
+    # ``factrix._metric_index`` has no such cycle, so it is called directly.
     try:
         import factrix._dag as _dag
 
-        if hasattr(_dag._registry_callable_table, "cache_clear"):
-            _dag._registry_callable_table.cache_clear()
+        _dag._registry_callable_table.cache_clear()
     except (ImportError, AttributeError):
         pass

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -931,11 +931,11 @@ def net_spread(
 
         The alternative convention quotes ``estimated_cost_bps`` as a
         **round-trip** cost (one buy *and* its later sell priced together),
-        under which the coefficient is ``2 τ c`` — the pre-0.20 factrix
-        behaviour. factrix picks the one-way convention because the
-        estimates practitioners have to hand (half-spread, per-order
-        impact, per-share commission, and the default ``30`` bps here) are
-        one-way quantities; charging them ``2 τ`` under-states the drag by
+        under which the coefficient is ``2 τ c``. factrix picks the one-way
+        convention because the estimates practitioners have to hand
+        (half-spread, per-order impact, per-share commission, and the
+        default ``30`` bps here) are one-way quantities; charging them
+        ``2 τ`` under-states the drag by
         exactly half. ``breakeven_cost`` inverts the *same* coefficient, so
         the two remain consistent: the breakeven bps it returns is the
         one-way cost at which this function's ``net`` reaches zero.

--- a/factrix/stats/__init__.py
+++ b/factrix/stats/__init__.py
@@ -4,8 +4,6 @@ The slice-test selection classes carry pure identity semantics
 (``name`` / ``description``, no ``compute``); their numerics live in
 the slice-test dispatch path and the ``factrix._stats`` kernels.
 Series-mean HAC inference lives in ``factrix.inference``.
-``InferenceResult`` — harmonized return shape (canonical home is
-``factrix.inference``; re-exported here).
 ``WaldNWCluster`` / ``WaldTwoWayCluster`` — cluster-robust Wald χ²
 selection-only instances for slice contrasts.
 ``DriscollKraay`` — [Driscoll-Kraay (1998)][driscoll-kraay-1998]
@@ -20,7 +18,6 @@ family-wise error-rate adjustments across a declared search family.
 
 from __future__ import annotations
 
-from factrix.inference._base import InferenceResult
 from factrix.stats.block_bootstrap import BlockBootstrap
 from factrix.stats.bootstrap import (
     bootstrap_mean_ci,
@@ -38,7 +35,6 @@ from factrix.stats.wald_cluster import WaldNWCluster, WaldTwoWayCluster
 __all__ = [
     "BlockBootstrap",
     "DriscollKraay",
-    "InferenceResult",
     "WaldNWCluster",
     "WaldTwoWayCluster",
     "bhy_adjust",

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -8,11 +8,9 @@ primary clone, so one run covers every worktree under it.
 
 Idempotent: re-running just rewrites the same hook shims.
 
-Migration: earlier setups pointed ``core.hooksPath`` at the tracked
-``.githooks`` directory, which is gone. That setting would shadow the
-``.git/hooks`` shims pre-commit installs, so it is unset here. A
-``core.hooksPath`` pointing anywhere else is a contributor-managed hook
-surface — the script aborts rather than overwrite it.
+A set ``core.hooksPath`` would shadow the ``.git/hooks`` shims pre-commit
+installs, and it is a contributor-managed hook surface — the script aborts
+with instructions rather than overwrite it.
 
 Usage::
 
@@ -24,12 +22,11 @@ from __future__ import annotations
 import subprocess
 import sys
 
-_LEGACY_HOOKS_PATH = ".githooks"
 _HOOK_TYPES = ("pre-commit", "commit-msg", "pre-push")
 
 
-def _run_git(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(["git", *args], capture_output=True, text=True, check=check)
+def _run_git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=False)
 
 
 def _git_config_get(key: str) -> str | None:
@@ -61,14 +58,7 @@ def main() -> int:
 
     hooks_path = _git_config_get("core.hooksPath")
 
-    if hooks_path == _LEGACY_HOOKS_PATH:
-        _run_git("config", "--unset", "core.hooksPath", check=True)
-        print(
-            f"[setup_dev] unset core.hooksPath (was {_LEGACY_HOOKS_PATH!r}). "
-            "The tracked hook scripts moved under the pre-commit framework; "
-            "leaving the old path set would shadow the hooks installed below."
-        )
-    elif hooks_path is not None:
+    if hooks_path is not None:
         print(
             f"[setup_dev] ERROR: core.hooksPath is set to {hooks_path!r}, which "
             "shadows the hooks pre-commit installs into .git/hooks.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Shared fixtures for factrix unit tests.
 
-Tests build synthetic panels locally and no longer depend on legacy
-profile/artifact fixtures or auto-use rule isolation.
+Tests build synthetic panels locally.
 """
 
 from datetime import datetime, timedelta

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -54,7 +54,7 @@ class TestCanonicalRenames:
             assert c not in out.columns, f"{c} source should have been renamed"
 
     def test_partial_ohlcv_is_allowed(self):
-        # User only needs 'high' for generate_52w_high_ratio
+        # User only needs 'high' for their own factor construction
         out = adapt(
             _raw_panel(),
             date="trade_date",

--- a/tests/test_docs_metric_routing.py
+++ b/tests/test_docs_metric_routing.py
@@ -1,4 +1,9 @@
-"""Regression checks for issue #726 routing guidance."""
+"""Docs regression checks for metric routing guidance.
+
+Pins two published contracts against prose drift: that the sparse-event
+docs still state the single-asset and event-magnitude rules, and that the
+metrics index still lists what stays out of ``evaluate()``.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -14,8 +14,6 @@ def test_subclasses_factrix_error_and_value_error() -> None:
 
 
 def test_other_error_subclasses_inheritance() -> None:
-    import factrix
-    import factrix._errors
     from factrix._errors import (
         IncompatibleAxisError,
         InsufficientSampleError,
@@ -26,10 +24,6 @@ def test_other_error_subclasses_inheritance() -> None:
 
     assert issubclass(InsufficientSampleError, FactrixError)
     assert not issubclass(InsufficientSampleError, ValueError)
-
-    # Verify ConfigError is completely removed
-    assert not hasattr(factrix, "ConfigError")
-    assert not hasattr(factrix._errors, "ConfigError")
 
 
 def test_caught_by_generic_value_error() -> None:


### PR DESCRIPTION
## What

factrix is pre-1.0 and carries no compatibility shims. A read-only audit confirmed the **code** has none — what remained was prose describing APIs that no longer exist, plus a few small vestigial items. This removes all of it in one commit.

Every removed name was re-grepped repo-wide afterwards (`by_regime`, `regime_ic`, `run_metrics_iter`, `run_metrics_chunked`, `evaluate_iter`, `evaluate_chunked`, `q1_q5_spread`, `.githooks`, `factors.technical`, `factors.liquidity`, `ConfigError`, `stats.InferenceResult`) — zero hits outside `docs/plans/archive/**`, which is deliberately untouched.

### Public-facing stale prose

- **`factrix/adapt.py`** — the module docstring and four `Args` entries pointed at `factrix.factors.technical` / `.liquidity` and five `generate_*` symbols. **`factrix/factors/` does not exist** and none of those symbols do. Each parameter now says what the column *is* and what consumes it. A grep for consumers found that nothing in factrix reads `open` / `high` / `low` / `volume`, so they are now documented as canonicalised pass-throughs; `price` names its real consumers (`compute_forward_return`, and `caar` / `event_horizon` as a volatility source). The `pl.Date` promotion comment no longer names `regime_labels` / `spanning_base_spreads` (neither exists).
- **`docs/guides/large-scale-evaluation.md`** — dropped the "replaces the retired built-in streaming/chunking APIs" sentence. Reframed `## Design trade-off: why built-in streaming was removed` as `## Design trade-off: why factrix has no built-in batch API`, present tense, with the three substantive bullets kept. Checked `mkdocs.yml` and every page linking this guide: **nothing linked the old heading anchor**, so no fixups were needed. `mkdocs build --strict` passes.
- **`docs/guides/slice-analysis.md`** — dropped the "legacy `by_regime` / `regime_ic` surface has been removed" sentence; the table directly below already routes the reader.
- **`factrix/metrics/tradability.py`** — `net_spread` no longer calls the round-trip convention "the pre-0.20 factrix behaviour". The round-trip-vs-one-way explanation is untouched (worked from current `main`, i.e. post-#876).
- **`docs/development/contributing.md`** — (a) dropped the `regime_<metric>` curated-wrapper table row; (b) the §7.3 release-checklist grep for the dead `q1_q5_spread` now builds `PATTERN` from the cycle's own breaking changes, with a note that it is rebuilt per release rather than inherited; (c) the BC-change reminder example is now the live, verifiable `overlap_periods → holding_periods` rename on `breakeven_cost` / `net_spread` (v0.23.0 → next, #876).
- **`docs/reference/statistical-methods.md`** — dropped only the "previously described here as a conservative simplification" sentence. The ICC(1)-vs-raw-ratio statistical comparison around it stands.
- **`docs/guides/panel-timeseries.md`** — dropped the parenthetical about the removed automatic block-bootstrap switch, replaced with a link to the canonical measured note in `docs/reference/stat-keys-by-metric.md#shared-small-n-note` (anchor verified present in the strict build output).

### Internal history comments → present tense

`tests/conftest.py`, `factrix/_family.py` (what `expand_over` *is*; where inference *is* selected), `factrix/_types.py`, `factrix/__init__.py`, `factrix/inference/__init__.py`.

On `MIN_IC_ASSETS_WARN`: no measured justification for the value exists in code, docs or git history (`f7c34358`, #727/#728, records no simulation), so the gloss now states honestly that it is the warn-tier counterpart of the hard floor, guards reliability rather than computability, and is a judgement floor rather than a simulated one.

### Tests / vestigial files

- `tests/test_errors.py` — dropped the three `ConfigError`-is-absent lines, plus the two `import factrix` / `import factrix._errors` statements they were the sole user of (ruff F401 otherwise).
- `tests/test_docs_issue_726.py` → `tests/test_docs_metric_routing.py`, docstring now describes what the two tests pin instead of naming an issue number.
- `tests/scripts/` — empty vestigial package; file and directory removed.

### Decided items

- **`factrix/stats/__init__.py`** — removed the `InferenceResult` re-export (import line, `__all__` entry, and the two docstring lines). Canonical home is `factrix.inference`. Grepped `factrix/ tests/ docs/ examples/` for `stats.InferenceResult` and `from factrix.stats import … InferenceResult`: **the audit's "none" is confirmed**. `tests/test_public_namespace.py` passes.
- **`scripts/setup_dev.py`** — removed the `.githooks` migration branch: `_LEGACY_HOOKS_PATH`, the auto-unset branch, the "Migration:" docstring paragraph, and the `check=` parameter on `_run_git` that only the unset call used. The `elif hooks_path is not None:` error path is now the single `if`. `docs/development/contributing.md`'s description of the auto-unset was dropped to match; `CONTRIBUTING.md` did not describe it.

## Item 17 outcome — the `_registry.py` experiment

**Split result: the guard is load-bearing for `_dag` and dead weight for `_metric_index`.**

All four `hasattr(<fn>, "cache_clear")` probes are gone — this repo decorates all four functions with `@functools.cache`, so the probes could never be false.

Removing *both* `try: … except (ImportError, AttributeError): pass` blocks made `uv run python -c "import factrix"` fail immediately:

```
File "factrix/metrics/_registry.py", line 44, in register
    _dag._registry_callable_table.cache_clear()
AttributeError: partially initialized module 'factrix._dag' from '…/factrix/_dag.py'
has no attribute '_registry_callable_table' (most likely due to a circular import)
```

The mechanism is exactly the predicted import-order one: `factrix/_dag.py:45` imports `factrix.metrics._helpers`, which pulls in every metric module, whose `@metric` decorators call `register()` — all while `_dag` is still executing its module body and `_registry_callable_table` (defined at line 473) does not exist yet.

So per the task's instruction I kept **only that** `try/except` and added a `WHY:` comment explaining the import-order reason — the real defect was that the original code had no explanation. `factrix._metric_index` has no such cycle: with its guard removed and `_dag`'s kept, `import factrix` succeeds and the full suite passes, so its three calls are now direct and unguarded.

## Gates

| Command | Result |
|---|---|
| `uv run ruff check .` | `All checks passed!` |
| `uv run ruff format --check .` | `213 files already formatted` |
| `uv run mypy factrix` | `Success: no issues found in 84 source files` |
| `uv run pytest -q` | `2916 passed, 3 skipped, 173 warnings in 145.06s (0:02:25)` |
| `uv run pytest --doctest-modules factrix/ -q` | `96 passed, 1 skipped, 10 warnings in 7.19s` |
| `uv run pre-commit run --hook-stage pre-push --all-files` | `CHANGELOG polish + mkdocs --strict + mypy................................Passed` |

## Out of scope (deliberately untouched)

The ~60 "An earlier version … measured X → now Y" WHY comments across the metrics/stat modules (project convention), `docs/plans/archive/**`, `CHANGELOG.md`, `docs/development/changelog.md`, `_resolve_series_value_col`'s `"ic"` fallback, the `test_the_old_convention_was_oversized`-style guard tests, and anything in the `factrix/stats` vs `factrix/_stats` public/private split.
