### PR TITLE
chore(devx): sync all extras for the release audit; skip on a dangling pandas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ together with the `ruff==` pin in `pyproject.toml` (a test enforces it).
 For release checks, sync the docs toolchain too:
 
 ```bash
-uv sync --frozen --extra dev --extra docs
+uv sync --frozen --all-extras
 ```
 
 ## Development Cycle

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -551,8 +551,12 @@ Before running a release bump (see §9), run this checklist on `main`:
 #    not inherited — a pattern that survives past its removal only adds noise.
 git grep -nE "$PATTERN"
 
-# 2. Sync the release-check toolchain from locked project metadata.
-uv sync --frozen --extra dev --extra docs
+# 2. Sync the release-check toolchain from locked project metadata. All
+#    extras, not just dev + docs: the full suite expects the optional
+#    ``pandas`` / ``pyarrow`` path installed (CI runs the no-pandas floor
+#    separately), and dropping the extra leaves a dangling
+#    ``site-packages/pandas/`` that imports without ``DataFrame``.
+uv sync --frozen --all-extras
 
 # 3. Lint, formatting, and typing — mirrors the CI lint job.
 uv run ruff check .

--- a/tests/test_data_input.py
+++ b/tests/test_data_input.py
@@ -38,8 +38,23 @@ def test_coerce_lazyframe_collects(data_pl: pl.DataFrame) -> None:
     assert out.equals(data_pl)
 
 
-def test_coerce_pandas_dataframe_is_rejected_with_guidance() -> None:
+def _pandas():
+    """``pandas`` or skip — and skip on a *dangling* pandas too.
+
+    ``pytest.importorskip`` is satisfied by a bare namespace package: after
+    ``uv sync`` drops the ``pandas`` extra, a leftover ``site-packages/pandas/``
+    directory (stale ``__pycache__`` under ``pandas/tests``) still imports, with
+    no ``DataFrame`` on it. That is "pandas absent", not a failure of the
+    rejection path this file tests.
+    """
     pd = pytest.importorskip("pandas")
+    if not hasattr(pd, "DataFrame"):
+        pytest.skip("pandas is a leftover namespace package, not an install")
+    return pd
+
+
+def test_coerce_pandas_dataframe_is_rejected_with_guidance() -> None:
+    pd = _pandas()
     pdf = pd.DataFrame({"a": [1, 2]})
     with pytest.raises(TypeError, match=r"factrix\.adapt|pl\.from_pandas"):
         _coerce_data(pdf)
@@ -63,7 +78,8 @@ def test_evaluate_accepts_lazyframe_end_to_end(data_pl: pl.DataFrame) -> None:
 
 
 def test_evaluate_rejects_pandas_with_guidance(data_pl: pl.DataFrame) -> None:
-    pytest.importorskip("pandas")
+    _pandas()
+    pytest.importorskip("pyarrow")  # ``DataFrame.to_pandas`` needs it
     pdf = data_pl.to_pandas()
     from factrix.metrics import ic
 


### PR DESCRIPTION
## Problem

The release-train checklist (contributing §7.3 step 2) synced only the dev + docs extras. That drops the optional pandas / pyarrow path the full suite expects, and `uv sync` leaves a dangling `site-packages/pandas/` (stale `__pycache__` under `pandas/tests`) that `pytest.importorskip("pandas")` accepts as an install: `import pandas` succeeds with no `DataFrame` on it, and the two pandas-rejection tests fail instead of skipping. Seen while auditing `main` for v0.24.0 — 3 spurious failures.

## Change

- §7.3 step 2 and `CONTRIBUTING.md` sync `--all-extras`, with the reason recorded next to the command; CI keeps covering the no-pandas floor in its own job.
- `tests/test_data_input.py`: a pandas module without `DataFrame` is "pandas absent" → skip; the `to_pandas` path also skips without pyarrow.

## Tests

`tests/test_data_input.py` + docs checks: 227 passed, 30 skipped (all extras installed); the guarded tests skip cleanly on the dangling-namespace environment that produced the failures.