### PR TITLE
feat(tradability): expose leg-level notional turnover

### DIFF
--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -140,6 +140,7 @@ is no deprecation shim, so a call using either older name raises `TypeError`.
 | Goal                                                                            | Function             |
 |---------------------------------------------------------------------------------|----------------------|
 | Per-rebalance Q1/Qn membership churn — feeds the cost formulas (default $\tau$) | `notional_turnover`  |
+| Top-leg-only churn — matched proxy for an equal-weight top-quantile long-only book (not a cost model) | `notional_turnover` → `metadata["mean_top_turnover"]` |
 | Rank-stability diagnostic across the full cross-section (or tail-union)         | `rank_turnover`           |
 | Breakeven trading cost in bps, given a gross spread and $\tau$                  | `breakeven_cost`     |
 | Net per-period spread after a venue-specific cost estimate                      | `net_spread`         |

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -913,7 +913,11 @@ inference.
 #### `notional_turnover`
 
 - *descriptive*: `n_rebalances`, `n_groups`, `overlap_periods`,
-  `rebalance_lag`, `mean_tail_size`.
+  `rebalance_lag`, `mean_top_turnover`, `mean_bottom_turnover`
+  (each leg's mean replaced fraction; `value` is their mean —
+  `mean_top_turnover` is the matched proxy for an equal-weight top-quantile
+  long-only book), `mean_tail_size`, `mean_top_tail_size`,
+  `mean_bottom_tail_size`.
 
 Both turnover metrics report two strides. `overlap_periods` is the panel's
 evaluation-grid overlap stamp — an inference quantity, injected, never a user

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -442,9 +442,22 @@ def notional_turnover(
         ``0`` = identical tail sets every rebalance; ``1`` = full rotation.
         Metadata: ``n_rebalances``, ``n_groups``, ``overlap_periods`` (the
         panel's stamp, unchanged), ``rebalance_lag`` (the stride actually
-        sampled at), ``mean_tail_size`` (per-date average of
-        ``(|Q_top| + |Q_bot|)/2``; ≠ ``n_assets / n_groups`` signals
-        unbalanced buckets from ties or a short universe), ``method``.
+        sampled at), ``mean_top_turnover`` / ``mean_bottom_turnover`` (each
+        leg's mean replaced fraction — ``value`` is their mean),
+        ``mean_tail_size`` (per-date average of ``(|Q_top| + |Q_bot|)/2``;
+        ≠ ``n_assets / n_groups`` signals unbalanced buckets from ties or a
+        short universe) with its per-leg split ``mean_top_tail_size`` /
+        ``mean_bottom_tail_size``, ``method``.
+
+        **Long-only reading.** ``mean_top_turnover`` is the membership churn
+        of the equal-weight top-quantile book on its own — the matched
+        turnover proxy for a long-only allocation that holds the top bucket
+        against a benchmark, which pays nothing for bottom-leg churn. It is
+        a pre-strategy feasibility diagnostic, not a cost model: weights,
+        benchmark-relative trades, slippage and capacity stay downstream.
+        Feed ``value`` (the two-leg mean) to ``breakeven_cost`` /
+        ``net_spread`` — their ``4 × τ`` accounting is the long-short
+        book's — and do not mix the two readings.
 
     Notes:
         Per rebalance date ``t``::
@@ -537,13 +550,15 @@ def notional_turnover(
             (pl.col("is_bot") & pl.col("was_bot")).sum().alias("n_bot_kept"),
         )
         .filter((pl.col("n_top") > 0) & (pl.col("n_bot") > 0))
+        # Each leg's replaced fraction is kept on its own: the long-short
+        # ``value`` is their mean, but a long-only top-quantile book pays only
+        # the top leg's churn, and the two can differ materially.
         .with_columns(
-            (
-                (1 - pl.col("n_top_kept") / pl.col("n_top"))
-                + (1 - pl.col("n_bot_kept") / pl.col("n_bot"))
-            )
-            .truediv(2)
-            .alias("turnover")
+            (1 - pl.col("n_top_kept") / pl.col("n_top")).alias("top_turnover"),
+            (1 - pl.col("n_bot_kept") / pl.col("n_bot")).alias("bot_turnover"),
+        )
+        .with_columns(
+            ((pl.col("top_turnover") + pl.col("bot_turnover")) / 2).alias("turnover")
         )
         .sort("date")
     )
@@ -570,11 +585,13 @@ def notional_turnover(
 
     turnover_arr = per_date["turnover"].to_numpy()
     mean_turnover = float(np.mean(turnover_arr))
+    mean_top_turnover = float(per_date["top_turnover"].mean())  # type: ignore[arg-type]
+    mean_bottom_turnover = float(per_date["bot_turnover"].mean())  # type: ignore[arg-type]
     tail_pct = 1.0 / n_groups
 
-    mean_tail_size = float(
-        per_date.select(((pl.col("n_top") + pl.col("n_bot")) / 2).mean()).item()
-    )
+    mean_top_tail_size = float(per_date["n_top"].mean())  # type: ignore[arg-type]
+    mean_bottom_tail_size = float(per_date["n_bot"].mean())  # type: ignore[arg-type]
+    mean_tail_size = (mean_top_tail_size + mean_bottom_tail_size) / 2
     return MetricResult(
         value=mean_turnover,
         # Rebalances — one per adjacent-period transition, not (date, asset)
@@ -586,7 +603,11 @@ def notional_turnover(
             "n_groups": n_groups,
             "overlap_periods": overlap_periods,
             "rebalance_lag": lag,
+            "mean_top_turnover": mean_top_turnover,
+            "mean_bottom_turnover": mean_bottom_turnover,
             "mean_tail_size": mean_tail_size,
+            "mean_top_tail_size": mean_top_tail_size,
+            "mean_bottom_tail_size": mean_bottom_tail_size,
             "method": (
                 f"one-sided overlap on top/bottom {tail_pct:.0%} "
                 f"quantile, top/bot averaged"

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -624,3 +624,61 @@ class TestHoldingPeriodsAmortisesCost:
         assert breakeven_cost(
             spread, turnover=0.20, holding_periods=20
         ).value == pytest.approx(250.0)
+
+
+class TestLegLevelNotionalTurnover:
+    """#884 — each leg's churn is kept beside the long-short mean.
+
+    ``value`` stays the top/bottom average (the ``4 × τ`` accounting in the
+    cost helpers is the long-short book's); ``mean_top_turnover`` is the
+    matched proxy for an equal-weight top-quantile long-only book, which pays
+    nothing for bottom-leg churn.
+    """
+
+    TEN: ClassVar[list[str]] = [chr(ord("A") + i) for i in range(10)]
+
+    def test_asymmetric_churn_keeps_both_legs_and_their_mean(self):
+        """Top pair rotates fully every date, bottom pair never moves.
+
+        n_groups=5 on ten names: bottom = {A, B}, top = the two largest.
+        Alternate the top slot between {I, J} and {G, H} while A and B stay
+        the two smallest, so top churn is 1, bottom churn 0 and the
+        long-short mean 0.5.
+        """
+
+        def factor(t, a):
+            base = ord(a) - ord("A")
+            if a in ("G", "H", "I", "J"):
+                # Even dates: I, J on top; odd dates: G, H on top.
+                return 20 + base if (t % 2 == 0) == (a in ("I", "J")) else base
+            return base
+
+        df = _panel(6, self.TEN, factor)
+        out = notional_turnover(df, n_groups=5, overlap_periods=1)
+        assert out.metadata["mean_top_turnover"] == pytest.approx(1.0)
+        assert out.metadata["mean_bottom_turnover"] == pytest.approx(0.0)
+        assert out.value == pytest.approx(0.5)
+        assert out.value == pytest.approx(
+            (out.metadata["mean_top_turnover"] + out.metadata["mean_bottom_turnover"])
+            / 2
+        )
+        assert out.metadata["mean_top_tail_size"] == pytest.approx(2.0)
+        assert out.metadata["mean_bottom_tail_size"] == pytest.approx(2.0)
+        assert out.metadata["mean_tail_size"] == pytest.approx(2.0)
+
+    def test_full_rotation_and_static_book_bound_the_legs(self):
+        def reversed_every_date(t, a):
+            base = ord(a) - ord("A")
+            return base if t % 2 == 0 else (9 - base)
+
+        rotated = notional_turnover(
+            _panel(5, self.TEN, reversed_every_date), n_groups=5, overlap_periods=1
+        )
+        assert rotated.metadata["mean_top_turnover"] == pytest.approx(1.0)
+        assert rotated.metadata["mean_bottom_turnover"] == pytest.approx(1.0)
+
+        static = notional_turnover(
+            _panel(5, self.TEN, lambda t, a: ord(a)), n_groups=5, overlap_periods=1
+        )
+        assert static.metadata["mean_top_turnover"] == pytest.approx(0.0)
+        assert static.metadata["mean_bottom_turnover"] == pytest.approx(0.0)


### PR DESCRIPTION
## Problem

`notional_turnover` computed each leg's membership churn and kept only their mean. A long-only allocation that holds the top quantile against a benchmark pays nothing for bottom-leg churn, so the long-short mean over-states its turnover; `rank_turnover` (full-rank stability) is not a substitute (#884).

## Change

- `value` unchanged — still the top/bottom mean the cost helpers' `4 × τ` accounting assumes.
- Metadata gains `mean_top_turnover` / `mean_bottom_turnover` (each leg's mean replaced fraction) and `mean_top_tail_size` / `mean_bottom_tail_size` beside the existing `mean_tail_size`.
- Docstring, stat-keys reference and the tradability page state the long-only reading (`mean_top_turnover` = matched proxy for an equal-weight top-quantile book; pre-strategy feasibility, not a cost model) and keep `rank_turnover` / long-short notional / top-leg notional apart. No weights, benchmark-relative trades, slippage or capacity — those stay downstream.

## Tests

- Asymmetric case: top pair rotates fully every rebalance while the bottom pair never moves → `mean_top_turnover = 1`, `mean_bottom_turnover = 0`, `value = 0.5 =` their mean; tail sizes 2/2.
- Full rotation → both legs 1; static book → both legs 0.
- Targeted suites (tradability, n_groups floor, stat-key docs, docs examples): 143 passed.

Closes #884.