### PR TITLE
refactor(metrics)!: validate metric knobs at construction through one MetricBase hook

### DIFF
--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -43,14 +43,35 @@ overlap_periods=0)` and `evaluate(..., overlap_periods=0)` both raise
 an unvetted `inference=` raises `IncompatibleInferenceError` whether the
 sample-floor pre-flight or the metric body sees it first.
 
+### Metric knobs fail at construction
+
+A metric's knobs are validated when the metric object is built, not when
+it runs. `quantile_spread(n_groups=1)` raises immediately; so does
+`quantile_spread(panel, n_groups=1)`, because the direct-call form builds
+the same object first. Both raise the same class with the same `.field`,
+and a battery configured up front fails on the bad knob rather than three
+metrics into the `evaluate`:
+
+```python title="Illustrative"
+metrics = {
+    "ic": ic(),
+    "spread": quantile_spread(n_groups=1),   # raises here, not in evaluate()
+}
+```
+
+The three rules are the metric's `Literal`-annotated knobs (closed sets),
+its `inference=` allowlist, and its declared numeric bounds — see
+[Custom metrics](../guides/custom-metrics.md) for `@metric(validate=...)`.
+The panel's `overlap_periods` is not a knob: it is injected from the data
+at dispatch and validated there.
+
 `except fx.FactrixError` does not yet block *every* library-raised
 failure. What still surfaces as a builtin:
 
 | Still builtin | Where | Why |
 |---|---|---|
 | `TypeError` | An argument of the wrong Python type (`by_slice(rows, ...)` on a non-frame, a metric class passed where an instance is required, a positional metric knob) | Wrong *type* is a `TypeError` by Python convention; wrong *value* is a `UserInputError`. |
-| `ValueError` | Numeric knob guards on some metrics (`k_spread(k=0)`, `notional_turnover(rebalance_lag=0)`, `holding_periods`, `neutral_epsilon`) | Not yet on the structured contract; they carry a plain message and no `.field`. |
-| `ValueError` | The low-level helpers in [`factrix.stats`](stats.md) (`bhy_adjust`, `romano_wolf_adjusted_p`, `stationary_bootstrap`, …) and the result exporters (`to_frame` / `to_dict` collisions) | Array-shape and finiteness guards on numeric primitives, documented per function. |
+| `ValueError` | Library invariants outside the metric-knob / `factrix.stats` / result-exporter contract: `factrix.metrics.register()` re-registering a name, the metric-index declaration checks, the numeric kernels in `factrix._stats`, and the `adapt` / `preprocess.orthogonalize` schema guards | Developer- or invariant-facing — a mis-declared metric, or a non-finite array reaching a kernel. Every metric knob, `factrix.stats` argument and `to_frame` / `to_dict` collision is a `UserInputError`. |
 
 `UserInputError` multi-inherits from `ValueError`, so
 `except ValueError` catches both it and everything in the table.

--- a/docs/api/evaluation-results.md
+++ b/docs/api/evaluation-results.md
@@ -18,7 +18,7 @@ The leading `factor` / `forward_periods` / `params` block is the **hypothesis id
 **Schema:**
 - `factor` (`str`): The factor column name.
 - `forward_periods` (`i64`): The return horizon — the hypothesis.
-- one column per `params` key (dtype inferred): the caller-supplied hypothesis knobs. A `params` key colliding with a fixed column name above raises `ValueError`. Results whose `params` keys differ need `pl.concat(..., how="diagonal")`.
+- one column per `params` key (dtype inferred): the caller-supplied hypothesis knobs. A `params` key colliding with a fixed column name above raises `UserInputError`. Results whose `params` keys differ need `pl.concat(..., how="diagonal")`.
 - `overlap_periods` (`i64`): The evaluation-grid overlap inference consumed (equal to `forward_periods` on the full grid). Bookkeeping, not identity.
 - `n_assets` (`i64`): Total unique assets.
 - `metric_name` (`str`): The metric identifier.
@@ -38,8 +38,8 @@ The fixed schema is the cross-metric contract; estimator-specific definitions (a
 
 - the column keeps the row's `factor` / `metric_name` pairing, so stacking many results keeps every cell next to the metric it came from;
 - a metric that does not carry the key gets `null`;
-- only scalar values export (`bool` / `int` / `float` / `str`; `NaN` / `Inf` become `null` like `value`, numpy scalars are unwrapped). A list, dict or other nested value raises `ValueError` naming the metric and key — that is what `to_dict()` is for;
-- a key that collides with a fixed column, a `params` key, or repeats raises `ValueError`, so metadata never shadows the identity block or the fixed schema;
+- only scalar values export (`bool` / `int` / `float` / `str`; `NaN` / `Inf` become `null` like `value`, numpy scalars are unwrapped). A list, dict or other nested value raises `UserInputError` naming the metric and key — that is what `to_dict()` is for;
+- a key that collides with a fixed column, a `params` key, or repeats raises `UserInputError`, so metadata never shadows the identity block or the fixed schema;
 - dtypes are inferred per column.
 
 !!! example "Tradability audit — is the turnover pricing the same book as the spread?"

--- a/docs/guides/custom-metrics.md
+++ b/docs/guides/custom-metrics.md
@@ -86,6 +86,57 @@ results = fx.evaluate(
 )
 ```
 
+### Validating knobs
+
+Knob validation is not written into the body. `@metric` builds the metric's
+constructor, and every knob contract is enforced there — once, for both the
+config form (`custom_trimmed_ic(trim_ratio=1.5)`) and the direct-call form
+(`custom_trimmed_ic(ic_df, trim_ratio=1.5)`), which builds the same object
+before it runs.
+
+Two rules need no declaration:
+
+- a parameter annotated with a `Literal` alias is checked against that alias,
+  so the annotation *is* the runtime contract (`tie_policy: TiePolicy` rejects
+  anything outside `"ordinal"` / `"average"`);
+- a parameter named `inference` is checked against the `applicable_inference`
+  frozenset your module declares at top level.
+
+Anything a closed set cannot express — a numeric bound, a pair of knobs that
+are mutually exclusive — goes in a `validate=` hook: a module-level callable
+taking the constructed instance and raising `UserInputError`.
+
+```python title="Illustrative"
+from factrix import UserInputError
+
+
+def _validate_custom_trimmed_ic(m) -> None:
+    if not 0.0 <= m.trim_ratio < 0.5:
+        raise UserInputError(
+            func_name="custom_trimmed_ic",
+            field="trim_ratio",
+            value=m.trim_ratio,
+            expected="a fraction in [0, 0.5): each tail is trimmed once",
+            docs_path="api/metrics",
+        )
+
+
+@metric(
+    cell=_CUSTOM_CELL,
+    aggregation=Aggregation.CS_THEN_TS,
+    input_shape=InputShape.SERIES,
+    requires={"ic_df": compute_ic},
+    sample_threshold=SampleThreshold(min_periods=10),
+    validate=_validate_custom_trimmed_ic,
+)
+def custom_trimmed_ic(ic_df: pl.DataFrame, trim_ratio: float = 0.05):
+    ...
+```
+
+`overlap_periods` and `expected_warnings` are injected at dispatch rather than
+configured, so they are never validated here — the constructor rejects them
+outright.
+
 ---
 
 ## 2. Using `@metric_spec` and `register()`

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -18,6 +18,7 @@ import polars as pl
 
 from factrix._axis import DataStructure, FactorDensity, FactorScope
 from factrix._codes import WarningCode
+from factrix._errors import UserInputError
 from factrix._types import SampleAxis
 
 PValueAlternative = Literal["two-sided", "greater", "less"]
@@ -74,32 +75,56 @@ class MetricResult:
 
     def __post_init__(self) -> None:
         if (self.p_value is None) != (self.alternative is None):
-            raise ValueError(
-                "MetricResult: p_value and alternative must either both be "
-                "provided or both be None."
+            raise UserInputError(
+                func_name="MetricResult",
+                field="alternative",
+                value=self.alternative,
+                expected=(
+                    "p_value and alternative supplied together, or both None: "
+                    "a p-value without the alternative it was computed under "
+                    "is uninterpretable."
+                ),
+                docs_path="api/evaluation-results#factrix.MetricResult",
             )
         # WHY: bool is a subclass of float's numeric tower — `True` passes the
         # [0, 1] range check and then serialises as a probability of 1.0.
         if isinstance(self.p_value, bool):
-            raise ValueError(
-                "MetricResult: p_value must be a float probability, not a bool; "
-                f"got {self.p_value!r}."
+            raise UserInputError(
+                func_name="MetricResult",
+                field="p_value",
+                value=self.p_value,
+                expected=(
+                    "a float probability, not a bool. A bool passes the "
+                    "[0, 1] range check and then serialises as a probability "
+                    "of 1.0."
+                ),
+                docs_path="api/evaluation-results#factrix.MetricResult",
             )
         if self.p_value is not None and (
             not math.isfinite(self.p_value) or not 0.0 <= self.p_value <= 1.0
         ):
-            raise ValueError(
-                "MetricResult: p_value must be finite and lie in [0, 1]; "
-                f"got {self.p_value!r}."
+            raise UserInputError(
+                func_name="MetricResult",
+                field="p_value",
+                value=self.p_value,
+                expected="a finite probability inside [0, 1]",
+                docs_path="api/evaluation-results#factrix.MetricResult",
             )
         if self.alternative is not None and self.alternative not in _ALTERNATIVES:
-            raise ValueError(
-                "MetricResult: alternative must be one of "
-                f"{sorted(_ALTERNATIVES)}; got {self.alternative!r}."
+            raise UserInputError(
+                func_name="MetricResult",
+                field="alternative",
+                value=self.alternative,
+                candidates=sorted(_ALTERNATIVES),
+                docs_path="api/evaluation-results#factrix.MetricResult",
             )
         if self.n_obs is not None and self.n_obs < 0:
-            raise ValueError(
-                f"MetricResult: n_obs must be non-negative; got {self.n_obs!r}."
+            raise UserInputError(
+                func_name="MetricResult",
+                field="n_obs",
+                value=self.n_obs,
+                expected="a non-negative count",
+                docs_path="api/evaluation-results#factrix.MetricResult",
             )
         # WHY: NaN is a legitimate `stat` — an estimator that ran but could not
         # form its statistic reports NaN, the same "computed, undefined" marker
@@ -107,9 +132,16 @@ class MetricResult:
         # division by an unguarded zero standard error, which silently reads
         # out as infinite significance downstream.
         if self.stat is not None and math.isinf(self.stat):
-            raise ValueError(
-                "MetricResult: stat must be finite (NaN allowed for a statistic "
-                f"that could not be formed); got {self.stat!r}."
+            raise UserInputError(
+                func_name="MetricResult",
+                field="stat",
+                value=self.stat,
+                expected=(
+                    "a finite statistic, or NaN for one that could not be "
+                    "formed. An infinite stat always comes from a division by "
+                    "an unguarded zero standard error."
+                ),
+                docs_path="api/evaluation-results#factrix.MetricResult",
             )
 
     def __repr__(self) -> str:
@@ -310,24 +342,29 @@ class EvaluationResult:
         - only **scalar** values are exported — ``bool`` / ``int`` /
           ``float`` / ``str`` (``NaN`` / ``Inf`` become ``null`` like
           ``value``; numpy scalars are unwrapped). A list, dict, tuple or
-          other nested value raises ``ValueError`` naming the metric and
+          other nested value raises ``UserInputError`` naming the metric and
           key — those are what :meth:`to_dict` is for;
         - a key colliding with a fixed column, a :attr:`params` key or a
-          repeated key raises ``ValueError``, so metadata never shadows
+          repeated key raises ``UserInputError``, so metadata never shadows
           identity or the fixed schema;
         - dtypes are inferred per column from the values present.
 
         Raises:
-            ValueError: a :attr:`params` key collides with a fixed column
+            UserInputError: a :attr:`params` key collides with a fixed column
                 name; a ``metadata`` key collides, repeats, or names a
                 non-scalar value on some metric.
         """
         collisions = sorted(set(self.params) & set(_TO_FRAME_SCHEMA))
         if collisions:
-            raise ValueError(
-                f"EvaluationResult.to_frame(): params key(s) {collisions} collide "
-                f"with fixed column name(s); rename the params key(s). Reserved: "
-                f"{sorted(_TO_FRAME_SCHEMA)}"
+            raise UserInputError(
+                func_name="EvaluationResult.to_frame",
+                field="params",
+                value=collisions,
+                expected=(
+                    f"params key(s) that do not collide with a fixed column "
+                    f"name; rename them. Reserved: {sorted(_TO_FRAME_SCHEMA)}"
+                ),
+                docs_path="api/evaluation-results#to_frame",
             )
         meta_keys = _validate_metadata_keys(metadata, params=self.params)
         by_metric: dict[str, list[str]] = {}
@@ -555,30 +592,48 @@ def _validate_metadata_keys(
 ) -> tuple[str, ...]:
     """Normalise ``to_frame(metadata=)``: a sequence of distinct, non-reserved keys."""
     if isinstance(metadata, str) or not isinstance(metadata, Sequence):
-        raise ValueError(
-            "EvaluationResult.to_frame(): metadata= takes a sequence of metadata "
-            f"key names, e.g. metadata=('n_groups', 'rebalance_lag'); got "
-            f"{metadata!r}"
+        raise UserInputError(
+            func_name="EvaluationResult.to_frame",
+            field="metadata",
+            value=metadata,
+            expected=(
+                "a sequence of metadata key names, e.g. "
+                "metadata=('n_groups', 'rebalance_lag')"
+            ),
+            docs_path="api/evaluation-results#to_frame",
         )
     keys = tuple(metadata)
     bad = [k for k in keys if not isinstance(k, str)]
     if bad:
-        raise ValueError(
-            f"EvaluationResult.to_frame(): metadata keys must be strings; got {bad!r}"
+        raise UserInputError(
+            func_name="EvaluationResult.to_frame",
+            field="metadata",
+            value=bad,
+            expected="every metadata key a string",
+            docs_path="api/evaluation-results#to_frame",
         )
     repeated = sorted({k for k in keys if keys.count(k) > 1})
     if repeated:
-        raise ValueError(
-            f"EvaluationResult.to_frame(): metadata key(s) {repeated} repeated"
+        raise UserInputError(
+            func_name="EvaluationResult.to_frame",
+            field="metadata",
+            value=repeated,
+            expected="distinct metadata keys",
+            docs_path="api/evaluation-results#to_frame",
         )
     reserved = set(_TO_FRAME_SCHEMA) | set(_TO_FRAME_IDENTITY) | set(params)
     collisions = sorted(set(keys) & reserved)
     if collisions:
-        raise ValueError(
-            f"EvaluationResult.to_frame(): metadata key(s) {collisions} collide "
-            f"with a fixed column or a params key; the fixed schema and the "
-            f"hypothesis identity are never shadowed by metadata. Reserved: "
-            f"{sorted(reserved)}"
+        raise UserInputError(
+            func_name="EvaluationResult.to_frame",
+            field="metadata",
+            value=collisions,
+            expected=(
+                f"metadata key(s) that shadow neither a fixed column nor a "
+                f"params key: the fixed schema and the hypothesis identity are "
+                f"never shadowed. Reserved: {sorted(reserved)}"
+            ),
+            docs_path="api/evaluation-results#to_frame",
         )
     return keys
 
@@ -606,10 +661,15 @@ def _scalar_metadata(label: str, key: str, value: object) -> Any:
         return value
     if isinstance(value, float):
         return _float_or_none(value)
-    raise ValueError(
-        f"EvaluationResult.to_frame(): metadata[{key!r}] on metric {label!r} is "
-        f"a {type(value).__name__}, not a scalar; metadata= exports bool / int / "
-        f"float / str cells only. Use to_dict() for nested values."
+    raise UserInputError(
+        func_name="EvaluationResult.to_frame",
+        field=f"metadata[{key!r}]",
+        value=value,
+        expected=(
+            f"a scalar on metric {label!r}: metadata= exports bool / int / "
+            f"float / str cells only. Use to_dict() for nested values."
+        ),
+        docs_path="api/evaluation-results#to_frame",
     )
 
 

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -211,11 +211,66 @@ class MetricBase(metaclass=MetricMeta):
     # constructor, and injected at dispatch into the metrics whose ``_impl``
     # declares them. Empty for a metric that takes no injected param.
     _injected_param_names: ClassVar[tuple[str, ...]] = ()
+    # Closed-set knobs: ``(field, Literal alias)`` for every user-configurable
+    # field annotated with a ``Literal``, resolved once by the decorator.
+    _literal_fields: ClassVar[tuple[tuple[str, Any], ...]] = ()
+    # The metric's own knob validator, declared as ``@metric(validate=...)``.
+    _knob_validator: ClassVar[Callable[[MetricBase], None] | None] = None
     _logger: ClassVar[logging.Logger]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         cls._logger = logging.getLogger(f"factrix.metric.{cls.__name__}")
+
+    def __post_init__(self) -> None:
+        """Validate every configured knob, once, at construction.
+
+        The single site every metric's knob contract is enforced at. Both call
+        forms reach it: ``metric(n_groups=1)`` is plain dataclass
+        instantiation, and ``metric(data, n_groups=1)`` builds the same
+        instance first (:meth:`MetricMeta.__call__`) and only then runs the
+        body. So a bad knob raises where the caller wrote it — a config object
+        cannot be built now and fail three metrics into an ``evaluate`` — and
+        raises identically whichever form was used.
+
+        Three rules, in the order a caller meets them:
+
+        1. a field annotated with a ``Literal`` alias is checked against that
+           alias, so the annotation is the runtime contract;
+        2. an ``inference=`` field is checked against the module's
+           ``applicable_inference`` allowlist;
+        3. the metric's own ``@metric(validate=...)`` hook runs, for the
+           numeric bounds the first two cannot express.
+
+        ``overlap_periods`` is deliberately absent: it is injected from the
+        panel at dispatch rather than configured, so it is validated where it
+        enters, in :meth:`__call__`.
+        """
+        from factrix.metrics._helpers import (
+            _check_applicable_inference,
+            _validate_choice,
+        )
+        from factrix.metrics._metric_capabilities import resolve_applicable_inference
+
+        func_name = type(self).__name__
+        for field, alias in self._literal_fields:
+            _validate_choice(
+                getattr(self, field),
+                alias,
+                func_name=func_name,
+                field=field,
+                docs_path=self._docs_path(),
+            )
+        applicable = resolve_applicable_inference(self)
+        if applicable is not None:
+            _check_applicable_inference(
+                self.inference,  # type: ignore[attr-defined]
+                applicable,
+                func_name=func_name,
+            )
+        validator = type(self)._knob_validator
+        if validator is not None:
+            validator(self)
 
     @classmethod
     def spec(cls) -> MetricSpec:

--- a/factrix/metrics/_decorators.py
+++ b/factrix/metrics/_decorators.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import types
+import typing
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -42,6 +44,39 @@ def _normalize_threshold(
     return declared, None
 
 
+def _resolve_hints(fn: Callable[..., Any]) -> dict[str, Any]:
+    """Resolved annotations for ``fn``, or ``{}`` when they cannot be resolved.
+
+    Metric modules use ``from __future__ import annotations``, so a signature
+    carries annotation *strings*; the closed-set rule below needs the real
+    ``Literal`` alias behind the name. A third-party metric may annotate with a
+    name that only exists under ``TYPE_CHECKING``, which no first-party metric
+    does — resolution failing there degrades to the raw annotation object
+    rather than breaking the decorator.
+    """
+    try:
+        return typing.get_type_hints(fn)
+    except Exception:
+        return {}
+
+
+def _literal_alias(annotation: Any) -> Any | None:
+    """The ``Literal`` alias behind ``annotation``, or ``None`` if there is none.
+
+    Unwraps a union (``Literal[...] | None``, ``Optional[Literal[...]]``) so an
+    optional closed-set knob is still recognised as one; the ``None`` member is
+    not a legal token, so an optional knob declares it in its own ``Literal``
+    if it wants one.
+    """
+    if typing.get_origin(annotation) is typing.Literal:
+        return annotation
+    if typing.get_origin(annotation) in (typing.Union, types.UnionType):
+        for arg in typing.get_args(annotation):
+            if typing.get_origin(arg) is typing.Literal:
+                return arg
+    return None
+
+
 def metric(
     cell: Cell,
     aggregation: Aggregation,
@@ -56,6 +91,7 @@ def metric(
     | None = None,
     requires_continuous_magnitude: bool = False,
     slice_boundary_sensitive: bool = False,
+    validate: Callable[[MetricBase], None] | None = None,
 ) -> Callable[[_F], _F]:
     """Decorator to define a Metric class from a function definition.
 
@@ -66,6 +102,16 @@ def metric(
     like the original function. It is typed as the wrapped callable (``_F``)
     so direct calls and ``requires=`` references type-check against the real
     signature; the class identity is an internal registry concern.
+
+    ``validate`` is the metric's own knob validator: a callable taking the
+    constructed instance and raising :class:`~factrix._errors.UserInputError`
+    for a knob outside its bounds. It runs from
+    :meth:`MetricBase.__post_init__`, alongside the two rules the decorator
+    derives on its own (``Literal``-annotated fields against their alias, and
+    ``inference=`` against the module's ``applicable_inference`` allowlist), so
+    every knob mistake fails at construction on both the config and the
+    direct-call path. Bounds a ``Literal`` cannot express are the only thing it
+    is for — a closed set belongs in the annotation.
     """
 
     def decorator(fn: _F) -> _F:
@@ -111,6 +157,18 @@ def metric(
             name for name, *_ in fields if name not in _INJECTED_PARAMS
         )
 
+        # Closed-set knobs, resolved once at class creation: every field
+        # annotated with a ``Literal`` alias, paired with that alias. The
+        # constructor validates against it, so the annotation *is* the runtime
+        # contract and the two cannot drift.
+        hints = _resolve_hints(fn)
+        literal_fields = tuple(
+            (name, alias)
+            for name, annotation, *_ in fields
+            if name in user_param_names
+            and (alias := _literal_alias(hints.get(name, annotation))) is not None
+        )
+
         # 2. Normalize the floor declaration into the single resolver type.
         # A ``SampleThreshold`` constant (or ``None``) becomes a resolver that
         # returns it verbatim; a callable is taken as-is. The ``SampleThreshold |
@@ -135,6 +193,8 @@ def metric(
             "_first_param_name": first_param_name,
             "_param_names": user_param_names,
             "_injected_param_names": injected_param_names,
+            "_literal_fields": literal_fields,
+            "_knob_validator": staticmethod(validate) if validate else None,
             "__module__": fn.__module__,
             "__doc__": fn.__doc__,
         }

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -1590,6 +1590,74 @@ def _validate_open_unit_interval(
         )
 
 
+def _validate_factor_cols(
+    factor_cols: object, *, func_name: str, docs_path: str
+) -> None:
+    """Reject an empty ``factor_cols`` on a batch-native metric.
+
+    A batch metric returns one result per requested factor, so an empty
+    request has no answer to return — it would hand back an empty mapping
+    that reads as "every factor failed". ``evaluate`` rejects the same empty
+    list at its own boundary; this is the constructor-side twin for a metric
+    configured or called directly.
+    """
+    from factrix._errors import UserInputError
+
+    if not list(factor_cols):  # type: ignore[call-overload]
+        raise UserInputError(
+            func_name=func_name,
+            field="factor_cols",
+            value=factor_cols,
+            expected="a non-empty sequence of factor column names",
+            docs_path=docs_path,
+        )
+
+
+def _validate_positive_count(
+    value: object, *, func_name: str, field: str, detail: str, docs_path: str
+) -> None:
+    """Reject a count knob below 1 (a period stride, a leg size, a lag).
+
+    The counterpart of :func:`_validate_open_unit_interval` for the integer
+    knobs: one shared shape for "this is a count of periods / names, and zero
+    or negative has no meaning". A bool is an int to Python and would
+    otherwise pass as ``True == 1``.
+    """
+    from factrix._errors import UserInputError
+
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise UserInputError(
+            func_name=func_name,
+            field=field,
+            value=value,
+            expected=f"an integer >= 1. {detail}",
+            docs_path=docs_path,
+        )
+
+
+def _validate_adf_threshold(
+    adf_threshold: object, *, func_name: str, docs_path: str
+) -> None:
+    """Reject an ``adf_threshold`` outside ``(0, 1)``; ``None`` skips the gate.
+
+    Shared by the two metrics that gate on a stationarity test: the knob is the
+    p-value the augmented Dickey-Fuller test is compared against, so it is a
+    probability, and ``None`` means "do not run the gate" rather than a bound.
+    """
+    if adf_threshold is None:
+        return
+    _validate_open_unit_interval(
+        adf_threshold,  # type: ignore[arg-type]
+        func_name=func_name,
+        field="adf_threshold",
+        detail=(
+            "It is the p-value the augmented Dickey-Fuller test is compared "
+            "against; pass None to skip the stationarity gate."
+        ),
+        docs_path=docs_path,
+    )
+
+
 def _validate_n_groups(n_groups: int, *, func_name: str, docs_path: str) -> None:
     """Reject a quantile count below :data:`~factrix._types.N_GROUPS_FLOOR`.
 

--- a/factrix/metrics/_primitives/_common_betas.py
+++ b/factrix/metrics/_primitives/_common_betas.py
@@ -17,8 +17,13 @@ from factrix._axis import (
 from factrix._metric_index import cell
 from factrix._stats.ols import _ols_nw_slope_se
 from factrix._types import EPSILON
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _attach_drop_stats, _finite_expr
+from factrix.metrics._helpers import (
+    _attach_drop_stats,
+    _finite_expr,
+    _validate_factor_cols,
+)
 
 # Minimum complete (factor, return) observations per asset to fit a
 # time-series slope. Mirrors the historical per-asset floor.
@@ -99,6 +104,15 @@ def _ew_portfolio_slope(
     return slope, se * se, n_periods
 
 
+def _validate_compute_common_betas(m: MetricBase) -> None:
+    """Knob bounds for ``compute_common_betas``, applied at construction."""
+    _validate_factor_cols(
+        m.factor_cols,  # type: ignore[attr-defined]
+        func_name="compute_common_betas",
+        docs_path="api/metrics/common_beta",
+    )
+
+
 @metric(
     cell=cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.TS_THEN_CS,
@@ -106,6 +120,7 @@ def _ew_portfolio_slope(
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
     batchable=True,
+    validate=_validate_compute_common_betas,
 )
 def compute_common_betas(
     data: pl.DataFrame,
@@ -195,8 +210,6 @@ def compute_common_betas(
         assets from any t-based aggregate while keeping their ``beta``.
     """
     cols = list(factor_cols)
-    if not cols:
-        raise ValueError("factor_cols must be non-empty")
 
     return {f: _common_betas_one(data, f, return_col, overlap_periods) for f in cols}
 

--- a/factrix/metrics/_primitives/_fm_betas.py
+++ b/factrix/metrics/_primitives/_fm_betas.py
@@ -14,14 +14,28 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._metric_index import cell
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _attach_drop_stats, _finite_expr
+from factrix.metrics._helpers import (
+    _attach_drop_stats,
+    _finite_expr,
+    _validate_factor_cols,
+)
 
 # Minimum complete (factor, return) pairs per date to estimate a slope.
 # Two parameters (intercept + slope) leave one residual degree of freedom
 # at three observations.
 MIN_FM_ASSETS_HARD: int = 3
 MIN_FM_ASSETS_WARN: int = 10
+
+
+def _validate_compute_fm_betas(m: MetricBase) -> None:
+    """Knob bounds for ``compute_fm_betas``, applied at construction."""
+    _validate_factor_cols(
+        m.factor_cols,  # type: ignore[attr-defined]
+        func_name="compute_fm_betas",
+        docs_path="api/metrics/fm_beta",
+    )
 
 
 @metric(
@@ -33,6 +47,7 @@ MIN_FM_ASSETS_WARN: int = 10
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
     batchable=True,
+    validate=_validate_compute_fm_betas,
 )
 def compute_fm_betas(
     data: pl.DataFrame,
@@ -85,8 +100,6 @@ def compute_fm_betas(
         pair count doubles as the effective ``n``.
     """
     cols = list(factor_cols)
-    if not cols:
-        raise ValueError("factor_cols must be non-empty")
 
     agg_exprs: list[pl.Expr] = []
     for f in cols:

--- a/factrix/metrics/_primitives/_group_returns.py
+++ b/factrix/metrics/_primitives/_group_returns.py
@@ -13,6 +13,7 @@ from factrix._axis import (
 )
 from factrix._metric_index import cell
 from factrix._types import TiePolicy
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups,
@@ -20,6 +21,15 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _validate_n_groups,
 )
+
+
+def _validate_compute_group_returns(m: MetricBase) -> None:
+    """Knob bounds for ``compute_group_returns``, applied at construction."""
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="compute_group_returns",
+        docs_path="api/metrics/quantile",
+    )
 
 
 @metric(
@@ -30,6 +40,7 @@ from factrix.metrics._helpers import (
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
+    validate=_validate_compute_group_returns,
 )
 def compute_group_returns(
     data: pl.DataFrame,
@@ -84,9 +95,6 @@ def compute_group_returns(
         >>> set(groups.columns) >= {"group", "mean_return"}
         True
     """
-    _validate_n_groups(
-        n_groups, func_name="compute_group_returns", docs_path="api/metrics/quantile"
-    )
     sampled = _sample_non_overlapping(data, overlap_periods)
     grouped = _assign_quantile_groups(
         sampled,

--- a/factrix/metrics/_primitives/_ic.py
+++ b/factrix/metrics/_primitives/_ic.py
@@ -15,8 +15,22 @@ from factrix._axis import (
 )
 from factrix._metric_index import cell
 from factrix._types import MIN_IC_ASSETS_HARD
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _attach_drop_stats, _finite_expr
+from factrix.metrics._helpers import (
+    _attach_drop_stats,
+    _finite_expr,
+    _validate_factor_cols,
+)
+
+
+def _validate_compute_ic(m: MetricBase) -> None:
+    """Knob bounds for ``compute_ic``, applied at construction."""
+    _validate_factor_cols(
+        m.factor_cols,  # type: ignore[attr-defined]
+        func_name="compute_ic",
+        docs_path="api/metrics/ic",
+    )
 
 
 @metric(
@@ -28,6 +42,7 @@ from factrix.metrics._helpers import _attach_drop_stats, _finite_expr
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
     batchable=True,
+    validate=_validate_compute_ic,
 )
 def compute_ic(
     data: pl.DataFrame,
@@ -65,8 +80,6 @@ def compute_ic(
         $1 - n_{\mathrm{unique}} / n$ in $[0, 1]$.
     """
     cols = list(factor_cols)
-    if not cols:
-        raise ValueError("factor_cols must be non-empty")
 
     # Spearman ρ must rank each factor and the return over the *pairwise-complete*
     # (factor, return) set per date: a missing value in either column would otherwise shift

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -13,6 +13,7 @@ from factrix._axis import (
 )
 from factrix._metric_index import cell
 from factrix._types import EPSILON
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 
 DEFAULT_MIN_ESTIMATION_PERIODS: int = 20
@@ -36,6 +37,25 @@ def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
     }
 
 
+def _validate_compute_mfe_mae(m: MetricBase) -> None:
+    """Knob bounds for ``compute_mfe_mae``, applied at construction."""
+    from factrix._errors import UserInputError
+
+    value = m.min_estimation_periods  # type: ignore[attr-defined]
+    if not isinstance(value, int) or isinstance(value, bool) or value < 2:
+        raise UserInputError(
+            func_name="compute_mfe_mae",
+            field="min_estimation_periods",
+            value=value,
+            expected=(
+                "an integer >= 2. It is the pre-event window the volatility "
+                "normalizer is estimated on, and a sample standard deviation "
+                "(ddof=1) needs at least two observations."
+            ),
+            docs_path="api/metrics/mfe_mae",
+        )
+
+
 @metric(
     cell=cell(
         None, FactorDensity.SPARSE, DataStructure.PANEL, raw="(*, SPARSE, PANEL)"
@@ -44,6 +64,7 @@ def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
     input_shape=InputShape.PANEL,
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
+    validate=_validate_compute_mfe_mae,
 )
 def compute_mfe_mae(
     data: pl.DataFrame,
@@ -104,12 +125,6 @@ def compute_mfe_mae(
         the excursion is attained at entry, before any path bar — and
         otherwise stay 1-based offsets into the post-event window.
     """
-    if min_estimation_periods < 2:
-        raise ValueError(
-            f"min_estimation_periods must be >= 2 (std needs ddof=1 "
-            f"and at least 2 observations), got {min_estimation_periods}"
-        )
-
     date_dtype = data.schema["date"]
     empty_schema = _empty_mfe_mae_schema(date_dtype)
 

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -15,14 +15,30 @@ from factrix._axis import (
 )
 from factrix._metric_index import cell
 from factrix._types import TiePolicy
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups_batch,
     _finite_expr,
     _sample_non_overlapping,
+    _validate_factor_cols,
     _validate_n_groups,
     _warn_thin_quantile_groups,
 )
+
+
+def _validate_compute_spread_series(m: MetricBase) -> None:
+    """Knob bounds for ``compute_spread_series``, applied at construction."""
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="compute_spread_series",
+        docs_path="api/metrics/quantile",
+    )
+    _validate_factor_cols(
+        m.factor_cols,  # type: ignore[attr-defined]
+        func_name="compute_spread_series",
+        docs_path="api/metrics/quantile",
+    )
 
 
 @metric(
@@ -34,6 +50,7 @@ from factrix.metrics._helpers import (
     output_shape=OutputShape.SERIES,
     role=SpecRole.PIPELINE,
     batchable=True,
+    validate=_validate_compute_spread_series,
 )
 def compute_spread_series(
     data: pl.DataFrame,
@@ -102,11 +119,6 @@ def compute_spread_series(
         True
     """
     cols = list(factor_cols)
-    if not cols:
-        raise ValueError("factor_cols must be non-empty")
-    _validate_n_groups(
-        n_groups, func_name="compute_spread_series", docs_path="api/metrics/quantile"
-    )
 
     sampled = _sample_non_overlapping(data, overlap_periods)
 

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -43,6 +43,7 @@ from factrix._stats import (
 )
 from factrix._stats.constants import MIN_ASSETS_WARN
 from factrix._types import DDOF, EPSILON
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _degenerate_test_fields,
@@ -325,6 +326,25 @@ def common_beta(
 # ---------------------------------------------------------------------------
 
 
+def _validate_common_beta_profile(m: MetricBase) -> None:
+    """``neutral_epsilon`` is an absolute-beta width, so it cannot be negative."""
+    from factrix._errors import UserInputError
+
+    value = m.neutral_epsilon  # type: ignore[attr-defined]
+    numeric = not isinstance(value, bool) and isinstance(value, int | float)
+    if not numeric or float(value) < 0.0:
+        raise UserInputError(
+            func_name="common_beta_profile",
+            field="neutral_epsilon",
+            value=value,
+            expected=(
+                "a non-negative number. It is the half-width of the |beta| "
+                "band counted as neutral, so a negative width has no meaning."
+            ),
+            docs_path="api/metrics/common_beta",
+        )
+
+
 @metric(
     cell=_COMMON_BETA_CELL,
     aggregation=Aggregation.TS_THEN_CS,
@@ -332,6 +352,7 @@ def common_beta(
     input_shape=InputShape.SERIES,
     requires={"common_betas_df": compute_common_betas},
     sample_threshold=SampleThreshold(min_assets=1),
+    validate=_validate_common_beta_profile,
 )
 def common_beta_profile(
     common_betas_df: pl.DataFrame,
@@ -356,8 +377,6 @@ def common_beta_profile(
         MetricResult with descriptive beta-profile metadata and
         ``p_value=None``.
     """
-    if neutral_epsilon < 0.0:
-        raise ValueError("neutral_epsilon must be non-negative")
     if "beta" not in common_betas_df.columns:
         return _short_circuit_output(
             "common_beta_profile",

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -38,6 +38,7 @@ from factrix._stats import (
     _wald_p_linear,
 )
 from factrix._types import MIN_PORTFOLIO_PERIODS_HARD
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _aggregate_to_per_date,
@@ -54,10 +55,26 @@ __all__ = [
 _MIN_BUCKET_PERIODS_WARN = 5
 
 
+def _validate_common_quantile_spread(m: MetricBase) -> None:
+    """Bucketing floor for ``common_quantile_spread``.
+
+    This metric buckets the factor *history* with its own ordinal cut rather
+    than the panel kernel, so it states the shared floor here instead of
+    inheriting it from the kernel: one bucket has no top-minus-bottom contrast
+    to test.
+    """
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="common_quantile_spread",
+        docs_path="api/metrics/common_quantile",
+    )
+
+
 @metric(
     cell=cell(FactorScope.COMMON, FactorDensity.DENSE, structure=DataStructure.PANEL),
     aggregation=Aggregation.CS_THEN_TS,
     sample_threshold=SampleThreshold(min_periods=MIN_PORTFOLIO_PERIODS_HARD),
+    validate=_validate_common_quantile_spread,
 )
 def common_quantile_spread(
     data: pl.DataFrame,
@@ -139,14 +156,6 @@ def common_quantile_spread(
         >>> result.name == ""
         True
     """
-    # This metric buckets the factor *history* with its own ordinal cut rather
-    # than the panel kernel, so it applies the shared floor explicitly: one
-    # bucket has no top-minus-bottom contrast to test.
-    _validate_n_groups(
-        n_groups,
-        func_name="common_quantile_spread",
-        docs_path="api/metrics/common_quantile",
-    )
     # ``date`` / ``asset_id`` are gated by the direct-call key-column check in
     # ``MetricBase.__call__``, which also rejects a caller-named column the
     # frame does not carry (and ``evaluate`` validates the panel schema), so

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -36,6 +36,7 @@ from factrix._types import (
     MIN_PORTFOLIO_PERIODS_WARN,
     ConcentrationWeight,
 )
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _compute_tie_ratio,
@@ -46,7 +47,6 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _scaled_periods_threshold,
     _short_circuit_output,
-    _validate_choice,
     _validate_open_unit_interval,
     _warn_below_scaled_floor,
 )
@@ -54,6 +54,27 @@ from factrix.metrics._helpers import (
 __all__ = [
     "top_concentration",
 ]
+
+
+_DOCS_CONCENTRATION = "api/metrics/concentration"
+
+
+def _validate_top_concentration(m: MetricBase) -> None:
+    """``q_top`` is a fraction of the cross-section, strictly inside (0, 1).
+
+    ``weight_by`` is a closed set the constructor reads off its ``Literal``
+    annotation.
+    """
+    _validate_open_unit_interval(
+        m.q_top,  # type: ignore[attr-defined]
+        func_name="top_concentration",
+        field="q_top",
+        detail=(
+            "0 leaves no top bucket and 1 selects the whole cross-section, "
+            "so no top-bucket concentration is defined."
+        ),
+        docs_path=_DOCS_CONCENTRATION,
+    )
 
 
 @metric(
@@ -68,6 +89,7 @@ __all__ = [
     sample_threshold=_scaled_periods_threshold(
         MIN_PORTFOLIO_PERIODS_HARD, warn=MIN_PORTFOLIO_PERIODS_WARN
     ),
+    validate=_validate_top_concentration,
 )
 def top_concentration(
     data: pl.DataFrame,
@@ -183,23 +205,6 @@ def top_concentration(
         >>> result.name == ""
         True
     """
-    _validate_choice(
-        weight_by,
-        ConcentrationWeight,
-        func_name="top_concentration",
-        field="weight_by",
-        docs_path="api/metrics/concentration",
-    )
-    _validate_open_unit_interval(
-        q_top,
-        func_name="top_concentration",
-        field="q_top",
-        detail=(
-            "0 leaves no top bucket and 1 selects the whole cross-section, "
-            "so no top-bucket concentration is defined."
-        ),
-        docs_path="api/metrics/concentration",
-    )
     if weight_by == "alpha_contribution" and return_col not in data.columns:
         return _short_circuit_output(
             "top_concentration",

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -51,6 +51,7 @@ from factrix._stats import (
 )
 from factrix._stats.constants import MIN_PERIODS_WARN, PERSISTENT_SERIES_AUTOCORR
 from factrix._types import EPSILON
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _degenerate_test_fields,
@@ -504,13 +505,6 @@ def _pooled_beta_driscoll_kraay(
     ``_MIN_DK_PERIODS_HARD`` periods (HAC undefined), mirroring the clustered
     ``G < 3`` guard.
     """
-    if two_way_cluster_col is not None:
-        raise ValueError(
-            "pooled_beta: driscoll_kraay=True is mutually exclusive with "
-            "two_way_cluster_col. Driscoll-Kraay already handles "
-            "cross-sectional dependence across the panel; pick one SE method."
-        )
-
     from factrix._stats.hac import _driscoll_kraay_cov as _dk_cov
 
     period_ids = data[cluster_col].to_numpy()
@@ -583,6 +577,31 @@ def _pooled_beta_driscoll_kraay(
     )
 
 
+def _validate_pooled_beta(m: MetricBase) -> None:
+    """``driscoll_kraay`` and ``two_way_cluster_col`` are two SE methods, not one.
+
+    Driscoll-Kraay already handles cross-sectional dependence across the whole
+    panel, so pairing it with a second cluster dimension would silently drop
+    one of the two requests. Rejected at construction rather than inside the
+    DK branch, so the conflict surfaces where the caller wrote it.
+    """
+    from factrix._errors import UserInputError
+
+    if m.driscoll_kraay and m.two_way_cluster_col is not None:  # type: ignore[attr-defined]
+        raise UserInputError(
+            func_name="pooled_beta",
+            field="driscoll_kraay",
+            value=True,
+            expected=(
+                "driscoll_kraay=True is mutually exclusive with "
+                "two_way_cluster_col. Driscoll-Kraay already handles "
+                "cross-sectional dependence across the panel; pick one SE "
+                "method."
+            ),
+            docs_path="api/metrics/fm_beta",
+        )
+
+
 @metric(
     cell=_FM_CELL,
     aggregation=Aggregation.CS_THEN_TS,
@@ -591,6 +610,7 @@ def _pooled_beta_driscoll_kraay(
         min_periods=_MIN_DK_PERIODS_HARD,
         warn_periods=MIN_PERIODS_WARN,
     ),
+    validate=_validate_pooled_beta,
 )
 def pooled_beta(
     data: pl.DataFrame,
@@ -626,7 +646,8 @@ def pooled_beta(
     the default; the chosen SE method is recorded in
     ``metadata["se_method"]`` (``"driscoll_kraay"`` vs the cluster
     ``method`` string). ``driscoll_kraay=True`` is mutually exclusive
-    with ``two_way_cluster_col`` (raises ``ValueError``).
+    with ``two_way_cluster_col`` (raises ``UserInputError`` at
+    construction).
 
     Short-circuits to ``value=NaN`` / ``stat=None`` / $p=1.0$ when
     ``n_obs < 10`` (no regression), when the effective $G < 3$ (clustered SE

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -49,7 +49,6 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _DROP_STATS_COL,
     TIE_RATIO_WARN_THRESHOLD,
-    _check_applicable_inference,
     _degenerate_test_fields,
     _enforce_min_floor,
     _read_drop_stats,
@@ -198,13 +197,10 @@ def _ic_sample_threshold(self: MetricBase) -> SampleThreshold:
     """
     # ``inference`` is an ``ic``-specific field; the resolver is only ever bound
     # to ``ic``, but its declared param type is the ``MetricBase`` contract.
+    # ``inference`` was vetted against ``applicable_inference`` at construction
+    # (``MetricBase.__post_init__``), so the floor can dereference it without a
+    # guard of its own: an instance carrying an unvetted method does not exist.
     inference = self.inference  # type: ignore[attr-defined]
-    # The floor dereferences ``inference`` before the body ever runs, so an
-    # unvetted value (a stray string, a non-allowlisted method) would surface
-    # here as an ``AttributeError`` from the pre-flight instead of the body's
-    # ``IncompatibleInferenceError``. Same chokepoint, same error, whichever
-    # runs first.
-    _check_applicable_inference(inference, applicable_inference, func_name="ic")
     return SampleThreshold(
         min_periods=inference.min_input_periods(self.overlap_periods)
     )
@@ -319,7 +315,6 @@ def ic(
         >>> result.name == ""
         True
     """
-    _check_applicable_inference(inference, applicable_inference, func_name="ic")
     warning_codes: list[str] = []
     median_tie = _warn_if_high_ic_tie_ratio(
         ic_df, "ic", warning_codes, expected_warnings=expected_warnings

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -48,10 +48,10 @@ from factrix.inference import (
     NonOverlapping,
     StationaryBootstrap,
 )
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _all_dates_degenerate,
-    _check_applicable_inference,
     _compute_tie_ratio,
     _degenerate_test_fields,
     _enforce_scaled_floor,
@@ -63,7 +63,7 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _spread_significance_with_inference,
     _surface_null_drop,
-    _validate_choice,
+    _validate_positive_count,
     _warn_high_tie_ratio,
 )
 
@@ -183,6 +183,24 @@ def _build_k_spread_series(
     return series, clean
 
 
+_DOCS_K_SPREAD = "api/metrics/k_spread"
+
+
+def _validate_k_spread(m: MetricBase) -> None:
+    """``k`` is the size of each leg, so at least one name per side.
+
+    ``tie_policy`` and ``inference`` are covered by the constructor's own
+    ``Literal`` / allowlist rules.
+    """
+    _validate_positive_count(
+        m.k,  # type: ignore[attr-defined]
+        func_name="k_spread",
+        field="k",
+        detail="k is the number of names in each leg of the spread.",
+        docs_path=_DOCS_K_SPREAD,
+    )
+
+
 @metric(
     cell=cell(
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
@@ -192,6 +210,7 @@ def _build_k_spread_series(
     # spread series is sub-sampled at ``overlap_periods``, so pre-flight and the
     # in-body gate share ``MIN_PORTFOLIO_PERIODS_HARD`` + ``_scaled_min_periods``.
     sample_threshold=_k_spread_threshold,
+    validate=_validate_k_spread,
 )
 def k_spread(
     data: pl.DataFrame,
@@ -315,16 +334,6 @@ def k_spread(
         >>> result.name == ""
         True
     """
-    _validate_choice(
-        tie_policy,
-        TiePolicy,
-        func_name="k_spread",
-        field="tie_policy",
-        docs_path="api/metrics/k_spread",
-    )
-    if k < 1:
-        raise ValueError(f"k must be >= 1; got {k}")
-    _check_applicable_inference(inference, applicable_inference, func_name="k_spread")
     if return_col not in data.columns:
         return _short_circuit_output(
             "k_spread",

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -28,7 +28,6 @@ from factrix._axis import (
     FactorScope,
 )
 from factrix._codes import WarningCode
-from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import _calc_t_stat, _p_value_from_t
@@ -43,6 +42,7 @@ from factrix._types import (
     MIN_MONOTONICITY_PERIODS_HARD,
     TiePolicy,
 )
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _assign_quantile_groups_batch,
@@ -52,7 +52,7 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _scaled_periods_threshold,
     _short_circuit_output,
-    _validate_choice,
+    _validate_factor_cols,
     _validate_n_groups,
     _warn_high_tie_ratio,
 )
@@ -163,6 +163,33 @@ def _mr_test(
     return j_stat, p_value, metadata
 
 
+_DOCS_MONOTONICITY = "api/metrics/monotonicity"
+
+
+def _validate_monotonicity(m: MetricBase) -> None:
+    """Numeric knob bounds for ``monotonicity``.
+
+    ``tie_policy`` and ``direction`` are closed sets the constructor reads off
+    their ``Literal`` annotations, so only the bucketing floor, the resampling
+    count and the batch request are stated here.
+    """
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="monotonicity",
+        docs_path=_DOCS_MONOTONICITY,
+    )
+    _check_n_resamples(
+        m.n_resamples,  # type: ignore[attr-defined]
+        func_name="monotonicity",
+        docs_path=_DOCS_MONOTONICITY,
+    )
+    _validate_factor_cols(
+        m.factor_cols,  # type: ignore[attr-defined]
+        func_name="monotonicity",
+        docs_path=_DOCS_MONOTONICITY,
+    )
+
+
 @metric(
     cell=cell(
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
@@ -170,6 +197,7 @@ def _mr_test(
     aggregation=Aggregation.CS_THEN_TS,
     batchable=True,
     sample_threshold=_monotonicity_sample_threshold,
+    validate=_validate_monotonicity,
 )
 def monotonicity(
     data: pl.DataFrame,
@@ -273,33 +301,7 @@ def monotonicity(
         >>> result["factor"].name == ""
         True
     """
-    _validate_choice(
-        tie_policy,
-        TiePolicy,
-        func_name="monotonicity",
-        field="tie_policy",
-        docs_path="api/metrics/monotonicity",
-    )
-    if direction not in ("increasing", "decreasing"):
-        # A typo must not silently run the opposite one-sided test.
-        raise UserInputError(
-            func_name="monotonicity",
-            field="direction",
-            value=direction,
-            expected="'increasing' (default) or 'decreasing'",
-            docs_path="api/metrics/monotonicity",
-        )
-    _check_n_resamples(
-        n_resamples,
-        func_name="monotonicity",
-        docs_path="api/metrics/monotonicity",
-    )
     cols = list(factor_cols)
-    if not cols:
-        raise ValueError("factor_cols must be non-empty")
-    _validate_n_groups(
-        n_groups, func_name="monotonicity", docs_path="api/metrics/monotonicity"
-    )
 
     # Raw (pre-sampling) date count: the axis the stride-scaled periods floor is
     # calibrated against, shared across all factors.

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -31,6 +31,7 @@ from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import EPSILON, MIN_OOS_PERIODS_HARD
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     DEGENERATE_SIGNAL_STATUS,
@@ -38,6 +39,7 @@ from factrix.metrics._helpers import (
     _resolve_series_value_col,
     _short_circuit_output,
     _surface_null_drop,
+    _validate_open_unit_interval,
 )
 from factrix.metrics.ic import compute_ic
 
@@ -52,6 +54,20 @@ GateStatus = Literal["PASS", "VETOED"]
 _MIN_SPLIT_OBS = 2
 
 
+def _validate_oos_decay(m: MetricBase) -> None:
+    """``is_ratio`` splits the series, so it is a fraction strictly inside (0, 1)."""
+    _validate_open_unit_interval(
+        m.is_ratio,  # type: ignore[attr-defined]
+        func_name="oos_decay",
+        field="is_ratio",
+        detail=(
+            "0 leaves no in-sample window and 1 leaves no out-of-sample "
+            "window, so no survival ratio is defined."
+        ),
+        docs_path="api/metrics/oos_decay",
+    )
+
+
 @metric(
     cell=cell(
         FactorScope.INDIVIDUAL, FactorDensity.DENSE, structure=DataStructure.PANEL
@@ -61,6 +77,7 @@ _MIN_SPLIT_OBS = 2
     input_shape=InputShape.SERIES,
     requires={"series": compute_ic},
     sample_threshold=SampleThreshold(min_periods=MIN_OOS_PERIODS_HARD * 2),
+    validate=_validate_oos_decay,
 )
 def oos_decay(
     series: pl.DataFrame,
@@ -84,7 +101,8 @@ def oos_decay(
             (default ``0.5``).
 
     Raises:
-        ValueError: ``is_ratio`` is not strictly inside ``(0, 1)``.
+        UserInputError: ``is_ratio`` is not strictly inside ``(0, 1)``.
+            Raised at construction, before any data work.
 
     Returns:
         MetricResult with:
@@ -156,13 +174,6 @@ def oos_decay(
         >>> result.name == ""
         True
     """
-    if not 0.0 < is_ratio < 1.0:
-        raise ValueError(
-            f"is_ratio must be a fraction strictly inside (0, 1), got {is_ratio!r}. "
-            "0 leaves no in-sample window and 1 leaves no out-of-sample window, "
-            "so no survival ratio is defined."
-        )
-
     value_col = _resolve_series_value_col(series, value_col)
     sorted_series = series.sort("date")
     vals = sorted_series[value_col].drop_nulls().drop_nans()

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -37,12 +37,14 @@ from factrix._stats.constants import (
 )
 from factrix._stats.ols import _amihud_hurvich_beta
 from factrix._types import DDOF, EPSILON
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _degenerate_test_fields,
     _enforce_min_floor,
     _finite_expr,
     _short_circuit_output,
+    _validate_adf_threshold,
     _warn_below_floor,
 )
 
@@ -59,6 +61,15 @@ __all__ = ["predictive_beta"]
 _STAMBAUGH_CHANNEL_WARN: float = 0.7
 
 
+def _validate_predictive_beta(m: MetricBase) -> None:
+    """``adf_threshold`` is a probability, or ``None`` to skip the ADF gate."""
+    _validate_adf_threshold(
+        m.adf_threshold,  # type: ignore[attr-defined]
+        func_name="predictive_beta",
+        docs_path="api/metrics/predictive_beta",
+    )
+
+
 @metric(
     cell=cell(None, FactorDensity.DENSE, structure=DataStructure.TIMESERIES),
     aggregation=Aggregation.TS_ONLY,
@@ -68,6 +79,7 @@ _STAMBAUGH_CHANNEL_WARN: float = 0.7
         min_periods=MIN_PERIODS_HARD,
         warn_periods=MIN_PERIODS_WARN,
     ),
+    validate=_validate_predictive_beta,
 )
 def predictive_beta(
     data: pl.DataFrame,
@@ -231,11 +243,6 @@ def predictive_beta(
         nominal 5%, while the raw-``n`` gate stayed silent. At ``h = 1`` the
         effective and raw counts coincide, so nothing changes there.
     """
-    if adf_threshold is not None and not (0.0 < adf_threshold < 1.0):
-        raise ValueError(
-            f"adf_threshold must be a probability in (0, 1) or None, "
-            f"got {adf_threshold!r}"
-        )
     if factor_col not in data.columns:
         return _short_circuit_output(
             "predictive_beta",

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -45,11 +45,11 @@ from factrix.inference import (
     NonOverlapping,
     StationaryBootstrap,
 )
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _all_dates_degenerate,
     _assign_quantile_groups,
-    _check_applicable_inference,
     _compute_tie_ratio,
     _degenerate_test_fields,
     _enforce_scaled_floor,
@@ -63,7 +63,7 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _spread_significance_with_inference,
     _surface_null_drop,
-    _validate_choice,
+    _validate_factor_cols,
     _validate_n_groups,
     _warn_high_tie_ratio,
     _warn_thin_quantile_groups,
@@ -156,11 +156,31 @@ def _quantile_groups_threshold(self) -> SampleThreshold:
     )
 
 
+def _validate_quantile_spread(m: MetricBase) -> None:
+    """Numeric knob bounds for ``quantile_spread``.
+
+    ``tie_policy`` and ``inference`` are covered by the constructor's own
+    ``Literal`` / allowlist rules, so only the bucketing floor and the batch
+    request are left to state here.
+    """
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="quantile_spread",
+        docs_path=_DOCS_QUANTILE,
+    )
+    _validate_factor_cols(
+        m.factor_cols,  # type: ignore[attr-defined]
+        func_name="quantile_spread",
+        docs_path=_DOCS_QUANTILE,
+    )
+
+
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     batchable=True,
     sample_threshold=_quantile_groups_threshold,
+    validate=_validate_quantile_spread,
 )
 def quantile_spread(
     data: pl.DataFrame,
@@ -257,25 +277,15 @@ def quantile_spread(
         >>> result["factor"].name == ""
         True
     """
-    _validate_choice(
-        tie_policy,
-        TiePolicy,
-        func_name="quantile_spread",
-        field="tie_policy",
-        docs_path="api/metrics/quantile",
-    )
     cols = list(factor_cols)
-    if not cols:
-        raise ValueError("factor_cols must be non-empty")
     if _precomputed_series is not None and set(_precomputed_series) != set(cols):
+        # Dispatch internal, not a knob: ``_precomputed_series`` is hidden from
+        # the public signature and only the executor supplies it, so a mismatch
+        # is a library invariant rather than a caller mistake.
         raise ValueError(
             "_precomputed_series keys must match factor_cols "
             f"(got {sorted(_precomputed_series)} vs {sorted(cols)})"
         )
-    _check_applicable_inference(
-        inference, applicable_inference, func_name="quantile_spread"
-    )
-    _validate_n_groups(n_groups, func_name="quantile_spread", docs_path=_DOCS_QUANTILE)
 
     # Sample once across all factors; bucketing tie_ratio is computed
     # on the sampled subset (what bucketing actually sees) rather than
@@ -580,10 +590,20 @@ def _vw_spread_series(
     )
 
 
+def _validate_quantile_spread_vw(m: MetricBase) -> None:
+    """Bucketing floor for ``quantile_spread_vw`` (see its unweighted sibling)."""
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="quantile_spread_vw",
+        docs_path=_DOCS_QUANTILE,
+    )
+
+
 @metric(
     cell=_Q_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     sample_threshold=_quantile_groups_threshold,
+    validate=_validate_quantile_spread_vw,
 )
 def quantile_spread_vw(
     data: pl.DataFrame,
@@ -712,21 +732,6 @@ def quantile_spread_vw(
         >>> result.name == ""
         True
     """
-    _validate_choice(
-        tie_policy,
-        TiePolicy,
-        func_name="quantile_spread_vw",
-        field="tie_policy",
-        docs_path="api/metrics/quantile",
-    )
-    _check_applicable_inference(
-        inference, applicable_inference, func_name="quantile_spread_vw"
-    )
-    _validate_n_groups(
-        n_groups, func_name="quantile_spread_vw", docs_path=_DOCS_QUANTILE
-    )
-    # Knobs first, data verdict second: a caller mistake must not be answered
-    # with a short-circuit that reads as a property of the panel.
     if weight_col not in data.columns:
         return _short_circuit_output(
             "quantile_spread_vw",

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -37,6 +37,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
 )
+from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._ols import ols_alpha as _ols_alpha
 from factrix._results import MetricResult
@@ -129,6 +130,8 @@ def _selection_to_result(acc: _ForwardSelection, n_obs: int) -> MetricResult:
 
 def _align_spread_series(
     series_dict: dict[str, pl.DataFrame],
+    *,
+    func_name: str,
 ) -> tuple[pl.DataFrame, dict[str, np.ndarray]]:
     """Align multiple spread series to common dates with finite spreads.
 
@@ -140,7 +143,7 @@ def _align_spread_series(
     ``common_dates[i]`` regardless of the input frames' row order.
 
     Raises:
-        ValueError: if any input series has duplicate ``date`` rows. A
+        UserInputError: if any input series has duplicate ``date`` rows. A
             duplicated date makes the date → value map ambiguous and silently
             produces arrays of unequal length (``np.column_stack`` then raises
             a shape error far from the cause).
@@ -164,10 +167,17 @@ def _align_spread_series(
     all_dates = None
     for name, data in series_dict.items():
         if data["date"].n_unique() != data.height:
-            raise ValueError(
-                f"_align_spread_series: series {name!r} has duplicate dates "
-                f"({data.height} rows, {data['date'].n_unique()} unique); "
-                f"date-keyed alignment is ambiguous. De-duplicate first."
+            raise UserInputError(
+                func_name=func_name,
+                field="series",
+                value=name,
+                expected=(
+                    f"one row per period in each spread series; {name!r} has "
+                    f"{data.height} rows for {data['date'].n_unique()} "
+                    f"distinct periods, so date-keyed alignment is ambiguous. "
+                    f"De-duplicate first."
+                ),
+                docs_path="api/metrics/spanning",
             )
         valid = (
             data.filter(pl.col("spread").is_not_null() & pl.col("spread").is_not_nan())
@@ -338,7 +348,7 @@ def spanning_alpha(
         )
 
     all_series = {"_candidate_": factor_spread, **base_spreads}
-    _common_dates, arrays = _align_spread_series(all_series)
+    _common_dates, arrays = _align_spread_series(all_series, func_name="spanning_alpha")
     if "_candidate_" not in arrays:
         return _short_circuit_output(
             "spanning_alpha",
@@ -540,7 +550,9 @@ def greedy_forward_selection(
         base_spreads = {}
 
     all_series = {**base_spreads, **factor_spreads}
-    common_dates, all_arrays = _align_spread_series(all_series)
+    common_dates, all_arrays = _align_spread_series(
+        all_series, func_name="greedy_forward_selection"
+    )
 
     if not all_arrays:
         return _selection_to_result(_ForwardSelection(), n_obs=0)

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -55,6 +55,7 @@ from factrix.metrics._helpers import (
     _sample_non_overlapping,
     _short_circuit_output,
     _validate_n_groups,
+    _validate_positive_count,
 )
 
 _DOCS_TRADABILITY = "api/metrics/tradability"
@@ -92,10 +93,34 @@ def _resolve_rebalance_lag(rebalance_lag: int | None, overlap_periods: int) -> i
     return overlap_periods if rebalance_lag is None else rebalance_lag
 
 
-def _validate_rebalance_lag(rebalance_lag: int | None) -> None:
+def _validate_rebalance_lag(rebalance_lag: int | None, *, func_name: str) -> None:
     """``rebalance_lag`` is optional, but a supplied value is a positive count."""
-    if rebalance_lag is not None and rebalance_lag < 1:
-        raise ValueError(f"rebalance_lag must be ≥ 1, got {rebalance_lag!r}")
+    if rebalance_lag is None:
+        return
+    _validate_positive_count(
+        rebalance_lag,
+        func_name=func_name,
+        field="rebalance_lag",
+        detail=(
+            "It is the rebalance stride in evaluation-grid periods; pass None "
+            "to keep the panel's injected overlap."
+        ),
+        docs_path=_DOCS_TRADABILITY,
+    )
+
+
+def _validate_holding_periods(holding_periods: object, *, func_name: str) -> None:
+    """``holding_periods`` divides the per-rebalance cost into a per-period one."""
+    _validate_positive_count(
+        holding_periods,
+        func_name=func_name,
+        field="holding_periods",
+        detail=(
+            "It is the holding span in periods that the per-rebalance cost is "
+            "amortized over."
+        ),
+        docs_path=_DOCS_TRADABILITY,
+    )
 
 
 def _rank_turnover_min_dates(rebalance_lag: int) -> int:
@@ -117,11 +142,39 @@ def _rank_turnover_sample_threshold(self: MetricBase) -> SampleThreshold:
     return SampleThreshold(min_periods=_rank_turnover_min_dates(lag))
 
 
+def _validate_rank_turnover(m: MetricBase) -> None:
+    """Rebalance stride and the optional leg fraction."""
+    _validate_rebalance_lag(
+        m.rebalance_lag,
+        func_name="rank_turnover",
+    )
+    quantile = m.quantile  # type: ignore[attr-defined]
+    if quantile is None:
+        return
+    from factrix._errors import UserInputError
+
+    numeric = not isinstance(quantile, bool) and isinstance(quantile, int | float)
+    if not numeric or not 0.0 < float(quantile) < 0.5:
+        raise UserInputError(
+            func_name="rank_turnover",
+            field="quantile",
+            value=quantile,
+            expected=(
+                "a fraction strictly inside (0, 0.5), or None for the full "
+                "cross-section. It is the size of each tail the rank "
+                "autocorrelation is restricted to, so the two tails cannot "
+                "meet in the middle."
+            ),
+            docs_path=_DOCS_TRADABILITY,
+        )
+
+
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.TS_ONLY,
     slice_boundary_sensitive=True,
     sample_threshold=_rank_turnover_sample_threshold,
+    validate=_validate_rank_turnover,
 )
 def rank_turnover(
     data: pl.DataFrame,
@@ -241,11 +294,6 @@ def rank_turnover(
         >>> result.name == ""
         True
     """
-    if quantile is not None and not 0.0 < quantile < 0.5:
-        raise ValueError(f"quantile must be in (0, 0.5), got {quantile!r}")
-    if overlap_periods < 1:
-        raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
-    _validate_rebalance_lag(rebalance_lag)
     lag = _resolve_rebalance_lag(rebalance_lag, overlap_periods)
 
     all_dates = data["date"].unique().sort()
@@ -357,10 +405,24 @@ def _notional_turnover_sample_threshold(self) -> SampleThreshold:
     return SampleThreshold(min_periods=2, min_assets=self.n_groups)
 
 
+def _validate_notional_turnover(m: MetricBase) -> None:
+    """Bucketing floor and rebalance stride."""
+    _validate_n_groups(
+        m.n_groups,  # type: ignore[attr-defined]
+        func_name="notional_turnover",
+        docs_path=_DOCS_TRADABILITY,
+    )
+    _validate_rebalance_lag(
+        m.rebalance_lag,
+        func_name="notional_turnover",
+    )
+
+
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     sample_threshold=_notional_turnover_sample_threshold,
+    validate=_validate_notional_turnover,
 )
 def notional_turnover(
     data: pl.DataFrame,
@@ -489,16 +551,6 @@ def notional_turnover(
         >>> result.name == ""
         True
     """
-    if overlap_periods < 1:
-        raise ValueError(f"overlap_periods must be ≥ 1, got {overlap_periods!r}")
-    _validate_rebalance_lag(rebalance_lag)
-    # The shared bucketing floor, checked up front rather than left to the
-    # kernel call below so an invalid split fails before the date floor can
-    # short-circuit it into an "insufficient_dates" result.
-    _validate_n_groups(
-        n_groups, func_name="notional_turnover", docs_path=_DOCS_TRADABILITY
-    )
-
     lag = _resolve_rebalance_lag(rebalance_lag, overlap_periods)
     if lag > 1:
         data = _sample_non_overlapping(data, lag)
@@ -697,11 +749,20 @@ def _unpack_cost_inputs(
     return float(spread_value), float(turnover_value), checked
 
 
+def _validate_breakeven_cost(m: MetricBase) -> None:
+    """``holding_periods`` amortizes the per-rebalance cost, so it is >= 1."""
+    _validate_holding_periods(
+        m.holding_periods,  # type: ignore[attr-defined]
+        func_name="breakeven_cost",
+    )
+
+
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     input_shape=InputShape.SCALAR,
     sample_threshold=SampleThreshold(),
+    validate=_validate_breakeven_cost,
 )
 def breakeven_cost(
     gross_spread: float | MetricResult,
@@ -819,8 +880,6 @@ def breakeven_cost(
         >>> result.name == ""
         True
     """
-    if holding_periods < 1:
-        raise ValueError(f"holding_periods must be ≥ 1, got {holding_periods!r}")
     gross_spread, turnover, checked = _unpack_cost_inputs(
         gross_spread, turnover, holding_periods
     )
@@ -852,11 +911,20 @@ def breakeven_cost(
     )
 
 
+def _validate_net_spread(m: MetricBase) -> None:
+    """``holding_periods`` amortizes the per-rebalance cost, so it is >= 1."""
+    _validate_holding_periods(
+        m.holding_periods,  # type: ignore[attr-defined]
+        func_name="net_spread",
+    )
+
+
 @metric(
     cell=_TR_CELL,
     aggregation=Aggregation.CS_THEN_TS,
     input_shape=InputShape.SCALAR,
     sample_threshold=SampleThreshold(),
+    validate=_validate_net_spread,
 )
 def net_spread(
     gross_spread: float | MetricResult,
@@ -985,8 +1053,6 @@ def net_spread(
         >>> result.name == ""
         True
     """
-    if holding_periods < 1:
-        raise ValueError(f"holding_periods must be ≥ 1, got {holding_periods!r}")
     gross_spread, turnover, checked = _unpack_cost_inputs(
         gross_spread, turnover, holding_periods
     )

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -31,6 +31,7 @@ from factrix._results import MetricResult
 from factrix._stats import _adf, _mann_kendall_hamed_rao
 from factrix._stats.constants import PERSISTENT_SERIES_AUTOCORR
 from factrix._stats.diagnostics import _lag1_autocorr
+from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _degenerate_test_fields,
@@ -40,6 +41,7 @@ from factrix.metrics._helpers import (
     _scaled_periods_threshold,
     _short_circuit_output,
     _surface_null_drop,
+    _validate_adf_threshold,
 )
 from factrix.metrics.ic import compute_ic
 
@@ -50,6 +52,15 @@ __all__ = [
 #: Minimum *non-overlapping* observations the trend test needs. The raw
 #: series must supply ``_MIN_TREND_PERIODS * overlap_periods`` periods.
 _MIN_TREND_PERIODS = 10
+
+
+def _validate_ic_trend(m: MetricBase) -> None:
+    """``adf_threshold`` is a probability, or ``None`` to skip the ADF gate."""
+    _validate_adf_threshold(
+        m.adf_threshold,  # type: ignore[attr-defined]
+        func_name="ic_trend",
+        docs_path="api/metrics/trend",
+    )
 
 
 @metric(
@@ -63,6 +74,7 @@ _MIN_TREND_PERIODS = 10
     # The trend test runs on the non-overlapping subsample, so the periods
     # floor scales with the stride exactly as ``positive_rate``'s does.
     sample_threshold=_scaled_periods_threshold(_MIN_TREND_PERIODS),
+    validate=_validate_ic_trend,
 )
 def ic_trend(
     series: pl.DataFrame,
@@ -248,11 +260,6 @@ def ic_trend(
         True
     """
     value_col = _resolve_series_value_col(series, value_col)
-    if adf_threshold is not None and not (0.0 < adf_threshold < 1.0):
-        raise ValueError(
-            f"adf_threshold must be a probability in (0, 1) or None, "
-            f"got {adf_threshold!r}"
-        )
 
     # Primary periods gate on the RAW date count against the stride-scaled
     # floor, matching the inspect_data pre-flight.

--- a/factrix/stats/bootstrap.py
+++ b/factrix/stats/bootstrap.py
@@ -35,6 +35,7 @@ from typing import Literal, NamedTuple
 
 import numpy as np
 
+from factrix._errors import UserInputError
 from factrix._stats.bootstrap import Rng, _check_n_resamples, _resolve_rng
 
 
@@ -140,16 +141,32 @@ def stationary_bootstrap_resamples(
 
     values = np.asarray(values, dtype=float)
     if values.ndim not in (1, 2):
-        raise ValueError(f"values must have shape (T,) or (T, m); got {values.shape}.")
+        raise UserInputError(
+            func_name="stationary_bootstrap_resamples",
+            field="values",
+            value=values.shape,
+            expected="an array of shape (T,) or (T, m)",
+            docs_path="api/stats#factrix.stats.stationary_bootstrap_resamples",
+        )
     if values.size and not np.all(np.isfinite(values)):
-        raise ValueError("values must be finite.")
+        raise UserInputError(
+            func_name="stationary_bootstrap_resamples",
+            field="values",
+            value=values.shape,
+            expected="every value finite (no NaN or +/-inf)",
+            docs_path="api/stats#factrix.stats.stationary_bootstrap_resamples",
+        )
     if (
         isinstance(n_resamples, bool)
         or not isinstance(n_resamples, Integral)
         or n_resamples < 1
     ):
-        raise ValueError(
-            f"n_resamples must be a positive integer; got {n_resamples!r}."
+        raise UserInputError(
+            func_name="stationary_bootstrap_resamples",
+            field="n_resamples",
+            value=n_resamples,
+            expected="a positive integer",
+            docs_path="api/stats#factrix.stats.stationary_bootstrap_resamples",
         )
     n_resamples = int(n_resamples)
     n = len(values)
@@ -159,7 +176,16 @@ def stationary_bootstrap_resamples(
     if block_length is None:
         block_length = _resolve_auto_block_length(values)
     if block_length < 1.0:
-        raise ValueError(f"block_length must be >= 1.0, got {block_length!r}")
+        raise UserInputError(
+            func_name="stationary_bootstrap_resamples",
+            field="block_length",
+            value=block_length,
+            expected=(
+                "a mean block length of at least 1.0 period, or None for the "
+                "Politis-White plug-in"
+            ),
+            docs_path="api/stats#factrix.stats.stationary_bootstrap_resamples",
+        )
 
     rng, _ = _resolve_rng(
         rng,
@@ -283,7 +309,6 @@ def bootstrap_mean_ci(
         - [Götze & Künsch (1996)][gotze-kunsch-1996]. Second-order
           correctness of the blockwise bootstrap for a studentized root.
     """
-    from factrix._errors import UserInputError
     from factrix._stats.bootstrap import _batch_means_se
 
     if not 0.0 < ci < 1.0:

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -57,6 +57,8 @@ from numbers import Integral
 import numpy as np
 import numpy.typing as npt
 
+from factrix._errors import UserInputError
+
 
 # WHY: lru_cache — multiple_testing_correct() calls bhy_adjust() and
 # bhy_adjusted_p() back-to-back with the same n; without memoization the
@@ -68,17 +70,57 @@ def _bhy_correction_factor(m: int) -> float:
     return float(np.sum(1.0 / np.arange(1, m + 1)))
 
 
+#: Docs anchor template for a public ``factrix.stats`` function. Held as a
+#: template rather than an f-string so the literal never reads as a complete
+#: ``api/`` path — the docs-path test enumerates these by function name.
+_STATS_DOCS_TEMPLATE = "api/stats#factrix.stats.{func_name}"
+
+
+#: Kernels this module exports through ``factrix.stats`` and therefore renders
+#: a symbol anchor for. ``simes_p`` / ``partial_conjunction_p`` are internal
+#: combiners the ``multi_factor`` procedures call, so they carry the page.
+_STATS_DOCUMENTED = frozenset(
+    {
+        "bhy_adjust",
+        "bhy_adjusted_p",
+        "holm_adjusted_p",
+        "romano_wolf_adjusted_p",
+    }
+)
+
+
+def _stats_docs_path(func_name: str) -> str:
+    """Docs anchor for a ``factrix.stats`` kernel."""
+    if func_name not in _STATS_DOCUMENTED:
+        return "api/stats"
+    return _STATS_DOCS_TEMPLATE.format(func_name=func_name)
+
+
 def _validate_p_values(p_values: npt.ArrayLike, *, func_name: str) -> np.ndarray:
     """Return a validated one-dimensional, finite p-value array."""
     p = np.asarray(p_values, dtype=float)
     if p.ndim != 1:
-        raise ValueError(f"{func_name}: p_values must be 1-D; got shape {p.shape}.")
+        raise UserInputError(
+            func_name=func_name,
+            field="p_values",
+            value=p.shape,
+            expected="a 1-D array of p-values",
+            docs_path=_stats_docs_path(func_name),
+        )
     if p.size and (not np.all(np.isfinite(p)) or not np.all((p >= 0) & (p <= 1))):
-        raise ValueError(f"{func_name}: p_values must all lie in [0, 1] and be finite.")
+        raise UserInputError(
+            func_name=func_name,
+            field="p_values",
+            value=p_values,
+            expected="every p-value finite and inside [0, 1]",
+            docs_path=_stats_docs_path(func_name),
+        )
     return p
 
 
-def _resolve_family_size(n_submitted: int, n_tests: int | None) -> int:
+def _resolve_family_size(
+    n_submitted: int, n_tests: int | None, *, func_name: str
+) -> int:
     """Validate ``n_tests`` and return the complete family size.
 
     ``n_tests < n_submitted`` would mean the caller is claiming the
@@ -87,12 +129,24 @@ def _resolve_family_size(n_submitted: int, n_tests: int | None) -> int:
     if n_tests is None:
         return n_submitted
     if isinstance(n_tests, bool) or not isinstance(n_tests, Integral):
-        raise ValueError(f"n_tests must be an integer; got {n_tests!r}.")
+        raise UserInputError(
+            func_name=func_name,
+            field="n_tests",
+            value=n_tests,
+            expected="an integer, or None to take the submitted set as the family",
+            docs_path=_stats_docs_path(func_name),
+        )
     if n_tests < n_submitted:
-        raise ValueError(
-            f"n_tests ({n_tests}) must be >= len(p_values) ({n_submitted}). "
-            f"Submitted p-values must be a subset of the full candidate "
-            f"family; a smaller n_tests is incoherent."
+        raise UserInputError(
+            func_name=func_name,
+            field="n_tests",
+            value=n_tests,
+            expected=(
+                f"an integer >= len(p_values) ({n_submitted}). Submitted "
+                f"p-values must be a subset of the full candidate family; a "
+                f"smaller n_tests is incoherent."
+            ),
+            docs_path=_stats_docs_path(func_name),
         )
     return int(n_tests)
 
@@ -130,8 +184,14 @@ def bhy_adjust(
     p = _validate_p_values(p_values, func_name="bhy_adjust")
     n = len(p)
     if not (0 < fdr < 1):
-        raise ValueError(f"bhy_adjust: fdr must be in (0, 1); got {fdr}.")
-    m = _resolve_family_size(n, n_tests)
+        raise UserInputError(
+            func_name="bhy_adjust",
+            field="fdr",
+            value=fdr,
+            expected="a target false-discovery rate strictly inside (0, 1)",
+            docs_path=_stats_docs_path("bhy_adjust"),
+        )
+    m = _resolve_family_size(n, n_tests, func_name="bhy_adjust")
     if n == 0:
         return np.zeros(0, dtype=bool)
 
@@ -180,7 +240,7 @@ def bhy_adjusted_p(
     """
     p = _validate_p_values(p_values, func_name="bhy_adjusted_p")
     n = len(p)
-    m = _resolve_family_size(n, n_tests)
+    m = _resolve_family_size(n, n_tests, func_name="bhy_adjusted_p")
     if n == 0:
         return np.zeros(0, dtype=float)
 
@@ -236,7 +296,7 @@ def holm_adjusted_p(
     """
     p = _validate_p_values(p_values, func_name="holm_adjusted_p")
     n = len(p)
-    m = _resolve_family_size(n, n_tests)
+    m = _resolve_family_size(n, n_tests, func_name="holm_adjusted_p")
     if n == 0:
         return np.zeros(0, dtype=float)
 
@@ -344,32 +404,59 @@ def romano_wolf_adjusted_p(
           Testing." Statistics & Probability Letters, 113, 38-40.
     """
     if not isinstance(one_sided, bool):
-        raise ValueError(f"one_sided must be a bool; got {one_sided!r}.")
+        raise UserInputError(
+            func_name="romano_wolf_adjusted_p",
+            field="one_sided",
+            value=one_sided,
+            expected="True or False",
+            docs_path=_stats_docs_path("romano_wolf_adjusted_p"),
+        )
 
     observed = np.asarray(statistics, dtype=float)
     if observed.ndim != 1:
-        raise ValueError(
-            f"romano_wolf_adjusted_p: statistics must be 1-D; "
-            f"got shape {observed.shape}."
+        raise UserInputError(
+            func_name="romano_wolf_adjusted_p",
+            field="statistics",
+            value=observed.shape,
+            expected="a 1-D array of observed test statistics",
+            docs_path=_stats_docs_path("romano_wolf_adjusted_p"),
         )
     if observed.size and not np.all(np.isfinite(observed)):
-        raise ValueError("romano_wolf_adjusted_p: statistics must be finite.")
+        raise UserInputError(
+            func_name="romano_wolf_adjusted_p",
+            field="statistics",
+            value=statistics,
+            expected="every observed test statistic finite",
+            docs_path=_stats_docs_path("romano_wolf_adjusted_p"),
+        )
 
     bootstrap = np.asarray(bootstrap_statistics, dtype=float)
     m = len(observed)
     if bootstrap.ndim != 2 or bootstrap.shape[1] != m:
-        raise ValueError(
-            f"romano_wolf_adjusted_p: bootstrap_statistics must have shape "
-            f"(B, {m}); got {bootstrap.shape}."
+        raise UserInputError(
+            func_name="romano_wolf_adjusted_p",
+            field="bootstrap_statistics",
+            value=bootstrap.shape,
+            expected=f"an array of shape (B, {m}), one column per statistic",
+            docs_path=_stats_docs_path("romano_wolf_adjusted_p"),
         )
     if bootstrap.size and not np.all(np.isfinite(bootstrap)):
-        raise ValueError("romano_wolf_adjusted_p: bootstrap_statistics must be finite.")
+        raise UserInputError(
+            func_name="romano_wolf_adjusted_p",
+            field="bootstrap_statistics",
+            value=bootstrap_statistics,
+            expected="every resampled test statistic finite",
+            docs_path=_stats_docs_path("romano_wolf_adjusted_p"),
+        )
     if m == 0:
         return np.zeros(0, dtype=float)
     if bootstrap.shape[0] < 1:
-        raise ValueError(
-            "romano_wolf_adjusted_p: bootstrap_statistics must have at "
-            "least 1 resample."
+        raise UserInputError(
+            func_name="romano_wolf_adjusted_p",
+            field="bootstrap_statistics",
+            value=bootstrap.shape,
+            expected="at least 1 resample (B >= 1)",
+            docs_path=_stats_docs_path("romano_wolf_adjusted_p"),
         )
     if bootstrap.shape[0] < _MIN_ROMANO_WOLF_RESAMPLES:
         # Warn rather than raise: a handful of hand-built resamples is the
@@ -431,7 +518,7 @@ def simes_p(p_values: npt.ArrayLike) -> float:
         The Simes combined p-value, clipped to ``[0, 1]``.
 
     Raises:
-        ValueError: ``len(p_values) == 0`` (Simes is undefined on an
+        UserInputError: ``len(p_values) == 0`` (Simes is undefined on an
             empty group).
 
     References:
@@ -447,7 +534,13 @@ def simes_p(p_values: npt.ArrayLike) -> float:
     p = _validate_p_values(p_values, func_name="simes_p")
     m = len(p)
     if m == 0:
-        raise ValueError("simes_p: p_values must be non-empty.")
+        raise UserInputError(
+            func_name="simes_p",
+            field="p_values",
+            value=p_values,
+            expected="a non-empty array of p-values",
+            docs_path=_stats_docs_path("simes_p"),
+        )
     sorted_p = np.sort(p)
     k_vec = np.arange(1, m + 1)
     return float(min(np.min((m / k_vec) * sorted_p), 1.0))
@@ -487,20 +580,33 @@ def partial_conjunction_p(
     p = _validate_p_values(p_values, func_name="partial_conjunction_p")
     m = len(p)
     if m == 0:
-        raise ValueError("partial_conjunction_p: p_values must be non-empty.")
+        raise UserInputError(
+            func_name="partial_conjunction_p",
+            field="p_values",
+            value=p_values,
+            expected="a non-empty array of p-values",
+            docs_path=_stats_docs_path("partial_conjunction_p"),
+        )
     # Type guard first, matching ``_resolve_family_size``. Without it
     # ``min_pass=2.5`` reached ``sorted_p[min_pass - 1]`` and surfaced as a
     # raw IndexError, and ``min_pass=True`` silently became ``k = 1`` - the
     # union semantics ``partial_conjunction`` refuses outright because they
     # inflate FDR to about 2q.
     if isinstance(min_pass, bool) or not isinstance(min_pass, Integral):
-        raise ValueError(
-            f"partial_conjunction_p: min_pass must be an integer; got {min_pass!r}."
+        raise UserInputError(
+            func_name="partial_conjunction_p",
+            field="min_pass",
+            value=min_pass,
+            expected="an integer",
+            docs_path=_stats_docs_path("partial_conjunction_p"),
         )
     if not 1 <= min_pass <= m:
-        raise ValueError(
-            f"partial_conjunction_p: min_pass ({min_pass}) must satisfy "
-            f"1 <= min_pass <= m ({m})."
+        raise UserInputError(
+            func_name="partial_conjunction_p",
+            field="min_pass",
+            value=min_pass,
+            expected=f"an integer k with 1 <= k <= m ({m})",
+            docs_path=_stats_docs_path("partial_conjunction_p"),
         )
     min_pass = int(min_pass)
     sorted_p = np.sort(p)

--- a/tests/stats/test_multiple_testing.py
+++ b/tests/stats/test_multiple_testing.py
@@ -64,15 +64,15 @@ class TestBhyAdjust:
         assert list(mask) == [False, True, False, True, False]
 
     def test_fdr_bounds(self):
-        with pytest.raises(ValueError, match="fdr must be in"):
+        with pytest.raises(ValueError, match="invalid fdr"):
             bhy_adjust([0.01, 0.02], fdr=0.0)
-        with pytest.raises(ValueError, match="fdr must be in"):
+        with pytest.raises(ValueError, match="invalid fdr"):
             bhy_adjust([0.01, 0.02], fdr=1.0)
 
     def test_rejects_out_of_range_pvalues(self):
-        with pytest.raises(ValueError, match="must all lie in"):
+        with pytest.raises(ValueError, match=r"finite and inside \[0, 1\]"):
             bhy_adjust([-0.1, 0.5])
-        with pytest.raises(ValueError, match="must all lie in"):
+        with pytest.raises(ValueError, match=r"finite and inside \[0, 1\]"):
             bhy_adjust([0.5, 1.1])
 
     def test_higher_fdr_rejects_more(self):
@@ -245,10 +245,14 @@ class TestRomanoWolfAdjustedP:
     @pytest.mark.parametrize(
         ("statistics", "bootstrap", "message"),
         [
-            ([[1.0, 2.0]], np.ones((10, 2)), "statistics must be 1-D"),
-            ([1.0, np.nan], np.ones((10, 2)), "statistics must be finite"),
+            ([[1.0, 2.0]], np.ones((10, 2)), "a 1-D array of observed"),
+            ([1.0, np.nan], np.ones((10, 2)), "every observed test statistic finite"),
             ([1.0, 2.0], np.ones((10, 3)), r"shape \(B, 2\)"),
-            ([1.0, 2.0], np.array([[1.0, np.inf]]), "must be finite"),
+            (
+                [1.0, 2.0],
+                np.array([[1.0, np.inf]]),
+                "every resampled test statistic finite",
+            ),
             ([1.0, 2.0], np.empty((0, 2)), "at least 1 resample"),
         ],
     )
@@ -257,28 +261,28 @@ class TestRomanoWolfAdjustedP:
             romano_wolf_adjusted_p(statistics, bootstrap)
 
     def test_rejects_non_boolean_tail_mode(self):
-        with pytest.raises(ValueError, match="one_sided must be a bool"):
+        with pytest.raises(ValueError, match="invalid one_sided"):
             romano_wolf_adjusted_p([1.0], np.ones((10, 1)), one_sided=1)
 
 
 @pytest.mark.parametrize("adjust", [bhy_adjusted_p, holm_adjusted_p])
 class TestAdjustedPValidation:
     def test_rejects_non_vector_input(self, adjust):
-        with pytest.raises(ValueError, match="must be 1-D"):
+        with pytest.raises(ValueError, match="a 1-D array of p-values"):
             adjust([[0.01, 0.02]])
 
     @pytest.mark.parametrize("value", [np.nan, np.inf, -0.1, 1.1])
     def test_rejects_non_finite_or_out_of_range_pvalues(self, adjust, value):
-        with pytest.raises(ValueError, match=r"lie in \[0, 1\].*finite"):
+        with pytest.raises(ValueError, match=r"finite and inside \[0, 1\]"):
             adjust([0.01, value])
 
     @pytest.mark.parametrize("n_tests", [True, 2.5])
     def test_rejects_non_integer_family_size(self, adjust, n_tests):
-        with pytest.raises(ValueError, match="must be an integer"):
+        with pytest.raises(ValueError, match="invalid n_tests"):
             adjust([0.01, 0.02], n_tests=n_tests)
 
     def test_rejects_family_size_smaller_than_submission(self, adjust):
-        with pytest.raises(ValueError, match=r"n_tests .* must be >="):
+        with pytest.raises(ValueError, match=r"integer >= len\(p_values\)"):
             adjust([0.01, 0.02], n_tests=1)
 
 
@@ -321,9 +325,9 @@ class TestNTotal:
         """n_tests < len(p) is incoherent — BHY assumes submitted is a
         subset of the full family."""
         p = np.array([0.01, 0.02, 0.03, 0.04, 0.05])
-        with pytest.raises(ValueError, match=r"n_tests .* must be >="):
+        with pytest.raises(ValueError, match=r"integer >= len\(p_values\)"):
             bhy_adjust(p, n_tests=2)
-        with pytest.raises(ValueError, match=r"n_tests .* must be >="):
+        with pytest.raises(ValueError, match=r"integer >= len\(p_values\)"):
             bhy_adjusted_p(p, n_tests=2)
 
     def test_adjusted_p_monotone_in_n_tests(self):
@@ -363,9 +367,9 @@ class TestPartialConjunctionP:
             partial_conjunction_p([], min_pass=1)
 
     def test_min_pass_out_of_range_raises(self):
-        with pytest.raises(ValueError, match="1 <= min_pass <= m"):
+        with pytest.raises(ValueError, match=r"1 <= k <= m"):
             partial_conjunction_p([0.01, 0.02], min_pass=3)
-        with pytest.raises(ValueError, match="1 <= min_pass <= m"):
+        with pytest.raises(ValueError, match=r"1 <= k <= m"):
             partial_conjunction_p([0.01, 0.02], min_pass=0)
 
 
@@ -436,13 +440,13 @@ class TestNonFiniteRejectedByEveryKernel:
     @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
     @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_raises(self, name, kernel, bad):
-        with pytest.raises(ValueError, match="must all lie in"):
+        with pytest.raises(ValueError, match=r"finite and inside \[0, 1\]"):
             kernel(np.array([0.1, bad, 0.3]))
 
     @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
     @pytest.mark.parametrize("bad", [-0.1, 1.5])
     def test_out_of_range_raises(self, name, kernel, bad):
-        with pytest.raises(ValueError, match="must all lie in"):
+        with pytest.raises(ValueError, match=r"finite and inside \[0, 1\]"):
             kernel(np.array([0.1, bad, 0.3]))
 
     @pytest.mark.parametrize("name,kernel", KERNELS, ids=[k[0] for k in KERNELS])
@@ -467,12 +471,12 @@ class TestNonFiniteRejectedByEveryKernel:
 
         bad_stats = statistics.copy()
         bad_stats[1] = float("nan")
-        with pytest.raises(ValueError, match="statistics must be finite"):
+        with pytest.raises(ValueError, match="every observed test statistic finite"):
             romano_wolf_adjusted_p(bad_stats, bootstrap)
 
         bad_boot = bootstrap.copy()
         bad_boot[5, 1] = float("inf")
-        with pytest.raises(ValueError, match="bootstrap_statistics must be finite"):
+        with pytest.raises(ValueError, match="every resampled test statistic finite"):
             romano_wolf_adjusted_p(statistics, bad_boot)
 
 
@@ -481,13 +485,13 @@ class TestPartialConjunctionMinPassValidation:
 
     def test_rejects_a_float(self):
         """Reached ``sorted_p[min_pass - 1]`` and surfaced a raw IndexError."""
-        with pytest.raises(ValueError, match="min_pass must be an integer"):
+        with pytest.raises(ValueError, match="invalid min_pass"):
             partial_conjunction_p([0.1, 0.2, 0.3], min_pass=2.5)
 
     def test_rejects_a_bool(self):
         """``min_pass=True`` silently became k=1 - the union semantics
         ``partial_conjunction`` refuses because they inflate FDR to ~2q."""
-        with pytest.raises(ValueError, match="min_pass must be an integer"):
+        with pytest.raises(ValueError, match="invalid min_pass"):
             partial_conjunction_p([0.1, 0.2, 0.3], min_pass=True)
 
     def test_accepts_a_numpy_integer(self):

--- a/tests/test_common_betas.py
+++ b/tests/test_common_betas.py
@@ -184,7 +184,9 @@ class TestComputeCommonBetasBatch:
             ), col
 
     def test_empty_factor_list_rejected(self):
-        with pytest.raises(ValueError, match="factor_cols must be non-empty"):
+        with pytest.raises(
+            ValueError, match="non-empty sequence of factor column names"
+        ):
             compute_common_betas(_common_factor_panel(3, 30, seed=8), factor_cols=[])
 
 

--- a/tests/test_docs_paths.py
+++ b/tests/test_docs_paths.py
@@ -27,6 +27,15 @@ build = pytest.importorskip("mkdocs.commands.build").build
 load_config = pytest.importorskip("mkdocs.config").load_config
 
 PACKAGE_ROOT = pathlib.Path("factrix")
+#: ``factrix.stats`` functions whose validators build their docs anchor from
+#: ``_STATS_DOCS_TEMPLATE`` (one shared validator serves several functions), so
+#: the literal path never appears in the source for the sweep below to find.
+_STATS_DOCS_FUNCTIONS = (
+    "bhy_adjust",
+    "bhy_adjusted_p",
+    "holm_adjusted_p",
+    "romano_wolf_adjusted_p",
+)
 _DYNAMIC_DOCS_FUNCTIONS = (
     "compare",
     "bhy",
@@ -53,7 +62,9 @@ def _literal_docs_paths() -> set[str]:
 
 
 DOCS_PATHS = sorted(
-    _literal_docs_paths() | {_api_docs_path(name) for name in _DYNAMIC_DOCS_FUNCTIONS}
+    _literal_docs_paths()
+    | {_api_docs_path(name) for name in _DYNAMIC_DOCS_FUNCTIONS}
+    | {f"api/stats#factrix.stats.{name}" for name in _STATS_DOCS_FUNCTIONS}
 )
 
 

--- a/tests/test_evaluation_result.py
+++ b/tests/test_evaluation_result.py
@@ -142,7 +142,7 @@ class TestEvaluationResultToFrame:
         r = dataclasses.replace(
             _sample_result(_sample_group()), params={"value": 1, "n_obs": 2}
         )
-        with pytest.raises(ValueError, match=r"collide with fixed column"):
+        with pytest.raises(ValueError, match=r"collide with a fixed column name"):
             r.to_frame()
 
     def test_n_obs_carries_per_metric_sample_size(self):
@@ -255,11 +255,11 @@ class TestMetricResultPValueContract:
             )
 
     def test_rejects_p_value_without_alternative(self):
-        with pytest.raises(ValueError, match="both be provided"):
+        with pytest.raises(ValueError, match="supplied together, or both None"):
             MetricResult(value=0.0, p_value=0.5)
 
     def test_rejects_alternative_without_p_value(self):
-        with pytest.raises(ValueError, match="both be provided"):
+        with pytest.raises(ValueError, match="supplied together, or both None"):
             MetricResult(value=0.0, alternative="greater")
 
 
@@ -302,7 +302,7 @@ class TestMetricResultFieldContract:
     """``__post_init__`` guards on fields other than ``p_value``."""
 
     def test_rejects_unknown_alternative(self):
-        with pytest.raises(ValueError, match="alternative must be one of"):
+        with pytest.raises(ValueError, match="unknown alternative"):
             MetricResult(value=0.0, p_value=0.5, alternative="bigger")  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("alternative", ["two-sided", "greater", "less"])
@@ -311,7 +311,7 @@ class TestMetricResultFieldContract:
         assert out.alternative == alternative
 
     def test_rejects_negative_n_obs(self):
-        with pytest.raises(ValueError, match="n_obs must be non-negative"):
+        with pytest.raises(ValueError, match="a non-negative count"):
             MetricResult(value=0.0, n_obs=-1)
 
     def test_accepts_zero_n_obs(self):
@@ -324,7 +324,7 @@ class TestMetricResultFieldContract:
 
     @pytest.mark.parametrize("stat", [float("inf"), float("-inf")])
     def test_rejects_infinite_stat(self, stat: float):
-        with pytest.raises(ValueError, match="stat must be finite"):
+        with pytest.raises(ValueError, match="a finite statistic"):
             MetricResult(value=0.0, stat=stat)
 
     def test_allows_nan_stat(self):
@@ -400,22 +400,29 @@ class TestToFrameMetadataExport:
         assert set(frame["factor"].to_list()) == {"mom_12_1"}
 
     def test_nested_values_are_refused_not_flattened(self):
-        with pytest.raises(ValueError, match=r"metadata\['legs'\].*quantile_spread"):
+        with pytest.raises(ValueError, match=r"metadata\['legs'\]") as excinfo:
             self._result().to_frame(metadata=("legs",))
+        assert "quantile_spread" in str(excinfo.value)
 
     def test_reserved_and_repeated_keys_are_refused(self):
-        with pytest.raises(ValueError, match="collide"):
+        with pytest.raises(
+            ValueError, match="shadow neither a fixed column nor a params key"
+        ):
             self._result().to_frame(metadata=("value",))
-        with pytest.raises(ValueError, match="collide"):
+        with pytest.raises(
+            ValueError, match="shadow neither a fixed column nor a params key"
+        ):
             self._result().to_frame(metadata=("forward_periods",))
-        with pytest.raises(ValueError, match="repeated"):
+        with pytest.raises(ValueError, match="distinct metadata keys"):
             self._result().to_frame(metadata=("n_groups", "n_groups"))
         with pytest.raises(ValueError, match="sequence"):
             self._result().to_frame(metadata="n_groups")  # type: ignore[arg-type]
 
     def test_params_keys_are_reserved_too(self):
         res = dataclasses.replace(self._result(), params={"n_groups": 2})
-        with pytest.raises(ValueError, match="collide"):
+        with pytest.raises(
+            ValueError, match="shadow neither a fixed column nor a params key"
+        ):
             res.to_frame(metadata=("n_groups",))
 
     def test_end_to_end_tradability_audit(self):

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -221,7 +221,9 @@ class TestComputeFMBetasBatch:
             assert batch[col].equals(single), col
 
     def test_empty_factor_list_rejected(self, tiny_panel):
-        with pytest.raises(ValueError, match="factor_cols must be non-empty"):
+        with pytest.raises(
+            ValueError, match="non-empty sequence of factor column names"
+        ):
             compute_fm_betas(tiny_panel, factor_cols=[])
 
 

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -129,7 +129,7 @@ class TestShortCircuits:
     def test_invalid_k_raises(self):
         factor = np.arange(8, dtype=float)
         returns = np.zeros((5, 8))
-        with pytest.raises(ValueError, match="k must be"):
+        with pytest.raises(ValueError, match="invalid k=0"):
             k_spread(_panel_from_matrix(factor, returns), overlap_periods=1, k=0)
 
     def test_constant_factor_returns_explicit_no_signal(self):

--- a/tests/test_knob_validation.py
+++ b/tests/test_knob_validation.py
@@ -1,34 +1,95 @@
-"""Closed-set and bounded metric knobs are validated before any computation.
+"""Metric knobs are validated at construction, at one site.
 
-A knob annotated with a ``Literal`` alias is a contract, not a hint: a typo
-must raise :class:`~factrix.UserInputError` naming the legal values, never
-fall through to whichever branch happens to have no ``else`` and never leak
-the underlying engine's own vocabulary. The bounded fractions (``q_top``)
-are the same contract on an interval instead of a set.
+Every knob contract — a closed set annotated with a ``Literal``, an
+``inference=`` allowlist, a numeric bound declared as ``@metric(validate=...)``
+— is enforced by :meth:`MetricBase.__post_init__`, so a bad value raises where
+the caller wrote it rather than several metrics into an ``evaluate``. Both call
+forms reach the same site: ``metric(n_groups=1)`` is plain dataclass
+instantiation and ``metric(data, n_groups=1)`` builds the instance first.
 
-The parametrisations below are the one place that enumerates the knobs, so a
-new closed-set knob that skips its validator shows up as a missing row rather
-than as a silently wrong number.
+The tables below are the one place that enumerates the knobs, so a new closed
+set or bound that skips the constructor shows up as a missing row rather than
+as a silently wrong number.
 """
 
 from __future__ import annotations
 
+import pathlib
 from datetime import datetime
 from typing import Any, get_args
 
 import polars as pl
 import pytest
 from factrix import UserInputError
-from factrix._types import ConcentrationWeight, TiePolicy
+from factrix._errors import IncompatibleInferenceError
 from factrix.datasets import make_cs_panel
+from factrix.metrics._registry import REGISTRY
 from factrix.metrics.concentration import top_concentration
 from factrix.metrics.k_spread import k_spread
-from factrix.metrics.monotonicity import MRDirection, monotonicity
+from factrix.metrics.monotonicity import monotonicity
 from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
 from factrix.preprocess import compute_forward_return
 from factrix.preprocess.normalize import Center, cross_sectional_zscore
 
 BAD_TOKEN = "bogus"
+
+#: Stand-in first argument for the direct-call form. Knob validation runs in
+#: the constructor, before the body ever touches the data, so the parity checks
+#: below never need a real panel.
+_UNUSED_DATA = pl.DataFrame()
+
+
+def _metrics_with_literal_fields() -> list[tuple[str, type, str, object]]:
+    """Every registered metric x every ``Literal``-annotated knob it carries."""
+    return [
+        (f"{name}.{field}", cls, field, alias)
+        for name, cls in sorted(REGISTRY.items())
+        for field, alias in cls._literal_fields
+    ]
+
+
+LITERAL_KNOBS = _metrics_with_literal_fields()
+
+# (metric name, knob, an out-of-bounds value) — one row per bound a
+# ``@metric(validate=...)`` hook enforces. ``_HOOK_COVERAGE`` below pins the
+# table against the registry so a new hook cannot land untested.
+BOUNDED_KNOBS: list[tuple[str, dict[str, Any], str]] = [
+    ("quantile_spread", {"n_groups": 1}, "n_groups"),
+    ("quantile_spread", {"factor_cols": []}, "factor_cols"),
+    ("quantile_spread_vw", {"n_groups": 1}, "n_groups"),
+    ("monotonicity", {"n_groups": 1}, "n_groups"),
+    ("monotonicity", {"n_resamples": 0}, "n_resamples"),
+    ("monotonicity", {"factor_cols": ()}, "factor_cols"),
+    ("top_concentration", {"q_top": 1.0}, "q_top"),
+    ("k_spread", {"k": 0}, "k"),
+    ("common_quantile_spread", {"n_groups": 1}, "n_groups"),
+    ("rank_turnover", {"rebalance_lag": 0}, "rebalance_lag"),
+    ("rank_turnover", {"quantile": 0.5}, "quantile"),
+    ("notional_turnover", {"n_groups": 1}, "n_groups"),
+    ("notional_turnover", {"rebalance_lag": 0}, "rebalance_lag"),
+    # ``turnover`` is a required field on the two cost metrics, not a knob
+    # under test; it is supplied so the constructor can be reached at all.
+    ("breakeven_cost", {"turnover": 0.2, "holding_periods": 0}, "holding_periods"),
+    ("net_spread", {"turnover": 0.2, "holding_periods": 0}, "holding_periods"),
+    ("oos_decay", {"is_ratio": 1.0}, "is_ratio"),
+    ("ic_trend", {"adf_threshold": 1.5}, "adf_threshold"),
+    ("predictive_beta", {"adf_threshold": 0.0}, "adf_threshold"),
+    ("common_beta_profile", {"neutral_epsilon": -1.0}, "neutral_epsilon"),
+    (
+        "pooled_beta",
+        {"driscoll_kraay": True, "two_way_cluster_col": "asset_id"},
+        "driscoll_kraay",
+    ),
+    ("compute_spread_series", {"n_groups": 1}, "n_groups"),
+    ("compute_spread_series", {"factor_cols": []}, "factor_cols"),
+    ("compute_group_returns", {"n_groups": 1}, "n_groups"),
+    ("compute_fm_betas", {"factor_cols": []}, "factor_cols"),
+    ("compute_common_betas", {"factor_cols": []}, "factor_cols"),
+    ("compute_ic", {"factor_cols": []}, "factor_cols"),
+    ("compute_mfe_mae", {"min_estimation_periods": 1}, "min_estimation_periods"),
+]
+
+_HOOK_COVERAGE = {name for name, _, _ in BOUNDED_KNOBS}
 
 
 @pytest.fixture(scope="module")
@@ -47,48 +108,166 @@ def _call(func: Any, data: pl.DataFrame, **knob: object) -> Any:
     return func(data, **knob)
 
 
-# (label, callable, knob name, Literal alias) — one row per closed-set knob.
-CLOSED_SET_KNOBS = [
-    (
-        "top_concentration.weight_by",
-        top_concentration,
-        "weight_by",
-        ConcentrationWeight,
-    ),
-    ("quantile_spread.tie_policy", quantile_spread, "tie_policy", TiePolicy),
-    ("k_spread.tie_policy", k_spread, "tie_policy", TiePolicy),
-    ("monotonicity.tie_policy", monotonicity, "tie_policy", TiePolicy),
-    ("monotonicity.direction", monotonicity, "direction", MRDirection),
-]
+class TestClosedSetKnobsAtConstruction:
+    """A ``Literal`` annotation is the runtime contract, enforced by the
+    constructor for every registered metric that carries one."""
+
+    def test_the_sweep_is_not_empty(self) -> None:
+        assert LITERAL_KNOBS, "no metric declares a Literal-annotated knob"
+
+    @pytest.mark.parametrize(
+        ("cls", "field", "alias"),
+        [pytest.param(c, f, a, id=label) for label, c, f, a in LITERAL_KNOBS],
+    )
+    def test_bad_token_raises_at_construction(
+        self, cls: type, field: str, alias: object
+    ) -> None:
+        with pytest.raises(UserInputError) as excinfo:
+            cls(**{field: BAD_TOKEN})
+        exc = excinfo.value
+        assert exc.func_name == cls.__name__
+        assert exc.field == field
+        assert exc.value == BAD_TOKEN
+        rendered = str(exc)
+        for legal in get_args(alias):
+            assert legal in rendered
+
+    @pytest.mark.parametrize(
+        ("cls", "field", "alias"),
+        [pytest.param(c, f, a, id=label) for label, c, f, a in LITERAL_KNOBS],
+    )
+    def test_every_legal_token_constructs(
+        self, cls: type, field: str, alias: object
+    ) -> None:
+        for legal in get_args(alias):
+            cls(**{field: legal})
+
+    @pytest.mark.parametrize(
+        ("cls", "field"),
+        [pytest.param(c, f, id=label) for label, c, f, _ in LITERAL_KNOBS],
+    )
+    def test_config_and_direct_call_raise_identically(
+        self, cls: type, field: str
+    ) -> None:
+        with pytest.raises(UserInputError) as config:
+            cls(**{field: BAD_TOKEN})
+        with pytest.raises(UserInputError) as direct:
+            cls(_UNUSED_DATA, **{field: BAD_TOKEN})
+        assert type(config.value) is type(direct.value)
+        assert config.value.field == direct.value.field
+        assert str(config.value) == str(direct.value)
 
 
-@pytest.mark.parametrize(
-    ("func", "field", "alias"),
-    [pytest.param(f, k, a, id=label) for label, f, k, a in CLOSED_SET_KNOBS],
-)
-def test_bad_closed_set_value_raises(
-    panel: pl.DataFrame, func: Any, field: str, alias: object
-) -> None:
-    with pytest.raises(UserInputError) as excinfo:
-        _call(func, panel, **{field: BAD_TOKEN})
-    exc = excinfo.value
-    assert exc.field == field
-    assert exc.value == BAD_TOKEN
-    # The legal set reaches the caller, whichever branch rendered it.
-    rendered = str(exc)
-    for legal in get_args(alias):
-        assert legal in rendered
+class TestBoundedKnobsAtConstruction:
+    """Bounds a ``Literal`` cannot express, declared as ``@metric(validate=)``."""
+
+    def test_every_hook_is_covered(self) -> None:
+        """A metric declaring a validator without a row here is untested."""
+        declared = {
+            name for name, cls in REGISTRY.items() if cls._knob_validator is not None
+        }
+        assert declared == _HOOK_COVERAGE
+
+    @pytest.mark.parametrize(
+        ("name", "knobs", "field"),
+        [pytest.param(n, k, f, id=f"{n}.{f}") for n, k, f in BOUNDED_KNOBS],
+    )
+    def test_out_of_bounds_raises_at_construction(
+        self, name: str, knobs: dict[str, Any], field: str
+    ) -> None:
+        cls = REGISTRY[name]
+        with pytest.raises(UserInputError) as excinfo:
+            cls(**knobs)
+        assert excinfo.value.func_name == name
+        assert excinfo.value.field == field
+
+    @pytest.mark.parametrize(
+        ("name", "knobs", "field"),
+        [pytest.param(n, k, f, id=f"{n}.{f}") for n, k, f in BOUNDED_KNOBS],
+    )
+    def test_config_and_direct_call_raise_identically(
+        self, name: str, knobs: dict[str, Any], field: str
+    ) -> None:
+        cls = REGISTRY[name]
+        with pytest.raises(UserInputError) as config:
+            cls(**knobs)
+        with pytest.raises(UserInputError) as direct:
+            cls(_UNUSED_DATA, **knobs)
+        assert type(config.value) is type(direct.value)
+        assert config.value.field == direct.value.field
+        assert str(config.value) == str(direct.value)
 
 
-@pytest.mark.parametrize(
-    ("func", "field", "alias"),
-    [pytest.param(f, k, a, id=label) for label, f, k, a in CLOSED_SET_KNOBS],
-)
-def test_every_legal_value_is_accepted(
-    panel: pl.DataFrame, func: Any, field: str, alias: object
-) -> None:
-    for legal in get_args(alias):
-        _call(func, panel, **{field: legal})
+class TestInferenceAllowlistAtConstruction:
+    """``inference=`` is vetted against the module allowlist at construction."""
+
+    @pytest.mark.parametrize(
+        "name",
+        sorted(n for n, c in REGISTRY.items() if "inference" in c._param_names),
+    )
+    def test_unvetted_inference_raises_at_construction(self, name: str) -> None:
+        cls = REGISTRY[name]
+        with pytest.raises(IncompatibleInferenceError) as excinfo:
+            cls(inference=BAD_TOKEN)
+        assert excinfo.value.func_name == name
+
+    @pytest.mark.parametrize(
+        "name",
+        sorted(n for n, c in REGISTRY.items() if "inference" in c._param_names),
+    )
+    def test_config_and_direct_call_raise_identically(self, name: str) -> None:
+        cls = REGISTRY[name]
+        with pytest.raises(IncompatibleInferenceError) as config:
+            cls(inference=BAD_TOKEN)
+        with pytest.raises(IncompatibleInferenceError) as direct:
+            cls(_UNUSED_DATA, inference=BAD_TOKEN)
+        assert str(config.value) == str(direct.value)
+
+
+def test_no_metric_body_calls_a_knob_validator() -> None:
+    """The validators are called from the constructor hook, nowhere else.
+
+    A body-level call is the duplicate this contract replaced: it left a
+    config object constructible with a knob the metric would later refuse.
+    """
+    validators = (
+        "_validate_choice(",
+        "_validate_n_groups(",
+        "_validate_open_unit_interval(",
+        "_validate_factor_cols(",
+        "_validate_positive_count(",
+        "_validate_adf_threshold(",
+        "_check_applicable_inference(",
+    )
+    package = pathlib.Path("factrix/metrics")
+    offenders: list[str] = []
+    for source in sorted(package.rglob("*.py")):
+        if source.name in {"_helpers.py", "_base.py"}:
+            continue
+        for lineno, line in enumerate(
+            source.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            stripped = line.strip()
+            if not any(v in stripped for v in validators):
+                continue
+            # A call inside a ``_validate_<metric>`` hook is the sanctioned
+            # site; a call at any other indentation is a body-level duplicate.
+            if line.startswith("    ") and _in_validator_hook(source, lineno):
+                continue
+            offenders.append(f"{source}:{lineno}: {stripped}")
+    assert not offenders, "knob validators called outside the constructor hook:\n" + (
+        "\n".join(offenders)
+    )
+
+
+def _in_validator_hook(source: pathlib.Path, lineno: int) -> bool:
+    """True when line ``lineno`` sits inside a module-level ``_validate_*`` def."""
+    lines = source.read_text(encoding="utf-8").splitlines()
+    for i in range(lineno - 1, -1, -1):
+        line = lines[i]
+        if line.startswith("def ") or line.startswith("class "):
+            return line.startswith("def _validate_")
+    return False
 
 
 def test_quantile_spread_vw_rejects_bad_tie_policy(

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -446,7 +446,7 @@ class TestAlignSpreadSeriesRegressions:
         # np.column_stack crashed far from the cause.
         base, cand = self._linked_pair()
         dup_base = pl.concat([base, base.head(1)])
-        with pytest.raises(ValueError, match="duplicate dates"):
+        with pytest.raises(ValueError, match="distinct periods"):
             spanning_alpha(cand, base_spreads={"base": dup_base})
 
     def test_nan_spread_dropped_not_propagated(self):


### PR DESCRIPTION
> **TL;DR** — metric 旋鈕的驗證收斂到**一個站點** `MetricBase.__post_init__`：(1) 所有 `Literal` 註記欄位自動以 `_validate_choice` 驗證（合法集合由型別推導）；(2) `inference` 欄位對 `resolve_applicable_inference` 的既有 allowlist 驗證；(3) 呼叫 `@metric(validate=...)` 宣告的數值界鉤子。因直呼路徑在 `MetricMeta.__call__` 中先建構實例，config 物件與直呼都被同一處覆蓋；各 body 的重複驗證全數刪除。殘餘 ~50 處使用者可達的裸 `ValueError` → `UserInputError`。**Breaking**：錯值改為建構時 raise。

Closes #941

## 機制
- `_decorators.py`：`@metric(validate=)` 存為 `_knob_validator` ClassVar；`_literal_fields` 於類別建立時經 `typing.get_type_hints` 解析一次（模組用 `from __future__ import annotations`，raw annotation 是字串），union 包裹的 Literal 會拆開。
- 21 個 metric / producer 取得 `validate=` 鉤子（`n_groups`、`q_top`、`k`、`rebalance_lag`、`holding_periods`、`quantile`、`is_ratio`、`adf_threshold`、`neutral_epsilon`、`n_resamples`、`factor_cols`、`min_estimation_periods`、`driscoll_kraay × two_way_cluster_col`）；三個新共用驗證器（`_validate_factor_cols`、`_validate_positive_count`、`_validate_adf_threshold`），其餘重用既有。
- `_ic_sample_threshold` 的防禦性 allowlist 檢查移除——帶未 vetting 成員的實例不再可能存在。

## 審核紀錄（實作者 opus，審核者本 session）
獨立探針：六種旋鈕錯值於**建構時** `UserInputError` 帶 `field`；`ic(inference="newey_west")` 與 `quantile_spread(inference=HANSEN_HODRICK)` 建構時 `IncompatibleInferenceError`；直呼與 config 同型別；合法值正常執行。AST 檢查：`factrix/metrics/*.py` 內驗證呼叫全部位於 `_validate_*` 鉤子。與 main 無衝突。

保留的裸 `ValueError`：`_registry.py`（開發者面註冊）、`quantile.py:285`（執行器內部 `_precomputed_series` 不變量）；`errors.md` 殘餘表如實列出未在本 issue grep 範圍的模組（`_metric_index`、`_dag`、`_inspect`、`_ols`、`_stats/*`、`adapt.py`、`orthogonalize.py`）。

實作者判斷（接受）：`monotonicity(direction=)` 的手寫訊息改為通用 `candidates=` 渲染；`factor_cols must be non-empty` 移入建構（batch dispatch 繞過建構，但 `evaluate` 邊界已擋空 `factor_cols`，已驗證）；`MetricResult.__post_init__` 六個 guard 改 `UserInputError`。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3496 passed, 42 skipped**（pytest rc=0 直接檢查）。`tests/test_knob_validation.py` 30 → 109：對 `REGISTRY` 全部 metric × Literal 欄位的建構期掃描、`validate=` 界表（新鉤子無對應列即失敗）、allowlist 掃描、config-vs-direct parity、來源守衛（已種入違規呼叫確認會觸發）。