### PR TITLE
fix(stats): align alpha HAC scaling (#957)

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -40,8 +40,8 @@ def ols_alpha(
 
     Point estimates are plain OLS. ``alpha_t`` divides by the Newey-West
     HAC standard error (Bartlett kernel, [Newey-West (1994)][newey-west-1994]
-    automatic bandwidth, floored at ``overlap_periods - 1``) rather than the
-    homoskedastic OLS SE. Spanning alphas are routinely reported with HAC
+    automatic bandwidth, floored at ``3 * (overlap_periods - 1)``) rather than
+    the homoskedastic OLS SE. Spanning alphas are routinely reported with HAC
     t-stats (Barillas-Shanken, Fama-French).
 
     ``overlap_periods`` is the overlap horizon of the spread series being
@@ -56,11 +56,13 @@ def ols_alpha(
     scalar statistic. The default ``1`` (no floor) is the non-overlapping
     case.
 
-    **The trade, measured.** Empirical size at a nominal 5% under a true
-    null (``alpha = 0``, one base factor, 4000 draws, read against
-    ``t(n - k)``):
+    **The trade, measured.** Both columns below predate the current scalar HAR
+    recipe and are retained because they motivated retiring the OLS SE. The
+    current recipe's measurements follow the table. Empirical size at a
+    nominal 5% under a true null (``alpha = 0``, one base factor, 4000 draws,
+    read against ``t(n - k)``):
 
-    | residuals | OLS | HAC (narrow rule) |
+    | residuals | OLS | HAC (narrow rule, superseded) |
     |---|---|---|
     | iid, n=60 | 0.047 | 0.071 |
     | iid, n=120 | 0.052 | 0.065 |
@@ -180,7 +182,8 @@ def ols_alpha(
     # the same degenerate result the OLS path produced.
     lags, hac_scale, hac_dof = _resolve_scalar_wald_hac(n_obs, None, overlap_periods)
     _, v_hac, _ = _ols_nw_multivariate(candidate, X, lags=lags)
-    se_alpha = float(np.sqrt(max(v_hac[0, 0] * hac_scale, 0.0)))
+    v_hac = v_hac * hac_scale
+    se_alpha = float(np.sqrt(max(v_hac[0, 0], 0.0)))
 
     if se_alpha < EPSILON:
         # A collapsed HAC SE -- a perfect fit, or a design so nearly

--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -38,11 +38,10 @@ def ols_alpha(
 ) -> _OLSResult:
     """OLS regression ``candidate = alpha + beta @ base + epsilon`` with a HAC t on alpha.
 
-    Point estimates are plain OLS. ``alpha_t`` divides by the Newey-West
-    HAC standard error (Bartlett kernel, [Newey-West (1994)][newey-west-1994]
-    automatic bandwidth, floored at ``3 * (overlap_periods - 1)``) rather than
-    the homoskedastic OLS SE. Spanning alphas are routinely reported with HAC
-    t-stats (Barillas-Shanken, Fama-French).
+    Point estimates are plain OLS. ``alpha_t`` divides by a Bartlett-kernel
+    HAC standard error on the scalar HAR recipe's bandwidth (next paragraph)
+    rather than the homoskedastic OLS SE. Spanning alphas are routinely
+    reported with HAC t-stats (Barillas-Shanken, Fama-French).
 
     ``overlap_periods`` is the overlap horizon of the spread series being
     regressed. Spreads built from ``h``-period overlapping forward returns
@@ -102,10 +101,10 @@ def ols_alpha(
     documented harder.
 
     Returns:
-        _OLSResult with alpha, HAC t_stat, betas, R², and residual degrees
-        of freedom ``df_resid = n_obs - (1 + n_base_factors)`` (the
-        reference the t is read against — see ``_stats.hac`` on why the
-        full-count df is kept).
+        _OLSResult with alpha, HAC t_stat, betas, R², the residual degrees
+        of freedom ``df_resid = n_obs - (1 + n_base_factors)`` (reporting
+        only) and ``alpha_dof``, the fixed-``b`` effective df the t is read
+        against — well below ``df_resid`` at a research sample size.
 
     A fit that cannot be formed -- fewer than three observations, or a
     rank-deficient design -- returns ``alpha`` and ``alpha_t`` as NaN.
@@ -178,14 +177,15 @@ def ols_alpha(
         )
 
     # HAC covariance of the OLS coefficients; ``_ols_nw_multivariate`` returns
-    # zeros when X'X is singular, which the EPSILON guard below turns into
-    # the same degenerate result the OLS path produced.
+    # a NaN matrix when X'X is singular. The guard below folds that into the
+    # same degenerate result as a collapsed SE -- NaN fails every ``<``, so
+    # the EPSILON test alone would let it through with ``alpha_dof`` set.
     lags, hac_scale, hac_dof = _resolve_scalar_wald_hac(n_obs, None, overlap_periods)
     _, v_hac, _ = _ols_nw_multivariate(candidate, X, lags=lags)
     v_hac = v_hac * hac_scale
     se_alpha = float(np.sqrt(max(v_hac[0, 0], 0.0)))
 
-    if se_alpha < EPSILON:
+    if not np.isfinite(se_alpha) or se_alpha < EPSILON:
         # A collapsed HAC SE -- a perfect fit, or a design so nearly
         # rank-deficient that the residuals vanish -- leaves no t. NaN, not
         # 0.0: the alpha itself is real (a duplicated base column still

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -135,6 +135,11 @@ class TestOLSAlpha:
         duplicates the intercept still produces an intercept estimate, so
         the alpha survives while the t is withheld; reporting ``t = 0``
         would turn that live estimate into a decisive "not significant".
+
+        REGRESSION: an exactly singular ``X'X`` makes the HAC kernel return a
+        NaN covariance, and a NaN SE fails ``se < EPSILON``; the guard must
+        still fire so ``alpha_dof`` stays at its withheld value of ``0.0``
+        rather than reporting a reference df for a t that was never formed.
         """
         import math
 
@@ -143,6 +148,7 @@ class TestOLSAlpha:
         ols = _ols_alpha(candidate, np.ones((40, 1)))
         assert math.isfinite(ols.alpha) and ols.alpha != 0.0
         assert math.isnan(ols.alpha_t)
+        assert ols.alpha_dof == 0.0
 
     def test_df_resid_excludes_base_regressors(self):
         rng = np.random.default_rng(42)


### PR DESCRIPTION
## Summary

Align the scalar HAR finite-sample scaling order in `ols_alpha` with the other covariance consumers, and correct the stale bandwidth and calibration wording.

## Verification

- `pytest tests/test_spanning.py tests/test_spanning_hac_bandwidth.py tests/stats/test_scalar_wald_overlap_size.py tests/stats/test_ols_nw_multivariate.py -q` (55 passed)
- `ruff check factrix/_ols.py`
- `git diff --check`

Closes #957