### PR TITLE
fix(metrics)!: reject a mis-named user column at the metric gate instead of answering it

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -68,6 +68,7 @@ Concrete messages, what triggers them, and where to look for the fix.
 |---|---|---|
 | `factor_cols 'X' not in data columns` | Typo or wrong column name | Check `data.columns`; pass the actual name to `factor_cols=`. See [Data schema](data-schema.md). |
 | `forward_return column missing` | Forgot the preprocess step | `compute_forward_return(raw, forward_periods=h)` before `evaluate`. See [Preparing data](../guides/preparing-data.md). |
+| `<metric>(): unknown factor_col='X'` | Typo in a column named on a direct metric call (`factor_col` / `return_col` / `weight_col` / `factor_cols`) | Read `.candidates` / `.suggestions` — they are the frame's own columns. A mis-named column is a caller error, not a thin sample: it never returns a NaN "insufficient data" result. |
 
 ### Structural and sample failures
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -30,7 +30,18 @@ below:
 
 Hypothesis-test metrics share a common envelope (`p_value`,
 `stat_type`, `h0`, `method`) — listed once here, not repeated per
-metric below. Cross-slice inference functions
+metric below.
+
+A `no_*_column` short-circuit is a statement about the **data**, never about
+the call: it fires only for a column parameter left at its documented default
+(`factor`, `forward_return`, `price`, `market_cap`) that the frame does not
+carry. A column the caller *named* — any `*_col` / `*_cols` argument set away
+from its default — is validated at the metric gate instead, and a name the
+frame lacks raises `UserInputError` with the frame's columns as did-you-mean
+candidates rather than returning a NaN envelope. Every `reason` is a fixed
+token, so consumers can branch on it.
+
+Cross-slice inference functions
 ([`slice_pairwise_test`][factrix.slice_pairwise_test] /
 [`slice_joint_test`][factrix.slice_joint_test]) are
 not listed in the table: their headline output is a DataFrame of

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -22,6 +22,9 @@ polars throughout) and avoids hiding the pd → pl copy inside every
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import polars as pl
 import polars.selectors as cs
 
@@ -276,6 +279,49 @@ def _validate_panel_key_columns(data: object, *, func_name: str) -> None:
         ),
         docs_path=_DOCS_DATA_SCHEMA,
     )
+
+
+def _validate_named_columns(
+    data: object,
+    named: Mapping[str, Any],
+    *,
+    func_name: str,
+    docs_path: str,
+) -> None:
+    """Reject a direct metric call naming a column the frame does not carry.
+
+    ``named`` maps a metric parameter (``factor_col``, ``return_col``,
+    ``weight_col``, ``factor_cols``, ...) to the caller's value. A name the
+    frame lacks is a call the caller has to change, so it fails here — with
+    the frame's own columns as did-you-mean candidates — rather than reaching
+    a polars ``ColumnNotFoundError`` from inside an expression, or a NaN
+    "insufficient data" envelope that reads as a property of the data.
+
+    ``None`` is skipped: a metric that documents an optional column uses it to
+    mean "not configured", not "a column called None".
+    """
+    if not isinstance(data, pl.DataFrame):
+        return
+    columns = data.columns
+    # The reserved stamps are evaluate-internal bookkeeping, never a legal
+    # answer to "which column did you mean?".
+    candidates = [c for c in columns if c not in _STAMP_COLUMNS]
+    for field, value in named.items():
+        if value is None:
+            continue
+        wanted: Sequence[str] = (
+            [value] if isinstance(value, str) else [str(v) for v in value]
+        )
+        for name in wanted:
+            if name in columns:
+                continue
+            raise UserInputError(
+                func_name=func_name,
+                field=field,
+                value=name,
+                candidates=candidates,
+                docs_path=docs_path,
+            )
 
 
 def _normalize_panel(data: pl.DataFrame) -> pl.DataFrame:

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -12,7 +12,11 @@ from factrix._axis import (
     OutputShape,
     SpecRole,
 )
-from factrix._data_input import _OVERLAP_PERIODS_COL, _validate_panel_key_columns
+from factrix._data_input import (
+    _OVERLAP_PERIODS_COL,
+    _validate_named_columns,
+    _validate_panel_key_columns,
+)
 from factrix._metric_index import Cell, MetricSpec, SampleThreshold
 
 # Parameters that ``evaluate`` injects at dispatch rather than the user
@@ -307,6 +311,39 @@ class MetricBase(metaclass=MetricMeta):
             if value is not None and name in self._injected_param_names
         }
 
+    def _named_column_params(self) -> dict[str, Any]:
+        """Column names this call *chose* — the ones the caller can mis-type.
+
+        Every metric already follows one naming convention: a parameter ending
+        in ``_col`` carries one column name, one ending in ``_cols`` a sequence
+        of them. Only values that differ from the signature default are
+        returned. A param left at its default names a column the metric
+        documents (``factor``, ``forward_return``, ``price``, ``market_cap``),
+        and its absence is a fact about the data — a short-circuit verdict the
+        body already reports — not a typo the caller can fix by renaming.
+        """
+        named: dict[str, Any] = {}
+        for name in self._param_names:
+            if not name.endswith(("_col", "_cols")):
+                continue
+            value = getattr(self, name)
+            field = self.__dataclass_fields__[name]  # type: ignore[attr-defined]
+            if value != field.default:
+                named[name] = value
+        return named
+
+    def _docs_path(self) -> str:
+        """Docs page for this metric — one page per public metrics module.
+
+        A private (underscore-prefixed) module holds a producer the DAG
+        configures rather than a documented metric, so it has no page of its
+        own; those point at the metrics index.
+        """
+        module = self.__class__.__module__.rsplit(".", 1)[-1]
+        if module.startswith("_"):
+            return "api/metrics"
+        return f"api/metrics/{module}"
+
     def __call__(
         self,
         *args: Any,
@@ -324,6 +361,17 @@ class MetricBase(metaclass=MetricMeta):
             # ``requires`` consumer takes a producer's derived frame instead —
             # its schema is the producer's contract, not the panel's.
             _validate_panel_key_columns(args[0], func_name=self.__class__.__name__)
+            # Then the columns this call named itself: a mis-typed
+            # ``factor_col`` / ``return_col`` / ``weight_col`` is the same
+            # class of mistake as a mis-typed ``asset_id`` and fails the same
+            # way, instead of reaching a polars expression or being answered
+            # with a NaN "insufficient data" envelope.
+            _validate_named_columns(
+                args[0],
+                self._named_column_params(),
+                func_name=self.__class__.__name__,
+                docs_path=self._docs_path(),
+            )
         if overlap_periods is None and args:
             # Standalone call: the horizon is a property of the data, so read
             # the stamp rather than letting the signature default diverge from

--- a/factrix/metrics/common_asymmetry.py
+++ b/factrix/metrics/common_asymmetry.py
@@ -148,14 +148,23 @@ def common_asymmetry(
         True
     """
     # ``date`` / ``asset_id`` are gated by the direct-call key-column check in
-    # ``MetricBase.__call__`` (and by ``evaluate``'s baseline gate), so only
-    # the configurable columns are checked here.
-    for col in (factor_col, return_col):
-        if col not in data.columns:
-            return _short_circuit_output(
-                "common_asymmetry",
-                f"no_{col}_column",
-            )
+    # ``MetricBase.__call__``, which also rejects a caller-named column the
+    # frame does not carry (and ``evaluate`` validates the panel schema), so
+    # what reaches here is the *default* column missing from the data — a
+    # data-availability verdict, reported on the fixed ``reason`` tokens the
+    # sibling metrics use so consumers can branch on them.
+    if factor_col not in data.columns:
+        return _short_circuit_output(
+            "common_asymmetry",
+            "no_factor_column",
+            missing_column=factor_col,
+        )
+    if return_col not in data.columns:
+        return _short_circuit_output(
+            "common_asymmetry",
+            "no_return_column",
+            missing_column=return_col,
+        )
 
     per_date = _aggregate_to_per_date(
         data,

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -144,14 +144,23 @@ def common_quantile_spread(
     # bucket has no top-minus-bottom contrast to test.
     _validate_n_groups(n_groups)
     # ``date`` / ``asset_id`` are gated by the direct-call key-column check in
-    # ``MetricBase.__call__`` (and by ``evaluate``'s baseline gate), so only
-    # the configurable columns are checked here.
-    for col in (factor_col, return_col):
-        if col not in data.columns:
-            return _short_circuit_output(
-                "common_quantile_spread",
-                f"no_{col}_column",
-            )
+    # ``MetricBase.__call__``, which also rejects a caller-named column the
+    # frame does not carry (and ``evaluate`` validates the panel schema), so
+    # what reaches here is the *default* column missing from the data — a
+    # data-availability verdict, reported on the fixed ``reason`` tokens the
+    # sibling metrics use so consumers can branch on them.
+    if factor_col not in data.columns:
+        return _short_circuit_output(
+            "common_quantile_spread",
+            "no_factor_column",
+            missing_column=factor_col,
+        )
+    if return_col not in data.columns:
+        return _short_circuit_output(
+            "common_quantile_spread",
+            "no_return_column",
+            missing_column=return_col,
+        )
 
     per_date = _aggregate_to_per_date(
         data,

--- a/tests/test_direct_call_schema.py
+++ b/tests/test_direct_call_schema.py
@@ -1,4 +1,4 @@
-"""Direct raw-panel metric calls validate the key columns up front (#882).
+"""Direct raw-panel metric calls validate their columns up front.
 
 ``evaluate`` gates the baseline schema once and projects a view per factor;
 a standalone ``metric(data, ...)`` call skipped that gate, so a mis-named
@@ -8,6 +8,18 @@ column the caller never wrote. The check now lives in ``MetricBase.__call__``
 for every metric that consumes the raw panel (``input_shape=PANEL`` with no
 ``requires``), so each direct-call path fails the same way ``evaluate`` does,
 with the same error type and docs pointer, and no metric carries its own copy.
+
+The gate covers two kinds of column. The panel's *key* columns (``date`` /
+``asset_id``) are a fixed contract. On top of them, every column this call
+*named* — any ``*_col`` / ``*_cols`` parameter set away from its documented
+default — must exist on the frame: a mis-typed ``factor_col`` is the same
+mistake as a mis-typed ``asset_id`` and must fail the same way, rather than
+reaching a polars expression or being answered with a NaN "insufficient
+data" envelope that reads as a property of the data. A parameter left at its
+default names a column the metric documents (``factor``, ``forward_return``,
+``price``, ``market_cap``); its absence is a fact about the data, and the
+metric bodies keep reporting it as a short-circuit verdict.
+
 Consumers of a producer's derived frame (``ic`` on ``compute_ic`` output,
 ``common_beta`` on per-asset betas) are not gated: that schema is the
 producer's contract, not the panel's.
@@ -92,3 +104,86 @@ def test_evaluate_and_direct_call_agree_on_the_error_contract(panel):
     with pytest.raises(UserInputError, match=r"asset_id") as direct:
         notional_turnover(renamed, n_groups=2)
     assert via_evaluate.value.field == direct.value.field == "data"
+
+
+def _panel_metrics_with_named_columns():
+    """Every public raw-panel metric paired with each column it lets you name."""
+    import factrix.metrics as metrics_module
+    from factrix._axis import InputShape
+
+    cases = []
+    for name in sorted(dir(metrics_module)):
+        cls = getattr(metrics_module, name)
+        if not isinstance(cls, type):
+            continue
+        if getattr(cls, "input_shape", None) is not InputShape.PANEL:
+            continue
+        if getattr(cls, "requires", None):
+            continue
+        for param in getattr(cls, "_param_names", ()):
+            if param.endswith(("_col", "_cols")):
+                cases.append((name, cls, param))
+    return cases
+
+
+_NAMED_COLUMN_CASES = _panel_metrics_with_named_columns()
+
+
+def test_every_raw_panel_metric_exposes_a_named_column():
+    """Guard the sweep below against silently enumerating nothing."""
+    assert len({case[0] for case in _NAMED_COLUMN_CASES}) >= 15
+
+
+@pytest.mark.parametrize(
+    ("label", "cls", "param"),
+    _NAMED_COLUMN_CASES,
+    ids=[f"{label}-{param}" for label, _, param in _NAMED_COLUMN_CASES],
+)
+def test_a_mis_named_column_is_a_user_input_error(panel, label, cls, param):
+    typo = ["nope"] if param.endswith("_cols") else "nope"
+    with pytest.raises(UserInputError) as info:
+        cls(panel, **{param: typo})
+    err = info.value
+    assert err.func_name == label
+    assert err.field == param
+    assert err.value == "nope"
+    assert "factor" in err.candidates  # the frame's own columns are the candidates
+    assert "_overlap_periods" not in err.candidates  # reserved stamps are not
+    assert err.docs_url.rstrip("/").split("/factrix/")[-1].startswith("api/metrics")
+
+
+def test_the_suggestion_points_at_the_column_the_caller_meant(panel):
+    from factrix.metrics import k_spread
+
+    with pytest.raises(UserInputError) as info:
+        k_spread(panel, k=1, return_col="forward_returns")
+    assert info.value.suggestions == ("forward_return",)
+
+
+def test_a_column_left_at_its_default_stays_a_data_verdict(panel):
+    """An absent *documented* column is a fact about the data, not a typo.
+
+    ``market_cap`` is optional schema: a panel without it is an ordinary
+    configuration ``evaluate`` reports as a short-circuit, so the gate must
+    not convert it into a caller error.
+    """
+    from factrix.metrics import quantile_spread_vw
+
+    assert "market_cap" not in panel.columns
+    out = quantile_spread_vw(panel, overlap_periods=5, n_groups=2)
+    assert out.metadata["reason"] == "no_weight_column"
+
+
+def test_evaluate_and_direct_call_agree_on_a_mis_named_factor_column(panel):
+    with pytest.raises(UserInputError) as via_evaluate:
+        fx.evaluate(
+            panel,
+            metrics={"qs": quantile_spread(n_groups=2)},
+            factor_cols=["nope"],
+        )
+    with pytest.raises(UserInputError) as direct:
+        quantile_spread(panel, n_groups=2, factor_cols=["nope"])
+    assert via_evaluate.value.func_name == "evaluate"
+    assert direct.value.func_name == "quantile_spread"
+    assert "nope" in str(via_evaluate.value)
+    assert "nope" in str(direct.value)


### PR DESCRIPTION
> **TL;DR** — `factor_col="nope"` 原本在 17 個 metric 漏出 polars `ColumnNotFoundError`、在 4 個 metric 回 `value=nan, p=1.0` 的「資料不足」信封。`MetricBase.__call__` 的閘門現在對每個使用者**明確指定**的 `*_col` / `*_cols` 參數驗證欄位存在，`UserInputError` 帶欄位候選與 did-you-mean；`common_asymmetry` / `common_quantile_spread` 的無界 `reason` token `f"no_{col}_column"` 改為固定 token + `missing_column`。**Breaking**。

Closes #922

## 實作者的判斷（審核後接受）
brief 要求刪除 missing-column short-circuit；實作者先照做、破了 14 個已文件化的測試後改為：閘門只對**改離預設值**的欄位名觸發，缺少預設名稱的選配欄位（`price` → `no_price_data`、`market_cap` → `no_weight_column`）維持資料判定。理由：`evaluate` 也走同一閘門，且 `_inspect.py` 的引導與 `tests/test_evaluate.py::TestStrict` 都依賴「缺選配欄位是資料事實」——打錯字與資料缺欄只能靠「是否改離預設」區分。DoD 兩項仍成立。

## 審核紀錄（實作者 opus，審核者本 session）
獨立探針：`predictive_beta(factor_col="nope")` → `UserInputError(field="factor_col")` 列出可用欄位；`common_asymmetry(factor_col="factr")` → `Did you mean: "factor"?`；`quantile_spread_vw(weight_col="mcap")` → `UserInputError`；預設名稱缺 `market_cap` → `no_weight_column` + `metric_unavailable`；`evaluate(factor_cols=["nope"])` → `UserInputError(field="factor_cols")`。已 rebase 至含 #937 的 main，無衝突。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3316 passed, 42 skipped**（+61：全部公開 raw-panel metric × 全部欄位參數的 60 格參數化掃描 + parity 測試）。`tests/test_direct_call_schema.py` 的 docstring 現在為真，並移除了其中的 issue 編號。