### PR TITLE
fix(metrics)!: count the mfe_mae excursion window in panel periods

### DIFF
--- a/docs/api/metrics/mfe_mae.md
+++ b/docs/api/metrics/mfe_mae.md
@@ -19,17 +19,18 @@ title: factrix.metrics.mfe_mae
     ---
 
     For each event, find the peak gain (MFE) and peak loss (MAE) over
-    the post-event window, plus bars-to-peak. Descriptive of the
+    the post-event window, plus periods-to-peak. Descriptive of the
     *shape* of the post-event price path, not just its endpoint.
 
 -   __Risk-adjusted favourability__
 
     ---
 
-    Headline ratio $\mathrm{MFE}_{p50} / |\mathrm{MAE}_{p75}|$ pairs
-    the median favourable excursion against the 75th percentile
-    adverse excursion — captures whether typical upside exceeds worst-
-    quartile downside.
+    Headline ratio $\mathrm{MFE}_{p50} / |\mathrm{MAE}_{p25}|$ pairs
+    the median favourable excursion against the worst adverse
+    quartile (MAE is a signed non-positive excursion, so the worst
+    quartile is the 25th percentile) — captures whether typical
+    upside exceeds worst-quartile downside.
 
 -   __Cross-horizon / cross-regime comparison__
 
@@ -42,6 +43,25 @@ title: factrix.metrics.mfe_mae
     regimes.
 
 </div>
+
+## Windows are counted on the panel's period grid
+
+`window` and `estimation_window` are counts of periods on the panel's own
+distinct-date grid, not counts of an asset's rows. Each event asset is laid
+onto the full grid before the excursion is walked, so on a ragged panel — an
+asset missing periods the other names have — the excursion spans exactly
+`window` grid periods and the missing periods count as missing observations
+inside it, instead of the walk stepping over the hole and reaching further
+out. A dense panel is unaffected. `bars_to_mfe` / `bars_to_mae` are offsets in
+grid periods.
+
+A ragged panel records `WarningCode.ragged_period_grid` on the `mfe_mae`
+result: the windows still span the requested number of periods, but a name
+missing periods carries fewer observations inside them than the rest, so its
+`est_sigma` (and the z-scored siblings) rest on a smaller sample. Declare it
+with `evaluate(..., expected_warnings=("ragged_period_grid",))` to silence the
+echo — the code is still recorded — or reindex the panel onto a common grid
+before calling.
 
 ## Choosing a function
 

--- a/factrix/_stats/constants.py
+++ b/factrix/_stats/constants.py
@@ -81,3 +81,11 @@ def har_bandwidth(T: int) -> int:
 # NEGATIVE autocorrelation also breaks HAC calibration (it is what drives
 # RECT_KERNEL_NEGATIVE_VARIANCE) and is deliberately not covered here.
 PERSISTENT_SERIES_AUTOCORR: float = 0.3
+
+
+# Minimum number of period returns inside the pre-event estimation window
+# before ``compute_mfe_mae`` will report ``est_sigma`` (and with it the
+# z-normalised excursions). The window is counted on the panel's period grid,
+# so periods an asset is missing count as missing observations inside it and a
+# ragged name can fall under this floor where a dense one does not.
+DEFAULT_MIN_ESTIMATION_PERIODS: int = 20

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -12,11 +12,16 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._metric_index import cell
+from factrix._stats.constants import DEFAULT_MIN_ESTIMATION_PERIODS
 from factrix._types import EPSILON
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
+from factrix.metrics._helpers import (
+    _densify_on_period_grid,
+    _ragged_event_grid_message,
+)
 
-DEFAULT_MIN_ESTIMATION_PERIODS: int = 20
+__all__ = ["DEFAULT_MIN_ESTIMATION_PERIODS", "compute_mfe_mae"]
 
 
 def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
@@ -34,6 +39,7 @@ def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
         "est_sigma": pl.Float64(),
         "bars_to_mfe": pl.Int32(),
         "bars_to_mae": pl.Int32(),
+        "ragged_period_grid_note": pl.String(),
     }
 
 
@@ -78,8 +84,23 @@ def compute_mfe_mae(
     r"""Per-event Maximum Favorable/Adverse Excursion.
 
     For each event ($\text{factor} \neq 0$), examines the ``window``
-    subsequent bars to find the peak gain (MFE) and peak loss (MAE)
+    subsequent periods to find the peak gain (MFE) and peak loss (MAE)
     relative to event entry price, adjusted for density direction.
+
+    Period grid:
+        ``window`` and ``estimation_window`` are counts of periods on the
+        panel's own distinct-date grid, not counts of the asset's rows. Each
+        event asset is laid onto the full grid before the excursion walk, so
+        on a ragged panel — an asset missing periods the other names have —
+        the excursion spans exactly ``window`` grid periods and the missing
+        ones count as missing observations inside it, rather than the walk
+        stepping over a hole and reaching further out. A dense panel is
+        unaffected. Any price that is not finite is treated the same way, as
+        a period with no observation. ``bars_to_mfe`` / ``bars_to_mae`` are
+        therefore offsets in grid periods. The raggedness is reported to the
+        caller as the ``ragged_period_grid_note`` column, which
+        :func:`~factrix.metrics.mfe_mae.mfe_mae` records as
+        :attr:`~factrix._codes.WarningCode.RAGGED_PERIOD_GRID`.
 
     Entry convention:
         Entry is the **event bar's own close**, ``prices[idx]``; the
@@ -142,15 +163,22 @@ def compute_mfe_mae(
     # times). Restrict to event assets first so non-event assets are not
     # materialised.
     event_assets = set(events["asset_id"].unique().to_list())
+    # Windows are counted on the panel's period grid, not on the asset's own
+    # rows: lay every event asset onto the full grid first, so a period an
+    # asset is missing becomes a null price that is *excluded* from the
+    # excursion rather than a period that is stepped over (which stretched a
+    # ``window``-period excursion across more grid periods on a ragged name).
+    # The grid is the whole panel's, so non-event assets still define it.
+    dense, _ = _densify_on_period_grid(sorted_df)
     asset_groups: dict[str, tuple[dict, np.ndarray]] = {}
     for key, asset_data in (
-        sorted_df.filter(pl.col("asset_id").is_in(list(event_assets)))
+        dense.filter(pl.col("asset_id").is_in(list(event_assets)))
         .partition_by("asset_id", as_dict=True, maintain_order=True)
         .items()
     ):
         asset_id = key[0]
         date_to_idx = {d: i for i, d in enumerate(asset_data["date"].to_list())}
-        prices = asset_data[price_col].to_numpy()
+        prices = asset_data[price_col].cast(pl.Float64).to_numpy(allow_copy=True)
         asset_groups[asset_id] = (date_to_idx, prices)
 
     rows: list[dict] = []
@@ -165,35 +193,49 @@ def compute_mfe_mae(
             continue
 
         entry_price = prices[idx]
-        if entry_price < EPSILON:
+        if not np.isfinite(entry_price) or entry_price < EPSILON:
             continue
 
+        # ``window`` grid periods after the event bar, whether or not this
+        # asset trades on all of them.
         end_idx = min(idx + window + 1, len(prices))
         if idx + 1 >= end_idx:
             continue
 
         future_prices = prices[idx + 1 : end_idx]
-        signed_returns = direction * (future_prices / entry_price - 1)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            signed_returns = direction * (future_prices / entry_price - 1)
+        # A period the asset is missing contributes no excursion; it neither
+        # poisons the extremes with NaN nor pulls a later period into the
+        # window to replace itself.
+        if not np.isfinite(signed_returns).any():
+            continue
+        signed_returns = np.where(np.isfinite(signed_returns), signed_returns, np.nan)
 
         # Sweeney floor: excursions are measured against the entry itself,
         # so a trade that never traded above (below) entry has zero
         # favorable (adverse) excursion. bars_to_* = 0 marks "attained at
         # entry", i.e. the floor bound and no path bar is responsible.
-        raw_mfe = float(np.max(signed_returns))
-        raw_mae = float(np.min(signed_returns))
+        raw_mfe = float(np.nanmax(signed_returns))
+        raw_mae = float(np.nanmin(signed_returns))
         mfe = max(0.0, raw_mfe)
         mae = min(0.0, raw_mae)
-        bars_to_mfe = int(np.argmax(signed_returns)) + 1 if raw_mfe > 0.0 else 0
-        bars_to_mae = int(np.argmin(signed_returns)) + 1 if raw_mae < 0.0 else 0
+        bars_to_mfe = int(np.nanargmax(signed_returns)) + 1 if raw_mfe > 0.0 else 0
+        bars_to_mae = int(np.nanargmin(signed_returns)) + 1 if raw_mae < 0.0 else 0
 
+        # The estimation window is the ``estimation_window`` grid periods
+        # before the event; periods the asset is missing count as missing
+        # observations inside it rather than reaching further back.
         est_start = max(0, idx - estimation_window)
         est_prices = prices[est_start:idx]
         est_sigma = float("nan")
         if len(est_prices) > min_estimation_periods:
             prior = est_prices[:-1]
-            safe = prior > EPSILON
+            here = est_prices[1:]
+            with np.errstate(invalid="ignore"):
+                safe = (prior > EPSILON) & np.isfinite(here)
             if safe.sum() >= min_estimation_periods:
-                period_rets = (est_prices[1:][safe] / prior[safe]) - 1.0
+                period_rets = (here[safe] / prior[safe]) - 1.0
                 if len(period_rets) >= 2:
                     est_sigma = float(np.std(period_rets, ddof=1))
         window_scale = (
@@ -229,4 +271,11 @@ def compute_mfe_mae(
         pl.col("date").cast(date_dtype),
         pl.col("bars_to_mfe").cast(pl.Int32),
         pl.col("bars_to_mae").cast(pl.Int32),
+        # Raggedness is a property of the panel, which only this node sees;
+        # ``mfe_mae`` reads the note off the frame and records the code there.
+        # Empty rather than null on a dense panel, so a caller's ``drop_nulls``
+        # over the per-event table does not empty it.
+        pl.lit(
+            _ragged_event_grid_message("mfe_mae", data) or "", dtype=pl.String
+        ).alias("ragged_period_grid_note"),
     )

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -29,7 +29,11 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import EPSILON, MIN_EVENTS_HARD
 from factrix.metrics._decorators import metric
-from factrix.metrics._helpers import _enforce_min_floor, _short_circuit_output
+from factrix.metrics._helpers import (
+    _enforce_min_floor,
+    _record_ragged_event_grid,
+    _short_circuit_output,
+)
 from factrix.metrics._primitives import compute_mfe_mae
 
 __all__ = [
@@ -75,7 +79,11 @@ def _excursion_ratio(mfe: float, mae: float) -> tuple[float, str]:
     requires={"mfe_mae_df": compute_mfe_mae},
     sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD),
 )
-def mfe_mae(mfe_mae_df: pl.DataFrame) -> MetricResult:
+def mfe_mae(
+    mfe_mae_df: pl.DataFrame,
+    *,
+    expected_warnings: tuple[str, ...] = (),
+) -> MetricResult:
     """Aggregate MFE/MAE statistics.
 
     The static event floor (sample_threshold=SampleThreshold(min_events=MIN_EVENTS_HARD)) gates the summary on the per-event MFE/MAE count. Pre-flight reads the raw non-zero factor count as a loose upper bound.
@@ -85,6 +93,8 @@ def mfe_mae(mfe_mae_df: pl.DataFrame) -> MetricResult:
 
     Args:
         mfe_mae_df: Output of ``compute_mfe_mae()``.
+        expected_warnings: Warning codes the caller declares; a declared code
+            is still recorded, the ``UserWarning`` echo is silenced.
 
     Returns:
         MetricResult with value=MFE_p50/|MAE_p25| ratio. On insufficient
@@ -127,7 +137,13 @@ def mfe_mae(mfe_mae_df: pl.DataFrame) -> MetricResult:
         (``mfe >= 0``, ``mae <= 0``, the Sweeney/Tharp definition), so the
         sign of ``mae`` is guaranteed here rather than assumed. Entry is
         the event bar's own close — see ``compute_mfe_mae`` for why this
-        primitive enters one bar earlier than the return-profile ones.
+        primitive enters one period earlier than the return-profile ones.
+
+        The excursion and estimation windows are counted on the panel's
+        period grid (see ``compute_mfe_mae``). A ragged panel records
+        ``WarningCode.RAGGED_PERIOD_GRID``: the windows still span the
+        requested number of periods, but an asset missing periods carries
+        fewer observations inside them than the rest.
 
     Examples:
         Chain from :func:`compute_mfe_mae` output:
@@ -152,6 +168,17 @@ def mfe_mae(mfe_mae_df: pl.DataFrame) -> MetricResult:
             n_events=0,
         )
 
+    # The panel itself is one DAG node upstream, so compute_mfe_mae measures
+    # the raggedness and broadcasts its note; the code is recorded here, where
+    # the metric's warning codes live.
+    warning_codes: list[str] = []
+    if "ragged_period_grid_note" in mfe_mae_df.columns and mfe_mae_df.height:
+        _record_ragged_event_grid(
+            mfe_mae_df["ragged_period_grid_note"][0] or None,
+            warning_codes,
+            expected_warnings=expected_warnings,
+        )
+
     mfe = mfe_mae_df["mfe"].drop_nulls().drop_nans()
     mae = mfe_mae_df["mae"].drop_nulls().drop_nans()
 
@@ -162,6 +189,7 @@ def mfe_mae(mfe_mae_df: pl.DataFrame) -> MetricResult:
         n_events,
         "insufficient_events",
         axis="events",
+        warning_codes=tuple(warning_codes),
         mfe_mae_ratio=float("nan"),
         n_events=n_events,
     )
@@ -202,5 +230,6 @@ def mfe_mae(mfe_mae_df: pl.DataFrame) -> MetricResult:
         value=ratio,
         n_obs=n_events,
         n_obs_axis="events",
+        warning_codes=tuple(warning_codes),
         metadata=metadata,
     )

--- a/tests/test_event_period_grid.py
+++ b/tests/test_event_period_grid.py
@@ -28,7 +28,7 @@ from factrix.metrics._helpers import (
     _densify_on_period_grid,
     _warn_ragged_event_grid,
 )
-from factrix.metrics._primitives import compute_event_returns
+from factrix.metrics._primitives import compute_event_returns, compute_mfe_mae
 
 _D0 = date(2020, 1, 1)
 
@@ -165,6 +165,42 @@ class TestGoldenDensePanel:
             (pl.col("signed_return") - pl.col("signed_return_golden")).abs().max()
         ).item() == pytest.approx(0.0, abs=0.0)
 
+    def test_mfe_mae_matches_per_asset_row_excursions(self) -> None:
+        panel = _dense_event_panel()
+        window = 10
+        got = compute_mfe_mae(panel, window=window)
+        # The old row form: walk each asset's own rows for the excursion.
+        rows: list[dict] = []
+        sorted_df = panel.sort(["asset_id", "date"])
+        for aid, adf in sorted_df.group_by("asset_id", maintain_order=True):
+            prices = adf["price"].to_numpy()
+            idx_of = {d: i for i, d in enumerate(adf["date"].to_list())}
+            for row in adf.filter(pl.col("factor") != 0).iter_rows(named=True):
+                i = idx_of[row["date"]]
+                direction = 1.0 if row["factor"] > 0 else -1.0
+                end = min(i + window + 1, len(prices))
+                if i + 1 >= end:
+                    continue
+                signed = direction * (prices[i + 1 : end] / prices[i] - 1)
+                rows.append(
+                    {
+                        "date": row["date"],
+                        "asset_id": aid[0],
+                        "mfe_golden": max(0.0, float(np.max(signed))),
+                        "mae_golden": min(0.0, float(np.min(signed))),
+                    }
+                )
+        golden = pl.DataFrame(rows).with_columns(
+            pl.col("date").cast(panel.schema["date"])
+        )
+        assert got.height == golden.height
+        merged = got.join(golden, on=["date", "asset_id"], how="inner")
+        assert merged.height == got.height
+        for col in ("mfe", "mae"):
+            assert merged.select(
+                (pl.col(col) - pl.col(f"{col}_golden")).abs().max()
+            ).item() == pytest.approx(0.0, abs=0.0)
+
 
 class TestRaggedHandCase:
     """2 assets, a 120-period grid, B missing periods 60-79, window 30, h = 5."""
@@ -267,6 +303,66 @@ class TestRaggedOffsets:
         assert float(b["signed_return"][0]) == pytest.approx(expected, rel=1e-12)
 
 
+class TestRaggedExcursionWindow:
+    """The mfe_mae excursion spans grid periods, not the asset's own rows."""
+
+    def test_excursion_spans_window_grid_periods(self) -> None:
+        # B's event sits at period 55 and the hole is 60-79, so a 10-period
+        # excursion covers grid periods 56..65: five observed periods, then
+        # five that B is missing. The row form would have walked on to period
+        # 85 — a "10-period" excursion spanning 30 grid periods.
+        panel = _panel(gap=(60, 80), event_at=55)
+        out = compute_mfe_mae(panel, window=10)
+        b = out.filter(pl.col("asset_id") == "B")
+        assert b.height == 1
+
+        prices = dict(
+            zip(
+                panel.filter(pl.col("asset_id") == "B")["date"].to_list(),
+                panel.filter(pl.col("asset_id") == "B")["price"].to_list(),
+                strict=True,
+            )
+        )
+        entry = prices[_D0 + timedelta(days=55)]
+        grid_periods = list(range(56, 66))
+        assert len(grid_periods) == 10
+        # Periods 60..65 fall in B's hole and contribute nothing; the window
+        # does NOT walk on past the hole to collect ten observed periods.
+        grid_path = [
+            prices[_D0 + timedelta(days=t)] / entry - 1.0
+            for t in grid_periods
+            if _D0 + timedelta(days=t) in prices
+        ]
+        assert len(grid_path) == 4
+        assert float(b["mfe"][0]) == pytest.approx(
+            max(0.0, max(grid_path)), rel=1e-12, abs=1e-15
+        )
+        assert float(b["mae"][0]) == pytest.approx(
+            min(0.0, min(grid_path)), rel=1e-12, abs=1e-15
+        )
+
+        # The row form reached over the hole to periods 80..84.
+        row_periods = list(range(56, 60)) + list(range(80, 86))
+
+        assert len(row_periods) == 10
+        assert row_periods[-1] - row_periods[0] + 1 == 30
+        row_path = [prices[_D0 + timedelta(days=t)] / entry - 1.0 for t in row_periods]
+        assert len(row_path) == 10
+        # The extra periods it swept in carry a deeper adverse excursion.
+        assert float(b["mae"][0]) != pytest.approx(min(0.0, min(row_path)), rel=1e-9)
+
+        # A dense name on the same panel is untouched.
+        assert out.filter(pl.col("asset_id") == "A").height == 1
+
+    def test_excursion_entirely_inside_the_hole_yields_no_event(self) -> None:
+        # Event at period 59, hole 60-79, window 10: every period of the
+        # excursion is missing for B, so there is no excursion to report.
+        panel = _panel(gap=(60, 80), event_at=59)
+        out = compute_mfe_mae(panel, window=10)
+        assert out.filter(pl.col("asset_id") == "B").height == 0
+        assert out.filter(pl.col("asset_id") == "A").height == 1
+
+
 def _ragged_event_panel(*, ragged: bool) -> pl.DataFrame:
     """A 20-asset event panel with the forward return, optionally ragged.
 
@@ -300,16 +396,22 @@ _RAGGED_CODE = WarningCode.RAGGED_PERIOD_GRID.value
 def _entry_points() -> dict[str, object]:
     """The event metrics that must record ``ragged_period_grid``.
 
-    ``caar`` runs through its ``compute_caar`` pipeline node, which is where
-    the panel is seen; the rest read it off their own input.
+    ``caar`` and ``mfe_mae`` run through their own pipeline node
+    (``compute_caar`` / ``compute_mfe_mae``), which is where the panel is
+    seen; the rest read it off their own input.
     """
     from factrix.metrics.caar import bmp_z, caar, compute_caar
     from factrix.metrics.corrado_rank import corrado_rank
     from factrix.metrics.event_horizon import event_around_return
     from factrix.metrics.event_quality import event_hit_rate, event_ic, event_skewness
+    from factrix.metrics.mfe_mae import compute_mfe_mae as _compute_mfe_mae
+    from factrix.metrics.mfe_mae import mfe_mae
 
     def _caar(panel: pl.DataFrame, **kwargs: object) -> object:
         return caar(compute_caar(panel), **kwargs)  # type: ignore[arg-type]
+
+    def _mfe_mae(panel: pl.DataFrame, **kwargs: object) -> object:
+        return mfe_mae(_compute_mfe_mae(panel), **kwargs)  # type: ignore[arg-type]
 
     return {
         "bmp_z": bmp_z,
@@ -319,6 +421,7 @@ def _entry_points() -> dict[str, object]:
         "event_ic": event_ic,
         "event_skewness": event_skewness,
         "event_around_return": event_around_return,
+        "mfe_mae": _mfe_mae,
     }
 
 


### PR DESCRIPTION
> **TL;DR** — `mfe_mae` 不經 `compute_event_returns`，`compute_mfe_mae` 自行逐資產走列，excursion 視窗與估計視窗以資產內列數計。現在先以 `_densify_on_period_grid` 鋪到 panel period grid（缺期 NaN、排除於 excursion 之外），密集面板逐位元不變（golden `abs=0.0`），ragged 時 `RAGGED_PERIOD_GRID` 落到 `warning_codes`（可宣告）。`DEFAULT_MIN_ESTIMATION_PERIODS` 移入 `_stats/constants.py`。**Breaking**：ragged 面板數值改變；`mfe_mae` 增加 `expected_warnings`。

Closes #948

## 審核紀錄（實作者 opus，審核者本 session）
探針：ragged 面板 → `ragged_period_grid` 記錄且 echo；宣告後記錄保留；密集面板不記錄；與 main 無衝突。實作者判斷（接受）：廣播欄在密集面板上為空字串而非 null（null 會讓使用者面的 per-event 表被 `drop_nulls()` 清空，測試抓到）；非有限價格一律視為缺期（密集化後兩者不可區分，且過去 NaN 價格會毒化該事件的 MFE/MAE）；順手修正文件卡片把分位數寫成 p75 的錯誤（程式與 docstring 皆為 p25）。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3595 passed, 42 skipped**（pytest rc=0）。