### PR TITLE
refactor(stats)!: unify the bootstrap resample knobs, floor and Monte-Carlo error

### DIFF
--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -95,6 +95,11 @@ covariance. A two-valued `method` flag selects the estimator:
 | `"bootstrap"` (default) | Independent stationary block bootstrap (Politis-White automatic block length) | Romano-Wolf step-down | Short regimes (T ≈ 30-80); never invalid |
 | `"analytic"` | Per-slice Newey-West HAC, Welch-style pairwise contrast | Holm step-down | Long spans (T ≳ 100); fast, deterministic |
 
+Under `method="bootstrap"` both take `n_resamples=` (default 999, floored
+at 199) and `seed=` — the library-wide resampling knobs, see
+[Resampling knobs](../reference/statistical-methods.md#resampling-knobs).
+`"analytic"` ignores both.
+
 Each slice's per-period series must clear the metric's own sample floor,
 resolved at the panel's stamped or declared `overlap_periods` — the same
 floor `by_slice` short-circuits on — otherwise the test raises `ValueError`

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -24,8 +24,8 @@ The selection-only estimator classes under `factrix.stats`:
 - **`bhy_adjusted_p(p_values, *, n_tests=None)`**: BHY-adjusted p-values (clipped at 1.0).
 - **`holm_adjusted_p(p_values, *, n_tests=None)`**: Holm step-down FWER-adjusted p-values under arbitrary dependence. Use FWER when a search selects one winner or every retained hypothesis must avoid any false positive; use FDR when retaining a batch and controlling its expected false-discovery proportion.
 - **`romano_wolf_adjusted_p(statistics, bootstrap_statistics, *, one_sided=False)`**: Dependence-aware step-down max-t FWER-adjusted p-values. This expert primitive requires every searched hypothesis and each bootstrap row to be a joint, null-centred draw with the same studentization as the observed statistics; independently resampled or omitted columns are invalid. Its empirical p-value resolution is `1 / (B + 1)`. Use Holm when a valid joint bootstrap family is unavailable.
-- **`stationary_bootstrap_resamples(values, n_bootstrap, ...)`**: Politis-Romano (1994) bootstrap resamples. An aligned `(T, m)` per-period statistic matrix is resampled with common row indices and returns `(B, T, m)`, preserving cross-hypothesis dependence for Romano-Wolf; separate per-column calls do not.
-- **`bootstrap_mean_ci(values, *, n_bootstrap, ci, ...)`**: Stationary-bootstrap CI for a statistic.
+- **`stationary_bootstrap_resamples(values, n_resamples, ...)`**: Politis-Romano (1994) bootstrap resamples. An aligned `(T, m)` per-period statistic matrix is resampled with common row indices and returns `(B, T, m)`, preserving cross-hypothesis dependence for Romano-Wolf; separate per-column calls do not.
+- **`bootstrap_mean_ci(values, *, n_resamples, ci, ...)`**: Stationary-bootstrap CI for a statistic.
 
 Holm and BHY consume already calibrated p-values, so a declared family may
 contain a documented mix of `two-sided`, `greater`, and `less` alternatives;

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -836,9 +836,10 @@ Künsch, H. R. (1989). "The Jackknife and the Bootstrap for General
 Stationary Observations." *Annals of Statistics* 17(3), 1217–1241.
 
 Originates the fixed-length moving-block bootstrap, where blocks are
-drawn only from starts that fit inside the sample. factrix's
-``scheme="fixed"`` implements the circular variant below, not this one;
-kept as the origin of the fixed-length block idea.
+drawn only from starts that fit inside the sample. factrix implements
+neither this nor the circular variant below — only the stationary
+scheme — but both are kept as the origin of the block bootstrap idea
+the stationary scheme generalises.
 
 ### Politis & Romano (1992)
 [](){ #politis-romano-1992 }
@@ -850,9 +851,20 @@ LePage, R. & Billard, L. (eds.), Wiley, 263–270.
 Circular block bootstrap: fixed-length blocks whose starts are uniform
 over all ``n`` positions and wrap modulo ``n``, so every observation is
 resampled with equal weight (the moving-block scheme under-weights the
-two tails). Underlies factrix's ``scheme="fixed"`` block bootstrap, and
-supplies the ``(4/3)·g(0)²`` variance constant its automatic
-block-length selector uses.
+two tails). Not implemented by factrix, which exposes the stationary
+scheme only; kept because the automatic block-length selector below is
+derived for both and the ``(4/3)·g(0)²`` constant is this scheme's.
+
+### Davidson & MacKinnon (2000)
+[](){ #davidson-mackinnon-2000 }
+
+Davidson, R. & MacKinnon, J. G. (2000). "Bootstrap Tests: How Many
+Bootstraps?" *Econometric Reviews* 19(1), 55–68.
+
+Shows that a bootstrap p-value lives on the ``1/(B+1)`` grid, so ``B``
+should be chosen with ``alpha·(B + 1)`` an integer — 199 / 399 / 999 at
+the conventional levels. Supplies the grid argument behind factrix's
+``BOOTSTRAP_RESAMPLES_FLOOR``.
 
 ### Politis & Romano (1994)
 [](){ #politis-romano-1994 }

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -89,6 +89,7 @@ contrasts, not a sidecar to a primary value.
 - *primary*: `p_value` — test on the per-period IC series, from the configured `inference`: a `t`-test on a non-overlapping stride of `overlap_periods` (default), a Newey-West HAC `t`-test, or a stationary-bootstrap empirical `p`.
 - *descriptive*: `n_periods` (the sample the `value` / `stat` / `p_value` describe — the strided subsample under `NonOverlapping`, the full series under `NeweyWest` / `StationaryBootstrap`; equals `n_obs`), `n_periods_full` and `mean_ic_full` (the full per-period series, for reference), `overlap_periods`, `tie_ratio` (median across periods), `min_assets_per_period` / `warn_assets_per_period` when the upstream IC series carries per-period asset counts, `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`), `h0` (`"mu=0"`), `method`.
 - *descriptive* (conditional, `NeweyWest`): `nw_lags` (resolved Bartlett bandwidth) and `hac_dof` (the effective degrees of freedom the `t` is read against; `None` when the sample is too short to run the kernel).
+- *descriptive* (conditional, `StationaryBootstrap`): `n_resamples` and `seed` (the resolved seed, reported even when not supplied, so an unseeded run stays reproducible), `p_value_mc_se` (Monte-Carlo SE of the empirical `p`), `block_length` (the resolved Politis-White mean block length) and `studentized`. See [Resampling knobs](statistical-methods.md#resampling-knobs).
 - *warning*: `WarningCode.FEW_ASSETS` when retained per-period IC cross-sections are below `MIN_IC_ASSETS_WARN`; `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` under `NeweyWest` when the resolved bandwidth exceeds `n_periods / 5`.
 - *short-circuit*: `reason` `insufficient_ic_periods` (too few periods) carries `min_required`; `insufficient_ic_assets` (every cross-section below `MIN_IC_ASSETS_HARD`, so no per-period IC survived — common on one-valid-pair panels) carries `min_assets_required`.
 
@@ -436,12 +437,13 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 
 - *primary*: `p_value` — bootstrap p for the MR test.
 - *MR detail*: `mr_min_diff`, `mr_adjacent_diffs` (every `Δ̄_i`, so the
-  binding step is visible), `mr_direction`, `n_bootstrap`,
-  `bootstrap_seed` (resolved and reported when not supplied, so an
+  binding step is visible), `mr_direction`, `n_resamples`,
+  `seed` (resolved and reported when not supplied, so an
   unseeded run is still reproducible after the fact), `p_value_mc_se`
-  (Monte-Carlo SE of the empirical p, `sqrt(p(1-p)/n_bootstrap)` — how far
+  (Monte-Carlo SE of the empirical p, `sqrt(p(1-p)/n_resamples)` — how far
   the p would move on a re-run with a different seed, ~0.7pp at the default
-  `n_bootstrap=1000` and p near 0.05; `n_bootstrap` is floored at 200).
+  `n_resamples=999` and p near 0.05; `n_resamples` is floored at 199 — see
+  [Resampling knobs](statistical-methods.md#resampling-knobs)).
 - *descriptive Spearman shape*: `mean_abs_spearman` (magnitude, ≥ 0),
   `mean_signed` (direction consistency), `signed_spearman_t`,
   `signed_spearman_p_value`. A high magnitude with a near-zero signed mean

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -293,6 +293,44 @@ literature ([Berk-Brown-Buja-Zhang-Zhao 2013][berk-brown-buja-zhang-zhao-2013],
 correction; factrix does not implement it because the function is
 intended as a diagnostic, not a hypothesis test.
 
+
+### Resampling knobs
+
+Every entry point that turns a resample count into a reported p or
+interval takes the same two knobs under the same names, with the same
+default and the same refusal floor.
+
+| Entry point | `n_resamples` default | `seed` | Floor enforced | Reports `p_value_mc_se` |
+|---|---|---|---|---|
+| `ic(inference=StationaryBootstrap(...))` | 999 | yes | yes | yes (`metadata`) |
+| `monotonicity(...)` | 999 | yes | yes | yes (`metadata`) |
+| `bootstrap_mean_ci(...)` | 999 | yes | yes | no (returns an interval, not a p) |
+| `slice_period_pairwise_test` / `slice_period_joint_test` (`method="bootstrap"`) | 999 | yes | yes | no (see below) |
+| `stationary_bootstrap_resamples(...)` | 999 | yes | **no** | no (returns draws, not inference) |
+
+The floor is `BOOTSTRAP_RESAMPLES_FLOOR = 199` and a lower count raises
+`UserInputError`. A Davison-Hinkley smoothed p lives on the `1/(B+1)`
+grid, so `B` should be chosen with `α·(B + 1)` an integer
+([Davidson-MacKinnon 2000][davidson-mackinnon-2000]): 199 / 399 / 999 at
+the conventional levels. 199 is the smallest such grid point — below it
+the p resolves no finer than 0.005 — and the default 999 is
+[Politis-White (2004)][politis-white-2004]'s recommendation for two-sided
+5% work. `stationary_bootstrap_resamples` sits outside the floor
+deliberately: it returns draws and claims no inference on them.
+
+`p_value_mc_se` is `sqrt(p(1-p)/B)`, the binomial SE of the resampling
+draw itself — how far the reported p would move on a re-run with a
+different seed, not a statistical SE of the estimate. At `B = 999` and
+p near 0.05 it is ~0.7pp, so 0.043 and 0.058 are one draw apart. It
+shrinks only as `1/sqrt(B)`; no amount of data shrinks it. The period
+slice tests do **not** report it: their `p_adj` is a Romano-Wolf
+step-down adjustment, not a single binomial draw, so the formula does
+not apply.
+
+Passing `seed=None` (the default) draws from system entropy and reports
+the resolved seed back in `metadata["seed"]`, so an unseeded run is
+still reproducible after the fact.
+
 ---
 
 ## 3. Robust scale and outlier handling

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -1,19 +1,18 @@
 """Block-bootstrap primitives backing ``StationaryBootstrap`` and the period slice tests.
 
-Two resampling schemes for dependent time series, plus the
+The stationary resampling scheme for dependent time series
+([Politis-Romano (1994)][politis-romano-1994]) — geometric block lengths
+with mean ``L``, circular sampling — plus the
 [Politis-White (2004)][politis-white-2004] automatic block-length
-selector and a paired-diff empirical p-value:
+selector and a paired-diff empirical p-value. Resamples are themselves
+stationary processes, which is what downstream estimators relying on
+stationarity (CI for serially-correlated means, Sharpe) need.
 
-- **Stationary scheme** ([Politis-Romano (1994)][politis-romano-1994]) —
-  geometric block lengths with mean ``L``. Resamples are themselves
-  stationary processes; preferred when downstream estimators rely on
-  stationarity (CI for serially-correlated means, Sharpe).
-- **Fixed scheme** ([Politis-Romano (1992)][politis-romano-1992]) —
-  deterministic block length ``L``, starts uniform over all ``n``
-  positions and wrapped modulo ``n`` (the *circular* block bootstrap, not
-  Künsch's moving-block scheme: wrapping keeps every observation equally
-  weighted). Cleaner for variance estimation; loses stationarity at the
-  join points but tighter at small ``B``.
+Only the stationary scheme is implemented. The fixed-length circular
+scheme ([Politis-Romano (1992)][politis-romano-1992]) lived here for a
+while with no public entry point able to select it, and no size table of
+its own; factrix exposes measured paths only, so it was removed rather
+than promoted to a knob.
 
 The public ``factrix.stats.bootstrap`` module ships standalone
 ``stationary_bootstrap_resamples`` / ``bootstrap_mean_ci`` for callers
@@ -23,9 +22,6 @@ private module is consumed by ``factrix.inference.StationaryBootstrap``
 (``_stationary_block_indices`` / ``_politis_white_block_length``).
 
 References:
-    - Politis, D. N. & Romano, J. P. (1992). "A Circular Block-
-      Resampling Procedure for Stationary Data." In Exploring the Limits
-      of Bootstrap, 263–270. Wiley.
     - Politis, D. N. & Romano, J. P. (1994). "The Stationary
       Bootstrap." Journal of the American Statistical Association,
       89(428), 1303–1313.
@@ -43,49 +39,81 @@ import numpy as np
 
 from factrix._types import EPSILON
 
-Scheme = Literal["fixed", "stationary"]
-
-#: Below this many resamples a bootstrap quantile or empirical p is dominated
-#: by resampling noise: at B=200 the 2.5% tail is the 5th order statistic.
-#: Politis-White (2004) recommend >= 999 for two-sided 5% work; this is the
-#: refusal floor shared by every entry point that exposes a user-settable
-#: resample count *and* reports an inference drawn from it: ``bootstrap_mean_ci``
-#: and ``monotonicity``'s MR test. Not the recommendation.
-#: Two neighbours are deliberately outside it: ``stationary_bootstrap_resamples``
-#: and ``_block_bootstrap_diff_p`` return draws / a raw p to internal callers
-#: without owning a user-facing knob, and the slice paths fix their own count at
-#: 999, already above the floor.
-#: The 200 is argued above from the quantile side (interval endpoints). On the
-#: empirical-p side it is looser than it looks: at ``p = 0.05`` the Monte-Carlo
-#: SE is ``sqrt(.05*.95/200)`` = 1.5pp, so a p printed as 0.05 carries a ~95%
-#: resampling range of roughly [0.02, 0.08] and straddles the conventional
-#: threshold in both directions. The floor refuses the indefensible, it does not
-#: certify 200; ``bootstrap_p_mc_se`` is reported so the cost is visible, and
-#: Politis-White's >= 999 remains the recommendation for two-sided 5% work.
+#: Refusal floor for every entry point that exposes a user-settable resample
+#: count *and* reports an inference drawn from it (``bootstrap_mean_ci``,
+#: ``monotonicity``'s MR test, ``StationaryBootstrap``, the period slice
+#: tests). A Davison-Hinkley empirical p lives on the ``1/(B+1)`` grid, so
+#: ``B`` should be chosen with ``alpha * (B + 1)`` an integer
+#: ([Davidson-MacKinnon (2000)][davidson-mackinnon-2000]): 199 / 399 / 999 for
+#: the usual levels. 199 is the smallest such grid point, and below it the p
+#: resolves no finer than 0.005 while its Monte-Carlo SE at ``p = 0.05`` is
+#: ``sqrt(.05*.95/199)`` = 1.5pp — a p printed as 0.05 then straddles the
+#: conventional threshold in both directions. The floor refuses the
+#: indefensible; it does not certify 199. Politis-White (2004) recommend
+#: >= 999 for two-sided 5% work, which is the default everywhere, and
+#: ``p_value_mc_se`` is reported so the cost of a lower ``B`` stays visible.
+#: ``stationary_bootstrap_resamples`` is deliberately outside the floor: it
+#: returns draws, not an inference.
 #: Deliberately not named ``MIN_*``: that prefix is reserved (FX003) for
 #: sample-size floors on a data axis, and a resample count is an algorithm
 #: knob, not an axis.
-BOOTSTRAP_RESAMPLES_FLOOR: int = 200
+BOOTSTRAP_RESAMPLES_FLOOR: int = 199
 
 
-def bootstrap_p_mc_se(p_value: float, n_bootstrap: int) -> float:
-    """Monte-Carlo standard error of a bootstrap empirical p-value.
+def _check_n_resamples(n_resamples: int, *, func_name: str, docs_path: str) -> None:
+    """Reject a resample count below ``BOOTSTRAP_RESAMPLES_FLOOR``.
 
-    ``sqrt(p * (1 - p) / B)`` — the binomial SE of the resampling draw
-    itself, *not* a statistical SE of the estimate. It says how much the
-    reported p would move on a re-run with a different seed, which is the
-    quantity a reader needs when a p sits near a decision threshold: at
-    ``B = 1000`` and ``p = 0.05`` it is ~0.7pp, so 0.043 and 0.058 are one
-    draw apart. Shrinks as ``1 / sqrt(B)``; raise ``n_bootstrap`` to shrink
-    it, since no amount of data does.
-
-    Callers are the gated inference entry points, so ``n_bootstrap`` is always
-    at or above ``BOOTSTRAP_RESAMPLES_FLOOR`` and ``p_value`` is a
-    Davison-Hinkley smoothed p confined to ``[1/(B+1), 1]``. No clamping or
-    zero-guard is needed at that contract, and none is done.
+    The one validator behind every entry point that turns a resample count
+    into a reported p or interval, so the floor, the message and the
+    exception type cannot drift apart. ``func_name`` / ``docs_path`` must
+    name the *public* entry point the caller reached this through — the
+    message is user-facing.
     """
-    p = float(p_value)
-    return float(np.sqrt(p * (1.0 - p) / n_bootstrap))
+    from factrix._errors import UserInputError
+
+    if n_resamples < BOOTSTRAP_RESAMPLES_FLOOR:
+        raise UserInputError(
+            func_name=func_name,
+            field="n_resamples",
+            value=n_resamples,
+            expected=(
+                f"at least {BOOTSTRAP_RESAMPLES_FLOOR} resamples — below that "
+                f"the empirical p / interval endpoints are resampling noise "
+                f"(p resolves no finer than 1/(B+1) = 0.005)"
+            ),
+            docs_path=docs_path,
+        )
+
+
+def _empirical_p(n_extreme: int, n_resamples: int) -> tuple[float, float]:
+    """Davison-Hinkley smoothed empirical p and its Monte-Carlo SE.
+
+    ``p = (n_extreme + 1) / (B + 1)`` — the ``+1`` smoothing keeps the p
+    strictly positive, so log-scale plots and downstream multi-stage
+    adjustments never see a hard zero, and it is the unbiased form under the
+    null (Davison-Hinkley smoothing).
+
+    The second element is ``sqrt(p * (1 - p) / B)``, the binomial SE of the
+    resampling draw itself — *not* a statistical SE of the estimate. It says
+    how much the reported p would move on a re-run with a different seed,
+    which is the quantity a reader needs when a p sits near a decision
+    threshold: at ``B = 1000`` and ``p = 0.05`` it is ~0.7pp, so 0.043 and
+    0.058 are one draw apart. It shrinks as ``1 / sqrt(B)``; raise ``B`` to
+    shrink it, since no amount of data does.
+
+    Args:
+        n_extreme: Count of resamples at least as extreme as the observed
+            statistic.
+        n_resamples: ``B``, the number of resamples the count is out of.
+
+    Returns:
+        ``(p_value, p_value_mc_se)``. Callers are gated entry points, so
+        ``B >= BOOTSTRAP_RESAMPLES_FLOOR`` and ``p`` is confined to
+        ``[1/(B+1), 1]``; no clamping or zero-guard is needed, and none is
+        done.
+    """
+    p = (n_extreme + 1.0) / (n_resamples + 1.0)
+    return float(p), float(np.sqrt(p * (1.0 - p) / n_resamples))
 
 
 def _flat_top_kernel(t: float) -> float:
@@ -104,20 +132,14 @@ def _flat_top_kernel(t: float) -> float:
     return 0.0
 
 
-def _politis_white_block_length(
-    values: np.ndarray,
-    *,
-    scheme: Scheme = "stationary",
-) -> float:
+def _politis_white_block_length(values: np.ndarray) -> float:
     """[Politis-White (2004)][politis-white-2004] automatic block length.
 
     Implements the spectral plug-in described in PW §3-4:
     ``L̂ = (2 Ĝ² / D̂)^(1/3) · T^(1/3)`` where ``Ĝ`` and ``D̂`` are
     flat-top kernel estimates of, respectively, the first derivative
-    and variance of the spectral density at frequency 0. Caller picks
-    ``scheme`` because ``D̂`` differs by a factor (``2 g(0)²`` for
-    stationary, ``(4/3) g(0)²`` for the fixed-length circular blocks;
-    PW eq 9 / 12).
+    and variance of the spectral density at frequency 0, with the
+    stationary scheme's ``D̂ = 2 g(0)²`` (PW eq 9).
 
     Falls back to ``max(1, 1.75 · T^(1/3))`` (the widely-cited practical
     PW approximation, also used by ``factrix.stats.bootstrap``) when
@@ -174,12 +196,7 @@ def _politis_white_block_length(
     # `range(1, M)` covers every non-zero contributor.
     g0 = gamma[0] + 2.0 * sum(_flat_top_kernel(k / M) * gamma[k] for k in range(1, M))
     g_deriv = 2.0 * sum(_flat_top_kernel(k / M) * k * gamma[k] for k in range(1, M))
-    if scheme == "stationary":
-        d_hat = 2.0 * g0 * g0
-    elif scheme == "fixed":
-        d_hat = (4.0 / 3.0) * g0 * g0
-    else:
-        raise ValueError(f"scheme must be 'fixed' or 'stationary'; got {scheme!r}")
+    d_hat = 2.0 * g0 * g0
 
     if d_hat < EPSILON or not np.isfinite(g_deriv):
         return fallback
@@ -234,8 +251,8 @@ def _max_block_length(n: int) -> int:
     ``ceil(min(3 * sqrt(n), n / 3))`` — ``arch``'s ``b_max``
     (``arch.bootstrap._single_optimal_block``). Bounding ``L`` relative to
     ``n`` is what keeps enough effective blocks (``~n/L``) for the resample
-    distribution to carry information: at ``L >= n`` the circular fixed-block
-    resample degenerates to a rotation of the whole series, every resample is
+    distribution to carry information: at ``L >= n`` the circular resample
+    degenerates to a rotation of the whole series, every resample is
     a permutation of the same values, and the centred bootstrap mean is
     identically zero — so the empirical p is ``1/(B+1)`` on any data
     whatsoever, the strongest possible significance from a parameter typo.
@@ -341,51 +358,13 @@ def _stationary_block_indices(
     return idx
 
 
-def _fixed_block_indices(
-    n: int,
-    n_resamples: int,
-    block_length: int,
-    rng: np.random.Generator,
-) -> np.ndarray:
-    """[Politis-Romano (1992)][politis-romano-1992] circular fixed-block
-    index matrix, shape ``(B, n)``.
-
-    Picks ``ceil(n / L)`` random block starts per resample, lays the
-    blocks contiguously (modulo ``n`` for circular wrap), then truncates
-    to length ``n``. Each resample is composed of ``ceil(n/L)`` blocks
-    of identical length ``L`` — the cleaner variance-estimation path
-    when serial correlation has a known horizon.
-
-    Starts are uniform over all ``n`` positions and wrap, which makes
-    this the circular block bootstrap rather than [Künsch
-    (1989)][kunsch-1989]'s moving-block scheme (starts restricted to
-    ``n - L + 1`` positions, leaving the first and last ``L - 1``
-    observations under-represented). The distinction is load-bearing for
-    the block-length selector: ``_politis_white_block_length(...,
-    scheme="fixed")`` uses PW's ``(4/3) g(0)²`` constant, which is
-    derived for circular blocks.
-    """
-    if n == 0:
-        return np.empty((n_resamples, 0), dtype=np.int64)
-    _validate_block_length(
-        block_length, n, "StationaryBootstrap", "reference/statistical-methods"
-    )
-    n_blocks = int(np.ceil(n / block_length))
-    starts = rng.integers(0, n, size=(n_resamples, n_blocks))
-    offsets = np.arange(block_length, dtype=np.int64)
-    # Broadcast (B, n_blocks, 1) + (block_length,) → (B, n_blocks, block_length).
-    idx = (starts[:, :, None] + offsets[None, None, :]) % n
-    return idx.reshape(n_resamples, n_blocks * block_length)[:, :n]
-
-
 def _block_bootstrap_diff_p(
     diff: np.ndarray,
     *,
     block_length: int | Literal["auto"] = "auto",
     n_resamples: int = 999,
-    scheme: Scheme = "stationary",
     overlap_periods: int | None = None,
-    rng_seed: int | None = None,
+    seed: int | None = None,
 ) -> tuple[float, dict[str, float | int | str]]:
     r"""Two-sided empirical p for ``H₀: E[diff] = 0`` on a paired series.
 
@@ -434,16 +413,13 @@ def _block_bootstrap_diff_p(
         block_length: ``"auto"`` runs Politis-White; an explicit ``int``
             is used unchanged. Either way the resolved value must land in
             ``[1, ceil(min(3*sqrt(n), n/3))]`` or ``UserInputError`` is
-            raised — see :func:`_validate_block_length`. Under
-            ``"stationary"`` the resolved value is the *mean* of the
-            geometric block-length distribution and stays fractional;
-            under ``"fixed"`` it is a literal block size and is rounded to
-            an integer.
+            raised — see :func:`_validate_block_length`. The resolved value
+            is the *mean* of the geometric block-length distribution and
+            stays fractional.
         n_resamples: ``B``. [Politis-White (2004)][politis-white-2004] recommends ≥ 999 for two-sided
-            5% tests; default matches.
-        scheme: ``"fixed"`` (fixed-length circular blocks,
-            Politis-Romano 1992) or ``"stationary"`` (geometric blocks,
-            Politis-Romano 1994).
+            5% tests; default matches. Validated against
+            ``BOOTSTRAP_RESAMPLES_FLOOR`` by the public entry point, not
+            here.
         overlap_periods: Overlap horizon ``h`` of the series. When set,
             floors the resolved block length at ``h``: Politis-Romano
             validity needs the mean block length to dominate the
@@ -452,16 +428,16 @@ def _block_bootstrap_diff_p(
             to rediscover it from a short noisy sample and systematically
             under-shoots (measured mean L of 7.95 against a needed 21 at
             T=60, h=21). Mirrors the HAC paths' bandwidth floor.
-        rng_seed: ``None`` draws from system entropy; the resolved seed
+        seed: ``None`` draws from system entropy; the resolved seed
             is returned in the metadata dict so the caller can record it.
 
     Returns:
         ``(p_value, metadata)`` — p in ``[1/(B+1), 1]``; metadata
-        records the resolved block length (a float: fractional under
-        ``"stationary"``, integral under ``"fixed"``), scheme,
-        n_resamples, whether the root was studentized, and the actual
-        seed used (so the run is reproducible from the logged metadata
-        even when the caller passed ``rng_seed=None``).
+        records the resolved (fractional) block length, ``n_resamples``,
+        whether the root was studentized, the Monte-Carlo SE of the
+        reported p (``p_value_mc_se``), and the actual seed used (so the
+        run is reproducible from the logged metadata even when the caller
+        passed ``seed=None``).
 
         A series too short to test (``n < 2``) returns ``p = nan`` with
         ``block_length = nan`` and ``n_resamples = 0``. NaN rather than
@@ -480,23 +456,22 @@ def _block_bootstrap_diff_p(
         return float("nan"), {
             "block_length": float("nan"),
             "n_resamples": 0,
-            "scheme": scheme,
             "studentized": False,
-            "rng_seed": rng_seed if rng_seed is not None else -1,
+            "p_value_mc_se": float("nan"),
+            "seed": seed if seed is not None else -1,
         }
 
     L: float
     if block_length == "auto":
-        L_auto = _politis_white_block_length(diff, scheme=scheme)
-        # Only the fixed scheme's L is a block *size* and has to be integral.
-        # The stationary scheme's is the MEAN of a geometric distribution —
+        L_auto = _politis_white_block_length(diff)
+        # L stays fractional: it is the MEAN of a geometric distribution —
         # ``_stationary_block_indices`` only ever reads it as
         # ``p_new = 1 / L`` — so rounding discretizes the renewal probability
-        # for nothing: L=3.4 turns p_new 0.294 into 0.333. It also put this
-        # function out of step with the other two consumers of the same
+        # for nothing: L=3.4 turns p_new 0.294 into 0.333. It would also put
+        # this function out of step with the other two consumers of the same
         # estimate, ``stationary_bootstrap_resamples`` and
         # ``slicing.period_inference``, which both pass the float through.
-        L = max(1.0, L_auto) if scheme == "stationary" else float(max(1, round(L_auto)))
+        L = max(1.0, L_auto)
     else:
         L = float(int(block_length))
 
@@ -511,15 +486,12 @@ def _block_bootstrap_diff_p(
     # `secrets.randbits(32)` is the purpose-built "give me a random int
     # seed" call — `SeedSequence().entropy` is typed as `int | Sequence[int]
     # | None` and the Sequence branch breaks the bit-mask path.
-    seed_used = secrets.randbits(32) if rng_seed is None else int(rng_seed)
+    seed_used = secrets.randbits(32) if seed is None else int(seed)
     rng = np.random.default_rng(seed_used)
 
     # Centre under H0 (mean=0) before resampling.
     centred = diff - float(np.mean(diff))
-    if scheme == "stationary":
-        idx = _stationary_block_indices(n, n_resamples, L, rng)
-    else:
-        idx = _fixed_block_indices(n, n_resamples, int(L), rng)
+    idx = _stationary_block_indices(n, n_resamples, L, rng)
     resamples = centred[idx]
     boot_means = resamples.mean(axis=1)
     observed = float(np.mean(diff))
@@ -545,12 +517,12 @@ def _block_bootstrap_diff_p(
         extreme = int(np.sum(np.abs(boot_means) >= abs(observed)))
         n_used = int(n_resamples)
 
-    p = (extreme + 1.0) / (n_used + 1.0)
+    p, p_mc_se = _empirical_p(extreme, n_used)
     metadata: dict[str, float | int | str] = {
         "block_length": L,
         "n_resamples": int(n_resamples),
-        "scheme": scheme,
         "studentized": studentized,
-        "rng_seed": seed_used,
+        "p_value_mc_se": p_mc_se,
+        "seed": seed_used,
     }
     return float(p), metadata

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -55,10 +55,12 @@ Per-metric allowlist enforcement
 The closed union is a type annotation, not a runtime gate, so every
 ``inference=``-bearing metric additionally declares a module-level
 ``applicable_inference`` frozenset and validates against it on entry (via
-``_check_applicable_inference``). A method outside the set raises
-:class:`~factrix.IncompatibleInferenceError` listing the allowed members,
-rather than running an unintended test or silently falling back to the
-default. ``quantile_spread`` / ``k_spread`` allow
+``_check_applicable_inference``). Membership is by the member's exact
+type, not its value, so a configured ``StationaryBootstrap(n_resamples=,
+seed=)`` is admitted wherever the method is. A method outside the set
+raises :class:`~factrix.IncompatibleInferenceError` listing the allowed
+members, rather than running an unintended test or silently falling back
+to the default. ``quantile_spread`` / ``k_spread`` allow
 ``{NON_OVERLAPPING, NEWEY_WEST}``; ``ic`` additionally allows
 ``STATIONARY_BOOTSTRAP`` (see below); ``resolve_applicable_inference``
 reads the set back for discovery.

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -14,7 +14,9 @@ SE via a HAC kernel. ``StationaryBootstrap`` also keeps every observation
 but replaces the analytic SE with a block-bootstrap empirical p, for
 series too short or non-normal for a HAC t-test to be trusted. The
 lag / bandwidth / block length is derived from the compute-time sample,
-so the dataclasses take no constructor knobs.
+so the dataclasses take no *statistical* constructor knobs;
+``StationaryBootstrap`` carries the two resampling knobs (``n_resamples``
+/ ``seed``) that only the caller can decide.
 
 These are metric-internal inference units: ``compute`` returns an
 ``InferenceResult`` whose ``stat`` / ``p_value`` feed a ``MetricResult``
@@ -305,8 +307,7 @@ class StationaryBootstrap:
     horizon from a short noisy sample and systematically under-shoots it
     (measured mean ``L`` of 7.95 against a needed 21 at T=60, h=21, for a
     41.7% rejection rate at a nominal 5%). The resolved seed is reported in
-    ``metadata`` so the run is reproducible after the fact even though the
-    dataclass itself carries no seed knob.
+    ``metadata`` so an unseeded run is still reproducible after the fact.
 
     Size on an overlapping MA(h-1) null at nominal 5% (300 sims per
     cell, B=499), before = no horizon floor and an unstudentized root:
@@ -334,12 +335,36 @@ class StationaryBootstrap:
     Delegates to ``factrix._stats.bootstrap._block_bootstrap_diff_p``, the
     library's single studentized block-bootstrap empirical-p kernel, so the
     convention is one implementation, not a parallel one.
+
+    Args:
+        n_resamples: ``B``, the number of bootstrap resamples the empirical
+            p is drawn from. Must be at least
+            ``BOOTSTRAP_RESAMPLES_FLOOR`` — the shared floor every factrix
+            entry point reporting an inference from resamples enforces.
+            The default 999 is [Politis-White (2004)][politis-white-2004]'s
+            recommendation for two-sided 5% work; the Monte-Carlo cost of a
+            lower ``B`` is reported as ``metadata["p_value_mc_se"]``.
+        seed: Reproducibility seed. ``None`` draws from system entropy and
+            reports the resolved seed in ``metadata["seed"]``, so a run
+            stays reproducible after the fact.
     """
+
+    n_resamples: int = 999
+    seed: int | None = None
 
     test: ClassVar[str] = "bootstrap-mean"
     se: ClassVar[str | None] = "bootstrap"
     summary: ClassVar[str] = "stationary-bootstrap empirical p-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
+
+    def __post_init__(self) -> None:
+        from factrix._stats.bootstrap import _check_n_resamples
+
+        _check_n_resamples(
+            self.n_resamples,
+            func_name="StationaryBootstrap",
+            docs_path="reference/statistical-methods",
+        )
 
     def min_input_periods(self, overlap_periods: int) -> int:
         """Minimum input series length (periods); no overlap-specific floor."""
@@ -353,7 +378,10 @@ class StationaryBootstrap:
         vals = _clean_series(data, value_col).to_numpy()
         n = len(vals)
         p_value, boot_metadata = _block_bootstrap_diff_p(
-            vals, overlap_periods=overlap_periods
+            vals,
+            n_resamples=self.n_resamples,
+            overlap_periods=overlap_periods,
+            seed=self.seed,
         )
 
         warnings: frozenset[WarningCode] = frozenset()

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -133,14 +133,20 @@ def _check_applicable_inference(
     """Reject an ``inference=`` outside the metric's allowlist.
 
     Single chokepoint every ``inference=``-bearing metric calls before it
-    dispatches: membership is by value (the members are frozen
-    dataclasses), so it catches both a non-vetted ``Inference``
+    dispatches: it catches both a non-vetted ``Inference``
     (``HansenHodrick``) and a non-``Inference`` object (a stray string)
     without the metric body reaching an unintended ``compute`` or a silent
     non-overlap fallback. Raises :class:`IncompatibleInferenceError`
     listing the allowed methods.
+
+    Membership is by **exact type**, not by value: ``StationaryBootstrap``
+    carries resampling knobs (``n_resamples`` / ``seed``), so a configured
+    instance is a different value from the allowlisted default one while
+    being the same vetted method. Comparing by value would allowlist the
+    method and then reject every configuration of it. Exact type (not
+    ``isinstance``) so a subclass cannot ride in on a vetted base.
     """
-    if inference not in applicable:
+    if type(inference) not in {type(member) for member in applicable}:
         raise IncompatibleInferenceError(
             func_name=func_name,
             value=inference,

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -383,6 +383,12 @@ def ic(
         "method": inference.summary,
         "tie_ratio": median_tie,
     }
+    # Surface the resampling knobs the bootstrap path actually ran with (and
+    # only that path defines them), so a reported empirical p is reproducible
+    # from the result alone and its Monte-Carlo error is readable next to it.
+    for key in ("n_resamples", "seed", "p_value_mc_se"):
+        if key in result.metadata:
+            metadata[key] = result.metadata[key]
     _warn_if_few_ic_assets(
         ic_df, "ic", metadata, warning_codes, expected_warnings=expected_warnings
     )

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -32,10 +32,7 @@ from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
-from factrix._stats.bootstrap import (
-    BOOTSTRAP_RESAMPLES_FLOOR,
-    bootstrap_p_mc_se,
-)
+from factrix._stats.bootstrap import _check_n_resamples, _empirical_p
 from factrix._types import (
     DDOF,
     MIN_MONOTONICITY_PERIODS_HARD,
@@ -106,7 +103,7 @@ def _mr_test(
     bucket_means: np.ndarray,
     *,
     direction: MRDirection,
-    n_bootstrap: int,
+    n_resamples: int,
     seed: int | None,
 ) -> tuple[float, float, dict[str, object]]:
     """Patton-Timmermann (2010) MR test on a ``(n_periods, n_groups)`` block.
@@ -124,8 +121,8 @@ def _mr_test(
     column by column.
 
     ``p = (1 + #{J* >= J}) / (B + 1)`` — the Davison-Hinkley ``+1`` smoothing
-    the rest of the library's empirical-p paths use, so the p can never be
-    exactly 0.
+    the rest of the library's empirical-p paths use (:func:`_empirical_p`),
+    so the p can never be exactly 0.
     """
     from factrix.stats import stationary_bootstrap_resamples
 
@@ -139,18 +136,20 @@ def _mr_test(
         # Mirror ``StationaryBootstrap``: resolve a seed and report it, so a run
         # is reproducible after the fact without a mandatory knob.
         seed = int(np.random.default_rng().integers(0, 2**31 - 1))
-    resamples = stationary_bootstrap_resamples(diffs, n_bootstrap, seed=seed)
+    resamples = stationary_bootstrap_resamples(diffs, n_resamples, seed=seed)
     # (B, T, K-1) -> (B, K-1) bootstrap means, recentred under H0.
     j_star = (resamples.mean(axis=1) - delta_bar).min(axis=1)
-    p_value = float((1 + int(np.count_nonzero(j_star >= j_stat))) / (n_bootstrap + 1))
+    p_value, p_mc_se = _empirical_p(
+        int(np.count_nonzero(j_star >= j_stat)), n_resamples
+    )
 
     metadata: dict[str, object] = {
         "mr_direction": direction,
         "mr_min_diff": j_stat,
         "mr_adjacent_diffs": [float(v) for v in delta_bar],
-        "n_bootstrap": n_bootstrap,
-        "bootstrap_seed": seed,
-        "p_value_mc_se": bootstrap_p_mc_se(p_value, n_bootstrap),
+        "n_resamples": n_resamples,
+        "seed": seed,
+        "p_value_mc_se": p_mc_se,
     }
     return j_stat, p_value, metadata
 
@@ -171,7 +170,7 @@ def monotonicity(
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
     direction: MRDirection = "increasing",
-    n_bootstrap: int = 1000,
+    n_resamples: int = 999,
     seed: int | None = None,
     expected_warnings: tuple[str, ...] = (),
 ) -> dict[str, MetricResult]:
@@ -196,19 +195,18 @@ def monotonicity(
             (default) or ``"decreasing"`` in bucket index. Declare it from the
             factor's hypothesis; running both and reporting the smaller p is a
             two-sided search charged at a one-sided level.
-        n_bootstrap: Bootstrap resamples for the MR null distribution. Must
-            be at least ``BOOTSTRAP_RESAMPLES_FLOOR`` (200) — the same floor
-            ``factrix.stats.bootstrap_mean_ci`` enforces, since both report an
-            inference drawn from the resamples rather than the resamples
-            themselves. Below it the empirical p is dominated by resampling
+        n_resamples: Bootstrap resamples for the MR null distribution. Must
+            be at least ``BOOTSTRAP_RESAMPLES_FLOOR`` — the shared floor every
+            factrix entry point reporting an inference drawn from resamples
+            enforces. Below it the empirical p is dominated by resampling
             noise: the Monte-Carlo SE of the reported p is
-            ``sqrt(p(1-p)/n_bootstrap)``, reported as
-            ``metadata["p_value_mc_se"]``. At the default 1000 resamples a p
+            ``sqrt(p(1-p)/n_resamples)``, reported as
+            ``metadata["p_value_mc_se"]``. At the default 999 resamples a p
             near 0.05 carries ~0.7pp of MC SE, so 0.043 and 0.058 are one
-            draw apart; raise ``n_bootstrap`` to shrink it, since no amount
+            draw apart; raise ``n_resamples`` to shrink it, since no amount
             of data does.
         seed: Bootstrap seed. ``None`` resolves one and reports it in
-            ``metadata["bootstrap_seed"]``, so a run stays reproducible after
+            ``metadata["seed"]``, so a run stays reproducible after
             the fact. An unseeded re-run redraws the null, moving the p by
             roughly ``metadata["p_value_mc_se"]``.
 
@@ -257,7 +255,7 @@ def monotonicity(
         ...     forward_periods=5,
         ... )
         >>> result = monotonicity(
-        ...     panel, overlap_periods=5, n_groups=5, n_bootstrap=200, seed=0
+        ...     panel, overlap_periods=5, n_groups=5, n_resamples=199, seed=0
         ... )
         >>> result["factor"].name == ""
         True
@@ -271,18 +269,11 @@ def monotonicity(
             expected="'increasing' (default) or 'decreasing'",
             docs_path="api/metrics/monotonicity",
         )
-    if n_bootstrap < BOOTSTRAP_RESAMPLES_FLOOR:
-        raise UserInputError(
-            func_name="monotonicity",
-            field="n_bootstrap",
-            value=n_bootstrap,
-            expected=(
-                f"at least {BOOTSTRAP_RESAMPLES_FLOOR} bootstrap resamples — "
-                f"below that the MR empirical p is dominated by resampling "
-                f"noise (the same floor bootstrap_mean_ci enforces)"
-            ),
-            docs_path="api/metrics/monotonicity",
-        )
+    _check_n_resamples(
+        n_resamples,
+        func_name="monotonicity",
+        docs_path="api/metrics/monotonicity",
+    )
     cols = list(factor_cols)
     if not cols:
         raise ValueError("factor_cols must be non-empty")
@@ -401,7 +392,7 @@ def monotonicity(
         j_stat, p_mr, mr_metadata = _mr_test(
             mat,
             direction=direction,
-            n_bootstrap=n_bootstrap,
+            n_resamples=n_resamples,
             seed=seed,
         )
         # Descriptive shape statistics, kept because magnitude and direction

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -72,7 +72,8 @@ from factrix._codes import WarningCode, _validate_expected_warnings_arg
 from factrix._data_input import _resolve_overlap_periods
 from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
-    Scheme,
+    _check_n_resamples,
+    _empirical_p,
     _politis_white_block_length,
     _stationary_block_indices,
 )
@@ -91,9 +92,6 @@ from factrix.slicing.inference import (
 from factrix.stats.multiple_testing import holm_adjusted_p, romano_wolf_adjusted_p
 
 Method = Literal["bootstrap", "analytic"]
-
-_N_RESAMPLES = 999
-_SCHEME: Scheme = "stationary"
 
 # Slice length below which the joint test's realised size exceeds ~1.5× its
 # nominal level on a true null with K >= 3 slices. Set from the measured
@@ -249,6 +247,7 @@ def _build_per_slice_series(
 def _bootstrap_slice_means(
     series_list: list[np.ndarray],
     *,
+    n_resamples: int,
     rng: np.random.Generator,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Independent stationary-block bootstrap of each slice's mean.
@@ -262,11 +261,11 @@ def _bootstrap_slice_means(
     """
     k = len(series_list)
     obs_means = np.empty(k)
-    boot = np.empty((k, _N_RESAMPLES))
+    boot = np.empty((k, n_resamples))
     for i, s in enumerate(series_list):
         obs_means[i] = float(s.mean())
-        block_len = _politis_white_block_length(s, scheme=_SCHEME)
-        idx = _stationary_block_indices(len(s), _N_RESAMPLES, float(block_len), rng)
+        block_len = _politis_white_block_length(s)
+        idx = _stationary_block_indices(len(s), n_resamples, float(block_len), rng)
         boot[i] = s[idx].mean(axis=1)
     return obs_means, boot
 
@@ -279,7 +278,8 @@ def slice_period_pairwise_test(
     factor_col: str,
     method: Method = "bootstrap",
     overlap_periods: int | None = None,
-    rng_seed: int | None = None,
+    n_resamples: int = 999,
+    seed: int | None = None,
     strict: bool = True,
 ) -> pl.DataFrame:
     """Pairwise cross-slice contrasts for a **date-disjoint** partition.
@@ -317,10 +317,15 @@ def slice_period_pairwise_test(
             contract is :func:`factrix.evaluate`'s — a value disagreeing with
             the stamp is rejected, and an unstamped panel with no declaration
             is an error rather than a silent default.
-        rng_seed: Reproducibility seed for the ``"bootstrap"`` path
+        n_resamples: ``B`` for the ``"bootstrap"`` path (ignored by
+            ``"analytic"``). Must be at least ``BOOTSTRAP_RESAMPLES_FLOOR``
+            — the shared floor every factrix entry point reporting an
+            inference drawn from resamples enforces. The default 999 is
+            [Politis-White (2004)][politis-white-2004]'s recommendation for
+            two-sided 5% work.
+        seed: Reproducibility seed for the ``"bootstrap"`` path
             (ignored by ``"analytic"``). ``None`` draws from system
-            entropy. This is plumbing, not a statistical knob — block
-            length, ``B``, and scheme are fixed by sensible defaults.
+            entropy.
         strict: ``True`` (default) raises ``ValueError`` when any slice is
             below the metric's sample floor. ``False`` keeps the schema and
             returns every pair touching a thin slice as an unavailable row
@@ -371,6 +376,9 @@ def slice_period_pairwise_test(
     """
     _validate_metric_instance(metric, "slice_period_pairwise_test")
     _validate_method(method, "slice_period_pairwise_test")
+    _check_n_resamples(
+        n_resamples, func_name="slice_period_pairwise_test", docs_path=_DOCS_SLICE
+    )
     op = _resolve_overlap_periods(
         data, overlap_periods, horizon=None, func_name="slice_period_pairwise_test"
     )
@@ -399,7 +407,8 @@ def slice_period_pairwise_test(
         tested_pairs,
         method=method,
         overlap_periods=op,
-        rng_seed=rng_seed,
+        n_resamples=n_resamples,
+        seed=seed,
     )
     by_pair = {
         (tested[i], tested[j]): row
@@ -454,7 +463,8 @@ def _pairwise_contrasts(
     *,
     method: Method,
     overlap_periods: int | None,
-    rng_seed: int | None,
+    n_resamples: int,
+    seed: int | None,
 ) -> list[tuple[float, float, float, float, float | None]]:
     """Studentized contrast per pair: ``(mean_diff, stat, p_raw, p_adj, df_denom)``.
 
@@ -464,8 +474,10 @@ def _pairwise_contrasts(
     family, which runs over the computable pairs only.
     """
     if method == "bootstrap":
-        rng = np.random.default_rng(rng_seed)
-        obs_means, boot = _bootstrap_slice_means(series_list, rng=rng)
+        rng = np.random.default_rng(seed)
+        obs_means, boot = _bootstrap_slice_means(
+            series_list, n_resamples=n_resamples, rng=rng
+        )
         t_obs: list[float] = []
         boot_cols: list[np.ndarray] = []
         mean_diffs: list[float] = []
@@ -478,7 +490,7 @@ def _pairwise_contrasts(
                 # No resampling dispersion in the contrast: no test. NaN,
                 # not t = 0 / p = 1 — see ``_stats.wald._NOT_COMPUTABLE``.
                 t = float("nan")
-                col = np.full(_N_RESAMPLES, float("nan"))
+                col = np.full(n_resamples, float("nan"))
             else:
                 t = diff_obs / se
                 # Centre on the OBSERVED difference, not the bootstrap mean:
@@ -494,7 +506,9 @@ def _pairwise_contrasts(
                 p_raw.append(float("nan"))
             else:
                 extreme = int(np.sum(np.abs(col) >= abs(t)))
-                p_raw.append((extreme + 1.0) / (_N_RESAMPLES + 1.0))
+                # Raw p only; the Romano-Wolf step-down p_adj below is not a
+                # single binomial draw, so no MC SE is reported here.
+                p_raw.append(_empirical_p(extreme, n_resamples)[0])
         # Romano-Wolf runs over the computable pairs; a collapsed pair stays
         # NaN in stat / p_raw / p_adj.
         t_arr = np.asarray(t_obs, dtype=float)
@@ -651,9 +665,8 @@ def _wald_bootstrap_omnibus(
     # the Wald quadratic form per draw (einsum over the (r, B) contrasts).
     null_contrasts = restriction @ (boot - obs_means[:, None])
     w_boot = np.einsum("ib,ij,jb->b", null_contrasts, middle_inv, null_contrasts)
-    b = boot.shape[1]
-    p = (int(np.sum(w_boot >= stat)) + 1.0) / (b + 1.0)
-    return stat, float(p)
+    p, _mc_se = _empirical_p(int(np.sum(w_boot >= stat)), boot.shape[1])
+    return stat, p
 
 
 def slice_period_joint_test(
@@ -664,7 +677,8 @@ def slice_period_joint_test(
     factor_col: str,
     method: Method = "bootstrap",
     overlap_periods: int | None = None,
-    rng_seed: int | None = None,
+    n_resamples: int = 999,
+    seed: int | None = None,
     strict: bool = True,
     expected_warnings: tuple[str, ...] = (),
 ) -> pl.DataFrame:
@@ -701,8 +715,15 @@ def slice_period_joint_test(
             contract is :func:`factrix.evaluate`'s — a value disagreeing with
             the stamp is rejected, and an unstamped panel with no declaration
             is an error rather than a silent default.
-        rng_seed: Reproducibility seed for the ``"bootstrap"`` path
-            (ignored by ``"analytic"``).
+        n_resamples: ``B`` for the ``"bootstrap"`` path (ignored by
+            ``"analytic"``). Must be at least ``BOOTSTRAP_RESAMPLES_FLOOR``
+            — the shared floor every factrix entry point reporting an
+            inference drawn from resamples enforces. The default 999 is
+            [Politis-White (2004)][politis-white-2004]'s recommendation for
+            two-sided 5% work.
+        seed: Reproducibility seed for the ``"bootstrap"`` path
+            (ignored by ``"analytic"``). ``None`` draws from system
+            entropy.
         strict: ``True`` (default) raises ``ValueError`` when any slice is
             below the metric's sample floor. ``False`` returns the same
             single-row schema as an unavailable row instead (``stat`` /
@@ -785,6 +806,9 @@ def slice_period_joint_test(
     """
     _validate_metric_instance(metric, "slice_period_joint_test")
     _validate_method(method, "slice_period_joint_test")
+    _check_n_resamples(
+        n_resamples, func_name="slice_period_joint_test", docs_path=_DOCS_SLICE
+    )
     expected = _validate_expected_warnings_arg(
         expected_warnings, func_name="slice_period_joint_test", docs_path=_DOCS_SLICE
     )
@@ -867,8 +891,10 @@ def slice_period_joint_test(
     restriction = _equality_restriction(k)
 
     if method == "bootstrap":
-        rng = np.random.default_rng(rng_seed)
-        obs_means, boot = _bootstrap_slice_means(series_list, rng=rng)
+        rng = np.random.default_rng(seed)
+        obs_means, boot = _bootstrap_slice_means(
+            series_list, n_resamples=n_resamples, rng=rng
+        )
         variances = boot.var(axis=1, ddof=1)
         stat, p = _wald_bootstrap_omnibus(obs_means, boot, variances, restriction)
         df_denom = None

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -35,7 +35,7 @@ from typing import Literal, NamedTuple
 
 import numpy as np
 
-from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
+from factrix._stats.bootstrap import _check_n_resamples
 
 
 def _resolve_auto_block_length(values: np.ndarray) -> float:
@@ -50,25 +50,22 @@ def _resolve_auto_block_length(values: np.ndarray) -> float:
     from factrix._stats.bootstrap import _politis_white_block_length
 
     if values.ndim == 1:
-        return _politis_white_block_length(values, scheme="stationary")
+        return _politis_white_block_length(values)
     if values.shape[1] == 0:
-        return _politis_white_block_length(
-            np.zeros(values.shape[0]), scheme="stationary"
-        )
+        return _politis_white_block_length(np.zeros(values.shape[0]))
     return max(
-        _politis_white_block_length(values[:, j], scheme="stationary")
-        for j in range(values.shape[1])
+        _politis_white_block_length(values[:, j]) for j in range(values.shape[1])
     )
 
 
 def stationary_bootstrap_resamples(
     values: np.ndarray,
-    n_bootstrap: int = 1000,
+    n_resamples: int = 999,
     *,
     block_length: float | None = None,
     seed: int | None = None,
 ) -> np.ndarray:
-    """Draw ``n_bootstrap`` stationary-bootstrap resamples of ``values``.
+    """Draw ``n_resamples`` stationary-bootstrap resamples of ``values``.
 
     Each resample has the same length ``T`` as the input. One-dimensional
     input returns ``(B, T)``; two-dimensional ``(T, m)`` input returns
@@ -82,7 +79,7 @@ def stationary_bootstrap_resamples(
             Matrix columns are always resampled jointly; do not call the
             function separately per column when cross-column dependence
             matters.
-        n_bootstrap: Number of resamples to draw.
+        n_resamples: Number of resamples to draw.
         block_length: Mean geometric block length. Defaults to the
             [Politis-White (2004)][politis-white-2004] automatic spectral
             plug-in (falling back to the practical ``1.75 * T^(1/3)`` rule
@@ -99,8 +96,8 @@ def stationary_bootstrap_resamples(
             reproducible.
 
     Returns:
-        ``(n_bootstrap, T)`` array for vector input or
-        ``(n_bootstrap, T, m)`` for matrix input.
+        ``(n_resamples, T)`` array for vector input or
+        ``(n_resamples, T, m)`` for matrix input.
 
     Notes:
         **This function returns resamples, not inference.** Forming a
@@ -144,17 +141,17 @@ def stationary_bootstrap_resamples(
     if values.size and not np.all(np.isfinite(values)):
         raise ValueError("values must be finite.")
     if (
-        isinstance(n_bootstrap, bool)
-        or not isinstance(n_bootstrap, Integral)
-        or n_bootstrap < 1
+        isinstance(n_resamples, bool)
+        or not isinstance(n_resamples, Integral)
+        or n_resamples < 1
     ):
         raise ValueError(
-            f"n_bootstrap must be a positive integer; got {n_bootstrap!r}."
+            f"n_resamples must be a positive integer; got {n_resamples!r}."
         )
-    n_bootstrap = int(n_bootstrap)
+    n_resamples = int(n_resamples)
     n = len(values)
     if n == 0:
-        return np.empty((n_bootstrap, *values.shape), dtype=float)
+        return np.empty((n_resamples, *values.shape), dtype=float)
 
     if block_length is None:
         block_length = _resolve_auto_block_length(values)
@@ -162,7 +159,7 @@ def stationary_bootstrap_resamples(
         raise ValueError(f"block_length must be >= 1.0, got {block_length!r}")
 
     rng = np.random.default_rng(seed)
-    idx = _stationary_block_indices(n, n_bootstrap, float(block_length), rng)
+    idx = _stationary_block_indices(n, n_resamples, float(block_length), rng)
     return values[idx]
 
 
@@ -183,7 +180,7 @@ class BootstrapCI(NamedTuple):
 def bootstrap_mean_ci(
     values: np.ndarray,
     *,
-    n_bootstrap: int = 1000,
+    n_resamples: int = 999,
     ci: float = 0.95,
     block_length: float | None = None,
     seed: int | None = None,
@@ -232,8 +229,8 @@ def bootstrap_mean_ci(
     Args:
         values: 1-D array of the original series, at least 2 finite
             observations.
-        n_bootstrap: Resample count. Must be at least
-            ``BOOTSTRAP_RESAMPLES_FLOOR`` (200); below that the interval
+        n_resamples: Resample count. Must be at least
+            ``BOOTSTRAP_RESAMPLES_FLOOR``; below that the interval
             endpoints are resampling noise. At ``B=1`` the old
             implementation returned a zero-width interval that did not
             even contain its own point estimate.
@@ -260,7 +257,7 @@ def bootstrap_mean_ci(
 
     Raises:
         UserInputError: ``ci`` outside ``(0, 1)``, an unknown ``method``,
-            non-1-D ``values``, fewer than 2 observations, ``n_bootstrap``
+            non-1-D ``values``, fewer than 2 observations, ``n_resamples``
             below the floor, or ``method="studentized"`` with a custom
             ``statistic``. One exception type across every input check —
             ``UserInputError`` is the repo's user-facing shape.
@@ -312,17 +309,11 @@ def bootstrap_mean_ci(
             expected="at least 2 observations to resample",
             docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
         )
-    if n_bootstrap < BOOTSTRAP_RESAMPLES_FLOOR:
-        raise UserInputError(
-            func_name="bootstrap_mean_ci",
-            field="n_bootstrap",
-            value=n_bootstrap,
-            expected=(
-                f"at least {BOOTSTRAP_RESAMPLES_FLOOR} resamples — below that "
-                f"the interval endpoints are resampling noise"
-            ),
-            docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
-        )
+    _check_n_resamples(
+        n_resamples,
+        func_name="bootstrap_mean_ci",
+        docs_path="api/stats#factrix.stats.bootstrap_mean_ci",
+    )
     if statistic is not None and method == "studentized":
         raise UserInputError(
             func_name="bootstrap_mean_ci",
@@ -340,7 +331,7 @@ def bootstrap_mean_ci(
         block_length = _resolve_auto_block_length(values)
     resamples = stationary_bootstrap_resamples(
         values,
-        n_bootstrap=n_bootstrap,
+        n_resamples=n_resamples,
         block_length=block_length,
         seed=seed,
     )

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -396,12 +396,12 @@ def romano_wolf_adjusted_p(
         bootstrap_use = np.abs(bootstrap)
 
     desc_order = np.argsort(-observed_use, kind="stable")
-    n_bootstrap = bootstrap_use.shape[0]
+    n_resamples = bootstrap_use.shape[0]
     observed_desc = observed_use[desc_order]
     bootstrap_desc = bootstrap_use[:, desc_order]
     max_remaining = np.maximum.accumulate(bootstrap_desc[:, ::-1], axis=1)[:, ::-1]
     exceedances = np.sum(max_remaining >= observed_desc, axis=0)
-    p_initial = (exceedances + 1.0) / (n_bootstrap + 1.0)
+    p_initial = (exceedances + 1.0) / (n_resamples + 1.0)
     p_adj_desc = np.maximum.accumulate(p_initial)
     np.minimum(p_adj_desc, 1.0, out=p_adj_desc)
 

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -215,15 +215,15 @@ class TestStationaryBootstrap:
         assert set(result.metadata) == {
             "block_length",
             "n_resamples",
-            "scheme",
-            "rng_seed",
+            "p_value_mc_se",
+            "seed",
             "studentized",
         }
         # overlap_periods must be part of the replay: the member floors the
         # resolved block length at the overlap horizon, so a replay without
         # it reproduces a different (shorter-block) bootstrap.
         p_replay, _ = _block_bootstrap_diff_p(
-            series, overlap_periods=5, rng_seed=result.metadata["rng_seed"]
+            series, overlap_periods=5, seed=result.metadata["seed"]
         )
         assert result.p_value == p_replay
         assert result.metadata["block_length"] >= 5
@@ -349,7 +349,7 @@ class TestStationaryBootstrapHonoursTheHorizon:
         for _ in range(n_reps):
             vals = self._overlapping_null(120, 21, rng)
             p, _ = _block_bootstrap_diff_p(
-                vals, overlap_periods=21, n_resamples=299, rng_seed=0
+                vals, overlap_periods=21, n_resamples=299, seed=0
             )
             rejects += p < 0.05
         # Was 0.277 with the horizon discarded and an unstudentized root.

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -1,4 +1,4 @@
-"""Tests for ``factrix._stats.bootstrap`` (Künsch / PR / PW)."""
+"""Tests for ``factrix._stats.bootstrap`` (Politis-Romano / Politis-White)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from factrix._stats.bootstrap import (
     _block_bootstrap_diff_p,
-    _fixed_block_indices,
     _politis_white_block_length,
     _stationary_block_indices,
 )
@@ -19,7 +18,7 @@ class TestPolitisWhiteBlockLength:
         # IID series: optimal block length should be small (< T^(1/3) * something).
         rng = np.random.default_rng(seed=0)
         x = rng.standard_normal(size=500)
-        L = _politis_white_block_length(x, scheme="stationary")
+        L = _politis_white_block_length(x)
         assert 1.0 <= L <= 50.0  # generous upper bound for IID
 
     def test_persistent_returns_longer_block(self):
@@ -30,24 +29,11 @@ class TestPolitisWhiteBlockLength:
         x[0] = rng.standard_normal()
         for t in range(1, n):
             x[t] = 0.7 * x[t - 1] + rng.standard_normal()
-        L_persist = _politis_white_block_length(x, scheme="stationary")
+        L_persist = _politis_white_block_length(x)
         # Generate matched-length IID and compare.
         x_iid = rng.standard_normal(size=n)
-        L_iid = _politis_white_block_length(x_iid, scheme="stationary")
+        L_iid = _politis_white_block_length(x_iid)
         assert L_persist > L_iid
-
-    def test_fixed_smaller_than_stationary(self):
-        # PW eq 9 vs 12: D_CB = (4/3)·g(0)² > D_SB = 2·g(0)²? No — 4/3 < 2,
-        # so fixed L = (2G²/D_CB)^(1/3) > stationary L. Verify direction.
-        rng = np.random.default_rng(seed=2)
-        n = 400
-        x = np.empty(n)
-        x[0] = rng.standard_normal()
-        for t in range(1, n):
-            x[t] = 0.5 * x[t - 1] + rng.standard_normal()
-        L_sb = _politis_white_block_length(x, scheme="stationary")
-        L_cb = _politis_white_block_length(x, scheme="fixed")
-        assert L_cb >= L_sb
 
     def test_fallback_on_short_series(self):
         # n=3 < 4 → fallback to 1.75 * n^(1/3).
@@ -57,11 +43,6 @@ class TestPolitisWhiteBlockLength:
     def test_fallback_on_zero_variance(self):
         L = _politis_white_block_length(np.zeros(100))
         assert pytest.approx(max(1.0, 1.75 * 100 ** (1.0 / 3.0))) == L
-
-    def test_rejects_unknown_scheme(self):
-        rng = np.random.default_rng(seed=7)
-        with pytest.raises(ValueError, match="scheme must be"):
-            _politis_white_block_length(rng.standard_normal(200), scheme="other")  # type: ignore[arg-type]
 
 
 class TestPolitisWhiteUpperBound:
@@ -111,50 +92,6 @@ class TestPolitisWhiteUpperBound:
         assert 1.0 < L < np.ceil(min(3 * np.sqrt(300), 100))
 
 
-class TestFixedBlockIndices:
-    def test_shape_and_range(self):
-        rng = np.random.default_rng(seed=0)
-        idx = _fixed_block_indices(100, 50, block_length=5, rng=rng)
-        assert idx.shape == (50, 100)
-        assert idx.min() >= 0 and idx.max() < 100
-
-    def test_block_contiguity(self):
-        # Within each block of length L, indices should be consecutive
-        # modulo n. Sample one resample.
-        rng = np.random.default_rng(seed=42)
-        n, L = 50, 4
-        idx = _fixed_block_indices(n, 1, block_length=L, rng=rng)[0]
-        # Each block of length L (except maybe last) should have
-        # idx[t+1] = (idx[t] + 1) % n.
-        n_full_blocks = len(idx) // L
-        for b in range(n_full_blocks):
-            block = idx[b * L : (b + 1) * L]
-            diffs = (block[1:] - block[:-1]) % n
-            assert np.all(diffs == 1)
-
-    def test_rejects_zero_block_length(self):
-        rng = np.random.default_rng()
-        with pytest.raises(ValueError, match="invalid block_length"):
-            _fixed_block_indices(10, 5, block_length=0, rng=rng)
-
-    def test_rejects_block_length_at_or_past_the_sample(self):
-        """L >= n makes every resample a rotation of the whole series, so
-        the centred bootstrap mean is identically 0 and p == 1/(B+1) on any
-        data. Refuse rather than return the strongest possible significance
-        from a validation-parameter typo."""
-        rng = np.random.default_rng()
-        for bad in (11, 30, 40):
-            with pytest.raises(ValueError, match="invalid block_length"):
-                _fixed_block_indices(30, 5, block_length=bad, rng=rng)
-        # ceil(min(3*sqrt(30), 30/3)) == 10 is the last admissible value.
-        assert _fixed_block_indices(30, 5, block_length=10, rng=rng).shape == (5, 30)
-
-    def test_empty(self):
-        rng = np.random.default_rng()
-        idx = _fixed_block_indices(0, 5, block_length=3, rng=rng)
-        assert idx.shape == (5, 0)
-
-
 class TestStationaryBlockIndices:
     def test_shape_and_range(self):
         rng = np.random.default_rng(seed=0)
@@ -193,7 +130,7 @@ class TestStudentizedDiffP:
         # particular, large p on a series with mean ≈ 0.
         rng = np.random.default_rng(seed=0)
         diff = rng.standard_normal(size=200)  # mean ≈ 0
-        p, _meta = _block_bootstrap_diff_p(diff, n_resamples=499, rng_seed=0)
+        p, _meta = _block_bootstrap_diff_p(diff, n_resamples=499, seed=0)
         assert 0.0 < p <= 1.0
         # mean ≈ 0 → not significant.
         assert p > 0.1
@@ -201,36 +138,22 @@ class TestStudentizedDiffP:
     def test_power_under_strong_alt(self):
         rng = np.random.default_rng(seed=1)
         diff = rng.standard_normal(size=200) + 0.5  # strong positive shift
-        p, _ = _block_bootstrap_diff_p(diff, n_resamples=499, rng_seed=0)
+        p, _ = _block_bootstrap_diff_p(diff, n_resamples=499, seed=0)
         assert p < 0.01
 
     def test_seed_recorded_when_none(self):
         diff = np.array([0.1, -0.2, 0.3, -0.1, 0.2, 0.0, -0.05, 0.15])
-        _p, meta = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=None)
-        assert isinstance(meta["rng_seed"], int)
-        assert meta["rng_seed"] >= 0
+        _p, meta = _block_bootstrap_diff_p(diff, n_resamples=199, seed=None)
+        assert isinstance(meta["seed"], int)
+        assert meta["seed"] >= 0
         assert meta["n_resamples"] == 199
 
     def test_explicit_seed_reproducible(self):
         diff = np.array([0.3, -0.1, 0.4, -0.2, 0.1, 0.05, -0.15, 0.2, 0.0, 0.1])
-        p1, m1 = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=123)
-        p2, m2 = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=123)
+        p1, m1 = _block_bootstrap_diff_p(diff, n_resamples=199, seed=123)
+        p2, m2 = _block_bootstrap_diff_p(diff, n_resamples=199, seed=123)
         assert p1 == p2
-        assert m1["rng_seed"] == m2["rng_seed"] == 123
-
-    def test_fixed_scheme(self):
-        rng = np.random.default_rng(seed=2)
-        diff = rng.standard_normal(size=100) + 0.4
-        p_fixed, m_fixed = _block_bootstrap_diff_p(
-            diff,
-            block_length=5,
-            scheme="fixed",
-            n_resamples=499,
-            rng_seed=0,
-        )
-        assert p_fixed < 0.05
-        assert m_fixed["scheme"] == "fixed"
-        assert m_fixed["block_length"] == 5
+        assert m1["seed"] == m2["seed"] == 123
 
     def test_stationary_auto_block_length_is_not_discretized(self):
         """The stationary L is a geometric MEAN, so it must stay fractional.
@@ -246,10 +169,10 @@ class TestStudentizedDiffP:
         for t in range(1, 300):
             x[t] = 0.6 * x[t - 1] + rng.standard_normal()
 
-        expected = _politis_white_block_length(x, scheme="stationary")
+        expected = _politis_white_block_length(x)
         assert expected != round(expected), "fixture must exercise a fractional L"
 
-        _p, meta = _block_bootstrap_diff_p(x, n_resamples=199, rng_seed=0)
+        _p, meta = _block_bootstrap_diff_p(x, n_resamples=199, seed=0)
         assert meta["block_length"] == pytest.approx(expected)
 
     def test_stationary_auto_matches_period_inference(self):
@@ -260,34 +183,14 @@ class TestStudentizedDiffP:
         rounded it first, so the two re-sampled the same series with
         different effective block lengths.
         """
-        from factrix.slicing.period_inference import _SCHEME
-
         rng = np.random.default_rng(seed=11)
         x = np.empty(300)
         x[0] = rng.standard_normal()
         for t in range(1, 300):
             x[t] = 0.6 * x[t - 1] + rng.standard_normal()
 
-        _p, meta = _block_bootstrap_diff_p(
-            x, n_resamples=199, rng_seed=0, scheme=_SCHEME
-        )
-        assert meta["block_length"] == pytest.approx(
-            _politis_white_block_length(x, scheme=_SCHEME)
-        )
-
-    def test_fixed_auto_block_length_stays_integral(self):
-        """The fixed scheme's L IS a block size, so rounding is correct there."""
-        rng = np.random.default_rng(seed=7)
-        x = np.empty(300)
-        x[0] = rng.standard_normal()
-        for t in range(1, 300):
-            x[t] = 0.6 * x[t - 1] + rng.standard_normal()
-
-        _p, meta = _block_bootstrap_diff_p(
-            x, n_resamples=199, rng_seed=0, scheme="fixed"
-        )
-        L = meta["block_length"]
-        assert int(L) == L
+        _p, meta = _block_bootstrap_diff_p(x, n_resamples=199, seed=0)
+        assert meta["block_length"] == pytest.approx(_politis_white_block_length(x))
 
     def test_short_series_withholds_the_test(self):
         """n < 2 admits no test. NaN, not 1.0: an untestable sample is not
@@ -302,7 +205,7 @@ class TestStudentizedDiffP:
     def test_p_floor_smoothing(self):
         # p should never be exactly 0 (Davison-Hinkley smoothing).
         diff = np.full(100, 100.0)  # huge mean → all bootstrap means 0
-        p, _ = _block_bootstrap_diff_p(diff, n_resamples=99, rng_seed=0)
+        p, _ = _block_bootstrap_diff_p(diff, n_resamples=99, seed=0)
         assert p == pytest.approx(1.0 / 100.0)
 
 
@@ -313,7 +216,7 @@ class TestRejectsNonFinite:
         significance — so a NaN must be refused, not tolerated."""
         diff = np.array([0.1, 0.2, float("nan"), 0.3, 0.1, 0.2])
         with pytest.raises(ValueError, match="finite"):
-            _block_bootstrap_diff_p(diff, rng_seed=0)
+            _block_bootstrap_diff_p(diff, seed=0)
 
     def test_politis_white_falls_back_on_nan(self):
         x = np.array([0.1, float("nan"), 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
@@ -341,10 +244,10 @@ class TestStudentizedRoot:
 
         rng = np.random.default_rng(0)
         diff = rng.standard_normal(120)
-        p, meta = _block_bootstrap_diff_p(diff, n_resamples=199, rng_seed=7)
+        p, meta = _block_bootstrap_diff_p(diff, n_resamples=199, seed=7)
         assert meta["studentized"] is True
 
-        L = _politis_white_block_length(diff, scheme="stationary")
+        L = _politis_white_block_length(diff)
         assert meta["block_length"] == pytest.approx(L)
         idx = _stationary_block_indices(120, 199, L, np.random.default_rng(7))
         resamples = (diff - diff.mean())[idx]
@@ -376,13 +279,13 @@ class TestStudentizedRoot:
         rng = np.random.default_rng(2)
         for n in (6, 20, 120):
             _, meta = _block_bootstrap_diff_p(
-                rng.standard_normal(n), n_resamples=99, rng_seed=0
+                rng.standard_normal(n), n_resamples=99, seed=0
             )
             assert meta["studentized"] is True
 
     def test_degenerate_series_falls_back_to_the_raw_mean_root(self):
         """A zero-dispersion series leaves no SE to divide by."""
-        _, meta = _block_bootstrap_diff_p(np.full(40, 2.0), n_resamples=99, rng_seed=0)
+        _, meta = _block_bootstrap_diff_p(np.full(40, 2.0), n_resamples=99, seed=0)
         assert meta["studentized"] is False
 
     @pytest.mark.parametrize(("n", "phi"), [(120, 0.5), (500, 0.8)])
@@ -398,10 +301,10 @@ class TestStudentizedRoot:
         studentized = plain = 0
         for _ in range(n_reps):
             diff = self._ar1(n, phi, rng)
-            p, _ = _block_bootstrap_diff_p(diff, n_resamples=299, rng_seed=1)
+            p, _ = _block_bootstrap_diff_p(diff, n_resamples=299, seed=1)
             studentized += p < 0.05
             # Same draws, unstudentized root (the pre-fix behaviour).
-            L = _politis_white_block_length(diff, scheme="stationary")
+            L = _politis_white_block_length(diff)
             idx = _stationary_block_indices(n, 299, L, np.random.default_rng(1))
             boot = (diff - diff.mean())[idx].mean(axis=1)
             p_plain = (np.sum(np.abs(boot) >= abs(diff.mean())) + 1.0) / 300.0
@@ -415,7 +318,7 @@ class TestOverlapHorizonFloor:
         rng = np.random.default_rng(3)
         diff = rng.standard_normal(200)
         _, meta = _block_bootstrap_diff_p(
-            diff, overlap_periods=21, n_resamples=99, rng_seed=0
+            diff, overlap_periods=21, n_resamples=99, seed=0
         )
         assert meta["block_length"] >= 21
 
@@ -426,7 +329,7 @@ class TestOverlapHorizonFloor:
         rng = np.random.default_rng(3)
         diff = rng.standard_normal(30)
         _, meta = _block_bootstrap_diff_p(
-            diff, overlap_periods=100, n_resamples=99, rng_seed=0
+            diff, overlap_periods=100, n_resamples=99, seed=0
         )
         assert meta["block_length"] == _max_block_length(30)
 
@@ -434,9 +337,9 @@ class TestOverlapHorizonFloor:
         rng = np.random.default_rng(3)
         diff = rng.standard_normal(200)
         _, floored = _block_bootstrap_diff_p(
-            diff, overlap_periods=1, n_resamples=99, rng_seed=0
+            diff, overlap_periods=1, n_resamples=99, seed=0
         )
-        _, plain = _block_bootstrap_diff_p(diff, n_resamples=99, rng_seed=0)
+        _, plain = _block_bootstrap_diff_p(diff, n_resamples=99, seed=0)
         assert floored["block_length"] == plain["block_length"]
 
 

--- a/tests/stats/test_bootstrap.py
+++ b/tests/stats/test_bootstrap.py
@@ -16,9 +16,7 @@ from factrix.stats.bootstrap import (
 class TestResolveAutoBlockLength:
     def test_vector_matches_politis_white(self):
         x = np.random.default_rng(0).standard_normal(200)
-        assert _resolve_auto_block_length(x) == _politis_white_block_length(
-            x, scheme="stationary"
-        )
+        assert _resolve_auto_block_length(x) == _politis_white_block_length(x)
 
     def test_matrix_takes_max_of_per_column_estimates(self):
         rng = np.random.default_rng(0)
@@ -30,15 +28,15 @@ class TestResolveAutoBlockLength:
         values = np.column_stack([iid, persistent])
 
         expected = max(
-            _politis_white_block_length(iid, scheme="stationary"),
-            _politis_white_block_length(persistent, scheme="stationary"),
+            _politis_white_block_length(iid),
+            _politis_white_block_length(persistent),
         )
         assert _resolve_auto_block_length(values) == expected
 
     def test_zero_column_matrix_falls_back_like_degenerate_series(self):
         assert _resolve_auto_block_length(
             np.empty((10, 0))
-        ) == _politis_white_block_length(np.zeros(10), scheme="stationary")
+        ) == _politis_white_block_length(np.zeros(10))
 
 
 class TestStationaryBootstrapResamples:
@@ -46,7 +44,7 @@ class TestStationaryBootstrapResamples:
         x = np.arange(100, dtype=float)
         resamples = stationary_bootstrap_resamples(
             x,
-            n_bootstrap=50,
+            n_resamples=50,
             seed=0,
         )
         assert resamples.shape == (50, 100)
@@ -55,7 +53,7 @@ class TestStationaryBootstrapResamples:
         x = np.arange(50, dtype=float)
         resamples = stationary_bootstrap_resamples(
             x,
-            n_bootstrap=20,
+            n_resamples=20,
             seed=0,
         )
         # Every draw must come from the original series.
@@ -63,8 +61,8 @@ class TestStationaryBootstrapResamples:
 
     def test_reproducible_with_seed(self):
         x = np.random.default_rng(0).standard_normal(200)
-        a = stationary_bootstrap_resamples(x, n_bootstrap=30, seed=42)
-        b = stationary_bootstrap_resamples(x, n_bootstrap=30, seed=42)
+        a = stationary_bootstrap_resamples(x, n_resamples=30, seed=42)
+        b = stationary_bootstrap_resamples(x, n_resamples=30, seed=42)
         np.testing.assert_array_equal(a, b)
 
     def test_matrix_columns_share_resampled_rows(self):
@@ -72,7 +70,7 @@ class TestStationaryBootstrapResamples:
         values = np.column_stack([base, 10.0 * base + 3.0])
         resamples = stationary_bootstrap_resamples(
             values,
-            n_bootstrap=20,
+            n_resamples=20,
             seed=42,
         )
         assert resamples.shape == (20, 40, 2)
@@ -83,13 +81,13 @@ class TestStationaryBootstrapResamples:
     def test_matrix_first_column_matches_vector_with_same_seed(self):
         base = np.arange(40, dtype=float)
         values = np.column_stack([base, -base])
-        vector = stationary_bootstrap_resamples(base, n_bootstrap=20, seed=42)
-        matrix = stationary_bootstrap_resamples(values, n_bootstrap=20, seed=42)
+        vector = stationary_bootstrap_resamples(base, n_resamples=20, seed=42)
+        matrix = stationary_bootstrap_resamples(values, n_resamples=20, seed=42)
         np.testing.assert_array_equal(matrix[:, :, 0], vector)
 
     def test_empty_matrix_preserves_column_axis(self):
         resamples = stationary_bootstrap_resamples(
-            np.empty((0, 3)), n_bootstrap=5, seed=0
+            np.empty((0, 3)), n_resamples=5, seed=0
         )
         assert resamples.shape == (5, 0, 3)
 
@@ -114,13 +112,13 @@ class TestStationaryBootstrapResamples:
 
         iid = stationary_bootstrap_resamples(
             x,
-            n_bootstrap=100,
+            n_resamples=100,
             block_length=1.0,
             seed=1,
         )
         block = stationary_bootstrap_resamples(
             x,
-            n_bootstrap=100,
+            n_resamples=100,
             block_length=30.0,
             seed=1,
         )
@@ -135,7 +133,7 @@ class TestStationaryBootstrapResamples:
         x = rng.standard_normal(500) + 0.2
         resamples = stationary_bootstrap_resamples(
             x,
-            n_bootstrap=1000,
+            n_resamples=1000,
             seed=0,
         )
         # Grand mean across all resamples ≈ sample mean.
@@ -145,29 +143,29 @@ class TestStationaryBootstrapResamples:
         with pytest.raises(ValueError, match="block_length"):
             stationary_bootstrap_resamples(
                 np.arange(10.0),
-                n_bootstrap=5,
+                n_resamples=5,
                 block_length=0.5,
             )
 
     def test_rejects_unsupported_shape(self):
         with pytest.raises(ValueError, match=r"shape \(T,\) or \(T, m\)"):
-            stationary_bootstrap_resamples(np.ones((2, 3, 4)), n_bootstrap=5)
+            stationary_bootstrap_resamples(np.ones((2, 3, 4)), n_resamples=5)
 
-    @pytest.mark.parametrize("n_bootstrap", [0, -1, True, 2.5])
-    def test_rejects_invalid_resample_count(self, n_bootstrap):
+    @pytest.mark.parametrize("n_resamples", [0, -1, True, 2.5])
+    def test_rejects_invalid_resample_count(self, n_resamples):
         with pytest.raises(ValueError, match="positive integer"):
-            stationary_bootstrap_resamples(np.arange(10.0), n_bootstrap=n_bootstrap)
+            stationary_bootstrap_resamples(np.arange(10.0), n_resamples=n_resamples)
 
     def test_rejects_non_finite_values(self):
         with pytest.raises(ValueError, match="finite"):
-            stationary_bootstrap_resamples(np.array([[1.0, np.nan]]), n_bootstrap=5)
+            stationary_bootstrap_resamples(np.array([[1.0, np.nan]]), n_resamples=5)
 
 
 class TestBootstrapMeanCI:
     def test_basic_ci_brackets_sample_mean(self):
         rng = np.random.default_rng(0)
         x = rng.standard_normal(300) + 0.1
-        lo, hi, point = bootstrap_mean_ci(x, n_bootstrap=500, seed=1)
+        lo, hi, point = bootstrap_mean_ci(x, n_resamples=500, seed=1)
         assert lo < point < hi
         # Narrow range — 300 iid normals give CI ≈ ±0.11.
         assert hi - lo < 0.5
@@ -177,7 +175,7 @@ class TestBootstrapMeanCI:
         x = rng.standard_normal(200)
         lo, hi, point = bootstrap_mean_ci(
             x,
-            n_bootstrap=300,
+            n_resamples=300,
             seed=2,
             statistic=np.median,
             method="percentile",
@@ -231,11 +229,11 @@ class TestBootstrapMeanCIStudentized:
 
         rng = np.random.default_rng(5)
         x = rng.standard_normal(150)
-        result = bootstrap_mean_ci(x, n_bootstrap=499, seed=9)
+        result = bootstrap_mean_ci(x, n_resamples=499, seed=9)
 
         L = _resolve_auto_block_length(x)
         resamples = stationary_bootstrap_resamples(
-            x, n_bootstrap=499, block_length=L, seed=9
+            x, n_resamples=499, block_length=L, seed=9
         )
         point = float(x.mean())
         se_obs = float(_batch_means_se(x, L)[0])
@@ -253,8 +251,8 @@ class TestBootstrapMeanCIStudentized:
         studentized = percentile = 0
         for i in range(n_sims):
             x = self._ar1(100, 0.8, rng)
-            s = bootstrap_mean_ci(x, n_bootstrap=299, seed=i)
-            p = bootstrap_mean_ci(x, n_bootstrap=299, seed=i, method="percentile")
+            s = bootstrap_mean_ci(x, n_resamples=299, seed=i)
+            p = bootstrap_mean_ci(x, n_resamples=299, seed=i, method="percentile")
             studentized += s.low <= 0 <= s.high
             percentile += p.low <= 0 <= p.high
         assert studentized >= percentile
@@ -266,7 +264,7 @@ class TestBootstrapMeanCIStudentized:
         covered = 0
         for i in range(n_sims):
             x = rng.standard_normal(200)
-            result = bootstrap_mean_ci(x, n_bootstrap=299, seed=i)
+            result = bootstrap_mean_ci(x, n_resamples=299, seed=i)
             covered += result.low <= 0 <= result.high
         assert 0.90 <= covered / n_sims <= 0.99
 
@@ -281,8 +279,8 @@ class TestBootstrapMeanCIValidation:
     def test_rejects_too_few_resamples(self):
         """B=1 returned (3.4, 3.4, 4.5) — a point estimate outside its own CI."""
         rng = np.random.default_rng(0)
-        with pytest.raises(UserInputError, match="at least 200 resamples"):
-            bootstrap_mean_ci(rng.standard_normal(50), n_bootstrap=1)
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            bootstrap_mean_ci(rng.standard_normal(50), n_resamples=1)
 
     def test_rejects_block_length_at_or_past_the_sample(self):
         """L >= T made every resample a rotation and the CI zero-width."""
@@ -296,5 +294,5 @@ class TestBootstrapMeanCIValidation:
             bootstrap_mean_ci(rng.standard_normal(50), statistic=np.median)
 
     def test_constant_series_gives_a_degenerate_interval_not_a_crash(self):
-        result = bootstrap_mean_ci(np.full(50, 2.0), n_bootstrap=200, seed=0)
+        result = bootstrap_mean_ci(np.full(50, 2.0), n_resamples=200, seed=0)
         assert result == (2.0, 2.0, 2.0)

--- a/tests/stats/test_resample_knobs.py
+++ b/tests/stats/test_resample_knobs.py
@@ -1,0 +1,222 @@
+"""The shared bootstrap resampling contract: ``n_resamples`` / ``seed``.
+
+Every entry point that turns a resample count into a *reported inference*
+takes the same two knobs under the same names, defaults to 999, and refuses
+a count below ``BOOTSTRAP_RESAMPLES_FLOOR`` with the same exception. These
+tests hold that contract across all four together, so a fifth entry point
+cannot be added with its own spelling of the same knob.
+
+``stationary_bootstrap_resamples`` is deliberately outside the floor: it
+returns draws and claims no inference on them.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+import pytest
+from factrix._errors import UserInputError
+from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR, _empirical_p
+from factrix.inference import StationaryBootstrap
+from factrix.metrics import ic, monotonicity
+from factrix.slicing import slice_period_joint_test, slice_period_pairwise_test
+from factrix.stats import bootstrap_mean_ci, stationary_bootstrap_resamples
+
+from tests._slice_panel import build_disjoint_period_panel
+
+
+def _ic_series(n: int = 80):
+    from datetime import datetime, timedelta
+
+    import polars as pl
+
+    vals = np.random.default_rng(0).standard_normal(n) * 0.05
+    dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame({"date": dates, "ic": vals}).with_columns(
+        pl.col("date").cast(pl.Datetime("ms"))
+    )
+
+
+def _mono_panel():
+    import factrix as fx
+
+    return fx.preprocess.compute_forward_return(
+        fx.datasets.make_cs_panel(n_assets=40, n_dates=120, seed=3),
+        forward_periods=1,
+    )
+
+
+def _regime_panel():
+    return build_disjoint_period_panel(
+        seed=1, spans={"bull": (60, 0.1), "bear": (60, 0.1)}, label_col="regime"
+    )
+
+
+def test_the_floor_is_the_smallest_davison_hinkley_grid_point() -> None:
+    """199, not 200: p lives on the ``1/(B+1)`` grid and ``alpha*(B+1)``
+    must be an integer (Davidson-MacKinnon), so 199 / 399 / 999 are the
+    admissible counts and 199 is the smallest of them."""
+    assert BOOTSTRAP_RESAMPLES_FLOOR == 199
+    for alpha in (0.05, 0.10):
+        assert (alpha * (BOOTSTRAP_RESAMPLES_FLOOR + 1)) % 1 == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    ("func", "param"),
+    [
+        (StationaryBootstrap, "n_resamples"),
+        (monotonicity, "n_resamples"),
+        (bootstrap_mean_ci, "n_resamples"),
+        (stationary_bootstrap_resamples, "n_resamples"),
+        (slice_period_pairwise_test, "n_resamples"),
+        (slice_period_joint_test, "n_resamples"),
+    ],
+    ids=[
+        "stationary_bootstrap",
+        "monotonicity",
+        "bootstrap_mean_ci",
+        "stationary_bootstrap_resamples",
+        "slice_pairwise",
+        "slice_joint",
+    ],
+)
+def test_resample_count_is_spelled_n_resamples_and_defaults_to_999(
+    func: object, param: str
+) -> None:
+    sig = inspect.signature(func)  # type: ignore[arg-type]
+    assert param in sig.parameters, f"{func} does not expose {param}"
+    assert sig.parameters[param].default == 999
+    assert sig.parameters["seed"].default is None
+
+
+@pytest.mark.parametrize("bad", [0, 1, BOOTSTRAP_RESAMPLES_FLOOR - 1])
+class TestFloorIsEnforcedAtEveryInferenceEntryPoint:
+    def test_stationary_bootstrap(self, bad: int) -> None:
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            StationaryBootstrap(n_resamples=bad)
+
+    def test_ic_through_the_inference_member(self, bad: int) -> None:
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            ic(_ic_series(), overlap_periods=1, inference=StationaryBootstrap(bad))
+
+    def test_monotonicity(self, bad: int) -> None:
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            monotonicity(_mono_panel(), n_resamples=bad, seed=0)
+
+    def test_bootstrap_mean_ci(self, bad: int) -> None:
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            bootstrap_mean_ci(np.arange(50.0), n_resamples=bad)
+
+    def test_slice_period_pairwise_test(self, bad: int) -> None:
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            slice_period_pairwise_test(
+                _regime_panel(),
+                ic(),
+                by="regime",
+                factor_col="factor",
+                n_resamples=bad,
+            )
+
+    def test_slice_period_joint_test(self, bad: int) -> None:
+        with pytest.raises(UserInputError, match="at least 199 resamples"):
+            slice_period_joint_test(
+                _regime_panel(),
+                ic(),
+                by="regime",
+                factor_col="factor",
+                n_resamples=bad,
+            )
+
+
+def test_resample_draws_are_deliberately_not_floored() -> None:
+    """``stationary_bootstrap_resamples`` returns draws, not an inference,
+    so it stays outside the floor — only a non-positive count is refused."""
+    out = stationary_bootstrap_resamples(np.arange(30.0), 5, seed=0)
+    assert out.shape == (5, 30)
+
+
+class TestIcSurfacesTheBootstrapKnobs:
+    def test_configured_member_is_reproducible_and_reports_its_knobs(self) -> None:
+        df = _ic_series()
+        member = StationaryBootstrap(n_resamples=399, seed=7)
+        a = ic(df, overlap_periods=1, inference=member)
+        b = ic(df, overlap_periods=1, inference=member)
+        assert a.p_value == b.p_value
+        assert a.metadata["n_resamples"] == 399
+        assert a.metadata["seed"] == 7
+        assert a.metadata["p_value_mc_se"] == pytest.approx(
+            float(np.sqrt(a.p_value * (1.0 - a.p_value) / 399)), rel=1e-6
+        )
+
+    def test_an_unseeded_run_reports_the_resolved_seed(self) -> None:
+        result = ic(
+            _ic_series(),
+            overlap_periods=1,
+            inference=StationaryBootstrap(n_resamples=199),
+        )
+        assert isinstance(result.metadata["seed"], int)
+        assert result.metadata["seed"] >= 0
+
+    def test_a_configured_member_is_still_allowlisted(self) -> None:
+        """The allowlist is by method, not by configuration: a knob-carrying
+        member must not be rejected for differing from the default value."""
+        assert not np.isnan(
+            ic(
+                _ic_series(),
+                overlap_periods=1,
+                inference=StationaryBootstrap(n_resamples=199, seed=1),
+            ).value
+        )
+
+
+class TestSlicePeriodTestsAreReproducible:
+    def test_pairwise(self) -> None:
+        panel = _regime_panel()
+        kw = dict(by="regime", factor_col="factor", n_resamples=199, seed=3)
+        a = slice_period_pairwise_test(panel, ic(), **kw)
+        b = slice_period_pairwise_test(panel, ic(), **kw)
+        assert a["p_raw"].to_list() == b["p_raw"].to_list()
+
+    def test_joint(self) -> None:
+        panel = _regime_panel()
+        kw = dict(by="regime", factor_col="factor", n_resamples=199, seed=3)
+        a = slice_period_joint_test(panel, ic(), **kw)
+        b = slice_period_joint_test(panel, ic(), **kw)
+        assert a["p_value"].to_list() == b["p_value"].to_list()
+
+    def test_n_resamples_sets_the_p_grid(self) -> None:
+        """``p_raw`` is a Davison-Hinkley p, so ``p*(B+1)`` is an integer."""
+        panel = _regime_panel()
+        out = slice_period_pairwise_test(
+            panel, ic(), by="regime", factor_col="factor", n_resamples=199, seed=3
+        )
+        for p in out["p_raw"].to_list():
+            assert p is not None
+            assert (p * 200) == pytest.approx(round(p * 200))
+
+
+class TestEmpiricalP:
+    def test_davison_hinkley_smoothing(self) -> None:
+        p, _se = _empirical_p(0, 999)
+        assert p == pytest.approx(1 / 1000)
+        p, _se = _empirical_p(999, 999)
+        assert p == pytest.approx(1.0)
+
+    def test_monte_carlo_se_matches_hardcoded_analytic_values(self) -> None:
+        """Hardcoded so a wrong-but-self-consistent formula (say ``/(B+1)``)
+        fails here rather than being re-derived from the value under test.
+        ``sqrt(.05*.95/999) = 0.006895`` is the ~0.7pp the docstrings quote.
+        """
+        p, se = _empirical_p(49, 999)
+        assert p == pytest.approx(0.05)
+        assert se == pytest.approx(0.006895, abs=1e-6)
+
+        p, se = _empirical_p(199, 399)
+        assert p == pytest.approx(0.5)
+        assert se == pytest.approx(0.025031, abs=1e-6)
+
+    def test_se_shrinks_as_one_over_sqrt_b(self) -> None:
+        _p, se_small = _empirical_p(9, 199)
+        _p, se_large = _empirical_p(99, 1999)
+        assert se_small / se_large == pytest.approx(np.sqrt(1999 / 199), rel=0.02)

--- a/tests/test_expected_warnings_metric_echoes.py
+++ b/tests/test_expected_warnings_metric_echoes.py
@@ -424,7 +424,7 @@ class TestHighTieRatio:
 
     @pytest.mark.parametrize(
         "label, metric",
-        [("ks", k_spread(k=5)), ("mono", monotonicity(n_groups=3, n_bootstrap=200))],
+        [("ks", k_spread(k=5)), ("mono", monotonicity(n_groups=3, n_resamples=199))],
     )
     def test_declared_is_quiet_but_recorded_on_the_other_bucket_metrics(
         self, label, metric
@@ -434,7 +434,7 @@ class TestHighTieRatio:
         )
 
     @pytest.mark.parametrize(
-        "metric", [k_spread(k=5), monotonicity(n_groups=3, n_bootstrap=200)]
+        "metric", [k_spread(k=5), monotonicity(n_groups=3, n_resamples=199)]
     )
     def test_undeclared_other_bucket_metrics_still_echo(self, metric):
         _assert_undeclared_still_echoes(

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -38,15 +38,15 @@ class TestComputeMonotonicity:
         draw at 0 while the observed J sits above it, so p is the floor
         ``1 / (B + 1)``.
         """
-        n_bootstrap = 200
+        n_resamples = 199
         result = monotonicity(
             self._perfect(noisy_panel),
             overlap_periods=1,
             n_groups=5,
-            n_bootstrap=n_bootstrap,
+            n_resamples=n_resamples,
             seed=0,
         )["factor"]
-        assert result.p_value == pytest.approx(1 / (n_bootstrap + 1))
+        assert result.p_value == pytest.approx(1 / (n_resamples + 1))
         assert result.alternative == "greater"
         assert result.stat == result.value
         assert result.metadata["stat_type"] == "mr"
@@ -84,11 +84,11 @@ class TestComputeMonotonicity:
             overlap_periods=1,
             n_groups=5,
             direction="decreasing",
-            n_bootstrap=200,
+            n_resamples=199,
             seed=0,
         )["factor"]
         assert result.value > 0
-        assert result.p_value == pytest.approx(1 / 201)
+        assert result.p_value == pytest.approx(1 / 200)
         assert result.metadata["mr_direction"] == "decreasing"
 
     def test_insufficient_periods(self):
@@ -324,7 +324,7 @@ class TestPattonTimmermannMRTest:
                 panel,
                 overlap_periods=1,
                 n_groups=n_groups,
-                n_bootstrap=200,
+                n_resamples=199,
                 seed=rep,
             )["factor"]
             rejections += result.p_value < 0.05
@@ -338,7 +338,7 @@ class TestPattonTimmermannMRTest:
 
         panel = self._null_panel(n_dates=60, n_assets=20, seed=3)
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=4, n_bootstrap=200, seed=2
+            panel, overlap_periods=1, n_groups=4, n_resamples=199, seed=2
         )["factor"]
         diffs = np.asarray(result.metadata["mr_adjacent_diffs"])
         assert len(diffs) == 3  # n_groups - 1 adjacent steps
@@ -347,15 +347,15 @@ class TestPattonTimmermannMRTest:
 
     def test_bootstrap_is_reproducible_and_reports_its_seed(self):
         panel = self._null_panel(n_dates=60, n_assets=20, seed=4)
-        kwargs = {"overlap_periods": 1, "n_groups": 4, "n_bootstrap": 200}
+        kwargs = {"overlap_periods": 1, "n_groups": 4, "n_resamples": 199}
         a = monotonicity(panel, seed=7, **kwargs)["factor"]
         b = monotonicity(panel, seed=7, **kwargs)["factor"]
         assert a.p_value == b.p_value
-        assert a.metadata["bootstrap_seed"] == 7
+        assert a.metadata["seed"] == 7
         # An unseeded run resolves one and reports it, so the run stays
         # reproducible after the fact.
         c = monotonicity(panel, **kwargs)["factor"]
-        assert isinstance(c.metadata["bootstrap_seed"], int)
+        assert isinstance(c.metadata["seed"], int)
 
     def test_monotone_signal_is_detected(self):
         from datetime import datetime, timedelta
@@ -380,7 +380,7 @@ class TestPattonTimmermannMRTest:
             }
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=5, n_bootstrap=200, seed=5
+            panel, overlap_periods=1, n_groups=5, n_resamples=199, seed=5
         )["factor"]
         assert result.value > 0
         assert result.p_value < 0.05
@@ -408,7 +408,7 @@ class TestTieRatioCountsFiniteValuesOnly:
                 )
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=3, n_bootstrap=200, seed=0
+            panel, overlap_periods=1, n_groups=3, n_resamples=199, seed=0
         )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.0)
 
@@ -432,7 +432,7 @@ class TestTieRatioCountsFiniteValuesOnly:
                 )
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = monotonicity(
-            panel, overlap_periods=1, n_groups=3, n_bootstrap=200, seed=0
+            panel, overlap_periods=1, n_groups=3, n_resamples=199, seed=0
         )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.0)
 
@@ -457,7 +457,7 @@ class TestTieRatioCountsFiniteValuesOnly:
         panel = pl.DataFrame(rows).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         with pytest.warns(UserWarning, match="tie_ratio"):
             result = monotonicity(
-                panel, overlap_periods=1, n_groups=3, n_bootstrap=200, seed=0
+                panel, overlap_periods=1, n_groups=3, n_resamples=199, seed=0
             )["factor"]
         assert result.metadata["tie_ratio"] == pytest.approx(0.8)
 
@@ -475,23 +475,7 @@ class TestMRArgumentValidation:
         from factrix.metrics.monotonicity import monotonicity
 
         with pytest.raises(UserInputError, match="direction"):
-            monotonicity(self._panel(), n_bootstrap=200, seed=0, direction="decrease")
-
-    def test_n_bootstrap_below_the_shared_inference_floor_is_rejected(self):
-        """The MR empirical p shares ``bootstrap_mean_ci``'s refusal floor.
-
-        Both report an inference drawn from the resamples, so both refuse a
-        resample count at which the reported number is resampling noise.
-        ``stationary_bootstrap_resamples`` is deliberately *not* gated — it
-        returns draws and claims no inference on them.
-        """
-        from factrix._errors import UserInputError
-        from factrix._stats.bootstrap import BOOTSTRAP_RESAMPLES_FLOOR
-        from factrix.metrics.monotonicity import monotonicity
-
-        for bad in (0, 1, BOOTSTRAP_RESAMPLES_FLOOR - 1):
-            with pytest.raises(UserInputError, match="at least 200"):
-                monotonicity(self._panel(), n_bootstrap=bad, seed=0)
+            monotonicity(self._panel(), n_resamples=199, seed=0, direction="decrease")
 
     def test_p_value_mc_se_is_reported_and_shrinks_with_resamples(self):
         """The reported p carries its own Monte-Carlo SE.
@@ -500,21 +484,16 @@ class TestMRArgumentValidation:
         different seed — the quantity a reader needs near a threshold. It is
         a property of the draw, not of the data, so it shrinks only in ``B``.
         """
-        from factrix._stats.bootstrap import bootstrap_p_mc_se
+        import numpy as np
         from factrix.metrics.monotonicity import monotonicity
 
-        # Hardcoded so a wrong-but-self-consistent formula (say /(B+1)) fails
-        # here rather than being re-derived from the value under test. This is
-        # the ~0.7pp the monotonicity docstring quotes.
-        assert bootstrap_p_mc_se(0.05, 1000) == pytest.approx(0.006892, abs=1e-6)
-        assert bootstrap_p_mc_se(0.5, 400) == pytest.approx(0.025, abs=1e-9)
-
         panel = self._panel()
-        small = monotonicity(panel, n_bootstrap=200, seed=0)["factor"]
-        large = monotonicity(panel, n_bootstrap=2000, seed=0)["factor"]
+        small = monotonicity(panel, n_resamples=199, seed=0)["factor"]
+        large = monotonicity(panel, n_resamples=1999, seed=0)["factor"]
 
-        for res, b in ((small, 200), (large, 2000)):
+        for res, b in ((small, 199), (large, 1999)):
+            p_hat = res.p_value
             assert res.metadata["p_value_mc_se"] == pytest.approx(
-                bootstrap_p_mc_se(res.p_value, b)
+                float(np.sqrt(p_hat * (1.0 - p_hat) / b))
             )
         assert large.metadata["p_value_mc_se"] < small.metadata["p_value_mc_se"]

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -39,7 +39,7 @@ def test_single_row_shape(method: str) -> None:
         label_col="regime",
     )
     out = slice_period_joint_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=1
+        df, ic(), by="regime", factor_col="factor", method=method, seed=1
     )
     assert out.height == 1
     assert out.columns == _JOINT_COLS
@@ -90,7 +90,7 @@ def test_two_slice_df_is_one(method: str) -> None:
         seed=2, spans={"a": (80, 0.1), "b": (80, 0.1)}, label_col="regime"
     )
     out = slice_period_joint_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=2
+        df, ic(), by="regime", factor_col="factor", method=method, seed=2
     )
     assert out["df_num"][0] == 1
 
@@ -103,7 +103,7 @@ def test_detects_difference(method: str) -> None:
         label_col="regime",
     )
     out = slice_period_joint_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=3
+        df, ic(), by="regime", factor_col="factor", method=method, seed=3
     )
     assert out["p_value"][0] < 0.05
 
@@ -124,10 +124,10 @@ def test_identical_signal_less_significant_than_split(method: str) -> None:
         seed=4, spans={"a": (200, 0.3), "b": (200, -0.2)}, label_col="regime"
     )
     p_same = slice_period_joint_test(
-        same, ic(), by="regime", factor_col="factor", method=method, rng_seed=4
+        same, ic(), by="regime", factor_col="factor", method=method, seed=4
     )["p_value"][0]
     p_split = slice_period_joint_test(
-        split, ic(), by="regime", factor_col="factor", method=method, rng_seed=4
+        split, ic(), by="regime", factor_col="factor", method=method, seed=4
     )["p_value"][0]
     assert p_same > p_split
 
@@ -141,10 +141,8 @@ def test_bootstrap_joint_is_bootstrap_native_for_two_slices() -> None:
     df = build_disjoint_period_panel(
         seed=11, spans={"a": (60, 0.15), "b": (60, 0.0)}, label_col="regime"
     )
-    pw = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=5
-    )
-    jt = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=5)
+    pw = slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=5)
+    jt = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", seed=5)
     # Both empirical with the same B → identical 1/(B+1) granularity.
     assert jt["p_value"][0] == pytest.approx(pw["p_raw"][0])
 
@@ -155,8 +153,8 @@ def test_bootstrap_reproducible_under_seed() -> None:
         spans={"a": (80, 0.1), "b": (80, -0.05), "c": (80, 0.0)},
         label_col="regime",
     )
-    a = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=42)
-    b = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=42)
+    a = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", seed=42)
+    b = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", seed=42)
     assert a["stat"][0] == b["stat"][0]
 
 
@@ -213,7 +211,7 @@ def test_raises_when_slice_below_metric_floor() -> None:
         seed=11, spans={"a": (30, 0.1), "b": (30, 0.1)}, label_col="regime"
     )
     with pytest.raises(ValueError, match="sample floor"):
-        slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng_seed=11)
+        slice_period_joint_test(df, ic(), by="regime", factor_col="factor", seed=11)
 
 
 class TestShortSliceDisclosure:
@@ -305,11 +303,11 @@ class TestFloorFollowsPanelStamp:
         )
         assert all(r.metrics["positive_rate"].n_obs == 20 for r in per_slice.values())
         joint = slice_period_joint_test(
-            panel, positive_rate(), by="regime", factor_col="factor", rng_seed=1
+            panel, positive_rate(), by="regime", factor_col="factor", seed=1
         )
         assert joint["k_slices"].item() == 2
         pairwise = slice_period_pairwise_test(
-            panel, positive_rate(), by="regime", factor_col="factor", rng_seed=1
+            panel, positive_rate(), by="regime", factor_col="factor", seed=1
         )
         assert pairwise.select("n_periods_a", "n_periods_b").row(0) == (20, 20)
 
@@ -342,7 +340,7 @@ class TestFloorFollowsPanelStamp:
             by="regime",
             factor_col="factor",
             overlap_periods=1,
-            rng_seed=1,
+            seed=1,
         )
         assert joint["k_slices"].item() == 2
         assert joint["min_periods"].item() == 10
@@ -352,7 +350,7 @@ class TestFloorFollowsPanelStamp:
             by="regime",
             factor_col="factor",
             overlap_periods=1,
-            rng_seed=1,
+            seed=1,
         )
         assert pairwise.select("n_periods_a", "n_periods_b").row(0) == (20, 20)
 
@@ -386,7 +384,7 @@ class TestFloorFollowsPanelStamp:
             by="regime",
             factor_col="factor",
             overlap_periods=1,
-            rng_seed=1,
+            seed=1,
         )
         assert joint["reason"].item() is None
         assert (
@@ -439,7 +437,7 @@ class TestNonStrict:
             seed=5, spans={"a": (60, 0.1), "b": (60, 0.1)}, label_col="regime"
         )
         out = slice_period_joint_test(
-            df, ic(), by="regime", factor_col="factor", rng_seed=1, strict=False
+            df, ic(), by="regime", factor_col="factor", seed=1, strict=False
         )
         row = out.row(0, named=True)
         assert row["reason"] is None
@@ -450,7 +448,7 @@ class TestNonStrict:
         df = build_disjoint_period_panel(
             seed=5, spans={"a": (60, 0.1), "b": (60, 0.1)}, label_col="regime"
         )
-        kw = dict(by="regime", factor_col="factor", rng_seed=1)
+        kw = dict(by="regime", factor_col="factor", seed=1)
         strict = slice_period_joint_test(df, ic(), **kw)
         loose = slice_period_joint_test(df, ic(), strict=False, **kw)
         assert strict.equals(loose)

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -42,7 +42,7 @@ def test_two_slice_returns_one_row(
         seed=1, spans={"bull": (60, 0.1), "bear": (60, 0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=1
+        df, ic(), by="regime", factor_col="factor", method=method, seed=1
     )
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS
@@ -133,9 +133,7 @@ def test_three_slice_returns_three_rows() -> None:
         spans={"bull": (60, 0.1), "bear": (60, 0.1), "flat": (60, 0.1)},
         label_col="regime",
     )
-    out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=2
-    )
+    out = slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=2)
     assert out.height == 3
     pairs = set(zip(out["slice_a"].to_list(), out["slice_b"].to_list(), strict=False))
     assert pairs == {("bull", "bear"), ("bull", "flat"), ("bear", "flat")}
@@ -146,9 +144,7 @@ def test_per_slice_period_counts_reported() -> None:
     df = build_disjoint_period_panel(
         seed=3, spans={"early": (50, 0.1), "late": (90, 0.1)}, label_col="regime"
     )
-    out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=3
-    )
+    out = slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=3)
     row = out.row(0, named=True)
     assert row["n_periods_a"] == 50
     assert row["n_periods_b"] == 90
@@ -159,9 +155,7 @@ def test_disjoint_dates_do_not_raise() -> None:
     df = build_disjoint_period_panel(
         seed=4, spans={"a": (50, 0.1), "b": (50, 0.1)}, label_col="regime"
     )
-    out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=4
-    )
+    out = slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=4)
     assert out.height == 1
     assert np.isfinite(out["stat"][0])
 
@@ -172,7 +166,7 @@ def test_detects_signal_difference(method: str) -> None:
         seed=5, spans={"hot": (200, 0.4), "cold": (200, -0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=5
+        df, ic(), by="regime", factor_col="factor", method=method, seed=5
     )
     assert out["p_raw"][0] < 0.05
 
@@ -183,7 +177,7 @@ def test_mean_diff_sign_matches_direction(method: str) -> None:
         seed=15, spans={"hot": (200, 0.4), "cold": (200, -0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=6
+        df, ic(), by="regime", factor_col="factor", method=method, seed=6
     )
     row = out.row(0, named=True)
     # mean_diff = μ_a − μ_b; positive iff slice_a is the higher-IC regime.
@@ -198,7 +192,7 @@ def test_p_adj_dominates_raw(method: str) -> None:
         label_col="regime",
     )
     out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", method=method, rng_seed=7
+        df, ic(), by="regime", factor_col="factor", method=method, seed=7
     )
     for raw, adj in zip(out["p_raw"].to_list(), out["p_adj"].to_list(), strict=False):
         assert adj >= raw - 1e-12
@@ -208,12 +202,8 @@ def test_bootstrap_reproducible_under_seed() -> None:
     df = build_disjoint_period_panel(
         seed=8, spans={"a": (80, 0.1), "b": (80, -0.05)}, label_col="regime"
     )
-    a = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=99
-    )
-    b = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=99
-    )
+    a = slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=99)
+    b = slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=99)
     assert a["stat"].to_list() == b["stat"].to_list()
     assert a["p_adj"].to_list() == b["p_adj"].to_list()
 
@@ -223,7 +213,7 @@ def test_fama_macbeth_metric_accepted() -> None:
         seed=9, spans={"x": (60, 0.1), "y": (60, 0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
-        df, fm_beta(), by="regime", factor_col="factor", rng_seed=9
+        df, fm_beta(), by="regime", factor_col="factor", seed=9
     )
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS
@@ -247,7 +237,7 @@ def test_caar_metric_accepted_for_event_regimes() -> None:
         .alias("regime")
     )
     out = slice_period_pairwise_test(
-        panel, caar(), by="regime", factor_col="factor_0000", rng_seed=9
+        panel, caar(), by="regime", factor_col="factor_0000", seed=9
     )
     assert out.height == 1
     assert out.columns == _PAIRWISE_COLS
@@ -326,9 +316,7 @@ def test_raises_when_slice_below_metric_floor() -> None:
         seed=18, spans={"a": (30, 0.1), "b": (30, 0.1)}, label_col="regime"
     )
     with pytest.raises(ValueError, match="sample floor"):
-        slice_period_pairwise_test(
-            df, ic(), by="regime", factor_col="factor", rng_seed=18
-        )
+        slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor", seed=18)
 
 
 def test_runs_at_metric_floor() -> None:
@@ -337,7 +325,7 @@ def test_runs_at_metric_floor() -> None:
         seed=19, spans={"a": (50, 0.1), "b": (60, 0.1)}, label_col="regime"
     )
     out = slice_period_pairwise_test(
-        df, ic(), by="regime", factor_col="factor", rng_seed=19
+        df, ic(), by="regime", factor_col="factor", seed=19
     )
     assert out.height == 1
 
@@ -364,7 +352,7 @@ def test_constant_slices_carry_nan_not_a_non_rejection(method: str):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         out = slice_period_pairwise_test(
-            df, ic(), by="regime", factor_col="factor", method=method, rng_seed=1
+            df, ic(), by="regime", factor_col="factor", method=method, seed=1
         )
     is_ab = (pl.col("slice_a") == "a") & (pl.col("slice_b") == "b")
     ab = out.filter(is_ab)
@@ -417,7 +405,7 @@ class TestNonStrict:
             by="regime",
             factor_col="factor",
             method=method,
-            rng_seed=1,
+            seed=1,
             strict=False,
         )
         assert out.columns == _PAIRWISE_COLS
@@ -442,7 +430,7 @@ class TestNonStrict:
         self, method: str
     ) -> None:
         panel = self._panel()
-        kw = dict(by="regime", factor_col="factor", method=method, rng_seed=1)
+        kw = dict(by="regime", factor_col="factor", method=method, seed=1)
         loose = slice_period_pairwise_test(panel, ic(), strict=False, **kw)
         only_valid = slice_period_pairwise_test(
             panel.filter(pl.col("regime") != "bear"), ic(), **kw


### PR DESCRIPTION
> **TL;DR** — 四條活的 bootstrap 推論入口統一為 `n_resamples` / `seed`、預設 999、下限 199、一個共用驗證器（`UserInputError`）與一個 `_empirical_p` helper（回傳 Davison–Hinkley 平滑 p 與其 Monte-Carlo SE）。`StationaryBootstrap` 首次可調 B 與固定 seed，`ic` 的 bootstrap 路徑因此可重現並回報 `p_value_mc_se`。一併移除無公開入口的 circular fixed scheme。**Breaking**（參數與 metadata 鍵改名、預設 1000→999、下限 200→199）。

Closes #910

## 對外契約
見 #908 top comment 的契約表與決策表；本 PR 逐條實作，DoD 全部達成（`grep -rn "n_bootstrap\|rng_seed\|_N_RESAMPLES\|bootstrap_seed\|scheme=\"fixed\""` 於 `factrix docs tests` 為空）。

## 三處偏離規格（實作者主動標出，審核後接受）
1. **`_check_applicable_inference` 改為精確型別比對**。規格漏了：allowlist 是 frozenset of *instances*，`StationaryBootstrap` 一有欄位，`StationaryBootstrap(seed=7)` 就不再等於 `STATIONARY_BOOTSTRAP`，`ic` 會拒絕自己 DoD 要求的呼叫。其他成員零欄位，值相等本就等價於型別相等；用 `type() in {…}` 而非 `isinstance` 防子類偷渡。
2. **`ic` 補上三個 metadata 鍵的資料流**（`n_resamples` / `seed` / `p_value_mc_se` 從 `InferenceResult.metadata` 轉出），規格未說明來源。
3. **MC SE 硬編值 0.006895 而非 0.006892**：`_empirical_p` 產生 p=0.05 的唯一方式是 `(49+1)/(999+1)`，分母是 B=999。分母用 B（非 B+1）是標準 plug-in；精確式 `sqrt(p(1-p)/B)·B/(B+1)` 只差 0.1%。

## 獨立驗證（審核者）
- seed 掃描 80 次：emp sd / `p_value_mc_se` = **1.03**（B=199）、**0.96**（B=999）
- `ic(inference=StationaryBootstrap(seed=s))`、`slice_period_pairwise_test` / `slice_period_joint_test(method="bootstrap", seed=s)` 同 seed 可重現、異 seed 有變
- `method="analytic"` 下 `n_resamples=50` 仍 raise：與「拒絕無意義值」一致，接受
- 移除 `_politis_white_block_length` 的 fixed 分支後 stationary 數值逐位元不變（實作者驗證；stationary 常數 `2·g0²` 未動）

## 驗證
`ruff check` / `ruff format --check` / `mypy factrix`（83 files）/ `mkdocs build --strict` 綠；全套 **3126 passed, 42 skipped**（+35 為新增的 `tests/stats/test_resample_knobs.py`）。