### PR TITLE
feat(results): export named estimator metadata from to_frame

### DIFF
--- a/docs/api/evaluation-results.md
+++ b/docs/api/evaluation-results.md
@@ -32,6 +32,42 @@ The leading `factor` / `forward_periods` / `params` block is the **hypothesis id
 - `reason` (`str` | `null`): Short-circuit reason when `is_applicable` is `false`.
 - `warning_codes` (`list[str]`): Warnings attached to the metric — the bundle-level `Warning` records sourced on it, unioned (de-duplicated, first-seen order) with the producer's own `MetricResult.warning_codes`.
 
+#### Exporting estimator metadata (`metadata=`)
+
+The fixed schema is the cross-metric contract; estimator-specific definitions (a spread's `n_groups`, a turnover's `rebalance_lag` or `mean_tail_size`) stay in `MetricResult.metadata` and are **not** expanded by default. `to_frame(metadata=(...))` names the keys to carry along — one trailing column per key, in the order requested — so a CSV written from the stacked frame can be audited without the `MetricResult` objects:
+
+- the column keeps the row's `factor` / `metric_name` pairing, so stacking many results keeps every cell next to the metric it came from;
+- a metric that does not carry the key gets `null`;
+- only scalar values export (`bool` / `int` / `float` / `str`; `NaN` / `Inf` become `null` like `value`, numpy scalars are unwrapped). A list, dict or other nested value raises `ValueError` naming the metric and key — that is what `to_dict()` is for;
+- a key that collides with a fixed column, a `params` key, or repeats raises `ValueError`, so metadata never shadows the identity block or the fixed schema;
+- dtypes are inferred per column.
+
+!!! example "Tradability audit — is the turnover pricing the same book as the spread?"
+
+    ```python
+    import factrix as fx
+    from factrix.metrics import notional_turnover, quantile_spread
+    from factrix.preprocess import compute_forward_return
+
+    raw = fx.datasets.make_cs_panel(n_assets=6, n_dates=120, seed=0)
+    panel = compute_forward_return(raw, forward_periods=5)
+    result = fx.evaluate(
+        panel,
+        metrics={
+            "spread": quantile_spread(n_groups=2),
+            "turnover": notional_turnover(n_groups=2, rebalance_lag=1),
+        },
+        factor_cols=["factor"],
+    )["factor"]
+
+    audit = result.to_frame(metadata=("n_groups", "rebalance_lag", "mean_tail_size"))
+    print(audit.select("metric_name", "value", "n_groups", "rebalance_lag", "mean_tail_size"))
+    # spread    ...  2  null  3.0
+    # turnover  ...  2  1     3.0
+    ```
+
+    Both rows show `n_groups = 2`, so the spread and the turnover describe the same top-half / bottom-half book; the spread row's `rebalance_lag` is `null` because a spread carries no such key.
+
 ### `to_dict()`
 Converts the result into a JSON-friendly nested dictionary. It normalizes floats (e.g., `NaN` and `Inf` to `None`) so that it can be serialized directly using standard `json.dumps` without raising errors.
 

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -7,9 +7,10 @@ methods.
 
 from __future__ import annotations
 
+import contextlib
 import html
 import math
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, get_args
 
@@ -259,10 +260,11 @@ class EvaluationResult:
                 f"no metric {label!r} on this result; available: {available}"
             ) from None
 
-    def to_frame(self) -> pl.DataFrame:
+    def to_frame(self, *, metadata: Sequence[str] = ()) -> pl.DataFrame:
         r"""One row per produced metric, prefixed with bundle identity.
 
-        Schema (column order is stable):
+        Schema (column order is stable; ``metadata=`` columns, if any, follow
+        ``warning_codes`` in the order requested):
 
         | column | dtype | source |
         |---|---|---|
@@ -292,8 +294,33 @@ class EvaluationResult:
         (results whose :attr:`params` keys differ need
         ``pl.concat(..., how="diagonal")``, as in :func:`factrix.compare`).
 
+        **Exporting estimator metadata.** The fixed schema is the stable
+        cross-metric contract; estimator-specific definitions (a spread's
+        ``n_groups``, a turnover's ``rebalance_lag`` / ``mean_tail_size``)
+        live in ``MetricResult.metadata`` and do not leak into it by default.
+        ``metadata=`` names the keys to carry along, one column per key, so a
+        CSV written from the stacked frame can be audited without the
+        ``MetricResult`` objects:
+
+        - the column is named after the key and keeps the row's
+          ``factor`` / ``metric_name`` pairing — stacking many results keeps
+          every metadata cell next to the metric it came from;
+        - a metric that does not carry the key gets ``null`` (a spread row
+          has no ``rebalance_lag``);
+        - only **scalar** values are exported — ``bool`` / ``int`` /
+          ``float`` / ``str`` (``NaN`` / ``Inf`` become ``null`` like
+          ``value``; numpy scalars are unwrapped). A list, dict, tuple or
+          other nested value raises ``ValueError`` naming the metric and
+          key — those are what :meth:`to_dict` is for;
+        - a key colliding with a fixed column, a :attr:`params` key or a
+          repeated key raises ``ValueError``, so metadata never shadows
+          identity or the fixed schema;
+        - dtypes are inferred per column from the values present.
+
         Raises:
-            ValueError: a :attr:`params` key collides with a fixed column name.
+            ValueError: a :attr:`params` key collides with a fixed column
+                name; a ``metadata`` key collides, repeats, or names a
+                non-scalar value on some metric.
         """
         collisions = sorted(set(self.params) & set(_TO_FRAME_SCHEMA))
         if collisions:
@@ -302,6 +329,7 @@ class EvaluationResult:
                 f"with fixed column name(s); rename the params key(s). Reserved: "
                 f"{sorted(_TO_FRAME_SCHEMA)}"
             )
+        meta_keys = _validate_metadata_keys(metadata, params=self.params)
         by_metric: dict[str, list[str]] = {}
         for w in self.warnings:
             if w.source is None:
@@ -315,6 +343,7 @@ class EvaluationResult:
                 "overlap_periods": self.overlap_periods,
                 "n_assets": self.n_assets,
                 **_output_row(key, out, by_metric),
+                **_metadata_columns(key, out, meta_keys),
             }
             for key, out in self.metrics.items()
         ]
@@ -325,6 +354,8 @@ class EvaluationResult:
             **dict.fromkeys(self.params),
             "overlap_periods": pl.Int64,
             **{k: v for k, v in _TO_FRAME_SCHEMA.items() if k != "factor"},
+            # Metadata values are estimator-specific scalars — inferred too.
+            **dict.fromkeys(meta_keys),
         }
         return pl.DataFrame(rows, schema=schema)
 
@@ -512,6 +543,74 @@ def _output_row(
         "reason": out.reason,
         "warning_codes": list(codes),
     }
+
+
+# Columns ``to_frame`` always emits ahead of the fixed schema; a metadata key
+# may not shadow any of them.
+_TO_FRAME_IDENTITY: tuple[str, ...] = ("forward_periods", "overlap_periods")
+
+
+def _validate_metadata_keys(
+    metadata: object, *, params: Mapping[str, Hashable]
+) -> tuple[str, ...]:
+    """Normalise ``to_frame(metadata=)``: a sequence of distinct, non-reserved keys."""
+    if isinstance(metadata, str) or not isinstance(metadata, Sequence):
+        raise ValueError(
+            "EvaluationResult.to_frame(): metadata= takes a sequence of metadata "
+            f"key names, e.g. metadata=('n_groups', 'rebalance_lag'); got "
+            f"{metadata!r}"
+        )
+    keys = tuple(metadata)
+    bad = [k for k in keys if not isinstance(k, str)]
+    if bad:
+        raise ValueError(
+            f"EvaluationResult.to_frame(): metadata keys must be strings; got {bad!r}"
+        )
+    repeated = sorted({k for k in keys if keys.count(k) > 1})
+    if repeated:
+        raise ValueError(
+            f"EvaluationResult.to_frame(): metadata key(s) {repeated} repeated"
+        )
+    reserved = set(_TO_FRAME_SCHEMA) | set(_TO_FRAME_IDENTITY) | set(params)
+    collisions = sorted(set(keys) & reserved)
+    if collisions:
+        raise ValueError(
+            f"EvaluationResult.to_frame(): metadata key(s) {collisions} collide "
+            f"with a fixed column or a params key; the fixed schema and the "
+            f"hypothesis identity are never shadowed by metadata. Reserved: "
+            f"{sorted(reserved)}"
+        )
+    return keys
+
+
+def _metadata_columns(
+    key: str, out: MetricResult, meta_keys: Sequence[str]
+) -> dict[str, Any]:
+    """One scalar cell per requested metadata key; ``None`` where absent."""
+    label = out.name or key
+    return {k: _scalar_metadata(label, k, out.metadata.get(k)) for k in meta_keys}
+
+
+def _scalar_metadata(label: str, key: str, value: object) -> Any:
+    """Coerce a metadata value to a frame cell or refuse a nested one."""
+    if value is None:
+        return None
+    # numpy scalars (np.float64 is a float subclass, np.int64 is not) unwrap
+    # via ``item()``; strings expose no such method.
+    if not isinstance(value, (bool, int, float, str)) and hasattr(value, "item"):
+        # A multi-element array also has ``item()`` and refuses; it then falls
+        # through to the nested-value error below.
+        with contextlib.suppress(TypeError, ValueError):
+            value = value.item()
+    if isinstance(value, bool | int | str):
+        return value
+    if isinstance(value, float):
+        return _float_or_none(value)
+    raise ValueError(
+        f"EvaluationResult.to_frame(): metadata[{key!r}] on metric {label!r} is "
+        f"a {type(value).__name__}, not a scalar; metadata= exports bool / int / "
+        f"float / str cells only. Use to_dict() for nested values."
+    )
 
 
 def _float_or_none(x: object) -> float | None:

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -352,3 +352,97 @@ class TestReprHtmlValueTolerance:
     def test_nan_value_renders_null(self):
         g = MappingProxyType({"ic": MetricResult(value=float("nan"), name="ic")})
         assert "null" in _sample_result(g)._repr_html_()
+
+
+class TestToFrameMetadataExport:
+    """#883 — ``to_frame(metadata=)`` carries named estimator scalars along.
+
+    The fixed schema stays the default; a requested key becomes one column
+    named after it, ``null`` on metrics that do not carry it, and nested
+    values / reserved names are refused rather than silently flattened.
+    """
+
+    @staticmethod
+    def _result():
+        spread = MetricResult(
+            value=0.001,
+            n_obs=80,
+            name="quantile_spread",
+            metadata={"n_groups": 2, "mean_tail_size": 3.0, "legs": [0.1, -0.2]},
+        )
+        turnover = MetricResult(
+            value=0.25,
+            n_obs=79,
+            name="notional_turnover",
+            metadata={"n_groups": 2, "rebalance_lag": 1, "mean_tail_size": 3.0},
+        )
+        return _sample_result(
+            MappingProxyType({"spread": spread, "turnover": turnover})
+        )
+
+    def test_default_schema_is_unchanged(self):
+        frame = self._result().to_frame()
+        assert "n_groups" not in frame.columns
+        assert frame.columns[-1] == "warning_codes"
+
+    def test_requested_keys_become_trailing_columns_with_nulls_where_absent(self):
+        frame = self._result().to_frame(
+            metadata=("n_groups", "rebalance_lag", "mean_tail_size")
+        )
+        assert frame.columns[-3:] == ["n_groups", "rebalance_lag", "mean_tail_size"]
+        rows = {r["metric_name"]: r for r in frame.to_dicts()}
+        assert rows["quantile_spread"]["n_groups"] == 2
+        assert rows["notional_turnover"]["n_groups"] == 2
+        assert rows["quantile_spread"]["rebalance_lag"] is None
+        assert rows["notional_turnover"]["rebalance_lag"] == 1
+        assert rows["notional_turnover"]["mean_tail_size"] == pytest.approx(3.0)
+        # Still pairs with the identity block, so stacked frames stay auditable.
+        assert set(frame["factor"].to_list()) == {"mom_12_1"}
+
+    def test_nested_values_are_refused_not_flattened(self):
+        with pytest.raises(ValueError, match=r"metadata\['legs'\].*quantile_spread"):
+            self._result().to_frame(metadata=("legs",))
+
+    def test_reserved_and_repeated_keys_are_refused(self):
+        with pytest.raises(ValueError, match="collide"):
+            self._result().to_frame(metadata=("value",))
+        with pytest.raises(ValueError, match="collide"):
+            self._result().to_frame(metadata=("forward_periods",))
+        with pytest.raises(ValueError, match="repeated"):
+            self._result().to_frame(metadata=("n_groups", "n_groups"))
+        with pytest.raises(ValueError, match="sequence"):
+            self._result().to_frame(metadata="n_groups")  # type: ignore[arg-type]
+
+    def test_params_keys_are_reserved_too(self):
+        res = dataclasses.replace(self._result(), params={"n_groups": 2})
+        with pytest.raises(ValueError, match="collide"):
+            res.to_frame(metadata=("n_groups",))
+
+    def test_end_to_end_tradability_audit(self):
+        """The reporter's case: spread and turnover n_groups checkable from CSV."""
+        import factrix as fx
+        from factrix.metrics import notional_turnover, quantile_spread
+        from factrix.preprocess import compute_forward_return
+
+        raw = fx.datasets.make_cs_panel(n_assets=6, n_dates=120, seed=0)
+        panel = compute_forward_return(raw, forward_periods=5)
+        out = fx.evaluate(
+            panel,
+            metrics={
+                "spread": quantile_spread(n_groups=2),
+                "turnover": notional_turnover(n_groups=2, rebalance_lag=1),
+            },
+            factor_cols=["factor"],
+        )["factor"]
+        frame = out.to_frame(metadata=("n_groups", "rebalance_lag", "mean_tail_size"))
+        # ``metric_name`` is the caller's label inside ``evaluate``.
+        rows = {r["metric_name"]: r for r in frame.to_dicts()}
+        assert rows["spread"]["n_groups"] == 2
+        assert rows["turnover"]["n_groups"] == 2
+        assert rows["turnover"]["rebalance_lag"] == 1
+        assert rows["spread"]["rebalance_lag"] is None
+        assert rows["turnover"]["mean_tail_size"] == pytest.approx(3.0)
+        # The exported cells are scalars, so the frame is CSV-safe once the
+        # (pre-existing) list-typed ``warning_codes`` column is set aside.
+        text = frame.drop("warning_codes").write_csv()
+        assert "turnover" in text and "n_groups" in text.splitlines()[0]


### PR DESCRIPTION
## Problem

`EvaluationResult.to_frame()` emits a fixed cross-metric schema, so the estimator-specific definitions a research CSV needs to audit a row — a spread's `n_groups`, a turnover's `rebalance_lag` / `mean_tail_size` — were reachable only through the `MetricResult` objects. Expanding all free-form metadata unconditionally would break the stable schema (#883).

## Change

`to_frame(metadata=(...))` — an explicit, opt-in list of keys:

- one trailing column per key, in the order requested; the default schema is byte-for-byte unchanged;
- the row's `factor` / `metric_name` pairing is kept, so stacked frames stay auditable;
- a metric without the key gets `null`;
- only scalars export (`bool` / `int` / `float` / `str`; `NaN` / `Inf` → `null` like `value`; numpy scalars unwrapped). A list / dict / other nested value raises `ValueError` naming the metric and key — `to_dict()` is the nested view;
- a key that collides with a fixed column, the identity block (`forward_periods` / `overlap_periods`) or a `params` key, or that repeats, raises `ValueError`;
- dtypes are inferred per column.

Docs: rules plus a tradability audit example on the `EvaluationResult` page (spread and turnover `n_groups` checkable from the export; the example executes under the docs-example harness).

## Tests

`TestToFrameMetadataExport`: default schema unchanged; requested keys become trailing columns with `null` where absent; nested values refused; reserved / identity / params / repeated / bare-string keys refused; end-to-end `evaluate` with `quantile_spread(n_groups=2)` and `notional_turnover(n_groups=2, rebalance_lag=1)` → both rows `n_groups = 2`, turnover `rebalance_lag = 1`, spread `null`, CSV-safe once the pre-existing list-typed `warning_codes` column is set aside.

Closes #883.