### PR TITLE
fix(metrics)!: read the Shanken-corrected t against the HAR df and require the factor-return variance

### DIFF
--- a/docs/api/metrics/fm_beta.md
+++ b/docs/api/metrics/fm_beta.md
@@ -38,12 +38,15 @@ title: factrix.metrics.fm_beta
 
     ---
 
-    Set `is_estimated_factor=True` (with `factor_return_var=` where the
-    factor-mimicking-portfolio return series is available) to apply the
+    Set `is_estimated_factor=True` **together with** `factor_return_var=`
+    — the variance of the factor-mimicking portfolio return — to apply the
     Shanken (1992) single-factor EIV correction (the multi-factor
     multiplicative term collapses to $1 + \hat\lambda^2/\sigma^2_f$).
     Required when the FactorDensity column is itself estimated — rolling beta,
-    PCA score, ML prediction.
+    PCA score, ML prediction. There is no default $\sigma^2_f$: omitting it
+    raises `UserInputError`, because the obvious proxy
+    $\mathrm{var}(\hat\beta_t)$ makes the multiplier $1 + t^2/T$
+    identically and carries no EIV information.
 
 -   __Pooled OLS robustness check__
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -119,11 +119,13 @@ is emitted.
 - *warning*: `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` when the resolved
   bandwidth exceeds `n_periods / 5`.
 - *descriptive* (conditional, Shanken applied): `shanken_c`,
-  `shanken_factor_return_var`, `shanken_factor_return_var_source`.
+  `shanken_factor_return_var` (the caller-supplied σ²_f). The corrected
+  `p_value` is read against the same `hac_dof` as `p_value_uncorrected`,
+  so `p_value >= p_value_uncorrected` always.
 - *descriptive* (conditional, σ²_f ≈ 0): `shanken_correction` =
   `"skipped_zero_factor_variance"` — the correction is undefined
   when the factor-return variance collapses; the uncorrected NW
-  result is reported.
+  result is reported and `WarningCode.DEGENERATE_VARIANCE` is raised.
 
 #### `pooled_beta` (emits `MetricResult.name = "pooled_beta"`)
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -181,14 +181,24 @@ omits: at finite $T$ the omission **understates** the EIV inflation
 and so **overstates** the resulting $t$. The simplification is honest
 only when $T$ is large enough that the dropped term is negligible.
 
-When `factor_return_var` is not supplied, factrix falls back to
-$\mathrm{var}(\hat\beta_t)$ as a proxy for $\sigma^2_f$. Because
-$\hat\beta_t$ already absorbs
-estimation noise from the upstream factor score, this proxy
-**inflates the denominator** of the EIV factor and so **further
-deflates** the correction. Treat the
-`betas_timeseries_proxy` result as a lower bound on the true
-inflation — i.e. an upper bound on the reported `t`.
+`factor_return_var` is **required** under `is_estimated_factor=True`;
+omitting it raises `UserInputError`. There is no default because the
+only readily-available substitute, $\mathrm{var}(\hat\beta_t)$, makes the
+multiplier $1 + \overline{\beta}^2 / \mathrm{var}(\hat\beta_t) \equiv
+1 + t^2_{\mathrm{iid}} / T$ identically — an algebraic restatement of the
+$t$-stat that carries no errors-in-variables information about the
+regressor at all. When $\sigma^2_f$ collapses below machine epsilon the
+multiplier is undefined; factrix skips the correction, returns the
+uncorrected Newey-West $p$, and raises
+`WarningCode.DEGENERATE_VARIANCE` rather than switching silently.
+
+The corrected $t$ is read against the **same** effective degrees of
+freedom $\nu$ as the uncorrected one (`metadata["hac_dof"]`), so
+$c \ge 1$ translates into $p_{\text{Shanken}} \ge p_{\text{uncorrected}}$
+on any given series. Reading it against $T - 1$ instead would widen the
+reference distribution far enough to more than undo the $\sqrt{c}$ SE
+inflation and make the "conservative" correction return the *smaller*
+$p$.
 
 Default versus paired t-test is a separate choice: the mainstream
 metrics (`ic`, `caar`) use **non-overlapping resampling** as the
@@ -586,6 +596,30 @@ or Andrews-Monahan prewhitening) would change every HAC $p$-value in the
 library and is a project rather than a patch. Read HAC $p$-values near the
 threshold as optimistic when the input is persistent — the `persistence`
 diagnostic in section 4 flags exactly that case.
+
+### Shanken EIV correction on `fm_beta`: measured size
+
+Rejection frequency at a nominal 5% on a true null —
+`make_cs_panel(ic_target=0.0)`, 50 assets, 300 replications per cell,
+seed 20260830 + replication. $\sigma^2_f$ is the variance of the panel's
+own realised long-short forward return (top-minus-bottom quintile,
+equal-weighted, computed from the same panel), which is what a caller
+holding the traded spread would supply.
+
+| $T$ | $h$ | uncorrected | Shanken |
+|---|---|---|---|
+| 120 | 1 | 7.3% | 7.3% |
+| 120 | 5 | 3.3% | 3.3% |
+| 240 | 1 | 4.3% | 4.0% |
+| 240 | 5 | 6.0% | 6.0% |
+
+Under the null $\overline{\beta} \to 0$, so $c \to 1$ and the correction is
+close to inert: the row simply inherits the scalar series-mean size of the
+HAR path in the table above. That is the intended shape — the correction
+costs no size on a true null and only shrinks $t$ where a premium is
+actually estimated. Producing module:
+`tests/stats/test_fm_beta_shanken_size.py`, which re-measures the same
+grid at a reduced replication count.
 
 ### Joint period test on short slices: known over-rejection
 

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -138,10 +138,6 @@ PValue = NewType("PValue", float)
 # correlation source the Z is built from.
 KPSource = Literal["icc", "no_multi_event_dates"]
 
-# Shanken (1992) errors-in-variables correction — which σ²(λ) input feeds
-# the second-stage variance inflation.
-ShankenVarSource = Literal["user_supplied", "betas_timeseries_proxy"]
-
 # Top-bucket concentration weight basis — pure factor magnitude vs.
 # realised contribution to the long-leg's α.
 ConcentrationWeight = Literal["abs_factor", "alpha_contribution"]

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -41,6 +41,7 @@ from factrix._axis import (
     InputShape,
 )
 from factrix._codes import WarningCode
+from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import (
@@ -49,7 +50,7 @@ from factrix._stats import (
     _p_value_from_t,
 )
 from factrix._stats.constants import MIN_PERIODS_WARN, PERSISTENT_SERIES_AUTOCORR
-from factrix._types import DDOF, EPSILON, ShankenVarSource
+from factrix._types import EPSILON
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _degenerate_test_fields,
@@ -91,6 +92,9 @@ per_date_series = per_date_series_rename("beta")
 # that the asymptotic t is borderline). ``T ≥ WARN`` is silent.
 MIN_FM_PERIODS_HARD: int = 4
 MIN_FM_PERIODS_WARN: int = 30
+
+# Docs page the ``factor_return_var`` input error points at.
+_DOCS_FM_BETA = "api/metrics/fm_beta"
 
 
 def _min_fm_assets(beta_df: pl.DataFrame) -> int | None:
@@ -177,7 +181,8 @@ def fm_beta(
             kernel is consistent *and* the reference distribution is
             calibrated under the MA($h-1$) overlap structure of
             $h$-period returns.
-        is_estimated_factor: Set True when the ``Signal_i`` column used by
+        is_estimated_factor: Requires ``factor_return_var``. Set True when
+            the ``Signal_i`` column used by
             ``compute_fm_betas`` is itself an **estimated** quantity
             (rolling ordinary least squares (OLS) $\beta$ to another factor, PCA score,
             ML-predicted score, residual from a first-stage regression).
@@ -206,19 +211,20 @@ def fm_beta(
             diagnostic literature.
 
         factor_return_var: $\sigma^2_f$, the time-series variance of the
-            factor-mimicking portfolio return. Prefer supplying this when
-            you have a spread-portfolio return series (the long-short
-            spread actually traded on the density). When ``None`` and
-            ``is_estimated_factor=True``, falls back to
-            $\mathrm{var}(\beta_t)$ as a rough placeholder —
-            $\hat\beta_t$ is *not* the factor-mimicking return but is
-            usually the only readily-available series. Because
-            $\mathrm{var}(\hat\beta_t)$ already absorbs upstream
-            estimation noise, it inflates the denominator of the EIV
-            factor and so deflates the SE correction; treat the
-            ``betas_timeseries_proxy`` result as a **lower bound on the
-            true SE inflation** — i.e. an **upper bound on the reported
-            $t$-stat** — not a precise estimate.
+            factor-mimicking portfolio return — the long-short spread
+            actually traded on the density. **Mandatory** when
+            ``is_estimated_factor=True``; ``None`` there raises
+            ``UserInputError``. There is deliberately no default: the
+            obvious candidate, $\mathrm{var}(\hat\beta_t)$, makes the
+            multiplier $1 + \overline{\beta}^2/\mathrm{var}(\hat\beta_t)
+            \equiv 1 + t^2_{\mathrm{iid}}/T$ identically — an algebraic
+            restatement of the $t$-stat that carries no
+            errors-in-variables information about the regressor. When
+            $\sigma^2_f$ is below machine epsilon the multiplier is
+            undefined; the correction is skipped, the uncorrected
+            Newey-West $p$ is returned, and
+            ``WarningCode.DEGENERATE_VARIANCE`` is raised alongside
+            ``metadata["shanken_correction"]``.
 
     Notes:
         Stage 2 of FM:
@@ -230,7 +236,9 @@ def fm_beta(
         $\nu = \min(1.5T/L - 1,\, T/h - 1)$.
         With ``is_estimated_factor=True``, the
         [Shanken (1992)][shanken-1992] single-factor correction scales
-        SE by $\sqrt{1 + \overline{\beta}^2 / \sigma^2_f}$.
+        SE by $\sqrt{1 + \overline{\beta}^2 / \sigma^2_f}$, and the
+        corrected $t$ is read against the same effective $\nu$ as the
+        uncorrected one — so the correction can only move $p$ upward.
 
         factrix uses the [LLSW (2018)][llsw-2018] HAR bandwidth rule
         floored against the Hansen-Hodrick overlap horizon, with a
@@ -282,6 +290,22 @@ def fm_beta(
         >>> result.name == ""
         True
     """
+    if is_estimated_factor and factor_return_var is None:
+        raise UserInputError(
+            func_name="fm_beta",
+            field="factor_return_var",
+            value=factor_return_var,
+            expected=(
+                "the time-series variance of the factor-mimicking portfolio "
+                "return (a float) whenever is_estimated_factor=True. There is "
+                "no usable default: substituting var(β̂_t) makes the Shanken "
+                "multiplier 1 + mean(β)²/var(β̂_t) identically 1 + t²/T, which "
+                "is a restatement of the t-stat and carries no "
+                "errors-in-variables information about the regressor"
+            ),
+            docs_path=_DOCS_FM_BETA,
+        )
+
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
 
@@ -340,34 +364,45 @@ def fm_beta(
     }
 
     if is_estimated_factor:
-        sigma2_f = (
-            float(factor_return_var)
-            if factor_return_var is not None
-            else float(np.var(betas, ddof=DDOF))
-        )
+        sigma2_f = float(factor_return_var)  # type: ignore[arg-type]
         # σ²_f ≈ 0 means the factor premium series is flat; Shanken's
         # denominator collapses and the correction is undefined. Skip
         # rather than divide into EPSILON — the uncorrected NW result
-        # is the honest answer in a degenerate regime.
+        # is the honest answer in a degenerate regime. A skipped
+        # correction is a regime switch, so it carries a warning code
+        # rather than only a metadata string.
         if sigma2_f < EPSILON:
             metadata["shanken_correction"] = "skipped_zero_factor_variance"
+            code = WarningCode.DEGENERATE_VARIANCE.value
+            if code not in warning_codes:
+                warning_codes.append(code)
+            if code not in expected_warnings:
+                warnings.warn(
+                    f"fm_beta: factor_return_var={sigma2_f!r} is below "
+                    f"EPSILON={EPSILON}, so the Shanken (1992) EIV multiplier "
+                    f"1 + mean(β)²/σ²_f is undefined. The correction is "
+                    f"skipped and the UNCORRECTED Newey-West p-value is "
+                    f"returned — read it as un-adjusted for the estimated "
+                    f"regressor.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         else:
             c = 1.0 + (mean_beta**2) / sigma2_f
             sqrt_c = math.sqrt(c)
             t_shanken = t / sqrt_c
-            p_shanken = _p_value_from_t(t_shanken, n)
-            source: ShankenVarSource = (
-                "user_supplied"
-                if factor_return_var is not None
-                else "betas_timeseries_proxy"
-            )
+            # Read the corrected t against the SAME effective df the
+            # uncorrected p used. Falling back to n-1 widens the reference
+            # distribution far enough to more than undo the √c SE inflation,
+            # which turns a conservative correction into a p-value that is
+            # SMALLER than the uncorrected one.
+            p_shanken = _p_value_from_t(t_shanken, n, dof=metadata["hac_dof"])
             metadata.update(
                 {
                     "p_value_uncorrected": p,
                     "stat_uncorrected": t,
                     "shanken_c": c,
                     "shanken_factor_return_var": sigma2_f,
-                    "shanken_factor_return_var_source": source,
                     "method": ("Fama-MacBeth + Newey-West + Shanken (1992) EIV"),
                 }
             )

--- a/tests/stats/test_fm_beta_shanken_size.py
+++ b/tests/stats/test_fm_beta_shanken_size.py
@@ -1,0 +1,113 @@
+"""Null size of ``fm_beta``'s Shanken path, corrected against uncorrected.
+
+The panel is ``make_cs_panel(ic_target=0.0)``, so the FM premium is truly
+zero; ``factor_return_var`` is the variance of the panel's own realised
+long-short (top-minus-bottom quintile) forward return, which is what a
+caller with a traded spread would supply. Measured over 300 replications
+per cell at seed 20260830 + rep, at a nominal 5%:
+
+| T | h | uncorrected | Shanken |
+|---|---|---|---|
+| 120 | 1 | 7.3% | 7.3% |
+| 120 | 5 | 3.3% | 3.3% |
+| 240 | 1 | 4.3% | 4.0% |
+| 240 | 5 | 6.0% | 6.0% |
+
+Under the null the multiplier ``c = 1 + mean(beta)^2 / sigma^2_f`` sits at
+essentially 1 — mean(beta) is zero by construction — so the correction is
+close to inert and the row inherits the scalar series-mean size of the HAR
+path. That is the point of the table: the correction costs nothing under
+the null and only shrinks ``t`` when a premium is actually present.
+
+The same script measured the pre-fix code — the corrected ``t`` read
+against ``n - 1`` instead of the HAR effective df — returning a p-value
+BELOW the uncorrected one in 300/300 draws in every cell.
+
+Replication count here is cut to keep the module fast, so the bounds
+characterise rather than pin.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._stats import _p_value_from_t
+from factrix.datasets import make_cs_panel
+from factrix.metrics.fm_beta import compute_fm_betas, fm_beta
+from factrix.preprocess import compute_forward_return
+
+SEED = 20260830
+N_REPS = 60
+N_ASSETS = 50
+
+
+def _long_short_variance(panel: pl.DataFrame) -> float:
+    """Variance of the realised top-minus-bottom-quintile forward return."""
+    labels = [str(i) for i in range(5)]
+    bucketed = panel.with_columns(
+        pl.col("factor").qcut(5, labels=labels).over("date").alias("bucket")
+    )
+    per_period = (
+        bucketed.group_by(["date", "bucket"])
+        .agg(pl.col("forward_return").mean().alias("leg"))
+        .pivot(on="bucket", index="date", values="leg")
+        .drop_nulls()
+    )
+    spread = (per_period["4"] - per_period["0"]).to_numpy()
+    return float(np.var(spread, ddof=1))
+
+
+def _rejection_rates(n_periods: int, horizon: int) -> tuple[float, float, float]:
+    """(uncorrected size, Shanken size, fraction where the pre-fix p is smaller)."""
+    rejected_uncorrected = rejected_shanken = prefix_smaller = kept = 0
+    for rep in range(N_REPS):
+        raw = make_cs_panel(
+            n_assets=N_ASSETS,
+            n_dates=n_periods + horizon + 1,
+            ic_target=0.0,
+            rng=SEED + rep,
+        )
+        panel = compute_forward_return(raw, forward_periods=horizon)
+        beta_df = compute_fm_betas(panel)["factor"]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out = fm_beta(
+                beta_df,
+                overlap_periods=horizon,
+                is_estimated_factor=True,
+                factor_return_var=_long_short_variance(panel),
+            )
+        p_uncorrected = out.metadata.get("p_value_uncorrected")
+        if out.p_value is None or p_uncorrected is None:
+            continue
+        kept += 1
+        rejected_uncorrected += p_uncorrected < 0.05
+        rejected_shanken += out.p_value < 0.05
+        # The pre-fix path: same corrected t, read against n - 1.
+        prefix_smaller += (
+            _p_value_from_t(out.stat, out.metadata["n_periods"]) < p_uncorrected
+        )
+    return (
+        rejected_uncorrected / kept,
+        rejected_shanken / kept,
+        prefix_smaller / kept,
+    )
+
+
+@pytest.mark.parametrize(
+    ("n_periods", "horizon"), [(120, 1), (120, 5), (240, 1), (240, 5)]
+)
+def test_shanken_path_is_sized_like_the_uncorrected_one(n_periods, horizon):
+    size_uncorrected, size_shanken, prefix_smaller = _rejection_rates(
+        n_periods, horizon
+    )
+    assert size_uncorrected <= 0.12
+    assert size_shanken <= 0.12
+    # Under a true null the multiplier is ~1, so the correction neither
+    # buys nor costs size; it must never be ANTI-conservative.
+    assert size_shanken <= size_uncorrected + 1e-12
+    # And the pre-fix df bug is reproducible on every draw in every cell.
+    assert prefix_smaller == 1.0

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -7,6 +7,7 @@ batch element equals the corresponding list-of-one call).
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -508,3 +509,109 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert out.metadata["n_clusters_a"] == 10
         assert out.metadata["n_clusters_b"] == 2
         assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
+
+
+class TestShankenCorrection:
+    """The EIV path: mandatory σ²_f, HAR df, and the degenerate regime."""
+
+    @staticmethod
+    def _beta_df(betas: np.ndarray) -> pl.DataFrame:
+        start = datetime(2020, 1, 1)
+        return pl.DataFrame(
+            {
+                "date": [start + timedelta(days=i) for i in range(len(betas))],
+                "beta": betas,
+            }
+        )
+
+    @staticmethod
+    def _draw(n: int, mean: float, rng_seed: int) -> np.ndarray:
+        rng = np.random.default_rng(rng_seed)
+        return mean + rng.standard_normal(n) * 0.01
+
+    @pytest.mark.parametrize("n_periods", [60, 120, 240])
+    @pytest.mark.parametrize("overlap_periods", [None, 5])
+    def test_correction_can_only_raise_the_p_value(self, n_periods, overlap_periods):
+        """c >= 1 shrinks |t|; read against the SAME df, p can only grow.
+
+        The bug this pins: the corrected t used to be read against ``n - 1``
+        while the uncorrected p used the HAR effective df (~16 at T = 240),
+        so the wider reference distribution more than undid the sqrt(c) SE
+        inflation and the "conservative" correction returned a SMALLER p.
+        """
+        betas = self._draw(n_periods, 0.004, 11)
+        beta_df = self._beta_df(betas)
+        out = fm_beta(
+            beta_df,
+            overlap_periods=overlap_periods,
+            is_estimated_factor=True,
+            factor_return_var=0.0004,
+        )
+        assert out.metadata["shanken_c"] >= 1.0
+        assert abs(out.stat) <= abs(out.metadata["stat_uncorrected"])
+        assert out.p_value >= out.metadata["p_value_uncorrected"]
+
+    def test_corrected_p_is_read_against_the_reported_hac_dof(self):
+        from factrix._stats import _p_value_from_t
+
+        betas = self._draw(120, 0.004, 3)
+        out = fm_beta(
+            self._beta_df(betas),
+            overlap_periods=5,
+            is_estimated_factor=True,
+            factor_return_var=0.0004,
+        )
+        assert out.p_value == pytest.approx(
+            _p_value_from_t(out.stat, out.n_obs, dof=out.metadata["hac_dof"])
+        )
+
+    def test_estimated_factor_without_a_variance_is_a_user_input_error(self):
+        from factrix._errors import UserInputError
+
+        betas = self._draw(120, 0.004, 5)
+        with pytest.raises(UserInputError) as excinfo:
+            fm_beta(self._beta_df(betas), is_estimated_factor=True)
+        err = excinfo.value
+        assert err.field == "factor_return_var"
+        assert err.func_name == "fm_beta"
+        # The proxy is refused because it is algebraically inert, and the
+        # message has to say so — see the docstring's 1 + t^2/T identity.
+        assert "1 + t" in str(err)
+
+    def test_degenerate_factor_variance_raises_a_warning_code(self):
+        betas = self._draw(120, 0.004, 7)
+        with pytest.warns(UserWarning, match="Shanken"):
+            out = fm_beta(
+                self._beta_df(betas),
+                is_estimated_factor=True,
+                factor_return_var=0.0,
+            )
+        assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
+        assert out.metadata["shanken_correction"] == "skipped_zero_factor_variance"
+        # Skipped, so the uncorrected result stands and no Shanken key appears.
+        assert "shanken_c" not in out.metadata
+        uncorrected = fm_beta(self._beta_df(betas))
+        assert out.p_value == pytest.approx(uncorrected.p_value)
+
+    def test_expected_warnings_silences_the_degenerate_regime(self):
+        betas = self._draw(120, 0.004, 7)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            out = fm_beta(
+                self._beta_df(betas),
+                is_estimated_factor=True,
+                factor_return_var=0.0,
+                expected_warnings=(WarningCode.DEGENERATE_VARIANCE.value,),
+            )
+        assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
+
+    def test_no_variance_source_key_is_reported(self):
+        """Only one source survives, so the key carries no information."""
+        betas = self._draw(120, 0.004, 9)
+        out = fm_beta(
+            self._beta_df(betas),
+            is_estimated_factor=True,
+            factor_return_var=0.0004,
+        )
+        assert "shanken_factor_return_var_source" not in out.metadata
+        assert out.metadata["shanken_factor_return_var"] == pytest.approx(0.0004)


### PR DESCRIPTION
> **TL;DR** — `fm_beta(is_estimated_factor=True)` 的 Shanken 修正 p 原本對 `t_{n-1}` 讀，未修正路徑卻用 HAR 有效自由度（T=240 時 ≈16）；自由度放大抵銷並超過 √c 的 SE 膨脹，「保守」修正反而讓 p 變小（修正前 300/300 次）。現在改用同一個 `hac_dof`；移除 `var(β̂_t)` 代理（它使 `c = 1+t²/T` 恆等、不含 EIV 資訊），`factor_return_var` 成為必填；σ²_f 退化時掛 `DEGENERATE_VARIANCE`。**Breaking**。

Closes #918

## 審核紀錄（實作者 opus，審核者本 session）
獨立探針：60 組 β 序列上 `p_shanken < p_uncorrected` **0/60**（修正前為 100%）；缺 `factor_return_var` → `UserInputError(field="factor_return_var")`；σ²_f=0 → `warning_codes=('degenerate_variance',)`。

實作者的判斷（接受）：`ShankenVarSource` Literal 與 `shanken_factor_return_var_source` 鍵一併刪除——只剩單一值的鍵不承載資訊；`shanken_factor_return_var` 保留回顯實際使用的數值。null 下修正是惰性的（β̄→0 ⇒ c→1），size 表因此修正前後相同，文件如實陳述而非製造對比；修正的價值由方向性質測試鎖定。

## Size 表（nominal 5%，`make_cs_panel(ic_target=0)`，50 資產，300 reps/格，seed 20260830+rep；σ²_f = 面板已實現的 top−bottom 五分位 forward return 變異數）
| T | h | 未修正 | Shanken |
|---|---|---|---|
| 120 | 1 | 7.3% | 7.3% |
| 120 | 5 | 3.3% | 3.3% |
| 240 | 1 | 4.3% | 4.0% |
| 240 | 5 | 6.0% | 6.0% |

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3207 passed, 42 skipped**（+12）。