### PR TITLE
docs(guides): centralize the allocation decision boundaries

### DIFF
--- a/docs/guides/validating-allocation-signals.md
+++ b/docs/guides/validating-allocation-signals.md
@@ -27,6 +27,53 @@ The research question determines the first-pass metric. In particular,
 `directional_hit_rate` tests absolute sign prediction; it does not replace rank
 IC when the allocation rule ranks assets against one another.
 
+## Separate promotion evidence from diagnostics
+
+One entry point for the whole path: the research question, the evidence that
+can promote a candidate, the diagnostics and robustness checks that cannot,
+and what stays outside factrix. Every cell links to the page that owns the
+contract; none of the derivations are restated here.
+
+| Research question / stage | Primary evidence | Supplementary or robustness evidence | Do not infer |
+|---|---|---|---|
+| Cross-sectional asset ranking | [`ic`](../api/metrics/ic.md) or [`fm_beta`](../api/metrics/fm_beta.md) over a [declared hypothesis family](#declare-selection-families), read against the [persistent-series caveat](../reference/statistical-methods.md#persistent-per-period-series-no-hac-or-bootstrap-path-is-calibrated) | [`k_spread`](../api/metrics/k_spread.md), [`monotonicity`](../api/metrics/monotonicity.md), [`directional_pair_accuracy`](../api/metrics/directional_pair_accuracy.md), [`ic_ir`](../api/metrics/ic.md) stability | That one diagnostic passing promotes the candidate |
+| Single-asset time-series predictability | [`predictive_beta`](../api/metrics/predictive_beta.md) | [Persistence](../reference/statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors) and sample diagnostics, `PERSISTENT_REGRESSOR` in [warning codes](../reference/warning-codes.md) | That the slope is cross-sectional ranking evidence |
+| Regime robustness | [`by_slice`](../api/by-slice.md), [`slice_period_pairwise_test`](../api/slice-test.md) contrasts, effect sizes | [`slice_period_joint_test`](../api/slice-test.md) where it is calibrated — `K = 2`, or `K >= 3` on longer slices | That a declared `short_slice_joint_test` corrected the p-value, or that a short-slice joint p is an admission gate |
+| Candidate redundancy | Correlation and fixed-base [`spanning_alpha`](../api/metrics/spanning.md) | Economic reading of the residual alpha | That `greedy_forward_selection` t-stats are post-selection inference |
+| Broad adaptive search / winner selection | Held-out evaluation, or an external search-wide procedure | [BHY](../api/multi-factor.md) over the separately declared marginal family | That BHY has controlled the whole research search |
+
+The boundaries the table compresses, each owned by the page it links to:
+
+- `expected_warnings` affects presentation and the audit fields only — it marks
+  matching records as expected and quiets their echo, and it does not change
+  the estimator, the p-value, or the sample requirement
+  ([warning contract](../api/slice-test.md#warning-contract-slice_period_joint_test)).
+- A regime joint test on short slices with `K >= 3` carries a
+  [disclosed over-rejection](../reference/statistical-methods.md#joint-period-test-on-short-slices-known-over-rejection),
+  and declaring `short_slice_joint_test` as expected does not calibrate that
+  p-value, so it stays robustness evidence rather than an admission gate.
+- `spanning_alpha` is a fixed-base incremental-information / redundancy
+  diagnostic, and `greedy_forward_selection`'s t-stats are
+  selection-conditioned rather than
+  [post-selection inference](../api/metrics/spanning.md).
+- BHY controls the FDR of the declared hypothesis family, not the winner of an
+  adaptive search across many candidates; for that use held-out evaluation or
+  an external search-wide procedure — Hansen SPA / White Reality Check, which
+  [factrix does not implement](../reference/statistical-methods.md#2-multiple-testing-under-dependence).
+- An uneven evaluation grid is disclosed by `uneven_evaluation_grid`
+  ([warning codes](../reference/warning-codes.md)); the series-mean paths are
+  calibrated there and the regression HAC, persistence, event-window and
+  adjacent-period paths are not — read the
+  [scope of that disclosure](../reference/statistical-methods.md#1-hac-se-under-overlapping-returns)
+  instead of generalizing it.
+
+The metric follows the research question rather than a global ranking of
+metrics: `predictive_beta` is the primary evidence for single-asset
+time-series predictability and is not cross-sectional ranking evidence, just as
+rank IC says nothing about one asset's own series. Regime, redundancy and
+search-wide questions come after a primary screen, and everything past a
+promoted candidate — weights, execution, capacity — is downstream of factrix.
+
 ## Small-universe workflow
 
 A small cross-section reduces power; it does not change the estimand. IC and FM

--- a/tests/test_docs_allocation_boundaries.py
+++ b/tests/test_docs_allocation_boundaries.py
@@ -1,0 +1,141 @@
+"""Docs regression checks for the allocation decision-boundary table.
+
+The allocation guide centralizes which evidence may promote a candidate and
+which evidence may not. Pin the row labels, the per-row metric roles, the
+outbound links, and the five boundary statements by literal substring so the
+table cannot drift away from the pages that own those contracts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+GUIDE = "docs/guides/validating-allocation-signals.md"
+
+ROW_LABELS = (
+    "Cross-sectional asset ranking",
+    "Single-asset time-series predictability",
+    "Regime robustness",
+    "Candidate redundancy",
+    "Broad adaptive search / winner selection",
+)
+
+LINK_TARGETS = (
+    "../api/metrics/ic.md",
+    "../api/metrics/fm_beta.md",
+    "../api/metrics/predictive_beta.md",
+    "../api/metrics/spanning.md",
+    "../api/by-slice.md",
+    "../api/slice-test.md",
+    "../api/multi-factor.md",
+    "../reference/warning-codes.md",
+    "../reference/statistical-methods.md#1-hac-se-under-overlapping-returns",
+    "../reference/statistical-methods.md#2-multiple-testing-under-dependence",
+    "../reference/statistical-methods.md"
+    "#4-persistence-diagnostics-under-near-unit-root-predictors",
+    "../reference/statistical-methods.md"
+    "#joint-period-test-on-short-slices-known-over-rejection",
+    "../reference/statistical-methods.md"
+    "#persistent-per-period-series-no-hac-or-bootstrap-path-is-calibrated",
+    "../api/slice-test.md#warning-contract-slice_period_joint_test",
+)
+
+BOUNDARY_STATEMENTS = (
+    "`expected_warnings` affects presentation and the audit fields only",
+    "A regime joint test on short slices with `K >= 3` carries a",
+    "`spanning_alpha` is a fixed-base incremental-information / redundancy",
+    "BHY controls the FDR of the declared hypothesis family, not the winner",
+    "An uneven evaluation grid is disclosed by `uneven_evaluation_grid`",
+)
+
+
+def _guide_text() -> str:
+    return Path(GUIDE).read_text(encoding="utf-8")
+
+
+def _boundary_row(label: str) -> list[str]:
+    """Return the decision-boundary cells of the row starting with ``label``."""
+    prefix = f"| {label} |"
+    rows = [line for line in _guide_text().splitlines() if line.startswith(prefix)]
+    assert len(rows) == 1, f"expected exactly one boundary row for {label!r}"
+    cells = [cell.strip() for cell in rows[0].strip().strip("|").split("|")]
+    assert len(cells) == 4, f"boundary row for {label!r} must have four columns"
+    return cells
+
+
+def test_decision_boundary_table_header_and_intro() -> None:
+    text = _guide_text()
+    assert "## Separate promotion evidence from diagnostics" in text
+    assert (
+        "| Research question / stage | Primary evidence | "
+        "Supplementary or robustness evidence | Do not infer |" in text
+    )
+
+
+@pytest.mark.parametrize("label", ROW_LABELS)
+def test_decision_boundary_rows_present(label: str) -> None:
+    assert len(_boundary_row(label)) == 4
+
+
+def test_predictive_beta_is_the_single_asset_primary_evidence() -> None:
+    single_asset = _boundary_row("Single-asset time-series predictability")
+    cross_section = _boundary_row("Cross-sectional asset ranking")
+    assert "`predictive_beta`" in single_asset[1]
+    assert "predictive_beta" not in cross_section[1]
+    assert "cross-sectional ranking evidence" in single_asset[3]
+
+
+def test_cross_sectional_ranking_keeps_ic_and_fm_as_primary_evidence() -> None:
+    cells = _boundary_row("Cross-sectional asset ranking")
+    assert "`ic`" in cells[1]
+    assert "`fm_beta`" in cells[1]
+    assert "declared hypothesis family" in cells[1]
+    for diagnostic in ("`k_spread`", "`monotonicity`", "`directional_pair_accuracy`"):
+        assert diagnostic in cells[2]
+    assert "one diagnostic passing promotes the candidate" in cells[3]
+
+
+def test_regime_robustness_row_keeps_the_joint_test_out_of_the_gate() -> None:
+    cells = _boundary_row("Regime robustness")
+    assert "`by_slice`" in cells[1]
+    assert "`slice_period_pairwise_test`" in cells[1]
+    assert "slice_period_joint_test" not in cells[1]
+    assert "`slice_period_joint_test`" in cells[2]
+    assert "short-slice joint p is an admission gate" in cells[3]
+
+
+def test_redundancy_row_keeps_spanning_fixed_base_and_greedy_out_of_inference() -> None:
+    cells = _boundary_row("Candidate redundancy")
+    assert "fixed-base [`spanning_alpha`]" in cells[1]
+    assert "`greedy_forward_selection` t-stats are post-selection inference" in cells[3]
+
+
+def test_search_wide_row_keeps_bhy_out_of_the_primary_column() -> None:
+    cells = _boundary_row("Broad adaptive search / winner selection")
+    assert "Held-out evaluation" in cells[1]
+    assert "external search-wide procedure" in cells[1]
+    assert "BHY" not in cells[1]
+    assert "BHY" in cells[2]
+    assert "BHY has controlled the whole research search" in cells[3]
+
+
+@pytest.mark.parametrize("target", LINK_TARGETS)
+def test_decision_boundary_links_are_present(target: str) -> None:
+    assert f"]({target})" in _guide_text()
+
+
+@pytest.mark.parametrize("statement", BOUNDARY_STATEMENTS)
+def test_boundary_statements_are_present(statement: str) -> None:
+    assert statement in _guide_text()
+
+
+def test_predictive_beta_stays_estimand_neutral() -> None:
+    text = _guide_text()
+    assert "The metric follows the research question" in text
+    assert (
+        "`predictive_beta` is the primary evidence for single-asset\n"
+        "time-series predictability and is not cross-sectional ranking evidence"
+    ) in text
+    assert "Hansen SPA / White Reality Check" in text


### PR DESCRIPTION
> **TL;DR** — Adds one scannable decision-boundary table to the allocation guide so a supplementary diagnostic, a robustness check or an uncalibrated p-value cannot be read as a candidate-promotion gate. Docs + docs tests only; no estimator, floor, warning-code or p-value change.

## Summary

`Validating allocation signals` gains a new section, **Separate promotion
evidence from diagnostics**, placed directly after `Match the metric to the
signal`. That is the point where the reader has just learned metric-to-signal
routing and has not yet reached the small-universe, family-declaration and
robustness sections — so the table works as the entry point from research
question to selection evidence, diagnostic, robustness and downstream
validation, and forward-links into those sections rather than repeating them.

Every cell links to the page that owns the contract; no derivation is restated
in the guide. Five statements around the table pin the boundaries that are
easiest to misread.

## DoD → where covered

| DoD item | Where |
|---|---|
| Central, scannable decision-boundary table covering selection, diagnostic, robustness, redundancy and search-wide inference | `docs/guides/validating-allocation-signals.md` § Separate promotion evidence from diagnostics — five rows: cross-sectional ranking, single-asset time-series predictability, regime robustness, candidate redundancy, broad adaptive search |
| Explicit estimand boundary between cross-sectional ranking and single-asset predictability | Rows 1–2 plus the closing paragraph: the metric follows the research question; `predictive_beta` is primary for a single-asset predictive slope and is not cross-sectional ranking evidence. Nothing in the docs labels it globally supplementary, so no other page needed changing |
| Short-slice regime warning, fixed-base spanning, BHY family scope and the unimplemented SPA / Reality Check reachable from that entry point | Bullets 2–4, linking to `statistical-methods.md#joint-period-test-on-short-slices-known-over-rejection`, `metrics/spanning.md`, and `statistical-methods.md#2-multiple-testing-under-dependence` |
| `expected_warnings` affects presentation and audit fields only | Bullet 1, linking to the `slice_period_joint_test` warning contract |
| Uneven-grid limitation linked, not copied or generalized | Bullet 5, naming `uneven_evaluation_grid` and linking to `statistical-methods.md#1-hac-se-under-overlapping-returns` for the scope of the disclosure |
| Docs tests guarding metric roles, links and boundary wording | `tests/test_docs_allocation_boundaries.py` |

## Test plan

`tests/test_docs_allocation_boundaries.py` (31 cases) parses the table by row
label and pins, per row, which column each metric may appear in — e.g.
`predictive_beta` in the single-asset row's primary column and not in the
cross-sectional row's; `slice_period_joint_test` in the regime row's robustness
column and not its primary column; BHY out of the search-wide primary column.
It also pins all 14 outbound link targets (including the five
statistical-methods anchors) and the five boundary statements by literal
substring, following the existing `tests/test_docs_metric_routing.py` pattern.
Each assertion was checked against a mutation of the guide and then reverted.

- `uv run ruff check` → All checks passed
- `uv run ruff format --check` → 219 files already formatted
- `uv run mypy factrix` → Success: no issues found in 84 source files
- `uv run pytest -q -x` → 3110 passed, 42 skipped
- `uv run mkdocs build --strict` → built in 2.85s (anchor validation is `warn` + strict, so every new anchor link resolves)
- `git status` clean after the build — no generated-doc drift

Closes #902
