### PR TITLE
refactor(metrics)!: spell the Newey-West lag knob one way and state the inference surface

### DIFF
--- a/docs/api/metrics/index.md
+++ b/docs/api/metrics/index.md
@@ -115,12 +115,13 @@ passed method against its own allowlist and raises
 `IncompatibleInferenceError` for anything outside it, instead of running an
 unvetted test or falling back silently.
 
-`factrix.inference.HANSEN_HODRICK` is available as a standalone series-mean
-inference member, but it is deliberately in no metric's allowlist. The
-metric-supported choices are `NON_OVERLAPPING` and `NEWEY_WEST` on every
-`inference=`-bearing metric, plus `STATIONARY_BOOTSTRAP` on `ic` only —
-`quantile_spread`, `quantile_spread_vw` and `k_spread` hard-branch on
-`isinstance(NeweyWest)` and would need a polymorphic dispatch first.
+The metric-supported choices are `NON_OVERLAPPING`, `NEWEY_WEST` and
+`STATIONARY_BOOTSTRAP` on every `inference=`-bearing metric.
+`HansenHodrick` is **research-only**: it is in no metric's allowlist, so it
+is not exported from `factrix.inference` at all. Import it from
+`factrix.inference.series_mean` and call
+`HANSEN_HODRICK.compute(series_df, value_col=..., overlap_periods=...)`
+directly for a comparison study.
 
 ## Cell vs. DataStructure
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -199,6 +199,43 @@ Dispatch runs through the DAG executor
 
 ---
 
+## `overlap_periods`: injection order and signature defaults
+
+`overlap_periods` is an **injected** parameter (`MetricBase._INJECTED_PARAMS`),
+not a user knob: it describes the data, not the test. `MetricBase.__call__`
+resolves it in a fixed order:
+
+1. the caller's explicit `overlap_periods=` (re-validated at the boundary, so a
+   standalone call rejects the same bad value `evaluate` would);
+2. otherwise, for a frame input, the panel's reserved overlap stamp written by
+   `compute_forward_return` (`MetricBase._stamped_overlap_periods`);
+3. otherwise, the body's signature default.
+
+So the signature default is **unreachable under `evaluate`** — that path always
+injects the stamped horizon. It binds only on a standalone call against an
+unstamped frame, against a non-frame input (series consumers), or against a
+producer's derived frame that carries no stamp (`fm_beta`'s `beta_df`). Reading
+a signature default as "the horizon this metric assumes" is therefore wrong; it
+is only the fallback for an undeclared, unstamped input.
+
+Three defaults are in use, and the difference is deliberate:
+
+| Default | Metrics | Meaning |
+|---|---|---|
+| `5` (`DEFAULT_FORWARD_PERIODS`) | most metrics — `ic`, `quantile_spread`, `k_spread`, `caar`, `event_quality.*`, `predictive_beta`, … | "Assume the library's default forward horizon." It matches `compute_forward_return`'s own default, so a hand-built unstamped panel is treated the way the default pipeline would have stamped it. |
+| `1` | `spanning_alpha`, `rank_turnover` | The input is non-overlapping by construction — `spanning_alpha` consumes `compute_spread_series`' already-strided output, and on `rank_turnover` the value is a *stride* fallback rather than a HAC floor. `1` means "one period, no overlap". |
+| `None` | `fm_beta`, `common_quantile_spread`, `common_asymmetry` | "No horizon declared." The value flows straight into the optional-typed HAC resolvers (`_resolve_nw_lags`, `_resolve_har_lags`, `_har_dof`), which read `None` as "apply no overlap floor and no effective-dof cap". |
+
+`None` and `1` are **numerically identical** in all three resolvers — the floor
+is `max(h - 1, 0) = 0` and the dof cap is guarded by `h > 1` — so the `int` /
+`int | None` split is a semantic one (undeclared vs declared-as-one), not a
+behavioural one. `None` and `5` are not: the `5` default raises the bandwidth at
+small `T` and always tightens the dof cap, so unifying the `None` group onto
+`DEFAULT_FORWARD_PERIODS` would silently move p-values on every unstamped
+standalone call. That is why the three groups are left as they are.
+
+---
+
 ## PANEL / TIMESERIES equivalence
 
 Both structures produce real `MetricResult.p_value` values — neither is degraded.
@@ -547,9 +584,10 @@ Only the series-mean family (`ic`, `quantile_spread`, `quantile_spread_vw`,
 selectable `inference=`; every other metric carries a fixed estimator by
 its statistical shape, so the absence of the knob is by design. The
 `factrix.inference` module docstring is the SSOT for the full rule — the
-per-family rationale, the closed-union policy, and why `HANSEN_HODRICK` and
-`STATIONARY_BOOTSTRAP` are each exported but not admitted into every
-metric's union.
+per-family rationale, the closed-union policy, and why `HansenHodrick` is
+research-only — kept in `factrix.inference.series_mean` for standalone
+comparison studies, admitted to no metric's union and not exported from
+`factrix.inference`.
 
 ### `individual_continuous(IC)` — cross-section first
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -911,7 +911,7 @@ Two complementary methods:
   `method_b`, `stat_type_method_b`, `beta_pos`, `beta_neg`,
   `p_wald_slopes`.
 - *descriptive*: `beta_long`, `beta_short`, `abs_short_over_long`,
-  `n_pos`, `n_neg`, `n_zero`, `n_periods`, `nw_lags_used`,
+  `n_pos`, `n_neg`, `n_zero`, `n_periods`, `newey_west_lags_used`,
   `method_b_skipped` (conditional), `intercept` (conditional),
   `beta_zero` (conditional).
 
@@ -927,7 +927,7 @@ Two complementary methods:
 - *secondary-test*: `spearman_rho`, `spearman_p` — small-sample
   Spearman of (bucket-idx, mean-return) for monotonicity diagnostic.
 - *descriptive*: `n_groups`, `n_periods`, `n_distinct_factor`,
-  `nw_lags_used`, `buckets` (list of `{idx, mean_return, n}`).
+  `newey_west_lags_used`, `buckets` (list of `{idx, mean_return, n}`).
 
 ### `tradability` (`factrix.metrics.tradability`)
 

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -228,7 +228,7 @@ approximation assumption all three analytic methods still make:
 | Procedure | Mechanism | Strengths | Weaknesses | Where factrix uses it |
 |---|---|---|---|---|
 | **Newey-West (1987)** | Bartlett-kernel HAC on the full overlapping series, bandwidth `L = max(bandwidth_base, h−1)`. | Simple, deterministic, asymptotically valid for arbitrary autocorrelation up to `L`. | Asymptotic Gaussian — finite-sample size distortion when `h/T` is non-trivial; bandwidth rule is conservative. | `ic` / `quantile_spread` / `quantile_spread_vw` / `k_spread` (with `NeweyWest` inference), `fm_beta` stage 2, `pooled_beta`, `common_quantile_spread`, `common_asymmetry`. |
-| **Hansen-Hodrick (HH) (1980)** | A generalized method of moments (GMM)-style HAC estimator with a rectangular kernel truncated at `h−1`; the canonical reference for overlap-aware long-horizon SEs. | Targets the MA(`h−1`) residual structure overlap induces. | Rectangular kernel can yield a non-PSD covariance matrix in finite samples; still asymptotic. | Exposed as `factrix.inference.HANSEN_HODRICK` (rectangular-kernel SE → t-statistic → two-sided p-value), but deliberately in **no** metric's `applicable_inference` allowlist — passing it to a metric raises `IncompatibleInferenceError`. Also borrows the `h−1` lag idea as a floor on the NW bandwidth above. |
+| **Hansen-Hodrick (HH) (1980)** | A generalized method of moments (GMM)-style HAC estimator with a rectangular kernel truncated at `h−1`; the canonical reference for overlap-aware long-horizon SEs. | Targets the MA(`h−1`) residual structure overlap induces. | Rectangular kernel can yield a non-PSD covariance matrix in finite samples; still asymptotic. | **Research-only.** Implemented as `factrix.inference.series_mean.HANSEN_HODRICK` (rectangular-kernel SE → t-statistic → two-sided p-value) and usable standalone via `HANSEN_HODRICK.compute(...)`, but deliberately in **no** metric's `applicable_inference` allowlist — passing it to a metric raises `IncompatibleInferenceError` — and for that reason not re-exported from `factrix.inference`. Also borrows the `h−1` lag idea as a floor on the NW bandwidth above. |
 | **Hodrick (1992) "1B"** | Reverse-regression: regress one-period return on the predictor sum `X_t = Σ x_{t-j}` over the last `h` periods. | Size-correct in finite samples even at large `h/T`; no bandwidth choice. | Coefficient interpretation differs — `β` is the response to a cumulative-predictor stimulus (MA on the RHS) rather than a long-horizon forecast slope (MA on the LHS in the standard form); not a drop-in replacement for the canonical `β`. | **Not implemented**. Cited as the right tool when overlap is severe; the `Individual × Continuous` cell side-steps the issue with non-overlapping resampling instead. |
 | **Stationary bootstrap (Politis-Romano 1994)** | Block-resamples the series (geometric block length, Politis-White 2004 automatic selection), centred under `H0`, studentizes both the observed and the resampled root by a batch-means SE at the same block length, and reports the empirical two-sided p from the resampled `t` ratios. | No normality or asymptotic-variance assumption at all — valid when the IC/return distribution is heavy-tailed or skewed enough that NW's / HH's Gaussian p-value is itself suspect. | Heavier to compute (resampling, not closed-form); the reported `stat` is the observed mean rather than the root the p is computed from. On a zero-dispersion sample there is no block SE to divide by, and the kernel falls back to the raw-mean root — reported as `metadata["studentized"] = False` and `degenerate_variance`. | Exposed as `factrix.inference.STATIONARY_BOOTSTRAP` on `ic`, `quantile_spread`, `quantile_spread_vw` and `k_spread` — every one of them dispatches the member polymorphically, and the spread series carries its own measured size table (§6). |
 
@@ -246,6 +246,24 @@ Practical rule of thumb:
   prefer `STATIONARY_BOOTSTRAP` over any of the analytic methods above —
   it is the only one of the four that does not assume asymptotic
   normality.
+
+### Which metrics take `inference=`, and which take a raw lag knob
+
+Two different surfaces set the HAC bandwidth, and which one a metric
+offers is decided by whether that metric's series has a **measured size
+table**, not by convenience:
+
+| Metric | Bandwidth surface | Why |
+|---|---|---|
+| `ic`, `quantile_spread`, `quantile_spread_vw`, `k_spread` | `inference=` (allowlist: `NON_OVERLAPPING`, `NEWEY_WEST`, `STATIONARY_BOOTSTRAP`) | Headline test is "average an overlapping per-date series, test `mean != 0`". The IC series and the spread series each carry their own measured size table (this section and §6), so each member is admitted on the strength of it, and the bandwidth is chosen for the caller by the member. |
+| `fm_beta`, `predictive_beta`, `common_quantile_spread`, `common_asymmetry` | raw `newey_west_lags` | Same Newey-West kernel, but no size table has been measured **on these metrics' own series**, so there is nothing to admit an `inference` member against. `None` (the default, and the only calibrated setting) resolves the bandwidth by the standard rule; an explicit integer is an unvetted override for research use. |
+| `pooled_beta` | raw `driscoll_kraay_lags` | A different estimator entirely — Driscoll-Kraay is a two-dimensional (period × asset) kernel, not the series-mean HAC, so it is neither an `inference` member nor a `newey_west_lags`. |
+| `spanning_alpha`, the slice Wald tests | neither | Bandwidth is fully determined by `overlap_periods` through `_resolve_nw_lags`; there is no caller knob to mis-set. |
+
+The rule for moving a metric from the second row to the first is the same
+one that governs the allowlists: measure size on **that metric's own
+series** first, then admit. Until then the raw knob is deliberately raw —
+it does not pretend to be a vetted choice.
 
 ---
 

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -74,8 +74,8 @@ and the long-short spread series have different distributions, so each
 carries its own size table (see ``reference/statistical-methods``) and
 each admits a member only on the strength of it.
 
-``HANSEN_HODRICK`` vs the metric allowlists
--------------------------------------------
+``HansenHodrick`` is research-only
+----------------------------------
 ``HansenHodrick`` is a complete series-mean member (same ``compute``
 contract as the others) and is in no metric's ``applicable_inference``.
 The reason is statistical, not structural: its rectangular kernel has no
@@ -85,6 +85,13 @@ PSD guarantee and can clamp a negative variance (see
 *is* admitted everywhere the family is offered — it makes no
 asymptotic-variance assumption at all, so it is the recommended read when
 a series is too short or too heavy-tailed for a HAC member to be trusted.
+
+Because no metric can accept it, ``HansenHodrick`` / ``HANSEN_HODRICK``
+are **not** re-exported here: a name on ``fx.inference.*`` reads as
+"pass this to a metric", and every such call raises
+``IncompatibleInferenceError``. They stay importable from
+``factrix.inference.series_mean`` for standalone comparison studies —
+call ``HANSEN_HODRICK.compute(...)`` on a series directly.
 
 Who builds which series
 -----------------------
@@ -104,22 +111,18 @@ from __future__ import annotations
 
 from factrix.inference._base import Inference, InferenceResult
 from factrix.inference.series_mean import (
-    HANSEN_HODRICK,
     NEWEY_WEST,
     NON_OVERLAPPING,
     STATIONARY_BOOTSTRAP,
-    HansenHodrick,
     NeweyWest,
     NonOverlapping,
     StationaryBootstrap,
 )
 
 __all__ = [
-    "HANSEN_HODRICK",
     "NEWEY_WEST",
     "NON_OVERLAPPING",
     "STATIONARY_BOOTSTRAP",
-    "HansenHodrick",
     "Inference",
     "InferenceResult",
     "NeweyWest",

--- a/factrix/metrics/common_asymmetry.py
+++ b/factrix/metrics/common_asymmetry.py
@@ -75,7 +75,7 @@ def common_asymmetry(
     factor_col: str = "factor",
     return_col: str = "forward_return",
     overlap_periods: int | None = None,
-    nw_lags: int | None = None,
+    newey_west_lags: int | None = None,
 ) -> MetricResult:
     """Long/short asymmetry of factor → return relationship.
 
@@ -97,7 +97,7 @@ def common_asymmetry(
         overlap_periods: Overlap horizon of the forward return; used
             to floor the NW bandwidth so the kernel is consistent
             with the autocorrelation it must absorb.
-        nw_lags: Override for the NW lag count. ``None`` resolves to
+        newey_west_lags: Override for the NW lag count. ``None`` resolves to
             the standard rule given ``overlap_periods`` and ``T``.
 
     Returns:
@@ -209,7 +209,7 @@ def common_asymmetry(
             ),
         )
 
-    lags = _resolve_nw_lags(n_periods, nw_lags, overlap_periods)
+    lags = _resolve_nw_lags(n_periods, newey_west_lags, overlap_periods)
 
     # Drop the zero column when n_zero==0 to keep the design matrix full-rank.
     cols = [pos_mask.astype(float), neg_mask.astype(float)]
@@ -278,7 +278,7 @@ def common_asymmetry(
         "n_neg": n_neg,
         "n_zero": n_zero,
         "n_periods": n_periods,
-        "nw_lags_used": lags,
+        "newey_west_lags_used": lags,
         **method_b,
     }
     stat, p_out, alternative = _degenerate_test_fields(

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -83,7 +83,7 @@ def common_quantile_spread(
     return_col: str = "forward_return",
     n_groups: int = 5,
     overlap_periods: int | None = None,
-    nw_lags: int | None = None,
+    newey_west_lags: int | None = None,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
     """Bucket time-series factor by historical quantiles, test conditional means.
@@ -110,7 +110,7 @@ def common_quantile_spread(
             shape check is reported as NaN below ``K = 3``.
         overlap_periods: Overlap horizon of the forward return; floors
             the Newey-West (NW) bandwidth.
-        nw_lags: Override for the NW lag count. ``None`` resolves to
+        newey_west_lags: Override for the NW lag count. ``None`` resolves to
             the standard rule given ``overlap_periods`` and ``T``.
 
     Returns:
@@ -234,7 +234,7 @@ def common_quantile_spread(
     X = np.zeros((n_periods, n_groups))
     X[np.arange(n_periods), bucket_idx] = 1.0
 
-    lags = _resolve_nw_lags(n_periods, nw_lags, overlap_periods)
+    lags = _resolve_nw_lags(n_periods, newey_west_lags, overlap_periods)
     beta, V_hac, _ = _ols_nw_multivariate(r, X, lags=lags)
 
     R = np.zeros((1, n_groups))
@@ -279,7 +279,7 @@ def common_quantile_spread(
         "n_groups": n_groups,
         "n_periods": n_periods,
         "n_distinct_factor": n_distinct,
-        "nw_lags_used": lags,
+        "newey_west_lags_used": lags,
         "buckets": [
             {
                 "idx": int(k),

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -32,12 +32,12 @@ from factrix.inference import (
     NEWEY_WEST,
     NON_OVERLAPPING,
     STATIONARY_BOOTSTRAP,
-    HansenHodrick,
     Inference,
     NeweyWest,
     NonOverlapping,
     StationaryBootstrap,
 )
+from factrix.inference.series_mean import HansenHodrick
 
 
 def _series_df(values: np.ndarray) -> pl.DataFrame:

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -7,6 +7,7 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix.inference import NeweyWest, NonOverlapping, StationaryBootstrap
+from factrix.inference.series_mean import HANSEN_HODRICK
 from factrix.metrics.ic import compute_ic, ic, ic_ir
 
 
@@ -462,7 +463,7 @@ class TestICInferenceAllowlist:
             ic(
                 self._ic_series(40),
                 overlap_periods=1,
-                inference=fx.inference.HANSEN_HODRICK,
+                inference=HANSEN_HODRICK,
             )
         assert exc.value.func_name == "ic"
         assert exc.value.applicable == (

--- a/tests/test_k_spread.py
+++ b/tests/test_k_spread.py
@@ -8,6 +8,7 @@ from datetime import date, timedelta
 import numpy as np
 import polars as pl
 import pytest
+from factrix.inference.series_mean import HANSEN_HODRICK
 from factrix.metrics.k_spread import k_spread
 from factrix.metrics.quantile import quantile_spread
 
@@ -288,9 +289,7 @@ class TestInference:
 
         panel = self._ample_panel()
         with pytest.raises(fx.IncompatibleInferenceError) as exc:
-            k_spread(
-                panel, overlap_periods=5, k=5, inference=fx.inference.HANSEN_HODRICK
-            )
+            k_spread(panel, overlap_periods=5, k=5, inference=HANSEN_HODRICK)
         assert exc.value.func_name == "k_spread"
         assert exc.value.applicable == (
             "NeweyWest",

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -8,7 +8,8 @@ import polars as pl
 import pytest
 from factrix._codes import WarningCode
 from factrix._errors import IncompatibleInferenceError
-from factrix.inference import HANSEN_HODRICK, NEWEY_WEST
+from factrix.inference import NEWEY_WEST
+from factrix.inference.series_mean import HANSEN_HODRICK
 from factrix.metrics.quantile import (
     compute_spread_series,
     quantile_spread,
@@ -400,7 +401,7 @@ class TestQuantileSpreadInference:
                 panel,
                 overlap_periods=5,
                 n_groups=5,
-                inference=fx.inference.HANSEN_HODRICK,
+                inference=HANSEN_HODRICK,
             )
         assert exc.value.func_name == "quantile_spread"
         assert exc.value.applicable == (

--- a/tests/test_spread_inference_dispatch.py
+++ b/tests/test_spread_inference_dispatch.py
@@ -24,12 +24,12 @@ import pytest
 from factrix._errors import IncompatibleInferenceError
 from factrix._results import MetricResult
 from factrix.inference import (
-    HANSEN_HODRICK,
     NEWEY_WEST,
     NON_OVERLAPPING,
     STATIONARY_BOOTSTRAP,
     StationaryBootstrap,
 )
+from factrix.inference.series_mean import HANSEN_HODRICK
 from factrix.metrics.k_spread import k_spread
 from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
 from factrix.preprocess import compute_forward_return


### PR DESCRIPTION
> **TL;DR** — `common_asymmetry` / `common_quantile_spread` 的 `nw_lags` → `newey_west_lags`（metadata `nw_lags_used` → `newey_west_lags_used`），與 `fm_beta` / `predictive_beta` 一致；`HANSEN_HODRICK` 從 `factrix.inference` 的再匯出與 `__all__` 移除（`series_mean` 仍可匯入，供比較研究），文件標為 research-only；§1 新增「哪些 metric 走 `inference=`、哪些吃裸 lag 旋鈕、原因」的四列表；`overlap_periods` 預設規則寫進 architecture 頁。**Breaking**。

Closes #932

## `overlap_periods` 預設規則（實作者查出，不統一）
它是注入參數：`MetricBase.__call__` 依序取呼叫端明給值 → 面板 stamp → 簽名預設；**在 `evaluate` 下簽名預設不可達**，只在無 stamp 的直呼生效。三種預設各有語意：`5` = 假設預設 forward horizon；`1`（`spanning_alpha`、`rank_turnover`）= 輸入依構造不重疊；`None`（`fm_beta`、`common_*`）= 未宣告 horizon，resolver 讀為無下限無 dof 上限。數值驗證 `None ≡ 1`、`None ≠ 5`（T=60 時 `_har_dof` 21.5 vs 11.0），統一會移動無 stamp 直呼的 p → 依 brief 停止規則不統一、只記錄。

## 審核紀錄（實作者 opus，審核者本 session）
探針：兩個 metric 簽名含 `newey_west_lags`、不含 `nw_lags`；`fx.inference.HANSEN_HODRICK` 不存在、`__all__` 不含；`series_mean.HANSEN_HODRICK` 可匯入。與 main 無衝突。

實作者判斷（接受）：`driscoll_kraay_lags` 保留（不同估計量）；私有 `_resolve_nw_lags` 與 `NeweyWest` 成員的 `metadata["nw_lags"]` 鍵未改（後者影響 stat-keys 與 `k_spread` / `quantile` 測試）→ 併入 #943（該 issue 本就要動 `_resolve_nw_lags`）。順手修正 `api/metrics/index.md` 一句過期敘述（`STATIONARY_BOOTSTRAP` 已非 `ic` 專屬）。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3496 passed, 42 skipped**（pytest rc=0）。