### PR TITLE
fix(metrics): one n_groups floor for every quantile-bucketing metric

### DIFF
--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -204,5 +204,5 @@ DEFAULT_N_GROUPS: int = 5
 # the same values with the same message instead of each carrying its own
 # bound (``notional_turnover`` used to demand three groups while
 # ``quantile_spread`` priced the two-group book it could not pair with).
-MIN_N_GROUPS: int = 2
+N_GROUPS_FLOOR: int = 2
 DEFAULT_FORWARD_PERIODS: int = 5

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -193,4 +193,16 @@ MIN_ORTHOGONALIZE_RESIDUAL_ASSETS: int = 10
 # ``monotonicity`` deliberately keeps its own ``n_groups=10``: a decile curve
 # is the shape it is calibrated to read, not a long-short leg.
 DEFAULT_N_GROUPS: int = 5
+# Coarsest quantile split any bucketing metric accepts. Two groups is the
+# top-half / bottom-half long-short book — the split the small-universe
+# guidance recommends and the coarsest one where "top" and "bottom" are still
+# distinct buckets. One group has no long-short leg at all: the spread is
+# identically zero, turnover has nothing to churn and a monotonicity curve is a
+# single point. Enforced once, in ``_assign_quantile_groups`` (and its batch
+# twin), so every consumer — ``quantile_spread``, ``quantile_spread_vw``,
+# ``compute_spread_series``, ``monotonicity``, ``notional_turnover`` — rejects
+# the same values with the same message instead of each carrying its own
+# bound (``notional_turnover`` used to demand three groups while
+# ``quantile_spread`` priced the two-group book it could not pair with).
+MIN_N_GROUPS: int = 2
 DEFAULT_FORWARD_PERIODS: int = 5

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult, PValueAlternative
 from factrix._stats import _calc_t_stat, _p_value_from_t
-from factrix._types import DDOF, EPSILON, KPSource, SampleAxis
+from factrix._types import DDOF, EPSILON, MIN_N_GROUPS, KPSource, SampleAxis
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
 # tie_policy="ordinal". 0.3 is the empirical cutoff for "crowded" factors
@@ -1468,6 +1468,22 @@ def _lag_within_asset(
     )
 
 
+def _validate_n_groups(n_groups: int) -> None:
+    """Reject a quantile count below :data:`~factrix._types.MIN_N_GROUPS`.
+
+    The single bound every bucketing path shares: both group-assignment
+    kernels call it, so a consumer cannot accept a split its siblings reject.
+    ``n_groups=1`` used to sail through ``quantile_spread`` as a spread of
+    exactly zero, while ``notional_turnover`` refused the two-group book the
+    spread had just priced.
+    """
+    if n_groups < MIN_N_GROUPS:
+        raise ValueError(
+            f"n_groups must be >= {MIN_N_GROUPS} (a long-short split needs "
+            f"distinct top and bottom buckets), got {n_groups!r}"
+        )
+
+
 def _assign_quantile_groups(
     data: pl.DataFrame,
     factor_col: str = "factor",
@@ -1489,6 +1505,7 @@ def _assign_quantile_groups(
     Returns:
         DataFrame with ``_group`` column appended.
     """
+    _validate_n_groups(n_groups)
     # A float NaN is *not* null to polars: ``rank`` places it above every
     # finite value (top bucket) and ``count`` includes it. Treat NaN like a
     # missing factor (pandas ``qcut`` / alphalens drop it) so it never lands
@@ -1536,6 +1553,7 @@ def _assign_quantile_groups_batch(
     ``compute_spread_series`` and ``monotonicity``; both consume the
     ``_group__<f>`` columns directly.
     """
+    _validate_n_groups(n_groups)
     rank_exprs = [
         pl.when(_finite_expr(f))
         .then(pl.col(f))

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult, PValueAlternative
 from factrix._stats import _calc_t_stat, _p_value_from_t
-from factrix._types import DDOF, EPSILON, MIN_N_GROUPS, KPSource, SampleAxis
+from factrix._types import DDOF, EPSILON, N_GROUPS_FLOOR, KPSource, SampleAxis
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
 # tie_policy="ordinal". 0.3 is the empirical cutoff for "crowded" factors
@@ -1469,7 +1469,7 @@ def _lag_within_asset(
 
 
 def _validate_n_groups(n_groups: int) -> None:
-    """Reject a quantile count below :data:`~factrix._types.MIN_N_GROUPS`.
+    """Reject a quantile count below :data:`~factrix._types.N_GROUPS_FLOOR`.
 
     The single bound every bucketing path shares: both group-assignment
     kernels call it, so a consumer cannot accept a split its siblings reject.
@@ -1477,9 +1477,9 @@ def _validate_n_groups(n_groups: int) -> None:
     exactly zero, while ``notional_turnover`` refused the two-group book the
     spread had just priced.
     """
-    if n_groups < MIN_N_GROUPS:
+    if n_groups < N_GROUPS_FLOOR:
         raise ValueError(
-            f"n_groups must be >= {MIN_N_GROUPS} (a long-short split needs "
+            f"n_groups must be >= {N_GROUPS_FLOOR} (a long-short split needs "
             f"distinct top and bottom buckets), got {n_groups!r}"
         )
 

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -88,7 +88,7 @@ def common_quantile_spread(
         factor_col: Column carrying the factor.
         return_col: Column carrying the forward return.
         n_groups: Number of quantile buckets ``K`` to cut the factor
-            history into. At least :data:`~factrix._types.MIN_N_GROUPS` = 2
+            history into. At least :data:`~factrix._types.N_GROUPS_FLOOR` = 2
             (the top-minus-bottom contrast needs two buckets); the Spearman
             shape check is reported as NaN below ``K = 3``.
         overlap_periods: Overlap horizon of the forward return; floors

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -44,6 +44,7 @@ from factrix.metrics._helpers import (
     _degenerate_test_fields,
     _enforce_min_floor,
     _short_circuit_output,
+    _validate_n_groups,
 )
 
 __all__ = [
@@ -87,7 +88,9 @@ def common_quantile_spread(
         factor_col: Column carrying the factor.
         return_col: Column carrying the forward return.
         n_groups: Number of quantile buckets ``K`` to cut the factor
-            history into.
+            history into. At least :data:`~factrix._types.MIN_N_GROUPS` = 2
+            (the top-minus-bottom contrast needs two buckets); the Spearman
+            shape check is reported as NaN below ``K = 3``.
         overlap_periods: Overlap horizon of the forward return; floors
             the Newey-West (NW) bandwidth.
         nw_lags: Override for the NW lag count. ``None`` resolves to
@@ -135,6 +138,10 @@ def common_quantile_spread(
         >>> result.name == ""
         True
     """
+    # This metric buckets the factor *history* with its own ordinal cut rather
+    # than the panel kernel, so it applies the shared floor explicitly: one
+    # bucket has no top-minus-bottom contrast to test.
+    _validate_n_groups(n_groups)
     if "date" not in data.columns:
         return _short_circuit_output(
             "common_quantile_spread",

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -399,7 +399,7 @@ def notional_turnover(
         n_groups: Number of quantile groups (default
             :data:`~factrix._types.DEFAULT_N_GROUPS` = 5 = quintiles, the
             same constant ``quantile_spread`` defaults to). Must be at least
-            :data:`~factrix._types.MIN_N_GROUPS` = 2 — the top-half /
+            :data:`~factrix._types.N_GROUPS_FLOOR` = 2 — the top-half /
             bottom-half book a small universe evaluates with
             ``quantile_spread(n_groups=2)``; this metric prices that same
             book, so it accepts the same split.

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -54,6 +54,7 @@ from factrix.metrics._helpers import (
     _median_universe_size,
     _sample_non_overlapping,
     _short_circuit_output,
+    _validate_n_groups,
 )
 
 _DOCS_TRADABILITY = "api/metrics/tradability"
@@ -397,8 +398,11 @@ def notional_turnover(
         factor_col: Name of the factor column.
         n_groups: Number of quantile groups (default
             :data:`~factrix._types.DEFAULT_N_GROUPS` = 5 = quintiles, the
-            same constant ``quantile_spread`` defaults to). Must be ≥ 3 so
-            top and bottom are distinct buckets.
+            same constant ``quantile_spread`` defaults to). Must be at least
+            :data:`~factrix._types.MIN_N_GROUPS` = 2 — the top-half /
+            bottom-half book a small universe evaluates with
+            ``quantile_spread(n_groups=2)``; this metric prices that same
+            book, so it accepts the same split.
         rebalance_lag: Rebalance stride, counted in **evaluation-grid
             observations** (periods of the panel handed to the metric). Must
             be a positive ``int``. When ``> 1``, sub-samples at that stride
@@ -475,10 +479,10 @@ def notional_turnover(
     if overlap_periods < 1:
         raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
     _validate_rebalance_lag(rebalance_lag)
-    if n_groups < 3:
-        raise ValueError(
-            f"n_groups must be ≥ 3 (need distinct top/bottom buckets), got {n_groups!r}"
-        )
+    # The shared bucketing floor, checked up front rather than left to the
+    # kernel call below so an invalid split fails before the date floor can
+    # short-circuit it into an "insufficient_dates" result.
+    _validate_n_groups(n_groups)
 
     lag = _resolve_rebalance_lag(rebalance_lag, overlap_periods)
     if lag > 1:

--- a/tests/test_n_groups_floor.py
+++ b/tests/test_n_groups_floor.py
@@ -1,0 +1,146 @@
+"""One ``n_groups`` floor for every quantile-bucketing metric (#878).
+
+``notional_turnover`` used to demand ``n_groups >= 3`` while
+``quantile_spread`` accepted — and priced — the two-group top-half /
+bottom-half book, so the matched spread / turnover pair a six-name
+allocation study needs could not be built. Meanwhile ``n_groups=1`` sailed
+through every spread metric as a spread of exactly zero. The bound now
+lives once, in :data:`factrix._types.MIN_N_GROUPS`, and is enforced by the
+shared group-assignment kernels, so these tests pin the *set* of consumers
+rather than one function each.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._errors import UserInputError
+from factrix._types import DEFAULT_FORWARD_PERIODS, MIN_N_GROUPS
+from factrix.metrics import (
+    breakeven_cost,
+    common_quantile_spread,
+    compute_spread_series,
+    monotonicity,
+    net_spread,
+    notional_turnover,
+    quantile_spread,
+    quantile_spread_vw,
+)
+from factrix.preprocess import compute_forward_return
+
+
+def _panel(n_assets: int = 8, n_dates: int = 60) -> pl.DataFrame:
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates, seed=0)
+    return compute_forward_return(raw, forward_periods=DEFAULT_FORWARD_PERIODS)
+
+
+def _weighted(panel: pl.DataFrame) -> pl.DataFrame:
+    return panel.with_columns(pl.lit(1.0).alias("market_cap"))
+
+
+# (label, callable(panel, n_groups) -> MetricResult-ish). Every public
+# consumer of the bucketing kernels plus the one metric with its own cut.
+_CONSUMERS = [
+    ("quantile_spread", lambda p, g: quantile_spread(p, n_groups=g)["factor"]),
+    # Single-factor by construction (one weight column), so it hands back the
+    # MetricResult itself rather than a per-factor dict.
+    (
+        "quantile_spread_vw",
+        lambda p, g: quantile_spread_vw(
+            _weighted(p), n_groups=g, weight_col="market_cap"
+        ),
+    ),
+    (
+        "compute_spread_series",
+        lambda p, g: compute_spread_series(p, n_groups=g)["factor"],
+    ),
+    ("monotonicity", lambda p, g: monotonicity(p, n_groups=g)["factor"]),
+    (
+        "common_quantile_spread",
+        lambda p, g: common_quantile_spread(
+            p.filter(pl.col("asset_id") == p["asset_id"][0]), n_groups=g
+        ),
+    ),
+    (
+        "notional_turnover",
+        lambda p, g: notional_turnover(p, n_groups=g, rebalance_lag=1),
+    ),
+]
+
+
+@pytest.mark.parametrize("n_groups", [0, 1])
+@pytest.mark.parametrize(("label", "run"), _CONSUMERS, ids=[c[0] for c in _CONSUMERS])
+def test_every_bucketing_metric_rejects_the_same_floor(label, run, n_groups):
+    with pytest.raises(ValueError, match="n_groups"):
+        run(_panel(), n_groups)
+
+
+@pytest.mark.parametrize(("label", "run"), _CONSUMERS, ids=[c[0] for c in _CONSUMERS])
+def test_every_bucketing_metric_accepts_the_two_group_book(label, run):
+    out = run(_panel(), MIN_N_GROUPS)
+    # A spread series is a frame; everything else is a MetricResult that ran.
+    if isinstance(out, pl.DataFrame):
+        assert out.height > 0
+    else:
+        assert out.metadata.get("reason") is None
+        assert out.metadata["n_groups"] == MIN_N_GROUPS
+
+
+class TestTwoGroupNotionalTurnover:
+    """#878 — six names, top 3 versus bottom 3."""
+
+    @staticmethod
+    def _six_country_panel() -> pl.DataFrame:
+        """Eight dates; on odd dates ``C2`` and ``C3`` swap halves.
+
+        Top half on even dates is ``{C3, C4, C5}``, on odd dates ``{C2, C4,
+        C5}`` — one of three names replaced in each leg at every transition,
+        so the per-leg replaced fraction is exactly ``1/3``.
+        """
+        rows = []
+        for t in range(8):
+            for a in range(6):
+                factor = float(a)
+                if t % 2 == 1 and a in (2, 3):
+                    factor = 5.0 - a  # C2 -> 3.0, C3 -> 2.0
+                rows.append(
+                    {
+                        "date": date(2024, 1, 1) + timedelta(days=t),
+                        "asset_id": f"C{a}",
+                        "factor": factor,
+                    }
+                )
+        return pl.DataFrame(rows)
+
+    def test_two_group_membership_churn(self):
+        out = notional_turnover(
+            self._six_country_panel(),
+            n_groups=2,
+            rebalance_lag=1,
+            overlap_periods=4,
+        )
+        assert out.value == pytest.approx(1.0 / 3.0)
+        assert out.n_obs == 7
+        assert out.metadata["n_groups"] == 2
+        assert out.metadata["overlap_periods"] == 4
+        assert out.metadata["rebalance_lag"] == 1
+        assert out.metadata["mean_tail_size"] == pytest.approx(3.0)
+
+    def test_pairs_with_the_two_group_spread(self):
+        panel = _panel(n_assets=6)
+        spread = quantile_spread(panel, n_groups=2)["factor"]
+        turnover = notional_turnover(panel, n_groups=2)
+        assert spread.metadata["n_groups"] == turnover.metadata["n_groups"] == 2
+
+        be = breakeven_cost(spread, turnover=turnover, holding_periods=5)
+        net = net_spread(spread, turnover=turnover, holding_periods=5)
+        assert be.metadata["pairing_checked"] is True
+        assert net.metadata["pairing_checked"] is True
+        assert be.metadata["n_groups"] == 2
+
+        # The bucketing check still bites when the books differ.
+        with pytest.raises(UserInputError, match="n_groups"):
+            breakeven_cost(spread, turnover=notional_turnover(panel, n_groups=3))

--- a/tests/test_n_groups_floor.py
+++ b/tests/test_n_groups_floor.py
@@ -5,7 +5,7 @@
 bottom-half book, so the matched spread / turnover pair a six-name
 allocation study needs could not be built. Meanwhile ``n_groups=1`` sailed
 through every spread metric as a spread of exactly zero. The bound now
-lives once, in :data:`factrix._types.MIN_N_GROUPS`, and is enforced by the
+lives once, in :data:`factrix._types.N_GROUPS_FLOOR`, and is enforced by the
 shared group-assignment kernels, so these tests pin the *set* of consumers
 rather than one function each.
 """
@@ -18,7 +18,7 @@ import factrix as fx
 import polars as pl
 import pytest
 from factrix._errors import UserInputError
-from factrix._types import DEFAULT_FORWARD_PERIODS, MIN_N_GROUPS
+from factrix._types import DEFAULT_FORWARD_PERIODS, N_GROUPS_FLOOR
 from factrix.metrics import (
     breakeven_cost,
     common_quantile_spread,
@@ -80,13 +80,13 @@ def test_every_bucketing_metric_rejects_the_same_floor(label, run, n_groups):
 
 @pytest.mark.parametrize(("label", "run"), _CONSUMERS, ids=[c[0] for c in _CONSUMERS])
 def test_every_bucketing_metric_accepts_the_two_group_book(label, run):
-    out = run(_panel(), MIN_N_GROUPS)
+    out = run(_panel(), N_GROUPS_FLOOR)
     # A spread series is a frame; everything else is a MetricResult that ran.
     if isinstance(out, pl.DataFrame):
         assert out.height > 0
     else:
         assert out.metadata.get("reason") is None
-        assert out.metadata["n_groups"] == MIN_N_GROUPS
+        assert out.metadata["n_groups"] == N_GROUPS_FLOOR
 
 
 class TestTwoGroupNotionalTurnover:

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -245,8 +245,11 @@ class TestNotionalTurnover:
         df = _panel(3, self.TEN_ASSETS, lambda t, a: ord(a))
         with pytest.raises(ValueError, match="overlap_periods"):
             notional_turnover(df, overlap_periods=0)
+        # The floor is the shared MIN_N_GROUPS = 2, not a private 3: the
+        # two-group top-half / bottom-half book is the one
+        # ``quantile_spread(n_groups=2)`` prices (#878).
         with pytest.raises(ValueError, match="n_groups"):
-            notional_turnover(df, n_groups=2)
+            notional_turnover(df, n_groups=1)
 
 
 class TestBreakevenCost:

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -245,7 +245,7 @@ class TestNotionalTurnover:
         df = _panel(3, self.TEN_ASSETS, lambda t, a: ord(a))
         with pytest.raises(ValueError, match="overlap_periods"):
             notional_turnover(df, overlap_periods=0)
-        # The floor is the shared MIN_N_GROUPS = 2, not a private 3: the
+        # The floor is the shared N_GROUPS_FLOOR = 2, not a private 3: the
         # two-group top-half / bottom-half book is the one
         # ``quantile_spread(n_groups=2)`` prices (#878).
         with pytest.raises(ValueError, match="n_groups"):


### PR DESCRIPTION
## Problem

`notional_turnover` demanded `n_groups >= 3` while `quantile_spread` accepted — and priced — the two-group top-half / bottom-half book, so the matched spread / turnover pair a six-name allocation study needs could not be built (#878).

That bound was also the only one in the library. Probing every bucketing metric at `n_groups ∈ {1, 2, 3}`:

| metric | `n_groups=1` | `n_groups=2` |
|---|---|---|
| `quantile_spread` / `quantile_spread_vw` / `compute_spread_series` | silently returns spread = 0.0 | OK |
| `common_quantile_spread` | silently returns 0.0 | OK |
| `monotonicity` | short-circuits with a misleading `insufficient_assets_for_quantile_groups` | OK |
| `notional_turnover` | `ValueError` | **`ValueError`** (the bug) |

## Change

- `factrix._types.N_GROUPS_FLOOR = 2` — the one floor: two groups is the coarsest split where top and bottom are still distinct buckets; one group has no long-short leg.
- `_helpers._validate_n_groups` enforces it inside both group-assignment kernels (`_assign_quantile_groups` and its batch twin), so `quantile_spread`, `quantile_spread_vw`, `compute_spread_series`, `monotonicity` and `notional_turnover` reject the same values with the same message without each carrying a private bound.
- `notional_turnover` calls it up front as well so an invalid split fails before the date floor can turn it into an `insufficient_dates` row; `common_quantile_spread` (its own ordinal cut, not the kernel) applies it explicitly.
- Docstrings state the shared floor.

## Breaking

`n_groups=1` now raises `ValueError` everywhere instead of returning a zero spread. `notional_turnover(n_groups=2)` is now accepted.

## Tests

- `tests/test_n_groups_floor.py`: parametrised over all six bucketing consumers — `0` and `1` rejected, `2` accepted with `n_groups` recorded in metadata.
- `TestTwoGroupNotionalTurnover`: six names, top 3 / bottom 3, one name swapped per leg each transition → value exactly `1/3`, `n_obs=7`, metadata `n_groups=2`, `overlap_periods=4`, `rebalance_lag=1`; the two-group spread and turnover pair through `breakeven_cost` / `net_spread`, and a three-group turnover is still rejected.
- Full suite: see the summary line in the PR conversation (the first push carried a naming-lint failure, FX003, fixed in the second commit).

Closes #878.