### PR TITLE
fix(stats): share one bootstrap-inference resample floor and report the p's MC error

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -438,7 +438,10 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 - *MR detail*: `mr_min_diff`, `mr_adjacent_diffs` (every `Δ̄_i`, so the
   binding step is visible), `mr_direction`, `n_bootstrap`,
   `bootstrap_seed` (resolved and reported when not supplied, so an
-  unseeded run is still reproducible after the fact).
+  unseeded run is still reproducible after the fact), `p_value_mc_se`
+  (Monte-Carlo SE of the empirical p, `sqrt(p(1-p)/n_bootstrap)` — how far
+  the p would move on a re-run with a different seed, ~0.7pp at the default
+  `n_bootstrap=1000` and p near 0.05; `n_bootstrap` is floored at 200).
 - *descriptive Spearman shape*: `mean_abs_spearman` (magnitude, ≥ 0),
   `mean_signed` (direction consistency), `signed_spearman_t`,
   `signed_spearman_p_value`. A high magnitude with a near-zero signed mean

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -44,6 +44,34 @@ from factrix._types import EPSILON
 
 Scheme = Literal["fixed", "stationary"]
 
+#: Below this many resamples a bootstrap quantile or empirical p is dominated
+#: by resampling noise: at B=200 the 2.5% tail is the 5th order statistic.
+#: Politis-White (2004) recommend >= 999 for two-sided 5% work; this is the
+#: refusal floor every bootstrap *inference* entry point shares, not the
+#: recommendation. It does not gate ``stationary_bootstrap_resamples``, which
+#: draws resamples without claiming an inference on them.
+#: Deliberately not named ``MIN_*``: that prefix is reserved (FX003) for
+#: sample-size floors on a data axis, and a resample count is an algorithm
+#: knob, not an axis.
+BOOTSTRAP_RESAMPLES_FLOOR: int = 200
+
+
+def bootstrap_p_mc_se(p_value: float, n_bootstrap: int) -> float:
+    """Monte-Carlo standard error of a bootstrap empirical p-value.
+
+    ``sqrt(p * (1 - p) / B)`` — the binomial SE of the resampling draw
+    itself, *not* a statistical SE of the estimate. It says how much the
+    reported p would move on a re-run with a different seed, which is the
+    quantity a reader needs when a p sits near a decision threshold: at
+    ``B = 1000`` and ``p = 0.05`` it is ~0.7pp, so 0.043 and 0.058 are one
+    draw apart. Shrinks as ``1 / sqrt(B)``; raise ``n_bootstrap`` to shrink
+    it, since no amount of data does.
+    """
+    if n_bootstrap < 1:
+        return float("nan")
+    p = min(max(float(p_value), 0.0), 1.0)
+    return float(np.sqrt(p * (1.0 - p) / n_bootstrap))
+
 
 def _flat_top_kernel(t: float) -> float:
     """Politis-Romano trapezoidal flat-top kernel.

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -47,9 +47,20 @@ Scheme = Literal["fixed", "stationary"]
 #: Below this many resamples a bootstrap quantile or empirical p is dominated
 #: by resampling noise: at B=200 the 2.5% tail is the 5th order statistic.
 #: Politis-White (2004) recommend >= 999 for two-sided 5% work; this is the
-#: refusal floor every bootstrap *inference* entry point shares, not the
-#: recommendation. It does not gate ``stationary_bootstrap_resamples``, which
-#: draws resamples without claiming an inference on them.
+#: refusal floor shared by every entry point that exposes a user-settable
+#: resample count *and* reports an inference drawn from it: ``bootstrap_mean_ci``,
+#: ``monotonicity``'s MR test, and ``BlockBootstrap``. Not the recommendation.
+#: Two neighbours are deliberately outside it: ``stationary_bootstrap_resamples``
+#: and ``_block_bootstrap_diff_p`` return draws / a raw p to internal callers
+#: without owning a user-facing knob, and the slice paths fix their own count at
+#: 999, already above the floor.
+#: The 200 is argued above from the quantile side (interval endpoints). On the
+#: empirical-p side it is looser than it looks: at ``p = 0.05`` the Monte-Carlo
+#: SE is ``sqrt(.05*.95/200)`` = 1.5pp, so a p printed as 0.05 carries a ~95%
+#: resampling range of roughly [0.02, 0.08] and straddles the conventional
+#: threshold in both directions. The floor refuses the indefensible, it does not
+#: certify 200; ``bootstrap_p_mc_se`` is reported so the cost is visible, and
+#: Politis-White's >= 999 remains the recommendation for two-sided 5% work.
 #: Deliberately not named ``MIN_*``: that prefix is reserved (FX003) for
 #: sample-size floors on a data axis, and a resample count is an algorithm
 #: knob, not an axis.
@@ -66,10 +77,13 @@ def bootstrap_p_mc_se(p_value: float, n_bootstrap: int) -> float:
     ``B = 1000`` and ``p = 0.05`` it is ~0.7pp, so 0.043 and 0.058 are one
     draw apart. Shrinks as ``1 / sqrt(B)``; raise ``n_bootstrap`` to shrink
     it, since no amount of data does.
+
+    Callers are the gated inference entry points, so ``n_bootstrap`` is always
+    at or above ``BOOTSTRAP_RESAMPLES_FLOOR`` and ``p_value`` is a
+    Davison-Hinkley smoothed p confined to ``[1/(B+1), 1]``. No clamping or
+    zero-guard is needed at that contract, and none is done.
     """
-    if n_bootstrap < 1:
-        return float("nan")
-    p = min(max(float(p_value), 0.0), 1.0)
+    p = float(p_value)
     return float(np.sqrt(p * (1.0 - p) / n_bootstrap))
 
 

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -32,6 +32,10 @@ from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
+from factrix._stats.bootstrap import (
+    BOOTSTRAP_RESAMPLES_FLOOR,
+    bootstrap_p_mc_se,
+)
 from factrix._types import (
     DDOF,
     MIN_MONOTONICITY_PERIODS_HARD,
@@ -146,6 +150,7 @@ def _mr_test(
         "mr_adjacent_diffs": [float(v) for v in delta_bar],
         "n_bootstrap": n_bootstrap,
         "bootstrap_seed": seed,
+        "p_value_mc_se": bootstrap_p_mc_se(p_value, n_bootstrap),
     }
     return j_stat, p_value, metadata
 
@@ -191,10 +196,21 @@ def monotonicity(
             (default) or ``"decreasing"`` in bucket index. Declare it from the
             factor's hypothesis; running both and reporting the smaller p is a
             two-sided search charged at a one-sided level.
-        n_bootstrap: Bootstrap resamples for the MR null distribution.
+        n_bootstrap: Bootstrap resamples for the MR null distribution. Must
+            be at least ``BOOTSTRAP_RESAMPLES_FLOOR`` (200) — the same floor
+            ``factrix.stats.bootstrap_mean_ci`` enforces, since both report an
+            inference drawn from the resamples rather than the resamples
+            themselves. Below it the empirical p is dominated by resampling
+            noise: the Monte-Carlo SE of the reported p is
+            ``sqrt(p(1-p)/n_bootstrap)``, reported as
+            ``metadata["p_value_mc_se"]``. At the default 1000 resamples a p
+            near 0.05 carries ~0.7pp of MC SE, so 0.043 and 0.058 are one
+            draw apart; raise ``n_bootstrap`` to shrink it, since no amount
+            of data does.
         seed: Bootstrap seed. ``None`` resolves one and reports it in
             ``metadata["bootstrap_seed"]``, so a run stays reproducible after
-            the fact.
+            the fact. An unseeded re-run redraws the null, moving the p by
+            roughly ``metadata["p_value_mc_se"]``.
 
     Returns:
         MetricResult with ``value`` = ``stat`` = the MR statistic and
@@ -255,12 +271,16 @@ def monotonicity(
             expected="'increasing' (default) or 'decreasing'",
             docs_path="api/metrics/monotonicity",
         )
-    if n_bootstrap < 1:
+    if n_bootstrap < BOOTSTRAP_RESAMPLES_FLOOR:
         raise UserInputError(
             func_name="monotonicity",
             field="n_bootstrap",
             value=n_bootstrap,
-            expected="a positive integer number of bootstrap resamples",
+            expected=(
+                f"at least {BOOTSTRAP_RESAMPLES_FLOOR} bootstrap resamples — "
+                f"below that the MR empirical p is dominated by resampling "
+                f"noise (the same floor bootstrap_mean_ci enforces)"
+            ),
             docs_path="api/metrics/monotonicity",
         )
     cols = list(factor_cols)

--- a/factrix/stats/block_bootstrap.py
+++ b/factrix/stats/block_bootstrap.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from typing import Literal
 
+from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
+
 
 class BlockBootstrap:
     """Block-bootstrap empirical p-value Estimator for paired-diff slice tests.
@@ -79,8 +81,13 @@ class BlockBootstrap:
             raise ValueError(
                 f"block_length must be 'auto' or int >= 1; got {block_length!r}."
             )
-        if n_resamples < 1:
-            raise ValueError(f"n_resamples must be >= 1; got {n_resamples!r}.")
+        if n_resamples < BOOTSTRAP_RESAMPLES_FLOOR:
+            raise ValueError(
+                f"n_resamples must be >= {BOOTSTRAP_RESAMPLES_FLOOR}; got "
+                f"{n_resamples!r}. Below that the Davison-Hinkley empirical p "
+                f"this estimator reports is dominated by resampling noise — the "
+                f"same floor bootstrap_mean_ci and monotonicity enforce."
+            )
         if scheme not in ("fixed", "stationary"):
             raise ValueError(f"scheme must be 'fixed' or 'stationary'; got {scheme!r}.")
         self.block_length = block_length

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -180,12 +180,6 @@ class BootstrapCI(NamedTuple):
     estimate: float
 
 
-#: Shared refusal floor for bootstrap *inference* entry points, defined once in
-#: :mod:`factrix._stats.bootstrap` and enforced identically by
-#: ``bootstrap_mean_ci`` and ``monotonicity``'s MR test.
-_BOOTSTRAP_RESAMPLES_FLOOR = BOOTSTRAP_RESAMPLES_FLOOR
-
-
 def bootstrap_mean_ci(
     values: np.ndarray,
     *,
@@ -239,7 +233,7 @@ def bootstrap_mean_ci(
         values: 1-D array of the original series, at least 2 finite
             observations.
         n_bootstrap: Resample count. Must be at least
-            200 resamples; below that the interval
+            ``BOOTSTRAP_RESAMPLES_FLOOR`` (200); below that the interval
             endpoints are resampling noise. At ``B=1`` the old
             implementation returned a zero-width interval that did not
             even contain its own point estimate.
@@ -318,13 +312,13 @@ def bootstrap_mean_ci(
             expected="at least 2 observations to resample",
             docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
-    if n_bootstrap < _BOOTSTRAP_RESAMPLES_FLOOR:
+    if n_bootstrap < BOOTSTRAP_RESAMPLES_FLOOR:
         raise UserInputError(
             func_name="bootstrap_mean_ci",
             field="n_bootstrap",
             value=n_bootstrap,
             expected=(
-                f"at least {_BOOTSTRAP_RESAMPLES_FLOOR} resamples — below that "
+                f"at least {BOOTSTRAP_RESAMPLES_FLOOR} resamples — below that "
                 f"the interval endpoints are resampling noise"
             ),
             docs_path="api/stats#factrix.stats.bootstrap_mean_ci",

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -35,6 +35,8 @@ from typing import Literal, NamedTuple
 
 import numpy as np
 
+from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
+
 
 def _resolve_auto_block_length(values: np.ndarray) -> float:
     """Politis-White (2004) block length, shared with ``BlockBootstrap``.
@@ -178,13 +180,10 @@ class BootstrapCI(NamedTuple):
     estimate: float
 
 
-#: Below this many resamples a bootstrap quantile is dominated by resampling
-#: noise: at B=200 the 2.5% tail is the 5th order statistic. Politis-White
-#: (2004) recommend >= 999 for two-sided 5% work; this is the refusal floor,
-#: not the recommendation. Deliberately not named ``MIN_*``: that prefix is
-#: reserved (FX003) for sample-size floors on a data axis, and a resample
-#: count is an algorithm knob, not an axis.
-_BOOTSTRAP_RESAMPLES_FLOOR: int = 200
+#: Shared refusal floor for bootstrap *inference* entry points, defined once in
+#: :mod:`factrix._stats.bootstrap` and enforced identically by
+#: ``bootstrap_mean_ci`` and ``monotonicity``'s MR test.
+_BOOTSTRAP_RESAMPLES_FLOOR = BOOTSTRAP_RESAMPLES_FLOOR
 
 
 def bootstrap_mean_ci(

--- a/tests/stats/test_slice_test_estimators.py
+++ b/tests/stats/test_slice_test_estimators.py
@@ -63,19 +63,25 @@ class TestBlockBootstrap:
         assert est.rng_seed == 42
 
     def test_description_reflects_config(self):
-        est = BlockBootstrap(block_length=10, scheme="fixed", n_resamples=199)
+        est = BlockBootstrap(block_length=10, scheme="fixed", n_resamples=299)
         d = est.description
         assert "fixed" in d
         assert "L=10" in d
-        assert "B=199" in d
+        assert "B=299" in d
 
     def test_rejects_bad_block_length(self):
         with pytest.raises(ValueError, match="block_length must be"):
             BlockBootstrap(block_length=0)
 
-    def test_rejects_bad_n_resamples(self):
-        with pytest.raises(ValueError, match="n_resamples must be >= 1"):
-            BlockBootstrap(n_resamples=0)
+    def test_n_resamples_below_the_shared_inference_floor_is_rejected(self):
+        """BlockBootstrap reports a Davison-Hinkley empirical p from a
+        user-settable resample count, so it shares the refusal floor with
+        ``bootstrap_mean_ci`` and ``monotonicity``."""
+        from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
+
+        for bad in (0, 1, BOOTSTRAP_RESAMPLES_FLOOR - 1):
+            with pytest.raises(ValueError, match="n_resamples must be >= 200"):
+                BlockBootstrap(n_resamples=bad)
 
     def test_rejects_bad_scheme(self):
         with pytest.raises(ValueError, match="scheme must be"):

--- a/tests/test_expected_warnings_metric_echoes.py
+++ b/tests/test_expected_warnings_metric_echoes.py
@@ -424,7 +424,7 @@ class TestHighTieRatio:
 
     @pytest.mark.parametrize(
         "label, metric",
-        [("ks", k_spread(k=5)), ("mono", monotonicity(n_groups=3, n_bootstrap=50))],
+        [("ks", k_spread(k=5)), ("mono", monotonicity(n_groups=3, n_bootstrap=200))],
     )
     def test_declared_is_quiet_but_recorded_on_the_other_bucket_metrics(
         self, label, metric
@@ -434,7 +434,7 @@ class TestHighTieRatio:
         )
 
     @pytest.mark.parametrize(
-        "metric", [k_spread(k=5), monotonicity(n_groups=3, n_bootstrap=50)]
+        "metric", [k_spread(k=5), monotonicity(n_groups=3, n_bootstrap=200)]
     )
     def test_undeclared_other_bucket_metrics_still_echo(self, metric):
         _assert_undeclared_still_echoes(

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -324,7 +324,7 @@ class TestPattonTimmermannMRTest:
                 panel,
                 overlap_periods=1,
                 n_groups=n_groups,
-                n_bootstrap=99,
+                n_bootstrap=200,
                 seed=rep,
             )["factor"]
             rejections += result.p_value < 0.05
@@ -338,7 +338,7 @@ class TestPattonTimmermannMRTest:
 
         panel = self._null_panel(n_dates=60, n_assets=20, seed=3)
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=4, n_bootstrap=100, seed=2
+            panel, overlap_periods=1, n_groups=4, n_bootstrap=200, seed=2
         )["factor"]
         diffs = np.asarray(result.metadata["mr_adjacent_diffs"])
         assert len(diffs) == 3  # n_groups - 1 adjacent steps
@@ -347,7 +347,7 @@ class TestPattonTimmermannMRTest:
 
     def test_bootstrap_is_reproducible_and_reports_its_seed(self):
         panel = self._null_panel(n_dates=60, n_assets=20, seed=4)
-        kwargs = {"overlap_periods": 1, "n_groups": 4, "n_bootstrap": 100}
+        kwargs = {"overlap_periods": 1, "n_groups": 4, "n_bootstrap": 200}
         a = monotonicity(panel, seed=7, **kwargs)["factor"]
         b = monotonicity(panel, seed=7, **kwargs)["factor"]
         assert a.p_value == b.p_value
@@ -408,7 +408,7 @@ class TestTieRatioCountsFiniteValuesOnly:
                 )
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=3, n_bootstrap=50, seed=0
+            panel, overlap_periods=1, n_groups=3, n_bootstrap=200, seed=0
         )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.0)
 
@@ -432,7 +432,7 @@ class TestTieRatioCountsFiniteValuesOnly:
                 )
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=3, n_bootstrap=50, seed=0
+            panel, overlap_periods=1, n_groups=3, n_bootstrap=200, seed=0
         )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.0)
 
@@ -457,7 +457,7 @@ class TestTieRatioCountsFiniteValuesOnly:
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         with pytest.warns(UserWarning, match="tie_ratio"):
             result = monotonicity(
-                panel, overlap_periods=1, n_groups=3, n_bootstrap=50, seed=0
+                panel, overlap_periods=1, n_groups=3, n_bootstrap=200, seed=0
             )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.8)
 
@@ -475,7 +475,7 @@ class TestMRArgumentValidation:
         from factrix.metrics.monotonicity import monotonicity
 
         with pytest.raises(UserInputError, match="direction"):
-            monotonicity(self._panel(), n_bootstrap=50, seed=0, direction="decrease")
+            monotonicity(self._panel(), n_bootstrap=200, seed=0, direction="decrease")
 
     def test_non_positive_n_bootstrap_is_rejected(self):
         from factrix._errors import UserInputError
@@ -483,3 +483,42 @@ class TestMRArgumentValidation:
 
         with pytest.raises(UserInputError, match="n_bootstrap"):
             monotonicity(self._panel(), n_bootstrap=0, seed=0)
+
+    def test_n_bootstrap_below_the_shared_inference_floor_is_rejected(self):
+        """The MR empirical p shares ``bootstrap_mean_ci``'s refusal floor.
+
+        Both report an inference drawn from the resamples, so both refuse a
+        resample count at which the reported number is resampling noise.
+        ``stationary_bootstrap_resamples`` is deliberately *not* gated — it
+        returns draws and claims no inference on them.
+        """
+        from factrix._errors import UserInputError
+        from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
+        from factrix.metrics.monotonicity import monotonicity
+
+        with pytest.raises(UserInputError, match="at least 200"):
+            monotonicity(
+                self._panel(), n_bootstrap=BOOTSTRAP_RESAMPLES_FLOOR - 1, seed=0
+            )
+
+    def test_p_value_mc_se_is_reported_and_shrinks_with_resamples(self):
+        """The reported p carries its own Monte-Carlo SE.
+
+        ``sqrt(p(1-p)/B)`` says how far the p would move on a re-run with a
+        different seed — the quantity a reader needs near a threshold. It is
+        a property of the draw, not of the data, so it shrinks only in ``B``.
+        """
+        import math
+
+        from factrix.metrics.monotonicity import monotonicity
+
+        panel = self._panel()
+        small = monotonicity(panel, n_bootstrap=200, seed=0)["factor"]
+        large = monotonicity(panel, n_bootstrap=2000, seed=0)["factor"]
+
+        for res, b in ((small, 200), (large, 2000)):
+            p = res.p_value
+            assert res.metadata["p_value_mc_se"] == pytest.approx(
+                math.sqrt(p * (1 - p) / b)
+            )
+        assert large.metadata["p_value_mc_se"] < small.metadata["p_value_mc_se"]

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -477,13 +477,6 @@ class TestMRArgumentValidation:
         with pytest.raises(UserInputError, match="direction"):
             monotonicity(self._panel(), n_bootstrap=200, seed=0, direction="decrease")
 
-    def test_non_positive_n_bootstrap_is_rejected(self):
-        from factrix._errors import UserInputError
-        from factrix.metrics.monotonicity import monotonicity
-
-        with pytest.raises(UserInputError, match="n_bootstrap"):
-            monotonicity(self._panel(), n_bootstrap=0, seed=0)
-
     def test_n_bootstrap_below_the_shared_inference_floor_is_rejected(self):
         """The MR empirical p shares ``bootstrap_mean_ci``'s refusal floor.
 
@@ -496,10 +489,9 @@ class TestMRArgumentValidation:
         from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
         from factrix.metrics.monotonicity import monotonicity
 
-        with pytest.raises(UserInputError, match="at least 200"):
-            monotonicity(
-                self._panel(), n_bootstrap=BOOTSTRAP_RESAMPLES_FLOOR - 1, seed=0
-            )
+        for bad in (0, 1, BOOTSTRAP_RESAMPLES_FLOOR - 1):
+            with pytest.raises(UserInputError, match="at least 200"):
+                monotonicity(self._panel(), n_bootstrap=bad, seed=0)
 
     def test_p_value_mc_se_is_reported_and_shrinks_with_resamples(self):
         """The reported p carries its own Monte-Carlo SE.
@@ -508,17 +500,21 @@ class TestMRArgumentValidation:
         different seed — the quantity a reader needs near a threshold. It is
         a property of the draw, not of the data, so it shrinks only in ``B``.
         """
-        import math
-
+        from factrix._stats.bootstrap import bootstrap_p_mc_se
         from factrix.metrics.monotonicity import monotonicity
+
+        # Hardcoded so a wrong-but-self-consistent formula (say /(B+1)) fails
+        # here rather than being re-derived from the value under test. This is
+        # the ~0.7pp the monotonicity docstring quotes.
+        assert bootstrap_p_mc_se(0.05, 1000) == pytest.approx(0.006892, abs=1e-6)
+        assert bootstrap_p_mc_se(0.5, 400) == pytest.approx(0.025, abs=1e-9)
 
         panel = self._panel()
         small = monotonicity(panel, n_bootstrap=200, seed=0)["factor"]
         large = monotonicity(panel, n_bootstrap=2000, seed=0)["factor"]
 
         for res, b in ((small, 200), (large, 2000)):
-            p = res.p_value
             assert res.metadata["p_value_mc_se"] == pytest.approx(
-                math.sqrt(p * (1 - p) / b)
+                bootstrap_p_mc_se(res.p_value, b)
             )
         assert large.metadata["p_value_mc_se"] < small.metadata["p_value_mc_se"]


### PR DESCRIPTION
> **TL;DR** — 兩處重抽樣的一致性缺口。(1) 200 次的 refusal floor 只有 `bootstrap_mean_ci` 在守，`monotonicity` 的 MR 檢定接受任何正整數；常數移到 primitives 當單一來源，兩邊共用。(2) MR 的 empirical p 現在回報自己的 Monte-Carlo SE。**Breaking**：`monotonicity(n_bootstrap<200)` 改為 raise。

## 1. B 的下限：三個入口三種政策

| 入口 | 修改前 | 修改後 |
|---|---|---|
| `bootstrap_mean_ci` | 硬下限 200，`UserInputError` | 不變（常數改為共用） |
| `monotonicity`（MR 檢定） | 只擋 `n_bootstrap < 1`——`n_bootstrap=5` 回傳 `p=1/6`，無任何提示 | 同一個 200 下限 |
| slice bootstrap | 寫死 `_N_RESAMPLES = 999` | 不變（已在下限之上，且不開放調整） |

`_BOOTSTRAP_RESAMPLES_FLOOR` 從 `factrix/stats/bootstrap.py` 移到 `factrix/_stats/bootstrap.py` 成為 `BOOTSTRAP_RESAMPLES_FLOOR`，兩個推論入口共用；公開模組保留私有別名指向它。

**`stationary_bootstrap_resamples` 刻意不設限**——它回傳的是抽樣結果、不宣稱任何推論，這條界線寫進了常數的註解與新測試的 docstring（與剛併入的 #906 說法一致）。

## 2. p 值的 Monte-Carlo 誤差

MR 檢定的 metadata 新增 `p_value_mc_se = sqrt(p(1-p)/n_bootstrap)`——**抽樣本身**的誤差，不是估計量的統計 SE。它回答讀者在門檻附近真正要問的問題：換個 seed 重跑，這個 p 會跑多遠。預設 B=1000、p≈0.05 時約 0.7pp，也就是 0.043 與 0.058 只差一次抽樣。因為 `seed=None` 預設會自行解析（回報於 `bootstrap_seed`），使用者本來就會遇到這件事。

沒有加 WarningCode：那需要一個門檻 alpha，而 factrix 的 metric 不收 alpha，硬編 0.05 等於偷渡一個使用者沒選的決策邊界。數字放進 metadata，判讀留給讀者。

**slice bootstrap 這次不加**：它的 p 經過 Romano-Wolf step-down 調整，不是單一次二項抽樣，套 `sqrt(p(1-p)/B)` 會給出錯的數字。要做需要另外推導，超出本 PR 範圍。

## Breaking change

`monotonicity(n_bootstrap=...)` 低於 200 改為 `UserInputError`。依 pre-1.0 政策直接破壞、不做過渡層。測試中 8 處為求速度用的 50/99/100 已調到 200（跑分無明顯變化）。

## 驗證

`ruff check` / `ruff format --check` / `mypy factrix`（84 files clean）；**全套 3112 passed, 42 skipped**。新增兩個測試：下限拒絕（並記錄 primitive 不設限的理由）、`p_value_mc_se` 與封閉式相符且隨 B 收斂。