### PR TITLE
fix(api): reject reserved stamp columns in factor_cols

### DIFF
--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -70,8 +70,7 @@ from factrix._compare import compare
 from factrix._dag import CycleError, DagExecutor, _Node
 from factrix._data_input import (
     _BASELINE_COLUMNS,
-    _FORWARD_PERIODS_COL,
-    _OVERLAP_PERIODS_COL,
+    _STAMP_COLUMNS,
     DataInput,
     _coerce_data,
     _read_forward_periods_stamp,
@@ -228,7 +227,8 @@ def evaluate(
     Raises:
         UserInputError: ``metrics`` not a ``dict[str, Metric]`` of
             instances; ``factor_cols`` empty / single ``str`` / contains
-            duplicates / references a column not on ``data``; ``data``
+            duplicates / names a reserved stamp column / references a column
+            not on ``data``; ``data``
             missing a baseline column; a metric ``requires`` a producer
             absent from the registry; under ``strict=True``, a metric
             inapplicable to the data; ``data`` carries no horizon stamp and
@@ -256,6 +256,7 @@ def evaluate(
     _validate_metrics_arg(metrics)
     expected = _validate_expected_warnings_arg(expected_warnings)
     cols = _validate_factor_cols_arg(factor_cols)
+    _validate_factor_cols_not_stamps(cols)
     data = _coerce_data(data)
     _validate_baseline_columns(data)
     _validate_factor_cols_on_data(data, cols)
@@ -268,9 +269,7 @@ def evaluate(
     # overlap defaults to the horizon unless declared via overlap_periods=.
     fp = _resolve_forward_periods(data, forward_periods)
     op = _resolve_overlap_periods(data, overlap_periods, horizon=fp)
-    data = data.drop(
-        [c for c in (_FORWARD_PERIODS_COL, _OVERLAP_PERIODS_COL) if c in data.columns]
-    )
+    data = data.drop([c for c in _STAMP_COLUMNS if c in data.columns])
 
     from factrix.metrics._base import MetricBase
 
@@ -1066,6 +1065,31 @@ def _validate_factor_cols_arg(factor_cols: object) -> list[str]:
                 docs_path=_DOCS_FACTOR_COLS,
             )
     return list(factor_cols)
+
+
+def _validate_factor_cols_not_stamps(cols: list[str]) -> None:
+    """Reject the reserved stamp columns as factor columns.
+
+    Runs before the strip below, so a stamp name fails on the factrix
+    UserInputError surface instead of vanishing between validation and
+    dispatch and surfacing as a polars ColumnNotFoundError.
+    """
+    stamps = [c for c in cols if c in _STAMP_COLUMNS]
+    if not stamps:
+        return
+    raise UserInputError(
+        func_name="evaluate",
+        field="factor_cols",
+        value=stamps,
+        expected=(
+            f"factor_cols to exclude the reserved stamp columns "
+            f"{list(_STAMP_COLUMNS)!r}. They are evaluate-internal stamps "
+            "left by compute_forward_return (the return horizon and the "
+            "evaluation-grid overlap), stripped before dispatch, and cannot "
+            "be factor columns."
+        ),
+        docs_path=_DOCS_FACTOR_COLS,
+    )
 
 
 def _validate_factor_cols_on_data(data: _pl.DataFrame, cols: list[str]) -> None:

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -82,6 +82,12 @@ _PANEL_KEY_COLUMNS: tuple[str, ...] = ("date", "asset_id")
 _FORWARD_PERIODS_COL: str = "_forward_periods"
 _OVERLAP_PERIODS_COL: str = "_overlap_periods"
 
+# The one list of the reserved stamp columns. Every consumer reads it from
+# here — ``evaluate`` rejects them as factor columns and strips them before
+# dispatch, ``inspect`` excludes them from the candidate factor columns — so
+# the rejected set and the stripped set can never drift apart.
+_STAMP_COLUMNS: tuple[str, ...] = (_FORWARD_PERIODS_COL, _OVERLAP_PERIODS_COL)
+
 
 def _stamp_horizons(
     data: pl.DataFrame, *, forward_periods: int, overlap_periods: int

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -41,7 +41,7 @@ import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope, InputShape, Tier
 from factrix._codes import WarningCode, cross_section_tier
-from factrix._data_input import _FORWARD_PERIODS_COL, _OVERLAP_PERIODS_COL, _coerce_data
+from factrix._data_input import _STAMP_COLUMNS, _coerce_data
 from factrix._metric_index import MetricSpec, public_specs
 from factrix._results import Warning
 from factrix._types import MIN_IC_ASSETS_HARD, MIN_IC_ASSETS_WARN
@@ -71,8 +71,7 @@ _INSPECT_RESERVED: frozenset[str] = frozenset(
         "forward_return",
         "price",
         "market_cap",
-        _FORWARD_PERIODS_COL,
-        _OVERLAP_PERIODS_COL,
+        *_STAMP_COLUMNS,
     }
 )
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -573,3 +573,46 @@ class TestEntryConsistency:
         assert not math.isnan(direct.value)
         assert direct.value == via.value
         assert direct.warning_codes == via.warning_codes == ()
+
+
+class TestReservedStampFactorCols:
+    """A reserved stamp column name must fail on the factrix UserInputError
+    surface, not leak the polars ColumnNotFoundError raised after the strip."""
+
+    @pytest.mark.parametrize("stamp", ["_forward_periods", "_overlap_periods"])
+    def test_stamp_column_as_factor_col_raises_user_input_error(self, stamp):
+        panel = _panel()
+        assert stamp in panel.columns
+        with pytest.raises(UserInputError) as exc:
+            fx.evaluate(panel, metrics={"ic": ic()}, factor_cols=["factor", stamp])
+        msg = str(exc.value)
+        assert stamp in msg
+        assert "stamp" in msg
+
+    @pytest.mark.parametrize("stamp", ["_forward_periods", "_overlap_periods"])
+    def test_by_slice_rejects_stamp_column(self, stamp):
+        panel = _panel().with_columns(
+            pl.when(pl.col("asset_id").rank("dense") % 2 == 0)
+            .then(pl.lit("a"))
+            .otherwise(pl.lit("b"))
+            .alias("sector")
+        )
+        with pytest.raises(UserInputError):
+            fx.by_slice(panel, ic(), by="sector", factor_col=stamp)
+
+    @pytest.mark.parametrize("stamp", ["_forward_periods", "_overlap_periods"])
+    def test_evaluate_horizons_rejects_stamp_column(self, stamp):
+        with pytest.raises(UserInputError):
+            fx.evaluate_horizons(
+                fx.datasets.make_cs_panel(n_assets=20, n_dates=120),
+                metrics={"ic": ic()},
+                factor_cols=[stamp],
+                forward_periods=[5],
+            )
+
+    def test_unknown_column_still_raises_user_input_error(self):
+        with pytest.raises(UserInputError) as exc:
+            fx.evaluate(
+                _panel(), metrics={"ic": ic()}, factor_cols=["definitely_not_a_column"]
+            )
+        assert "to exist on data" in str(exc.value)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -597,18 +597,20 @@ class TestReservedStampFactorCols:
             .otherwise(pl.lit("b"))
             .alias("sector")
         )
-        with pytest.raises(UserInputError):
+        with pytest.raises(UserInputError) as exc:
             fx.by_slice(panel, ic(), by="sector", factor_col=stamp)
+        assert "stamp" in str(exc.value)
 
     @pytest.mark.parametrize("stamp", ["_forward_periods", "_overlap_periods"])
     def test_evaluate_horizons_rejects_stamp_column(self, stamp):
-        with pytest.raises(UserInputError):
+        with pytest.raises(UserInputError) as exc:
             fx.evaluate_horizons(
                 fx.datasets.make_cs_panel(n_assets=20, n_dates=120),
                 metrics={"ic": ic()},
                 factor_cols=[stamp],
                 forward_periods=[5],
             )
+        assert "stamp" in str(exc.value)
 
     def test_unknown_column_still_raises_user_input_error(self):
         with pytest.raises(UserInputError) as exc:


### PR DESCRIPTION
> **TL;DR** — A reserved stamp column name (`_forward_periods` / `_overlap_periods`) in `factor_cols` now raises `factrix.UserInputError` instead of leaking a polars `ColumnNotFoundError`. Validation runs before the strip and shares one reserved-column list with it, so the two cannot drift.

## Summary

`compute_forward_return` stamps two reserved columns on a panel; `evaluate` reads them and strips them before dispatch. Column validation ran against the pre-strip schema and never filtered `factor_cols`, so a stamp name passed validation, disappeared at the strip, and failed inside polars — the one invalid factor column that did not land on the factrix error surface.

- `_STAMP_COLUMNS` in `factrix/_data_input.py` is now the single list of the reserved stamp columns. `evaluate`'s strip, the new `factor_cols` check, and `inspect`'s reserved set all read it.
- `_validate_factor_cols_not_stamps` runs right after the `factor_cols` argument check, i.e. before the strip and before schema coercion, so the message is identical whether or not the panel actually carries a stamp.
- Behavior for arbitrary unknown column names is unchanged (still the "every name in factor_cols to exist on data" `UserInputError`).
- `evaluate_horizons` and `by_slice` both delegate to `evaluate`, so the same check closes them; tests assert that rather than adding a second mechanism.

Error message:

```
evaluate(): invalid factor_cols=['_overlap_periods']
  Expected: factor_cols to exclude the reserved stamp columns
  ['_forward_periods', '_overlap_periods']. They are evaluate-internal stamps
  left by compute_forward_return (the return horizon and the evaluation-grid
  overlap), stripped before dispatch, and cannot be factor columns.
```

## Test plan

- New `TestReservedStampFactorCols` in `tests/test_evaluate.py`: both stamp names on `evaluate`, `by_slice` and `evaluate_horizons` (parametrized), plus an unchanged-behavior case for an arbitrary unknown column name.
- `uv run pytest -q tests` — 3031 passed, 29 skipped.
- `uv run ruff check` / `ruff format --check` / `mypy factrix` — all clean.

Closes #891
