### PR TITLE
docs(stats): note the accuracy cost of self-rolled inference on bootstrap resamples

### DIFF
--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -100,6 +100,30 @@ def stationary_bootstrap_resamples(
         ``(n_bootstrap, T)`` array for vector input or
         ``(n_bootstrap, T, m)`` for matrix input.
 
+    Notes:
+        **This function returns resamples, not inference.** Forming a
+        percentile interval or an empirical p directly from the returned
+        array gives a *first-order accurate* interval
+        ([DiCiccio-Efron (1996)][diciccio-efron-1996]) — it forgoes the
+        studentization :func:`bootstrap_mean_ci` applies by default, and
+        under dependence it compounds the block bootstrap's finite-sample
+        long-run-variance shortfall. The measured cost is the
+        ``percentile`` column of the AR(1) coverage table in
+        :func:`bootstrap_mean_ci`: at ``phi=0.8, T=100`` percentile covers
+        0.792 against studentized 0.890 (nominal 0.95).
+
+        This is the *default* path for a paired custom statistic, not an
+        edge case. Joint resampling of aligned columns is only available
+        here (2-D input), and :func:`bootstrap_mean_ci` takes 1-D input
+        and requires ``method="percentile"`` for any custom
+        ``statistic`` — the studentized root needs a block SE of the
+        statistic on every resample, which this module has only for the
+        mean. So a paired, non-mean statistic reaches percentile accuracy
+        from either entry point. Prefer :func:`bootstrap_mean_ci` whenever
+        the statistic is a mean of a 1-D series; when it is not, read the
+        resulting interval as first-order accurate and size the sample
+        accordingly.
+
     References:
         - [Politis & Romano (1994)][politis-romano-1994]. "The Stationary
           Bootstrap." Journal of the American Statistical Association,


### PR DESCRIPTION
> **TL;DR** — Issue #905 選項 1。`stationary_bootstrap_resamples` 加一段 `Notes`，說明直接拿其輸出自行做 percentile 推論會失去 `bootstrap_mean_ci` 的 studentization，並指向該處已有的 AR(1) 覆蓋率表格。純 docstring，無行為變更。選項 2 建議不做，理由見 issue 回覆。

Closes #905

## 缺口

`stationary_bootstrap_resamples` 把重抽機制記載得很完整（Politis-White 外掛選擇器、`b_max` clamp、`L >= T` 退化成 rotation），但完全沒提「直接用其輸出自行推論」的精度後果。而這是成對自訂統計量的**必經**路徑：

- 聯合重抽（同一組 row indices 套到每一欄）只有這個函式提供（2-D 輸入）
- `bootstrap_mean_ci` 只收 1-D，且自訂 `statistic` 被強制 `method="percentile"`

兩個入口夾起來，成對且非 mean 的統計量必然落到一階精度，使用者卻無從得知。

## 改動

新增 `Notes` 段，講三件事：回傳的是 resample 不是推論；一階精度的實測代價（引用 `bootstrap_mean_ci` 已有的表格，φ=0.8, T=100 時 percentile 0.792 vs studentized 0.890）；以及這是預設路徑而非邊緣情況，並說明為何 studentized 只對 mean 可用。

## 驗證

`ruff check` / `ruff format --check` / `mypy factrix`（84 files, no issues）；`tests/stats` + doc 測試 656 passed, 42 skipped。書目 anchor `#diciccio-efron-1996` 存在於 `docs/reference/bibliography.md:123`。