### PR TITLE
refactor(metrics)!: dispatch spread inference polymorphically and admit the stationary bootstrap

### DIFF
--- a/docs/api/metrics/k_spread.md
+++ b/docs/api/metrics/k_spread.md
@@ -39,8 +39,9 @@ title: factrix.metrics.k_spread
 
     ---
 
-    The headline test is the non-overlapping `t` on the strided spread
-    series (`_spread_significance`); with `n_assets < MIN_ASSETS_WARN`
+    The headline test is the one the `inference` member defines, run on the
+    strided or full spread series as that member declares; with
+    `n_assets < MIN_ASSETS_WARN`
     the metric attaches `few_assets` — the spread is a noisier estimate with
     few names per leg — and changes nothing else. `metadata["method"]`
     records the inference member that ran.
@@ -71,6 +72,18 @@ title: factrix.metrics.k_spread
     out = k_spread(panel, overlap_periods=5, k=3)
     print(out.value, out.metadata["method"], out.metadata["cross_sectional_dispersion"])
     # 0.0018  non-overlapping t-test  0.041   (approximate)
+
+    # A different inference member on the same metric. The stationary
+    # bootstrap keeps every period instead of striding and reports an
+    # empirical p, with the resampling knobs it ran with in metadata.
+    from factrix.inference import StationaryBootstrap
+
+    boot = k_spread(panel, overlap_periods=5, k=3,
+                    inference=StationaryBootstrap(seed=0))
+    print(boot.value, boot.p_value, boot.n_obs)
+    # 0.000443  0.248  174
+    print(boot.metadata["n_resamples"], boot.metadata["seed"])
+    # 999  0
     ```
 
 ## See also

--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -112,6 +112,20 @@ title: factrix.metrics.quantile
     print(vw.value, vw.stat)
     # 0.0020  8.85   (approximate — a VW spread well below EW would signal
     #                 that the EW result rests on small-cap names)
+
+    # Same metric, a different inference member. The stationary bootstrap
+    # makes no asymptotic-normality assumption, so it is the second read
+    # when the spread distribution is in doubt; it keeps every period
+    # (no stride) and reports an empirical p from B resamples.
+    from factrix.inference import StationaryBootstrap
+
+    boot = quantile_spread(panel, overlap_periods=5, n_groups=5,
+                           inference=StationaryBootstrap(seed=0))["factor"]
+    print(boot.value, boot.p_value, boot.n_obs)
+    # 0.001903  0.001  494
+    print(boot.metadata["n_resamples"], boot.metadata["seed"],
+          round(boot.metadata["p_value_mc_se"], 5))
+    # 999  0  0.001   (the Monte-Carlo error of the empirical p itself)
     ```
 
 ## See also

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -59,9 +59,9 @@ contrasts, not a sidecar to a primary value.
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | none — descriptive | — | mean bars per event |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | none — descriptive | — | mean leakage score |
 | [`monotonicity`][factrix.metrics.monotonicity.monotonicity] | Patton-Timmermann (2010) MR (stationary-bootstrap p) | `p_value` | `mr_min_diff` (min adjacent bucket-return difference) |
-| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | non-overlapping `t` on top-bottom spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
-| [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (NW HAC under `NEWEY_WEST`) | `p_value` | mean(spread) |
-| [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | non-overlap `t` (default) or NW HAC `t` on vw spread | `p_value` | mean(vw spread) |
+| [`quantile_spread`][factrix.metrics.quantile.quantile_spread] | non-overlapping `t` on top-bottom spread (NW HAC under `NEWEY_WEST`, empirical p under `STATIONARY_BOOTSTRAP`) | `p_value` | mean(spread) |
+| [`k_spread`][factrix.metrics.k_spread.k_spread] | non-overlapping `t` on top-K−bottom-K spread (NW HAC under `NEWEY_WEST`, empirical p under `STATIONARY_BOOTSTRAP`) | `p_value` | mean(spread) |
+| [`quantile_spread_vw`][factrix.metrics.quantile.quantile_spread_vw] | non-overlap `t` (default), NW HAC `t`, or bootstrap empirical p on vw spread | `p_value` | mean(vw spread) |
 | [`top_concentration`][factrix.metrics.concentration.top_concentration] | one-sided `t` on diversity ratio | `p_value` | mean(eff_n) = mean(1/HHI) |
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | none — descriptive | — | event-period Herfindahl-Hirschman index (HHI) |
 | [`mfe_mae`][factrix.metrics.mfe_mae.mfe_mae] | none — descriptive | — | MFE_p50 / \|MAE_p75\| |
@@ -458,7 +458,8 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 
 - *primary*: `p_value` — non-overlapping `t`-test on the
   (top − bottom) spread series (Newey-West HAC on the full series under
-  `inference=NEWEY_WEST`). Small cross-sections
+  `inference=NEWEY_WEST`, a block-bootstrap empirical p on the full
+  series under `inference=STATIONARY_BOOTSTRAP`). Small cross-sections
   (`median_cross_section < MIN_ASSETS_WARN`) attach `few_assets` and
   change nothing else; see the shared small-N note below.
 - *secondary-test*: `long_alpha`, `long_stat`, `long_p_value` —
@@ -472,7 +473,7 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
   overlapping series under `NEWEY_WEST`), `n_periods_strided` (the
   non-overlap count, always present), `median_cross_section` (median
   per-period count of finite factor values — what the small-N switch
-  reads), `tie_ratio`, `tie_policy`, `method`.
+  reads), `tie_ratio`, `tie_policy`, `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`), `method`.
 - *descriptive*: `n_periods_in`, `n_periods_out`, `n_dropped`,
   `drop_rate`, `drop_reason` — the null/NaN-drop bookkeeping on the
   **strided** spread series (`n_periods_in` also appears on the
@@ -489,8 +490,8 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 #### `quantile_spread_vw`
 
 Value-weighted variant. Same metadata shape as `quantile_spread` —
-including `median_cross_section`, `n_periods_strided` and whatever the
-selected inference member contributes — plus a `weights_lagged` flag
+including `median_cross_section`, `n_periods_strided`, `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`)
+and whatever the selected inference member contributes — plus a `weights_lagged` flag
 indicating whether the weighting input was lagged before the join
 (descriptive). It takes the same `inference=` knob off the same
 allowlist as `quantile_spread`, so the equal-weighted / value-weighted
@@ -514,7 +515,8 @@ Fixed-K (top-K − bottom-K) long-short spread; the small-N sibling of
 `quantile_spread`.
 
 - *primary*: `p_value` — non-overlapping `t`-test on the spread
-  series (`method` records the inference member that ran).
+  series (`method` records the inference member that ran, and
+  `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`) the statistic it reports).
 - *descriptive*: `k` (names per leg), `tie_ratio` / `tie_policy` (the
   same tie diagnostics `quantile_spread` and `monotonicity` report —
   the leg ranking used to be hard-coded `"ordinal"` with no tie ratio at

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -220,7 +220,7 @@ approximation assumption all three analytic methods still make:
 | **Newey-West (1987)** | Bartlett-kernel HAC on the full overlapping series, bandwidth `L = max(bandwidth_base, h−1)`. | Simple, deterministic, asymptotically valid for arbitrary autocorrelation up to `L`. | Asymptotic Gaussian — finite-sample size distortion when `h/T` is non-trivial; bandwidth rule is conservative. | `ic` / `quantile_spread` / `quantile_spread_vw` / `k_spread` (with `NeweyWest` inference), `fm_beta` stage 2, `pooled_beta`, `common_quantile_spread`, `common_asymmetry`. |
 | **Hansen-Hodrick (HH) (1980)** | A generalized method of moments (GMM)-style HAC estimator with a rectangular kernel truncated at `h−1`; the canonical reference for overlap-aware long-horizon SEs. | Targets the MA(`h−1`) residual structure overlap induces. | Rectangular kernel can yield a non-PSD covariance matrix in finite samples; still asymptotic. | Exposed as `factrix.inference.HANSEN_HODRICK` (rectangular-kernel SE → t-statistic → two-sided p-value), but deliberately in **no** metric's `applicable_inference` allowlist — passing it to a metric raises `IncompatibleInferenceError`. Also borrows the `h−1` lag idea as a floor on the NW bandwidth above. |
 | **Hodrick (1992) "1B"** | Reverse-regression: regress one-period return on the predictor sum `X_t = Σ x_{t-j}` over the last `h` periods. | Size-correct in finite samples even at large `h/T`; no bandwidth choice. | Coefficient interpretation differs — `β` is the response to a cumulative-predictor stimulus (MA on the RHS) rather than a long-horizon forecast slope (MA on the LHS in the standard form); not a drop-in replacement for the canonical `β`. | **Not implemented**. Cited as the right tool when overlap is severe; the `Individual × Continuous` cell side-steps the issue with non-overlapping resampling instead. |
-| **Stationary bootstrap (Politis-Romano 1994)** | Block-resamples the series (geometric block length, Politis-White 2004 automatic selection), centred under `H0`, studentizes both the observed and the resampled root by a batch-means SE at the same block length, and reports the empirical two-sided p from the resampled `t` ratios. | No normality or asymptotic-variance assumption at all — valid when the IC/return distribution is heavy-tailed or skewed enough that NW's / HH's Gaussian p-value is itself suspect. | Heavier to compute (resampling, not closed-form); the reported `stat` is the observed mean rather than the root the p is computed from. On a zero-dispersion sample there is no block SE to divide by, and the kernel falls back to the raw-mean root — reported as `metadata["studentized"] = False` and `degenerate_variance`. | Exposed as `factrix.inference.STATIONARY_BOOTSTRAP` on `ic` only — `quantile_spread` / `k_spread` dispatch on a hard `isinstance(NeweyWest)` check that would need to go polymorphic first. |
+| **Stationary bootstrap (Politis-Romano 1994)** | Block-resamples the series (geometric block length, Politis-White 2004 automatic selection), centred under `H0`, studentizes both the observed and the resampled root by a batch-means SE at the same block length, and reports the empirical two-sided p from the resampled `t` ratios. | No normality or asymptotic-variance assumption at all — valid when the IC/return distribution is heavy-tailed or skewed enough that NW's / HH's Gaussian p-value is itself suspect. | Heavier to compute (resampling, not closed-form); the reported `stat` is the observed mean rather than the root the p is computed from. On a zero-dispersion sample there is no block SE to divide by, and the kernel falls back to the raw-mean root — reported as `metadata["studentized"] = False` and `degenerate_variance`. | Exposed as `factrix.inference.STATIONARY_BOOTSTRAP` on `ic`, `quantile_spread`, `quantile_spread_vw` and `k_spread` — every one of them dispatches the member polymorphically, and the spread series carries its own measured size table (§6). |
 
 Practical rule of thumb:
 
@@ -682,6 +682,46 @@ and the regression kernels `_ols_nw_slope_t` / `_ols_nw_multivariate`
 would need their own measurement first — a vector series needs a VAR(1)
 fit and regression scores a different derivation.
 
+### Stationary bootstrap on the spread series: measured size
+
+`ic`'s size table is a table of the *IC* series. A long-short spread
+series is a different object — a cross-sectional bucket difference, not a
+rank correlation — so admitting `STATIONARY_BOOTSTRAP` to
+`quantile_spread` / `quantile_spread_vw` / `k_spread` needed its own
+measurement rather than an inherited one.
+
+True-null rejection rates at a nominal 5% on `quantile_spread`, measured
+on `make_cs_panel(n_assets=50, ic_target=0.0)` with
+`compute_forward_return(forward_periods=h)` and `overlap_periods=h`; 500
+replications per cell, `n_resamples=499`, base seed 20260830. Monte-Carlo
+standard error is ~1.0pp per cell. `T` counts periods on the evaluation
+grid before the stride.
+
+| T | h | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` |
+|---|---|---|---|
+| 60 | 1 | 0.074 | 0.082 |
+| 60 | 5 | 0.036 | 0.066 |
+| 60 | 21 | — | — |
+| 120 | 1 | 0.056 | 0.052 |
+| 120 | 5 | 0.054 | 0.072 |
+| 120 | 21 | 0.024 | 0.090 |
+| 240 | 1 | 0.046 | 0.048 |
+| 240 | 5 | 0.076 | 0.080 |
+| 240 | 21 | 0.036 | 0.068 |
+
+`T = 60, h = 21` is not measurable: the metric refuses that panel at its
+stride-scaled periods floor (`metric_unavailable`) rather than testing
+~2 effective periods, so there is no rejection rate to report.
+
+The bootstrap is calibrated-to-slightly-liberal across every measurable
+cell (4.8–9.0%) and never worse than the short-sample distortion already
+documented for the *t*. `NEWEY_WEST` is tighter at `h = 1` and
+conservative at long horizons (2.4–3.6% at `h = 21`), where the HAR
+effective df `T/h - 1` spends most of the sample. Neither dominates; both
+are reported, and the choice is the routing question the next section
+answers. A reduced-replication re-run of two cells guards the numbers in
+`tests/stats/test_spread_bootstrap_size.py`.
+
 ### Which path to read: a routing guide from the size measurements
 
 The measurements above and in §1 say where each inference path is
@@ -697,8 +737,8 @@ nominal 5%; sample sizes count periods on the evaluation grid after the
 |---|---|---|---|
 | Overlapping `forward_periods` panel, per-period series not persistent (the everyday case) | No warning | `NEWEY_WEST` 5–9% on real overlapping IC (h = 5, n = 240 / 480: 5.2% / 8.8%); `NON_OVERLAPPING` calibrated. | Keep the default member. |
 | Persistent per-period series (lag-1 φ ≥ 0.3 on the *tested* series) | `serial_correlation_detected` | No path is calibrated — NW 13–17%, stationary bootstrap 12–19%, plain *t* 32–34% at φ = 0.6 (table above). | Do **not** switch member; it moves the number without fixing it. Read the *t* against a raised hurdle (*t* > 3) or lengthen the sample. A coarser `overlap_periods` stride under `NON_OVERLAPPING` also helps mechanically — the strided sample sits at φ^h, and AR(0.6) strided at h = 21 measures 4.5%. |
-| Short strided series (fewer than ~120 periods after the stride) | `unreliable_se_short_periods`, or nothing on a moderately short series | The *t* / NW branch runs 7–9%. A block-bootstrap p is *worse* here — the spread metrics' former bootstrap branch (`_block_bootstrap_diff_p`, kernel-isolated on iid input) measured 13.6% at n = 12, 9.8% at 30, 7.4% at 60, reaching 5.2% only by 120 — and the strided series is short exactly when the horizon is long. | Stay on the analytic *t* / NW. Do not reach for the bootstrap to rescue a short sample; shorten the stride or lengthen the history instead. |
-| Long strided series (≥ ~120 periods) whose distribution is in doubt (heavy tails, skew) | No warning | On iid input `STATIONARY_BOOTSTRAP` sits at the same 7–9% baseline as NW (φ = 0 row above) — it buys no *size*. Its case is distributional: it is the only member that does not assume asymptotic normality of the mean (§1). | Read `STATIONARY_BOOTSTRAP` on `ic` alongside the analytic p when tails or skew are the doubt; the spread metrics keep `NON_OVERLAPPING` / `NEWEY_WEST` (their allowlist). A documented option, not a default. |
+| Short strided series (fewer than ~120 periods after the stride) | `unreliable_se_short_periods`, or nothing on a moderately short series | The *t* / NW branch runs 7–9%. A block-bootstrap p is *worse* here — the spread metrics' former automatic bootstrap branch (`_block_bootstrap_diff_p`, kernel-isolated on iid input) measured 13.6% at n = 12, 9.8% at 30, 7.4% at 60, reaching 5.2% only by 120 — and the strided series is short exactly when the horizon is long. The spread-series table above says the same at the short end: 8.2% at T = 60, h = 1. | Stay on the analytic *t* / NW. Do not reach for the bootstrap to rescue a short sample; shorten the stride or lengthen the history instead. |
+| Long strided series (≥ ~120 periods) whose distribution is in doubt (heavy tails, skew) | No warning | On iid input `STATIONARY_BOOTSTRAP` sits at the same 7–9% baseline as NW (φ = 0 row above) — it buys no *size*. On the spread series it measures 4.8–9.0% across the grid above, with its worst cell at the long horizon (9.0% at T = 120, h = 21) where NW is conservative instead (2.4%). Its case is distributional: it is the only member that does not assume asymptotic normality of the mean (§1). | Read `STATIONARY_BOOTSTRAP` alongside the analytic p — on `ic` and on all three spread metrics, which admit it on the strength of the table above — when tails or skew are the doubt. A documented option, not a default. |
 | Heavy-tailed *and* short | `unreliable_se_short_periods` | The *t* is size-robust to tails — 3–4% on t(3) input, i.e. conservative — while the small-n bootstrap is not (6–14%). | Keep the *t*. Tails are not a reason to bootstrap a short series. |
 | Thin cross-section (few names per leg) | `few_assets` | Each leg mean rests on a handful of names: a noisier estimate, not a differently-distributed one. The automatic bootstrap switch this once triggered rejected 8–20% against the *t*'s 7–9% and keyed on the wrong axis; it was removed. | Keep the requested member; read `n_assets` and treat the spread as fragile. |
 | Joint test on K ≥ 3 short slices | `slice_period_joint_test` warning | 8–9% for K = 5 on 50–90-period slices, converging by T ≈ 150; the bootstrap path inherits it (12%). K = 2 is calibrated throughout. | Read the pairwise contrasts on the same slices (5–6%) rather than the joint p, or lengthen the slices. |

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -60,35 +60,44 @@ type, not its value, so a configured ``StationaryBootstrap(n_resamples=,
 seed=)`` is admitted wherever the method is. A method outside the set
 raises :class:`~factrix.IncompatibleInferenceError` listing the allowed
 members, rather than running an unintended test or silently falling back
-to the default. ``quantile_spread`` / ``k_spread`` allow
-``{NON_OVERLAPPING, NEWEY_WEST}``; ``ic`` additionally allows
-``STATIONARY_BOOTSTRAP`` (see below); ``resolve_applicable_inference``
-reads the set back for discovery.
+to the default. ``ic`` / ``quantile_spread`` / ``quantile_spread_vw`` /
+``k_spread`` all allow ``{NON_OVERLAPPING, NEWEY_WEST,
+STATIONARY_BOOTSTRAP}``; ``resolve_applicable_inference`` reads the set
+back for discovery.
 
-``HANSEN_HODRICK`` / ``STATIONARY_BOOTSTRAP`` vs the metric allowlists
------------------------------------------------------------------------
-``HansenHodrick`` and ``StationaryBootstrap`` are complete series-mean
-members (same ``compute`` contract as the others), but neither is in
-every metric's ``applicable_inference``, for reasons that differ per
-dispatch style:
+The allowlist is a **vetting record, not a dispatch table**. Every
+``inference=``-bearing metric dispatches polymorphically — it calls
+``inference.compute(...)`` and reads the ``InferenceResult`` back — so it
+could in principle run any series-mean member. What the allowlist says is
+which members have been *measured on that metric's series*: the IC series
+and the long-short spread series have different distributions, so each
+carries its own size table (see ``reference/statistical-methods``) and
+each admits a member only on the strength of it.
 
-- ``ic`` dispatches **polymorphically** (``inference.compute(...)`` /
-  ``inference.min_input_periods(...)``), so it could in principle run
-  ``HANSEN_HODRICK`` — its allowlist is narrower than its capability. The
-  vetted HAC pair is kept: ``NeweyWest`` (Bartlett kernel, PSD-guaranteed) is
-  the recommended HAC, while ``HansenHodrick``'s rectangular kernel has no
-  PSD guarantee (it can clamp a negative variance — see
-  ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``). ``StationaryBootstrap``
-  runs through the same polymorphic path and *is* admitted — it makes no
-  asymptotic-variance assumption at all, so it is the recommended fallback
-  when the IC series is too short or too heavy-tailed for either HAC
-  member to be trusted.
-- ``quantile_spread`` / ``k_spread`` dispatch through
-  ``_spread_significance_with_inference``, which hard-branches on
-  ``isinstance(inference, NeweyWest)`` for the HAC path. The allowlist is
-  **load-bearing** there: it admits exactly the two members that dispatch
-  handles, so widening it to ``HANSEN_HODRICK`` or ``STATIONARY_BOOTSTRAP``
-  requires making that dispatch polymorphic first — not done here.
+``HANSEN_HODRICK`` vs the metric allowlists
+-------------------------------------------
+``HansenHodrick`` is a complete series-mean member (same ``compute``
+contract as the others) and is in no metric's ``applicable_inference``.
+The reason is statistical, not structural: its rectangular kernel has no
+PSD guarantee and can clamp a negative variance (see
+``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``), so the vetted HAC is
+``NeweyWest``'s PSD-guaranteed Bartlett kernel. ``StationaryBootstrap``
+*is* admitted everywhere the family is offered — it makes no
+asymptotic-variance assumption at all, so it is the recommended read when
+a series is too short or too heavy-tailed for a HAC member to be trusted.
+
+Who builds which series
+-----------------------
+Members differ in the series they consume, and each one declares that
+itself through the ``consumes_full_series`` ``ClassVar``:
+``NonOverlapping`` sub-samples, so a metric that already strided its own
+panel hands it the strided series; ``NeweyWest`` / ``HansenHodrick`` /
+``StationaryBootstrap`` correct or resample the dependence and need every
+period, so the metric builds the full overlapping series for them. The
+flag is series-mean-specific — a slice- or panel-shaped member has no
+"full series" to speak of — so it stays on the family's dataclasses and
+out of the base ``Inference`` Protocol, which constrains only the
+dimension-agnostic identity fields.
 """
 
 from __future__ import annotations

--- a/factrix/inference/_base.py
+++ b/factrix/inference/_base.py
@@ -6,7 +6,8 @@ labels. The Protocol constrains only the base identity ClassVars
 (``test`` / ``summary``); ``compute`` is deliberately **not** in the
 Protocol because its signature varies by target shape (series-mean /
 slice / panel) and a single Protocol cannot honestly cover all of them.
-Derived ClassVars (e.g. ``se``) are declared by downstream dataclasses as
+Derived ClassVars (e.g. ``se``, or the series-mean family's
+``consumes_full_series``) are declared by downstream dataclasses as
 needed, not hoisted into the base Protocol.
 
 ``InferenceResult`` is the harmonized return shape compute methods emit:

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -18,6 +18,12 @@ so the dataclasses take no *statistical* constructor knobs;
 ``StationaryBootstrap`` carries the two resampling knobs (``n_resamples``
 / ``seed``) that only the caller can decide.
 
+Each member also declares, through the ``consumes_full_series``
+``ClassVar``, whether it needs every period of the series or takes a
+pre-strided one: a metric that strides its own panel reads that flag to
+decide whether to pay for building the full overlapping series, instead
+of type-checking the member.
+
 These are metric-internal inference units: ``compute`` returns an
 ``InferenceResult`` whose ``stat`` / ``p_value`` feed a ``MetricResult``
 directly.
@@ -74,6 +80,9 @@ class NonOverlapping:
     se: ClassVar[str | None] = "ols"
     summary: ClassVar[str] = "non-overlapping t-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
+    # A metric that pre-strides its own panel hands this member the strided
+    # series directly; it needs no full overlapping series built for it.
+    consumes_full_series: ClassVar[bool] = False
 
     def min_input_periods(self, overlap_periods: int) -> int:
         """Minimum input series length (periods): need ``base · h`` rows to land ``base`` after striding."""
@@ -167,6 +176,10 @@ class NeweyWest:
     se: ClassVar[str | None] = "hac"
     summary: ClassVar[str] = "Newey-West HAC t-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
+    # Every observation is kept and the dependence is corrected for, so a
+    # metric that pre-strides its own panel must build the full overlapping
+    # series before calling ``compute``.
+    consumes_full_series: ClassVar[bool] = True
 
     def min_input_periods(self, overlap_periods: int) -> int:
         """Minimum input series length (periods) below which the HAC t-test cannot run."""
@@ -243,6 +256,10 @@ class HansenHodrick:
     se: ClassVar[str | None] = "hac"
     summary: ClassVar[str] = "Hansen-Hodrick HAC t-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
+    # Every observation is kept and the dependence is corrected for, so a
+    # metric that pre-strides its own panel must build the full overlapping
+    # series before calling ``compute``.
+    consumes_full_series: ClassVar[bool] = True
 
     def min_input_periods(self, overlap_periods: int) -> int:
         """Minimum input series length (periods) below which the HAC t-test cannot run."""
@@ -356,6 +373,10 @@ class StationaryBootstrap:
     se: ClassVar[str | None] = "bootstrap"
     summary: ClassVar[str] = "stationary-bootstrap empirical p-test"
     min_periods: ClassVar[int] = MIN_PERIODS_WARN
+    # Every observation is kept and the dependence is corrected for, so a
+    # metric that pre-strides its own panel must build the full overlapping
+    # series before calling ``compute``.
+    consumes_full_series: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         from factrix._stats.bootstrap import _check_n_resamples

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -34,11 +34,15 @@ from factrix._codes import WarningCode, cross_section_tier
 from factrix._errors import IncompatibleInferenceError
 
 if TYPE_CHECKING:
-    from factrix.inference import NeweyWest, NonOverlapping, StationaryBootstrap
+    from factrix.inference import (
+        InferenceResult,
+        NeweyWest,
+        NonOverlapping,
+        StationaryBootstrap,
+    )
     from factrix.metrics._base import MetricBase
 from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult, PValueAlternative
-from factrix._stats import _calc_t_stat, _p_value_from_t
 from factrix._types import DDOF, EPSILON, N_GROUPS_FLOOR, KPSource, SampleAxis
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
@@ -87,43 +91,6 @@ def _finite_values(series: pl.Series) -> pl.Series:
     return s.filter(s.is_finite())
 
 
-def _spread_significance(
-    spread: np.ndarray,
-    n_assets: int,
-) -> tuple[float, float, str, dict[str, object], tuple[str, ...]]:
-    """Headline significance for a per-period long-short spread series.
-
-    Returns ``(stat, p_value, method, extra_metadata, warning_codes)`` —
-    the non-overlapping ``t`` on the strided series, with the single
-    cross-section code (``FEW_ASSETS``) attached when
-    ``n_assets < MIN_ASSETS_WARN``. The warning is advisory: a thin
-    cross-section means each leg's mean rests on a handful of names, so the
-    spread is a noisier *estimate*, not a differently-distributed one.
-
-    An earlier version switched thin cross-sections to a block-bootstrap
-    CI on the grounds that few names per leg make the spread heavy-tailed
-    and the ``t`` unreliable. Measured, that was backwards on both counts.
-    The ``t``-test is size-robust to heavy tails — on t(3) input it rejects
-    3–4% at a nominal 5% — while the bootstrap p carries the usual small-n
-    distortion (iid input: 13.6% at ``n = 12``, 9.8% at 30, 7.4% at 60,
-    5.2% only by 120) and the strided spread series is short exactly when
-    ``overlap_periods`` is large. Through the public path the bootstrap
-    branch rejected 8–20% against the ``t`` branch's 7–9%. And the switch
-    keyed on the cross-section while the bootstrap's validity depends on
-    the number of periods, so it was effectively random which estimator a
-    panel got. Removing it returns the plain ``t`` that spread metrics
-    conventionally report; whether a long-series bootstrap route is worth
-    offering is a separate, larger routing question.
-    """
-    n = len(spread)
-    mean = float(np.mean(spread))
-    std = float(np.std(spread, ddof=DDOF))
-    t = _calc_t_stat(mean, std, n)
-    tier: WarningCode | None = cross_section_tier(n_assets)
-    codes = (tier.value,) if tier is not None else ()
-    return t, _p_value_from_t(t, n), "non-overlapping t-test", {}, codes
-
-
 def _check_applicable_inference(
     inference: object,
     applicable: frozenset[NonOverlapping | NeweyWest | StationaryBootstrap],
@@ -154,73 +121,134 @@ def _check_applicable_inference(
         )
 
 
+def _surface_inference_run_metadata(
+    result: InferenceResult, metadata: dict[str, object]
+) -> None:
+    """Copy the resampling knobs an ``Inference`` ran with into ``metadata``.
+
+    ``n_resamples`` / ``seed`` / ``p_value_mc_se`` are defined only by a
+    resampling member (``StationaryBootstrap``), and only that member emits
+    them. Surfacing them keeps a reported empirical p reproducible from the
+    result alone and puts its Monte-Carlo error next to it. Shared by ``ic``
+    and the spread chokepoint so both report the same three keys under the
+    same names.
+    """
+    for key in ("n_resamples", "seed", "p_value_mc_se"):
+        if key in result.metadata:
+            metadata[key] = result.metadata[key]
+
+
 def _spread_significance_with_inference(
-    inference: NonOverlapping | NeweyWest,
+    inference: NonOverlapping | NeweyWest | StationaryBootstrap,
     *,
-    strided_spread: np.ndarray,
+    strided_spread: pl.DataFrame,
     full_spread: pl.DataFrame | None,
     overlap_periods: int,
     n_assets: int,
-) -> tuple[float, float, float, str, dict[str, object], tuple[str, ...]]:
+) -> tuple[float, float, float, str, str, dict[str, object], tuple[str, ...]]:
     """Single headline-significance chokepoint shared by every spread metric.
 
-    Returns ``(value, stat, p_value, method, extra_metadata, warning_codes)``
-    where ``value`` is the mean-spread point estimate under the chosen
-    inference: the full-sample mean for the HAC path, the non-overlap mean
-    otherwise.
+    Returns ``(value, stat, p_value, method, stat_type, extra_metadata,
+    warning_codes)`` where ``value`` is the mean-spread point estimate over
+    the series the chosen member actually tested: the full overlapping series for a member
+    that consumes one, the strided series otherwise.
 
-    Both ``quantile_spread`` and ``k_spread`` route here so the policy
-    lives in one place. The requested member runs: ``NonOverlapping``
-    reproduces the non-overlap t **bit-for-bit** (``_t_stat_from_array`` is
-    the same ``_calc_t_stat`` formula on the same strided values, so the
-    default stays byte-identical), while ``NeweyWest`` keeps the *full*
-    overlapping ``full_spread`` series and HAC-corrects the MA(h-1) SE. A
-    thin cross-section (``n_assets < MIN_ASSETS_WARN``) attaches
-    ``FEW_ASSETS`` on either path and changes nothing else — the automatic
-    block-bootstrap fallback that used to override the requested member
-    there was removed after measurement (see :func:`_spread_significance`).
+    Both ``quantile_spread`` and ``k_spread`` route here so the policy lives
+    in one place, and the routing is the member's own declaration rather than
+    a type check here: ``Inference.consumes_full_series`` says whether the
+    member needs every period (it corrects or resamples the dependence
+    itself) or takes the pre-strided series (it sub-samples, and the metric's
+    panel-stride already did that). The chosen series then goes through the
+    ordinary ``compute(data, value_col=..., overlap_periods=...)`` call, the
+    same polymorphic path ``ic`` uses.
+
+    A pre-strided series is handed over with ``overlap_periods=1``: the
+    metric's panel-stride already broke the MA(h-1) overlap, and re-striding
+    it at ``h`` would sub-sample a second time. That also makes the member's
+    own stride bookkeeping a no-op, so it is not surfaced — the metric's
+    ``overlap_periods`` is the authority on the stride that was applied. This
+    keeps ``NonOverlapping`` **bit-for-bit** identical to the hard-branched
+    dispatch it replaced (same ``_calc_t_stat`` formula on the same values).
+
+    A thin cross-section (``n_assets < MIN_ASSETS_WARN``) attaches
+    ``FEW_ASSETS`` on either path and changes nothing else — the advisory
+    says each leg's mean rests on a handful of names, so the spread is a
+    noisier *estimate*, not a differently-distributed one.
+
+    An earlier version switched thin cross-sections to a block-bootstrap
+    CI on the grounds that few names per leg make the spread heavy-tailed
+    and the ``t`` unreliable. Measured, that was backwards on both counts.
+    The ``t``-test is size-robust to heavy tails — on t(3) input it rejects
+    3–4% at a nominal 5% — while the bootstrap p carries the usual small-n
+    distortion (iid input: 13.6% at ``n = 12``, 9.8% at 30, 7.4% at 60,
+    5.2% only by 120) and the strided spread series is short exactly when
+    ``overlap_periods`` is large. Through the public path the bootstrap
+    branch rejected 8–20% against the ``t`` branch's 7–9%. And the switch
+    keyed on the cross-section while the bootstrap's validity depends on
+    the number of periods, so it was effectively random which estimator a
+    panel got. That is why the bootstrap is offered as a member the caller
+    asks for by name — measured on the spread series, see the size table in
+    ``reference/statistical-methods`` — and never as an automatic switch.
 
     The two series inputs are a perf split, not duplicated logic: the cheap
     panel-stride feeds ``strided_spread`` for the common path; the full
-    series is built (h× more bucketing) only when the HAC path needs it.
-    ``full_spread`` is ``None`` off the HAC path; a missing one degrades to
-    the non-overlap path defensively and is flagged ``inference_overridden``.
+    series is built (h× more bucketing) only when the requested member
+    declares it consumes one. ``full_spread`` is ``None`` otherwise; a
+    missing one where the member needed it degrades to the strided
+    non-overlap path defensively and is flagged ``inference_overridden``.
     """
-    from factrix.inference import NeweyWest
+    from factrix.inference import NON_OVERLAPPING
 
-    strided_mean = float(np.mean(strided_spread))
-    use_hac = isinstance(inference, NeweyWest) and full_spread is not None
-    if not use_hac:
-        t, p, method, extra, codes = _spread_significance(strided_spread, n_assets)
-        if isinstance(inference, NeweyWest):
-            # Requested HAC but no full series was supplied — surface the
-            # degradation rather than report the non-overlap t as HAC.
-            extra = {
-                **extra,
-                "inference_requested": inference.summary,
-                "inference_overridden": True,
-            }
-        extra = {**extra, "n_periods_tested": len(strided_spread)}
-        return strided_mean, t, p, method, extra, codes
-
-    assert full_spread is not None  # narrowed by use_hac
-    res = inference.compute(
-        full_spread, value_col="spread", overlap_periods=overlap_periods
+    use_full = inference.consumes_full_series and full_spread is not None
+    member: NonOverlapping | NeweyWest | StationaryBootstrap = (
+        inference if use_full else NON_OVERLAPPING
     )
-    full_vals = _finite_values(full_spread["spread"])
-    full_mean = float(full_vals.mean())  # type: ignore[arg-type]
+    data = full_spread if use_full else strided_spread
+    assert data is not None  # narrowed by use_full
+    res = member.compute(
+        data, value_col="spread", overlap_periods=overlap_periods if use_full else 1
+    )
+    n_tested = res.n_obs if res.n_obs is not None else 0
+    # ``value`` must describe the sample the test ran on, and the member that
+    # ran is the only thing that knows what that sample was — a sub-sampling
+    # member tested the survivors of its own stride. So the headline estimate
+    # is always the member's, on every path.
+    mean_spread = res.estimate if res.estimate is not None else float("nan")
+
+    extra: dict[str, object]
+    if use_full:
+        extra = {**res.metadata, "n_periods_full": n_tested}
+    else:
+        extra = {}
+        _surface_inference_run_metadata(res, extra)
+        if inference.consumes_full_series:
+            # Requested a member that needs the full series but none was
+            # supplied — surface the degradation rather than report the
+            # strided non-overlap t under the requested method's name.
+            extra["inference_requested"] = inference.summary
+            extra["inference_overridden"] = True
     # ``n_periods_tested`` is the sample the stat / p / value describe: the
-    # full overlapping series here, the strided series on the other path.
-    extra = {
-        **res.metadata,
-        "n_periods_full": len(full_vals),
-        "n_periods_tested": len(full_vals),
-    }
+    # full overlapping series on one path, the strided series on the other.
+    extra["n_periods_tested"] = n_tested
+
     codes = tuple(code.value for code in res.warnings)
     tier: WarningCode | None = cross_section_tier(n_assets)
     if tier is not None and tier.value not in codes:
         codes = (*codes, tier.value)
-    return full_mean, res.stat, res.p_value, inference.summary, extra, codes
+    # ``method`` / ``stat_type`` describe the member that actually ran, not
+    # the one that was asked for: an ``inference_overridden`` degradation runs
+    # the non-overlap t and must say so, and a member whose ``stat`` is not a
+    # t-ratio (the bootstrap reports the observed mean under an empirical p)
+    # must not be read against a t-distribution.
+    return (
+        mean_spread,
+        res.stat,
+        res.p_value,
+        member.summary,
+        member.test,
+        extra,
+        codes,
+    )
 
 
 def _aggregate_to_per_date(

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -55,6 +55,7 @@ from factrix.metrics._helpers import (
     _read_drop_stats,
     _short_circuit_output,
     _surface_drop_stats,
+    _surface_inference_run_metadata,
     _warn_below_floor,
 )
 from factrix.metrics._metric_capabilities import per_date_series_rename
@@ -383,12 +384,10 @@ def ic(
         "method": inference.summary,
         "tie_ratio": median_tie,
     }
-    # Surface the resampling knobs the bootstrap path actually ran with (and
-    # only that path defines them), so a reported empirical p is reproducible
-    # from the result alone and its Monte-Carlo error is readable next to it.
-    for key in ("n_resamples", "seed", "p_value_mc_se"):
-        if key in result.metadata:
-            metadata[key] = result.metadata[key]
+    # Surface the resampling knobs the bootstrap path actually ran with —
+    # the same helper the spread chokepoint calls, so both report one set of
+    # keys under one set of names.
+    _surface_inference_run_metadata(result, metadata)
     _warn_if_few_ic_assets(
         ic_df, "ic", metadata, warning_codes, expected_warnings=expected_warnings
     )

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -40,7 +40,14 @@ from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
-from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
+from factrix.inference import (
+    NEWEY_WEST,
+    NON_OVERLAPPING,
+    STATIONARY_BOOTSTRAP,
+    NeweyWest,
+    NonOverlapping,
+    StationaryBootstrap,
+)
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _all_dates_degenerate,
@@ -63,12 +70,12 @@ __all__ = [
     "k_spread",
 ]
 
-# Inference allowlist: like ``quantile_spread``, the spread dispatch handles
-# exactly the non-overlap t-test and the Newey-West HAC; anything else
-# (``HansenHodrick``, a non-``Inference`` object) is rejected rather than
-# silently reported as non-overlap.
-applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
-    {NON_OVERLAPPING, NEWEY_WEST}
+# Inference allowlist: like ``quantile_spread``, a vetting record rather than a
+# dispatch constraint — the non-overlap t-test, the Newey-West HAC and the
+# stationary-bootstrap empirical p are the members measured on a spread series.
+# Anything else (``HansenHodrick``, a non-``Inference`` object) is rejected.
+applicable_inference: frozenset[NonOverlapping | NeweyWest | StationaryBootstrap] = (
+    frozenset({NON_OVERLAPPING, NEWEY_WEST, STATIONARY_BOOTSTRAP})
 )
 
 _K_SPREAD_PERIODS_FLOOR = _scaled_periods_threshold(MIN_PORTFOLIO_PERIODS_HARD)
@@ -192,7 +199,7 @@ def k_spread(
     factor_col: str = "factor",
     return_col: str = "forward_return",
     tie_policy: str = "ordinal",
-    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
+    inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
     r"""Fixed-K Top-K vs Bottom-K long-short spread.
@@ -401,12 +408,14 @@ def k_spread(
             tie_policy=tie_policy,
         )
 
-    arr = spread_vals.to_numpy()
-    # The HAC path needs the full overlapping spread series (every date);
+    strided_series = series.select("date", pl.col("spread").cast(pl.Float64)).filter(
+        _finite_expr("spread")
+    )
+    # A member that consumes the full overlapping series needs every period;
     # build it once on the unsampled panel. Non-finite spreads are filtered out
-    # before the HAC regression for the same reason ``arr`` is cleaned.
+    # before it for the same reason the strided series is cleaned.
     full_series: pl.DataFrame | None = None
-    if isinstance(inference, NeweyWest):
+    if inference.consumes_full_series:
         full_series, _ = _build_k_spread_series(
             data, k, factor_col, return_col, tie_policy
         )
@@ -416,10 +425,10 @@ def k_spread(
     # names, not the universe-wide unique asset count (see
     # ``_median_per_date_count``).
     median_xs = _median_per_date_count(clean)
-    mean_spread, t, p, sig_method, sig_extra, sig_codes = (
+    mean_spread, t, p, sig_method, sig_stat_type, sig_extra, sig_codes = (
         _spread_significance_with_inference(
             inference,
-            strided_spread=arr,
+            strided_spread=strided_series,
             full_spread=full_series,
             overlap_periods=overlap_periods,
             n_assets=median_xs,
@@ -448,7 +457,7 @@ def k_spread(
         "k": k,
         "tie_ratio": tie_ratio,
         "tie_policy": tie_policy,
-        "stat_type": "t",
+        "stat_type": sig_stat_type,
         "h0": "mu=0",
         "method": sig_method,
         "cross_sectional_dispersion": mean_dispersion,

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -36,7 +36,14 @@ from factrix._types import (
     DEFAULT_N_GROUPS,
     MIN_PORTFOLIO_PERIODS_HARD,
 )
-from factrix.inference import NEWEY_WEST, NON_OVERLAPPING, NeweyWest, NonOverlapping
+from factrix.inference import (
+    NEWEY_WEST,
+    NON_OVERLAPPING,
+    STATIONARY_BOOTSTRAP,
+    NeweyWest,
+    NonOverlapping,
+    StationaryBootstrap,
+)
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _all_dates_degenerate,
@@ -82,12 +89,14 @@ _Q_CELL = cell(
 # ``MIN_PORTFOLIO_PERIODS_HARD`` + ``_scaled_min_periods``, so the floors agree.
 _PORTFOLIO_PERIODS_FLOOR = _scaled_periods_threshold(MIN_PORTFOLIO_PERIODS_HARD)
 
-# Inference allowlist: the spread dispatch hard-branches on ``NeweyWest`` for the
-# HAC path and runs the non-overlap t-test otherwise, so the union is the exact
-# set it handles. Anything else (``HansenHodrick``, a non-``Inference`` object)
-# is rejected rather than silently reported as non-overlap.
-applicable_inference: frozenset[NonOverlapping | NeweyWest] = frozenset(
-    {NON_OVERLAPPING, NEWEY_WEST}
+# Inference allowlist: the vetted set, not a dispatch constraint — the spread
+# dispatch is polymorphic over any series-mean member. The non-overlap t-test,
+# the Bartlett-kernel Newey-West HAC and the stationary-bootstrap empirical p
+# are measured on the spread series (see the size table in
+# ``reference/statistical-methods``). ``HansenHodrick`` (rectangular kernel, no
+# PSD guarantee) is deliberately excluded, as is any non-``Inference`` object.
+applicable_inference: frozenset[NonOverlapping | NeweyWest | StationaryBootstrap] = (
+    frozenset({NON_OVERLAPPING, NEWEY_WEST, STATIONARY_BOOTSTRAP})
 )
 
 
@@ -154,7 +163,7 @@ def quantile_spread(
     n_groups: int = DEFAULT_N_GROUPS,
     factor_cols: Sequence[str] = ("factor",),
     tie_policy: str = "ordinal",
-    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
+    inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     *,
     expected_warnings: tuple[str, ...] = (),
     _precomputed_series: dict[str, pl.DataFrame] | None = None,
@@ -270,8 +279,9 @@ def quantile_spread(
             expected_warnings=expected_warnings,
         )
     )
-    # The HAC path needs the full overlapping spread series (every date);
-    # ``overlap_periods=1`` is the no-stride build of the same primitive.
+    # A member that consumes the full overlapping series needs every period;
+    # ``overlap_periods=1`` is the no-stride build of the same primitive. The
+    # member declares that itself, so this build is not keyed on its type.
     full_series_by_factor: dict[str, pl.DataFrame] | None = (
         compute_spread_series(
             data,
@@ -281,7 +291,7 @@ def quantile_spread(
             overlap_periods=1,
             expected_warnings=expected_warnings,
         )
-        if isinstance(inference, NeweyWest)
+        if inference.consumes_full_series
         else None
     )
     # Raw (pre-sampling) date count: the axis the stride-scaled periods floor is
@@ -313,7 +323,7 @@ def _quantile_spread_from_series(
     n_raw_periods: int,
     factor_col: str,
     tie_policy: str,
-    inference: NonOverlapping | NeweyWest,
+    inference: NonOverlapping | NeweyWest | StationaryBootstrap,
     overlap_periods: int,
     n_groups: int,
     full_series: pl.DataFrame | None,
@@ -380,8 +390,10 @@ def _quantile_spread_from_series(
         tie_policy,
         expected_warnings=expected_warnings,
     )
-    arr = spread_vals.to_numpy()
-    # Headline test: ``inference`` selects non-overlap t vs Newey-West HAC.
+    strided_series = series.select("date", pl.col("spread").cast(pl.Float64)).filter(
+        _finite_expr("spread")
+    )
+    # Headline test: ``inference`` selects the member; the chokepoint routes it.
     # ``mean_spread`` is the full-sample mean under HAC, the non-overlap mean
     # otherwise. The FEW_ASSETS advisory keys on the median *per-period*
     # finite-factor count, not the universe-wide unique asset count: how many
@@ -393,10 +405,10 @@ def _quantile_spread_from_series(
     clean_full_series = (
         full_series.filter(_finite_expr("spread")) if full_series is not None else None
     )
-    mean_spread, t, p, sig_method, sig_extra, sig_codes = (
+    mean_spread, t, p, sig_method, sig_stat_type, sig_extra, sig_codes = (
         _spread_significance_with_inference(
             inference,
-            strided_spread=arr,
+            strided_spread=strided_series,
             full_spread=clean_full_series,
             overlap_periods=overlap_periods,
             n_assets=n_assets,
@@ -433,7 +445,7 @@ def _quantile_spread_from_series(
         "median_cross_section": n_assets,
         "n_groups": n_groups,
         "overlap_periods": overlap_periods,
-        "stat_type": "t",
+        "stat_type": sig_stat_type,
         "h0": "mu=0",
         "method": sig_method,
         "long_alpha": mean_long,
@@ -567,7 +579,7 @@ def quantile_spread_vw(
     return_col: str = "forward_return",
     weight_col: str = "market_cap",
     tie_policy: str = "ordinal",
-    inference: NonOverlapping | NeweyWest = NON_OVERLAPPING,
+    inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     lag_weights: bool = True,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
@@ -775,15 +787,17 @@ def quantile_spread_vw(
         tie_policy,
         expected_warnings=expected_warnings,
     )
-    arr = spread_vals.to_numpy()
+    strided_series = vw_series.select(
+        "date", pl.col("spread_vw").cast(pl.Float64).alias("spread")
+    ).filter(_finite_expr("spread"))
     # Same headline chokepoint as the equal-weighted sibling, so the pair is
     # tested the same way on the same date set: ``NON_OVERLAPPING`` reproduces
-    # the previous strided t bit-for-bit, ``NEWEY_WEST`` keeps every date and
-    # HAC-corrects the MA(h-1) overlap. The FEW_ASSETS advisory rides along on
-    # the median per-period finite-factor count.
+    # the previous strided t bit-for-bit, a member that consumes the full
+    # series keeps every date. The FEW_ASSETS advisory rides along on the
+    # median per-period finite-factor count.
     n_assets = _median_finite_cross_section(sampled, factor_col)
     full_series = None
-    if isinstance(inference, NeweyWest):
+    if inference.consumes_full_series:
         full_panel = _lag_within_asset(data, weight_col) if lag_weights else data
         full_series = _vw_spread_series(
             full_panel,
@@ -795,10 +809,10 @@ def quantile_spread_vw(
         ).select("date", pl.col("spread_vw").alias("spread"))
         full_series = full_series.filter(_finite_expr("spread"))
 
-    mean_spread, t, p, sig_method, sig_extra, sig_codes = (
+    mean_spread, t, p, sig_method, sig_stat_type, sig_extra, sig_codes = (
         _spread_significance_with_inference(
             inference,
-            strided_spread=arr,
+            strided_spread=strided_series,
             full_spread=full_series,
             overlap_periods=overlap_periods,
             n_assets=n_assets,
@@ -817,7 +831,7 @@ def quantile_spread_vw(
         "n_groups": n_groups,
         "overlap_periods": overlap_periods,
         "method": sig_method,
-        "stat_type": "t",
+        "stat_type": sig_stat_type,
         "h0": "mu=0",
         "tie_ratio": tie_ratio,
         "tie_policy": tie_policy,

--- a/tests/stats/test_spread_bootstrap_size.py
+++ b/tests/stats/test_spread_bootstrap_size.py
@@ -1,0 +1,91 @@
+"""Null size of ``STATIONARY_BOOTSTRAP`` on a long-short spread series.
+
+``ic``'s bootstrap size table measures the IC series; a spread series is a
+cross-sectional bucket difference with a different distribution, so
+admitting the member to ``quantile_spread`` / ``quantile_spread_vw`` /
+``k_spread`` rests on its own measurement. The full 3x3 grid
+(``T`` in {60, 120, 240} x ``h`` in {1, 5, 21}, 500 replications per cell,
+``n_resamples=499``, base seed 20260830) is recorded in
+``reference/statistical-methods`` section 6; measured there, the bootstrap
+rejects 4.8-9.0% at a nominal 5% across every measurable cell and
+``NEWEY_WEST`` 2.4-7.6%.
+
+This module re-runs two of those cells at a cut replication count so the
+suite stays fast: the bounds characterise the result rather than pin it,
+and the Monte-Carlo standard error at 120 replications is ~2pp.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import factrix as fx
+import pytest
+from factrix.inference import NEWEY_WEST, StationaryBootstrap
+from factrix.metrics.quantile import quantile_spread
+from factrix.preprocess import compute_forward_return
+
+N_ASSETS = 50
+N_REPS = 120
+N_RESAMPLES = 499
+BASE_SEED = 20260830
+NOMINAL = 0.05
+
+
+def _rejection_rates(n_periods: int, overlap_periods: int) -> tuple[float, float]:
+    """(Newey-West, stationary-bootstrap) rejection rate on a zero-signal panel."""
+    rejected = {"nw": 0, "sb": 0}
+    tested = 0
+    for rep in range(N_REPS):
+        seed = BASE_SEED + 1000 * rep + 7 * overlap_periods + n_periods
+        raw = fx.datasets.make_cs_panel(
+            n_assets=N_ASSETS,
+            n_dates=n_periods + overlap_periods,
+            ic_target=0.0,
+            seed=seed,
+        )
+        panel = compute_forward_return(raw, forward_periods=overlap_periods)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            nw = quantile_spread(
+                panel, overlap_periods=overlap_periods, inference=NEWEY_WEST
+            )["factor"]
+            sb = quantile_spread(
+                panel,
+                overlap_periods=overlap_periods,
+                inference=StationaryBootstrap(n_resamples=N_RESAMPLES, seed=seed),
+            )["factor"]
+        tested += 1
+        rejected["nw"] += nw.p_value < NOMINAL
+        rejected["sb"] += sb.p_value < NOMINAL
+    return rejected["nw"] / tested, rejected["sb"] / tested
+
+
+@pytest.mark.parametrize(
+    ("n_periods", "overlap_periods"),
+    [(120, 5), (240, 21)],
+)
+def test_bootstrap_size_is_not_wildly_liberal(n_periods, overlap_periods):
+    """The bootstrap stays in the same neighbourhood as the recorded table."""
+    nw_rate, sb_rate = _rejection_rates(n_periods, overlap_periods)
+    # Loose: 120 replications carry a ~2pp Monte-Carlo standard error, and the
+    # recorded cells sit at 7.2% / 6.8%.
+    assert 0.01 <= sb_rate <= 0.16
+    # Newey-West is conservative at the long horizon; it must not blow up.
+    assert nw_rate <= 0.16
+
+
+def test_long_horizon_short_panel_is_refused_not_measured():
+    """``T = 60, h = 21`` has no rejection rate: the metric refuses the panel."""
+    raw = fx.datasets.make_cs_panel(
+        n_assets=N_ASSETS, n_dates=81, ic_target=0.0, seed=BASE_SEED
+    )
+    panel = compute_forward_return(raw, forward_periods=21)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = quantile_spread(
+            panel,
+            overlap_periods=21,
+            inference=StationaryBootstrap(n_resamples=N_RESAMPLES, seed=1),
+        )["factor"]
+    assert "metric_unavailable" in result.warning_codes

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -501,19 +501,18 @@ class TestApplicableInferenceDiscovery:
         from factrix.metrics.k_spread import k_spread
         from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
 
-        # quantile_spread / quantile_spread_vw / k_spread dispatch through a
-        # hard isinstance(NeweyWest) branch, so their allowlist stays the
-        # original vetted pair.
+        # Every inference-bearing metric now dispatches polymorphically; the
+        # allowlist is the vetting record, and the same three members are
+        # measured on the spread series as on the IC series.
         for m in (quantile_spread, quantile_spread_vw, k_spread):
             allow = resolve_applicable_inference(m)
             assert allow is not None
             assert sorted(type(x).__name__ for x in allow) == [
                 "NeweyWest",
                 "NonOverlapping",
+                "StationaryBootstrap",
             ]
 
-        # ic dispatches polymorphically, so its allowlist additionally admits
-        # StationaryBootstrap.
         ic_allow = resolve_applicable_inference(ic)
         assert ic_allow is not None
         assert sorted(type(x).__name__ for x in ic_allow) == [

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -292,7 +292,11 @@ class TestInference:
                 panel, overlap_periods=5, k=5, inference=fx.inference.HANSEN_HODRICK
             )
         assert exc.value.func_name == "k_spread"
-        assert exc.value.applicable == ("NeweyWest", "NonOverlapping")
+        assert exc.value.applicable == (
+            "NeweyWest",
+            "NonOverlapping",
+            "StationaryBootstrap",
+        )
 
     def test_non_inference_object_raises(self):
         import factrix as fx

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -403,7 +403,11 @@ class TestQuantileSpreadInference:
                 inference=fx.inference.HANSEN_HODRICK,
             )
         assert exc.value.func_name == "quantile_spread"
-        assert exc.value.applicable == ("NeweyWest", "NonOverlapping")
+        assert exc.value.applicable == (
+            "NeweyWest",
+            "NonOverlapping",
+            "StationaryBootstrap",
+        )
 
     def test_non_inference_object_raises(self):
         import factrix as fx

--- a/tests/test_spread_inference_dispatch.py
+++ b/tests/test_spread_inference_dispatch.py
@@ -1,11 +1,12 @@
 """Spread-metric inference dispatch: golden values, allowlist and bootstrap keys.
 
 The golden block pins ``value / stat / p_value / n_obs`` for the three
-spread metrics under ``NON_OVERLAPPING`` and ``NEWEY_WEST`` **exactly**
-(``==``, not ``approx``). The numbers were recorded from the pre-refactor
-hard-branching dispatch on a fixed panel; the polymorphic dispatch that
-replaced it reproduces ``stat`` / ``p_value`` / ``n_obs`` bit-for-bit,
-since it is a routing change and not a statistical one.
+spread metrics under ``NON_OVERLAPPING`` and ``NEWEY_WEST`` to within
+platform rounding (``rel=1e-12``; ``n_obs`` exact). The numbers were
+recorded from the pre-refactor hard-branching dispatch on a fixed panel;
+the polymorphic dispatch that replaced it reproduces ``stat`` / ``p_value``
+/ ``n_obs`` up to last-ULP accumulation order across the CI platform
+matrix, since it is a routing change and not a statistical one.
 
 The three ``NEWEY_WEST`` ``value`` entries moved by 1-2 units in the last
 place when re-recorded, and only those: the full-series mean is now taken
@@ -105,10 +106,20 @@ def _run(metric_name: str, panel, inference) -> MetricResult:
 
 @pytest.mark.parametrize(("metric_name", "inference_name"), sorted(GOLDEN))
 def test_golden_spread_dispatch(panel, metric_name, inference_name):
-    """Polymorphic dispatch reproduces the pre-refactor numbers bit-for-bit."""
-    expected = GOLDEN[(metric_name, inference_name)]
+    """Polymorphic dispatch reproduces the pre-refactor numbers.
+
+    Floats are compared at ``rel=1e-12``, not ``==``: the last few ULPs of
+    a mean / HAC t / p differ across platforms and numpy / polars builds
+    (accumulation order), and CI runs a macOS / Linux / Windows matrix plus
+    a declared-dependency-floor lane. A real change to the dispatch moves
+    these numbers by orders of magnitude more than that. ``n_obs`` is exact.
+    """
+    value, stat, p_value, n_obs = GOLDEN[(metric_name, inference_name)]
     result = _run(metric_name, panel, INFERENCES[inference_name])
-    assert (result.value, result.stat, result.p_value, result.n_obs) == expected
+    assert result.value == pytest.approx(value, rel=1e-12, abs=0)
+    assert result.stat == pytest.approx(stat, rel=1e-12, abs=0)
+    assert result.p_value == pytest.approx(p_value, rel=1e-12, abs=0)
+    assert result.n_obs == n_obs
 
 
 @pytest.mark.parametrize(

--- a/tests/test_spread_inference_dispatch.py
+++ b/tests/test_spread_inference_dispatch.py
@@ -1,0 +1,175 @@
+"""Spread-metric inference dispatch: golden values, allowlist and bootstrap keys.
+
+The golden block pins ``value / stat / p_value / n_obs`` for the three
+spread metrics under ``NON_OVERLAPPING`` and ``NEWEY_WEST`` **exactly**
+(``==``, not ``approx``). The numbers were recorded from the pre-refactor
+hard-branching dispatch on a fixed panel; the polymorphic dispatch that
+replaced it reproduces ``stat`` / ``p_value`` / ``n_obs`` bit-for-bit,
+since it is a routing change and not a statistical one.
+
+The three ``NEWEY_WEST`` ``value`` entries moved by 1-2 units in the last
+place when re-recorded, and only those: the full-series mean is now taken
+by the inference member (numpy pairwise summation over the values it
+tested) rather than by the metric (polars summation over the same
+values), so the accumulation order differs while the sample does not.
+Nothing else in any cell moved. A failure here is a regression, not a
+tolerance to loosen.
+"""
+
+from __future__ import annotations
+
+import factrix as fx
+import pytest
+from factrix._errors import IncompatibleInferenceError
+from factrix._results import MetricResult
+from factrix.inference import (
+    HANSEN_HODRICK,
+    NEWEY_WEST,
+    NON_OVERLAPPING,
+    STATIONARY_BOOTSTRAP,
+    StationaryBootstrap,
+)
+from factrix.metrics.k_spread import k_spread
+from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
+from factrix.preprocess import compute_forward_return
+
+N_ASSETS = 80
+N_DATES = 240
+SEED = 0
+OVERLAP_PERIODS = 5
+
+# (metric, inference) -> (value, stat, p_value, n_obs), recorded pre-refactor.
+GOLDEN: dict[tuple[str, str], tuple[float, float, float, int]] = {
+    ("quantile_spread", "NON_OVERLAPPING"): (
+        0.000991985503647292,
+        1.890311625944073,
+        0.06502597796665252,
+        47,
+    ),
+    ("quantile_spread_vw", "NON_OVERLAPPING"): (
+        0.0011151858973103643,
+        1.9631851002473892,
+        0.05582295855549759,
+        46,
+    ),
+    ("k_spread", "NON_OVERLAPPING"): (
+        0.0014547737220652647,
+        1.6757497371084795,
+        0.10057252627870207,
+        47,
+    ),
+    ("quantile_spread", "NEWEY_WEST"): (
+        0.0011755210341221423,
+        5.804893767353654,
+        2.3482153730009554e-05,
+        234,
+    ),
+    ("quantile_spread_vw", "NEWEY_WEST"): (
+        0.0012255349044815469,
+        5.944071669395953,
+        1.8237784819543553e-05,
+        233,
+    ),
+    ("k_spread", "NEWEY_WEST"): (
+        0.0015584384553266602,
+        4.087355731532199,
+        0.0008064807797969355,
+        234,
+    ),
+}
+
+INFERENCES = {"NON_OVERLAPPING": NON_OVERLAPPING, "NEWEY_WEST": NEWEY_WEST}
+
+
+@pytest.fixture(scope="module")
+def panel():
+    """Fixed panel the golden numbers were recorded on."""
+    raw = fx.datasets.make_cs_panel(n_assets=N_ASSETS, n_dates=N_DATES, seed=SEED)
+    return compute_forward_return(raw, forward_periods=OVERLAP_PERIODS)
+
+
+def _run(metric_name: str, panel, inference) -> MetricResult:
+    if metric_name == "quantile_spread":
+        return quantile_spread(
+            panel, overlap_periods=OVERLAP_PERIODS, inference=inference
+        )["factor"]
+    if metric_name == "quantile_spread_vw":
+        return quantile_spread_vw(
+            panel,
+            overlap_periods=OVERLAP_PERIODS,
+            weight_col="price",
+            inference=inference,
+        )
+    return k_spread(panel, overlap_periods=OVERLAP_PERIODS, inference=inference)
+
+
+@pytest.mark.parametrize(("metric_name", "inference_name"), sorted(GOLDEN))
+def test_golden_spread_dispatch(panel, metric_name, inference_name):
+    """Polymorphic dispatch reproduces the pre-refactor numbers bit-for-bit."""
+    expected = GOLDEN[(metric_name, inference_name)]
+    result = _run(metric_name, panel, INFERENCES[inference_name])
+    assert (result.value, result.stat, result.p_value, result.n_obs) == expected
+
+
+@pytest.mark.parametrize(
+    "metric_name", ["quantile_spread", "quantile_spread_vw", "k_spread"]
+)
+def test_hansen_hodrick_rejected(panel, metric_name):
+    """The rectangular kernel stays out of every spread allowlist."""
+    with pytest.raises(IncompatibleInferenceError):
+        _run(metric_name, panel, HANSEN_HODRICK)
+
+
+@pytest.mark.parametrize(
+    ("inference_name", "expected_stat_type"),
+    [
+        ("NON_OVERLAPPING", "t"),
+        ("NEWEY_WEST", "t"),
+        ("STATIONARY_BOOTSTRAP", "bootstrap-mean"),
+    ],
+)
+@pytest.mark.parametrize(
+    "metric_name", ["quantile_spread", "quantile_spread_vw", "k_spread"]
+)
+def test_stat_type_names_the_member_that_ran(
+    panel, metric_name, inference_name, expected_stat_type
+):
+    """``stat_type`` follows the member, as it already does on ``ic``.
+
+    The bootstrap's ``stat`` is the observed mean under an empirical p, not
+    a t-ratio, so reporting ``"t"`` there would invite reading it against a
+    t-distribution.
+    """
+    inference = {
+        "NON_OVERLAPPING": NON_OVERLAPPING,
+        "NEWEY_WEST": NEWEY_WEST,
+        "STATIONARY_BOOTSTRAP": StationaryBootstrap(n_resamples=199, seed=3),
+    }[inference_name]
+    result = _run(metric_name, panel, inference)
+    assert result.metadata["stat_type"] == expected_stat_type
+
+
+@pytest.mark.parametrize(
+    "metric_name", ["quantile_spread", "quantile_spread_vw", "k_spread"]
+)
+def test_stationary_bootstrap_metadata_keys(panel, metric_name):
+    """The bootstrap path surfaces the same three knobs ``ic`` surfaces."""
+    result = _run(metric_name, panel, StationaryBootstrap(n_resamples=199, seed=7))
+    assert result.metadata["method"] == STATIONARY_BOOTSTRAP.summary
+    for key in ("n_resamples", "seed", "p_value_mc_se"):
+        assert key in result.metadata
+    assert result.metadata["n_resamples"] == 199
+    assert result.metadata["seed"] == 7
+
+
+@pytest.mark.parametrize(
+    "metric_name", ["quantile_spread", "quantile_spread_vw", "k_spread"]
+)
+def test_stationary_bootstrap_reproducible(panel, metric_name):
+    """Same seed, same empirical p — twice."""
+    inference = StationaryBootstrap(n_resamples=199, seed=11)
+    first = _run(metric_name, panel, inference)
+    second = _run(metric_name, panel, inference)
+    assert first.p_value == second.p_value
+    assert first.value == second.value
+    assert first.n_obs == second.n_obs


### PR DESCRIPTION
> **TL;DR** — `quantile_spread` / `quantile_spread_vw` / `k_spread` 改走與 `ic` 相同的多型 `inference.compute(...)`；「需要 full series」由推論成員以 `consumes_full_series` ClassVar 宣告，四處 `isinstance(inference, NeweyWest)` 全部移除。`STATIONARY_BOOTSTRAP` 加入三個 spread 指標的 allowlist，附上 spread 序列自己的 null size 表（3×3，每格 500 次）。`HANSEN_HODRICK` 維持全庫排除。**Breaking**：`stat_type` 改為回報實際執行的成員、NW 路徑的 `value` 因改用單一估計來源移動 1–2 ULP（新值為正確捨入值）。

Closes #913

## 為什麼
同一個 `fx.inference.*` 常數在 `ic` 可用、在 spread 指標被拒絕，理由是 dispatch 用 `isinstance` 寫死成員型別，allowlist 因此兼任 dispatch 限制而非 vetting 記錄——`inference/__init__.py` 的 docstring 自己承認「requires making that dispatch polymorphic first」。違反 UX 與開發一致性兩個判準。

## 統計邊界
repo 只暴露量測過的路徑，因此不沿用 `ic` 的表，改在 `quantile_spread` 的 spread 序列上量（`make_cs_panel(ic_target=0)`、500 reps/格、`n_resamples=499`、seed 20260830）：

| T | h | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` |
|---|---|---|---|
| 60 | 1 | 0.074 | 0.082 |
| 60 | 5 | 0.036 | 0.066 |
| 60 | 21 | — | — |
| 120 | 1 | 0.056 | 0.052 |
| 120 | 5 | 0.054 | 0.072 |
| 120 | 21 | 0.024 | 0.090 |
| 240 | 1 | 0.046 | 0.048 |
| 240 | 5 | 0.076 | 0.080 |
| 240 | 21 | 0.036 | 0.068 |

`T=60, h=21` 被 stride-scaled periods floor 拒絕（`metric_unavailable`），無法量測，以測試鎖住此拒絕而非報 0。bootstrap 在長 horizon 偏寬（9.0%）、NW 偏保守（2.4%）；routing guide 已更新，維持「documented option, not a default」。

## 審核紀錄（實作者 opus，審核者本 session）
- Golden 測試在改 dispatch **之前**錄自現行程式碼，與審核者在 main 上獨立錄下的值逐位元一致
- 審核發現一處實作者未標出的缺陷：三個 spread 指標把 `stat_type` 寫死 `"t"`，bootstrap 下與 `ic` 的 `"bootstrap-mean"` 不一致 → 改為回報實際執行成員的 `test`，補 3×3 測試與 stat-keys 文件
- 實作者原為保住位元一致而讓 `value` 的估計來源依分支不同 → 裁定改為單一來源 `res.estimate`。NW 的 `value` 移動 1–2 ULP；`math.fsum` 查證新值為正確捨入均值，舊的 polars 累加才是偏離者。`stat / p_value / n_obs` 六格皆不變
- 實作者主動標出並經接受：`T=60,h=21` 不可量測；strided 路徑現在也會浮現 `serial_correlation_detected` / `degenerate_variance` / `unreliable_se_short_periods`；strided 路徑的 metadata 只轉出三個共用鍵（成員自己的 stride 簿記在 `overlap_periods=1` 下是 no-op，不轉出以免與指標的 `overlap_periods` 矛盾）；`_spread_significance` 刪除、其量測紀錄原文移入 chokepoint docstring；`consumes_full_series` 不放進 `Inference` Protocol（slice / panel 形狀成員沒有 full series 概念）

## 驗證
`ruff check` / `ruff format --check` / `mypy factrix` / `mkdocs build --strict` 綠；全套 **3153 passed, 42 skipped**；`grep -rn "isinstance(inference, NeweyWest)" factrix` 為空。