### PR TITLE
docs(stats): table the common_beta and ic_trend inference paths

### DIFF
--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -1229,7 +1229,7 @@ column. A reduced-replication re-run guards the numbers in
 ### Inference paths still without a size table
 
 Every other `p_value` factrix publishes has a measured size somewhere in
-this section. These four do not, and are listed here rather than left
+this section. These two do not, and are listed here rather than left
 silent so the gap is a documented one. A test
 (`tests/stats/test_section6_covers_every_p_value_path.py`) enumerates the
 metrics whose `MetricResult` can carry a non-`None` `p_value` and fails if
@@ -1249,13 +1249,77 @@ a calibration. Until then read both metrics' `p_value` at
 `overlap_periods > 1` as not calibrated — prefer `h = 1`, or read `value`
 and the bucket / slope detail in `metadata` descriptively.
 
-**`common_beta` and `ic_trend` — not yet measured.** Neither has a
-true-null size measurement on this page. Both are per-period series means
-tested with the same HAC machinery §1 measures, so the sizes documented
-there are the closest available guide, but neither has been measured on
-its own null and neither should be read as inheriting a table it does not
-have. Treat a borderline p from either as uncalibrated pending
-measurement.
+### `common_beta`: measured size of the calendar-time cross-asset $t$
+
+True-null rejection rates at a nominal 5% for `common_beta`'s
+cross-asset $t$ on $\mathbb{E}[\beta]$, on the COMMON-scope null the
+metric's cell describes: one AR($\varphi$) factor series broadcast to
+every asset, drawn from an RNG stream independent of the
+`make_cs_panel(n_assets=50, ic_target=0.0)` prices, so every true
+per-asset $\beta$ is zero while the assets keep the cross-sectional
+return correlation the panel generates. 300 replications per cell, seed
+`20260830 + rep` (factor stream `20260830 + 10000 + rep`), Monte-Carlo
+standard error ~1.3pp. `T` counts periods on the evaluation grid and `h`
+is `forward_periods`, passed through as `overlap_periods`.
+
+| T | h | φ = 0 | φ = 0.9 |
+|---|---|---|---|
+| 60 | 1 | 0.067 | 0.057 |
+| 60 | 5 | 0.073 | 0.033 |
+| 120 | 1 | 0.060 | 0.067 |
+| 120 | 5 | 0.067 | 0.027 |
+| 240 | 1 | 0.053 | 0.047 |
+| 240 | 5 | 0.053 | 0.020 |
+
+Calibrated across the grid (2.0–7.3%), with the worst cells at the short
+end where the Newey-West variance $V_{\mathrm{EW}}$ of the equal-weight
+portfolio slope rests on fewest periods. The calendar-time SE is what
+holds it there: the iid cross-asset $t$ the docstring keeps as
+`metadata["stat_uncorrected"]` is the one this null breaks, because 50
+assets loading on one shared regressor do not supply 50 independent
+betas. The persistent-factor column is the *conservative* direction at
+`h = 5` (3.3 / 2.7 / 2.0% against 7.3 / 6.7 / 5.3%) — a φ = 0.9 regressor
+read through an overlapping forward return leaves more serial dependence
+for the Newey-West kernel to pick up, so the SE widens. A
+reduced-replication re-run guards the numbers in
+`tests/stats/test_common_beta_size.py`. This is the panel-null companion
+to the synthetic-regime measurements in the function's own docstring
+(equicorrelated returns at fixed $T$, varying $N$ and $\rho$); neither
+covers a hand-built beta table, which falls back to the iid $t$ and says
+so in `metadata["calendar_time_se_applied"]`.
+
+### `ic_trend`: measured size of the Mann-Kendall trend test
+
+True-null rejection rates at a nominal 5% for `ic_trend`. The series is
+the per-period Spearman IC of `make_cs_panel(n_assets=50,
+ic_target=0.0)` through `compute_ic`, so the IC has no time trend to
+find; `factor_persistence` supplies the second null. The test runs on the
+non-overlapping subsample at stride `overlap_periods`, so the `h = 5`
+rows test roughly `T / 5` observations. 300 replications per cell, seed
+`20260830 + rep`, Monte-Carlo standard error ~1.3pp.
+
+| T | h | φ = 0 | φ = 0.9 |
+|---|---|---|---|
+| 60 | 1 | 0.040 | 0.030 |
+| 60 | 5 | 0.017 | 0.047 |
+| 120 | 1 | 0.043 | 0.050 |
+| 120 | 5 | 0.033 | 0.053 |
+| 240 | 1 | 0.017 | 0.047 |
+| 240 | 5 | 0.033 | 0.047 |
+
+Calibrated-to-conservative throughout (1.7–5.3%), and unlike the
+per-period mean paths in §1 the persistent factor moves nothing outside
+the iid band: factor persistence carries into the *level* of the
+per-period IC, not into a drift in it, and the Hamed-Rao variance
+correction absorbs the serial dependence the IC series does carry. Two
+things the table does not license. It is measured with the ADF gate at
+its default `adf_threshold=0.10`, on a null that is trend-free but also
+stationary — a unit-root input is the regime the gate exists for
+(`PERSISTENT_REGRESSOR`), and no size here speaks to it. And it is a
+*size* table only: the Theil-Sen slope's robustness is what recommends it
+over OLS, not a power advantage, and nothing above measures power. A
+reduced-replication re-run guards the numbers in
+`tests/stats/test_ic_trend_size.py`.
 
 ### Which path to read: a routing guide from the size measurements
 

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -208,7 +208,10 @@ def common_beta(
         $h > 1$ understates the overlap-inflated noise, so $\hat\tau^2$ is
         over-stated and the SE errs conservative there. On an unbalanced
         panel the equal-weight slope (``ew_portfolio_beta``) can differ from
-        the mean of the per-asset slopes; both are reported.
+        the mean of the per-asset slopes; both are reported. On a
+        COMMON-scope panel null the test measures 2.0-7.3% across
+        $T \in \{60, 120, 240\}$ and $h \in \{1, 5\}$
+        (``statistical-methods`` section 6).
 
     References:
         [Black-Jensen-Scholes 1972][black-jensen-scholes-1972]:

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -137,7 +137,9 @@ def ic_trend(
         which the trend null is rejected at inflated rates regardless of
         the true trend, and now carries
         ``WarningCode.PERSISTENT_REGRESSOR`` rather than sitting in
-        metadata alone.
+        metadata alone. On a trend-free IC series the Mann-Kendall p
+        measures 1.7-5.3% at a nominal 5% over ``T`` in 60/120/240 and
+        ``h`` in 1/5 (``statistical-methods`` section 6).
 
         **Two corrections for serial dependence.** Striding does ~99% of
         the work; Hamed-Rao handles the residual persistence that

--- a/tests/stats/test_common_beta_size.py
+++ b/tests/stats/test_common_beta_size.py
@@ -1,0 +1,108 @@
+"""Null size of ``common_beta``'s calendar-time-SE cross-asset t.
+
+The null is COMMON-scope, matching the metric's cell: one AR(phi) factor
+series broadcast to every asset, drawn from an RNG stream independent of
+the ``make_cs_panel(ic_target=0.0)`` prices, so every true per-asset beta
+is zero while the assets still share the cross-sectional return
+correlation the panel generates. Measured over 300 replications per cell
+at seed 20260830 + rep (factor stream 20260830 + 10000 + rep), 50 assets,
+at a nominal 5%:
+
+| T | h | phi = 0 | phi = 0.9 |
+|---|---|---|---|
+| 60 | 1 | 6.7% | 5.7% |
+| 60 | 5 | 7.3% | 3.3% |
+| 120 | 1 | 6.0% | 6.7% |
+| 120 | 5 | 6.7% | 2.7% |
+| 240 | 1 | 5.3% | 4.7% |
+| 240 | 5 | 5.3% | 2.0% |
+
+Calibrated across the grid (2.0-7.3%), with the worst cells at the short
+end where the Newey-West variance of the equal-weight portfolio slope is
+estimated from fewest periods. The persistent factor is the *conservative*
+direction at ``h = 5`` (3.3 / 2.7 / 2.0% against 7.3 / 6.7 / 5.3%): a
+phi = 0.9 regressor read through an overlapping forward return leaves more
+serial dependence for the Newey-West kernel behind ``V_EW`` to pick up, so
+the SE widens where the iid cross-asset t would not have.
+
+Replication count here is cut to keep the module fast, so the bounds
+characterise rather than pin.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.datasets import make_cs_panel
+from factrix.metrics._primitives import compute_common_betas
+from factrix.metrics.common_beta import common_beta
+from factrix.preprocess import compute_forward_return
+
+SEED = 20260830
+FACTOR_SEED_OFFSET = 10_000
+N_REPS = 60
+N_ASSETS = 50
+
+
+def _common_scope_panel(
+    n_periods: int, horizon: int, persistence: float, rep: int
+) -> pl.DataFrame:
+    """One AR(phi) factor shared by every asset, independent of the returns."""
+    raw = make_cs_panel(
+        n_assets=N_ASSETS,
+        n_dates=n_periods + horizon + 1,
+        ic_target=0.0,
+        rng=SEED + rep,
+    )
+    dates = raw["date"].unique().sort()
+    rng = np.random.default_rng(SEED + FACTOR_SEED_OFFSET + rep)
+    innovations = rng.standard_normal(len(dates))
+    factor = np.empty(len(dates))
+    factor[0] = innovations[0]
+    scale = np.sqrt(1 - persistence**2)
+    for i in range(1, len(dates)):
+        factor[i] = persistence * factor[i - 1] + scale * innovations[i]
+    common = pl.DataFrame({"date": dates, "_common_factor": factor})
+    panel = (
+        raw.drop("factor")
+        .join(common, on="date", how="inner")
+        .rename({"_common_factor": "factor"})
+    )
+    return compute_forward_return(panel, forward_periods=horizon)
+
+
+def _rejection_rate(n_periods: int, horizon: int, persistence: float) -> float:
+    rejected = kept = calendar = 0
+    for rep in range(N_REPS):
+        panel = _common_scope_panel(n_periods, horizon, persistence, rep)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            betas = compute_common_betas(panel, overlap_periods=horizon)["factor"]
+            out = common_beta(betas)
+        if out.p_value is None:
+            continue
+        kept += 1
+        rejected += out.p_value < 0.05
+        calendar += bool(out.metadata.get("calendar_time_se_applied"))
+    assert kept, "every replication short-circuited; the null grid is wrong"
+    # The calendar-time SE is load-bearing for the size above, so pin that it
+    # ran rather than the iid fallback.
+    assert calendar == kept
+    return rejected / kept
+
+
+@pytest.mark.parametrize("persistence", [0.0, 0.9])
+@pytest.mark.parametrize(
+    ("n_periods", "horizon"),
+    [(60, 1), (60, 5), (120, 1), (120, 5), (240, 1), (240, 5)],
+)
+def test_calendar_time_se_is_calibrated_on_a_common_scope_null(
+    n_periods, horizon, persistence
+):
+    # Upper bound only: at the reduced replication count a conservative cell
+    # (2.0% at the full 300 reps) legitimately returns 0/60, so a floor here
+    # would pin sampling noise rather than the path.
+    assert _rejection_rate(n_periods, horizon, persistence) <= 0.12

--- a/tests/stats/test_ic_trend_size.py
+++ b/tests/stats/test_ic_trend_size.py
@@ -1,0 +1,79 @@
+"""Null size of ``ic_trend``'s Mann-Kendall (Hamed-Rao) trend test.
+
+The series is the per-period Spearman IC of
+``make_cs_panel(ic_target=0.0)`` through ``compute_ic``, so the IC has no
+time trend to find; ``factor_persistence`` supplies the second null. The
+test runs on the non-overlapping subsample at stride ``overlap_periods``.
+Measured over 300 replications per cell at seed 20260830 + rep, at a
+nominal 5%:
+
+| T | h | phi = 0 | phi = 0.9 |
+|---|---|---|---|
+| 60 | 1 | 4.0% | 3.0% |
+| 60 | 5 | 1.7% | 4.7% |
+| 120 | 1 | 4.3% | 5.0% |
+| 120 | 5 | 3.3% | 5.3% |
+| 240 | 1 | 1.7% | 4.7% |
+| 240 | 5 | 3.3% | 4.7% |
+
+Calibrated-to-conservative throughout (1.7-5.3%), and the persistent
+factor moves nothing outside the iid band: factor persistence carries
+into the *level* of the per-period IC, not into a drift in it, and the
+Hamed-Rao variance correction absorbs what serial dependence the IC
+series does carry.
+
+Replication count here is cut to keep the module fast, so the bounds
+characterise rather than pin.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import polars as pl
+import pytest
+from factrix.datasets import make_cs_panel
+from factrix.metrics.ic import compute_ic
+from factrix.metrics.trend import ic_trend
+from factrix.preprocess import compute_forward_return
+
+SEED = 20260830
+N_REPS = 60
+N_ASSETS = 50
+
+
+def _rejection_rate(n_periods: int, horizon: int, persistence: float) -> float:
+    rejected = kept = 0
+    for rep in range(N_REPS):
+        raw = make_cs_panel(
+            n_assets=N_ASSETS,
+            n_dates=n_periods + horizon + 1,
+            ic_target=0.0,
+            factor_persistence=persistence,
+            rng=SEED + rep,
+        )
+        panel = compute_forward_return(raw, forward_periods=horizon)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            series = compute_ic(panel)["factor"].select(
+                "date", pl.col("ic").alias("value")
+            )
+            out = ic_trend(series, overlap_periods=horizon)
+        if out.p_value is None:
+            continue
+        kept += 1
+        rejected += out.p_value < 0.05
+    assert kept, "every replication short-circuited; the null grid is wrong"
+    return rejected / kept
+
+
+@pytest.mark.parametrize("persistence", [0.0, 0.9])
+@pytest.mark.parametrize(
+    ("n_periods", "horizon"),
+    [(60, 1), (60, 5), (120, 1), (120, 5), (240, 1), (240, 5)],
+)
+def test_mann_kendall_is_calibrated_on_a_true_null(n_periods, horizon, persistence):
+    # Upper bound only: at the reduced replication count a conservative cell
+    # (1.7% at the full 300 reps) legitimately returns 0/60, so a floor here
+    # would pin sampling noise rather than the path.
+    assert _rejection_rate(n_periods, horizon, persistence) <= 0.12


### PR DESCRIPTION
> **TL;DR** — §6 覆蓋守衛抓到的兩條無表路徑補齊：`common_beta`（COMMON-scope null，φ=0 / 0.9，2.0–7.3%）與 `ic_trend`（`make_cs_panel(ic_target=0, factor_persistence=φ)` IC 序列，1.7–5.3%），各 300 reps/格、seed 20260830+rep，附 60-rep guard 測試；§6 的「not yet measured」句移除。純文件與測試。

Closes #946

## 審核紀錄（實作者 opus，審核者本 session）
全格未超過 10%，依 brief 建表而非撤回；`calendar_time_se_applied` 在每次 draw 皆為真（測試鎖定）。與 main 無衝突。實作者指出 §6 的 `common_*`「measured, withheld」段落可能已被 #943 超越 → 併入 #927 的文件收尾。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3631 passed, 42 skipped**（pytest rc=0；+24）。