### PR TITLE
test(docs): guard the numbers in the reference pages

### DIFF
--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -67,8 +67,8 @@ Min sample*. `MIN_*` constants resolve to values in the
 
 | Metric | Sample axis | Min sample |
 |---|---|---|
-| [`pooled_beta`][factrix.metrics.fm_beta.pooled_beta] | `n_assets × T` | `n_assets >= 10`, effective clusters `G >= 3` |
-| [`fm_beta_sign_consistency`][factrix.metrics.fm_beta.fm_beta_sign_consistency] | `T` (β series) | `T ≥ MIN_FM_PERIODS_HARD` |
+| [`pooled_beta`][factrix.metrics.fm_beta.pooled_beta] | `n_assets × T` | `n_assets >= 10`, effective clusters `G >= 3`; warn if `T < MIN_FM_PERIODS_WARN` |
+| [`fm_beta_sign_consistency`][factrix.metrics.fm_beta.fm_beta_sign_consistency] | `T` (β series) | `T ≥ 1` finite β period (descriptive; no λ-series floor) |
 
 ### Quantile / Monotonicity / Concentration — Cell: Individual × Continuous
 
@@ -95,15 +95,15 @@ Min sample*. `MIN_*` constants resolve to values in the
 | Metric | Sample axis | Min sample |
 |---|---|---|
 | [`bmp_z`][factrix.metrics.caar.bmp_z] | `K`; `D` (event periods) when events cluster | `K ≥ MIN_EVENTS_HARD`; `estimation_window` periods per asset; warns on `D < MIN_EVENTS_WARN` when `D < K` |
-| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`event_ic`][factrix.metrics.event_quality.event_ic] | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | `K` | `K ≥ MIN_EVENTS_HARD`; warn if `K < MIN_EVENTS_WARN` |
+| [`event_ic`][factrix.metrics.event_quality.event_ic] | `K` | `K ≥ MIN_EVENTS_HARD`; warn if `K < MIN_EVENTS_WARN` |
 | [`profit_factor`][factrix.metrics.event_quality.profit_factor] | `K` | `K ≥ MIN_EVENTS_HARD` |
-| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | `K` | `K ≥ MIN_EVENTS_HARD` |
+| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | `K` | `K ≥ MIN_EVENTS_HARD`; warn if `K < MIN_EVENTS_WARN` |
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | `K` | `K ≥ 2` |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | per-offset `K` | `K ≥ MIN_EVENTS_HARD` |
 | [`mfe_mae`][factrix.metrics.mfe_mae.mfe_mae] | `K` | `K ≥ MIN_EVENTS_HARD`; `price` column required |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | `K`, `n_assets` | `n_assets >= 2`; `K >= MIN_EVENTS_HARD` |
-| [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] | `D` (event periods) | `K ≥ MIN_EVENTS_HARD` **and** `D ≥ MIN_EVENTS_HARD` |
+| [`corrado_rank`][factrix.metrics.corrado_rank.corrado_rank] | `D` (event periods) | `K ≥ MIN_EVENTS_HARD` **and** `D ≥ MIN_EVENTS_HARD`; warn if `D < MIN_EVENTS_WARN` |
 
 ### TS-β family — Cell: Common × Continuous
 
@@ -125,8 +125,8 @@ Min sample*. `MIN_*` constants resolve to values in the
 
 | Metric | Sample axis | Min sample |
 |---|---|---|
-| [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | `T` | aligned spread series |
-| [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | `T` | as `spanning_alpha` |
+| [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | `T` | aligned spread series; `T ≥ 10` |
+| [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | `T` | aligned spread series (each candidate fit as `spanning_alpha`) |
 
 ### IC-series diagnostics — Cell: Individual × Continuous
 
@@ -162,7 +162,7 @@ below.
 | `MIN_PAIR_ACCURACY_PAIRS_HARD` | 10 | comparable asset pairs | hard | `factrix/_types.py` | `directional_pair_accuracy` |
 | `MIN_PAIR_ACCURACY_PAIRS_WARN` | 30 | comparable asset pairs | warn | `factrix/_types.py` | `directional_pair_accuracy`; tags `WarningCode.FEW_ORDERING_PAIRS` |
 | `MIN_EVENTS_HARD` | 4 | `K` (event count) | hard | `factrix/_types.py` | `caar`, `bmp_z`, `event_hit_rate`, `event_ic`, `profit_factor`, `event_skewness`, `event_around_return`, `mfe_mae`, `clustering_hhi`, `corrado_rank` |
-| `MIN_EVENTS_WARN` | 30 | `K` | warn | `factrix/_types.py` | `caar` only (Brown-Warner literature floor; descriptive event-quality metrics use HARD only) |
+| `MIN_EVENTS_WARN` | 30 | `K` | warn | `factrix/_types.py` | `caar`, `bmp_z`, `event_hit_rate`, `event_ic`, `event_skewness`, `corrado_rank` (Brown-Warner literature floor); tags `WarningCode.FEW_EVENTS`. The purely descriptive event metrics (`profit_factor`, `mfe_mae`, `clustering_hhi`, `event_around_return`) use HARD only |
 | `MIN_OOS_PERIODS_HARD` | 5 | `T` (per split) | hard | `factrix/_types.py` | `oos_decay` (effective floor `T ≥ 2 × MIN_OOS_PERIODS_HARD = 10`) |
 | `MIN_PORTFOLIO_PERIODS_HARD` | 3 | `T/h` | hard | `factrix/_types.py` | `quantile_spread`, `quantile_spread_vw`, `top_concentration`, `common_quantile_spread`, `common_asymmetry` |
 | `MIN_PORTFOLIO_PERIODS_WARN` | 20 | `T/h` | warn | `factrix/_types.py` | `top_concentration` only (`quantile_spread` and the `ts_*` siblings are descriptive at the WARN tier and gate on HARD only) |

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -128,9 +128,11 @@ statements live in `factrix._stats.hac`'s docstring Notes.
 | SE scale | none (textbook is $\sqrt{\text{LRV}/T}$); Stata's `newey` scales by $T/(T-k)$ with $k$ = **regressor count**, never the bandwidth | $T/(T - L - 1)$ | Self-derived white-noise demeaning-bias correction: in-sample demeaning biases each $\hat\gamma_j$ by ≈$-\gamma_0/T$, giving $\mathbb{E}[\widehat{\text{LRV}}] \approx \gamma_0(1 - (L+1)/T)$, which this undoes exactly. | $h{=}5$: 8.2–9.6% → 6.2–6.7%. Partly double-counts with the fixed-$b$ reference (whose KV limit already embeds demeaning), so $h{=}1$ iid cells come out slightly *under*-sized (4.3–4.7% at $T \le 120$). |
 | Effective df | LLSW's `harreg.ado` uses $\lceil 1.5T/S \rceil$ | $\min(1.5T/L - 1,\; T/h - 1)$ | The $-1$ is a sub-one-df small-sample conservatism. The $T/h - 1$ cap is self-derived: an $h$-period overlapping series carries at most $T/h$ independent observations however the kernel is tuned. | Cap: $T{=}60$, $h{=}21$ size 12.2% → 4.3%. Cost: passing `forward_periods` on a series with *less* dependence than $h$ implies makes the test markedly conservative — measured 0.2% ($T{=}60$), 2.1% ($T{=}120$), 3.5% ($T{=}240$) on iid input at $h{=}21$. |
 
-Producing module: the three cells above are re-measured at reduced
-replication by `tests/stats/test_hac_overlap_size.py`; the full sweep
-behind the exact percentages is not committed.
+Producing module: `tests/stats/test_hac_overlap_size.py` re-measures the
+three pieces only as one contrast — the current recipe against the
+pre-fix recipe that swapped all three at once. The per-piece cells above
+are not re-measured by any committed module except where a cell names
+one.
 
 Two choices factrix deliberately did not adopt:
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -128,6 +128,10 @@ statements live in `factrix._stats.hac`'s docstring Notes.
 | SE scale | none (textbook is $\sqrt{\text{LRV}/T}$); Stata's `newey` scales by $T/(T-k)$ with $k$ = **regressor count**, never the bandwidth | $T/(T - L - 1)$ | Self-derived white-noise demeaning-bias correction: in-sample demeaning biases each $\hat\gamma_j$ by ≈$-\gamma_0/T$, giving $\mathbb{E}[\widehat{\text{LRV}}] \approx \gamma_0(1 - (L+1)/T)$, which this undoes exactly. | $h{=}5$: 8.2–9.6% → 6.2–6.7%. Partly double-counts with the fixed-$b$ reference (whose KV limit already embeds demeaning), so $h{=}1$ iid cells come out slightly *under*-sized (4.3–4.7% at $T \le 120$). |
 | Effective df | LLSW's `harreg.ado` uses $\lceil 1.5T/S \rceil$ | $\min(1.5T/L - 1,\; T/h - 1)$ | The $-1$ is a sub-one-df small-sample conservatism. The $T/h - 1$ cap is self-derived: an $h$-period overlapping series carries at most $T/h$ independent observations however the kernel is tuned. | Cap: $T{=}60$, $h{=}21$ size 12.2% → 4.3%. Cost: passing `forward_periods` on a series with *less* dependence than $h$ implies makes the test markedly conservative — measured 0.2% ($T{=}60$), 2.1% ($T{=}120$), 3.5% ($T{=}240$) on iid input at $h{=}21$. |
 
+Producing module: the three cells above are re-measured at reduced
+replication by `tests/stats/test_hac_overlap_size.py`; the full sweep
+behind the exact percentages is not committed.
+
 Two choices factrix deliberately did not adopt:
 
 - The data-adaptive plug-in of [Newey-West 1994][newey-west-1994] is
@@ -473,6 +477,11 @@ sizes are at a nominal 5% on a true null.
 | `predictive_beta` — single-restriction slope, $h > 1$ | `_resolve_har_lags` | $t_\nu$ via `_har_dof` | **7.5–14.5%** — known-oversized, see below |
 | `spanning_alpha`, `pooled_beta`, `common_quantile_spread`, `common_asymmetry`, `_ols.py`, the slice tests — $K$-restriction Wald / multivariate | `_resolve_nw_lags`: $\max(\text{auto\_bartlett}(T), h-1)$ | $t_{T-k}$ / $F_{r,\,T-k}$ | 5.4–7.1% on iid residuals ($n = 60 \to 240$), 11.5–18.5% on AR(0.6); **8–9%** for the $K = 5$ slice joint test on 50–90-period slices |
 
+Producing modules: `tests/stats/test_hac_overlap_size.py` for the scalar
+series-mean rows, `tests/test_stambaugh_bias.py` for the `predictive_beta`
+rows, and `tests/test_slice_period_joint_test.py` for the slice-test band
+in the last row.
+
 Two of these rows are **known-oversized regimes rather than calibrated
 ones**, and are disclosed rather than corrected:
 
@@ -521,7 +530,8 @@ Hotelling-style `F` on the HAC effective df, and a Satterthwaite ν on
 that df were each measured; none calibrates the iid short-slice case
 (prewhitening is the right tool for *autocorrelated* input — see the HAC
 size sweep tracker). The function warns in this regime and the
-characterisation test pins the measured band; pairwise contrasts on the
+characterisation test in `tests/test_slice_period_joint_test.py` pins the
+measured band; pairwise contrasts on the
 same slices (5–6%) are the better-calibrated read.
 ### Persistent per-period series: no HAC or bootstrap path is calibrated
 
@@ -586,6 +596,9 @@ rather than corrected. Against the plain Bartlett estimate (nominal 5%):
 | IC fixture, φ = 0.6 | 240 | 14.4% | 8.0% |
 | IC fixture, φ = 0.85 | 240 | 32.8% | 15.6% |
 | real overlapping IC, h=5 | 240 / 480 | 5.2% / 8.8% | 5.2% / 8.4% |
+
+The prewhitened-versus-plain bands above are pinned as characterisation
+bands in `tests/stats/test_prewhitening.py`.
 
 Two independent implementations agree on every row above. Read the IC
 fixture against its *own* φ = 0 baseline of 9.2% (a property of the

--- a/tests/test_docs_llms.py
+++ b/tests/test_docs_llms.py
@@ -33,6 +33,7 @@ import pathlib
 import re
 
 import factrix
+from factrix._codes import WarningCode
 
 from tests._doc_validation import (
     import_resolves,
@@ -43,6 +44,22 @@ from tests._doc_validation import (
 
 LLMS_FULL = pathlib.Path("factrix/llms-full.txt")
 LLMS_INDEX = pathlib.Path("factrix/llms.txt")
+
+# Preprocess / data-shape codes. They are raised outside the evaluation
+# path (``factrix.preprocess`` normalizers, ``orthogonalize_factor``,
+# ``compute_forward_return``), so the curated llms-full.txt table points
+# at the generated reference for them instead of restating their glosses.
+_PREPROCESS_CODES: frozenset[str] = frozenset(
+    {
+        WarningCode.ZERO_MAD_STD_FALLBACK.value,
+        WarningCode.SPARSE_WINSORIZE_SKIPPED.value,
+        WarningCode.INSUFFICIENT_SCALE_ASSETS.value,
+        WarningCode.NON_FINITE_INPUT_DROPPED.value,
+        WarningCode.INSUFFICIENT_REGRESSION_DF.value,
+        WarningCode.RANK_DEFICIENT_DESIGN.value,
+        WarningCode.RAGGED_PERIOD_GRID.value,
+    }
+)
 
 
 def test_every_referenced_symbol_resolves() -> None:
@@ -81,6 +98,42 @@ def test_every_public_symbol_mentioned_in_llms_full() -> None:
         "Public symbols in factrix.__all__ never mentioned in llms-full.txt:\n  "
         + "\n  ".join(missing)
         + "\nAdd at least one mention so LLM agents do not miss them."
+    )
+
+
+def test_warning_code_table_covers_every_evaluation_side_code() -> None:
+    """The curated ``WarningCode`` table must cover every evaluation-side code.
+
+    The table is hand-written (the generated
+    ``docs/reference/_generated_warning_codes.md`` carries the full enum
+    with its canonical glosses), and its intro states a count. Both the
+    count and the membership are pinned here: a new evaluation-side code
+    has to land in the table, and a new preprocess / data-shape code has
+    to be declared in :data:`_PREPROCESS_CODES`.
+    """
+    text = LLMS_FULL.read_text(encoding="utf-8")
+    section = text.split("## WarningCode reference", 1)[1]
+    listed = re.findall(r"^\| `([a-z0-9_]+)` \|", section, flags=re.M)
+
+    all_codes = {code.value for code in WarningCode}
+    unknown = sorted(set(listed) - all_codes)
+    assert not unknown, (
+        "llms-full.txt WarningCode table lists codes that are not in "
+        "WarningCode:\n  " + "\n  ".join(unknown)
+    )
+    missing = sorted(all_codes - set(listed) - _PREPROCESS_CODES)
+    assert not missing, (
+        "Evaluation-side WarningCode values missing from the llms-full.txt "
+        "table:\n  " + "\n  ".join(missing)
+    )
+    claimed = re.search(r"The (\d+) evaluation-side codes", section)
+    assert claimed is not None, (
+        "llms-full.txt no longer states the evaluation-side code count; "
+        "restore it or drop this assertion."
+    )
+    assert int(claimed.group(1)) == len(listed), (
+        f"llms-full.txt claims {claimed.group(1)} evaluation-side codes but "
+        f"its table has {len(listed)} rows."
     )
 
 

--- a/tests/test_docs_matrix.py
+++ b/tests/test_docs_matrix.py
@@ -57,6 +57,36 @@ def test_generated_matrix_exists_and_nonempty() -> None:
     )
 
 
+def test_generated_matrix_matches_renderer() -> None:
+    """Generated matrix file must match what the renderer produces.
+
+    Same byte-compare as ``test_generated_name_index_matches_renderer``:
+    the row-count check above cannot see a stale grouping (a metric that
+    moved cell or aggregation without a rebuild).
+    """
+    if not GENERATED_MATRIX.exists():
+        pytest.skip(
+            f"{GENERATED_MATRIX} not found — run "
+            "'python scripts/mkdocs_hooks/gen_metric_matrix.py' or 'mkdocs build' first."
+        )
+    from factrix._metric_index import public_specs
+    from scripts.mkdocs_hooks.gen_metric_matrix import (
+        _TABLE_HEADER,
+        _group_specs,
+        _render_row,
+    )
+
+    expected = _TABLE_HEADER + "".join(
+        _render_row(row) for row in _group_specs(public_specs())
+    )
+    actual = GENERATED_MATRIX.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"{GENERATED_MATRIX} is stale — re-run "
+        "'python scripts/mkdocs_hooks/gen_metric_matrix.py' "
+        "(or 'mkdocs build') to regenerate."
+    )
+
+
 def test_metric_output_name_matches_spec_name() -> None:
     """Every ``MetricResult(name=...)`` literal must match its spec's ``name``.
 

--- a/tests/test_docs_sample_thresholds.py
+++ b/tests/test_docs_sample_thresholds.py
@@ -1,0 +1,250 @@
+"""Drift guards for the sample-size numbers in ``metric-applicability.md``.
+
+The page is hand-written and number-dense: a constants table that
+restates every ``MIN_*`` literal, and a per-family ``Min sample`` column
+that declares which tier gates each metric. Nothing generates either, so
+both are parsed here and asserted against the live objects:
+
+1. Constants table — every row's value, tier and source module are
+   checked against the constant imported from that module.
+2. Inline claims — the ``` `NAME` (value) ``` / ``` `NAME = value` ```
+   forms scattered through the reference and development pages are
+   checked against the same constants.
+3. Per-metric floors — the HARD / WARN tiers each row claims are checked
+   against the resolved :attr:`MetricSpec.sample_threshold`.
+
+The floors in the spec are resolved at the metric's default overlap
+horizon, so they are scaled multiples of the raw constants; only the
+*presence* of a tier per axis is comparable, and that is what (3)
+asserts.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import re
+
+import pytest
+from factrix._metric_index import MetricSpec, public_specs
+
+APPLICABILITY = pathlib.Path("docs/reference/metric-applicability.md")
+DOCS_ROOT = pathlib.Path("docs")
+
+# Superseded design write-ups; they quote constants that no longer exist.
+_EXCLUDED_DOC_DIRS = ("plans",)
+
+_CONSTANT_TOKEN = r"(MIN_[A-Z0-9_]+|N_GROUPS_FLOOR|PERSISTENT_SERIES_AUTOCORR)"
+_VALUE = r"([0-9]+(?:\.[0-9]+)?)"
+
+_TABLE_ROW = re.compile(
+    rf"^\| `{_CONSTANT_TOKEN}` \| {_VALUE} \| [^|]* \| (hard|warn) \| "
+    r"`([^`]+)` \|",
+    re.M,
+)
+
+_INLINE_CLAIMS = (
+    # `MIN_X = 4`
+    re.compile(rf"`{_CONSTANT_TOKEN}\s*=\s*{_VALUE}`"),
+    # `MIN_X` = 4
+    re.compile(rf"`{_CONSTANT_TOKEN}`\s*=\s*{_VALUE}\b"),
+    # `MIN_X` (4)
+    re.compile(rf"`{_CONSTANT_TOKEN}`\s*\(\s*{_VALUE}\s*\)"),
+)
+
+# Rows of the per-family ``Metric | Sample axis | Min sample`` tables.
+_METRIC_ROW = re.compile(
+    r"^\| \[`([a-z0-9_]+)`\]\[factrix\.metrics\.[a-z0-9_.]+\] \| [^|]* \| ([^|]*) \|",
+    re.M,
+)
+
+# A metric whose gate cannot be declared as a static panel-shape floor, so
+# ``sample_threshold`` is deliberately empty while the page documents the
+# in-body floor. Each entry mirrors the reason stated at the metric.
+_NO_STATIC_FLOOR: dict[str, str] = {
+    # Gates within-period asset couples; DataProperties.n_pairs is a row
+    # count, so the floor is enforced in-body only.
+    "directional_pair_accuracy": "asset_pairs axis is not a DataProperties axis",
+    # Per-offset event counts are factor-context-dependent.
+    "event_around_return": "per-offset floor, no static panel-shape floor",
+    # >= 2 events is a math-degeneracy guard, not the statistical floor.
+    "signal_density": "in-body degeneracy guard, not a declared floor",
+}
+
+
+def _doc_pages() -> list[pathlib.Path]:
+    return sorted(
+        p
+        for p in DOCS_ROOT.rglob("*.md")
+        if not any(part in _EXCLUDED_DOC_DIRS for part in p.parts)
+    )
+
+
+def _constants_table() -> list[tuple[str, str, str, str]]:
+    """Return ``(name, value, tier, source module path)`` per table row."""
+    rows = _TABLE_ROW.findall(APPLICABILITY.read_text(encoding="utf-8"))
+    assert rows, f"{APPLICABILITY}: no sample-size constants table rows parsed"
+    return rows
+
+
+def _module_of(source_path: str) -> str:
+    return source_path.removesuffix(".py").replace("/", ".")
+
+
+def _live_value(module: str, name: str) -> object:
+    return getattr(importlib.import_module(module), name)
+
+
+@pytest.fixture(scope="module")
+def constant_namespace() -> dict[str, object]:
+    """Every sample-size constant an inline claim may name, keyed by name.
+
+    The page's own ``Source module`` column supplies the metric-side
+    modules, so a new constant module needs no second declaration here;
+    the two shared constant modules are added for the tokens that live
+    outside the table (``N_GROUPS_FLOOR``, ``PERSISTENT_SERIES_AUTOCORR``).
+    """
+    namespace = {
+        name: _live_value(_module_of(source), name)
+        for name, _value, _tier, source in _constants_table()
+    }
+    for module_name in ("factrix._types", "factrix._stats.constants"):
+        module = importlib.import_module(module_name)
+        namespace |= {
+            name: getattr(module, name)
+            for name in vars(module)
+            if re.fullmatch(_CONSTANT_TOKEN, name)
+        }
+    return namespace
+
+
+def test_constants_table_matches_code() -> None:
+    """Each table row's value, tier and source module must be live."""
+    mismatches: list[str] = []
+    for name, value, tier, source in _constants_table():
+        module = _module_of(source)
+        try:
+            live = _live_value(module, name)
+        except (AttributeError, ModuleNotFoundError):
+            mismatches.append(f"{name}: not importable from {module}")
+            continue
+        if float(value) != float(live):  # type: ignore[arg-type]
+            mismatches.append(f"{name}: doc says {value}, {module} says {live}")
+        expected_tier = "hard" if name.endswith("_HARD") else "warn"
+        if tier != expected_tier:
+            mismatches.append(
+                f"{name}: doc tier column says {tier!r}, name implies {expected_tier!r}"
+            )
+    assert not mismatches, (
+        f"{APPLICABILITY} sample-size constants table is stale:\n  "
+        + "\n  ".join(mismatches)
+    )
+
+
+def test_inline_constant_claims_match_code(
+    constant_namespace: dict[str, object],
+) -> None:
+    """Inline ``NAME (value)`` / ``NAME = value`` claims must match the code."""
+    mismatches: list[str] = []
+    for page in _doc_pages():
+        text = page.read_text(encoding="utf-8")
+        for pattern in _INLINE_CLAIMS:
+            for name, value in pattern.findall(text):
+                if name not in constant_namespace:
+                    mismatches.append(
+                        f"{page}: `{name}` is not in the sample-size constants "
+                        f"table of {APPLICABILITY}"
+                    )
+                    continue
+                live = constant_namespace[name]
+                if float(value) != float(live):  # type: ignore[arg-type]
+                    mismatches.append(f"{page}: `{name}` = {value}, code says {live}")
+    assert not mismatches, "Inline constant claims are stale:\n  " + "\n  ".join(
+        mismatches
+    )
+
+
+def _declared_tiers(min_sample_cell: str) -> tuple[bool, bool]:
+    """Return ``(claims a hard floor, claims a warn tier)`` for one doc cell."""
+    hard = bool(re.search(r"_HARD\b|>=|≥", min_sample_cell))
+    warn = bool(re.search(r"_WARN\b|warn", min_sample_cell))
+    return hard, warn
+
+
+def _spec_tiers(spec: MetricSpec) -> tuple[bool, bool]:
+    """Return ``(has a min_* floor, has a warn_* floor)`` for one spec."""
+    threshold = spec.sample_threshold
+    axes = ("periods", "assets", "pairs", "events")
+    return (
+        any(getattr(threshold, f"min_{axis}") is not None for axis in axes),
+        any(getattr(threshold, f"warn_{axis}") is not None for axis in axes),
+    )
+
+
+def _per_metric_rows() -> dict[str, str]:
+    """Return ``metric name -> Min sample cell`` for the per-family tables.
+
+    Only the ``Other metrics by family`` region carries floors; the
+    event-study tables further down share the row shape but describe
+    abnormal-return primitives.
+    """
+    text = APPLICABILITY.read_text(encoding="utf-8")
+    region = text.split("## Other metrics by family", 1)[1].split(
+        "## Sample-size constants", 1
+    )[0]
+    rows = dict(_METRIC_ROW.findall(region))
+    assert rows, f"{APPLICABILITY}: no per-metric rows parsed"
+    # ``as `other``` rows inherit the referenced row's floor verbatim.
+    for name, cell in list(rows.items()):
+        alias = re.fullmatch(r"\s*as `([a-z0-9_]+)`\s*", cell)
+        if alias is not None:
+            rows[name] = rows[alias.group(1)]
+    return rows
+
+
+def test_per_metric_floors_match_spec() -> None:
+    """Per-family ``Min sample`` cells must declare the tiers the spec carries."""
+    specs = {spec.name: spec for _stem, spec in public_specs()}
+
+    mismatches: list[str] = []
+    for name, cell in _per_metric_rows().items():
+        if name in _NO_STATIC_FLOOR:
+            continue
+        spec = specs.get(name)
+        if spec is None:
+            mismatches.append(f"{name}: documented but not a registered metric")
+            continue
+        doc_hard, doc_warn = _declared_tiers(cell)
+        spec_hard, spec_warn = _spec_tiers(spec)
+        if doc_hard != spec_hard:
+            mismatches.append(
+                f"{name}: doc {'declares' if doc_hard else 'declares no'} hard "
+                f"floor, spec {'has' if spec_hard else 'has no'} min_* floor"
+            )
+        if doc_warn != spec_warn:
+            mismatches.append(
+                f"{name}: doc {'declares' if doc_warn else 'declares no'} warn "
+                f"tier, spec {'has' if spec_warn else 'has no'} warn_* floor"
+            )
+    assert not mismatches, (
+        f"{APPLICABILITY} per-metric floors disagree with MetricSpec:\n  "
+        + "\n  ".join(mismatches)
+    )
+
+
+def test_no_static_floor_exemptions_still_empty() -> None:
+    """The exempted metrics must still declare no static floor.
+
+    Keeps :data:`_NO_STATIC_FLOOR` from silently masking a metric that
+    later gained a real ``sample_threshold``.
+    """
+    specs = {spec.name: spec for _stem, spec in public_specs()}
+    stale = [
+        f"{name} ({reason})"
+        for name, reason in _NO_STATIC_FLOOR.items()
+        if any(_spec_tiers(specs[name]))
+    ]
+    assert not stale, (
+        "These metrics now declare a sample_threshold — drop them from "
+        "_NO_STATIC_FLOOR and document the floor:\n  " + "\n  ".join(stale)
+    )

--- a/tests/test_docs_stat_keys_by_metric.py
+++ b/tests/test_docs_stat_keys_by_metric.py
@@ -1,19 +1,38 @@
-"""Drift guard: ``MetricResult.metadata`` keys ⊆ docs reference page.
+"""Drift guard: ``MetricResult.metadata`` keys ↔ docs reference page.
 
-AST-scans every public ``factrix/metrics/*.py`` for literal string keys
-that flow into ``MetricResult.metadata`` and asserts each appears as a
-backtick token in ``docs/reference/stat-keys-by-metric.md``.
+Code → doc: AST-scans every public ``factrix/metrics/*.py`` for literal
+string keys that flow into ``MetricResult.metadata`` and asserts each
+appears as a backtick token in ``docs/reference/stat-keys-by-metric.md``.
+
+Doc → code: every key the page's per-metric bullets name must still
+appear in the metric's own module or in the shared internal modules that
+build its metadata. Keys are assembled from f-strings and ``**kwargs``
+splats as well as dict literals, so the reverse direction reads source
+text rather than the AST — it catches a key deleted from the code and
+left behind in the page, not a key that moved between metrics.
 """
 
 from __future__ import annotations
 
 import ast
 import pathlib
+import re
 
 import pytest
+from factrix._metric_index import public_specs
 
 METRICS_DIR = pathlib.Path("factrix/metrics")
 DOCS_PAGE = pathlib.Path("docs/reference/stat-keys-by-metric.md")
+
+# Per-metric subsection heading, e.g. ``#### `ic_ir` ``.
+_SECTION_HEADING = re.compile(r"^`([a-z0-9_]+)`")
+# The role bullets that enumerate metadata keys (``*short-circuit*`` names
+# ``reason`` values, not keys, and is excluded).
+_KEY_BULLET = re.compile(
+    r"^- \*(?:primary|secondary-test|descriptive)\*[^\n]*(?:\n(?!- |#|$)[^\n]*)*",
+    re.M,
+)
+_BACKTICK_TOKEN = re.compile(r"`([a-z][a-z0-9_]*)`")
 
 _COMMON_KEYS: frozenset[str] = frozenset(
     {"p_value", "stat_type", "h0", "method", "reason"}
@@ -139,4 +158,50 @@ def test_metadata_keys_documented(path: pathlib.Path, docs_text: str) -> None:
     assert not missing, (
         f"{path.name}: metadata keys emitted but not referenced in "
         f"{DOCS_PAGE}: {missing}"
+    )
+
+
+def _shared_source() -> str:
+    """Source text of the internal modules that assemble metric metadata."""
+    return "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in sorted(pathlib.Path("factrix").rglob("*.py"))
+        if p.stem.startswith("_")
+        or p.parent.name in {"_primitives", "inference", "_stats"}
+    )
+
+
+def _documented_keys(section: str) -> set[str]:
+    """Backtick tokens named on the role bullets of one metric subsection."""
+    keys: set[str] = set()
+    for bullet in _KEY_BULLET.finditer(section):
+        keys |= set(_BACKTICK_TOKEN.findall(bullet.group(0)))
+    return keys
+
+
+def test_documented_keys_still_exist_in_code(docs_text: str) -> None:
+    """Every key the page names must still appear in the metric's sources."""
+    name_to_stem = {spec.name: stem for stem, spec in public_specs()}
+    shared = _shared_source()
+
+    sections = re.split(r"^#### ", docs_text, flags=re.M)[1:]
+    stale: list[str] = []
+    for section in sections:
+        heading = _SECTION_HEADING.match(section.split("\n", 1)[0])
+        if heading is None:
+            continue
+        name = heading.group(1)
+        stem = name_to_stem.get(name)
+        if stem is None:
+            stale.append(f"{name}: documented but not a registered metric")
+            continue
+        sources = (METRICS_DIR / f"{stem}.py").read_text(encoding="utf-8") + shared
+        stale += [
+            f"{name}: `{key}` is documented but no longer in factrix sources"
+            for key in sorted(_documented_keys(section))
+            if not re.search(rf"\b{key}\b", sources)
+        ]
+    assert not stale, (
+        f"{DOCS_PAGE} names metadata keys the code no longer carries:\n  "
+        + "\n  ".join(stale)
     )


### PR DESCRIPTION
> **TL;DR** — `statistical-methods.md` and `metric-applicability.md` were the only reference pages no test read. This adds four guards that parse them against the live constants, specs, renderer and enum, fixes the four residual drifts those guards surfaced, and cites the producing test module for the measured percentages that have one.

Closes #894

## Summary

The pages are hand-written and number-dense, and nothing read them, so
drift was only ever caught by a manual audit. The new checks follow the
pattern the generated name index already established: parse the page,
resolve the live object, assert. Each new assertion was sanity-checked by
mutating the doc and confirming the failure, then reverting.

Monte Carlo size tables stay out of scope (automating the sweep costs far
more than the miss), so the percentages that no test produces are
addressed by citation rather than by assertion.

## DoD → covering test

| DoD item | Test |
|---|---|
| Constants table tokens vs live constants | `tests/test_docs_sample_thresholds.py::test_constants_table_matches_code` (value, tier column, and importability from the row's own `Source module`), plus `::test_inline_constant_claims_match_code` for the `` `NAME` (value) `` / `` `NAME = value` `` forms across every docs page outside `docs/plans/` — this is what covers `PERSISTENT_SERIES_AUTOCORR` and would cover `N_GROUPS_FLOOR` |
| Per-metric floors vs resolved `MetricSpec.sample_threshold` | `tests/test_docs_sample_thresholds.py::test_per_metric_floors_match_spec` (HARD/WARN tier presence per metric), guarded by `::test_no_static_floor_exemptions_still_empty` so the three exempted metrics cannot silently gain a floor |
| `_generated_metric_matrix.md` byte-compare | `tests/test_docs_matrix.py::test_generated_matrix_matches_renderer` |
| `stat-keys-by-metric.md` doc → code | `tests/test_docs_stat_keys_by_metric.py::test_documented_keys_still_exist_in_code` |
| `llms-full.txt` WarningCode coverage | `tests/test_docs_llms.py::test_warning_code_table_covers_every_evaluation_side_code` |
| Percentages name their producing module | Doc edits in `statistical-methods.md` (see below) |

The smaller of the two options was taken for the `llms-full.txt` item:
the table stays curated (its glosses are rewritten for an LLM audience
and are not the generated ones), and the test pins both the membership
against `WarningCode` and the prose count against the row count.

## Doc drifts fixed

Surfaced by the new tests, all in `metric-applicability.md`:

- `fm_beta_sign_consistency` was documented at `T ≥ MIN_FM_PERIODS_HARD`; its spec floor is one finite beta period and it is descriptive.
- `MIN_EVENTS_WARN` was attributed to `caar` only; `bmp_z`, `event_hit_rate`, `event_ic`, `event_skewness` and `corrado_rank` all resolve a `warn_events` floor and fire `FEW_EVENTS`. Their per-family rows gained the warn tier too.
- `spanning_alpha` was documented as needing only "aligned spread series" while its spec declares a 10-period floor.
- `pooled_beta` was missing its warn tier.

## Percentages with no producing test module

Cited where a producer exists: `tests/stats/test_hac_overlap_size.py`
(the three HAR departures and the scalar series-mean rows),
`tests/test_stambaugh_bias.py` (the `predictive_beta` rows),
`tests/test_slice_period_joint_test.py` (the short-slice band, which the
page already alluded to as "the characterisation test"), and
`tests/stats/test_prewhitening.py` (the prewhitened-vs-plain table).

No producing module exists for these, so none was invented:

- The persistence table (φ = 0 / 0.6 / 0.85 across `NEWEY_WEST` / `STATIONARY_BOOTSTRAP` / plain *t*) — `build_autocorrelated_ic_panel` is a fixture builder, not a size sweep.
- The `spanning_alpha` iid / AR(0.6) 4000-draw table.
- The routing-guide table's numbers (restatements of the sections above, including the t(3), thin-cross-section and block-bootstrap figures).
- `top_concentration`'s "0 of 250 null draws at exactly 3 periods".
- The Theil-Sen 29.3% breakdown point and the quantile-interpolation ±0.02 (analytic properties, not measurements).
- In `metric-applicability.md`, the `bmp_z` Kolari-Pynnönen sizes (19.7% → 4.7% and the residual-by-event-period series) — `tests/test_caar.py` pins the behaviour but not the size.

The `T=240, h=21` overlap-floor row was left untouched; it is being
revised separately.

## Test plan

- `uv run pytest -q tests/test_docs_*.py` — 60 passed
- `uv run pytest -q -x` — 3031 passed, 29 skipped
- `uv run ruff check` / `ruff format --check` / `mypy factrix` — clean
- `uv run mkdocs build --strict` — clean, no regenerated file changed
- Each new assertion mutation-tested (constant value, tier, inline value, per-metric tier, matrix row, a fabricated metadata key, a removed table row, and the claimed code count) and reverted
