### PR TITLE
fix(multi_factor)!: exclude placeholder hypotheses from every screening family through one policy

### DIFF
--- a/docs/api/bhy-across-metrics.md
+++ b/docs/api/bhy-across-metrics.md
@@ -36,8 +36,9 @@ For the claim that a factor works on at least `k` predeclared endpoints, use
 - Entry order is result-major, then caller-supplied metric order.
 - `expand_over` retains the existing `bhy` meaning: it partitions by a result
   field or `params` key; metric labels remain pooled inside each bucket.
-- An `insufficient_*` cell stays in `entries` with `active=False` and
-  `adj_p=NaN`, but does not enter the active family or `n_tests`.
+- A placeholder cell (`insufficient_*` or `degenerate_variance`) stays in
+  `entries` with `active=False` and `adj_p=NaN`, but does not enter the family
+  or `n_tests` — see [the module-level policy](multi-factor.md#placeholder-hypotheses).
 - Other missing or invalid p-values raise rather than silently changing the
   family.
 
@@ -51,6 +52,7 @@ For the claim that a factor works on at least `k` predeclared endpoints, use
 | `metrics` | Metric labels in declared order |
 | `expand_over` | Keys partitioning separately reported families |
 | `n_tests` | Active factor × metric family size per bucket |
+| `n_hypotheses_inactive` | Placeholder cells excluded before adjustment |
 
 ::: factrix.multi_factor.CrossMetricBhyResult
     options:

--- a/docs/api/bhy-hierarchical.md
+++ b/docs/api/bhy-hierarchical.md
@@ -115,7 +115,8 @@ metric — the `_FdrResultBase` shape (`entries` / `survivors` / `adj_p` /
 | `adj_p` | Max-of-layers $\text{adj}_p$ for the survivors; survivor iff `adj_p <= q` |
 | `q` | The `q` you passed (single target, both layers) |
 | `group` | Context key naming the group axis (a single `str`) |
-| `n_tests` | Mapping `(group_value,) -> m_group` for **every** input group (covers dead families too, so "N of M families survived" claims are computable directly). Counter to `partial_conjunction`, which keeps surviving identities only. |
+| `n_tests` | Mapping `(group_value,) -> m_group` for **every** group holding a real hypothesis (covers dead families too, so "N of M families survived" claims are computable directly), so `G = len(n_tests)`. Placeholder members leave their inner family, and a group made up entirely of them leaves `G` rather than entering the outer layer at a Simes p of 1.0 — see [the module-level policy](multi-factor.md#placeholder-hypotheses). |
+| `n_hypotheses_inactive` | Placeholder members excluded before adjustment |
 
 Per-survivor group label: `survivor.params[result.group]`.
 

--- a/docs/api/bhy.md
+++ b/docs/api/bhy.md
@@ -52,7 +52,8 @@ The returned dictionary maps each mainstream metric label to a `BhyResult` conta
 | `adj_p` | `np.ndarray` | Adjusted p-value for the survivors, aligned with `survivors` (derived). |
 | `q` | `float` | The nominal target FDR you passed. |
 | `expand_over` | `tuple[str, ...]` | `()` for a single family; `("regime_id",)` etc. otherwise. |
-| `n_tests` | `Mapping[tuple, int]` | `{(): N}` or `{bucket_key: m_per_bucket}`. |
+| `n_tests` | `Mapping[tuple, int]` | `{(): N}` or `{bucket_key: m_per_bucket}`, counting real hypotheses only. |
+| `n_hypotheses_inactive` | `int` | Placeholder cells excluded from every family before adjustment (see [the module-level policy](multi-factor.md#placeholder-hypotheses)). |
 
 Call `result.to_frame()` for a `factor | adj_p | survived` DataFrame over
 **all** tested factors — so a screen of N factors passing 2 still shows how

--- a/docs/api/multi-factor.md
+++ b/docs/api/multi-factor.md
@@ -30,6 +30,24 @@ only when the predeclared selection rule may choose among metric labels or
 requires confirmation on at least `k` endpoints; use the hierarchical function
 only for a predeclared group structure.
 
+## Placeholder hypotheses
+
+A metric output that never ran a test is not a hypothesis. Two shapes qualify:
+a data-shortage short-circuit (`reason` starting `insufficient_`) and a
+`degenerate_variance` result (observations but no dispersion, so no statistic
+exists).
+
+Every function on this page applies the same rule: such a cell is **excluded
+from its family before any adjustment**. It never enters `m`, never enters `G`,
+and never enters a `k`-of-`m` denominator. It stays in `entries` for audit with
+`adj_p = NaN`, and each result reports how many were dropped under one key,
+`n_hypotheses_inactive`.
+
+Counting placeholders instead would inflate every real hypothesis's adjusted
+p-value — the surviving factors would pay a correction for tests that never
+ran — and it would make the same input answer differently depending on which
+function screened it.
+
 ## See also
 
 <div class="grid cards" markdown>

--- a/docs/api/partial-conjunction-across-metrics.md
+++ b/docs/api/partial-conjunction-across-metrics.md
@@ -23,21 +23,31 @@ screen = fx.multi_factor.partial_conjunction_across_metrics(
 
 screen.to_frame()
 # factor | pc_p | adj_p | survived | active
-#        | n_tests | n_active | n_passed_uncorr
+#        | n_tests | n_passed_uncorr
 ```
 
 This differs from [`bhy_across_metrics`](bhy-across-metrics.md): pooled BHY
 selects factor × metric cells, while partial conjunction returns factor
 identities supported by at least `k` endpoints.
 
-## Fixed-m data-shortage rule
+## Placeholder endpoints leave `m`
 
-The declared metric list fixes `m`. An `insufficient_*` endpoint is retained in
-`hypotheses` and conservatively enters the k-of-m calculation as `p=1`; it is
-never deleted in a way that would lower the confirmation bar. If fewer than
-`min_pass` endpoints are active, that identity remains visible with
-`active=False` and empty PC/adjusted p-values, and does not enter the outer BHY
-family.
+The declared metric list fixes the endpoints you may claim on; `m` is how many
+of them actually ran a test. A placeholder endpoint (`insufficient_*`
+short-circuit or `degenerate_variance`) never ran one, so it is excluded from
+the k-of-m denominator rather than entering it at `p=1` — the same policy every
+other screening function applies, so the same degenerate cell costs the same
+whichever verb sees it. See [the module-level
+policy](multi-factor.md#placeholder-hypotheses).
+
+The endpoint stays in `hypotheses` for audit, and `n_hypotheses_inactive`
+reports how many were dropped. If fewer than `min_pass` real endpoints remain,
+that identity cannot support the claim: it stays visible with `active=False`
+and empty PC/adjusted p-values, and does not enter the outer BHY family.
+
+`min_pass` must be declared before the p-values are seen — `(m - k + 1) *
+p_(k)` is not monotone in `k` (see
+[`partial_conjunction`](partial-conjunction.md#declare-min_pass-before-you-look-at-the-p-values)).
 
 Descriptive endpoints and other invalid p-values fail loudly. The function does
 not implement `min_pass=1` any-metric promotion.
@@ -52,8 +62,8 @@ not implement `min_pass=1` any-metric promotion.
 | `adj_p_all` | BHY-adjusted PC p-value per identity |
 | `survivors` / `adj_p` | Passing factor identities and their adjusted p-values |
 | `metrics` / `min_pass` | Declared m endpoints and required k |
-| `n_tests` | Fixed condition count m per identity |
-| `n_active` | Computable endpoint count per identity |
+| `n_tests` | Count of real endpoints m per identity — the k-of-m denominator |
+| `n_hypotheses_inactive` | Placeholder endpoints excluded before adjustment |
 | `n_identities` | Identities entering the outer BHY family |
 
 ::: factrix.multi_factor.CrossMetricPartialConjunctionResult

--- a/docs/api/partial-conjunction.md
+++ b/docs/api/partial-conjunction.md
@@ -75,6 +75,10 @@ hypothesis per factor.
 | **Strict** (`n_conditions=int`) | Paper-grade; you know the design (e.g. exactly 2 universes, exactly 4 horizons) | Identity with any condition count other than `n_conditions` raises. Data gaps surface fail-loud. |
 | **Lenient** (`n_conditions=None`) | EDA / prototyping; condition count varies by identity | `m` inferred per identity from the data; only requires `m >= min_pass`. |
 
+Both modes count the conditions you submitted. Placeholder conditions are then
+excluded from `m` before the PC combination (see below), so a strictly declared
+design can still leave an identity with too few real conditions to screen.
+
 ```python title="Illustrative"
 # Strict: 2 universes required for every factor; missing one raises.
 fx.multi_factor.partial_conjunction(
@@ -106,6 +110,31 @@ $k = \texttt{min\_pass}$. Two corner cases worth knowing:
   `bhy(expand_over=...)`, where the family-level FDR inflation is
   explicit rather than hidden in a "robust across" claim.
 
+### Declare `min_pass` before you look at the p-values
+
+$p_{\text{PC}}$ is **not monotone in $k$**: the multiplier $m - k + 1$ falls as
+the order statistic $p_{(k)}$ rises, so demanding *more* passing conditions can
+*lower* the PC $p$-value. For $p = [0.01, 0.02, 0.9]$, $k = 2$ gives $0.04$ and
+$k = 3$ gives $0.9$; for $p = [0.01, 0.4, 0.5]$ the ordering reverses ($0.8$
+against $0.5$). Which direction helps depends on the data.
+
+Choosing $k$ after seeing the $p$-values is therefore a selection effect the
+outer BHY step-up does not correct — it is the same shopping this function
+exists to prevent, one level up. The "$k$ of $m$" claim is part of the
+hypothesis: fix it with the design.
+
+### Placeholder conditions leave $m$
+
+A condition whose metric never ran a test (`insufficient_*` short-circuit or
+`degenerate_variance`) is not a condition. It is dropped before the PC
+combination rather than entering it at $p = 1$, so `n_tests` is the count of
+*real* conditions per identity and the same degenerate cell costs the same here
+as under [`bhy`](bhy.md) — see [the module-level
+policy](multi-factor.md#placeholder-hypotheses).
+An identity left with fewer than `min_pass` real conditions cannot support the
+claim: it stays in `entries` for audit with `pc_p` / `adj_p` of `NaN` and never
+enters the outer BHY family.
+
 The PC $p$-values are then fed to a standard Benjamini-Hochberg-Yekutieli (BHY) step-up across
 identities, controlling group-level FDR ≤ `q`. The harmonic dependence
 correction $c(m) = \sum 1/i$ is applied because PC $p$-values across
@@ -132,8 +161,9 @@ per metric — the same `_FdrResultBase` shape as `bhy`'s
 | `pc_p_all` | Raw PC $p$-value (pre-BHY), aligned with `entries` |
 | `survivors` / `adj_p` | Surviving subset and its adjusted p-value (derived from `adj_p_all <= q`) |
 | `min_pass` | The $k$ you passed |
-| `n_tests` | Keyed by the identity tuple — `factor`, then `forward_periods` and `params` items not named by `expand_over` → condition count $m$ for that identity |
-| `n_passed_uncorr_all` | Per-identity count of raw $p < q$, aligned with `entries`. Descriptive — flags borderline (`n_passed_uncorr_all == min_pass`) and data-gap cases at a glance. **Cutoff is your `q`**, so the count moves with `q` — using it to override `adj_p` survivor selection is the anti-shopping failure mode this function exists to prevent. |
+| `n_tests` | Keyed by the identity tuple — `factor`, then `forward_periods` and `params` items not named by `expand_over` → count of *real* conditions $m$ for that identity |
+| `n_hypotheses_inactive` | Placeholder conditions excluded before adjustment |
+| `n_passed_uncorr_all` | Per-identity count of real conditions with raw $p \le q$ — the same `<=` rejection rule every screen uses — aligned with `entries`. Descriptive — flags borderline (`n_passed_uncorr_all == min_pass`) and data-gap cases at a glance. **Cutoff is your `q`**, so the count moves with `q` — using it to override `adj_p` survivor selection is the anti-shopping failure mode this function exists to prevent. |
 
 `to_frame()` gives a `factor | adj_p | survived` DataFrame over every tested
 identity, eliminated ones included.
@@ -152,7 +182,8 @@ identity, eliminated ones included.
 | `expand_over` names an identity field (`factor` / `forward_periods`) | [`UserInputError`][factrix.UserInputError] (anti-shopping defense — same as `bhy`). |
 | `n_conditions < min_pass` | [`UserInputError`][factrix.UserInputError] (unsatisfiable). |
 | Strict mode: identity's condition count $\neq$ `n_conditions` | [`UserInputError`][factrix.UserInputError] — surfaces missing-universe / missing-horizon data gaps. |
-| Identity with condition count $<$ `min_pass` (lenient) | [`UserInputError`][factrix.UserInputError]. |
+| Identity with submitted condition count $<$ `min_pass` (lenient) | [`UserInputError`][factrix.UserInputError]. |
+| Identity with fewer than `min_pass` *real* conditions (the rest placeholders) | No error — audited with `NaN`, excluded from the outer BHY family. |
 | Duplicate `(identity, expand_over_values)` partition key | [`UserInputError`][factrix.UserInputError] (family-resolution invariant). |
 
 ## References

--- a/factrix/_family.py
+++ b/factrix/_family.py
@@ -325,7 +325,8 @@ def _resolve_p_value(
         # way a data shortage is treated rather than aborting the whole
         # family: 1.0 is the inert placeholder, and
         # ``_is_inactive_hypothesis`` keeps it out of the BHY denominator so
-        # it cannot dilute the other factors' adjusted p-values.
+        # it cannot inflate the other factors' adjusted p-values (a
+        # placeholder counted in m raises every BH threshold divisor).
         return 1.0
     if p is None:
         raise UserInputError(

--- a/factrix/_multi_factor.py
+++ b/factrix/_multi_factor.py
@@ -287,7 +287,13 @@ class _FdrResultBase(_ScreenResultMixin):
         adj_p_all: BHY-adjusted p-value aligned with ``entries``; ``NaN``
             for an entry dropped before the family formed (data shortage).
         q: Nominal FDR target; must satisfy ``0 < q < 1``.
-        n_tests: Per-bucket / per-identity family size keyed by tuple.
+        n_tests: Per-bucket / per-identity family size keyed by tuple,
+            counting real hypotheses only.
+        n_hypotheses_inactive: Placeholder cells excluded from every family
+            before adjustment — a data-shortage short-circuit or a
+            ``degenerate_variance`` result never ran a test, so it is not a
+            hypothesis and does not enter ``m`` (or ``G``). Reported by every
+            screening verb under this one key.
     """
 
     metric_name: str
@@ -295,6 +301,7 @@ class _FdrResultBase(_ScreenResultMixin):
     adj_p_all: np.ndarray
     q: float
     n_tests: Mapping[tuple[Any, ...], int]
+    n_hypotheses_inactive: int
 
     def to_frame(self) -> pl.DataFrame:
         """Every tested factor with its adjusted p-value and survive flag.
@@ -364,8 +371,9 @@ class BhyResult(_FdrResultBase):
 class MetricHypothesis:
     """One traceable ``EvaluationResult`` x metric hypothesis.
 
-    ``is_active=False`` marks an ``insufficient_*`` data-shortage cell. The
-    record remains auditable but is excluded from the BHY denominator.
+    ``is_active=False`` marks a placeholder cell (data-shortage
+    short-circuit or degenerate variance). The record remains auditable but
+    is not a hypothesis, so it is excluded from every family.
     """
 
     result: EvaluationResult
@@ -386,6 +394,7 @@ class CrossMetricBhyResult(_ScreenResultMixin):
     metrics: tuple[str, ...]
     expand_over: tuple[str, ...]
     n_tests: Mapping[tuple[Any, ...], int]
+    n_hypotheses_inactive: int
 
     def to_frame(self) -> pl.DataFrame:
         """Return every tested cell, including inactive and eliminated rows."""
@@ -443,8 +452,10 @@ class PartialConjunctionResult(_FdrResultBase):
     Shares ``metric_name`` / ``entries`` / ``adj_p_all`` / ``q`` /
     ``n_tests`` with :class:`_FdrResultBase`. ``entries`` is one
     representative :class:`EvaluationResult` per identity; ``adj_p_all`` is
-    the BHY-adjusted PC p-value; ``n_tests`` is the condition count per
-    identity, keyed by the identifier with the ``expand_over`` components
+    the BHY-adjusted PC p-value (``NaN`` for an identity left with fewer
+    than ``min_pass`` real conditions, which never enters the family);
+    ``n_tests`` is the count of *real* conditions per identity — ``m`` in
+    the k-of-m claim — keyed by the identifier with the ``expand_over`` components
     stripped (``factor``, then ``forward_periods`` and ``params`` items not
     named by ``expand_over``).
 
@@ -452,9 +463,10 @@ class PartialConjunctionResult(_FdrResultBase):
         pc_p_all: Raw PC p-value aligned with ``entries``.
         expand_over: ``params`` keys defining the condition axis.
         min_pass: ``k`` in the ``k`` of ``m`` partial conjunction test.
-        n_passed_uncorr_all: Per-identity count of raw p-values strictly
-            below ``q`` (descriptive — not used in inference), aligned
-            with ``entries``.
+        n_passed_uncorr_all: Per-identity count of real conditions whose
+            raw p-value is at or below ``q`` — the same ``<=`` rejection
+            rule every other screen uses (descriptive — not used in
+            inference), aligned with ``entries``.
     """
 
     pc_p_all: np.ndarray
@@ -514,9 +526,9 @@ class CrossMetricPartialConjunctionResult(_ScreenResultMixin):
     metrics: tuple[str, ...]
     min_pass: int
     n_tests: Mapping[tuple[Any, ...], int]
-    n_active: Mapping[tuple[Any, ...], int]
     n_identities: int
     n_passed_uncorr_all: np.ndarray
+    n_hypotheses_inactive: int
 
     def to_frame(self) -> pl.DataFrame:
         """Return one row per factor identity, including ineligible rows."""
@@ -528,10 +540,9 @@ class CrossMetricPartialConjunctionResult(_ScreenResultMixin):
                 "adj_p": self.adj_p_all,
                 "survived": self._survived,
                 "active": [
-                    self.n_active[identity] >= self.min_pass for identity in identities
+                    self.n_tests[identity] >= self.min_pass for identity in identities
                 ],
                 "n_tests": [self.n_tests[identity] for identity in identities],
-                "n_active": [self.n_active[identity] for identity in identities],
                 "n_passed_uncorr": self.n_passed_uncorr_all,
             }
         )
@@ -584,7 +595,10 @@ class HierarchicalBhyResult(_FdrResultBase):
     the ``q`` the screen ran at, since ``R`` (groups selected by the outer
     layer) depends on it; ``q`` is shared by both
     layers; ``n_tests`` is the per-group inner family size keyed by
-    ``(group_value,)`` — covering *all* input groups, not just survivors.
+    ``(group_value,)`` — covering every group holding a real hypothesis,
+    not just the survivors, so ``G`` is ``len(n_tests)``. Placeholder
+    members, and groups made up entirely of them, are absent from the
+    family and carry ``NaN``.
 
     Attributes:
         group: ``params`` key naming the group axis.
@@ -688,10 +702,10 @@ def bhy(
     out: dict[str, BhyResult] = {}
     for spec in metric_list:
         entries = _attach_p_values(partition, func_name="bhy", metric=spec)
+        active_idx, n_inactive = _active_entries(entries, metric=spec)
+        active_set = set(active_idx)
         active_buckets: dict[tuple[Any, ...], list[int]] = {
-            bucket_key: [
-                i for i in ix if not _is_inactive_hypothesis(entries[i].result, spec)
-            ]
+            bucket_key: [i for i in ix if i in active_set]
             for bucket_key, ix in buckets.items()
         }
         active_buckets = {k: ix for k, ix in active_buckets.items() if ix}
@@ -717,6 +731,7 @@ def bhy(
             q=q_target,
             expand_over=expand_over_tuple,
             n_tests=n_tests,
+            n_hypotheses_inactive=n_inactive,
         )
     return out
 
@@ -730,14 +745,49 @@ def _is_inactive_hypothesis(result: EvaluationResult, metric: str) -> bool:
     (see ``factrix.metrics._helpers._degenerate_test_fields``); its
     ``p_value`` is ``None`` and ``_resolve_p_value`` substitutes an inert
     1.0. Neither is a hypothesis that was genuinely on the table, so both
-    stay out of the BHY denominator — counting them would shrink every
-    other factor's adjusted p for free.
+    stay out of every screening family — counting them would inflate every
+    other factor's adjusted p, penalising the real hypotheses for tests
+    that never ran.
     """
     out = result.metrics[metric]
     reason = out.metadata.get("reason")
     if isinstance(reason, str) and reason.startswith("insufficient_"):
         return True
     return WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
+
+
+def _active_entries(
+    entries: Sequence[Any],
+    *,
+    metric: str | None = None,
+) -> tuple[list[int], int]:
+    """Split a candidate family into real hypotheses and placeholders.
+
+    One policy for every screening verb: a placeholder (see
+    :func:`_is_inactive_hypothesis`) is not a hypothesis, so it never joins
+    a family, never enters ``m`` (or ``G``), and never reaches an
+    adjustment. The same degenerate input therefore yields the same
+    adjusted p for the surviving hypotheses whichever verb screens it.
+
+    Args:
+        entries: Family entries. Each exposes ``result``; a
+            :class:`MetricHypothesis` also carries its own ``metric_name``.
+        metric: Metric label for entries that do not carry one.
+
+    Returns:
+        ``(active_indices, n_inactive)`` — positions into ``entries`` that
+        are real hypotheses, in input order, and how many were dropped.
+    """
+    active: list[int] = []
+    n_inactive = 0
+    for idx, entry in enumerate(entries):
+        label = getattr(entry, "metric_name", metric)
+        assert label is not None
+        if _is_inactive_hypothesis(entry.result, label):
+            n_inactive += 1
+        else:
+            active.append(idx)
+    return active, n_inactive
 
 
 def _normalize_metric_hypotheses(
@@ -818,10 +868,10 @@ def bhy_across_metrics(
         func_name="bhy_across_metrics",
         expand_over=expand_over_tuple,
     )
+    active_idx, n_inactive = _active_entries(entries)
     buckets: dict[tuple[Any, ...], list[int]] = defaultdict(list)
-    for idx, entry in enumerate(entries):
-        if entry.is_active:
-            buckets[entry.expand_over_values].append(idx)
+    for idx in active_idx:
+        buckets[entries[idx].expand_over_values].append(idx)
 
     n_tests = {bucket_key: len(ix) for bucket_key, ix in buckets.items()}
     singleton = sum(1 for ix in buckets.values() if len(ix) == 1)
@@ -846,6 +896,7 @@ def bhy_across_metrics(
         metrics=tuple(metric_list),
         expand_over=expand_over_tuple,
         n_tests=n_tests,
+        n_hypotheses_inactive=n_inactive,
     )
 
 
@@ -871,6 +922,19 @@ def partial_conjunction(
     ``p_PC = (m - k + 1) * p_((k))`` capped at 1.
     ``k = 1`` reduces to ``m * min(p)`` (union semantics) and is
     forbidden.
+
+    **``min_pass`` must be declared before the p-values are seen.**
+    ``(m - k + 1) * p_((k))`` is not monotone in ``k``: raising the bar from
+    "2 of 4" to "3 of 4" can *lower* the PC p-value and turn a non-survivor
+    into a survivor. Picking ``k`` after looking at the p-values is
+    therefore a selection effect the outer BHY step-up does not correct —
+    the k-of-m claim is part of the hypothesis, not a knob to tune.
+
+    Placeholder conditions (a data-shortage short-circuit or a
+    ``degenerate_variance`` result) are not conditions: they leave ``m``
+    rather than entering it at ``p = 1``, exactly as in :func:`bhy`. An
+    identity left with fewer than ``min_pass`` real conditions stays in the
+    audit output with ``NaN`` and never enters the outer BHY family.
 
     Args:
         results: :class:`EvaluationResult` records. The aggregation
@@ -993,10 +1057,12 @@ def _partial_conjunction_one(
             identities_ordered.append(identity)
         entries_by_identity[identity].append(entry)
 
-    pc_p_arr = np.empty(len(identities_ordered), dtype=np.float64)
-    n_passed_arr = np.empty(len(identities_ordered), dtype=np.int64)
+    pc_p_arr = np.full(len(identities_ordered), np.nan, dtype=np.float64)
+    n_passed_arr = np.zeros(len(identities_ordered), dtype=np.int64)
     n_tests_per_id: dict[tuple[Any, ...], int] = {}
     rep_results: list[EvaluationResult] = []
+    eligible: list[int] = []
+    n_inactive = 0
 
     for i, identity in enumerate(identities_ordered):
         group = entries_by_identity[identity]
@@ -1030,14 +1096,22 @@ def _partial_conjunction_one(
                 docs_path="api/partial-conjunction#validation-summary",
             )
 
-        ps = np.array([e.p_value for e in group], dtype=np.float64)
-        pc_p_arr[i] = partial_conjunction_p(ps, min_pass=min_pass)
-        n_passed_arr[i] = int(np.sum(ps < q))
-        n_tests_per_id[identity] = m
+        active_idx, group_inactive = _active_entries(group, metric=metric)
+        n_inactive += group_inactive
+        ps = np.array([group[j].p_value for j in active_idx], dtype=np.float64)
+        # One placeholder policy: an inactive condition is not a condition, so
+        # it leaves both the k-of-m denominator and the raw pass count. An
+        # identity left with fewer than ``min_pass`` real conditions cannot
+        # support the claim and stays out of the outer BHY family.
+        n_tests_per_id[identity] = len(active_idx)
+        n_passed_arr[i] = int(np.sum(ps <= q))
+        if len(active_idx) >= min_pass:
+            pc_p_arr[i] = partial_conjunction_p(ps, min_pass=min_pass)
+            eligible.append(i)
         rep_results.append(group[0].result)
 
     if n_conditions is None:
-        m_values = set(n_tests_per_id.values())
+        m_values = {n_tests_per_id[identities_ordered[i]] for i in eligible}
         if len(m_values) > 1:
             warnings.warn(
                 "partial_conjunction: inferred condition counts (n_conditions=None) "
@@ -1050,7 +1124,9 @@ def _partial_conjunction_one(
                 stacklevel=3,
             )
 
-    adj_p_all = bhy_adjusted_p(pc_p_arr)
+    adj_p_all = np.full(len(identities_ordered), np.nan, dtype=np.float64)
+    if eligible:
+        adj_p_all[eligible] = bhy_adjusted_p(pc_p_arr[eligible])
     return PartialConjunctionResult(
         metric_name=metric,
         entries=rep_results,
@@ -1061,6 +1137,7 @@ def _partial_conjunction_one(
         min_pass=min_pass,
         n_tests=n_tests_per_id,
         n_passed_uncorr_all=n_passed_arr,
+        n_hypotheses_inactive=n_inactive,
     )
 
 
@@ -1075,17 +1152,21 @@ def partial_conjunction_across_metrics(
 
     Metric labels are the predeclared condition axis. For each result, the
     Bonferroni-style partial-conjunction p-value is computed across the fixed
-    ``m=len(metrics)`` endpoints, then BHY runs across factor identities.
-    ``insufficient_*`` endpoints are conservatively assigned p=1 rather than
-    shrinking ``m``; identities with fewer than ``min_pass`` active endpoints
-    remain in the audit output but do not enter the outer BHY family.
+    ``m`` real endpoints, then BHY runs across factor identities.
+    Placeholder endpoints (a data-shortage short-circuit or a
+    ``degenerate_variance`` result) never ran a test, so they leave ``m``
+    instead of entering it at ``p = 1``; identities with fewer than
+    ``min_pass`` real endpoints remain in the audit output but do not enter
+    the outer BHY family. ``min_pass`` must be declared before the p-values
+    are seen — ``(m - k + 1) * p_((k))`` is not monotone in ``k``.
 
     Args:
         results: Unique :class:`EvaluationResult` hypotheses. Horizon and all
             ``params`` remain part of each factor identity.
         metrics: At least two unique, predeclared inferential metric labels.
         min_pass: ``k`` in the claim "at least k of m metrics carry signal".
-            Must satisfy ``2 <= min_pass <= len(metrics)``.
+            Must satisfy ``2 <= min_pass <= len(metrics)``. Declared before
+            the p-values are seen.
         q: Nominal FDR target for BHY across factor identities.
 
     Returns:
@@ -1141,29 +1222,26 @@ def partial_conjunction_across_metrics(
 
     m = len(metric_list)
     identifiers = [_hypothesis_identity(result) for result in results]
-    n_tests = {identity: m for identity in identifiers}
-    n_active: dict[tuple[Any, ...], int] = {}
+    n_tests: dict[tuple[Any, ...], int] = {}
     pc_p_all = np.full(len(results), np.nan, dtype=np.float64)
     n_passed = np.zeros(len(results), dtype=np.int64)
     eligible: list[int] = []
+    n_inactive = 0
 
     for idx, identity in enumerate(identifiers):
         conditions = hypotheses[idx * m : (idx + 1) * m]
-        active_count = sum(condition.is_active for condition in conditions)
-        n_active[identity] = active_count
-        n_passed[idx] = sum(
-            condition.is_active and condition.p_value < q_target
-            for condition in conditions
-        )
-        if active_count < min_pass_int:
-            continue
+        # One placeholder policy: an inactive endpoint is not an endpoint. It
+        # leaves the k-of-m denominator instead of entering it at p=1.0, so
+        # the same degenerate cell costs the same here as under bhy().
+        active_idx, identity_inactive = _active_entries(conditions)
+        n_inactive += identity_inactive
+        n_tests[identity] = len(active_idx)
         p_values = np.array(
-            [
-                condition.p_value if condition.is_active else 1.0
-                for condition in conditions
-            ],
-            dtype=np.float64,
+            [conditions[j].p_value for j in active_idx], dtype=np.float64
         )
+        n_passed[idx] = int(np.sum(p_values <= q_target))
+        if len(active_idx) < min_pass_int:
+            continue
         pc_p_all[idx] = partial_conjunction_p(p_values, min_pass=min_pass_int)
         eligible.append(idx)
 
@@ -1180,9 +1258,9 @@ def partial_conjunction_across_metrics(
         metrics=tuple(metric_list),
         min_pass=min_pass_int,
         n_tests=n_tests,
-        n_active=n_active,
         n_identities=len(eligible),
         n_passed_uncorr_all=n_passed,
+        n_hypotheses_inactive=n_inactive,
     )
 
 
@@ -1261,7 +1339,10 @@ def bhy_hierarchical(
         group: Single key naming the group axis.
         q: Nominal FDR target. The outer layer runs at ``q``; the inner
             layer at the selective ``q · R / G``. Must satisfy
-            ``0 < q < 1``.
+            ``0 < q < 1``. ``G`` counts only groups holding at least one
+            real hypothesis: placeholder members leave their inner family,
+            and a group with none of them leaves the outer layer instead of
+            entering it at a Simes p of 1.0.
 
     Returns:
         ``dict[str, HierarchicalBhyResult]`` keyed by ``label``.
@@ -1305,35 +1386,37 @@ def _bhy_hierarchical_one(
         field="group",
     )
 
-    buckets: dict[Any, list[int]] = defaultdict(list)
+    submitted: dict[Any, list[int]] = defaultdict(list)
     for idx, entry in enumerate(entries):
-        buckets[entry.expand_over_values[0]].append(idx)
-    group_keys_ordered = list(
+        submitted[entry.expand_over_values[0]].append(idx)
+    declared_keys = list(
         dict.fromkeys(entry.expand_over_values[0] for entry in entries)
     )
 
-    n_groups = len(group_keys_ordered)
-    if n_groups == 1:
+    # The group-axis validations below judge the declared design, so they read
+    # the submitted input. Family formation below reads active hypotheses only.
+    n_declared = len(declared_keys)
+    if n_declared == 1:
         raise UserInputError(
             func_name="bhy_hierarchical",
             field="group",
             value=group,
             expected=(
                 "a key with at least 2 distinct values across input "
-                f"results; got 1 group ({group_keys_ordered[0]!r}). A "
+                f"results; got 1 group ({declared_keys[0]!r}). A "
                 "single group reduces the procedure to plain BHY on the "
                 "members. Call bhy(results, metrics=[...]) directly"
             ),
             docs_path="api/bhy-hierarchical#validation-summary",
         )
-    if n_groups == len(entries) and len(entries) >= 3:
+    if n_declared == len(entries) and len(entries) >= 3:
         raise UserInputError(
             func_name="bhy_hierarchical",
             field="group",
             value=group,
             expected=(
                 f"a key that partitions results into groups of size >= 2; "
-                f"got {n_groups} groups across {len(entries)} results "
+                f"got {n_declared} groups across {len(entries)} results "
                 "(every result is its own group). Pick a coarser "
                 "categorical (family / region / sector) or call bhy() "
                 "without grouping"
@@ -1341,7 +1424,31 @@ def _bhy_hierarchical_one(
             docs_path="api/bhy-hierarchical#validation-summary",
         )
 
-    singletons = sum(1 for ix in buckets.values() if len(ix) == 1)
+    # One placeholder policy: a placeholder is not a hypothesis, so it joins
+    # neither an inner family nor G. A group with no real member drops out of
+    # the outer layer entirely rather than entering it at a Simes p of 1.0.
+    active_idx, n_inactive = _active_entries(entries, metric=metric)
+    active_set = set(active_idx)
+    buckets = {
+        gkey: [i for i in ix if i in active_set] for gkey, ix in submitted.items()
+    }
+    group_keys_ordered = [gkey for gkey in declared_keys if buckets[gkey]]
+    n_groups = len(group_keys_ordered)
+
+    adj_p_all = np.full(len(entries), np.nan, dtype=np.float64)
+    if n_groups == 0:
+        return HierarchicalBhyResult(
+            n_selected_groups=0,
+            metric_name=metric,
+            entries=[e.result for e in entries],
+            adj_p_all=adj_p_all,
+            q=q,
+            group=group,
+            n_tests={},
+            n_hypotheses_inactive=n_inactive,
+        )
+
+    singletons = sum(1 for gkey in group_keys_ordered if len(buckets[gkey]) == 1)
     if singletons * 2 > n_groups:
         warnings.warn(
             f"bhy_hierarchical: {singletons} of {n_groups} groups "
@@ -1374,7 +1481,6 @@ def _bhy_hierarchical_one(
     n_selected = int(np.sum(outer_adj <= q))
     selection_scale = n_groups / n_selected if n_selected else np.inf
 
-    adj_p_all = np.empty(len(entries), dtype=np.float64)
     for g_idx, gkey in enumerate(group_keys_ordered):
         for j, idx in enumerate(buckets[gkey]):
             inner_selective = min(1.0, inner_adjs[g_idx][j] * selection_scale)
@@ -1388,6 +1494,7 @@ def _bhy_hierarchical_one(
         q=q,
         group=group,
         n_tests=n_tests,
+        n_hypotheses_inactive=n_inactive,
     )
 
 

--- a/factrix/stats/multiple_testing.py
+++ b/factrix/stats/multiple_testing.py
@@ -563,6 +563,15 @@ def partial_conjunction_p(
     (1-indexed). ``k = m`` reduces to ``max(p)`` (full conjunction);
     ``k = 1`` reduces to Bonferroni-corrected ``min(p)``.
 
+    **``min_pass`` must be declared before the p-values are seen.** The
+    combined p-value is not monotone in ``k``: the multiplier
+    ``m - k + 1`` falls as the order statistic ``p_((k))`` rises, so
+    demanding *more* passing conditions can *lower* ``p_PC`` — for
+    ``p = [0.01, 0.02, 0.9]``, ``k = 2`` gives ``0.04`` while ``k = 3``
+    gives ``0.9``, and for ``p = [0.01, 0.4, 0.5]`` the ordering reverses.
+    Choosing ``k`` after inspecting the p-values is a selection effect that
+    no downstream step-up corrects.
+
     Args:
         p_values: 1-D array of m per-condition p-values for a single
             hypothesis (e.g. one factor across m universes).

--- a/tests/test_partial_conjunction_across_metrics.py
+++ b/tests/test_partial_conjunction_across_metrics.py
@@ -62,7 +62,7 @@ def test_computes_metric_k_of_m_then_bhy_across_factor_identities():
     assert len(out.hypotheses) == 6
 
 
-def test_insufficient_endpoint_keeps_fixed_m_and_ineligible_factor_is_audited():
+def test_insufficient_endpoint_leaves_m_and_ineligible_factor_is_audited():
     fixed_m = make_result(
         factor="fixed_m",
         p=0.001,
@@ -90,14 +90,15 @@ def test_insufficient_endpoint_keeps_fixed_m_and_ineligible_factor_is_audited():
     )
     frame = out.to_frame()
 
-    # Fixed m=3 gives 2 * p_(2) = 0.004; silently shrinking to m=2 would
-    # incorrectly produce 0.002.
-    assert out.pc_p_all[0] == pytest.approx(0.004)
+    # One placeholder policy: the insufficient endpoint is not an endpoint, so
+    # m = 2 real conditions and p_PC = (2 - 2 + 1) * p_(2) = 0.002. Keeping it
+    # at p=1.0 with m=3 would have doubled that to 0.004.
+    assert out.pc_p_all[0] == pytest.approx(0.002)
     assert np.isnan(out.pc_p_all[1])
     assert out.n_identities == 1
+    assert out.n_hypotheses_inactive == 3
     assert frame["active"].to_list() == [True, False]
-    assert frame["n_active"].to_list() == [2, 1]
-    assert frame["n_tests"].to_list() == [3, 3]
+    assert frame["n_tests"].to_list() == [2, 1]
 
 
 def test_to_frame_reports_factor_level_contract():
@@ -114,7 +115,6 @@ def test_to_frame_reports_factor_level_contract():
         "survived",
         "active",
         "n_tests",
-        "n_active",
         "n_passed_uncorr",
     ]
 

--- a/tests/test_screening_placeholder_policy.py
+++ b/tests/test_screening_placeholder_policy.py
@@ -1,0 +1,248 @@
+"""One placeholder policy shared by every screening verb.
+
+A placeholder cell — a data-shortage short-circuit or a
+``degenerate_variance`` result — never ran a test, so it is not a hypothesis:
+it leaves every family before any adjustment, whichever verb screens it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from factrix._codes import WarningCode
+from factrix._multi_factor import (
+    bhy,
+    bhy_across_metrics,
+    bhy_hierarchical,
+    partial_conjunction,
+    partial_conjunction_across_metrics,
+)
+from factrix._results import MetricResult
+
+from .conftest import make_result, make_spec
+
+
+def _real(factor: str, p: float, *, metric: str = "ic", **kwargs):
+    return make_result(factor=factor, p=p, metric=metric, **kwargs)
+
+
+def _shortage(factor: str, *, metric: str = "ic", **kwargs):
+    return make_result(
+        factor=factor,
+        p=1.0,
+        metric=metric,
+        metadata={"reason": "insufficient_periods"},
+        **kwargs,
+    )
+
+
+def _degenerate(factor: str, *, metric: str = "ic", **kwargs):
+    return make_result(
+        factor=factor,
+        p=None,
+        metric=metric,
+        warning_codes=(WarningCode.DEGENERATE_VARIANCE.value,),
+        **kwargs,
+    )
+
+
+def _output(name: str, p: float | None, *, reason: str | None = None) -> MetricResult:
+    metadata: dict[str, object] = {} if p is None else {"p_value": p}
+    if reason is not None:
+        metadata["reason"] = reason
+    return MetricResult(
+        value=float("nan") if reason else 0.1,
+        p_value=p,
+        alternative=None if p is None else "two-sided",
+        n_obs=100,
+        name=name,
+        metadata=metadata,
+    )
+
+
+# ``bhy_adjusted_p([0.01, 0.5])`` on the two real hypotheses.
+EXPECTED_ADJ = [0.03, 0.75]
+
+
+def test_bhy_excludes_placeholders_and_reports_the_count():
+    make_spec("ic")
+    out = bhy(
+        [_real("a", 0.01), _real("b", 0.5), _shortage("c"), _degenerate("d")],
+        metrics=["ic"],
+    )["ic"]
+
+    np.testing.assert_allclose(out.adj_p_all[:2], EXPECTED_ADJ)
+    assert np.isnan(out.adj_p_all[2:]).all()
+    assert out.n_tests == {(): 2}
+    assert out.n_hypotheses_inactive == 2
+
+
+def test_partial_conjunction_matches_bhy_on_the_same_degenerate_family():
+    """Full conjunction (k = m = 2) reduces the PC p to ``max(p)``.
+
+    So the outer step-up sees the same ``[0.01, 0.5]`` family ``bhy`` sees,
+    and the shared hypotheses must land on the same adjusted p-values.
+    """
+    make_spec("ic")
+    results = [
+        _real("a", 0.01, params={"region": "US"}),
+        _real("a", 0.01, params={"region": "EU"}),
+        _real("b", 0.5, params={"region": "US"}),
+        _real("b", 0.5, params={"region": "EU"}),
+        _shortage("c", params={"region": "US"}),
+        _degenerate("c", params={"region": "EU"}),
+    ]
+    out = partial_conjunction(
+        results, metrics=["ic"], min_pass=2, expand_over=("region",)
+    )["ic"]
+
+    np.testing.assert_allclose(out.pc_p_all[:2], [0.01, 0.5])
+    np.testing.assert_allclose(out.adj_p_all[:2], EXPECTED_ADJ)
+    assert np.isnan(out.adj_p_all[2])
+    assert out.n_tests[("c", 5)] == 0
+    assert out.n_hypotheses_inactive == 2
+
+
+def test_hierarchical_matches_bhy_on_the_same_degenerate_family():
+    """Two singleton-after-exclusion groups make the inner layer inert.
+
+    ``inner_adj`` is the member's own p and ``q`` is loose enough that the
+    outer layer selects both groups (``R = G``, no selection inflation), so
+    each member's adjusted p is its outer BHY value — the same ``[0.03,
+    0.75]`` the flat screen produces on the two real hypotheses.
+    """
+    make_spec("ic")
+    results = [
+        _real("a", 0.01, params={"family": "momentum"}),
+        _degenerate("a_dead", params={"family": "momentum"}),
+        _real("b", 0.5, params={"family": "value"}),
+        _shortage("b_dead", params={"family": "value"}),
+        _shortage("c", params={"family": "carry"}),
+    ]
+    with pytest.warns(RuntimeWarning, match="single result"):
+        out = bhy_hierarchical(results, metrics=["ic"], group="family", q=0.8)["ic"]
+
+    np.testing.assert_allclose(out.adj_p_all[0], EXPECTED_ADJ[0])
+    np.testing.assert_allclose(out.adj_p_all[2], EXPECTED_ADJ[1])
+    assert np.isnan(out.adj_p_all[[1, 3, 4]]).all()
+    # The all-placeholder group leaves G entirely.
+    assert set(out.n_tests) == {("momentum",), ("value",)}
+    assert out.n_hypotheses_inactive == 3
+
+
+@pytest.mark.parametrize(
+    "verb",
+    ["bhy", "partial_conjunction", "bhy_hierarchical"],
+)
+def test_a_placeholder_costs_the_real_hypotheses_nothing(verb):
+    """Submitting a placeholder gives the same adjusted p as not submitting it."""
+    make_spec("ic")
+    if verb == "bhy":
+        live = [_real("a", 0.01), _real("b", 0.2), _real("c", 0.5)]
+        dead = [_shortage("d"), _degenerate("e")]
+
+        def run(results):
+            return bhy(results, metrics=["ic"])["ic"].adj_p_all[:3]
+
+    elif verb == "partial_conjunction":
+        live = [
+            _real(factor, p, params={"region": region})
+            for factor, p in (("a", 0.01), ("b", 0.2), ("c", 0.5))
+            for region in ("US", "EU")
+        ]
+        dead = [
+            _shortage("d", params={"region": "US"}),
+            _degenerate("d", params={"region": "EU"}),
+        ]
+
+        def run(results):
+            out = partial_conjunction(
+                results, metrics=["ic"], min_pass=2, expand_over=("region",)
+            )["ic"]
+            return out.adj_p_all[:3]
+
+    else:
+        live = [
+            _real("a", 0.01, params={"family": "momentum"}),
+            _real("b", 0.2, params={"family": "momentum"}),
+            _real("c", 0.5, params={"family": "value"}),
+            _real("d", 0.6, params={"family": "value"}),
+        ]
+        dead = [
+            _degenerate("e", params={"family": "momentum"}),
+            _shortage("f", params={"family": "carry"}),
+        ]
+
+        def run(results):
+            out = bhy_hierarchical(results, metrics=["ic"], group="family", q=0.05)
+            return out["ic"].adj_p_all[:4]
+
+    np.testing.assert_allclose(run(live), run(live + dead))
+
+
+def test_cross_metric_verbs_report_the_same_inactive_count():
+    make_spec("ic")
+    results = [
+        make_result(
+            factor="a",
+            p=0.01,
+            metric="ic",
+            extra_outputs={
+                "beta": _output("beta", 0.02),
+                "spread": _output("spread", 1.0, reason="insufficient_assets"),
+            },
+        ),
+        make_result(
+            factor="b",
+            p=0.5,
+            metric="ic",
+            extra_outputs={
+                "beta": _output("beta", 0.6),
+                "spread": _output("spread", 0.7),
+            },
+        ),
+    ]
+    metrics = ["ic", "beta", "spread"]
+
+    flat = bhy_across_metrics(results, metrics=metrics)
+    factor_level = partial_conjunction_across_metrics(
+        results, metrics=metrics, min_pass=2, q=0.05
+    )
+
+    assert flat.n_hypotheses_inactive == 1
+    assert factor_level.n_hypotheses_inactive == 1
+    assert np.isnan(flat.adj_p_all[2])
+    # m drops to the two real endpoints: p_PC = (2 - 2 + 1) * p_(2) = 0.02.
+    assert factor_level.pc_p_all[0] == pytest.approx(0.02)
+    assert factor_level.n_tests[("a", 5)] == 2
+
+
+def test_n_passed_uncorr_counts_the_boundary_like_every_rejection_rule():
+    """``p == q`` is a rejection everywhere else, so it counts here too."""
+    make_spec("ic")
+    results = [
+        _real("a", 0.05, params={"region": "US"}),
+        _real("a", 0.05, params={"region": "EU"}),
+    ]
+    out = partial_conjunction(
+        results, metrics=["ic"], min_pass=2, expand_over=("region",), q=0.05
+    )["ic"]
+    assert out.n_passed_uncorr_all.tolist() == [2]
+
+    cross = partial_conjunction_across_metrics(
+        [
+            make_result(
+                factor="a",
+                p=0.05,
+                metric="ic",
+                extra_outputs={
+                    "beta": _output("beta", 0.05),
+                    "spread": _output("spread", 0.9),
+                },
+            )
+        ],
+        metrics=["ic", "beta", "spread"],
+        min_pass=2,
+        q=0.05,
+    )
+    assert cross.n_passed_uncorr_all.tolist() == [2]


### PR DESCRIPTION
> **TL;DR** — 三個篩選動詞對 inactive / degenerate 假設採三種政策（BHY 丟掉；hierarchical 與 partial conjunction 以 p=1.0 保留並計入 m / G；第三種在跨 metric 路徑），同一退化輸入依動詞 adjusted p 差 1.8×，且註解把方向寫反（計入會**膨脹**其他假設的 adjusted p，不是縮小）。現在一個 `_active_entries()` 政策：佔位不是假設，所有 family 形成前排除；`n_hypotheses_inactive` 統一回報；`n_passed_uncorr` 改 `<=` 與拒絕規則一致；`min_pass` 必須事前宣告寫進文件。**Breaking**：cross-metric PC 的 `n_active` 欄移除（`n_tests` 現為真實假設數）、adjusted p 在有佔位的 family 中改變。

Closes #930

## 審核紀錄（實作者 opus，審核者本 session）
`_active_entries` 在五個動詞入口共用（6 處呼叫）；`_family.py:328` 同樣寫反方向的註解由審核者順手修正（一行）。實作者判斷（接受）：驗證仍對**提交的**輸入做（壞宣告仍 fail loud），family 只在 active 項上形成；跨動詞相等以精確數字 `[0.03, 0.75]` 與「提交佔位 ≡ 未提交」不變量兩種方式鎖定；hierarchical 在 R=G 的 q 下相等，較嚴的 q 下選擇性尺度 `G/R` 合法地不同。與 main 無衝突。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3504 passed, 42 skipped**（pytest rc=0；+8 `tests/test_screening_placeholder_policy.py`，3 個既有斷言重釘）。