### PR TITLE
fix(evaluate)!: emit pre-flight warnings and frame every warning through one formatter

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -73,7 +73,70 @@ This output lets you verify that shared upstream producers (like `compute_ic`) a
 
 ---
 
-## 3. Rich Notebook Formatting (`_repr_html_`)
+## 4. Warnings: one channel, one shape
+
+A `WarningCode` reaches you twice, and both halves come from the same call.
+
+* **The record** — the code lands on `MetricResult.warning_codes` and, at
+  result assembly, on `EvaluationResult.warnings` as a `Warning`
+  (`code` / `source` / `message` / `expected`). `result.unexpected_warnings`
+  is the alert view. The record is kept whatever you declare.
+* **The echo** — a `UserWarning` on stderr, so the advisory shows up in a
+  notebook or a script run without anyone inspecting the result object.
+
+The two used to disagree: several codes were recorded and never echoed, so a
+thin sample was visible only to a reader who went looking. Every code now goes
+through one emitter, so if it is on the result it was on stderr — unless you
+declared it.
+
+### Message anatomy
+
+Every echo has the same three parts:
+
+```text
+<label>: <message> (<code>; declare it in expected_warnings=)
+```
+
+* `<label>` — the metric or function that raised it (`ic`, `bmp_z`,
+  `compute_forward_return`). This is what you act on.
+* `<message>` — the body, carrying the numbers that tripped the threshold.
+* `<code>` — the [`WarningCode`](../reference/warning-codes.md) value, and the
+  one declaration that silences it.
+
+For example, an 8-asset panel over 90 periods run through
+`quantile_spread(n_groups=3)` prints three of them:
+
+```text
+compute_spread_series: Median 2 assets per group (n_assets=8, n_groups=3). ... (thin_quantile_groups; declare it in expected_warnings=)
+quantile_spread: the inference member tested 17 periods, below the WARN floor of 30; ... (unreliable_se_short_periods; declare it in expected_warnings=)
+quantile_spread: the median cross-section holds 8 assets, below MIN_ASSETS_WARN=30; ... (few_assets; declare it in expected_warnings=)
+```
+
+### Declaring a regime
+
+`evaluate(..., expected_warnings=("few_assets",))` — and the same keyword on
+every metric — marks a code as the study's design. Marked, never dropped: the
+`Warning` record stays on the result with `expected=True`, and only the echo
+stops.
+
+```python
+from factrix.metrics import quantile_spread
+
+results = fx.evaluate(
+    data,
+    metrics={"quantile_spread": quantile_spread(n_groups=3)},
+    factor_cols=["factor"],
+    expected_warnings=("few_assets", "unreliable_se_short_periods"),
+)
+```
+
+Codes attached alongside a NaN short-circuit (`metric_unavailable`,
+`upstream_unavailable`) are records only: the metric did not run, the reason
+is in `MetricResult.metadata["reason"]`, and the result's repr carries it.
+
+---
+
+## 5. Rich Notebook Formatting (`_repr_html_`)
 
 For interactive analysis in Jupyter notebooks, `factrix` implements native HTML representations (`_repr_html_`) on key return types. When you print these objects as the final statement in a cell, they render as formatted tables.
 

--- a/factrix/_codes.py
+++ b/factrix/_codes.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings as _warnings
 from enum import StrEnum
 
 from factrix._errors import UserInputError
@@ -318,6 +319,62 @@ class WarningCode(StrEnum):
     @property
     def description(self) -> str:
         return _WARNING_DESCRIPTIONS[self]
+
+
+#: Trailing half of every warning frame: the code token plus the one action
+#: that silences it. Kept as a constant so the docs and the tests that lock
+#: the anatomy read the same string the emitter writes.
+_DECLARE_HINT = "declare it in expected_warnings="
+
+
+def _format_warning(code: WarningCode, message: str, *, label: str) -> str:
+    """Frame one warning body as ``<label>: <message> (<code>; declare ...)``.
+
+    ``label`` is the metric / function the reader has to act on, ``message``
+    the body with its numbers, and the parenthetical names the
+    :class:`WarningCode` to put in ``expected_warnings=``. Every warning the
+    library echoes for a code has this anatomy, so a reader never has to guess
+    which declaration would silence what they are looking at.
+    """
+    return f"{label}: {message} ({code.value}; {_DECLARE_HINT})"
+
+
+def _emit_warning(
+    code: WarningCode,
+    message: str,
+    *,
+    label: str,
+    expected_warnings: tuple[str, ...] = (),
+    warning_codes: list[str] | None = None,
+    stacklevel: int = 3,
+) -> str:
+    """Single emit chokepoint for every :class:`WarningCode` advisory.
+
+    Records then echoes, in that order — marked, never dropped:
+
+    * ``warning_codes``, when given, gains ``code.value`` (once) whatever the
+      caller declared. The structured record is the audit trail and a
+      declaration never removes it.
+    * The ``UserWarning`` echo, framed by :func:`_format_warning`, fires only
+      when the code is absent from ``expected_warnings``.
+
+    Returns ``code.value`` so a caller that keeps its own list can append the
+    return value instead of passing ``warning_codes``.
+
+    This is the only place in the library that calls ``warnings.warn`` for a
+    ``WarningCode``; ``tests/test_warning_formatter.py`` locks that with an AST
+    guard. ``stacklevel`` is counted from the caller of this function.
+    """
+    value = code.value
+    if warning_codes is not None and value not in warning_codes:
+        warning_codes.append(value)
+    if value not in expected_warnings:
+        _warnings.warn(
+            _format_warning(code, message, label=label),
+            UserWarning,
+            stacklevel=stacklevel + 1,
+        )
+    return value
 
 
 def _validate_expected_warnings_arg(

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -23,14 +23,13 @@ factors".
 from __future__ import annotations
 
 import math
-import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, get_args
 
 import numpy as np
 import polars as pl
 
-from factrix._codes import WarningCode, cross_section_tier
+from factrix._codes import WarningCode, _emit_warning, cross_section_tier
 from factrix._errors import IncompatibleInferenceError
 
 if TYPE_CHECKING:
@@ -148,6 +147,85 @@ def _surface_inference_run_metadata(
             metadata[key] = result.metadata[key]
 
 
+#: One-line echo body per :class:`WarningCode` an inference member can raise on
+#: the series it tested. The member records the code on its
+#: :class:`~factrix.inference.InferenceResult`; this names, in one line, what
+#: the reader is being told. ``{n}`` is the sample the member actually tested.
+#: Anything unmapped falls back to the code's own ``description``.
+_INFERENCE_CODE_MESSAGE: dict[WarningCode, str] = {
+    WarningCode.UNRELIABLE_SE_SHORT_PERIODS: (
+        "the inference member tested {n} periods, below the WARN floor of "
+        "{warn}; the HAC standard error on a series this short is biased. The "
+        "statistic is returned but read p-values cautiously."
+    ),
+    WarningCode.SERIAL_CORRELATION_DETECTED: (
+        "the tested per-period series is persistent beyond the overlap "
+        "horizon (lag-1 autocorrelation above {autocorr} on the strided "
+        "series, {n} periods). No HAC or bootstrap path is calibrated there — "
+        "read the p-value against a raised hurdle or lengthen the sample."
+    ),
+    WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED: (
+        "the resolved Bartlett bandwidth exceeds n_periods / 5 on the {n} "
+        "tested periods, so the long-run variance rests on too few lag "
+        "products to be stable. Read the p-value as indicative only."
+    ),
+    WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE: (
+        "the rectangular-kernel HAC variance-of-mean came out negative on the "
+        "{n} tested periods and was clamped to 0, so there is no SE to divide "
+        "by and the test is withheld."
+    ),
+    WarningCode.DEGENERATE_VARIANCE: (
+        "the {n} tested periods admit no test statistic (zero dispersion, or "
+        "an SE that collapsed to zero). The value is returned; stat and "
+        "p_value are withheld."
+    ),
+}
+
+
+def _emit_inference_warnings(
+    res: InferenceResult,
+    *,
+    label: str,
+    warning_codes: list[str],
+    expected_warnings: tuple[str, ...] = (),
+    stacklevel: int = 4,
+) -> None:
+    """Record **and echo** the codes an inference member raised on its series.
+
+    The member returns them as a ``frozenset[WarningCode]`` on its
+    :class:`~factrix.inference.InferenceResult`; before this existed every
+    consumer folded them into ``warning_codes`` and nothing ever reached
+    stderr, so a short or degenerate sample was visible only to a reader who
+    went looking at the result object. Routing them through
+    :func:`~factrix._codes._emit_warning` puts them on the one channel every
+    other advisory uses, under the same frame, and keeps the structured record
+    unchanged.
+    """
+    from factrix._stats.constants import (
+        MIN_PERIODS_WARN,
+        PERSISTENT_SERIES_AUTOCORR,
+    )
+
+    n = res.n_obs if res.n_obs is not None else 0
+    for code in sorted(res.warnings, key=lambda c: c.value):
+        template = _INFERENCE_CODE_MESSAGE.get(code)
+        message = (
+            template.format(
+                n=n, warn=MIN_PERIODS_WARN, autocorr=PERSISTENT_SERIES_AUTOCORR
+            )
+            if template is not None
+            else code.description
+        )
+        _emit_warning(
+            code,
+            message,
+            label=label,
+            expected_warnings=expected_warnings,
+            warning_codes=warning_codes,
+            stacklevel=stacklevel,
+        )
+
+
 def _spread_significance_with_inference(
     inference: NonOverlapping | NeweyWest | StationaryBootstrap,
     *,
@@ -155,6 +233,8 @@ def _spread_significance_with_inference(
     full_spread: pl.DataFrame | None,
     overlap_periods: int,
     n_assets: int,
+    metric_name: str,
+    expected_warnings: tuple[str, ...] = (),
 ) -> tuple[float, float, float, str, str, dict[str, object], tuple[str, ...]]:
     """Single headline-significance chokepoint shared by every spread metric.
 
@@ -207,6 +287,7 @@ def _spread_significance_with_inference(
     missing one where the member needed it degrades to the strided
     non-overlap path defensively and is flagged ``inference_overridden``.
     """
+    from factrix._stats.constants import MIN_ASSETS_WARN
     from factrix.inference import NON_OVERLAPPING
 
     use_full = inference.consumes_full_series and full_spread is not None
@@ -241,10 +322,27 @@ def _spread_significance_with_inference(
     # full overlapping series on one path, the strided series on the other.
     extra["n_periods_tested"] = n_tested
 
-    codes = tuple(code.value for code in res.warnings)
+    code_list: list[str] = []
+    _emit_inference_warnings(
+        res,
+        label=metric_name,
+        warning_codes=code_list,
+        expected_warnings=expected_warnings,
+    )
     tier: WarningCode | None = cross_section_tier(n_assets)
-    if tier is not None and tier.value not in codes:
-        codes = (*codes, tier.value)
+    if tier is not None:
+        _emit_warning(
+            tier,
+            f"the median cross-section holds {n_assets} assets, below "
+            f"MIN_ASSETS_WARN={MIN_ASSETS_WARN}; each bucket mean rests on a "
+            f"handful of names, so the spread is a noisier estimate (not a "
+            f"differently distributed one).",
+            label=metric_name,
+            expected_warnings=expected_warnings,
+            warning_codes=code_list,
+            stacklevel=3,
+        )
+    codes = tuple(code_list)
     # ``method`` / ``stat_type`` describe the member that actually ran, not
     # the one that was asked for: an ``inference_overridden`` degradation runs
     # the non-overlap t and must say so, and a member whose ``stat`` is not a
@@ -653,6 +751,7 @@ def _warn_below_floor(
     message: str,
     code: WarningCode,
     *,
+    label: str,
     axis: str = "periods",
     expected_warnings: tuple[str, ...] = (),
 ) -> str | None:
@@ -662,8 +761,8 @@ def _warn_below_floor(
     ``min`` floor (a result is still returned) but sits below ``warn``, so the
     metric runs with a documented bias. Reads ``warn_<axis>`` via an
     ``Any``-typed ``metric`` (no per-call ``# type: ignore[attr-defined]``);
-    when the floor is breached it emits ``message`` as a ``UserWarning`` and
-    returns ``code.value`` for the caller to fold into the result's
+    when the floor is breached it emits ``message`` through
+    :func:`~factrix._codes._emit_warning` under ``label`` and returns ``code.value`` for the caller to fold into the result's
     ``warning_codes``. Returns ``None`` when the warn floor is clear or ungated.
 
     Like :func:`_enforce_min_floor`, reads the default-config ``sample_threshold``
@@ -676,9 +775,13 @@ def _warn_below_floor(
     """
     warn = getattr(metric.sample_threshold, f"warn_{axis}")
     if warn is not None and n < warn:
-        if code.value not in expected_warnings:
-            warnings.warn(message, UserWarning, stacklevel=3)
-        return code.value
+        return _emit_warning(
+            code,
+            message,
+            label=label,
+            expected_warnings=expected_warnings,
+            stacklevel=3,
+        )
     return None
 
 
@@ -689,6 +792,7 @@ def _warn_below_scaled_floor(
     message: str,
     code: WarningCode,
     *,
+    label: str,
     expected_warnings: tuple[str, ...] = (),
 ) -> str | None:
     """Warn-tier twin of :func:`_enforce_scaled_floor`.
@@ -707,9 +811,13 @@ def _warn_below_scaled_floor(
     """
     warn = _scaled_min_periods(base_warn, overlap_periods)
     if n_raw < warn:
-        if code.value not in expected_warnings:
-            warnings.warn(message, UserWarning, stacklevel=3)
-        return code.value
+        return _emit_warning(
+            code,
+            message,
+            label=label,
+            expected_warnings=expected_warnings,
+            stacklevel=3,
+        )
     return None
 
 
@@ -910,20 +1018,19 @@ def _deflate_for_within_date_clustering(
     metadata["kolari_pynnonen_applied"] = True
     metadata["kolari_pynnonen_scaling"] = scale
     metadata["stat_uncorrected"] = stat
-    code = WarningCode.EVENT_CLUSTERING_ADJUSTED.value
-    if code not in expected_warnings:
-        warnings.warn(
-            f"{metric_name}: events share periods (mean {n_eff:.1f} per event "
-            f"period, within-period correlation of the per-event score "
-            f"r={r_hat:.3f}), so they are not independent draws. The statistic "
-            f"is deflated by the Kish design effect ({scale:.3f}) before the "
-            f"p-value; the point estimate is unchanged. Uncorrected statistic "
-            f"in metadata['stat_uncorrected'].",
-            UserWarning,
-            stacklevel=3,
-        )
-    if code not in warning_codes:
-        warning_codes.append(code)
+    _emit_warning(
+        WarningCode.EVENT_CLUSTERING_ADJUSTED,
+        f"events share periods (mean {n_eff:.1f} per event "
+        f"period, within-period correlation of the per-event score "
+        f"r={r_hat:.3f}), so they are not independent draws. The statistic "
+        f"is deflated by the Kish design effect ({scale:.3f}) before the "
+        f"p-value; the point estimate is unchanged. Uncorrected statistic "
+        f"in metadata['stat_uncorrected'].",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        warning_codes=warning_codes,
+        stacklevel=3,
+    )
     return stat * scale
 
 
@@ -1000,13 +1107,15 @@ def _densify_on_period_grid(
     return dense, True
 
 
-def _ragged_event_grid_message(metric_name: str, frame: pl.DataFrame) -> str | None:
+def _ragged_event_grid_message(frame: pl.DataFrame) -> str | None:
     """The ``RAGGED_PERIOD_GRID`` echo text for a ragged panel, else ``None``.
 
     Single owner of the wording, split out from the recorder because the
     ``caar`` pipeline sees the panel in ``compute_caar`` and the warning codes
     one node later in :func:`~factrix.metrics.caar.caar`; the message rides
-    between them as a broadcast column.
+    between them as a broadcast column. Returns the message **body** only —
+    the metric label and the code token are added by
+    :func:`~factrix._codes._emit_warning` at the recording end.
     """
     if "asset_id" not in frame.columns or "date" not in frame.columns:
         return None
@@ -1016,7 +1125,7 @@ def _ragged_event_grid_message(metric_name: str, frame: pl.DataFrame) -> str | N
     if not n_ragged:
         return None
     return (
-        f"{metric_name}: {WarningCode.RAGGED_PERIOD_GRID.value} — {n_ragged} of "
+        f"{n_ragged} of "
         f"{per_asset.height} assets are missing periods that others have "
         f"(panel grid: {n_periods} periods). Estimation windows, lags and "
         "event offsets are counted on the panel's period grid, so those "
@@ -1032,6 +1141,7 @@ def _record_ragged_event_grid(
     message: str | None,
     warning_codes: list[str],
     *,
+    label: str,
     expected_warnings: tuple[str, ...] = (),
 ) -> None:
     """Record ``RAGGED_PERIOD_GRID`` on ``warning_codes`` and echo ``message``.
@@ -1043,11 +1153,14 @@ def _record_ragged_event_grid(
     """
     if message is None:
         return
-    code = WarningCode.RAGGED_PERIOD_GRID.value
-    if code not in expected_warnings:
-        warnings.warn(message, UserWarning, stacklevel=3)
-    if code not in warning_codes:
-        warning_codes.append(code)
+    _emit_warning(
+        WarningCode.RAGGED_PERIOD_GRID,
+        message,
+        label=label,
+        expected_warnings=expected_warnings,
+        warning_codes=warning_codes,
+        stacklevel=3,
+    )
 
 
 def _warn_ragged_event_grid(
@@ -1065,8 +1178,9 @@ def _warn_ragged_event_grid(
     smaller sample than a caller comparing names would assume.
     """
     _record_ragged_event_grid(
-        _ragged_event_grid_message(metric_name, frame),
+        _ragged_event_grid_message(frame),
         warning_codes,
+        label=metric_name,
         expected_warnings=expected_warnings,
     )
 
@@ -1364,24 +1478,23 @@ def _warn_estimation_window_contamination(
     share = metadata.get("estimation_window_event_share")
     if share is None or share <= ESTIMATION_WINDOW_EVENT_SHARE_WARN:
         return
-    code = WarningCode.ESTIMATION_WINDOW_CONTAMINATED.value
-    if code not in expected_warnings:
-        warnings.warn(
-            f"{metric_name}: on average {share:.0%} of each tested event's "
-            f"estimation-window periods lie inside another event's "
-            f"forward-return window on the same asset (advisory floor "
-            f"{ESTIMATION_WINDOW_EVENT_SHARE_WARN:.0%}). The mean-adjusted "
-            f"abnormal return then subtracts neighbouring events' realised "
-            f"returns rather than the unconditional mean, the per-event "
-            f"abnormal returns are negatively correlated, and the test is "
-            f"conservative. Supply an 'abnormal_return' column "
-            f"(compute_abnormal_return) when the event universe is a small "
-            f"share of the panel, or read the p-value as an upper bound.",
-            UserWarning,
-            stacklevel=3,
-        )
-    if code not in warning_codes:
-        warning_codes.append(code)
+    _emit_warning(
+        WarningCode.ESTIMATION_WINDOW_CONTAMINATED,
+        f"on average {share:.0%} of each tested event's "
+        f"estimation-window periods lie inside another event's "
+        f"forward-return window on the same asset (advisory floor "
+        f"{ESTIMATION_WINDOW_EVENT_SHARE_WARN:.0%}). The mean-adjusted "
+        f"abnormal return then subtracts neighbouring events' realised "
+        f"returns rather than the unconditional mean, the per-event "
+        f"abnormal returns are negatively correlated, and the test is "
+        f"conservative. Supply an 'abnormal_return' column "
+        f"(compute_abnormal_return) when the event universe is a small "
+        f"share of the panel, or read the p-value as an upper bound.",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        warning_codes=warning_codes,
+        stacklevel=3,
+    )
 
 
 def _stride_dates(
@@ -1614,20 +1727,19 @@ def _warn_event_window_overlap(
     metadata["n_events_sampled"] = n_sampled
     if dropped <= 0:
         return
-    code = WarningCode.EVENT_WINDOW_OVERLAP.value
-    if code not in expected_warnings:
-        warnings.warn(
-            f"{metric_name}: {dropped} of {n_events} events sat within "
-            f"overlap_periods={overlap_periods} of the previously kept event on "
-            f"the same asset, so their forward-return windows overlapped. The "
-            f"test runs on the {n_sampled} non-overlapping events that survive "
-            f"the spacing pass; overlapping events are not independent draws "
-            f"and pooling them inflates the statistic.",
-            UserWarning,
-            stacklevel=3,
-        )
-    if code not in warning_codes:
-        warning_codes.append(code)
+    _emit_warning(
+        WarningCode.EVENT_WINDOW_OVERLAP,
+        f"{dropped} of {n_events} events sat within "
+        f"overlap_periods={overlap_periods} of the previously kept event on "
+        f"the same asset, so their forward-return windows overlapped. The "
+        f"test runs on the {n_sampled} non-overlapping events that survive "
+        f"the spacing pass; overlapping events are not independent draws "
+        f"and pooling them inflates the statistic.",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        warning_codes=warning_codes,
+        stacklevel=3,
+    )
 
 
 def _event_sample_threshold(self: MetricBase) -> SampleThreshold:
@@ -2000,16 +2112,17 @@ def _warn_high_tie_ratio(
         return False
     if tie_policy != "ordinal":
         return False
-    if WarningCode.HIGH_TIE_RATIO.value not in expected_warnings:
-        warnings.warn(
-            f"{metric_name}: median tie_ratio={ratio:.3f} exceeds "
-            f"{TIE_RATIO_WARN_THRESHOLD:.2f}. Ordinal tie-breaking on a "
-            f"low-cardinality factor injects sorting-artifact noise. "
-            f"Consider tie_policy='average' on the Config, or a coarser "
-            f"n_groups.",
-            UserWarning,
-            stacklevel=3,
-        )
+    _emit_warning(
+        WarningCode.HIGH_TIE_RATIO,
+        f"median tie_ratio={ratio:.3f} exceeds "
+        f"{TIE_RATIO_WARN_THRESHOLD:.2f}. Ordinal tie-breaking on a "
+        f"low-cardinality factor injects sorting-artifact noise. "
+        f"Consider tie_policy='average' on the Config, or a coarser "
+        f"n_groups.",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        stacklevel=3,
+    )
     return True
 
 
@@ -2145,18 +2258,16 @@ def _warn_if_high_drop_rate(
     drop_rate = float(stats["drop_rate"])
     if drop_rate <= DROP_RATE_WARN_THRESHOLD:
         return None
-    code = _DROP_CODE_BY_AXIS[axis].value
-    if code in expected_warnings:
-        return code
-    warnings.warn(
-        f"{metric_name}: {drop_rate:.0%} of {axis} dropped "
+    return _emit_warning(
+        _DROP_CODE_BY_AXIS[axis],
+        f"{drop_rate:.0%} of {axis} dropped "
         f"({stats[f'dropped_{axis}']}/{stats[f'n_{axis}_in']}) — "
         f"{stats['drop_reason']}. The metric was computed on the surviving "
         f"{stats[f'n_{axis}_out']} {axis}; read it against that shortened sample.",
-        UserWarning,
+        label=metric_name,
+        expected_warnings=expected_warnings,
         stacklevel=3,
     )
-    return code
 
 
 def _surface_drop_stats(
@@ -2322,6 +2433,7 @@ def _warn_thin_quantile_groups(
     sampled: pl.DataFrame,
     n_groups: int,
     *,
+    metric_name: str,
     stacklevel: int = 3,
     expected_warnings: tuple[str, ...] = (),
 ) -> bool:
@@ -2355,14 +2467,15 @@ def _warn_thin_quantile_groups(
             "This is already the coarsest long-short split; treat the "
             "spread as a fragile small-cross-section diagnostic."
         )
-    if WarningCode.THIN_QUANTILE_GROUPS.value not in expected_warnings:
-        warnings.warn(
-            f"Median {per_group} assets per group (n_assets={median_n}, "
-            f"n_groups={n_groups}). Spread may be dominated by "
-            f"individual assets. {guidance}",
-            UserWarning,
-            stacklevel=stacklevel,
-        )
+    _emit_warning(
+        WarningCode.THIN_QUANTILE_GROUPS,
+        f"Median {per_group} assets per group (n_assets={median_n}, "
+        f"n_groups={n_groups}). Bucket statistics may be dominated by "
+        f"individual assets. {guidance}",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        stacklevel=stacklevel,
+    )
     return True
 
 

--- a/factrix/metrics/_primitives/_caar.py
+++ b/factrix/metrics/_primitives/_caar.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 import polars as pl
 
 from factrix._axis import (
@@ -12,7 +10,7 @@ from factrix._axis import (
     OutputShape,
     SpecRole,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import cell
 from factrix._types import DEFAULT_FORWARD_PERIODS
 from factrix.metrics._decorators import metric
@@ -101,17 +99,16 @@ def compute_caar(
         ``_signed_car`` NaN.
     """
     sparse_magnitude_weighted = _is_sparse_magnitude_weighted(data, factor_col)
-    if (
-        sparse_magnitude_weighted
-        and WarningCode.SPARSE_MAGNITUDE_WEIGHTED.value not in expected_warnings
-    ):
-        warnings.warn(
-            "compute_caar: factor column is mixed-sign and not a clean ±1 "
+    if sparse_magnitude_weighted:
+        _emit_warning(
+            WarningCode.SPARSE_MAGNITUDE_WEIGHTED,
+            "factor column is mixed-sign and not a clean ±1 "
             "ternary. The result is the Sefcik-Thompson (1986) "
             "magnitude-weighted CAAR, not the textbook MacKinlay (1997) "
             "signed CAAR; apply .sign() to the column before calling for "
             "sign-flip semantics.",
-            UserWarning,
+            label="compute_caar",
+            expected_warnings=expected_warnings,
             stacklevel=2,
         )
     # The expected return is estimated on the FULL panel (non-event rows are
@@ -145,16 +142,15 @@ def compute_caar(
     n_dropped = events.filter(~raw_finite).height
     n_dropped_no_window = events.filter(raw_finite & ~ar_finite).height
     events = events.filter(raw_finite & ar_finite)
-    if (
-        n_dropped > 0
-        and WarningCode.NON_FINITE_INPUT_DROPPED.value not in expected_warnings
-    ):
-        warnings.warn(
-            f"compute_caar: dropped {n_dropped} of {n_events_in} event rows with "
+    if n_dropped > 0:
+        _emit_warning(
+            WarningCode.NON_FINITE_INPUT_DROPPED,
+            f"dropped {n_dropped} of {n_events_in} event rows with "
             f"a non-finite '{return_col}' or '{factor_col}' before aggregating. "
             f"Each per-period caar is the mean over the surviving finite events; "
             f"the count is reported as the 'n_events_dropped_non_finite' column.",
-            UserWarning,
+            label="compute_caar",
+            expected_warnings=expected_warnings,
             stacklevel=2,
         )
 
@@ -183,7 +179,7 @@ def compute_caar(
             ).alias("estimation_window_event_share"),
             # Raggedness is a property of the panel, which only this node sees;
             # `caar` reads the note off the frame and records the code there.
-            pl.lit(_ragged_event_grid_message("caar", data), dtype=pl.String).alias(
+            pl.lit(_ragged_event_grid_message(data), dtype=pl.String).alias(
                 "ragged_period_grid_note"
             ),
         )

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -275,7 +275,7 @@ def compute_mfe_mae(
         # ``mfe_mae`` reads the note off the frame and records the code there.
         # Empty rather than null on a dense panel, so a caller's ``drop_nulls``
         # over the per-event table does not empty it.
-        pl.lit(
-            _ragged_event_grid_message("mfe_mae", data) or "", dtype=pl.String
-        ).alias("ragged_period_grid_note"),
+        pl.lit(_ragged_event_grid_message(data) or "", dtype=pl.String).alias(
+            "ragged_period_grid_note"
+        ),
     )

--- a/factrix/metrics/_primitives/_spread_series.py
+++ b/factrix/metrics/_primitives/_spread_series.py
@@ -126,7 +126,12 @@ def compute_spread_series(
 
     sampled = _sample_non_overlapping(data, overlap_periods)
 
-    _warn_thin_quantile_groups(sampled, n_groups, expected_warnings=expected_warnings)
+    _warn_thin_quantile_groups(
+        sampled,
+        n_groups,
+        metric_name="compute_spread_series",
+        expected_warnings=expected_warnings,
+    )
 
     # Neutralise non-finite returns at the producer boundary: polars ``mean``
     # propagates float NaN, so one NaN return would turn a whole bucket mean —

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -39,8 +39,6 @@ References:
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import polars as pl
 
@@ -49,7 +47,7 @@ from factrix._axis import (
     FactorDensity,
     InputShape,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import (
@@ -321,7 +319,7 @@ def caar(
         n,
         MIN_EVENTS_WARN,
         overlap_periods,
-        f"caar: n_event_periods={n} below the floor of {raw_min_warn} "
+        f"n_event_periods={n} below the floor of {raw_min_warn} "
         f"(= MIN_EVENTS_WARN {MIN_EVENTS_WARN} x overlap_periods "
         f"{overlap_periods}). The t-test runs on the subsample left after "
         f"non-overlap sampling at stride h={overlap_periods}, which keeps "
@@ -331,6 +329,7 @@ def caar(
         f"across event *periods*, so this counts the number of periods with "
         f"an event, not events. t-stat returned but read p-values cautiously.",
         WarningCode.FEW_EVENTS,
+        label="caar",
         expected_warnings=expected_warnings,
     )
     if warn_code is not None:
@@ -409,6 +408,7 @@ def caar(
         _record_ragged_event_grid(
             caar_df["ragged_period_grid_note"][0],
             warning_codes,
+            label="caar",
             expected_warnings=expected_warnings,
         )
 
@@ -893,19 +893,19 @@ def bmp_z(
         "bmp_z", data, warning_codes, expected_warnings=expected_warnings
     )
     if not uses_price:
-        code = WarningCode.BMP_RETURN_VOL_FALLBACK.value
-        warning_codes.append(code)
-        if code not in expected_warnings:
-            warnings.warn(
-                f"bmp_z: no 'price' column; estimation-window volatility falls "
-                f"back to the per-asset rolling std of '{return_col}', lagged by "
-                f"overlap_periods={overlap_periods} so the window ends before "
-                f"each event's forward return. This is a coarser, "
-                f"horizon-overlapping vol proxy than a price-derived one-period "
-                f"std — supply 'price' for the clean BMP standardiser.",
-                UserWarning,
-                stacklevel=2,
-            )
+        _emit_warning(
+            WarningCode.BMP_RETURN_VOL_FALLBACK,
+            f"no 'price' column; estimation-window volatility falls "
+            f"back to the per-asset rolling std of '{return_col}', lagged by "
+            f"overlap_periods={overlap_periods} so the window ends before "
+            f"each event's forward return. This is a coarser, "
+            f"horizon-overlapping vol proxy than a price-derived one-period "
+            f"std — supply 'price' for the clean BMP standardiser.",
+            label="bmp_z",
+            expected_warnings=expected_warnings,
+            warning_codes=warning_codes,
+            stacklevel=2,
+        )
 
     if kolari_pynnonen_adjust:
         r_hat, n_eff, kp_source = _estimate_within_date_icc(
@@ -944,13 +944,14 @@ def bmp_z(
         n_valid_raw,
         MIN_EVENTS_WARN,
         overlap_periods,
-        f"bmp_z: n_events={n_valid_raw} below the floor of {raw_min_warn} "
+        f"n_events={n_valid_raw} below the floor of {raw_min_warn} "
         f"(= MIN_EVENTS_WARN {MIN_EVENTS_WARN} x overlap_periods "
         f"{overlap_periods}); {n_valid} events and {n_event_periods} event "
         f"periods survive non-overlap sampling at stride h={overlap_periods}, "
         f"which keeps up to one event in h per asset. z is returned but the "
         f"cross-sectional test is power-thin on a sample this short.",
         WarningCode.FEW_EVENTS,
+        label="bmp_z",
         expected_warnings=expected_warnings,
     )
     # (2) Events share periods, so the effective sample is closer to the
@@ -963,21 +964,21 @@ def bmp_z(
         and n_event_periods < n_valid
         and (n_event_periods < MIN_EVENTS_WARN)
     ):
-        warn_code = WarningCode.FEW_EVENTS.value
-        if warn_code not in expected_warnings:
-            warnings.warn(
-                f"bmp_z: n_event_periods={n_event_periods} below "
-                f"MIN_EVENTS_WARN={MIN_EVENTS_WARN} with n_events={n_valid}. "
-                f"Same-period events share a common shock, so the effective "
-                f"sample is closer to the number of distinct event periods than "
-                f"to the event count; the Kolari-Pynnönen adjustment removes the "
-                f"shared-shock inflation but not the small-sample residual "
-                f"(measured ~10% at 8 periods, ~14% at 4, ~7% at 15, clearing "
-                f"by ~30; nominal 5%). z is returned but read borderline p-values "
-                f"cautiously.",
-                UserWarning,
-                stacklevel=2,
-            )
+        warn_code = _emit_warning(
+            WarningCode.FEW_EVENTS,
+            f"n_event_periods={n_event_periods} below "
+            f"MIN_EVENTS_WARN={MIN_EVENTS_WARN} with n_events={n_valid}. "
+            f"Same-period events share a common shock, so the effective "
+            f"sample is closer to the number of distinct event periods than "
+            f"to the event count; the Kolari-Pynnönen adjustment removes the "
+            f"shared-shock inflation but not the small-sample residual "
+            f"(measured ~10% at 8 periods, ~14% at 4, ~7% at 15, clearing "
+            f"by ~30; nominal 5%). z is returned but read borderline p-values "
+            f"cautiously.",
+            label="bmp_z",
+            expected_warnings=expected_warnings,
+            stacklevel=2,
+        )
     if warn_code is not None:
         warning_codes.append(warn_code)
 

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -289,11 +289,12 @@ def common_beta(
     warn_code = _warn_below_floor(
         common_beta,
         n,
-        f"common_beta: n_assets={n} below MIN_ASSETS_WARN={MIN_ASSETS_WARN}; "
+        f"n_assets={n} below MIN_ASSETS_WARN={MIN_ASSETS_WARN}; "
         f"the cross-asset t-test on the mean per-asset beta runs on df={n - 1}, "
         f"so its critical value is well above the asymptotic one. mean(beta) is "
         f"returned but read borderline p-values cautiously.",
         WarningCode.FEW_ASSETS,
+        label="common_beta",
         axis="assets",
         expected_warnings=expected_warnings,
     )

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -17,8 +17,6 @@ Notes:
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
@@ -29,7 +27,7 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import (
@@ -226,15 +224,14 @@ def common_quantile_spread(
 
     per_bucket_periods = n_periods // n_groups
     thin_bucket_periods = per_bucket_periods < _MIN_BUCKET_PERIODS_WARN
-    if (
-        thin_bucket_periods
-        and WarningCode.THIN_QUANTILE_PERIODS.value not in expected_warnings
-    ):
-        warnings.warn(
-            f"common_quantile_spread: avg {per_bucket_periods} periods per "
+    if thin_bucket_periods:
+        _emit_warning(
+            WarningCode.THIN_QUANTILE_PERIODS,
+            f"avg {per_bucket_periods} periods per "
             f"bucket (T={n_periods}, n_groups={n_groups}). Each bucket mean "
             f"sits on a thin sample; consider reducing n_groups.",
-            UserWarning,
+            label="common_quantile_spread",
+            expected_warnings=expected_warnings,
             stacklevel=2,
         )
 

--- a/factrix/metrics/concentration.py
+++ b/factrix/metrics/concentration.py
@@ -15,8 +15,6 @@ Notes:
 
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import polars as pl
 
@@ -26,7 +24,7 @@ from factrix._axis import (
     FactorDensity,
     FactorScope,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import cell
 from factrix._results import MetricResult
 from factrix._types import (
@@ -313,8 +311,6 @@ def top_concentration(
         n_pos = int((finite_f > 0).sum())
         n_neg = int((finite_f < 0).sum())
         if finite_f.len() and (n_pos == 0 or n_neg == 0):
-            code = WarningCode.ONE_SIGNED_FACTOR.value
-            warning_codes.append(code)
             one_signed_meta = {
                 "n_positive_factor_values": n_pos,
                 "n_negative_factor_values": n_neg,
@@ -324,23 +320,25 @@ def top_concentration(
             # the counts made every call a distinct warning and a by_slice
             # sweep or multi-factor evaluate emitted one per call instead of
             # one per session.
-            if code not in expected_warnings:
-                warnings.warn(
-                    "top_concentration: weight_by='abs_factor' on a factor that "
-                    "never changes sign. |factor| is a density weight only when "
-                    "zero is the neutral point, and the HHI of |f| moves with an "
-                    "arbitrary level shift. Centre the factor (cross-sectional "
-                    "z-score) or use weight_by='alpha_contribution'. Counts are "
-                    "in metadata['n_positive_factor_values'] / "
-                    "['n_negative_factor_values'].",
-                    UserWarning,
-                    stacklevel=2,
-                )
+            _emit_warning(
+                WarningCode.ONE_SIGNED_FACTOR,
+                "weight_by='abs_factor' on a factor that "
+                "never changes sign. |factor| is a density weight only when "
+                "zero is the neutral point, and the HHI of |f| moves with an "
+                "arbitrary level shift. Centre the factor (cross-sectional "
+                "z-score) or use weight_by='alpha_contribution'. Counts are "
+                "in metadata['n_positive_factor_values'] / "
+                "['n_negative_factor_values'].",
+                label="top_concentration",
+                expected_warnings=expected_warnings,
+                warning_codes=warning_codes,
+                stacklevel=2,
+            )
     warn_code = _warn_below_scaled_floor(
         n_raw_periods,
         MIN_PORTFOLIO_PERIODS_WARN,
         overlap_periods,
-        f"top_concentration: {n_raw_periods} raw dates below "
+        f"{n_raw_periods} raw dates below "
         f"MIN_PORTFOLIO_PERIODS_WARN*overlap_periods="
         f"{MIN_PORTFOLIO_PERIODS_WARN * overlap_periods}; the mean effective "
         f"number of names is averaged over few periods and moves substantially "
@@ -348,6 +346,7 @@ def top_concentration(
         f"size), so read value and ratio_eff_to_total as a noisy estimate here "
         f"and lengthen the history before comparing panels.",
         WarningCode.BORDERLINE_PORTFOLIO_PERIODS,
+        label="top_concentration",
         expected_warnings=expected_warnings,
     )
     if warn_code is not None:

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -379,7 +379,7 @@ def corrado_rank(
         n_events,
         MIN_EVENTS_WARN,
         overlap_periods,
-        f"corrado_rank: n_events={n_events} below the floor of {raw_min_warn} "
+        f"n_events={n_events} below the floor of {raw_min_warn} "
         f"(= MIN_EVENTS_WARN {MIN_EVENTS_WARN} x overlap_periods "
         f"{overlap_periods}); {n_event_periods} event periods survive "
         f"non-overlap sampling at stride h={overlap_periods}, which keeps "
@@ -389,6 +389,7 @@ def corrado_rank(
         f"not add sample. z is returned but the normal approximation is "
         f"power-thin here.",
         WarningCode.FEW_EVENTS,
+        label="corrado_rank",
         expected_warnings=expected_warnings,
     )
     if warn_code is not None:

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -272,13 +272,14 @@ def directional_hit_rate(
     warn_code = _warn_below_floor(
         directional_hit_rate,
         n,
-        f"directional_hit_rate: n_pairs={n} below "
+        f"n_pairs={n} below "
         f"MIN_DIRECTIONAL_PAIRS_WARN={MIN_DIRECTIONAL_PAIRS_WARN}; the "
         f"Pesaran-Timmermann hit rate is returned but n counts pooled "
         f"non-overlapping (date, asset) directional trials, and the normal "
         f"approximation to S_n is power-thin below ~30 pooled pairs. Read "
         f"borderline p-values cautiously.",
         WarningCode.FEW_DIRECTIONAL_PAIRS,
+        label="directional_hit_rate",
         axis="pairs",
         expected_warnings=expected_warnings,
     )

--- a/factrix/metrics/directional_pair_accuracy.py
+++ b/factrix/metrics/directional_pair_accuracy.py
@@ -10,7 +10,6 @@ naive binomial p-value over same-date pairs.
 from __future__ import annotations
 
 import math
-import warnings
 
 import numpy as np
 import polars as pl
@@ -22,7 +21,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import (
@@ -172,18 +171,18 @@ def directional_pair_accuracy(
 
     warning_codes: list[str] = []
     if n_usable_pairs < MIN_PAIR_ACCURACY_PAIRS_WARN:
-        code = WarningCode.FEW_ORDERING_PAIRS.value
-        warning_codes.append(code)
-        if code not in expected_warnings:
-            warnings.warn(
-                f"directional_pair_accuracy: n_pairs={n_usable_pairs} below "
-                f"MIN_PAIR_ACCURACY_PAIRS_WARN={MIN_PAIR_ACCURACY_PAIRS_WARN}; "
-                f"the descriptive ordering accuracy is returned, but the "
-                f"comparable-pair sample is thin. Read it as a fragile "
-                f"small-N diagnostic.",
-                UserWarning,
-                stacklevel=3,
-            )
+        _emit_warning(
+            WarningCode.FEW_ORDERING_PAIRS,
+            f"n_pairs={n_usable_pairs} below "
+            f"MIN_PAIR_ACCURACY_PAIRS_WARN={MIN_PAIR_ACCURACY_PAIRS_WARN}; "
+            f"the descriptive ordering accuracy is returned, but the "
+            f"comparable-pair sample is thin. Read it as a fragile "
+            f"small-N diagnostic.",
+            label="directional_pair_accuracy",
+            expected_warnings=expected_warnings,
+            warning_codes=warning_codes,
+            stacklevel=3,
+        )
     pooled_accuracy = n_correct_pairs / n_usable_pairs
     mean_per_date_accuracy = float(np.mean(per_date_accuracy))
     min_pairs = min(pairs_per_period) if pairs_per_period else 0

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -249,13 +249,14 @@ def _spaced_events(
         n_raw,
         MIN_EVENTS_WARN,
         overlap_periods,
-        f"{metric_name}: n_events={n_raw} below the floor of {raw_min_warn} "
+        f"n_events={n_raw} below the floor of {raw_min_warn} "
         f"(= MIN_EVENTS_WARN {MIN_EVENTS_WARN} x overlap_periods "
         f"{overlap_periods}); {sampled.height} events survive non-overlap "
         f"sampling at stride h={overlap_periods}, which keeps up to one event "
         f"in h per asset. The statistic is returned but it pools the events "
         f"as independent draws and is thin on a sample this short.",
         WarningCode.FEW_EVENTS,
+        label=metric_name,
         expected_warnings=expected_warnings,
     )
     if warn_code is not None:

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -27,7 +27,6 @@ References:
 from __future__ import annotations
 
 import math
-import warnings
 from typing import cast
 
 import numpy as np
@@ -40,7 +39,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._errors import UserInputError
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
@@ -121,18 +120,17 @@ def _surface_fm_asset_warning(
     metadata["warn_assets_per_period"] = MIN_FM_ASSETS_WARN
     if min_assets_per_period >= MIN_FM_ASSETS_WARN:
         return
-    code = WarningCode.FEW_ASSETS.value
-    if code not in expected_warnings:
-        warnings.warn(
-            f"{metric_name}: min_assets_per_period={min_assets_per_period} below "
-            f"MIN_FM_ASSETS_WARN={MIN_FM_ASSETS_WARN}; per-period FM beta is "
-            "computable but the cross-section is thin. value is returned but read "
-            "it cautiously.",
-            UserWarning,
-            stacklevel=2,
-        )
-    if code not in warning_codes:
-        warning_codes.append(code)
+    _emit_warning(
+        WarningCode.FEW_ASSETS,
+        f"min_assets_per_period={min_assets_per_period} below "
+        f"MIN_FM_ASSETS_WARN={MIN_FM_ASSETS_WARN}; per-period FM beta is "
+        "computable but the cross-section is thin. value is returned but read "
+        "it cautiously.",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        warning_codes=warning_codes,
+        stacklevel=2,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -310,11 +308,13 @@ def fm_beta(
     warn_code = _warn_below_floor(
         fm_beta,
         n,
-        f"fm_beta: n_periods={n} below MIN_FM_PERIODS_WARN="
+        f"n_periods={n} below MIN_FM_PERIODS_WARN="
         f"{MIN_FM_PERIODS_WARN}; NW HAC SE on a short β series is "
         f"borderline (Fama-MacBeth convention is T≥30). t-stat is "
         f"returned but read p-values cautiously.",
         WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+        label="fm_beta",
+        expected_warnings=expected_warnings,
     )
     if warn_code is not None:
         warning_codes.append(warn_code)
@@ -330,19 +330,19 @@ def fm_beta(
     actual_lags = _resolve_har_lags(n, newey_west_lags, overlap_periods)
     beta_autocorr = _lag1_autocorr(betas)
     if beta_autocorr > PERSISTENT_SERIES_AUTOCORR:
-        code = WarningCode.SERIAL_CORRELATION_DETECTED.value
-        warning_codes.append(code)
-        if code not in expected_warnings:
-            warnings.warn(
-                f"fm_beta: the per-period beta series has lag-1 autocorrelation "
-                f"{beta_autocorr:.2f} (> {PERSISTENT_SERIES_AUTOCORR}). No HAC "
-                f"path is calibrated in this regime — Newey-West rejects 13–17% "
-                f"at a nominal 5% for phi=0.6 and ~30% at 0.85 — so read the "
-                f"p-value against a raised hurdle (t > 3) or lengthen the "
-                f"sample.",
-                UserWarning,
-                stacklevel=2,
-            )
+        _emit_warning(
+            WarningCode.SERIAL_CORRELATION_DETECTED,
+            f"the per-period beta series has lag-1 autocorrelation "
+            f"{beta_autocorr:.2f} (> {PERSISTENT_SERIES_AUTOCORR}). No HAC "
+            f"path is calibrated in this regime — Newey-West rejects 13–17% "
+            f"at a nominal 5% for phi=0.6 and ~30% at 0.85 — so read the "
+            f"p-value against a raised hurdle (t > 3) or lengthen the "
+            f"sample.",
+            label="fm_beta",
+            expected_warnings=expected_warnings,
+            warning_codes=warning_codes,
+            stacklevel=2,
+        )
 
     p_final = p
     metadata: dict = {
@@ -366,20 +366,19 @@ def fm_beta(
         # rather than only a metadata string.
         if sigma2_f < EPSILON:
             metadata["shanken_correction"] = "skipped_zero_factor_variance"
-            code = WarningCode.DEGENERATE_VARIANCE.value
-            if code not in warning_codes:
-                warning_codes.append(code)
-            if code not in expected_warnings:
-                warnings.warn(
-                    f"fm_beta: factor_return_var={sigma2_f!r} is below "
-                    f"EPSILON={EPSILON}, so the Shanken (1992) EIV multiplier "
-                    f"1 + mean(β)²/σ²_f is undefined. The correction is "
-                    f"skipped and the UNCORRECTED Newey-West p-value is "
-                    f"returned — read it as un-adjusted for the estimated "
-                    f"regressor.",
-                    UserWarning,
-                    stacklevel=2,
-                )
+            _emit_warning(
+                WarningCode.DEGENERATE_VARIANCE,
+                f"factor_return_var={sigma2_f!r} is below "
+                f"EPSILON={EPSILON}, so the Shanken (1992) EIV multiplier "
+                f"1 + mean(β)²/σ²_f is undefined. The correction is "
+                f"skipped and the UNCORRECTED Newey-West p-value is "
+                f"returned — read it as un-adjusted for the estimated "
+                f"regressor.",
+                label="fm_beta",
+                expected_warnings=expected_warnings,
+                warning_codes=warning_codes,
+                stacklevel=2,
+            )
         else:
             c = 1.0 + (mean_beta**2) / sigma2_f
             sqrt_c = math.sqrt(c)
@@ -534,17 +533,17 @@ def _pooled_beta_driscoll_kraay(
 
     warning_codes: list[str] = []
     if n_periods < MIN_PERIODS_WARN:
-        code = WarningCode.UNRELIABLE_SE_SHORT_PERIODS.value
-        warning_codes.append(code)
-        if code not in expected_warnings:
-            warnings.warn(
-                f"pooled_beta: Driscoll-Kraay SE on n_periods={n_periods} "
-                f"(< {MIN_PERIODS_WARN}); the cross-sectional HAC needs a long "
-                f"period series to be reliable. t-stat is returned but read "
-                f"p-values cautiously.",
-                UserWarning,
-                stacklevel=2,
-            )
+        _emit_warning(
+            WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+            f"Driscoll-Kraay SE on n_periods={n_periods} "
+            f"(< {MIN_PERIODS_WARN}); the cross-sectional HAC needs a long "
+            f"period series to be reliable. t-stat is returned but read "
+            f"p-values cautiously.",
+            label="pooled_beta",
+            expected_warnings=expected_warnings,
+            warning_codes=warning_codes,
+            stacklevel=2,
+        )
 
     metadata = {
         "stat_type": "t",

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -14,7 +14,6 @@ Notes:
 from __future__ import annotations
 
 import math
-import warnings as _warnings
 from typing import cast
 
 import polars as pl
@@ -26,7 +25,7 @@ from factrix._axis import (
     FactorScope,
     InputShape,
 )
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats.constants import MIN_PERIODS_HARD, MIN_PERIODS_WARN
@@ -51,6 +50,7 @@ from factrix.metrics._helpers import (
     _DROP_STATS_COL,
     TIE_RATIO_WARN_THRESHOLD,
     _degenerate_test_fields,
+    _emit_inference_warnings,
     _enforce_min_floor,
     _read_drop_stats,
     _short_circuit_output,
@@ -129,21 +129,21 @@ def _warn_if_high_ic_tie_ratio(
     """
     med = _median_tie_ratio(ic_df)
     if not math.isnan(med) and med > TIE_RATIO_WARN_THRESHOLD:
-        code = WarningCode.HIGH_TIE_RATIO.value
-        if code not in expected_warnings:
-            _warnings.warn(
-                f"{metric_name}: median tie_ratio={med:.3f} exceeds "
-                f"{TIE_RATIO_WARN_THRESHOLD:.2f}. The estimator is already the "
-                f"tie-corrected Spearman (Pearson on mid-ranks, identical to "
-                f"scipy.stats.spearmanr), so this is not a bias — but heavy "
-                f"ties shrink the attainable range of rho below ±1, so do not "
-                f"compare this IC magnitude against a factor with a different "
-                f"tie density. A continuous transform of the factor restores "
-                f"the full range.",
-                UserWarning,
-                stacklevel=2,
-            )
-        warning_codes.append(code)
+        _emit_warning(
+            WarningCode.HIGH_TIE_RATIO,
+            f"median tie_ratio={med:.3f} exceeds "
+            f"{TIE_RATIO_WARN_THRESHOLD:.2f}. The estimator is already the "
+            f"tie-corrected Spearman (Pearson on mid-ranks, identical to "
+            f"scipy.stats.spearmanr), so this is not a bias — but heavy "
+            f"ties shrink the attainable range of rho below ±1, so do not "
+            f"compare this IC magnitude against a factor with a different "
+            f"tie density. A continuous transform of the factor restores "
+            f"the full range.",
+            label=metric_name,
+            expected_warnings=expected_warnings,
+            warning_codes=warning_codes,
+            stacklevel=2,
+        )
     return med
 
 
@@ -178,16 +178,16 @@ def _warn_if_few_ic_assets(
     metadata["warn_assets_per_period"] = MIN_IC_ASSETS_WARN
     if min_assets_per_period >= MIN_IC_ASSETS_WARN:
         return
-    code = WarningCode.FEW_ASSETS.value
-    if code not in expected_warnings:
-        _warnings.warn(
-            f"{metric_name}: min_assets_per_period={min_assets_per_period} below "
-            f"MIN_IC_ASSETS_WARN={MIN_IC_ASSETS_WARN}; per-period IC is computable "
-            "but the cross-section is thin. value is returned but read it cautiously.",
-            UserWarning,
-            stacklevel=2,
-        )
-    warning_codes.append(code)
+    _emit_warning(
+        WarningCode.FEW_ASSETS,
+        f"min_assets_per_period={min_assets_per_period} below "
+        f"MIN_IC_ASSETS_WARN={MIN_IC_ASSETS_WARN}; per-period IC is computable "
+        "but the cross-section is thin. value is returned but read it cautiously.",
+        label=metric_name,
+        expected_warnings=expected_warnings,
+        warning_codes=warning_codes,
+        stacklevel=2,
+    )
 
 
 def _ic_sample_threshold(self: MetricBase) -> SampleThreshold:
@@ -400,9 +400,13 @@ def ic(
     # Surface the inference method's own soft-floor signals (e.g. a thin
     # post-stride sample tripping UNRELIABLE_SE_SHORT_PERIODS); de-dup so a
     # code already raised by the drop-stats pass is not repeated.
-    for code in result.warnings:
-        if code.value not in warning_codes:
-            warning_codes.append(code.value)
+    _emit_inference_warnings(
+        result,
+        label="ic",
+        warning_codes=warning_codes,
+        expected_warnings=expected_warnings,
+        stacklevel=2,
+    )
     # The chosen inference could not form a statistic: a strided subsample or
     # full series with no dispersion, or a HAC SE that collapsed to zero.
     # ``mean_ic`` still describes the sample; the test is withheld.
@@ -503,10 +507,12 @@ def ic_ir(
     warn_code = _warn_below_floor(
         ic_ir,
         n,
-        f"ic_ir: n_periods={n} below MIN_PERIODS_WARN={MIN_PERIODS_WARN}; "
+        f"n_periods={n} below MIN_PERIODS_WARN={MIN_PERIODS_WARN}; "
         f"the IC information ratio on a short series is unstable. value is "
         f"returned but read it cautiously.",
         WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+        label="ic_ir",
+        expected_warnings=expected_warnings,
     )
     if warn_code is not None:
         warning_codes.append(warn_code)

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -456,6 +456,8 @@ def k_spread(
             full_spread=full_series,
             overlap_periods=overlap_periods,
             n_assets=median_xs,
+            metric_name="k_spread",
+            expected_warnings=expected_warnings,
         )
     )
     # Sample the headline stat/p actually ran on: full overlapping series under

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -176,6 +176,7 @@ def mfe_mae(
         _record_ragged_event_grid(
             mfe_mae_df["ragged_period_grid_note"][0] or None,
             warning_codes,
+            label="mfe_mae",
             expected_warnings=expected_warnings,
         )
 

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -399,7 +399,7 @@ def predictive_beta(
     warn_code = _warn_below_floor(
         predictive_beta,
         n_effective,
-        f"predictive_beta: n_periods={n_used} at "
+        f"n_periods={n_used} at "
         f"overlap_periods={overlap_periods} "
         f"leaves an effective sample of {n_effective} non-overlapping "
         f"observations, below MIN_PERIODS_WARN={MIN_PERIODS_WARN}; Newey-West "
@@ -407,6 +407,7 @@ def predictive_beta(
         f"nominal 5% for n=98, h=21). t-stat is returned but read p-values "
         f"cautiously.",
         WarningCode.UNRELIABLE_SE_SHORT_PERIODS,
+        label="predictive_beta",
         expected_warnings=expected_warnings,
     )
     if warn_code is not None:

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -436,6 +436,8 @@ def _quantile_spread_from_series(
             full_spread=clean_full_series,
             overlap_periods=overlap_periods,
             n_assets=n_assets,
+            metric_name="quantile_spread",
+            expected_warnings=expected_warnings,
         )
     )
     # Sample the headline stat/p actually ran on: the full overlapping series on
@@ -748,7 +750,12 @@ def quantile_spread_vw(
     # off the same threshold: this metric exists as a capacity / robustness
     # cross-check, so it must not be the one that reports clean on a panel
     # whose legs hold a single name each.
-    _warn_thin_quantile_groups(sampled, n_groups, expected_warnings=expected_warnings)
+    _warn_thin_quantile_groups(
+        sampled,
+        n_groups,
+        metric_name="quantile_spread_vw",
+        expected_warnings=expected_warnings,
+    )
 
     vw_series = _vw_spread_series(
         sampled,
@@ -847,6 +854,8 @@ def quantile_spread_vw(
             full_spread=full_series,
             overlap_periods=overlap_periods,
             n_assets=n_assets,
+            metric_name="quantile_spread_vw",
+            expected_warnings=expected_warnings,
         )
     )
     n_tested = int(

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -56,6 +56,7 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _validate_n_groups,
     _validate_positive_count,
+    _warn_thin_quantile_groups,
 )
 
 _DOCS_TRADABILITY = "api/metrics/tradability"
@@ -574,6 +575,19 @@ def notional_turnover(
     if sc is not None:
         return sc
 
+    # Same dual-channel thin-bucket advisory ``quantile_spread`` gets, off the
+    # same threshold and on the same bucketing: turnover measured on buckets
+    # holding a couple of names each is dominated by individual assets, and
+    # this metric was the one bucketing consumer that reported clean there.
+    warning_codes: list[str] = []
+    if _warn_thin_quantile_groups(
+        data,
+        n_groups,
+        metric_name="notional_turnover",
+        expected_warnings=expected_warnings,
+    ):
+        warning_codes.append(WarningCode.THIN_QUANTILE_GROUPS.value)
+
     top_g = n_groups - 1
     bot_g = 0
     grouped = _assign_quantile_groups(data, factor_col, n_groups).select(
@@ -659,6 +673,7 @@ def notional_turnover(
         # pairs; the axis is periods.
         n_obs=int(per_date.height),
         n_obs_axis="periods",
+        warning_codes=tuple(warning_codes),
         metadata={
             "n_rebalances": int(per_date.height),
             "n_groups": n_groups,

--- a/factrix/preprocess/normalize.py
+++ b/factrix/preprocess/normalize.py
@@ -8,12 +8,11 @@ All functions expect canonical column names (date, asset_id).
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, Literal, cast
 
 import polars as pl
 
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._errors import UserInputError
 from factrix._types import (
     EPSILON,
@@ -217,34 +216,34 @@ def _warn_scale_regimes(
     n_sparse = int(stats["_sparse_zero"].sum()) if sparse_skipped else 0
     n_std_non_sparse = n_std - n_sparse
     if n_sparse:
-        warnings.warn(
-            f"{func_name}: {WarningCode.SPARSE_WINSORIZE_SKIPPED.value} — "
+        _emit_warning(
+            WarningCode.SPARSE_WINSORIZE_SKIPPED,
             f"{n_sparse}/{n_dates} dates carry a sparse {{0, R}} factor whose "
             "median and MAD are both 0. The standard-deviation fallback there "
             "is driven by the triggers themselves and shrinks with the trigger "
             "rate, so clipping would destroy event magnitudes; those dates are "
             "left unwinsorized.",
-            UserWarning,
+            label=func_name,
             stacklevel=3,
         )
     if n_std_non_sparse > 0:
-        warnings.warn(
-            f"{func_name}: {WarningCode.ZERO_MAD_STD_FALLBACK.value} — "
+        _emit_warning(
+            WarningCode.ZERO_MAD_STD_FALLBACK,
             f"{n_std_non_sparse}/{n_dates} dates had a zero MAD (>50% ties at "
             "the median) and fell back to the non-robust per-date standard "
             "deviation (ddof=1). Robust and non-robust dates are mixed in one "
             "output column.",
-            UserWarning,
+            label=func_name,
             stacklevel=3,
         )
     n_thin = counts.get("insufficient_assets", 0)
     if n_thin:
-        warnings.warn(
-            f"{func_name}: {WarningCode.INSUFFICIENT_SCALE_ASSETS.value} — "
+        _emit_warning(
+            WarningCode.INSUFFICIENT_SCALE_ASSETS,
             f"{n_thin}/{n_dates} dates carry fewer than {MIN_SCALE_ASSETS_HARD} "
             "finite factor values; no robust scale exists there, so those dates "
             "are left unscaled (z-score null, clip skipped).",
-            UserWarning,
+            label=func_name,
             stacklevel=3,
         )
 
@@ -257,13 +256,13 @@ def _warn_non_finite(data: pl.DataFrame, factor_col: str, func_name: str) -> Non
         ).item()
     )
     if n_bad:
-        warnings.warn(
-            f"{func_name}: {WarningCode.NON_FINITE_INPUT_DROPPED.value} — "
+        _emit_warning(
+            WarningCode.NON_FINITE_INPUT_DROPPED,
             f"{n_bad} row(s) carry NaN / +-Inf in {factor_col!r} and come back "
             "null. A non-finite tick is a data error, not an extreme value: "
             "clipping it into the band would manufacture a plausible-looking "
             "number that survives every downstream drop_nulls().drop_nans().",
-            UserWarning,
+            label=func_name,
             stacklevel=3,
         )
 

--- a/factrix/preprocess/orthogonalize.py
+++ b/factrix/preprocess/orthogonalize.py
@@ -13,13 +13,12 @@ This module is independently usable for any analysis that requires
 from __future__ import annotations
 
 import logging
-import warnings
 from dataclasses import dataclass, field
 
 import numpy as np
 import polars as pl
 
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._types import EPSILON, MIN_ORTHOGONALIZE_RESIDUAL_ASSETS
 
 logger = logging.getLogger(__name__)
@@ -449,10 +448,8 @@ def orthogonalize_factor(
 
     warning_codes: list[str] = []
     if n_dates_insufficient_df:
-        warning_codes.append(WarningCode.INSUFFICIENT_REGRESSION_DF.value)
-        warnings.warn(
-            f"orthogonalize_factor: "
-            f"{WarningCode.INSUFFICIENT_REGRESSION_DF.value} — "
+        _emit_warning(
+            WarningCode.INSUFFICIENT_REGRESSION_DF,
             f"{n_dates_insufficient_df}/{n_dates} dates left fewer than "
             f"{min_residual_df} residual degrees of freedom for {n_base} base "
             "factors + intercept and were skipped (original values kept). Raw "
@@ -460,20 +457,21 @@ def orthogonalize_factor(
             "reports noise as explanatory power while stripping most of the "
             "factor's variance. Reduce base_cols, or lower min_residual_df if "
             "the thin fit is wanted anyway.",
-            UserWarning,
+            label="orthogonalize_factor",
+            warning_codes=warning_codes,
             stacklevel=2,
         )
     if n_dates_rank_deficient:
-        warning_codes.append(WarningCode.RANK_DEFICIENT_DESIGN.value)
-        warnings.warn(
-            f"orthogonalize_factor: {WarningCode.RANK_DEFICIENT_DESIGN.value} "
-            f"— {n_dates_rank_deficient}/{n_dates} dates had a rank-deficient "
+        _emit_warning(
+            WarningCode.RANK_DEFICIENT_DESIGN,
+            f"{n_dates_rank_deficient}/{n_dates} dates had a rank-deficient "
             "design matrix. The residual is still exact (the projection is "
             "unique) but the betas are not identified there, so those dates "
             "are excluded from mean_betas. The usual cause is a full industry "
             "dummy set alongside the always-prepended intercept — drop one "
             "category as the reference level.",
-            UserWarning,
+            label="orthogonalize_factor",
+            warning_codes=warning_codes,
             stacklevel=2,
         )
 

--- a/factrix/preprocess/returns.py
+++ b/factrix/preprocess/returns.py
@@ -8,13 +8,12 @@ All functions expect canonical column names (date, asset_id, price).
 Use ``adapt()`` to rename before calling.
 """
 
-import warnings
 from collections.abc import Iterable
 
 import numpy as np
 import polars as pl
 
-from factrix._codes import WarningCode
+from factrix._codes import WarningCode, _emit_warning
 from factrix._errors import UserInputError
 
 _DOCS_FORWARD_RETURN = "api/preprocess#factrix.preprocess.compute_forward_return"
@@ -85,15 +84,15 @@ def _warn_if_ragged(indexed: pl.DataFrame, n_periods: int) -> None:
     )
     n_ragged = int((per_asset["_n_periods"] < n_periods).sum())
     if n_ragged:
-        warnings.warn(
-            f"compute_forward_return: {WarningCode.RAGGED_PERIOD_GRID.value} — "
+        _emit_warning(
+            WarningCode.RAGGED_PERIOD_GRID,
             f"{n_ragged} of {per_asset.height} assets are missing periods that "
             f"others have (panel grid: {n_periods} periods). The horizon is "
             "measured on the panel's period grid, so those assets simply have "
             "no observation to pair at the exit period rather than a stretched "
             "window; reindex onto a common grid if the horizons must be "
             "comparable across names.",
-            UserWarning,
+            label="compute_forward_return",
             stacklevel=3,
         )
 
@@ -108,9 +107,9 @@ def _warn_if_uneven(kept_index: list[int]) -> None:
     """
     strides = np.unique(np.diff(np.asarray(sorted(kept_index), dtype=np.int64)))
     if strides.size > 1:
-        warnings.warn(
-            f"compute_forward_return: {WarningCode.UNEVEN_EVALUATION_GRID.value} "
-            f"— the evaluation grid passed as dates= has {strides.size} distinct "
+        _emit_warning(
+            WarningCode.UNEVEN_EVALUATION_GRID,
+            f"the evaluation grid passed as dates= has {strides.size} distinct "
             f"spacings between adjacent kept rows ({int(strides.min())} to "
             f"{int(strides.max())} periods). Series-mean inference "
             "(NonOverlapping, NeweyWest) is calibrated on such a grid; the "
@@ -123,7 +122,7 @@ def _warn_if_uneven(kept_index: list[int]) -> None:
             "the caller's side: pass dates= at a constant stride on the panel's "
             "period grid if those paths must be calibrated; factrix does not "
             "resample.",
-            UserWarning,
+            label="compute_forward_return",
             stacklevel=3,
         )
 

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -13,12 +13,11 @@ Matrix-row: by_slice | (*, *, *, *) | dispatcher | none (no cross-slice test) | 
 from __future__ import annotations
 
 import dataclasses
-import warnings
 from typing import TYPE_CHECKING
 
 import polars as pl
 
-from factrix._codes import WarningCode, _validate_expected_warnings_arg
+from factrix._codes import WarningCode, _emit_warning, _validate_expected_warnings_arg
 from factrix._results import Warning
 from factrix.slicing._primitive import _slice_by
 
@@ -236,19 +235,23 @@ def _warn_date_axis_truncation(
         return None  # by is constant within each asset → cross-sectional
     name = spec.name
     message = (
-        f"by_slice: {name!r} depends on intact date ordering, "
+        f"{name!r} depends on intact date ordering, "
         f"but {by!r} is a date-axis partition (its value varies within an "
         f"asset over time). Each slice is evaluated on its own rows only, so "
         f"rolling windows / per-asset time-series regressions / event windows "
         f"see truncated history at slice boundaries — the per-slice value "
-        f"differs from the full-sample value decomposed by period "
-        f"({WarningCode.SLICE_BOUNDARY_TRUNCATION.value}). For a cross-"
+        f"differs from the full-sample value decomposed by period. For a cross-"
         f"sectional partition (constant within an asset, e.g. sector) this "
         f"warning does not apply."
     )
     expected = WarningCode.SLICE_BOUNDARY_TRUNCATION.value in expected_warnings
-    if not expected:
-        warnings.warn(message, UserWarning, stacklevel=3)
+    _emit_warning(
+        WarningCode.SLICE_BOUNDARY_TRUNCATION,
+        message,
+        label="by_slice",
+        expected_warnings=expected_warnings,
+        stacklevel=3,
+    )
     return Warning(
         code=WarningCode.SLICE_BOUNDARY_TRUNCATION,
         source=name,

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -60,7 +60,6 @@ Matrix-row: slice_period_pairwise_test, slice_period_joint_test | (*, *, *, *, *
 from __future__ import annotations
 
 import math
-import warnings
 from itertools import combinations
 from typing import Literal, NamedTuple
 
@@ -68,7 +67,7 @@ import numpy as np
 import polars as pl
 from scipy import stats as sp_stats
 
-from factrix._codes import WarningCode, _validate_expected_warnings_arg
+from factrix._codes import WarningCode, _emit_warning, _validate_expected_warnings_arg
 from factrix._data_input import _resolve_overlap_periods
 from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
@@ -999,23 +998,22 @@ def slice_period_joint_test(
     if built.thin:
         return _row(float("nan"), float("nan"), None, _REASON_INSUFFICIENT_PERIODS)
     if k >= 3 and shortest < _JOINT_SHORT_SLICE_PERIODS:
-        code = WarningCode.SHORT_SLICE_JOINT_TEST
-        warning_codes.append(code.value)
-        if code.value not in expected:
-            warnings.warn(
-                f"slice_period_joint_test: {len(series_list)} slices with the "
-                f"shortest at {shortest} periods "
-                f"(< {_JOINT_SHORT_SLICE_PERIODS}). On a true null the joint "
-                f"test over-rejects here — measured 8–9% at a nominal 5% for "
-                f"K=5 with 50–90-period slices, under both methods — because "
-                f"each slice's HAC variance is a noisy small-sample estimate "
-                f"inverted across K-1 restrictions. Read the p-value as "
-                f"indicative; pairwise contrasts on the same slices are "
-                f"better calibrated ({code.value}; declare it in "
-                f"expected_warnings= to keep the record and stop this echo).",
-                UserWarning,
-                stacklevel=2,
-            )
+        _emit_warning(
+            WarningCode.SHORT_SLICE_JOINT_TEST,
+            f"{len(series_list)} slices with the "
+            f"shortest at {shortest} periods "
+            f"(< {_JOINT_SHORT_SLICE_PERIODS}). On a true null the joint "
+            f"test over-rejects here — measured 8–9% at a nominal 5% for "
+            f"K=5 with 50–90-period slices, under both methods — because "
+            f"each slice's HAC variance is a noisy small-sample estimate "
+            f"inverted across K-1 restrictions. Read the p-value as "
+            f"indicative; pairwise contrasts on the same slices are "
+            f"better calibrated.",
+            label="slice_period_joint_test",
+            expected_warnings=expected,
+            warning_codes=warning_codes,
+            stacklevel=2,
+        )
     restriction = _equality_restriction(k)
 
     if method == "bootstrap":

--- a/tests/test_ic.py
+++ b/tests/test_ic.py
@@ -262,11 +262,15 @@ class TestComputeIC:
             pl.col("date").cast(pl.Datetime("ms"))
         )
         clean_ic = compute_ic(clean)["factor"]
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
+        # Only the tie advisory is under test: on a 40-period series the HAC
+        # member legitimately raises its own bandwidth code, which now reaches
+        # stderr through the same formatter instead of only the result object.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UserWarning)
             ic(clean_ic, overlap_periods=1)
             ic(clean_ic, overlap_periods=1, inference=NEWEY_WEST)
             ic_ir(clean_ic)
+        assert not [w for w in caught if "tie_ratio" in str(w.message)]
 
 
 class TestComputeICBatch:

--- a/tests/test_warning_formatter.py
+++ b/tests/test_warning_formatter.py
@@ -1,0 +1,182 @@
+"""One emit chokepoint, one warning frame.
+
+Every :class:`~factrix.WarningCode` advisory the library echoes goes through
+:func:`factrix._codes._emit_warning` and comes out as
+``<label>: <message> (<code>; declare it in expected_warnings=)``. Two things
+are locked here:
+
+* the *structural* guard — no ``warnings.warn`` call for a ``WarningCode``
+  exists anywhere outside the chokepoint, so a new advisory cannot quietly
+  invent its own wording; and
+* the *behavioural* guard — the panel from the report that motivated this
+  (8 assets, 90 periods, ``n_groups=3``) reaches stderr with every code it
+  records, each carrying its metric label and its code token.
+
+The second half is the one that would have caught the original defect: the
+codes were on ``MetricResult.warning_codes`` all along and nothing printed.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import warnings
+
+import factrix as fx
+import pytest
+from factrix._codes import _DECLARE_HINT, WarningCode, _emit_warning, _format_warning
+from factrix.metrics import notional_turnover, quantile_spread
+from factrix.preprocess import compute_forward_return
+
+_PACKAGE = pathlib.Path(fx.__file__).parent
+#: The chokepoint itself is the one module allowed to call ``warnings.warn``
+#: for a code.
+_CHOKEPOINT = _PACKAGE / "_codes.py"
+
+
+def _warn_calls(tree: ast.AST) -> list[ast.Call]:
+    """Every ``warnings.warn(...)`` / ``_warnings.warn(...)`` call in a module."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "warn"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in {"warnings", "_warnings"}
+    ]
+
+
+class TestOneEmitChokepoint:
+    """No ``WarningCode`` warning is raised outside :func:`_emit_warning`."""
+
+    def test_no_warning_code_warn_call_outside_the_chokepoint(self):
+        offenders: list[str] = []
+        for path in sorted(_PACKAGE.rglob("*.py")):
+            if path == _CHOKEPOINT:
+                continue
+            source = path.read_text()
+            tree = ast.parse(source)
+            lines = source.splitlines()
+            for call in _warn_calls(tree):
+                # A code-bearing site names WarningCode in the enclosing
+                # block; the surviving non-code advisories (bhy singletons,
+                # romano_wolf resample counts, the greedy-selection snooping
+                # note) name none.
+                context = "\n".join(
+                    lines[max(0, call.lineno - 25) : (call.end_lineno or call.lineno)]
+                )
+                if "WarningCode" in context:
+                    offenders.append(f"{path.relative_to(_PACKAGE)}:{call.lineno}")
+        assert offenders == [], (
+            "these warnings.warn sites raise a WarningCode without going "
+            f"through factrix._codes._emit_warning: {offenders}"
+        )
+
+    def test_chokepoint_frames_label_message_and_code(self):
+        text = _format_warning(
+            WarningCode.FEW_ASSETS, "n_assets=8 below the floor", label="ic"
+        )
+        assert text == (f"ic: n_assets=8 below the floor (few_assets; {_DECLARE_HINT})")
+
+    def test_record_survives_a_declaration_and_the_echo_stops(self):
+        codes: list[str] = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            returned = _emit_warning(
+                WarningCode.FEW_ASSETS,
+                "body",
+                label="ic",
+                expected_warnings=("few_assets",),
+                warning_codes=codes,
+            )
+        assert returned == "few_assets"
+        assert codes == ["few_assets"], "a declaration must not drop the record"
+        assert caught == []
+
+    def test_undeclared_echo_carries_the_frame(self):
+        codes: list[str] = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _emit_warning(
+                WarningCode.FEW_ASSETS, "body", label="ic", warning_codes=codes
+            )
+        assert codes == ["few_assets"]
+        assert len(caught) == 1
+        assert str(caught[0].message) == (f"ic: body (few_assets; {_DECLARE_HINT})")
+
+    def test_the_code_is_recorded_once_on_a_repeated_emit(self):
+        codes: list[str] = ["few_assets"]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _emit_warning(
+                WarningCode.FEW_ASSETS, "body", label="ic", warning_codes=codes
+            )
+        assert codes == ["few_assets"]
+
+
+@pytest.fixture(scope="module")
+def thin_panel():
+    """The panel from the report: 8 assets over 90 periods, h=5."""
+    return compute_forward_return(
+        fx.datasets.make_cs_panel(n_assets=8, n_dates=90, rng=0), forward_periods=5
+    )
+
+
+class TestThinPanelReachesStderr:
+    """Every code the thin panel records is also echoed, framed."""
+
+    def _run(self, panel, **kwargs):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = fx.evaluate(
+                panel,
+                metrics={
+                    "quantile_spread": quantile_spread(n_groups=3),
+                    "notional_turnover": notional_turnover(n_groups=3),
+                },
+                factor_cols=["factor"],
+                strict=False,
+                **kwargs,
+            )
+        return result["factor"], [str(w.message) for w in caught]
+
+    def test_all_three_codes_echo_with_label_and_token(self, thin_panel):
+        result, messages = self._run(thin_panel)
+        recorded = set(result.metrics["quantile_spread"].warning_codes)
+        assert recorded == {
+            "unreliable_se_short_periods",
+            "few_assets",
+            "thin_quantile_groups",
+        }
+        for code in recorded:
+            hits = [m for m in messages if f"({code}; {_DECLARE_HINT})" in m]
+            assert hits, f"{code} was recorded but never echoed: {messages}"
+            # Anatomy: every echo opens with the label that raised it.
+            for hit in hits:
+                label = hit.split(":", 1)[0]
+                assert label and " " not in label
+
+    def test_the_thin_group_advisory_names_the_metric_that_raised_it(self, thin_panel):
+        _, messages = self._run(thin_panel)
+        labels = {m.split(":", 1)[0] for m in messages if "thin_quantile_groups" in m}
+        # The turnover metric buckets the same cross-section and used to
+        # report clean where its spread sibling warned.
+        assert "notional_turnover" in labels
+
+    def test_notional_turnover_records_the_thin_group_code(self, thin_panel):
+        result, _ = self._run(thin_panel)
+        assert result.metrics["notional_turnover"].warning_codes == (
+            "thin_quantile_groups",
+        )
+
+    def test_a_declaration_silences_every_echo_and_keeps_every_record(self, thin_panel):
+        declared = (
+            "unreliable_se_short_periods",
+            "few_assets",
+            "thin_quantile_groups",
+        )
+        result, messages = self._run(thin_panel, expected_warnings=declared)
+        assert messages == []
+        assert set(result.metrics["quantile_spread"].warning_codes) == set(declared)
+        assert all(w.expected for w in result.warnings if w.code.value in declared)

--- a/tests/test_warning_formatter.py
+++ b/tests/test_warning_formatter.py
@@ -55,7 +55,7 @@ class TestOneEmitChokepoint:
         for path in sorted(_PACKAGE.rglob("*.py")):
             if path == _CHOKEPOINT:
                 continue
-            source = path.read_text()
+            source = path.read_text(encoding="utf-8")
             tree = ast.parse(source)
             lines = source.splitlines()
             for call in _warn_calls(tree):


### PR DESCRIPTION
> **TL;DR** — 一個 chokepoint `_emit_warning`（`_codes.py`）：先記錄 code（marked, never dropped），未宣告時以 `<label>: <message> (<code>; declare it in expected_warnings=)` echo。34 個 emit 站點、20 個模組經它輸出，訊息本體逐字保留（只統一前綴與 token），既有測試只改一個斷言。issue 指的「只記錄不 emit」通道其實不是 `_inspect.py`（那只被 `inspect_data()` 呼叫、`evaluate` 不經過），而是 `InferenceResult.warnings` 與 `cross_section_tier` 的 `few_assets`——實作者以全 registry 掃描實測定位並修正。**Breaking**：警告文字框架改變。

Closes #925

## DoD 面板（8 資產 × 90 期，`quantile_spread(n_groups=3)`，17 期）
修正前 stderr 只有一行「Median 2 assets per group」；現在三行各帶 label 與 code token：`compute_spread_series: … (thin_quantile_groups; …)`、`quantile_spread: … 17 periods, below the WARN floor of 30 … (unreliable_se_short_periods; …)`、`quantile_spread: … 8 assets, below MIN_ASSETS_WARN=30 … (few_assets; …)`。另：`notional_turnover(n_groups=3)` 過去既不記錄也不 echo `thin_quantile_groups`（只有空桶 short-circuit 路徑有），現在記錄 + echo，宣告後靜音。

## 審核紀錄（實作者 opus，審核者本 session）
探針：DoD 面板三則訊息、`notional_turnover` 記錄 / 宣告行為、與 main 無衝突。chokepoint 之外剩 8 個 `warnings.warn`，全是無 WarningCode 的一般警告（`_multi_factor` family 結構 `RuntimeWarning` ×5、`greedy_forward_selection` snooping、`romano_wolf_adjusted_p` 輸入 ×2），已帶 label，不在本 issue 範圍。
實作者判斷（接受）：`inspect_data` 不 echo（~40 個 metric 的結構化報告，逐條 echo 是噪音）；`metric_unavailable` / `upstream_unavailable` 維持只記錄（availability 通道，原因在 `metadata["reason"]`）；順手修 `fm_beta` / `ic_ir` 未把 `expected_warnings` 轉給 `_warn_below_floor` 的兩個潛伏 bug；共用 thin-group 訊息改為「Bucket statistics」（`notional_turnover` 量的是 churn 不是 spread）。

## 驗證
`ruff` / `mypy` / `mkdocs --strict` 綠；**3655 passed, 42 skipped**（pytest rc=0；+9 `tests/test_warning_formatter.py`）；`observability.md` 新 §4 記載訊息結構與兩個通道。