### PR TITLE
fix(api): validate the panel key columns on direct metric calls

### DIFF
--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -97,6 +97,8 @@ Error cases (both raise [`UserInputError`][factrix.UserInputError]):
 
 Per-cell extensions activate additional standalone metrics when present and short-circuit (`NaN` with `reason`) when absent — they never gate the core procedure.
 
+A **direct** call to a raw-panel metric validates the key columns `date` + `asset_id` before running and raises the same `UserInputError` as `evaluate` when one is missing; see [Standalone metrics](../guides/standalone-metrics.md#1-direct-standalone-calls).
+
 | Column | Activates | Cell |
 |---|---|---|
 | `market_cap` | `quantile_spread_vw` value-weighting | Individual × Continuous |

--- a/docs/guides/standalone-metrics.md
+++ b/docs/guides/standalone-metrics.md
@@ -28,6 +28,18 @@ You can call any metric callable directly. If the first argument is a Polars
 DataFrame, Series, or scalar input expected by the helper, the metric runs
 immediately and returns its results.
 
+A direct call to a metric that consumes the **raw panel** checks the key
+columns `date` and `asset_id` before any computation and raises the same
+`factrix.UserInputError` (field `data`, pointing at the
+[data schema](../api/data-schema.md)) that `evaluate` raises, instead of a
+polars `ColumnNotFoundError` from inside the estimator. Consumers of a
+producer's derived frame (`ic` on `compute_ic` output, `common_beta` on
+per-asset betas, the `(date, value)` series tools) are not gated — that
+schema is the producer's contract. `evaluate` additionally requires
+`forward_return`, because it dispatches return-consuming metrics; a direct
+call to a metric that reads returns names that column itself when it is
+missing.
+
 ### Panel-input metrics
 
 Metrics such as `quantile_spread` or `monotonicity` operate on a long-format panel containing `(date, asset_id, <factor_col>, forward_return)`.

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -48,6 +48,19 @@ the validation and dispatch contract is identical.
 _BASELINE_COLUMNS: tuple[str, ...] = ("date", "asset_id", "forward_return")
 _OPTIONAL_COLUMNS: tuple[str, ...] = ("price", "market_cap")
 
+# The key columns a *direct* call to a raw-panel metric must carry.
+# ``evaluate`` validates the full baseline once and projects a view per
+# factor; a standalone call skips that gate, so this is the floor it is
+# checked against before any polars expression runs — the same
+# UserInputError surface, not a ColumnNotFoundError from inside a quantile
+# join. ``forward_return`` is deliberately not here: a panel metric that never
+# reads returns (``rank_turnover``, ``notional_turnover``) is valid on
+# ``(date, asset_id, factor)``, and the metrics that do read it name the
+# missing column themselves. Consumers of an upstream producer's output
+# (``requires``) are not gated: their input is a derived frame whose schema
+# the producer owns, not the panel's.
+_PANEL_KEY_COLUMNS: tuple[str, ...] = ("date", "asset_id")
+
 # Reserved columns carrying the two horizon-like facts about a panel:
 #
 # * ``_forward_periods`` — the economic return horizon, the ``forward_periods``
@@ -231,6 +244,32 @@ def _resolve_overlap_periods(
 
 
 _DOCS_DATA_SCHEMA = "api/data-schema"
+
+
+def _validate_panel_key_columns(data: object, *, func_name: str) -> None:
+    """Reject a direct raw-panel metric call whose frame lacks the key columns.
+
+    Only a ``pl.DataFrame`` is inspected. Mirrors ``evaluate``'s baseline gate
+    in error type, field and docs pointer so the two entry points fail the
+    same way on the same mistake.
+    """
+    if not isinstance(data, pl.DataFrame):
+        return
+    missing = [c for c in _PANEL_KEY_COLUMNS if c not in data.columns]
+    if not missing:
+        return
+    raise UserInputError(
+        func_name=func_name,
+        field="data",
+        value=list(data.columns),
+        expected=(
+            f"a panel must carry the key columns {list(_PANEL_KEY_COLUMNS)!r}; "
+            f"missing {missing!r}. Rename the source columns "
+            f"(factrix.adapt(data, date=..., asset_id=..., price=...)) or pass "
+            f"the panel through factrix.evaluate, which validates the full schema"
+        ),
+        docs_path=_DOCS_DATA_SCHEMA,
+    )
 
 
 def _normalize_panel(data: pl.DataFrame) -> pl.DataFrame:

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -12,7 +12,7 @@ from factrix._axis import (
     OutputShape,
     SpecRole,
 )
-from factrix._data_input import _OVERLAP_PERIODS_COL
+from factrix._data_input import _OVERLAP_PERIODS_COL, _validate_panel_key_columns
 from factrix._metric_index import Cell, MetricSpec, SampleThreshold
 
 # Parameters that ``evaluate`` injects at dispatch rather than the user
@@ -315,6 +315,15 @@ class MetricBase(metaclass=MetricMeta):
         **kwargs: Any,
     ) -> Any:
         """Evaluate the metric on a single input (one factor's view / upstream)."""
+        if args and self.input_shape is InputShape.PANEL and not self.requires:
+            # Standalone call on the raw panel: ``evaluate`` validated the
+            # schema once and projected a view; a direct call skips that gate,
+            # so the panel's key columns are checked here, before any polars
+            # expression can turn a mis-named ``asset_id`` into a
+            # ColumnNotFoundError from deep inside a quantile join. A
+            # ``requires`` consumer takes a producer's derived frame instead —
+            # its schema is the producer's contract, not the panel's.
+            _validate_panel_key_columns(args[0], func_name=self.__class__.__name__)
         if overlap_periods is None and args:
             # Standalone call: the horizon is a property of the data, so read
             # the stamp rather than letting the signature default diverge from

--- a/factrix/metrics/common_asymmetry.py
+++ b/factrix/metrics/common_asymmetry.py
@@ -147,11 +147,9 @@ def common_asymmetry(
         >>> result.name == ""
         True
     """
-    if "date" not in data.columns:
-        return _short_circuit_output(
-            "common_asymmetry",
-            "no_date_column",
-        )
+    # ``date`` / ``asset_id`` are gated by the direct-call key-column check in
+    # ``MetricBase.__call__`` (and by ``evaluate``'s baseline gate), so only
+    # the configurable columns are checked here.
     for col in (factor_col, return_col):
         if col not in data.columns:
             return _short_circuit_output(

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -100,9 +100,10 @@ def common_quantile_spread(
         ``MetricResult`` whose ``value`` is the top-bottom bucket
         spread; bucket detail and the Spearman monotonicity diagnostic
         live in ``metadata``. Short-circuits with a reason code when
-        input shape is insufficient (no ``date`` / factor / return
-        column, fewer than ``MIN_PORTFOLIO_PERIODS_HARD`` rows, or factor
-        variation below ``n_groups * 2`` distinct values).
+        input shape is insufficient (no factor / return column, fewer
+        than ``MIN_PORTFOLIO_PERIODS_HARD`` rows, or factor variation
+        below ``n_groups * 2`` distinct values); a missing ``date`` /
+        ``asset_id`` is a ``UserInputError`` from the panel key-column gate.
 
     Notes:
         Aggregate the panel to per-date ``(_f, _r)``, ordinal-rank into
@@ -142,11 +143,9 @@ def common_quantile_spread(
     # than the panel kernel, so it applies the shared floor explicitly: one
     # bucket has no top-minus-bottom contrast to test.
     _validate_n_groups(n_groups)
-    if "date" not in data.columns:
-        return _short_circuit_output(
-            "common_quantile_spread",
-            "no_date_column",
-        )
+    # ``date`` / ``asset_id`` are gated by the direct-call key-column check in
+    # ``MetricBase.__call__`` (and by ``evaluate``'s baseline gate), so only
+    # the configurable columns are checked here.
     for col in (factor_col, return_col):
         if col not in data.columns:
             return _short_circuit_output(

--- a/tests/test_common_asymmetry.py
+++ b/tests/test_common_asymmetry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
+import pytest
 from factrix.metrics import common_asymmetry
 
 
@@ -129,12 +130,16 @@ class TestRatioDiagnostic:
 
 
 class TestMissingColumns:
-    def test_missing_date_short_circuits(self):
+    def test_missing_date_is_a_user_input_error(self):
+        """A raw-panel direct call fails the key-column gate the way
+        ``evaluate`` does (#882), not as a per-metric short-circuit."""
+        from factrix._errors import UserInputError
+
         df = pl.DataFrame(
             {"asset_id": [0, 0], "factor": [1.0, -1.0], "forward_return": [0.1, 0.2]}
         )
-        out = common_asymmetry(df)
-        assert out.metadata["reason"] == "no_date_column"
+        with pytest.raises(UserInputError, match=r"'date'"):
+            common_asymmetry(df)
 
 
 class TestNonFiniteInput:

--- a/tests/test_common_quantile.py
+++ b/tests/test_common_quantile.py
@@ -163,12 +163,16 @@ class TestPerBucketWarning:
 
 
 class TestMissingColumns:
-    def test_missing_date_short_circuits(self):
+    def test_missing_date_is_a_user_input_error(self):
+        """A raw-panel direct call fails the key-column gate the way
+        ``evaluate`` does (#882), not as a per-metric short-circuit."""
+        from factrix._errors import UserInputError
+
         df = pl.DataFrame(
             {"asset_id": [0, 0], "factor": [1.0, 2.0], "forward_return": [0.1, 0.2]}
         )
-        out = common_quantile_spread(df)
-        assert out.metadata["reason"] == "no_date_column"
+        with pytest.raises(UserInputError, match=r"'date'"):
+            common_quantile_spread(df)
 
     def test_missing_factor_short_circuits(self):
         df = pl.DataFrame(

--- a/tests/test_degenerate_sample_convention.py
+++ b/tests/test_degenerate_sample_convention.py
@@ -30,7 +30,7 @@ def _perfect_fit_panel(n_dates: int = 60, n_assets: int = 8) -> pl.DataFrame:
             rows.append(
                 {
                     "date": date,
-                    "asset": f"A{a}",
+                    "asset_id": f"A{a}",
                     "factor": f,
                     "forward_return": 0.01 * f,
                 }
@@ -67,7 +67,7 @@ class TestPooledBetaPerfectFit:
                 rows.append(
                     {
                         "date": date,
-                        "asset": f"A{a}",
+                        "asset_id": f"A{a}",
                         "factor": f,
                         "forward_return": 0.01 * f + 0.05 * rng.standard_normal(),
                     }
@@ -89,7 +89,12 @@ class TestPredictiveBetaPerfectFit:
         x = rng.standard_normal(n)
         dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
         return pl.DataFrame(
-            {"date": dates, "factor": x, "forward_return": 2.0 * x + 1.0}
+            {
+                "date": dates,
+                "asset_id": ["A"] * n,
+                "factor": x,
+                "forward_return": 2.0 * x + 1.0,
+            }
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
 
     def test_exact_linear_relation_withholds_the_test(self):
@@ -107,6 +112,7 @@ class TestPredictiveBetaPerfectFit:
         df = pl.DataFrame(
             {
                 "date": dates,
+                "asset_id": ["A"] * n,
                 "factor": x,
                 "forward_return": 2.0 * x + rng.standard_normal(n),
             }

--- a/tests/test_direct_call_schema.py
+++ b/tests/test_direct_call_schema.py
@@ -1,0 +1,94 @@
+"""Direct raw-panel metric calls validate the key columns up front (#882).
+
+``evaluate`` gates the baseline schema once and projects a view per factor;
+a standalone ``metric(data, ...)`` call skipped that gate, so a mis-named
+``asset_id`` surfaced as a polars ``ColumnNotFoundError`` from inside a
+quantile join — after ``_group`` had been attached, naming an internal
+column the caller never wrote. The check now lives in ``MetricBase.__call__``
+for every metric that consumes the raw panel (``input_shape=PANEL`` with no
+``requires``), so each direct-call path fails the same way ``evaluate`` does,
+with the same error type and docs pointer, and no metric carries its own copy.
+Consumers of a producer's derived frame (``ic`` on ``compute_ic`` output,
+``common_beta`` on per-asset betas) are not gated: that schema is the
+producer's contract, not the panel's.
+"""
+
+from __future__ import annotations
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._errors import UserInputError
+from factrix.metrics import (
+    breakeven_cost,
+    compute_ic,
+    notional_turnover,
+    positive_rate,
+    quantile_spread,
+    rank_turnover,
+)
+from factrix.preprocess import compute_forward_return
+
+
+@pytest.fixture(scope="module")
+def panel() -> pl.DataFrame:
+    raw = fx.datasets.make_cs_panel(n_assets=8, n_dates=60, seed=0)
+    return compute_forward_return(raw, forward_periods=5)
+
+
+_PANEL_METRICS = [
+    ("notional_turnover", lambda p: notional_turnover(p, n_groups=2, rebalance_lag=1)),
+    ("rank_turnover", lambda p: rank_turnover(p)),
+    ("quantile_spread", lambda p: quantile_spread(p, n_groups=2)),
+    ("compute_ic", lambda p: compute_ic(p)),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "run"), _PANEL_METRICS, ids=[m[0] for m in _PANEL_METRICS]
+)
+def test_missing_asset_id_is_a_user_input_error_before_any_polars_work(
+    panel, label, run
+):
+    renamed = panel.rename({"asset_id": "asset"})
+    with pytest.raises(UserInputError, match=r"asset_id") as info:
+        run(renamed)
+    message = str(info.value)
+    assert label in message  # named after the metric the caller invoked
+    assert "_group" not in message  # no internal column leaks into the message
+    assert "api/data-schema" in message
+
+
+def test_missing_date_is_reported_the_same_way(panel):
+    with pytest.raises(UserInputError, match=r"'date'"):
+        notional_turnover(panel.drop("date"), n_groups=2)
+
+
+def test_derived_frame_consumers_are_not_gated(panel):
+    series = compute_ic(panel)["factor"]
+    assert "asset_id" not in series.columns  # a producer's frame has no asset axis
+    assert positive_rate(series, value_col="ic").n_obs > 0
+
+
+def test_scalar_helpers_are_untouched():
+    assert breakeven_cost(0.001, turnover=0.2, holding_periods=5).value > 0
+
+
+def test_correct_schema_is_unchanged(panel):
+    assert (
+        notional_turnover(panel, n_groups=2, rebalance_lag=1).metadata["n_groups"] == 2
+    )
+    assert quantile_spread(panel, n_groups=2)["factor"].n_obs > 0
+
+
+def test_evaluate_and_direct_call_agree_on_the_error_contract(panel):
+    renamed = panel.rename({"asset_id": "asset"})
+    with pytest.raises(UserInputError, match=r"asset_id") as via_evaluate:
+        fx.evaluate(
+            renamed,
+            metrics={"nt": notional_turnover(n_groups=2)},
+            factor_cols=["factor"],
+        )
+    with pytest.raises(UserInputError, match=r"asset_id") as direct:
+        notional_turnover(renamed, n_groups=2)
+    assert via_evaluate.value.field == direct.value.field == "data"

--- a/tests/test_metric_base.py
+++ b/tests/test_metric_base.py
@@ -116,7 +116,9 @@ def test_metric_dual_interface():
             val = df_input["value"][0]
             return f"val={val * multiplier}{suffix}"
 
-        df = pl.DataFrame({"value": [10]})
+        # A raw-panel metric's direct call checks the panel key columns, so
+        # even a toy frame carries them.
+        df = pl.DataFrame({"date": [1], "asset_id": ["A"], "value": [10]})
 
         # 1. Instantiation + call style
         pipeline_inst = dummy_pipeline(shift=5)
@@ -240,7 +242,7 @@ def test_metric_parameter_ordering_and_reflection():
 
         # Test instantiation & execution (ordering is checked and bound properly)
         inst = ordered_metric(b=42, a=5)
-        data = pl.DataFrame({"value": [1]})
+        data = pl.DataFrame({"date": [1], "asset_id": ["A"], "value": [1]})
         res = inst(data)
         assert res == "a=5, b=42"
 

--- a/tests/test_predictive_beta.py
+++ b/tests/test_predictive_beta.py
@@ -204,7 +204,7 @@ class TestPredictiveBetaNonFinite:
         x = rng.standard_normal(n)
         y = 0.7 * x + rng.normal(0, 0.2, n)
         return pl.DataFrame(
-            {"date": dates, "factor": x, "forward_return": y}
+            {"date": dates, "asset_id": ["A"] * n, "factor": x, "forward_return": y}
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
 
     def test_nan_return_cell_is_dropped(self):


### PR DESCRIPTION
## Problem

A standalone `metric(data, ...)` call skipped the schema gate `evaluate` applies, so a mis-named `asset_id` surfaced as a polars `ColumnNotFoundError` from inside a quantile join — after the internal `_group` column had been attached — instead of the library's user-input error (#882).

## Change

`MetricBase.__call__` checks `date` / `asset_id` before dispatch for every metric that consumes the **raw panel** (`input_shape=PANEL`, no `requires`), raising the same `UserInputError` (field `data`, data-schema docs pointer) `evaluate` raises. One site, read off the metric's declared shape — no metric carries its own copy and the two entry points cannot drift.

Scope decisions:
- Consumers of a producer's derived frame (`ic` on `compute_ic` output, `common_beta` on per-asset betas, the `(date, value)` series tools) are **not** gated — that schema is the producer's contract, not the panel's. (A first cut gated by declared shape alone and immediately broke the `common_beta` docs example.)
- `forward_return` is not required here: panel metrics that never read returns (`rank_turnover`, `notional_turnover`) are valid without it, and the ones that do name it themselves. `evaluate` keeps requiring it because it dispatches return-consuming metrics.
- `common_asymmetry` / `common_quantile_spread` kept a `no_date_column` short-circuit neither entry point can reach any more; removed.

## Breaking

Direct calls on frames without `asset_id` now raise: single-asset `predictive_beta` frames, pooled panels naming the asset column `asset`, toy frames. This is the documented panel schema (`date, asset_id, ...`); the fixtures that relied on the leniency are aligned in the second commit.

## Tests

`tests/test_direct_call_schema.py`: `notional_turnover` / `rank_turnover` / `quantile_spread` / `compute_ic` on a renamed `asset_id` → `UserInputError` naming the metric, no internal column in the message, data-schema pointer; missing `date` same way; derived-frame consumers and scalar helpers untouched; correct schema unchanged; `evaluate` and the direct call raise the same field. Full suite summary line: `3015 passed, 30 skipped`.

Closes #882.