### PR TITLE
test(docs): declare illustrative doc examples explicitly

### DIFF
--- a/docs/api/bhy-across-metrics.md
+++ b/docs/api/bhy-across-metrics.md
@@ -13,7 +13,7 @@ factor × metric cell. Unlike [`bhy`](bhy.md), which deliberately runs one
 screen per metric label, this function flattens all declared labels into one
 Benjamini-Hochberg-Yekutieli family.
 
-```python
+```python title="Illustrative"
 screen = fx.multi_factor.bhy_across_metrics(
     results,
     metrics=["ic", "spread"],

--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -21,7 +21,7 @@ correlated members (0.03–0.04 vs nominal 0.10 at `size = 4`, `rho ≥ 0.5`).
 The selective level costs power only on large groups with dense signal;
 for those, flat [`bhy`](bhy.md) is both higher-power and theorem-backed.
 
-```python
+```python title="Illustrative"
 import dataclasses
 
 import factrix as fx

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -126,7 +126,7 @@ returned `EvaluationResult` with `dataclasses.replace`, same pattern as
 [`bhy_hierarchical`](bhy-hierarchical.md) and
 [`partial_conjunction`](partial-conjunction.md):
 
-```python
+```python title="Illustrative"
 import dataclasses
 
 import factrix as fx

--- a/docs/api/by-slice.md
+++ b/docs/api/by-slice.md
@@ -61,7 +61,7 @@ readable programmatically like any other bundle warning. If you want the
 full-sample metric decomposed by period instead, compute it once on the
 whole panel and group the per-date output yourself.
 
-```python
+```python title="Illustrative"
 result = by_slice(panel, positive_rate(), by="year", factor_col="factor")
 [w.code.value for w in result["2024"].warnings]
 # ['slice_boundary_truncation']
@@ -81,7 +81,7 @@ frame identifies the metric and two `by_slice` runs stack unambiguously.
 The standard `EvaluationResult.to_frame` stacking idiom builds a
 comparison table — tag each row with its slice key:
 
-```python
+```python title="Illustrative"
 result = by_slice(panel, ic(), by="sector", factor_col="factor")
 
 pl.concat([
@@ -137,7 +137,7 @@ slice, then `pl.concat`.
 `market` is "TWSE" / "OTC"; you want three slices: 上市, 上櫃, 全市場
 (every row also belongs to 全市場).
 
-```python
+```python title="Illustrative"
 import polars as pl
 
 mapping = {"TWSE": "上市", "OTC": "上櫃"}
@@ -153,7 +153,7 @@ by_slice(expanded, ic(), by="uni", factor_col="factor")
 Each index membership is a separate boolean column; the same row may
 have several `True` values.
 
-```python
+```python title="Illustrative"
 expanded = pl.concat([
     panel.filter(pl.col("in_sp500")).with_columns(pl.lit("SP500").alias("uni")),
     panel.filter(pl.col("in_nasdaq100")).with_columns(pl.lit("N100").alias("uni")),
@@ -165,7 +165,7 @@ by_slice(expanded, ic(), by="uni", factor_col="factor")
 
 Nested by market-cap rank; each tier contains every smaller tier.
 
-```python
+```python title="Illustrative"
 tiers = [(10, "Top10"), (50, "Top50"), (200, "LargeCap")]
 expanded = pl.concat([
     *[
@@ -182,7 +182,7 @@ by_slice(expanded, ic(), by="tier", factor_col="factor")
 
 Adjacent deciles overlap to smooth boundary noise:
 
-```python
+```python title="Illustrative"
 windows = [(0, 30), (10, 40), (20, 50), (30, 60),
            (40, 70), (50, 80), (60, 90), (70, 100)]
 expanded = pl.concat([
@@ -198,7 +198,7 @@ by_slice(expanded, ic(), by="adv_win", factor_col="factor")
 Not an overlap problem — `by` only takes a single column. Compose a
 composite column with `pl.concat_str`:
 
-```python
+```python title="Illustrative"
 panel = panel.with_columns(
     pl.concat_str(["market", "sector"], separator="-").alias("uni_sec")
 )
@@ -217,7 +217,7 @@ Cases 1–4 share one idiom — per-target-slice `filter` +
 `with_columns(by=...)`, then `pl.concat`. Overlapping rows are
 duplicated naturally by the concat.
 
-```python
+```python title="Illustrative"
 expanded = pl.concat([
     panel.filter(expr).with_columns(pl.lit(name).alias("group"))
     for name, expr in user_definitions.items()

--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -8,7 +8,7 @@ Leaderboard renderer that stacks N evaluation results side by side as a
 [polars `DataFrame`](https://docs.pola.rs/api/python/stable/reference/dataframe/index.html).
 Pure projection — no metric is recomputed.
 
-```python
+```python title="Illustrative"
 import factrix as fx
 from factrix.metrics import ic, quantile_spread
 
@@ -60,7 +60,7 @@ The returned `pl.DataFrame` contains the following columns:
 `rank` is created after sorting, so it is not a valid `sort_by` key. To sort
 by significance, use the p-value column and set `descending=False`:
 
-```python
+```python title="Illustrative"
 df = fx.compare(results, metrics=["ic"], sort_by="ic_p_value", descending=False)
 ```
 

--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -68,7 +68,7 @@ Every data-consuming entry point annotates its first argument as `DataInput` —
 
 Panels often arrive with the signal column named something other than `"factor"` (e.g. `"alpha"`, `"score"`, `"momentum_12_1"`). Pass a list of column names in `factor_cols=` to `fx.evaluate` to evaluate them:
 
-```python
+```python title="Illustrative"
 from factrix.metrics import ic
 
 results = fx.evaluate(

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -6,7 +6,7 @@ How to read factrix errors and which exception class to catch.
 
 ## TL;DR
 
-```python
+```python title="Illustrative"
 import factrix as fx
 from factrix.metrics import ic
 
@@ -112,7 +112,7 @@ For type / shape mismatches, the second line reads `Expected: <shape>` instead o
 
 The structured attributes are the contract — read them, do not parse the rendered message:
 
-```python
+```python title="Illustrative"
 import factrix as fx
 
 bad: dict[str, object] = {}

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -166,7 +166,7 @@ failed = status.filter(~pl.col("is_applicable"))
 
 Metric behaviors are defined by instantiating metric classes directly. The DAG executor handles dispatch automatically depending on the cell registered by the metric.
 
-```python
+```python title="Illustrative"
 import factrix as fx
 from factrix.metrics import ic, caar, common_beta
 

--- a/docs/api/metrics/common_beta.md
+++ b/docs/api/metrics/common_beta.md
@@ -119,7 +119,7 @@ and dispersion fields by group. Missing labels should be named explicitly
 rather than silently dropped. For guidance on matching metrics to allocation
 signals, see [Validating allocation signals](../../guides/validating-allocation-signals.md#match-the-metric-to-the-signal).
 
-```python
+```python title="Illustrative"
 import polars as pl
 from factrix.metrics.common_beta import compute_common_betas
 

--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -94,7 +94,7 @@ from factrix.metrics import ic, fm_beta, quantile_spread
 run on a given panel — and which are degraded or blocked by sample
 floors — inspect a real panel with `inspect_data`:
 
-```python
+```python title="Illustrative"
 info = fx.inspect_data(panel)
 [m.name for m in info.usable]     # production-safe metrics for this panel
 [m.name for m in info.degraded]   # run, but inference degraded

--- a/docs/api/partial-conjunction-across-metrics.md
+++ b/docs/api/partial-conjunction-across-metrics.md
@@ -13,7 +13,7 @@ signal on at least two of IC, beta, and spread." Metric labels are the fixed
 condition axis: each factor identity receives one k-of-m partial-conjunction
 p-value, followed by BHY across identities.
 
-```python
+```python title="Illustrative"
 screen = fx.multi_factor.partial_conjunction_across_metrics(
     results,
     metrics=["ic", "beta", "spread"],

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -11,7 +11,7 @@ $m$ conditions" claim. Replaces the notebook idiom
 with the partial conjunction test of
 [Benjamini & Heller (2008)](https://onlinelibrary.wiley.com/doi/10.1111/j.1541-0420.2008.00984.x).
 
-```python
+```python title="Illustrative"
 import dataclasses
 
 import factrix as fx
@@ -75,7 +75,7 @@ hypothesis per factor.
 | **Strict** (`n_conditions=int`) | Paper-grade; you know the design (e.g. exactly 2 universes, exactly 4 horizons) | Identity with any condition count other than `n_conditions` raises. Data gaps surface fail-loud. |
 | **Lenient** (`n_conditions=None`) | EDA / prototyping; condition count varies by identity | `m` inferred per identity from the data; only requires `m >= min_pass`. |
 
-```python
+```python title="Illustrative"
 # Strict: 2 universes required for every factor; missing one raises.
 fx.multi_factor.partial_conjunction(
     results, min_pass=2, n_conditions=2, expand_over=("universe_id",)

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -187,7 +187,7 @@ The functions accept a **single** `by` column. For cross-axis slice
 analysis (regime × universe), compose a composite label upstream
 with `pl.concat_str(...)`:
 
-```python
+```python title="Illustrative"
 ic_df = ic_df.with_columns(
     pl.concat_str(["regime", "universe"], separator="_").alias("regime_x_universe")
 )

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -163,7 +163,7 @@ explicit-call escape hatch for frequent event studies, not a discovery default:
 
 `factrix/_results.py`:
 
-```python
+```python title="Illustrative"
 @dataclass(frozen=True, slots=True)
 class EvaluationResult:
     factor: str

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -508,7 +508,7 @@ from being polluted with data.
 
 Pattern (see `tests/conftest.py`):
 
-```python
+```python title="Illustrative"
 @pytest.fixture
 def clean_panel():
     rng = np.random.default_rng(42)
@@ -644,7 +644,11 @@ Code blocks under `docs/api/**/*.md` carry two distinct intents; verify which la
 - **Runnable** — `pycon` blocks injected from docstring `Examples:` via mkdocstrings autodoc. Self-contained imports, no unbound names, no fragile output; the rendered page exposes a copy button that strips `>>>` and expected-output lines, so blocks must remain paste-ready Python.
 - **Illustrative** — hand-authored `python` fenced blocks that use unbound names (e.g. `panel_large`, `regime_labels`) to communicate semantic intent, plus ASCII / DataFrame layouts that document output schema. Deliberately not runnable; visual lookup value beats setup faithfulness. Do not "fix" these into runnable form — confirm the intent first.
 
-`tests/test_docs_examples.py` executes every hand-authored `python` fence on every docs page, in page order, sharing one namespace per page. The two layers are told apart mechanically: a block that raises `NameError` is illustrative (it leans on an unbound placeholder) and is skipped; **any other exception fails the page** — a `TypeError` from a stale keyword, an `AttributeError` from a removed helper, a `KeyError` from a renamed metadata key, a polars column error from an outdated schema. So a self-contained example must stay self-contained and current, and an illustrative block must reference its placeholder *before* anything that could fail for a different reason. Blocks must be side-effect free (no file I/O, no plotting). `docs/examples/*.md` are rendered from `examples/*.ipynb` — fix the notebook and re-render.
+`tests/test_docs_examples.py` executes every hand-authored `python` fence on `README.md` and every docs page, in page order, sharing one namespace per page. **Any exception fails the page** — a `NameError` from an unbound name, a `TypeError` from a stale keyword, an `AttributeError` from a removed helper, a `KeyError` from a renamed metadata key, a polars column error from an outdated schema.
+
+An illustrative block therefore has to say so, on its own fence — open it with <code>&#96;&#96;&#96;python title="Illustrative"</code> instead of a bare <code>&#96;&#96;&#96;python</code>. A declared block is compiled (it must still parse) but never executed, and the marker renders as a caption above the block, so the reader learns the same thing the harness does. `title=` is the only marker that works: a bare word (`python illustrative`) or an unknown key (`python exec="false"`) makes `pymdownx.superfences` drop the block to inline code. Declared blocks are not unchecked — `tests/test_docs_pages.py` still resolves every `factrix.*` symbol they name — and each one gets its own case in `test_illustrative_block_compiles`, so a `-v` run prints the full inventory of what was not executed.
+
+Reach for the marker only after a minimal setup has been ruled out: two lines of `fx.datasets.make_cs_panel(...)` + `fx.preprocess.compute_forward_return(...)` turn many placeholder blocks into real coverage. Blocks must be side-effect free (no file I/O, no plotting). `docs/examples/*.md` are rendered from `examples/*.ipynb` — fix the notebook and re-render.
 
 ### Metric docstring style
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -50,7 +50,7 @@ rarely do, so `adapt` is the **first** step of the pipeline — it renames
 your columns to the canonical names (and optionally cleans non-finite
 values), *before* `compute_forward_return`:
 
-```python
+```python title="Illustrative"
 import factrix as fx
 from factrix.adapt import adapt
 from factrix.preprocess import compute_forward_return

--- a/docs/guides/custom-metrics.md
+++ b/docs/guides/custom-metrics.md
@@ -30,10 +30,10 @@ Here is how to implement a custom Information Coefficient (IC) metric that accep
 ```python
 import polars as pl
 import factrix as fx
-from factrix._axis import Aggregation
+from factrix._axis import Aggregation, InputShape
 from factrix._metric_index import cell, SampleThreshold
 from factrix import MetricResult
-from factrix.metrics import metric
+from factrix.metrics import compute_ic, metric
 
 # 1. Define the metric cell and thresholds
 _CUSTOM_CELL = cell(
@@ -46,6 +46,8 @@ _CUSTOM_CELL = cell(
 @metric(
     cell=_CUSTOM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
+    input_shape=InputShape.SERIES,
+    requires={"ic_df": compute_ic},
     sample_threshold=SampleThreshold(min_periods=10),
 )
 def custom_trimmed_ic(
@@ -74,6 +76,9 @@ def custom_trimmed_ic(
 Now you can evaluate your custom metric:
 
 ```python
+raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80)
+data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
 results = fx.evaluate(
     data,
     metrics={"trimmed_ic": custom_trimmed_ic(trim_ratio=0.1)},
@@ -95,7 +100,7 @@ If you prefer a manual, lower-level approach where you retain full control over 
 A registered callable carries no configuration object, so it always runs on
 its signature defaults — pass the function itself, not a call of it:
 
-```python
+```python title="Illustrative"
 results = fx.evaluate(
     data,
     metrics={"my_custom_stat": my_custom_stat},   # the function, uncalled

--- a/docs/guides/large-scale-evaluation.md
+++ b/docs/guides/large-scale-evaluation.md
@@ -26,7 +26,7 @@ The most memory-efficient way to screen a wide panel (e.g. 500 candidate factor 
 
 Here is the complete pattern; `panel_path` is your own wide panel on disk:
 
-```python
+```python title="Illustrative"
 import polars as pl
 import factrix as fx
 from factrix.metrics import ic

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -48,6 +48,12 @@ Every `EvaluationResult` exposes the topological execution plan via the `plan` p
 ### Example Plan Output
 
 ```python
+import factrix as fx
+from factrix.metrics import ic, ic_ir
+
+raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80)
+data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
 results = fx.evaluate(
     data,
     metrics={"ic": ic(), "ic_ir": ic_ir()},

--- a/docs/guides/preparing-data.md
+++ b/docs/guides/preparing-data.md
@@ -33,7 +33,7 @@ accepted by any entry point.
 If your panel is already long but uses source-specific names, adapt the
 column names first:
 
-```python
+```python title="Illustrative"
 from factrix.adapt import adapt
 
 raw = adapt(
@@ -347,7 +347,7 @@ event_panel = panel.with_columns(
 If a regime label defines the event-of-interest, use the same contract on
 the panel carrying that label:
 
-```python
+```python title="Illustrative"
 regime_event_panel = regime_panel.with_columns(
     pl.when(pl.col("macro_regime") == "stress")
     .then(1.0)

--- a/docs/guides/reading-results.md
+++ b/docs/guides/reading-results.md
@@ -12,6 +12,12 @@ Each entry point in `factrix` returns a frozen result dataclass. This page walks
 ## `EvaluationResult` — single-factor `evaluate()` result
 
 ```python
+import factrix as fx
+from factrix.metrics import ic
+
+raw = fx.datasets.make_cs_panel(n_assets=15, n_dates=80)
+data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
 results = fx.evaluate(
     data,
     metrics={"ic": ic(inference=fx.inference.NEWEY_WEST)},

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -53,7 +53,7 @@ A single dispatcher carrying a single built-in cross-slice test would silently o
 
 The label is just a column on `df`. The constructions below use regime labels as the running example; the same pattern works for any partition (universe id, sector code, ADV bucket index):
 
-```python
+```python title="Illustrative"
 import polars as pl
 
 # 1. External classifier (NBER recession, factor return sign, ...)
@@ -68,7 +68,7 @@ vol_labels = vix.with_columns(
 
 Join the labels onto the metric's per-date input upstream:
 
-```python
+```python title="Illustrative"
 ic_df = compute_ic(panel)["factor"].join(vol_labels, on="date", how="inner")
 ```
 
@@ -107,7 +107,7 @@ regimes are **date-disjoint** (a given date is either high- or low-vol,
 never both), so the inference path here is the `slice_period_*` pair, not
 the cross-sectional one.
 
-```python
+```python title="Illustrative"
 import polars as pl
 from factrix import by_slice, slice_period_pairwise_test
 from factrix.metrics import ic
@@ -144,7 +144,7 @@ A regime study on short samples trips the omnibus's short-slice advisory
 the way you declare `few_assets` on a single-asset study in `evaluate`,
 and read the audit columns off the stacked rows instead of stderr:
 
-```python
+```python title="Illustrative"
 rows = pl.concat(
     fx.slice_period_joint_test(
         panel, m, by="regime", factor_col="factor",

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -373,7 +373,7 @@ Stage 1 → factrix: zipline Pipeline outputs a pandas MultiIndex
 `(date, asset)`, which converts to the polars panel factrix
 expects in two lines.
 
-```python
+```python title="Illustrative"
 import polars as pl
 import factrix as fx
 from factrix.preprocess import compute_forward_return
@@ -391,7 +391,7 @@ ic_p = results["factor"].metrics["ic"].p_value
 factrix → Stage 2: surviving factors after BHY feed a portfolio
 optimiser.
 
-```python
+```python title="Illustrative"
 import factrix as fx
 from factrix.metrics import ic
 

--- a/tests/_doc_validation.py
+++ b/tests/_doc_validation.py
@@ -17,6 +17,7 @@ import importlib
 import pathlib
 import re
 from collections.abc import Iterable
+from typing import NamedTuple
 
 import factrix
 
@@ -63,11 +64,21 @@ DOCS_EXCLUDED_PREFIXES = (DOCS_ROOT / "plans",)
 
 # A ```python fence, possibly indented inside an admonition or tab (up to 8
 # spaces); the closing fence must sit at the same indentation. The info string
-# after ``python`` is ignored so ``python title="..."`` still matches.
+# is captured so ``python title="..."`` both matches and stays inspectable.
 PYTHON_FENCE_RE = re.compile(
-    r"^(?P<indent> {0,8})```python[^\n]*\n(?P<body>.*?)^(?P=indent)```",
+    r"^(?P<indent> {0,8})```python(?P<info>[^\n]*)\n(?P<body>.*?)^(?P=indent)```",
     re.MULTILINE | re.DOTALL,
 )
+
+# The marker that declares a fence illustrative — a hand-authored sketch that
+# leans on unbound placeholder names and is therefore not executed by
+# ``test_docs_examples.py``. ``pymdownx.superfences`` renders ``title=`` as a
+# caption bar above the block, so the one token that opts the block out of
+# execution also tells the reader the code is a sketch. It has to be ``title=``
+# specifically: superfences accepts no bare words (```` ```python illustrative
+# ````) and no unknown keys (```` ```python exec="false" ````) — either one
+# makes the fence fall back to inline code instead of a highlighted block.
+ILLUSTRATIVE_MARKER = 'title="Illustrative"'
 
 
 def docs_page_paths() -> list[pathlib.Path]:
@@ -79,14 +90,27 @@ def docs_page_paths() -> list[pathlib.Path]:
     )
 
 
-def python_fences(text: str) -> list[tuple[int, str]]:
-    """``(start_line, body)`` for each ```python fence in ``text``, in order.
+class PythonFence(NamedTuple):
+    """One ```python fence on a page.
 
-    The body keeps its original indentation (dedent before compiling);
-    ``start_line`` is the 1-based line of the opening fence, for messages.
+    ``line`` is the 1-based line of the opening fence, for messages; ``body``
+    keeps its original indentation (dedent before compiling); ``illustrative``
+    is True when the info string carries :data:`ILLUSTRATIVE_MARKER`.
     """
+
+    line: int
+    body: str
+    illustrative: bool
+
+
+def python_fences(text: str) -> list[PythonFence]:
+    """Every ```python fence in ``text``, in page order."""
     return [
-        (text.count("\n", 0, m.start()) + 1, m.group("body"))
+        PythonFence(
+            line=text.count("\n", 0, m.start()) + 1,
+            body=m.group("body"),
+            illustrative=ILLUSTRATIVE_MARKER in m.group("info"),
+        )
         for m in PYTHON_FENCE_RE.finditer(text)
     ]
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,24 +1,31 @@
-"""Executes the ``python`` fenced examples on every ``docs/**/*.md`` page.
+"""Executes the ``python`` fenced examples on every authored markdown page.
 
 ``test_docs_pages.py`` checks that the names a page mentions resolve; this
 test checks that the code a page shows actually *runs* against the current
-API. The gap between the two is where the #845 rename leaked: a page can
-reference only live symbols and still call them with a keyword that no
-longer exists, and nothing short of executing the block catches that.
+API. The gap between the two is where a rename leaks: a page can reference
+only live symbols and still call them with a keyword that no longer exists,
+and nothing short of executing the block catches that.
 
 Execution contract (matches the "Runnable" / "Illustrative" split in
 ``docs/development/contributing.md``):
 
 * Every ``python`` fence on a page runs, in order, in one shared namespace —
-  later blocks may build on earlier ones, as the prose reads.
-* A block that raises ``NameError`` is **illustrative** by construction — it
-  leans on an unbound placeholder such as ``panel_large`` or ``your_df`` to
-  communicate intent — and is skipped. Nothing else is: a ``TypeError`` from
-  a stale keyword, an ``AttributeError`` from a removed helper, a
-  ``KeyError`` from a renamed metadata key, or a polars column error from an
-  outdated schema all fail the page.
+  later blocks may build on earlier ones, as the prose reads. Any exception
+  fails the page, ``NameError`` included.
+* A block that is *declared* illustrative — ``` ```python title="Illustrative"
+  ``` — is compiled but not executed. Declaring it is the only way out: an
+  undeclared block that leans on an unbound placeholder fails like any other
+  drift, so the decision is written down on the page rather than inferred
+  from the exception type at runtime.
 * Blocks must be side-effect free (no file I/O, no plotting); stdout and
   warnings are swallowed so a noisy example is not a failing one.
+
+Coverage is auditable from the test output: ``test_illustrative_block_compiles``
+is parametrized one case per declared-illustrative block, so the default ``-v``
+run prints the full inventory of what was *not* executed, page and line
+included. Those blocks are not unchecked — ``test_docs_pages.py`` resolves the
+``factrix.*`` symbols they name, which is what the two tests being
+complementary buys.
 
 ``docs/plans/**`` is excluded (fossilised planning artifacts, also excluded
 from the published site). ``docs/examples/*.md`` are generated from the
@@ -38,7 +45,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from tests._doc_validation import docs_page_paths, python_fences
+from tests._doc_validation import PythonFence, docs_page_paths, python_fences
 
 
 @dataclass(frozen=True)
@@ -81,17 +88,26 @@ def _isolated_metric_registry() -> Iterator[None]:
         dag._registry_callable_table.cache_clear()
 
 
-def _run_page(text: str) -> tuple[list[_BlockFailure], int, int]:
-    """Run a page's fences in order; return (failures, n_run, n_illustrative)."""
+def _compile(fence: PythonFence, index: int) -> object | None:
+    """Compile one fence; return the code object, or ``None`` on ``SyntaxError``."""
+    return compile(
+        textwrap.dedent(fence.body),
+        f"<docs block {index} @ line {fence.line}>",
+        "exec",
+    )
+
+
+def _run_page(text: str) -> list[_BlockFailure]:
+    """Run a page's executable fences in order, in one shared namespace."""
     namespace: dict[str, object] = {"__name__": "__docs_example__"}
     failures: list[_BlockFailure] = []
-    n_run = n_illustrative = 0
-    for index, (line, source) in enumerate(python_fences(text), start=1):
-        code_text = textwrap.dedent(source)
+    for index, fence in enumerate(python_fences(text), start=1):
+        if fence.illustrative:
+            continue
         try:
-            code = compile(code_text, f"<docs block {index} @ line {line}>", "exec")
+            code = _compile(fence, index)
         except SyntaxError as exc:
-            failures.append(_BlockFailure(index, line, f"SyntaxError: {exc.msg}"))
+            failures.append(_BlockFailure(index, fence.line, f"SyntaxError: {exc.msg}"))
             continue
         sink = io.StringIO()
         try:
@@ -102,35 +118,71 @@ def _run_page(text: str) -> tuple[list[_BlockFailure], int, int]:
             ):
                 warnings.simplefilter("ignore")
                 exec(code, namespace)
-        except NameError:
-            # Unbound placeholder → illustrative fragment; see module docstring.
-            n_illustrative += 1
-            continue
-        except Exception as exc:  # any other error is drift, not illustration
+        except Exception as exc:  # any error is drift, not illustration
             first_line = str(exc).splitlines()[0] if str(exc) else ""
             failures.append(
-                _BlockFailure(index, line, f"{type(exc).__name__}: {first_line}")
+                _BlockFailure(index, fence.line, f"{type(exc).__name__}: {first_line}")
             )
-            continue
-        n_run += 1
-    return failures, n_run, n_illustrative
+    return failures
 
 
 # README.md is the one authored page outside docs/ with a python fence; the
-# quickstart it carries is the first snippet any user runs.
+# quickstart it carries is the first snippet any user runs, and it lives under
+# the same rule as the docs pages — including the marker, which GitHub's
+# renderer ignores as trailing info-string text.
 _PAGES = [pathlib.Path("README.md"), *docs_page_paths()]
+
+# One case per declared-illustrative block, so the inventory of what is *not*
+# executed is printed by every ``-v`` run instead of being invisible.
+_ILLUSTRATIVE_BLOCKS = [
+    (path, index, fence)
+    for path in _PAGES
+    for index, fence in enumerate(
+        python_fences(path.read_text(encoding="utf-8")), start=1
+    )
+    if fence.illustrative
+]
 
 
 @pytest.mark.usefixtures("_isolated_metric_registry")
 @pytest.mark.parametrize("path", _PAGES, ids=lambda p: p.as_posix())
 def test_page_examples_execute(path: pathlib.Path) -> None:
     text = path.read_text(encoding="utf-8")
-    if not python_fences(text):
+    fences = python_fences(text)
+    if not fences:
         pytest.skip("no python fences on this page")
-    failures, _n_run, _n_illustrative = _run_page(text)
+    if all(fence.illustrative for fence in fences):
+        pytest.skip("every python fence on this page is declared illustrative")
+    failures = _run_page(text)
     assert not failures, (
         f"python examples in {path.as_posix()} no longer run against the "
-        "current API (blocks that only reference unbound placeholder names "
-        "are skipped as illustrative; everything else must execute):\n  "
+        "current API (a block that cannot run as written must declare itself "
+        'with ```python title="Illustrative"`):\n  '
         + "\n  ".join(f"block {f.index} (line {f.line}): {f.error}" for f in failures)
     )
+
+
+@pytest.mark.parametrize(
+    ("path", "index", "fence"),
+    _ILLUSTRATIVE_BLOCKS,
+    ids=[
+        f"{path.as_posix()}:block {index} @ line {fence.line}"
+        for path, index, fence in _ILLUSTRATIVE_BLOCKS
+    ],
+)
+def test_illustrative_block_compiles(
+    path: pathlib.Path, index: int, fence: PythonFence
+) -> None:
+    """A declared-illustrative block is not executed, but must still parse.
+
+    The test ids are the audit trail: they name every block the executing
+    test skipped, so removing a block from the run is a visible diff on this
+    file's output rather than a silent gap.
+    """
+    try:
+        _compile(fence, index)
+    except SyntaxError as exc:
+        pytest.fail(
+            f"illustrative block {index} (line {fence.line}) in "
+            f"{path.as_posix()} does not parse: {exc.msg}"
+        )

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -88,8 +88,12 @@ def _isolated_metric_registry() -> Iterator[None]:
         dag._registry_callable_table.cache_clear()
 
 
-def _compile(fence: PythonFence, index: int) -> object | None:
-    """Compile one fence; return the code object, or ``None`` on ``SyntaxError``."""
+def _compile(fence: PythonFence, index: int) -> object:
+    """Compile one fence to a code object.
+
+    Raises ``SyntaxError`` like :func:`compile` does; both call sites catch it
+    and report the offending block.
+    """
     return compile(
         textwrap.dedent(fence.body),
         f"<docs block {index} @ line {fence.line}>",


### PR DESCRIPTION
> **TL;DR** — The docs-example harness inferred "illustrative" from `NameError` and skipped in silence, so one unbound name switched off validation of a whole block with no trace in the output. Intent is now declared on the fence (<code>```python title="Illustrative"</code>), an undeclared block fails on any exception including `NameError`, and every declared block gets its own parametrized case so the skip inventory is printed by the default `-v` run. Triage made three previously-skipped blocks runnable, which exposed a real bug in the custom-metrics guide.

## Summary

`tests/test_docs_examples.py` executed every `python` fence on `README.md` and `docs/**/*.md`, but treated any `NameError` as proof that the block was a hand-authored sketch. That is an inference from an exception type, not a declaration: a block only had to reference one unbound name for its remaining — fully executable, potentially broken — lines to stop being checked, and the test output said nothing about it.

### Marker mechanism

The declaration is <code>```python title="Illustrative"</code>. `title=` is not a stylistic pick — it is the only marker that renders:

| Info string | `pymdownx.superfences` result |
|---|---|
| `python illustrative` | falls back to inline `<code>` — block breaks |
| `python exec="false"` | falls back to inline `<code>` — block breaks |
| `{.python .illustrative}` | renders, but no longer matches the <code>```python</code> fence walker |
| `python title="Illustrative"` | renders as a caption bar above the block |

So the same token that opts the block out of execution also tells the reader the code is a sketch. No plugin, no config change, no page-level opt-out list.

### Harness contract

- Undeclared block raising **any** exception (`NameError` included) → page fails.
- Declared block → compiled (must still parse) but never executed.
- `test_illustrative_block_compiles` is parametrized one case per declared block, id'd `path:block N @ line L`. The repo's `addopts = "-v"` means every run prints the full inventory of what was not executed; removing a block from the run is a visible diff in the test output.
- Declared blocks are not unchecked: `tests/test_docs_pages.py` still resolves the `factrix.*` symbols they name. That complementarity is why compile-only is enough here rather than a second execution path.

### Bug this surfaced

Making `docs/guides/custom-metrics.md` block 2 runnable exposed the guide's flagship `@metric` example failing with `ColumnNotFoundError: "ic" not found`. The custom `custom_trimmed_ic` names its first parameter `ic_df` and indexes `ic_df["ic"]`, but declared neither `input_shape=InputShape.SERIES` nor `requires={"ic_df": compute_ic}` — so the DAG handed it the raw panel. Fixed in place; the block now runs end to end.

### `README.md`

Same rule, unchanged scope. It was already in the parametrized page list and stays there: its single fence executes, so it needs no marker. Should one ever be needed, GitHub's renderer ignores trailing info-string text, so the marker degrades to a plain highlighted block there instead of breaking.

## Before / after

Executed = block ran to completion in the shared page namespace. Before, "skipped" was silent and inferred; after, it is declared on the fence and printed as a test id.

| Page | Fences | Executed before | Executed after | Declared illustrative |
|---|---:|---:|---:|---:|
| `README.md` | 1 | 1 | 1 | 0 |
| `docs/api/bhy-across-metrics.md` | 1 | 0 | 0 | 1 |
| `docs/api/bhy-hierarchical.md` | 1 | 0 | 0 | 1 |
| `docs/api/bhy.md` | 1 | 0 | 0 | 1 |
| `docs/api/by-slice.md` | 8 | 0 | 0 | 8 |
| `docs/api/compare.md` | 2 | 0 | 0 | 2 |
| `docs/api/data-schema.md` | 2 | 1 | 1 | 1 |
| `docs/api/errors.md` | 2 | 0 | 0 | 2 |
| `docs/api/evaluate.md` | 3 | 2 | 2 | 1 |
| `docs/api/metrics/common_beta.md` | 2 | 1 | 1 | 1 |
| `docs/api/metrics/index.md` | 4 | 3 | 3 | 1 |
| `docs/api/partial-conjunction-across-metrics.md` | 1 | 0 | 0 | 1 |
| `docs/api/partial-conjunction.md` | 2 | 0 | 0 | 2 |
| `docs/api/slice-test.md` | 1 | 0 | 0 | 1 |
| `docs/development/architecture.md` | 1 | 0 | 0 | 1 |
| `docs/development/contributing.md` | 1 | 0 | 0 | 1 |
| `docs/getting-started/quickstart.md` | 2 | 1 | 1 | 1 |
| `docs/guides/custom-metrics.md` | 4 | 2 | **3** | 1 |
| `docs/guides/large-scale-evaluation.md` | 1 | 0 | 0 | 1 |
| `docs/guides/observability.md` | 2 | 1 | **2** | 0 |
| `docs/guides/preparing-data.md` | 10 | 8 | 8 | 2 |
| `docs/guides/reading-results.md` | 1 | 0 | **1** | 0 |
| `docs/guides/slice-analysis.md` | 5 | 1 | 1 | 4 |
| `docs/where-factrix-fits.md` | 2 | 0 | 0 | 2 |
| *(all other pages with fences)* | 50 | 50 | 50 | 0 |
| **Total** | **110** | **71** | **74** | **36** |

Bolded cells are blocks made runnable by minimal setup. `docs/api/data-schema.md` block 2 was left illustrative deliberately: its `factor_cols=["momentum_12_1"]` names a column the page's own panel does not carry, so "minimal setup" would mean rewriting the panel the prose is illustrating.

### Triage rationale for the rest

Everything now marked leans on a placeholder that stands in for the reader's own data (`panel`, `data`, `your_df`, `vendor_df`, `panel_large`, `zipline_out`), forward-references a symbol a later block defines (`custom-metrics` block 3), or cannot be side-effect free (`large-scale-evaluation` reads a Parquet file from disk, which the harness forbids). `architecture.md` and `contributing.md` carry a dataclass sketch and a pytest sketch respectively — neither is meant to run.

## Test plan

```
uv run ruff check                → All checks passed!
uv run ruff format --check       → 216 files already formatted
uv run mypy factrix              → Success: no issues found in 84 source files
uv run pytest -q tests/test_docs_examples.py tests/test_docs_pages.py
                                 → 244 passed, 42 skipped in 2.33s
uv run pytest -q -x              → 3047 passed, 42 skipped, 180 warnings in 36.75s
uv run mkdocs build --strict     → Documentation built in 2.00 seconds (no drift in
                                   the tracked docs/reference/_generated_*.md files)
```

The rendered marker was verified in the built site: `<span class="filename">Illustrative</span>` above the block, block still highlighted as Python.

Reviewer's fastest check that this actually bites: drop the `title="Illustrative"` from any marked fence and re-run `tests/test_docs_examples.py` — the page fails with the `NameError` that used to be swallowed.

## Open questions

- `docs/api/compare.md` block 1 builds `results` as the dict `fx.evaluate` returns, and block 2 then passes that dict straight to `fx.compare(results, ...)` although the prose and signature both call for `list[EvaluationResult]`. Both blocks are declared illustrative here (they need caller-supplied `data` / `candidates`), so the harness still cannot see it. Worth a follow-up rather than widening this PR.
- 36 declared blocks is a large surface for the marker to hide behind. `test_docs_pages.py` covers the symbol half, but a stale *keyword* inside a declared block is still invisible. Making the guide pages runnable one at a time is the way to shrink it; this PR moved three.

Closes #892
