### PR TITLE
fix(slicing)!: refuse date-aligned slices on the period-family slice tests

### DIFF
--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -84,6 +84,28 @@ distinguishes them:
   shared-date count and blames the thin universe — widen each slice's
   asset universe or use a coarser partition.
 
+### The refusal is symmetric
+
+Each pair refuses the other's partition, before its metric runs, and names
+the entry point that fits:
+
+| You called | With slices that | You get |
+|---|---|---|
+| `slice_pairwise_test` / `slice_joint_test` | share <2 dates (date-disjoint) | `ValueError`: `<2 aligned dates … use slice_period_pairwise_test / slice_period_joint_test for date-disjoint partitions.` |
+| `slice_period_pairwise_test` / `slice_period_joint_test` | share ≥2 dates in any pair (date-aligned) | `UserInputError` on `by`: `slices 'tech' and 'fin' share 120 dates … use slice_pairwise_test / slice_joint_test for date-aligned partitions.` |
+
+The period-family refusal is a hard error, not a warning: those tests treat
+each slice as an **independent sample** with block-diagonal cross-slice
+covariance, so slices sharing dates would have their common shocks counted
+as independent evidence and the p-values would be anticonservative with
+nothing in the result marking it. Partially overlapping spans are refused
+on the same rule — the shared periods carry the shared shock whether they
+are 10% of the span or all of it. Slices sharing **exactly one** date are
+tolerated: a date-axis partition truncated at a regime boundary can leave
+one common period, which
+[`slice_boundary_truncation`](../reference/warning-codes.md) already
+describes.
+
 For genuinely time-disjoint slices, reach for
 `slice_period_pairwise_test` / `slice_period_joint_test`. They build the
 same per-slice per-date series but **do not** inner-join — each slice is

--- a/docs/guides/slice-analysis.md
+++ b/docs/guides/slice-analysis.md
@@ -11,9 +11,9 @@ Slice analysis asks "is this factor stable across a partition of the panel?" The
 The **inference** functions are not. Cross-slice testing splits on a statistical fault line the dispatcher does not see — **do the slices share dates?**
 
 - **Cross-sectional / date-aligned** slices (sector, size bucket, liquidity tier) co-exist in time; cross-slice covariance is real and enters through a joint Newey-West HAC. → [`slice_pairwise_test` / `slice_joint_test`](../api/slice-test.md).
-- **Date-disjoint** slices (market regime, calendar period, in/out-of-sample) share no dates; they are (approximately) independent samples with block-diagonal covariance. The cross-sectional pair inner-joins on `date` and raises `<2 aligned dates` here. → [`slice_period_pairwise_test` / `slice_period_joint_test`](../api/slice-test.md), which treat each slice as an independent sample (bootstrap by default, analytic HAC opt-in).
+- **Date-disjoint** slices (market regime, calendar period, in/out-of-sample) share no dates; they are (approximately) independent samples with block-diagonal covariance. The cross-sectional pair inner-joins on `date` and raises `<2 aligned dates` here; symmetrically, this pair raises `UserInputError` on `by` when any two slices share ≥2 dates and points back at the cross-sectional pair. → [`slice_period_pairwise_test` / `slice_period_joint_test`](../api/slice-test.md), which treat each slice as an independent sample (bootstrap by default, analytic HAC opt-in).
 
-Picking the wrong pair is not a tuning choice — it is the wrong statistical assumption, so the two are **separate, explicitly-named** functions rather than one auto-routing surface.
+Picking the wrong pair is not a tuning choice — it is the wrong statistical assumption, so the two are **separate, explicitly-named** functions rather than one auto-routing surface, and each refuses the other's partition instead of returning a number ([the symmetric refusal](../api/slice-test.md#the-refusal-is-symmetric)).
 
 factrix splits this work into two roles because **slicing the panel** and **testing significance across slices** are different jobs that need different APIs.
 
@@ -23,7 +23,7 @@ factrix splits this work into two roles because **slicing the panel** and **test
 |---|---|---|---|
 | Dispatcher | [`by_slice(data, metric, *, by, factor_col)`](../api/by-slice.md) | Partitions an evaluate-ready panel (`forward_return` already attached) on an existing column and runs `evaluate` per slice; returns `dict[str, EvaluationResult]` (same shape as `evaluate`, keyed by slice) | **No cross-slice statistical test** |
 | Inference (date-aligned) | [`slice_pairwise_test`](../api/slice-test.md) / [`slice_joint_test`](../api/slice-test.md) | Cross-sectional pairwise contrasts (joint NW-HAC Wald χ² + Holm) or omnibus χ² that all slice means are equal | Only accepts metrics with a `per_date_series` capability (`ic`, `fm_beta`, `positive_rate`); requires slices to share dates |
-| Inference (date-disjoint) | [`slice_period_pairwise_test`](../api/slice-test.md) / [`slice_period_joint_test`](../api/slice-test.md) | Independent-sample pairwise contrasts (bootstrap + Romano-Wolf, or analytic HAC + Holm) / block-diagonal omnibus χ² for regime / calendar-period splits | Same `per_date_series` requirement; treats each slice as an independent sample |
+| Inference (date-disjoint) | [`slice_period_pairwise_test`](../api/slice-test.md) / [`slice_period_joint_test`](../api/slice-test.md) | Independent-sample pairwise contrasts (bootstrap + Romano-Wolf, or analytic HAC + Holm) / block-diagonal omnibus χ² for regime / calendar-period splits | Same `per_date_series` requirement; refuses a date-aligned partition (any pair of slices sharing ≥2 dates) |
 
 **Use the dispatcher when:** you want raw per-slice numbers, or you want to compose your own cross-slice test.
 

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -185,6 +185,64 @@ def _require_slice_floor(
     )
 
 
+_MAX_TOLERATED_SHARED_DATES = 1
+
+
+def _require_date_disjoint(
+    slices: dict[str, pl.DataFrame],
+    labels: list[str],
+    *,
+    by: str,
+    func_name: str,
+) -> None:
+    """Refuse a partition whose slices share dates, before the metric runs.
+
+    Mirror of the cross-sectional guard: :func:`slice_pairwise_test` /
+    :func:`slice_joint_test` refuse a date-disjoint partition because their
+    inner-join collapses to <2 aligned rows; this pair must refuse the
+    opposite case just as loudly. The period-family maths treats each slice
+    as an **independent sample** with block-diagonal cross-slice covariance,
+    so slices that share dates (a cross-sectional partition — sector, size
+    bucket — carries every date in every slice) would be contrasted as if
+    their common shocks were independent, and the p-values would be
+    anticonservative with nothing in the result marking it.
+
+    Sharing a single date is tolerated: a date-axis partition truncated at a
+    regime boundary can leave one common date, which
+    ``slice_boundary_truncation`` already describes. Any pair sharing ≥2
+    dates is a date-aligned partition and raises.
+    """
+    date_sets = {
+        lbl: set(slices[lbl].get_column("date").unique().to_list()) for lbl in labels
+    }
+    worst: tuple[int, str, str] | None = None
+    for i, left in enumerate(labels):
+        for right in labels[i + 1 :]:
+            shared = len(date_sets[left] & date_sets[right])
+            if shared > _MAX_TOLERATED_SHARED_DATES and (
+                worst is None or shared > worst[0]
+            ):
+                worst = (shared, left, right)
+    if worst is None:
+        return
+    shared, left, right = worst
+    raise UserInputError(
+        func_name=func_name,
+        field="by",
+        value=by,
+        expected=(
+            f"a column whose slices are date-disjoint; slices {left!r} and "
+            f"{right!r} share {shared} dates. These tests are date-disjoint "
+            f"— they treat each slice as an independent sample, so slices "
+            f"must share ≤1 date (a truncated regime boundary). A "
+            f"date-aligned partition (e.g. sector, size bucket) shares its "
+            f"dates and is not supported here — use slice_pairwise_test / "
+            f"slice_joint_test for date-aligned partitions."
+        ),
+        docs_path=_DOCS_SLICE,
+    )
+
+
 def _build_per_slice_series(
     data: pl.DataFrame,
     metric: MetricBase,
@@ -204,8 +262,9 @@ def _build_per_slice_series(
     per-period metric values, plus the resolved floor and the labels below it
     (empty unless ``strict=False`` admitted them).
 
-    Raises ``UserInputError`` if ``factor_col`` is absent; ``ValueError``
-    on <2 slice values or any slice with <2 dates; ``TypeError`` (via
+    Raises ``UserInputError`` if ``factor_col`` is absent or the slices are
+    not date-disjoint; ``ValueError`` on <2 slice values or any slice with
+    <2 dates; ``TypeError`` (via
     resolver) if ``metric`` is not slice-test-eligible.
     """
     if factor_col not in data.columns:
@@ -224,6 +283,7 @@ def _build_per_slice_series(
             f"{func_name}: need ≥2 slice values on {by!r}; got {len(slices)}."
         )
     labels = list(slices.keys())
+    _require_date_disjoint(slices, labels, by=by, func_name=func_name)
     series_list: list[np.ndarray] = []
     for lbl in labels:
         produced = _run_producer_for_factor(producer, slices[lbl], factor_col)
@@ -369,9 +429,12 @@ def slice_period_pairwise_test(
 
     Raises:
         UserInputError: ``metric`` is not a metric instance, ``factor_col``
-            is absent, ``method`` is invalid, or ``overlap_periods`` is not a
+            is absent, ``method`` is invalid, ``overlap_periods`` is not a
             positive ``int`` / disagrees with the panel's stamp / is missing
-            on an unstamped panel.
+            on an unstamped panel, or ``by`` names a **date-aligned**
+            partition — any two slices sharing ≥2 dates are not independent
+            samples and belong to :func:`factrix.slice_pairwise_test` /
+            :func:`factrix.slice_joint_test`.
         ValueError: Fewer than two slice values, any slice with fewer than
             two dates, or (``strict=True``) any slice whose per-period series
             is below the metric's own ``SampleThreshold`` floor resolved at
@@ -789,9 +852,12 @@ def slice_period_joint_test(
 
     Raises:
         UserInputError: ``metric`` is not a metric instance, ``factor_col``
-            is absent, ``method`` is invalid, or ``overlap_periods`` is not a
+            is absent, ``method`` is invalid, ``overlap_periods`` is not a
             positive ``int`` / disagrees with the panel's stamp / is missing
-            on an unstamped panel.
+            on an unstamped panel, or ``by`` names a **date-aligned**
+            partition — any two slices sharing ≥2 dates are not independent
+            samples and belong to :func:`factrix.slice_pairwise_test` /
+            :func:`factrix.slice_joint_test`.
         ValueError: Fewer than two slice values, any slice with fewer than
             two dates, or (``strict=True``) any slice whose per-period series
             is below the metric's own ``SampleThreshold`` floor resolved at

--- a/tests/_slice_panel.py
+++ b/tests/_slice_panel.py
@@ -65,6 +65,7 @@ def build_disjoint_period_panel(
     n_assets: int = 40,
     noise: float = 0.3,
     overlap_periods: int | None = 5,
+    shared_periods: int = 0,
 ) -> pl.DataFrame:
     """Raw panel whose labels occupy **disjoint** calendar spans.
 
@@ -76,6 +77,11 @@ def build_disjoint_period_panel(
     ``slice_period_*`` pair handles. Spans may differ in length, exercising
     the per-slice ``n_periods_*`` reporting.
 
+    ``shared_periods`` back-dates each span's start so that it overlaps its
+    predecessor by that many periods — 0 (default) keeps the spans strictly
+    disjoint, 1 is the single boundary period the period tests tolerate, and
+    anything larger is a date-aligned partition they must refuse.
+
     ``overlap_periods`` stamps the panel the way ``compute_forward_return``
     would (horizon and overlap alike); pass ``None`` for the unstamped,
     self-attached ``forward_return`` panel that must declare its overlap at
@@ -86,7 +92,7 @@ def build_disjoint_period_panel(
     frames = []
     for lbl, (n_dates, s) in spans.items():
         dates = [cursor + dt.timedelta(days=i) for i in range(n_dates)]
-        cursor = dates[-1] + dt.timedelta(days=1)
+        cursor = dates[-1] + dt.timedelta(days=1 - shared_periods)
         date_series = pl.Series("date", dates, dtype=pl.Date)
         idx = np.repeat(np.arange(n_dates), n_assets)
         factor = rng.normal(size=n_dates * n_assets)

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -11,7 +11,7 @@ from factrix import slice_period_joint_test, slice_period_pairwise_test
 from factrix._errors import UserInputError
 from factrix.metrics import ic, monotonicity, positive_rate
 
-from tests._slice_panel import build_disjoint_period_panel
+from tests._slice_panel import build_disjoint_period_panel, build_labelled_raw_panel
 
 _JOINT_COLS = [
     "k_slices",
@@ -547,3 +547,46 @@ class TestShortSliceWarningContract:
                 self._null_panel(0, 3, 60),
                 expected_warnings="short_slice_joint_test",  # type: ignore[arg-type]
             )
+
+
+class TestDateAlignedPartitionRefused:
+    """Mirror of the cross-sectional `<2 aligned dates` guard."""
+
+    def test_fully_aligned_partition_names_the_cross_sectional_entry_point(
+        self,
+    ) -> None:
+        df = build_labelled_raw_panel(
+            n_dates=120, seed=21, signal={"tech": 0.2, "fin": 0.05}, label_col="sector"
+        )
+        with pytest.raises(UserInputError) as excinfo:
+            slice_period_joint_test(
+                df, ic(), by="sector", factor_col="factor", overlap_periods=5
+            )
+        message = str(excinfo.value)
+        assert "share 120 dates" in message
+        assert "slice_joint_test" in message
+        assert excinfo.value.field == "by"
+        assert excinfo.value.value == "sector"
+
+    def test_partially_overlapping_spans_refused(self) -> None:
+        df = build_disjoint_period_panel(
+            seed=22,
+            spans={"early": (80, 0.1), "late": (80, 0.1)},
+            label_col="regime",
+            shared_periods=8,
+        )
+        with pytest.raises(UserInputError, match="share 8 dates"):
+            slice_period_joint_test(df, ic(), by="regime", factor_col="factor")
+
+    def test_single_boundary_date_tolerated(self) -> None:
+        df = build_disjoint_period_panel(
+            seed=23,
+            spans={"early": (80, 0.1), "late": (80, 0.1)},
+            label_col="regime",
+            shared_periods=1,
+        )
+        out = slice_period_joint_test(
+            df, ic(), by="regime", factor_col="factor", rng=23
+        )
+        assert out.height == 1
+        assert math.isfinite(out["stat"][0])

--- a/tests/test_slice_period_pairwise_test.py
+++ b/tests/test_slice_period_pairwise_test.py
@@ -10,7 +10,7 @@ from factrix import slice_period_pairwise_test
 from factrix._errors import UserInputError
 from factrix.metrics import caar, fm_beta, ic, monotonicity
 
-from tests._slice_panel import build_disjoint_period_panel
+from tests._slice_panel import build_disjoint_period_panel, build_labelled_raw_panel
 
 _PAIRWISE_COLS = [
     "slice_a",
@@ -463,3 +463,53 @@ class TestNonStrict:
             df, ic(), by="regime", factor_col="factor", method="analytic"
         )
         assert out["reason"].to_list() == ["degenerate_variance"]
+
+
+class TestDateAlignedPartitionRefused:
+    """Mirror of the cross-sectional `<2 aligned dates` guard.
+
+    The period family treats slices as independent samples, so a partition
+    whose slices share dates (sector, size bucket) must be refused and
+    routed to the cross-sectional pair rather than silently tested.
+    """
+
+    def test_fully_aligned_partition_names_the_cross_sectional_entry_point(
+        self,
+    ) -> None:
+        df = build_labelled_raw_panel(
+            n_dates=120, seed=21, signal={"tech": 0.2, "fin": 0.05}, label_col="sector"
+        )
+        with pytest.raises(UserInputError) as excinfo:
+            slice_period_pairwise_test(
+                df, ic(), by="sector", factor_col="factor", overlap_periods=5
+            )
+        message = str(excinfo.value)
+        assert "share 120 dates" in message
+        assert "slice_pairwise_test" in message
+        assert excinfo.value.field == "by"
+        assert excinfo.value.value == "sector"
+
+    def test_partially_overlapping_spans_refused(self) -> None:
+        """10% shared periods is still a shared common shock, not a boundary."""
+        df = build_disjoint_period_panel(
+            seed=22,
+            spans={"early": (80, 0.1), "late": (80, 0.1)},
+            label_col="regime",
+            shared_periods=8,
+        )
+        with pytest.raises(UserInputError, match="share 8 dates"):
+            slice_period_pairwise_test(df, ic(), by="regime", factor_col="factor")
+
+    def test_single_boundary_date_tolerated(self) -> None:
+        """One shared truncation boundary stays inside the disjoint contract."""
+        df = build_disjoint_period_panel(
+            seed=23,
+            spans={"early": (80, 0.1), "late": (80, 0.1)},
+            label_col="regime",
+            shared_periods=1,
+        )
+        out = slice_period_pairwise_test(
+            df, ic(), by="regime", factor_col="factor", rng=23
+        )
+        assert out.height == 1
+        assert np.isfinite(out["stat"][0])


### PR DESCRIPTION
> **TL;DR** — `slice_pairwise_test` 遇到日期互斥的 slice 會拒絕並指向 period 系列；反方向 `slice_period_pairwise_test` / `slice_period_joint_test` 遇到共享全部 date 的 slice（依 asset 切分）卻靜默回傳結果。現在兩個 period 入口在任兩個 slice 共享 ≥2 個 date 時 `UserInputError`（`field="by"`），訊息鏡像 cross-sectional 那一側；共享 1 個邊界 date 容忍。**Breaking**。

Closes #920

## 審核紀錄（實作者 opus，審核者本 session）
獨立探針：依 `asset_id` 切 3 組（每組 300 個 date 全共享）→ 兩入口皆 `UserInputError: invalid by='grp'`；日期互斥 → 正常；共享 1 個邊界 date → 正常。實作者確認既有 fixture 無一共享 ≥2 date（guard 加入後全套仍綠，才動測試）。

實作者判斷（接受）：guard 放在 `_build_per_slice_series` 緊接 `_slice_by` 之後，一處涵蓋兩個入口且在 metric 執行前；回報共享數最多的那一對；部分重疊（8/80）同樣依 ≥2 規則拒絕，不設比例門檻；cross-sectional 那側既有的裸 `ValueError` 依 brief 不動（屬 #923）。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3197 passed, 42 skipped**（+6）。`docs/api/slice-test.md` 新增「The refusal is symmetric」小節並列兩側訊息；`slice-analysis.md:16` 的宣稱現在雙向為真。