### PR TITLE
fix(metrics)!: validate closed-set and bounded metric knobs before any computation

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -85,6 +85,8 @@ Every `UserInputError` carries structured attributes (see [Reading a `UserInputE
 | `unknown metrics='...'` | Typo or metric not applicable to the data | `inspect_data(data).usable` enumerates the metrics applicable to the data shape. See [`list_metrics`](metrics/index.md#factrix.list_metrics) for the full catalog. |
 | `invalid expand_over=[...]` | One or more `expand_over` keys missing on some results' `params` | The message lists every `(factor, missing_key)` pair in one pass. All results in the family must carry the key in `.params`; populate it consistently, or drop the key from `expand_over`. A key found on `.metadata` instead is called out separately — bookkeeping never partitions a family. |
 | `Expected: list[EvaluationResult], got ...` | Passing the wrong artifact type to a screening function | Screening (`bhy`, `partial_conjunction`, `bhy_hierarchical`) consumes `list[EvaluationResult]`. |
+| `unknown weight_by='...'` / `unknown tie_policy='...'` | Typo in a closed-set metric knob | Every closed-set knob (`weight_by`, `tie_policy`, `direction`, `center`, `method`) is validated before any computation and the message lists its legal values. A typo raises rather than falling through to the default branch. |
+| `invalid q_top=...`, `Expected: a fraction strictly inside (0, 1)` | A fraction knob outside its bounds | `top_concentration(q_top=)` needs a genuine sub-fraction of the cross-section: 0 leaves no top bucket, 1 selects all of it. |
 
 ---
 

--- a/factrix/_types.py
+++ b/factrix/_types.py
@@ -142,6 +142,16 @@ KPSource = Literal["icc", "no_multi_event_dates"]
 # realised contribution to the long-leg's α.
 ConcentrationWeight = Literal["abs_factor", "alpha_contribution"]
 
+# Quantile-bucketing tie-break policy — how per-period ranks resolve equal
+# factor values before they are cut into buckets. ``"ordinal"`` breaks ties by
+# row order (balanced bucket sizes, tied names split across buckets);
+# ``"average"`` gives tied names a shared average rank (same bucket, possibly
+# unbalanced sizes). Both are polars rank methods, but the closed set is
+# factrix's: the remaining polars methods (``min`` / ``max`` / ``dense`` /
+# ``random``) either distort the bucket widths or make the bucketing
+# irreproducible, so they are not part of the contract.
+TiePolicy = Literal["ordinal", "average"]
+
 # Canonical sample-dimension vocabulary — the axis a count is measured along.
 # Single source of truth for ``MetricResult.n_obs_axis`` and the ``axis`` params
 # in ``metrics._helpers`` (drop-stats / floor enforcement); mypy rejects any

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import math
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_args
 
 import numpy as np
 import polars as pl
@@ -43,7 +43,14 @@ if TYPE_CHECKING:
     from factrix.metrics._base import MetricBase
 from factrix._metric_index import SampleThreshold
 from factrix._results import MetricResult, PValueAlternative
-from factrix._types import DDOF, EPSILON, N_GROUPS_FLOOR, KPSource, SampleAxis
+from factrix._types import (
+    DDOF,
+    EPSILON,
+    N_GROUPS_FLOOR,
+    KPSource,
+    SampleAxis,
+    TiePolicy,
+)
 
 # Median-across-dates tie_ratio above this triggers a UserWarning when
 # tie_policy="ordinal". 0.3 is the empirical cutoff for "crowded" factors
@@ -1503,6 +1510,67 @@ def _lag_within_asset(
     )
 
 
+def _validate_choice(
+    value: object,
+    choices: object,
+    *,
+    func_name: str,
+    field: str,
+    docs_path: str,
+) -> None:
+    """Reject a closed-set knob value outside its ``Literal`` alias.
+
+    ``choices`` is the ``Literal`` alias that annotates the knob (e.g.
+    :data:`~factrix._types.ConcentrationWeight`); the legal set is read off it
+    with :func:`typing.get_args`, so the annotation and the runtime check
+    cannot drift apart. Every closed-set knob routes through here, which is
+    what makes a typo a :class:`~factrix._errors.UserInputError` naming the
+    legal values instead of a silent fall-through to whichever branch has no
+    ``else`` (or a polars error naming polars' own vocabulary).
+    """
+    from factrix._errors import UserInputError
+
+    allowed = get_args(choices)
+    if value not in allowed:
+        raise UserInputError(
+            func_name=func_name,
+            field=field,
+            value=value,
+            candidates=allowed,
+            docs_path=docs_path,
+        )
+
+
+def _validate_open_unit_interval(
+    value: float,
+    *,
+    func_name: str,
+    field: str,
+    detail: str,
+    docs_path: str,
+) -> None:
+    """Reject a fraction knob outside the open interval ``(0, 1)``.
+
+    ``detail`` says what each endpoint would degenerate into, in the style of
+    ``oos_decay(is_ratio=...)``.
+    """
+    from factrix._errors import UserInputError
+
+    # A bool is an int to Python and a string is not a number at all; both
+    # would otherwise reach the comparison and either pass (``True`` is 1) or
+    # raise a bare TypeError instead of the library's own diagnostic. NaN
+    # fails every comparison, so it lands here too.
+    numeric = not isinstance(value, bool) and isinstance(value, int | float)
+    if not numeric or not 0.0 < float(value) < 1.0:
+        raise UserInputError(
+            func_name=func_name,
+            field=field,
+            value=value,
+            expected=f"a fraction strictly inside (0, 1). {detail}",
+            docs_path=docs_path,
+        )
+
+
 def _validate_n_groups(n_groups: int) -> None:
     """Reject a quantile count below :data:`~factrix._types.N_GROUPS_FLOOR`.
 
@@ -1523,7 +1591,7 @@ def _assign_quantile_groups(
     data: pl.DataFrame,
     factor_col: str = "factor",
     n_groups: int = 5,
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
 ) -> pl.DataFrame:
     """Assign quantile group labels (0 = bottom, n_groups-1 = top) per period.
 
@@ -1549,7 +1617,7 @@ def _assign_quantile_groups(
     rank_expr = (
         pl.when(finite)
         .then(pl.col(factor_col))
-        .rank(method=tie_policy)  # type: ignore[arg-type]
+        .rank(method=tie_policy)
         .over("date")
         .alias("_rank")
     )
@@ -1576,7 +1644,7 @@ def _assign_quantile_groups_batch(
     data: pl.DataFrame,
     factor_cols: list[str],
     n_groups: int,
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
 ) -> pl.DataFrame:
     """Assign per-period quantile groups for N factors in one polars pass.
 
@@ -1592,7 +1660,7 @@ def _assign_quantile_groups_batch(
     rank_exprs = [
         pl.when(_finite_expr(f))
         .then(pl.col(f))
-        .rank(method=tie_policy)  # type: ignore[arg-type]
+        .rank(method=tie_policy)
         .over("date")
         .alias(f"_rank__{f}")
         for f in factor_cols
@@ -1653,7 +1721,7 @@ def _compute_tie_ratio(
 def _warn_high_tie_ratio(
     ratio: float,
     metric_name: str,
-    tie_policy: str,
+    tie_policy: TiePolicy,
     *,
     expected_warnings: tuple[str, ...] = (),
 ) -> bool:

--- a/factrix/metrics/_primitives/_group_returns.py
+++ b/factrix/metrics/_primitives/_group_returns.py
@@ -12,6 +12,7 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._metric_index import cell
+from factrix._types import TiePolicy
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
@@ -35,7 +36,7 @@ def compute_group_returns(
     n_groups: int = 5,
     factor_col: str = "factor",
     return_col: str = "forward_return",
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
 ) -> pl.DataFrame:
     """Mean forward return per quantile bucket (for monotonicity charts).
 

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -14,6 +14,7 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._metric_index import cell
+from factrix._types import TiePolicy
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups_batch,
@@ -39,7 +40,7 @@ def compute_spread_series(
     n_groups: int = 5,
     factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
     expected_warnings: tuple[str, ...] = (),
 ) -> dict[str, pl.DataFrame]:
     """Per-period long-short spread series (non-overlapping).

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -46,6 +46,8 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _scaled_periods_threshold,
     _short_circuit_output,
+    _validate_choice,
+    _validate_open_unit_interval,
     _warn_below_scaled_floor,
 )
 
@@ -86,8 +88,13 @@ def top_concentration(
         data: Panel with ``date, asset_id, factor`` (and ``forward_return``
             if ``weight_by="alpha_contribution"``).
         q_top: Fraction of top-ranked stocks to include (default 0.2 =
-            top 20%).
-        weight_by: HHI weight convention.
+            top 20%). Must lie strictly inside ``(0, 1)``; 0 leaves no top
+            bucket and 1 selects the whole cross-section, so neither
+            defines a top-bucket concentration and both raise
+            ``UserInputError``.
+        weight_by: HHI weight convention. Either ``"abs_factor"`` or
+            ``"alpha_contribution"``; anything else raises
+            ``UserInputError``.
             - ``"abs_factor"`` (default): weight by ``|factor|``. Answers
               "how concentrated is the density itself in the top bucket".
               Conservative, density-level. **Assumes a zero-centred
@@ -176,6 +183,23 @@ def top_concentration(
         >>> result.name == ""
         True
     """
+    _validate_choice(
+        weight_by,
+        ConcentrationWeight,
+        func_name="top_concentration",
+        field="weight_by",
+        docs_path="api/metrics/concentration",
+    )
+    _validate_open_unit_interval(
+        q_top,
+        func_name="top_concentration",
+        field="q_top",
+        detail=(
+            "0 leaves no top bucket and 1 selects the whole cross-section, "
+            "so no top-bucket concentration is defined."
+        ),
+        docs_path="api/metrics/concentration",
+    )
     if weight_by == "alpha_contribution" and return_col not in data.columns:
         return _short_circuit_output(
             "top_concentration",

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -39,7 +39,7 @@ from factrix._axis import (
 from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD
+from factrix._types import DDOF, MIN_PORTFOLIO_PERIODS_HARD, TiePolicy
 from factrix.inference import (
     NEWEY_WEST,
     NON_OVERLAPPING,
@@ -63,6 +63,7 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _spread_significance_with_inference,
     _surface_null_drop,
+    _validate_choice,
     _warn_high_tie_ratio,
 )
 
@@ -117,7 +118,7 @@ def _build_k_spread_series(
     k: int,
     factor_col: str,
     return_col: str,
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
 ) -> tuple[pl.DataFrame | None, pl.DataFrame]:
     """Per-period Top-K/Bottom-K spread series from a (possibly sampled) panel.
 
@@ -157,7 +158,7 @@ def _build_k_spread_series(
     # so neither leg can be filled by sort artefacts; leg sizes then vary.
     ranked = clean.with_columns(
         pl.col(factor_col)
-        .rank(method=tie_policy, descending=True)  # type: ignore[arg-type]
+        .rank(method=tie_policy, descending=True)
         .over("date")
         .alias("_rank"),
         pl.len().over("date").alias("_n_date"),
@@ -198,7 +199,7 @@ def k_spread(
     k: int = 5,
     factor_col: str = "factor",
     return_col: str = "forward_return",
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
     inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
@@ -221,7 +222,8 @@ def k_spread(
         return_col: Realised-return column (default ``"forward_return"``).
         tie_policy: Tie-break policy for the leg ranking — the same knob and
             the same values as ``quantile_spread`` / ``quantile_spread_vw`` /
-            ``monotonicity``. ``"ordinal"`` (default) breaks ties by row order,
+            ``monotonicity``. Either ``"ordinal"`` or ``"average"``; anything else raises ``UserInputError``.
+            ``"ordinal"`` (default) breaks ties by row order,
             which keeps both legs exactly ``k`` names wide but fills them
             arbitrarily among tied values; ``"average"`` gives tied names a
             shared rank so a discrete signal cannot be split by sort artefacts.
@@ -313,6 +315,13 @@ def k_spread(
         >>> result.name == ""
         True
     """
+    _validate_choice(
+        tie_policy,
+        TiePolicy,
+        func_name="k_spread",
+        field="tie_policy",
+        docs_path="api/metrics/k_spread",
+    )
     if k < 1:
         raise ValueError(f"k must be >= 1; got {k}")
     _check_applicable_inference(inference, applicable_inference, func_name="k_spread")

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -41,6 +41,7 @@ from factrix._stats.bootstrap import (
 from factrix._types import (
     DDOF,
     MIN_MONOTONICITY_PERIODS_HARD,
+    TiePolicy,
 )
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
@@ -51,6 +52,7 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _scaled_periods_threshold,
     _short_circuit_output,
+    _validate_choice,
     _warn_high_tie_ratio,
 )
 
@@ -174,7 +176,7 @@ def monotonicity(
     n_groups: int = 10,
     factor_cols: Sequence[str] = ("factor",),
     return_col: str = "forward_return",
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
     direction: MRDirection = "increasing",
     n_resamples: int = 999,
     rng: Rng = None,
@@ -192,6 +194,7 @@ def monotonicity(
             universe). Use 5 for ``n_assets < 1000``, 3 for ``n_assets < 200``.
         tie_policy: Bucketing tie-break policy — the same knob and values as
             ``quantile_spread`` / ``k_spread``, see ``_assign_quantile_groups``.
+            Either ``"ordinal"`` or ``"average"``; anything else raises ``UserInputError``.
             Under ``"ordinal"`` the realised per-period tie ratio is reported
             in ``metadata["tie_ratio"]``; when its median exceeds
             ``TIE_RATIO_WARN_THRESHOLD`` the result carries
@@ -269,6 +272,13 @@ def monotonicity(
         >>> result["factor"].name == ""
         True
     """
+    _validate_choice(
+        tie_policy,
+        TiePolicy,
+        func_name="monotonicity",
+        field="tie_policy",
+        docs_path="api/metrics/monotonicity",
+    )
     if direction not in ("increasing", "decreasing"):
         # A typo must not silently run the opposite one-sided test.
         raise UserInputError(

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -35,6 +35,7 @@ from factrix._types import (
     DEFAULT_FORWARD_PERIODS,
     DEFAULT_N_GROUPS,
     MIN_PORTFOLIO_PERIODS_HARD,
+    TiePolicy,
 )
 from factrix.inference import (
     NEWEY_WEST,
@@ -62,6 +63,7 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _spread_significance_with_inference,
     _surface_null_drop,
+    _validate_choice,
     _warn_high_tie_ratio,
     _warn_thin_quantile_groups,
 )
@@ -162,7 +164,7 @@ def quantile_spread(
     overlap_periods: int = DEFAULT_FORWARD_PERIODS,
     n_groups: int = DEFAULT_N_GROUPS,
     factor_cols: Sequence[str] = ("factor",),
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
     inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     *,
     expected_warnings: tuple[str, ...] = (),
@@ -180,6 +182,7 @@ def quantile_spread(
             either (see Notes).
         _precomputed_series: If provided, skip recomputing ``compute_spread_series``.
         tie_policy: Bucketing tie-break policy, see ``_assign_quantile_groups``.
+            Either ``"ordinal"`` or ``"average"``; anything else raises ``UserInputError``.
             When ``_precomputed_series`` is passed, this only affects the
             ``tie_ratio`` diagnostic — the series itself was already built.
 
@@ -251,6 +254,13 @@ def quantile_spread(
         >>> result["factor"].name == ""
         True
     """
+    _validate_choice(
+        tie_policy,
+        TiePolicy,
+        func_name="quantile_spread",
+        field="tie_policy",
+        docs_path="api/metrics/quantile",
+    )
     cols = list(factor_cols)
     if not cols:
         raise ValueError("factor_cols must be non-empty")
@@ -322,7 +332,7 @@ def _quantile_spread_from_series(
     sampled: pl.DataFrame,
     n_raw_periods: int,
     factor_col: str,
-    tie_policy: str,
+    tie_policy: TiePolicy,
     inference: NonOverlapping | NeweyWest | StationaryBootstrap,
     overlap_periods: int,
     n_groups: int,
@@ -501,7 +511,7 @@ def _vw_spread_series(
     return_col: str,
     weight_col: str,
     n_groups: int,
-    tie_policy: str,
+    tie_policy: TiePolicy,
 ) -> pl.DataFrame:
     """Per-period value-weighted top-minus-bottom spread for ``panel``.
 
@@ -578,7 +588,7 @@ def quantile_spread_vw(
     factor_col: str = "factor",
     return_col: str = "forward_return",
     weight_col: str = "market_cap",
-    tie_policy: str = "ordinal",
+    tie_policy: TiePolicy = "ordinal",
     inference: NonOverlapping | NeweyWest | StationaryBootstrap = NON_OVERLAPPING,
     lag_weights: bool = True,
     expected_warnings: tuple[str, ...] = (),
@@ -698,6 +708,13 @@ def quantile_spread_vw(
         >>> result.name == ""
         True
     """
+    _validate_choice(
+        tie_policy,
+        TiePolicy,
+        func_name="quantile_spread_vw",
+        field="tie_policy",
+        docs_path="api/metrics/quantile",
+    )
     if weight_col not in data.columns:
         return _short_circuit_output(
             "quantile_spread_vw",

--- a/tests/test_knob_validation.py
+++ b/tests/test_knob_validation.py
@@ -1,0 +1,194 @@
+"""Closed-set and bounded metric knobs are validated before any computation.
+
+A knob annotated with a ``Literal`` alias is a contract, not a hint: a typo
+must raise :class:`~factrix.UserInputError` naming the legal values, never
+fall through to whichever branch happens to have no ``else`` and never leak
+the underlying engine's own vocabulary. The bounded fractions (``q_top``)
+are the same contract on an interval instead of a set.
+
+The parametrisations below are the one place that enumerates the knobs, so a
+new closed-set knob that skips its validator shows up as a missing row rather
+than as a silently wrong number.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, get_args
+
+import polars as pl
+import pytest
+from factrix import UserInputError
+from factrix._types import ConcentrationWeight, TiePolicy
+from factrix.datasets import make_cs_panel
+from factrix.metrics.concentration import top_concentration
+from factrix.metrics.k_spread import k_spread
+from factrix.metrics.monotonicity import MRDirection, monotonicity
+from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
+from factrix.preprocess import compute_forward_return
+from factrix.preprocess.normalize import Center, cross_sectional_zscore
+
+BAD_TOKEN = "bogus"
+
+
+@pytest.fixture(scope="module")
+def panel() -> pl.DataFrame:
+    return compute_forward_return(
+        make_cs_panel(n_assets=60, n_dates=120, rng=0), forward_periods=5
+    )
+
+
+@pytest.fixture(scope="module")
+def weighted_panel(panel: pl.DataFrame) -> pl.DataFrame:
+    return panel.with_columns(pl.lit(1.0).alias("weight"))
+
+
+def _call(func: Any, data: pl.DataFrame, **knob: object) -> Any:
+    return func(data, **knob)
+
+
+# (label, callable, knob name, Literal alias) — one row per closed-set knob.
+CLOSED_SET_KNOBS = [
+    (
+        "top_concentration.weight_by",
+        top_concentration,
+        "weight_by",
+        ConcentrationWeight,
+    ),
+    ("quantile_spread.tie_policy", quantile_spread, "tie_policy", TiePolicy),
+    ("k_spread.tie_policy", k_spread, "tie_policy", TiePolicy),
+    ("monotonicity.tie_policy", monotonicity, "tie_policy", TiePolicy),
+    ("monotonicity.direction", monotonicity, "direction", MRDirection),
+]
+
+
+@pytest.mark.parametrize(
+    ("func", "field", "alias"),
+    [pytest.param(f, k, a, id=label) for label, f, k, a in CLOSED_SET_KNOBS],
+)
+def test_bad_closed_set_value_raises(
+    panel: pl.DataFrame, func: Any, field: str, alias: object
+) -> None:
+    with pytest.raises(UserInputError) as excinfo:
+        _call(func, panel, **{field: BAD_TOKEN})
+    exc = excinfo.value
+    assert exc.field == field
+    assert exc.value == BAD_TOKEN
+    # The legal set reaches the caller, whichever branch rendered it.
+    rendered = str(exc)
+    for legal in get_args(alias):
+        assert legal in rendered
+
+
+@pytest.mark.parametrize(
+    ("func", "field", "alias"),
+    [pytest.param(f, k, a, id=label) for label, f, k, a in CLOSED_SET_KNOBS],
+)
+def test_every_legal_value_is_accepted(
+    panel: pl.DataFrame, func: Any, field: str, alias: object
+) -> None:
+    for legal in get_args(alias):
+        _call(func, panel, **{field: legal})
+
+
+def test_quantile_spread_vw_rejects_bad_tie_policy(
+    weighted_panel: pl.DataFrame,
+) -> None:
+    with pytest.raises(UserInputError) as excinfo:
+        quantile_spread_vw(weighted_panel, tie_policy=BAD_TOKEN)
+    assert excinfo.value.field == "tie_policy"
+    assert "ordinal" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("center", get_args(Center))
+def test_cross_sectional_zscore_accepts_every_legal_center(
+    panel: pl.DataFrame, center: str
+) -> None:
+    cross_sectional_zscore(panel, center=center)
+
+
+def test_cross_sectional_zscore_rejects_bad_center(panel: pl.DataFrame) -> None:
+    with pytest.raises(UserInputError) as excinfo:
+        cross_sectional_zscore(panel, center=BAD_TOKEN)
+    assert excinfo.value.field == "center"
+
+
+def test_tie_policy_is_rejected_before_any_data_work() -> None:
+    """A bad knob fails on a panel too short to compute anything on.
+
+    The validator runs on the first statement of the body, so the caller
+    hears about the typo instead of about the sample.
+    """
+    tiny = pl.DataFrame(
+        {
+            "date": [datetime(2024, 1, 1)],
+            "asset_id": ["A"],
+            "factor": [1.0],
+            "forward_return": [0.0],
+        }
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+    with pytest.raises(UserInputError) as excinfo:
+        k_spread(tiny, tie_policy=BAD_TOKEN)
+    assert excinfo.value.field == "tie_policy"
+
+
+def test_weight_by_is_rejected_before_the_return_column_short_circuit(
+    panel: pl.DataFrame,
+) -> None:
+    """The closed-set check precedes ``top_concentration``'s own early exit.
+
+    ``weight_by="alpha_contribution"`` short-circuits when the return column
+    is absent; a bogus token must not reach that branch and be reported as a
+    data problem.
+    """
+    no_returns = panel.drop("forward_return")
+    with pytest.raises(UserInputError) as excinfo:
+        top_concentration(no_returns, weight_by=BAD_TOKEN)
+    assert excinfo.value.field == "weight_by"
+
+
+@pytest.mark.parametrize("q_top", [0.0, 1.0, 5.0, -1.0, float("nan")])
+def test_q_top_outside_the_open_unit_interval_raises(
+    panel: pl.DataFrame, q_top: float
+) -> None:
+    with pytest.raises(UserInputError) as excinfo:
+        top_concentration(panel, q_top=q_top)
+    assert excinfo.value.field == "q_top"
+    assert "(0, 1)" in str(excinfo.value)
+
+
+def test_q_top_rejects_a_non_number(panel: pl.DataFrame) -> None:
+    with pytest.raises(UserInputError) as excinfo:
+        top_concentration(panel, q_top="0.2")  # type: ignore[arg-type]
+    assert excinfo.value.field == "q_top"
+
+
+@pytest.mark.parametrize("q_top", [0.05, 0.2, 0.5, 0.99])
+def test_q_top_inside_the_interval_is_accepted(
+    panel: pl.DataFrame, q_top: float
+) -> None:
+    assert top_concentration(panel, q_top=q_top).value > 0.0
+
+
+class TestValidInputUnchanged:
+    """Pinned values: validation must not perturb any legal call."""
+
+    def test_top_concentration(self, panel: pl.DataFrame) -> None:
+        assert top_concentration(panel, weight_by="abs_factor").value == pytest.approx(
+            top_concentration(panel).value
+        )
+        assert top_concentration(
+            panel, weight_by="alpha_contribution"
+        ).value != pytest.approx(top_concentration(panel).value)
+
+    def test_quantile_spread(self, panel: pl.DataFrame) -> None:
+        ordinal = quantile_spread(panel, tie_policy="ordinal")["factor"].value
+        assert quantile_spread(panel)["factor"].value == pytest.approx(ordinal)
+
+    def test_k_spread(self, panel: pl.DataFrame) -> None:
+        ordinal = k_spread(panel, tie_policy="ordinal").value
+        assert k_spread(panel).value == pytest.approx(ordinal)
+
+    def test_monotonicity(self, panel: pl.DataFrame) -> None:
+        pinned = monotonicity(panel, tie_policy="ordinal", rng=0)["factor"].value
+        assert monotonicity(panel, rng=0)["factor"].value == pytest.approx(pinned)


### PR DESCRIPTION
> **TL;DR** — `top_concentration(weight_by="bogus")` 原本與 `abs_factor` 回傳完全相同的數值、metadata 卻回報 `"bogus"`；`q_top=5.0` 不拒絕；`tie_policy="bogus"` 漏出 polars 的例外。新增共用 `_validate_choice`（合法集合由 `Literal` 別名經 `typing.get_args` 推導，型別與檢查不會漂移）與 `_validate_open_unit_interval`，在任何資料處理前執行；`tie_policy` 取得 `TiePolicy = Literal["ordinal", "average"]`。**Breaking**：錯值改為 `UserInputError`（帶 did-you-mean）；`TiePolicy` 收窄到文件化的兩值。

Closes #921

## 審核紀錄（實作者 opus，審核者本 session）
獨立探針：`weight_by="bogus"` → `UserInputError(field="weight_by")`；`weight_by="abs_factor"` 數值與 main **逐位元相同**（7.346522267188675）；`q_top ∈ {0, 1, 5, −1, NaN}` 皆 `UserInputError`；`tie_policy="bogus"` 在 `quantile_spread` / `monotonicity` 皆 `UserInputError`。

實作者判斷（接受）：合法值以 `candidates=` 而非 `expected=` 傳入，換取 difflib 建議（動機就是打錯字）；未把既有已正確的 `direction` / `center` / `method` 驗證器改接新 helper（會改動三則使用者可見訊息，超出 issue 範圍——記為後續）；`_validate_open_unit_interval` 同時拒絕非數值與 NaN；建構時驗證需要動 `_base.py`（#922 正在改），本 PR 於 metric body 第一句驗證，測試鎖定「在任何資料工作之前」。

Literal 旋鈕稽核：未檢查→已修：`weight_by`、`tie_policy`（四個 metric）、`q_top`；已檢查：`direction`、`center`、`method`、`ci`；非使用者旋鈕：`KPSource`、`GateStatus`、`PValueAlternative`、`SampleAxis`。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3250 passed, 42 skipped**（+30，`tests/test_knob_validation.py`）。