### PR TITLE
feat(stats)!: accept a numpy Generator as seed and resolve the seed contract everywhere

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -89,7 +89,7 @@ contrasts, not a sidecar to a primary value.
 - *primary*: `p_value` — test on the per-period IC series, from the configured `inference`: a `t`-test on a non-overlapping stride of `overlap_periods` (default), a Newey-West HAC `t`-test, or a stationary-bootstrap empirical `p`.
 - *descriptive*: `n_periods` (the sample the `value` / `stat` / `p_value` describe — the strided subsample under `NonOverlapping`, the full series under `NeweyWest` / `StationaryBootstrap`; equals `n_obs`), `n_periods_full` and `mean_ic_full` (the full per-period series, for reference), `overlap_periods`, `tie_ratio` (median across periods), `min_assets_per_period` / `warn_assets_per_period` when the upstream IC series carries per-period asset counts, `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`), `h0` (`"mu=0"`), `method`.
 - *descriptive* (conditional, `NeweyWest`): `nw_lags` (resolved Bartlett bandwidth) and `hac_dof` (the effective degrees of freedom the `t` is read against; `None` when the sample is too short to run the kernel).
-- *descriptive* (conditional, `StationaryBootstrap`): `n_resamples` and `seed` (the resolved seed, reported even when not supplied, so an unseeded run stays reproducible), `p_value_mc_se` (Monte-Carlo SE of the empirical `p`), `block_length` (the resolved Politis-White mean block length) and `studentized`. See [Resampling knobs](statistical-methods.md#resampling-knobs).
+- *descriptive* (conditional, `StationaryBootstrap`): `n_resamples` and `seed` (the resolved seed, reported even when not supplied, so an unseeded run stays reproducible; `null` when a `numpy.random.Generator` was supplied — that stream is the caller's to reproduce), `p_value_mc_se` (Monte-Carlo SE of the empirical `p`), `block_length` (the resolved Politis-White mean block length) and `studentized`. See [Resampling knobs](statistical-methods.md#resampling-knobs).
 - *warning*: `WarningCode.FEW_ASSETS` when retained per-period IC cross-sections are below `MIN_IC_ASSETS_WARN`; `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` under `NeweyWest` when the resolved bandwidth exceeds `n_periods / 5`.
 - *short-circuit*: `reason` `insufficient_ic_periods` (too few periods) carries `min_required`; `insufficient_ic_assets` (every cross-section below `MIN_IC_ASSETS_HARD`, so no per-period IC survived — common on one-valid-pair panels) carries `min_assets_required`.
 
@@ -439,7 +439,8 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 - *MR detail*: `mr_min_diff`, `mr_adjacent_diffs` (every `Δ̄_i`, so the
   binding step is visible), `mr_direction`, `n_resamples`,
   `seed` (resolved and reported when not supplied, so an
-  unseeded run is still reproducible after the fact), `p_value_mc_se`
+  unseeded run is still reproducible after the fact; `null` when a
+  `numpy.random.Generator` was supplied), `p_value_mc_se`
   (Monte-Carlo SE of the empirical p, `sqrt(p(1-p)/n_resamples)` — how far
   the p would move on a re-run with a different seed, ~0.7pp at the default
   `n_resamples=999` and p near 0.05; `n_resamples` is floored at 199 — see

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -300,13 +300,13 @@ Every entry point that turns a resample count into a reported p or
 interval takes the same two knobs under the same names, with the same
 default and the same refusal floor.
 
-| Entry point | `n_resamples` default | `seed` | Floor enforced | Reports `p_value_mc_se` |
+| Entry point | `n_resamples` default | `seed` reported as | Floor enforced | Reports `p_value_mc_se` |
 |---|---|---|---|---|
-| `ic(inference=StationaryBootstrap(...))` | 999 | yes | yes | yes (`metadata`) |
-| `monotonicity(...)` | 999 | yes | yes | yes (`metadata`) |
-| `bootstrap_mean_ci(...)` | 999 | yes | yes | no (returns an interval, not a p) |
-| `slice_period_pairwise_test` / `slice_period_joint_test` (`method="bootstrap"`) | 999 | yes | yes | no (see below) |
-| `stationary_bootstrap_resamples(...)` | 999 | yes | **no** | no (returns draws, not inference) |
+| `ic(inference=StationaryBootstrap(...))` | 999 | `metadata["seed"]` | yes | yes (`metadata`) |
+| `monotonicity(...)` | 999 | `metadata["seed"]` | yes | yes (`metadata`) |
+| `bootstrap_mean_ci(...)` | 999 | not reported (returns an interval) | yes | no (returns an interval, not a p) |
+| `slice_period_pairwise_test` / `slice_period_joint_test` (`method="bootstrap"`) | 999 | the `seed` output column | yes | no (see below) |
+| `stationary_bootstrap_resamples(...)` | 999 | not reported (returns draws) | **no** | no (returns draws, not inference) |
 
 The floor is `BOOTSTRAP_RESAMPLES_FLOOR = 199` and a lower count raises
 `UserInputError`. A Davison-Hinkley smoothed p lives on the `1/(B+1)`
@@ -327,9 +327,22 @@ slice tests do **not** report it: their `p_adj` is a Romano-Wolf
 step-down adjustment, not a single binomial draw, so the formula does
 not apply.
 
-Passing `seed=None` (the default) draws from system entropy and reports
-the resolved seed back in `metadata["seed"]`, so an unseeded run is
-still reproducible after the fact.
+`seed` takes the same three types everywhere — including
+`datasets.make_*`, which reports nothing:
+
+- an **`int`** reproduces the run and is reported back unchanged;
+- **`None`** (the default) draws a 32-bit int from system entropy and
+  reports it, so an unseeded run is still reproducible after the fact;
+- a **`numpy.random.Generator`** is used as-is and *advanced* by the
+  call, so two calls on one generator draw differently while two
+  generators built from the same seed agree. That is the numpy / scipy
+  `rng=` semantics, and it is what a nested or large-scale simulation
+  running off one stream needs. The reported seed is then `None`: the
+  stream is the caller's, so only the caller can reproduce the draw.
+
+Anything else raises `UserInputError`. The period slice tests carry the
+report in a `seed` output column, which is null under
+`method="analytic"` (that path draws nothing).
 
 ---
 

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -33,6 +33,7 @@ References:
 from __future__ import annotations
 
 import secrets
+from numbers import Integral
 from typing import Literal
 
 import numpy as np
@@ -83,6 +84,63 @@ def _check_n_resamples(n_resamples: int, *, func_name: str, docs_path: str) -> N
             ),
             docs_path=docs_path,
         )
+
+
+#: Type of every ``seed`` knob in factrix. ``int`` reproduces a run exactly;
+#: ``None`` lets the entry point draw one from system entropy and report it
+#: back; a ``numpy.random.Generator`` hands the entry point a stream the
+#: caller owns and advances (the direction numpy, scipy's ``rng=`` and arch
+#: have converged on), which is what nested or large-scale simulation needs.
+#: Lives here rather than in ``factrix._types`` because that module is the
+#: numpy-free home of numerical constants and ``Literal`` option aliases.
+Seed = int | np.random.Generator | None
+
+
+def _resolve_rng(
+    seed: Seed, *, func_name: str, docs_path: str
+) -> tuple[np.random.Generator, int | None]:
+    """Resolve a ``seed`` knob into ``(generator, reported_seed)``.
+
+    The single place factrix builds a ``Generator``, so the three-way
+    contract cannot drift between entry points:
+
+    - ``None`` — draw a 32-bit int from system entropy, build a
+      ``default_rng`` on it and report the int, so an unseeded run stays
+      reproducible after the fact.
+    - ``int`` — ``default_rng(int)``, reported unchanged.
+    - ``Generator`` — used as-is and reported as ``None``: the caller owns
+      the stream, so only the caller can reproduce the draw, and the
+      generator is *advanced* by the call.
+
+    ``secrets.randbits(32)`` is the purpose-built "give me a random int
+    seed" call — ``SeedSequence().entropy`` is typed as
+    ``int | Sequence[int] | None`` and the Sequence branch breaks the
+    bit-mask path.
+
+    ``func_name`` / ``docs_path`` must name the *public* entry point the
+    caller reached this through — the rejection message is user-facing.
+    """
+    from factrix._errors import UserInputError
+
+    if isinstance(seed, np.random.Generator):
+        return seed, None
+    if seed is None:
+        resolved = secrets.randbits(32)
+        return np.random.default_rng(resolved), resolved
+    if isinstance(seed, bool) or not isinstance(seed, Integral):
+        raise UserInputError(
+            func_name=func_name,
+            field="seed",
+            value=seed,
+            expected=(
+                "an int (reproduces the run), None (one is drawn and "
+                "reported back), or a numpy.random.Generator (a stream the "
+                "caller owns and advances)"
+            ),
+            docs_path=docs_path,
+        )
+    resolved = int(seed)
+    return np.random.default_rng(resolved), resolved
 
 
 def _empirical_p(n_extreme: int, n_resamples: int) -> tuple[float, float]:
@@ -364,8 +422,8 @@ def _block_bootstrap_diff_p(
     block_length: int | Literal["auto"] = "auto",
     n_resamples: int = 999,
     overlap_periods: int | None = None,
-    seed: int | None = None,
-) -> tuple[float, dict[str, float | int | str]]:
+    seed: Seed = None,
+) -> tuple[float, dict[str, float | int | str | None]]:
     r"""Two-sided empirical p for ``H₀: E[diff] = 0`` on a paired series.
 
     Resamples ``diff`` under the centring ``diff - mean(diff)`` (the
@@ -428,16 +486,20 @@ def _block_bootstrap_diff_p(
             to rediscover it from a short noisy sample and systematically
             under-shoots (measured mean L of 7.95 against a needed 21 at
             T=60, h=21). Mirrors the HAC paths' bandwidth floor.
-        seed: ``None`` draws from system entropy; the resolved seed
-            is returned in the metadata dict so the caller can record it.
+        seed: ``None`` draws from system entropy and the resolved int is
+            returned in the metadata dict so the caller can record it; an
+            ``int`` is reported unchanged; a ``numpy.random.Generator`` is
+            used as-is and advanced, and the metadata reports ``None``
+            because only its owner can reproduce the draw.
 
     Returns:
         ``(p_value, metadata)`` — p in ``[1/(B+1), 1]``; metadata
         records the resolved (fractional) block length, ``n_resamples``,
         whether the root was studentized, the Monte-Carlo SE of the
-        reported p (``p_value_mc_se``), and the actual seed used (so the
-        run is reproducible from the logged metadata even when the caller
-        passed ``seed=None``).
+        reported p (``p_value_mc_se``), and the resolved seed (so the run
+        is reproducible from the logged metadata even when the caller
+        passed ``seed=None``) — ``None`` when the caller supplied a
+        ``Generator``.
 
         A series too short to test (``n < 2``) returns ``p = nan`` with
         ``block_length = nan`` and ``n_resamples = 0``. NaN rather than
@@ -452,13 +514,18 @@ def _block_bootstrap_diff_p(
     if diff.size and not np.all(np.isfinite(diff)):
         raise ValueError("_block_bootstrap_diff_p: diff must be finite (no NaN / inf).")
     n = len(diff)
+    # Resolve up front so the degenerate path reports the same resolved seed
+    # the testable path would, and a bogus seed is refused either way.
+    rng, seed_used = _resolve_rng(
+        seed, func_name="StationaryBootstrap", docs_path="reference/statistical-methods"
+    )
     if n < 2:
         return float("nan"), {
             "block_length": float("nan"),
             "n_resamples": 0,
             "studentized": False,
             "p_value_mc_se": float("nan"),
-            "seed": seed if seed is not None else -1,
+            "seed": seed_used,
         }
 
     L: float
@@ -481,13 +548,6 @@ def _block_bootstrap_diff_p(
     if overlap_periods is not None and overlap_periods > 1:
         L = max(L, float(min(overlap_periods, _max_block_length(n))))
     _validate_block_length(L, n, "StationaryBootstrap", "reference/statistical-methods")
-
-    # Resolve seed up front so it can be reported back even when None.
-    # `secrets.randbits(32)` is the purpose-built "give me a random int
-    # seed" call — `SeedSequence().entropy` is typed as `int | Sequence[int]
-    # | None` and the Sequence branch breaks the bit-mask path.
-    seed_used = secrets.randbits(32) if seed is None else int(seed)
-    rng = np.random.default_rng(seed_used)
 
     # Centre under H0 (mean=0) before resampling.
     centred = diff - float(np.mean(diff))
@@ -518,7 +578,7 @@ def _block_bootstrap_diff_p(
         n_used = int(n_resamples)
 
     p, p_mc_se = _empirical_p(extreme, n_used)
-    metadata: dict[str, float | int | str] = {
+    metadata: dict[str, float | int | str | None] = {
         "block_length": L,
         "n_resamples": int(n_resamples),
         "studentized": studentized,

--- a/factrix/datasets.py
+++ b/factrix/datasets.py
@@ -35,6 +35,8 @@ from datetime import datetime, timedelta
 import numpy as np
 import polars as pl
 
+from factrix._stats.bootstrap import Seed, _resolve_rng
+
 _DEFAULT_START = "2020-01-02"
 
 # Bumped whenever the default parameters or construction recipe of the
@@ -78,7 +80,7 @@ def make_cs_panel(
     n_dates: int = 252,
     ic_target: float = 0.04,
     signal_horizon: int = 5,
-    seed: int = 42,
+    seed: Seed = 42,
     start_date: str = _DEFAULT_START,
 ) -> pl.DataFrame:
     """Synthetic cross-sectional panel with a calibrated target information coefficient (IC).
@@ -137,7 +139,9 @@ def make_cs_panel(
             realize the nominal IC; different horizons realize a
             decayed IC (correct physics for a density with a natural
             time-scale, not a bug).
-        seed: RNG seed.
+        seed: RNG seed — an ``int``, ``None`` (drawn from system
+            entropy), or a ``numpy.random.Generator`` used as-is and
+            advanced by the call.
         start_date: ISO date for the first row.
 
     Returns:
@@ -169,7 +173,11 @@ def make_cs_panel(
             f"signal_horizon={signal_horizon})"
         )
 
-    rng = np.random.default_rng(seed)
+    rng, _ = _resolve_rng(
+        seed,
+        func_name="make_cs_panel",
+        docs_path="api/datasets#factrix.datasets.make_cs_panel",
+    )
     sigmas = rng.uniform(0.01, 0.03, size=n_assets)
     daily_ret = rng.standard_normal((n_dates, n_assets)) * sigmas
     prices = 100.0 * np.cumprod(1.0 + daily_ret, axis=0)
@@ -207,7 +215,7 @@ def make_event_panel(
     event_magnitude_jitter: float = 0.0,
     post_event_drift_bps: float = 10.0,
     signal_horizon: int = 5,
-    seed: int = 42,
+    seed: Seed = 42,
     start_date: str = _DEFAULT_START,
 ) -> pl.DataFrame:
     """Synthetic event-density panel — sparse ``{0, R}`` schema.
@@ -249,7 +257,9 @@ def make_event_panel(
             the nominal drift; different horizons realize a weakened or
             diluted density (correct physics for a density with a natural
             time-scale, not a bug).
-        seed: RNG seed.
+        seed: RNG seed — an ``int``, ``None`` (drawn from system
+            entropy), or a ``numpy.random.Generator`` used as-is and
+            advanced by the call.
         start_date: ISO date for the first row.
 
     Returns:
@@ -280,7 +290,11 @@ def make_event_panel(
             f"event_magnitude_jitter must be >= 0, got {event_magnitude_jitter}"
         )
 
-    rng = np.random.default_rng(seed)
+    rng, _ = _resolve_rng(
+        seed,
+        func_name="make_event_panel",
+        docs_path="api/datasets#factrix.datasets.make_event_panel",
+    )
     sigmas = rng.uniform(0.01, 0.03, size=n_assets)
     daily_ret = rng.standard_normal((n_dates, n_assets)) * sigmas
 
@@ -322,7 +336,7 @@ def make_multi_factor_panel(
     ic_target: float = 0.04,
     factor_correlation: float = 0.0,
     signal_horizon: int = 5,
-    seed: int = 42,
+    seed: Seed = 42,
     start_date: str = _DEFAULT_START,
 ) -> pl.DataFrame:
     """Synthetic multi-factor panel with calibrated IC and tunable
@@ -355,7 +369,9 @@ def make_multi_factor_panel(
             higher values share more of a common cross-sectional driver.
         signal_horizon: Horizon (in bars) at which the synthetic density
             lives.
-        seed: RNG seed.
+        seed: RNG seed — an ``int``, ``None`` (drawn from system
+            entropy), or a ``numpy.random.Generator`` used as-is and
+            advanced by the call.
         start_date: ISO date for the first row.
 
     Returns:
@@ -378,7 +394,11 @@ def make_multi_factor_panel(
             f"factor_correlation must be in [0, 1), got {factor_correlation}"
         )
 
-    rng = np.random.default_rng(seed)
+    rng, _ = _resolve_rng(
+        seed,
+        func_name="make_multi_factor_panel",
+        docs_path="api/datasets#factrix.datasets.make_multi_factor_panel",
+    )
     sigmas = rng.uniform(0.01, 0.03, size=n_assets)
     daily_ret = rng.standard_normal((n_dates, n_assets)) * sigmas
     prices = 100.0 * np.cumprod(1.0 + daily_ret, axis=0)
@@ -440,7 +460,7 @@ def make_multi_factor_event_panel(
     event_magnitude_jitter: float = 0.0,
     post_event_drift_bps: float = 10.0,
     signal_horizon: int = 5,
-    seed: int = 42,
+    seed: Seed = 42,
     start_date: str = _DEFAULT_START,
 ) -> pl.DataFrame:
     """Synthetic multi-factor event-density panel.
@@ -467,7 +487,9 @@ def make_multi_factor_event_panel(
             window (bars ``t+2 .. t+1+H``).
         signal_horizon: Horizon (in bars) over which post-event drift
             is distributed.
-        seed: RNG seed.
+        seed: RNG seed — an ``int``, ``None`` (drawn from system
+            entropy), or a ``numpy.random.Generator`` used as-is and
+            advanced by the call.
         start_date: ISO date for the first row.
 
     Returns:
@@ -500,7 +522,11 @@ def make_multi_factor_event_panel(
             f"event_magnitude_jitter must be >= 0, got {event_magnitude_jitter}"
         )
 
-    rng = np.random.default_rng(seed)
+    rng, _ = _resolve_rng(
+        seed,
+        func_name="make_multi_factor_event_panel",
+        docs_path="api/datasets#factrix.datasets.make_multi_factor_event_panel",
+    )
     sigmas = rng.uniform(0.01, 0.03, size=n_assets)
     daily_ret = rng.standard_normal((n_dates, n_assets)) * sigmas
 

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 from factrix._codes import WarningCode
+from factrix._stats.bootstrap import Seed
 from factrix._stats.constants import (
     MIN_PERIODS_HARD,
     MIN_PERIODS_WARN,
@@ -361,13 +362,24 @@ class StationaryBootstrap:
             The default 999 is [Politis-White (2004)][politis-white-2004]'s
             recommendation for two-sided 5% work; the Monte-Carlo cost of a
             lower ``B`` is reported as ``metadata["p_value_mc_se"]``.
-        seed: Reproducibility seed. ``None`` draws from system entropy and
-            reports the resolved seed in ``metadata["seed"]``, so a run
-            stays reproducible after the fact.
+        seed: An ``int``, ``None``, or a ``numpy.random.Generator``.
+            ``None`` draws from system entropy and reports the resolved
+            seed in ``metadata["seed"]``, so a run stays reproducible after
+            the fact.
+
+            A ``Generator`` is a stream the caller owns: the member is
+            frozen, but each ``compute`` call *advances* that stream, so
+            two calls on one instance draw different resamples and give
+            different p-values. That is the ``Generator`` semantics numpy
+            and scipy share, and it is the point of the type — a nested or
+            large-scale simulation runs off one stream. ``metadata["seed"]``
+            is then ``None``: only the caller can reproduce the draw. Pass
+            an ``int`` (or ``None``) whenever a single run must be
+            reproducible from its own metadata.
     """
 
     n_resamples: int = 999
-    seed: int | None = None
+    seed: Seed = None
 
     test: ClassVar[str] = "bootstrap-mean"
     se: ClassVar[str | None] = "bootstrap"

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -131,7 +131,8 @@ def _surface_inference_run_metadata(
     them. Surfacing them keeps a reported empirical p reproducible from the
     result alone and puts its Monte-Carlo error next to it. Shared by ``ic``
     and the spread chokepoint so both report the same three keys under the
-    same names.
+    same names. ``seed`` is ``None`` when the caller supplied a
+    ``numpy.random.Generator`` — that stream is the caller's to reproduce.
     """
     for key in ("n_resamples", "seed", "p_value_mc_se"):
         if key in result.metadata:

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -32,7 +32,12 @@ from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
-from factrix._stats.bootstrap import _check_n_resamples, _empirical_p
+from factrix._stats.bootstrap import (
+    Seed,
+    _check_n_resamples,
+    _empirical_p,
+    _resolve_rng,
+)
 from factrix._types import (
     DDOF,
     MIN_MONOTONICITY_PERIODS_HARD,
@@ -104,7 +109,7 @@ def _mr_test(
     *,
     direction: MRDirection,
     n_resamples: int,
-    seed: int | None,
+    seed: Seed,
 ) -> tuple[float, float, dict[str, object]]:
     """Patton-Timmermann (2010) MR test on a ``(n_periods, n_groups)`` block.
 
@@ -132,11 +137,12 @@ def _mr_test(
     delta_bar = diffs.mean(axis=0)
     j_stat = float(delta_bar.min())
 
-    if seed is None:
-        # Mirror ``StationaryBootstrap``: resolve a seed and report it, so a run
-        # is reproducible after the fact without a mandatory knob.
-        seed = int(np.random.default_rng().integers(0, 2**31 - 1))
-    resamples = stationary_bootstrap_resamples(diffs, n_resamples, seed=seed)
+    # Mirror ``StationaryBootstrap``: resolve the seed and report it, so a run
+    # is reproducible after the fact without a mandatory knob.
+    rng, seed_used = _resolve_rng(
+        seed, func_name="monotonicity", docs_path="api/metrics/monotonicity"
+    )
+    resamples = stationary_bootstrap_resamples(diffs, n_resamples, seed=rng)
     # (B, T, K-1) -> (B, K-1) bootstrap means, recentred under H0.
     j_star = (resamples.mean(axis=1) - delta_bar).min(axis=1)
     p_value, p_mc_se = _empirical_p(
@@ -148,7 +154,7 @@ def _mr_test(
         "mr_min_diff": j_stat,
         "mr_adjacent_diffs": [float(v) for v in delta_bar],
         "n_resamples": n_resamples,
-        "seed": seed,
+        "seed": seed_used,
         "p_value_mc_se": p_mc_se,
     }
     return j_stat, p_value, metadata
@@ -171,7 +177,7 @@ def monotonicity(
     tie_policy: str = "ordinal",
     direction: MRDirection = "increasing",
     n_resamples: int = 999,
-    seed: int | None = None,
+    seed: Seed = None,
     expected_warnings: tuple[str, ...] = (),
 ) -> dict[str, MetricResult]:
     """Quantile return monotonicity — Patton-Timmermann (2010) MR test.
@@ -205,10 +211,13 @@ def monotonicity(
             near 0.05 carries ~0.7pp of MC SE, so 0.043 and 0.058 are one
             draw apart; raise ``n_resamples`` to shrink it, since no amount
             of data does.
-        seed: Bootstrap seed. ``None`` resolves one and reports it in
-            ``metadata["seed"]``, so a run stays reproducible after
-            the fact. An unseeded re-run redraws the null, moving the p by
-            roughly ``metadata["p_value_mc_se"]``.
+        seed: Bootstrap seed — an ``int``, ``None``, or a
+            ``numpy.random.Generator``. ``None`` resolves one and reports it
+            in ``metadata["seed"]``, so a run stays reproducible after the
+            fact; a ``Generator`` is used as-is and advanced, and
+            ``metadata["seed"]`` is ``None`` because only its owner can
+            reproduce the draw. An unseeded re-run redraws the null, moving
+            the p by roughly ``metadata["p_value_mc_se"]``.
 
     Returns:
         MetricResult with ``value`` = ``stat`` = the MR statistic and

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -72,9 +72,11 @@ from factrix._codes import WarningCode, _validate_expected_warnings_arg
 from factrix._data_input import _resolve_overlap_periods
 from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
+    Seed,
     _check_n_resamples,
     _empirical_p,
     _politis_white_block_length,
+    _resolve_rng,
     _stationary_block_indices,
 )
 from factrix._stats.wald import _nw_hac_vector_mean, _wald_p_linear
@@ -279,7 +281,7 @@ def slice_period_pairwise_test(
     method: Method = "bootstrap",
     overlap_periods: int | None = None,
     n_resamples: int = 999,
-    seed: int | None = None,
+    seed: Seed = None,
     strict: bool = True,
 ) -> pl.DataFrame:
     """Pairwise cross-slice contrasts for a **date-disjoint** partition.
@@ -325,7 +327,12 @@ def slice_period_pairwise_test(
             two-sided 5% work.
         seed: Reproducibility seed for the ``"bootstrap"`` path
             (ignored by ``"analytic"``). ``None`` draws from system
-            entropy.
+            entropy and the resolved int is reported in the ``seed``
+            column; an ``int`` is reported unchanged; a
+            ``numpy.random.Generator`` is used as-is and advanced by the
+            call, and the column is null because only its owner can
+            reproduce the draw. Under ``method="analytic"`` the column is
+            null throughout.
         strict: ``True`` (default) raises ``ValueError`` when any slice is
             below the metric's sample floor. ``False`` keeps the schema and
             returns every pair touching a thin slice as an unavailable row
@@ -339,7 +346,7 @@ def slice_period_pairwise_test(
     Returns:
         Long-form ``pl.DataFrame`` with columns ``(slice_a, slice_b,
         n_periods_a, n_periods_b, mean_diff, stat, p_raw, p_adj, stat_type,
-        reference_dist, df_num, df_denom, multiplicity, min_periods,
+        reference_dist, df_num, df_denom, multiplicity, min_periods, seed,
         reason)``; one row per ordered slice pair ``(a, b)``. ``n_periods_*``
         are each slice's own date counts (disjoint spans differ in length)
         and ``min_periods`` the floor they were gated on (resolved at the
@@ -398,6 +405,14 @@ def slice_period_pairwise_test(
     # machinery below runs on that subset and the multiplicity family is the
     # tested pairs only. Pairs touching a thin slice (``strict=False``) are
     # assembled afterwards as unavailable rows in the same schema.
+    # Resolve once for the whole call: every pair's contrast draws from the
+    # same stream, and the resolved int is reported so an unseeded run stays
+    # reproducible. The analytic path draws nothing and reports null, but the
+    # seed is still validated so a bogus type is refused on both paths.
+    rng, seed_used = _resolve_rng(
+        seed, func_name="slice_period_pairwise_test", docs_path=_DOCS_SLICE
+    )
+    seed_reported = seed_used if method == "bootstrap" else None
     tested = [i for i, lbl in enumerate(labels) if lbl not in built.thin]
     series_list = [built.series[i] for i in tested]
     tested_pairs = list(combinations(range(len(tested)), 2))
@@ -408,7 +423,7 @@ def slice_period_pairwise_test(
         method=method,
         overlap_periods=op,
         n_resamples=n_resamples,
-        seed=seed,
+        rng=rng,
     )
     by_pair = {
         (tested[i], tested[j]): row
@@ -446,11 +461,13 @@ def slice_period_pairwise_test(
             "multiplicity": ["romano_wolf" if method == "bootstrap" else "holm"]
             * n_pairs,
             "min_periods": [built.min_periods] * n_pairs,
+            "seed": [seed_reported] * n_pairs,
             "reason": reasons,
         },
         schema_overrides={
             "df_denom": pl.Float64,
             "min_periods": pl.Int64,
+            "seed": pl.Int64,
             "reason": pl.String,
         },
     )
@@ -464,7 +481,7 @@ def _pairwise_contrasts(
     method: Method,
     overlap_periods: int | None,
     n_resamples: int,
-    seed: int | None,
+    rng: np.random.Generator,
 ) -> list[tuple[float, float, float, float, float | None]]:
     """Studentized contrast per pair: ``(mean_diff, stat, p_raw, p_adj, df_denom)``.
 
@@ -474,7 +491,6 @@ def _pairwise_contrasts(
     family, which runs over the computable pairs only.
     """
     if method == "bootstrap":
-        rng = np.random.default_rng(seed)
         obs_means, boot = _bootstrap_slice_means(
             series_list, n_resamples=n_resamples, rng=rng
         )
@@ -678,7 +694,7 @@ def slice_period_joint_test(
     method: Method = "bootstrap",
     overlap_periods: int | None = None,
     n_resamples: int = 999,
-    seed: int | None = None,
+    seed: Seed = None,
     strict: bool = True,
     expected_warnings: tuple[str, ...] = (),
 ) -> pl.DataFrame:
@@ -723,7 +739,12 @@ def slice_period_joint_test(
             two-sided 5% work.
         seed: Reproducibility seed for the ``"bootstrap"`` path
             (ignored by ``"analytic"``). ``None`` draws from system
-            entropy.
+            entropy and the resolved int is reported in the ``seed``
+            column; an ``int`` is reported unchanged; a
+            ``numpy.random.Generator`` is used as-is and advanced by the
+            call, and the column is null because only its owner can
+            reproduce the draw. Under ``method="analytic"`` the column is
+            null throughout.
         strict: ``True`` (default) raises ``ValueError`` when any slice is
             below the metric's sample floor. ``False`` returns the same
             single-row schema as an unavailable row instead (``stat`` /
@@ -742,8 +763,8 @@ def slice_period_joint_test(
     Returns:
         Single-row ``pl.DataFrame`` with columns ``(k_slices, n_periods_min,
         stat, p_value, stat_type, reference_dist, df_num, df_denom,
-        multiplicity, min_periods, short_slice_periods, warning_codes,
-        unexpected_warning_codes, reason)``. ``stat`` is the joint Wald
+        multiplicity, min_periods, seed, short_slice_periods,
+        warning_codes, unexpected_warning_codes, reason)``. ``stat`` is the joint Wald
         statistic; ``n_periods_min`` the shortest slice's date count and
         ``min_periods`` the floor it was gated on (resolved at the panel's
         stamped or declared ``overlap_periods``); ``reason`` is null when the test ran
@@ -812,6 +833,12 @@ def slice_period_joint_test(
     expected = _validate_expected_warnings_arg(
         expected_warnings, func_name="slice_period_joint_test", docs_path=_DOCS_SLICE
     )
+    # Resolved before the unavailable-row short-circuits so every row carries
+    # the same column, and so a bogus seed is refused on both methods.
+    rng, seed_used = _resolve_rng(
+        seed, func_name="slice_period_joint_test", docs_path=_DOCS_SLICE
+    )
+    seed_reported = seed_used if method == "bootstrap" else None
     op = _resolve_overlap_periods(
         data, overlap_periods, horizon=None, func_name="slice_period_joint_test"
     )
@@ -852,6 +879,7 @@ def slice_period_joint_test(
                 "df_denom": [df_denom],
                 "multiplicity": [None],
                 "min_periods": [built.min_periods],
+                "seed": [seed_reported],
                 "short_slice_periods": [_JOINT_SHORT_SLICE_PERIODS],
                 "warning_codes": [list(warning_codes)],
                 "unexpected_warning_codes": [unexpected],
@@ -861,6 +889,7 @@ def slice_period_joint_test(
                 "df_denom": pl.Float64,
                 "multiplicity": pl.String,
                 "min_periods": pl.Int64,
+                "seed": pl.Int64,
                 "short_slice_periods": pl.Int64,
                 "warning_codes": pl.List(pl.String),
                 "unexpected_warning_codes": pl.List(pl.String),
@@ -891,7 +920,6 @@ def slice_period_joint_test(
     restriction = _equality_restriction(k)
 
     if method == "bootstrap":
-        rng = np.random.default_rng(seed)
         obs_means, boot = _bootstrap_slice_means(
             series_list, n_resamples=n_resamples, rng=rng
         )

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -35,7 +35,7 @@ from typing import Literal, NamedTuple
 
 import numpy as np
 
-from factrix._stats.bootstrap import _check_n_resamples
+from factrix._stats.bootstrap import Seed, _check_n_resamples, _resolve_rng
 
 
 def _resolve_auto_block_length(values: np.ndarray) -> float:
@@ -63,7 +63,7 @@ def stationary_bootstrap_resamples(
     n_resamples: int = 999,
     *,
     block_length: float | None = None,
-    seed: int | None = None,
+    seed: Seed = None,
 ) -> np.ndarray:
     """Draw ``n_resamples`` stationary-bootstrap resamples of ``values``.
 
@@ -92,8 +92,11 @@ def stationary_bootstrap_resamples(
             same bound and raises ``UserInputError`` outside it, rather
             than being silently passed through: at ``L >= T`` a circular
             resample degenerates to a rotation of the input.
-        seed: Seed for ``np.random.default_rng`` to make the resample
-            reproducible.
+        seed: An ``int`` makes the resample reproducible, ``None`` draws
+            one from system entropy, and a ``numpy.random.Generator`` is
+            used as-is and advanced by the call, so consecutive calls on
+            one generator draw different resamples. The resolved seed is
+            not reported: this function returns draws, not an inference.
 
     Returns:
         ``(n_resamples, T)`` array for vector input or
@@ -158,7 +161,11 @@ def stationary_bootstrap_resamples(
     if block_length < 1.0:
         raise ValueError(f"block_length must be >= 1.0, got {block_length!r}")
 
-    rng = np.random.default_rng(seed)
+    rng, _ = _resolve_rng(
+        seed,
+        func_name="stationary_bootstrap_resamples",
+        docs_path="api/stats#factrix.stats.stationary_bootstrap_resamples",
+    )
     idx = _stationary_block_indices(n, n_resamples, float(block_length), rng)
     return values[idx]
 
@@ -183,7 +190,7 @@ def bootstrap_mean_ci(
     n_resamples: int = 999,
     ci: float = 0.95,
     block_length: float | None = None,
-    seed: int | None = None,
+    seed: Seed = None,
     statistic: Callable[[np.ndarray], float] | None = None,
     method: Literal["studentized", "percentile"] = "studentized",
 ) -> BootstrapCI:
@@ -240,7 +247,10 @@ def bootstrap_mean_ci(
             against ``[1, ceil(min(3*sqrt(T), T/3))]``; a length at or
             past ``T`` used to collapse every resample to a rotation of
             the input and return a zero-width interval.
-        seed: Reproducibility seed.
+        seed: An ``int`` reproduces the interval, ``None`` draws one from
+            system entropy, and a ``numpy.random.Generator`` is used as-is
+            and advanced by the call. Not reported back: this function
+            returns an interval, not a metadata-carrying result.
         statistic: Scalar function applied to each resample. Defaults
             to ``np.mean``.
         method: ``"studentized"`` (default) or ``"percentile"``. The

--- a/tests/test_seed_contract.py
+++ b/tests/test_seed_contract.py
@@ -1,0 +1,306 @@
+"""The shared ``seed`` contract across every entry point that resamples.
+
+One knob, one type (``int | numpy.random.Generator | None``), one
+resolution helper (``factrix._stats.bootstrap._resolve_rng``) and one
+reporting rule:
+
+- ``int`` — reproduces the run and is reported unchanged;
+- ``None`` — resolved from system entropy and reported, so an unseeded
+  run stays reproducible after the fact;
+- ``Generator`` — used as-is and *advanced* by the call (two calls on one
+  generator differ; two generators built from the same seed agree), and
+  reported as ``None`` because only its owner can reproduce the draw.
+
+Every entry point is exercised against the same five assertions so the
+contract cannot drift per module.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix import slice_period_joint_test, slice_period_pairwise_test
+from factrix._errors import UserInputError
+from factrix.datasets import make_cs_panel
+from factrix.inference import StationaryBootstrap
+from factrix.metrics import ic, monotonicity
+from factrix.stats import bootstrap_mean_ci, stationary_bootstrap_resamples
+
+from tests._slice_panel import build_disjoint_period_panel
+
+_B = 199
+_DAY_ZERO = datetime(2024, 1, 1)
+
+
+def _ic_series(n: int = 40) -> pl.DataFrame:
+    """A weak-signal IC series: its bootstrap p sits off the ``1/(B+1)``
+    floor, so a different draw shows up as a different p."""
+    rng = np.random.default_rng(0)
+    return pl.DataFrame(
+        {
+            "date": [_DAY_ZERO + timedelta(days=i) for i in range(n)],
+            "ic": rng.normal(0.02, 0.15, n),
+        }
+    )
+
+
+def _slice_panel() -> pl.DataFrame:
+    return build_disjoint_period_panel(
+        seed=1,
+        spans={"bull": (60, 0.1), "bear": (60, 0.1)},
+        label_col="regime",
+    )
+
+
+def _monotonicity_panel(n_dates: int = 40, n_assets: int = 30) -> pl.DataFrame:
+    rng = np.random.default_rng(7)
+    dates = np.repeat(np.arange(n_dates), n_assets)
+    factor = rng.normal(size=n_dates * n_assets)
+    # Weak signal on purpose: a perfectly ordered panel pins the MR p at
+    # the 1/(B+1) floor, where two different draws are indistinguishable.
+    fwd = 0.02 * factor + rng.normal(scale=0.7, size=n_dates * n_assets)
+    return pl.DataFrame(
+        {
+            "date": [_DAY_ZERO + timedelta(days=int(d)) for d in dates],
+            "asset_id": [f"a{i}" for i in np.tile(np.arange(n_assets), n_dates)],
+            "factor": factor,
+            "forward_return": fwd,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# ic(inference=StationaryBootstrap(...))
+# ---------------------------------------------------------------------------
+
+
+def _ic_p(seed) -> tuple[float, object]:
+    result = ic(
+        _ic_series(),
+        overlap_periods=1,
+        inference=StationaryBootstrap(n_resamples=_B, seed=seed),
+    )
+    return result.p_value, result.metadata["seed"]
+
+
+class TestStationaryBootstrapSeed:
+    def test_same_int_reproduces(self) -> None:
+        assert _ic_p(11) == _ic_p(11)
+        assert _ic_p(11)[1] == 11
+
+    def test_one_generator_advances(self) -> None:
+        gen = np.random.default_rng(11)
+        first, first_seed = _ic_p(gen)
+        second, _ = _ic_p(gen)
+        assert first_seed is None
+        assert first != second
+
+    def test_equal_generators_agree(self) -> None:
+        assert _ic_p(np.random.default_rng(11)) == _ic_p(np.random.default_rng(11))
+
+    def test_none_reports_a_seed_that_reproduces_the_run(self) -> None:
+        p_unseeded, reported = _ic_p(None)
+        assert isinstance(reported, int)
+        assert _ic_p(reported)[0] == p_unseeded
+
+    def test_bogus_type_rejected(self) -> None:
+        with pytest.raises(UserInputError) as excinfo:
+            _ic_p("11")
+        assert excinfo.value.field == "seed"
+
+    def test_degenerate_path_reports_the_resolved_seed(self) -> None:
+        """A series too short to test still reports a usable seed, not -1."""
+        from factrix._stats.bootstrap import _block_bootstrap_diff_p
+
+        _, metadata = _block_bootstrap_diff_p(np.array([1.0]), n_resamples=_B, seed=3)
+        assert metadata["seed"] == 3
+        _, metadata = _block_bootstrap_diff_p(np.array([1.0]), n_resamples=_B)
+        assert isinstance(metadata["seed"], int)
+        assert metadata["seed"] >= 0
+        _, metadata = _block_bootstrap_diff_p(
+            np.array([1.0]), n_resamples=_B, seed=np.random.default_rng(3)
+        )
+        assert metadata["seed"] is None
+
+
+# ---------------------------------------------------------------------------
+# monotonicity
+# ---------------------------------------------------------------------------
+
+
+def _mono(seed) -> tuple[float, object]:
+    result = monotonicity(
+        _monotonicity_panel(), overlap_periods=1, n_groups=5, n_resamples=_B, seed=seed
+    )["factor"]
+    return result.p_value, result.metadata["seed"]
+
+
+class TestMonotonicitySeed:
+    def test_same_int_reproduces(self) -> None:
+        assert _mono(11) == _mono(11)
+        assert _mono(11)[1] == 11
+
+    def test_one_generator_advances(self) -> None:
+        gen = np.random.default_rng(11)
+        first, first_seed = _mono(gen)
+        second, _ = _mono(gen)
+        assert first_seed is None
+        assert first != second
+
+    def test_equal_generators_agree(self) -> None:
+        assert _mono(np.random.default_rng(11)) == _mono(np.random.default_rng(11))
+
+    def test_none_reports_a_seed_that_reproduces_the_run(self) -> None:
+        p_unseeded, reported = _mono(None)
+        assert isinstance(reported, int)
+        assert _mono(reported)[0] == p_unseeded
+
+    def test_bogus_type_rejected(self) -> None:
+        with pytest.raises(UserInputError) as excinfo:
+            _mono(1.5)
+        assert excinfo.value.field == "seed"
+
+
+# ---------------------------------------------------------------------------
+# slice_period_pairwise_test / slice_period_joint_test
+# ---------------------------------------------------------------------------
+
+
+def _pairwise(seed, method: str = "bootstrap"):
+    out = slice_period_pairwise_test(
+        _slice_panel(),
+        ic(),
+        by="regime",
+        factor_col="factor",
+        method=method,
+        n_resamples=_B,
+        seed=seed,
+    )
+    return list(out["p_raw"]), out["seed"][0]
+
+
+def _joint(seed, method: str = "bootstrap"):
+    out = slice_period_joint_test(
+        _slice_panel(),
+        ic(),
+        by="regime",
+        factor_col="factor",
+        method=method,
+        n_resamples=_B,
+        seed=seed,
+    )
+    return out["p_value"][0], out["seed"][0]
+
+
+@pytest.mark.parametrize("run", [_pairwise, _joint], ids=["pairwise", "joint"])
+class TestSlicePeriodSeed:
+    def test_same_int_reproduces(self, run) -> None:
+        assert run(11) == run(11)
+        assert run(11)[1] == 11
+
+    def test_one_generator_advances(self, run) -> None:
+        gen = np.random.default_rng(11)
+        first, first_seed = run(gen)
+        second, _ = run(gen)
+        assert first_seed is None
+        assert first != second
+
+    def test_equal_generators_agree(self, run) -> None:
+        assert run(np.random.default_rng(11)) == run(np.random.default_rng(11))
+
+    def test_none_reports_a_seed_that_reproduces_the_run(self, run) -> None:
+        unseeded, reported = run(None)
+        assert isinstance(reported, int)
+        assert run(reported)[0] == unseeded
+
+    def test_analytic_reports_null(self, run) -> None:
+        assert run(11, "analytic")[1] is None
+
+    def test_bogus_type_rejected(self, run) -> None:
+        with pytest.raises(UserInputError) as excinfo:
+            run(object())
+        assert excinfo.value.field == "seed"
+
+
+# ---------------------------------------------------------------------------
+# stationary_bootstrap_resamples / bootstrap_mean_ci (draws, no reporting)
+# ---------------------------------------------------------------------------
+
+
+class TestStatsBootstrapSeed:
+    @staticmethod
+    def _values() -> np.ndarray:
+        return np.random.default_rng(0).normal(size=80)
+
+    def test_same_int_reproduces(self) -> None:
+        values = self._values()
+        first = stationary_bootstrap_resamples(values, _B, seed=11)
+        second = stationary_bootstrap_resamples(values, _B, seed=11)
+        assert np.array_equal(first, second)
+
+    def test_one_generator_advances(self) -> None:
+        values = self._values()
+        gen = np.random.default_rng(11)
+        first = stationary_bootstrap_resamples(values, _B, seed=gen)
+        second = stationary_bootstrap_resamples(values, _B, seed=gen)
+        assert not np.array_equal(first, second)
+
+    def test_equal_generators_agree(self) -> None:
+        values = self._values()
+        first = stationary_bootstrap_resamples(
+            values, _B, seed=np.random.default_rng(11)
+        )
+        second = stationary_bootstrap_resamples(
+            values, _B, seed=np.random.default_rng(11)
+        )
+        assert np.array_equal(first, second)
+
+    def test_none_still_draws(self) -> None:
+        assert stationary_bootstrap_resamples(self._values(), _B).shape == (_B, 80)
+
+    def test_bogus_type_rejected(self) -> None:
+        with pytest.raises(UserInputError) as excinfo:
+            stationary_bootstrap_resamples(self._values(), _B, seed="11")
+        assert excinfo.value.field == "seed"
+
+    def test_bootstrap_mean_ci_takes_a_generator(self) -> None:
+        values = self._values()
+        first = bootstrap_mean_ci(
+            values, n_resamples=_B, seed=np.random.default_rng(11)
+        )
+        second = bootstrap_mean_ci(
+            values, n_resamples=_B, seed=np.random.default_rng(11)
+        )
+        assert first == second
+        assert all(math.isfinite(v) for v in first)
+
+
+# ---------------------------------------------------------------------------
+# datasets.make_*
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetsSeed:
+    def test_same_int_reproduces(self) -> None:
+        assert make_cs_panel(seed=11).equals(make_cs_panel(seed=11))
+
+    def test_one_generator_advances(self) -> None:
+        gen = np.random.default_rng(11)
+        assert not make_cs_panel(seed=gen).equals(make_cs_panel(seed=gen))
+
+    def test_equal_generators_agree(self) -> None:
+        assert make_cs_panel(seed=np.random.default_rng(11)).equals(
+            make_cs_panel(seed=np.random.default_rng(11))
+        )
+
+    def test_none_still_draws(self) -> None:
+        assert make_cs_panel(seed=None).height > 0
+
+    def test_bogus_type_rejected(self) -> None:
+        with pytest.raises(UserInputError) as excinfo:
+            make_cs_panel(seed="11")
+        assert excinfo.value.field == "seed"

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -24,6 +24,7 @@ _JOINT_COLS = [
     "df_denom",
     "multiplicity",
     "min_periods",
+    "seed",
     "short_slice_periods",
     "warning_codes",
     "unexpected_warning_codes",

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -27,6 +27,7 @@ _PAIRWISE_COLS = [
     "df_denom",
     "multiplicity",
     "min_periods",
+    "seed",
     "reason",
 ]
 


### PR DESCRIPTION
> **TL;DR** — `seed` 在所有 bootstrap 入口、primitive 與 `datasets.make_*` 接受 `int | numpy.random.Generator | None`；一個 `_resolve_rng` helper 成為全庫唯一建 `Generator` 的地方，三種型別的契約統一（`None` → 解析並回報 int；`Generator` → 呼叫端擁有該流、回報 `None`）。slice period 檢定新增 `seed` 欄，`seed=None` 下的結果首次可事後重現；`-1` 哨兵移除。**Breaking**：新欄位、`metadata["seed"]` 可為 `None`。

Closes #915

## 為什麼
主流（numpy、scipy SPEC 7 `rng=`、arch）都接受 `Generator`，讓大規模 / 巢狀模擬共用一條隨機流。同時「`None` → 解析並回報」的契約原本只在 `ic` 與 `monotonicity` 成立、各用不同機制，slice period 檢定完全不回報——同名旋鈕三種行為。

## 審核紀錄（實作者 opus，審核者本 session）
獨立探針全過：全庫 RNG 建構只在 `_resolve_rng`；六個入口各驗「同 int 可重現 / 同一 `Generator` 兩次不同 / 等 seed 的兩個 `Generator` 相同 / `None` 回報的 int 可重現 / 錯型別 `UserInputError`」；slice 的 `seed` 欄在 bootstrap 下為 int 且可重現、analytic 下為 null。

實作者主動標出並接受：helper 帶 `func_name` / `docs_path` 以符合 `_check_n_resamples` 慣例；`Seed` 別名放 `_stats/bootstrap.py`（`_types.py` 為 numpy-free）；analytic 路徑同樣驗 seed 型別；測試資料改為弱訊號（強訊號把 p 釘在 `1/(B+1)` 地板，Generator 推進不可觀察）；`datasets.make_*` 保留 `seed=42` 預設。

## 驗證
`ruff check` / `ruff format --check` / `mypy factrix` / `mkdocs build --strict` 綠；全套 **3191 passed, 42 skipped**（+34 為 `tests/test_seed_contract.py`）。