### PR TITLE
feat(metrics): expose CAAR estimand metadata

### DIFF
--- a/docs/api/metrics/caar.md
+++ b/docs/api/metrics/caar.md
@@ -27,9 +27,29 @@ title: factrix.metrics.caar
     rather than undone here. With μ = 0.0008 per period over `h = 5`, the
     reported value is 0.001056 — the per-period average — not 5× that.
 
-    Multiply by `forward_periods` to recover the cumulative quantity the name
-    and the Brown-Warner / MacKinlay citations promise. Reading `caar.value`
-    directly as a 5-period event CAR is off by 5×.
+    The contract is machine-readable as
+    `result.metadata["return_scale"] == "per_period_simple"`. Multiply by
+    `EvaluationResult.forward_periods` to recover the cumulative quantity the
+    name and the Brown-Warner / MacKinlay citations promise. Do **not** multiply
+    by `overlap_periods`: that field controls inference and can be smaller than
+    the economic horizon on a coarse evaluation grid. Reading `caar.value`
+    directly as a 5-period event CAR is off by 5×. A caller-supplied
+    `abnormal_return` instead reports `"supplied_abnormal_return"`; factrix
+    does not guess that column's scale.
+
+!!! info "Inspect the event-weighting estimand"
+    `compute_caar` multiplies abnormal return by the factor without silently
+    coercing its magnitude. The producer column and downstream
+    `result.metadata["event_weighting"]` therefore report:
+
+    | Value | Factor contract | Estimand |
+    |---|---|---|
+    | `"sign"` | Every non-zero factor has magnitude 1 | Equal-event signed CAAR |
+    | `"factor_magnitude"` | At least one non-zero factor has non-unit magnitude | Factor-magnitude-weighted CAAR |
+
+    Strictly positive graded intensity factors are in the second row even
+    though they do not raise `SPARSE_MAGNITUDE_WEIGHTED`; that warning remains
+    reserved for the ambiguous mixed-sign, non-ternary case.
 
 ## Use cases
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -180,7 +180,8 @@ Descriptive; no test.
 - **`value` is per period.** It is `CAR / h`, inherited from
   `compute_forward_return`'s `/ forward_periods` normalisation, not the
   cumulative abnormal return the name suggests. Multiply by
-  `forward_periods` for the cumulative quantity.
+  `EvaluationResult.forward_periods` for the cumulative quantity; do not use
+  `overlap_periods`, which can be smaller on a coarse evaluation grid.
 - *descriptive*: `n_event_periods` (number of periods with an event),
   `total_events` (underlying events behind the portfolio),
   `n_event_periods_sampled`, `mean_caar_full` / `n_event_periods_full`
@@ -191,7 +192,11 @@ Descriptive; no test.
   `n_events_overlapping` / `n_events_sampled` (removed by, and surviving,
   the non-overlap spacing pass; a non-zero removal fires
   `EVENT_WINDOW_OVERLAP`), `n_events_dropped_no_estimation_window`,
-  `abnormal_return_model` and `estimation_window_event_share` (carried up
+  `return_scale` (`per_period_simple` on the standard pipeline,
+  `supplied_abnormal_return` for a caller-supplied abnormal-return column, or
+  `unspecified` for a hand-built CAAR frame), `event_weighting` (`sign`,
+  `factor_magnitude`, or `unspecified`), `abnormal_return_model` and
+  `estimation_window_event_share` (carried up
   from `compute_caar`; the share of each tested event's estimation window
   that lies inside other events' forward windows — above
   `ESTIMATION_WINDOW_EVENT_SHARE_WARN` the mean-adjusted model's abnormal

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -533,6 +533,16 @@ Appends `forward_return` to the DataFrame, stamps two reserved columns — `_for
 
 `dates=` evaluates on a coarser grid: the return is still computed on the full grid at `forward_periods`, only rows on those dates are kept (every value must be a member of the panel's distinct-date grid — nothing is snapped), and `overlap_periods` is derived on the full period index as `1 + max_i #{j in dates : 0 < idx(j) - idx(i) < h}` (stride 60 at h=60 → 1; stride 20 → 3; full grid → h; the maximum is taken because the evaluation grid may be spaced unevenly on the period grid — under-counting over-rejects, over-counting only thins the strided sample). Sub-sampling a panel by hand *after* this call leaves a stale `overlap_periods` stamp (still the horizon), so a 60-period return evaluated every 60 periods trips the stride-scaled `insufficient_*_periods` floor; the short-circuit message points at `dates=`. The unit of `forward_return` is unchanged: per period of the horizon, not per evaluation period.
 
+CAAR preserves that unit. On the standard pipeline,
+`caar(...).metadata["return_scale"] == "per_period_simple"`; recover cumulative
+simple CAR with `value * EvaluationResult.forward_periods`, never
+`overlap_periods` (the latter can be smaller on a coarse evaluation grid).
+`metadata["event_weighting"]` is `"sign"` when all non-zero factors have unit
+magnitude and `"factor_magnitude"` otherwise, including all-positive graded
+intensity signals. A hand-built CAAR frame reports `"unspecified"` for either
+missing contract; a supplied `abnormal_return` reports
+`return_scale="supplied_abnormal_return"` because its scale is caller-defined.
+
 ---
 
 ## Result Types

--- a/factrix/metrics/_primitives/_caar.py
+++ b/factrix/metrics/_primitives/_caar.py
@@ -12,13 +12,30 @@ from factrix._axis import (
 )
 from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import cell
-from factrix._types import DEFAULT_FORWARD_PERIODS
+from factrix._types import DEFAULT_FORWARD_PERIODS, EPSILON
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _attach_abnormal_return,
     _is_sparse_magnitude_weighted,
     _ragged_event_grid_message,
 )
+
+
+def _event_weighting(data: pl.DataFrame, factor_col: str) -> str:
+    """Name the estimand implied by the non-zero factor magnitudes."""
+    has_non_unit_event = bool(
+        data.select(
+            (
+                pl.col(factor_col).is_finite()
+                & (pl.col(factor_col) != 0)
+                & ((pl.col(factor_col).abs() - 1.0).abs() > EPSILON)
+            )
+            .fill_null(False)
+            .any()
+            .alias("has_non_unit_event")
+        ).item()
+    )
+    return "factor_magnitude" if has_non_unit_event else "sign"
 
 
 @metric(
@@ -81,6 +98,12 @@ def compute_caar(
         sparse_magnitude_weighted: whether the input factor is mixed-sign and
             not a clean ``{-1, 0, +1}`` ternary. Broadcast as a constant so
             downstream event tests can attach the structured warning code.
+        event_weighting: ``"sign"`` when every non-zero factor has unit
+            magnitude, otherwise ``"factor_magnitude"``. Unlike the warning
+            above, this also identifies an all-positive graded intensity.
+        return_scale: ``"per_period_simple"`` when the abnormal return is
+            derived from ``return_col``; ``"supplied_abnormal_return"`` when
+            the input's ``abnormal_return`` column is used as-is.
 
     Non-finite handling:
         polars' ``mean`` propagates float ``NaN`` (it only skips nulls), so a
@@ -98,6 +121,7 @@ def compute_caar(
         in polars, so a NaN factor survives the event filter and would make
         ``_signed_car`` NaN.
     """
+    event_weighting = _event_weighting(data, factor_col)
     sparse_magnitude_weighted = _is_sparse_magnitude_weighted(data, factor_col)
     if sparse_magnitude_weighted:
         _emit_warning(
@@ -120,6 +144,11 @@ def compute_caar(
         estimation_window=estimation_window,
         overlap_periods=overlap_periods,
         factor_col=factor_col,
+    )
+    return_scale = (
+        "supplied_abnormal_return"
+        if ar_diagnostics["abnormal_return_model"] == "market_adjusted_supplied"
+        else "per_period_simple"
     )
     events = adjusted.with_columns(
         (pl.col("date").rank(method="dense") - 1).alias("date_ordinal")
@@ -168,6 +197,8 @@ def compute_caar(
         .with_columns(
             pl.lit(n_dropped, dtype=pl.Int64).alias("n_events_dropped_non_finite"),
             pl.lit(sparse_magnitude_weighted).alias("sparse_magnitude_weighted"),
+            pl.lit(event_weighting).alias("event_weighting"),
+            pl.lit(return_scale).alias("return_scale"),
             pl.lit(n_dropped_no_window, dtype=pl.Int64).alias(
                 "n_events_dropped_no_estimation_window"
             ),

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -152,11 +152,13 @@ def caar(
     Args:
         caar_df: Output of ``compute_caar()`` with columns ``date, caar,
             n_events, date_ordinal, n_events_dropped_non_finite,
-            sparse_magnitude_weighted``. The diagnostic columns are optional
-            (hand-built frames omit them); when present the non-finite count is
-            echoed into ``metadata["n_events_dropped_non_finite"]`` and the
-            sparse-magnitude flag becomes ``WarningCode.SPARSE_MAGNITUDE_WEIGHTED``
-            on ``warning_codes``.
+            sparse_magnitude_weighted, event_weighting, return_scale``. The
+            diagnostic columns are optional (hand-built frames omit them);
+            when present the scale and weighting are copied into metadata, the
+            non-finite count is echoed into
+            ``metadata["n_events_dropped_non_finite"]``, and the
+            sparse-magnitude flag becomes
+            ``WarningCode.SPARSE_MAGNITUDE_WEIGHTED`` on ``warning_codes``.
         overlap_periods: Sampling interval for non-overlapping dates.
             Maps to ``config.overlap_periods`` — the return horizon used
             in ``compute_forward_return``. Distinct from
@@ -242,6 +244,18 @@ def caar(
         2.3 / 5.0% at $h = 1 / 5 / 21$), but a single asset at $h = 21$
         rejects 0.0% of true nulls (nominal 5%).
 
+        **Scale and weighting are explicit.** Standard pipeline output carries
+        ``metadata["return_scale"] == "per_period_simple"`` because
+        :func:`~factrix.preprocess.compute_forward_return` divides the simple
+        horizon return by ``forward_periods``. Recover the cumulative simple
+        CAR with ``value * EvaluationResult.forward_periods``. Do not use
+        ``overlap_periods``: on a coarse evaluation grid it can be smaller than
+        the economic horizon. A supplied ``abnormal_return`` column instead
+        carries ``"supplied_abnormal_return"`` because factrix does not know
+        its scale. ``metadata["event_weighting"]`` is ``"sign"`` for unit
+        non-zero factors and ``"factor_magnitude"`` for graded factors,
+        including strictly positive intensity signals.
+
         The across-events siblings are complementary, not redundant:
         ``bmp_z`` is the across-events standardized-AR z-test with the
         Kolari-Pynnönen clustering correction on by default — use it when
@@ -282,6 +296,16 @@ def caar(
     # the same usable sample. polars' drop_nulls does not remove float NaN,
     # hence the paired drop_nans (project convention for SERIES consumers).
     n_event_periods_full = caar_df.height
+    return_scale = (
+        str(caar_df["return_scale"][0])
+        if caar_df.height and "return_scale" in caar_df.columns
+        else "unspecified"
+    )
+    event_weighting = (
+        str(caar_df["event_weighting"][0])
+        if caar_df.height and "event_weighting" in caar_df.columns
+        else "unspecified"
+    )
     caar_df = caar_df.filter(pl.col("caar").is_not_null() & pl.col("caar").is_not_nan())
     vals = caar_df["caar"]
     n = len(vals)
@@ -311,6 +335,8 @@ def caar(
         "insufficient_event_periods",
         warning_codes=tuple(warning_codes),
         axis="events",
+        return_scale=return_scale,
+        event_weighting=event_weighting,
     )
     if sc is not None:
         return sc
@@ -371,6 +397,8 @@ def caar(
         "stat_type": "t",
         "h0": "mu=0",
         "method": "non-overlapping t-test",
+        "return_scale": return_scale,
+        "event_weighting": event_weighting,
     }
     _warn_event_window_overlap(
         "caar",

--- a/tests/test_caar.py
+++ b/tests/test_caar.py
@@ -4,6 +4,7 @@ import math
 import warnings
 from datetime import datetime, timedelta
 
+import factrix as fx
 import numpy as np
 import polars as pl
 import pytest
@@ -15,6 +16,7 @@ from factrix.metrics.caar import (
     compute_caar,
 )
 from factrix.metrics.event_quality import event_hit_rate, event_ic
+from factrix.preprocess import compute_forward_return
 
 from .conftest import with_estimation_window
 
@@ -280,6 +282,8 @@ class TestComputeCaarInputForms:
         df = _two_event_panel(-1.0, 1.0, -0.02, 0.03)
         result = compute_caar(df)
         assert result["caar"].to_list() == pytest.approx([0.02, 0.03])
+        assert result["event_weighting"].unique().to_list() == ["sign"]
+        assert result["return_scale"].unique().to_list() == ["per_period_simple"]
 
     def test_magnitude_weighted_zero_R(self):
         df = _two_event_panel(2.5, -3.0, 0.01, 0.02)
@@ -333,7 +337,22 @@ class TestComputeCaarInputForms:
         df = _two_event_panel(2.5, 3.0, 0.01, 0.02)
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
-            compute_caar(df)
+            result = compute_caar(df)
+        assert result["event_weighting"].unique().to_list() == [
+            "factor_magnitude"
+        ]
+
+    def test_supplied_abnormal_return_scale_is_not_inferred(self):
+        df = _two_event_panel(1.0, 1.0, 0.02, -0.01).with_columns(
+            pl.col("forward_return").alias("abnormal_return")
+        )
+        result = compute_caar(df)
+        assert result["return_scale"].unique().to_list() == [
+            "supplied_abnormal_return"
+        ]
+        assert result["abnormal_return_model"].unique().to_list() == [
+            "market_adjusted_supplied"
+        ]
 
     def test_no_warn_on_indicator_zero_one(self):
         df = _two_event_panel(1.0, 1.0, 0.02, -0.01)
@@ -369,6 +388,8 @@ class TestCaar:
         assert result.value > 0
         assert abs(result.stat) > 2.0
         assert result.p_value < 0.05
+        assert result.metadata["return_scale"] == "per_period_simple"
+        assert result.metadata["event_weighting"] == "sign"
 
     def test_noise_not_significant(self, noise_signal):
         caar_df = compute_caar(noise_signal)
@@ -385,6 +406,8 @@ class TestCaar:
         result = caar(df)
         assert math.isnan(result.value)
         assert result.stat is None
+        assert result.metadata["return_scale"] == "unspecified"
+        assert result.metadata["event_weighting"] == "unspecified"
 
     def test_total_events_in_metadata(self, strong_signal):
         # caar reports the underlying event count (across-asset, pre-collapse)
@@ -409,6 +432,33 @@ class TestCaar:
             warnings.simplefilter("ignore", UserWarning)
             result = caar(df, overlap_periods=1)
         assert result.metadata["total_events"] == result.metadata["n_event_periods"]
+        assert result.metadata["return_scale"] == "unspecified"
+        assert result.metadata["event_weighting"] == "unspecified"
+
+    def test_evaluate_keeps_horizon_scale_contract_on_coarse_grid(
+        self, strong_signal
+    ):
+        raw = strong_signal.drop("forward_return").with_columns(
+            pl.when(pl.col("factor") != 0)
+            .then(pl.col("factor").abs() * 2.5)
+            .otherwise(0.0)
+            .alias("factor")
+        )
+        grid = raw["date"].unique().sort().gather_every(5)
+        panel = compute_forward_return(raw, forward_periods=5, dates=grid)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            evaluated = fx.evaluate(
+                panel,
+                metrics={"caar": caar()},
+                factor_cols=["factor"],
+            )["factor"]
+
+        result = evaluated.metrics["caar"]
+        assert (evaluated.forward_periods, evaluated.overlap_periods) == (5, 1)
+        assert result.reason is None
+        assert result.metadata["return_scale"] == "per_period_simple"
+        assert result.metadata["event_weighting"] == "factor_magnitude"
 
 
 class TestCaarEventSpacedSampling:

--- a/tests/test_caar.py
+++ b/tests/test_caar.py
@@ -338,18 +338,14 @@ class TestComputeCaarInputForms:
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             result = compute_caar(df)
-        assert result["event_weighting"].unique().to_list() == [
-            "factor_magnitude"
-        ]
+        assert result["event_weighting"].unique().to_list() == ["factor_magnitude"]
 
     def test_supplied_abnormal_return_scale_is_not_inferred(self):
         df = _two_event_panel(1.0, 1.0, 0.02, -0.01).with_columns(
             pl.col("forward_return").alias("abnormal_return")
         )
         result = compute_caar(df)
-        assert result["return_scale"].unique().to_list() == [
-            "supplied_abnormal_return"
-        ]
+        assert result["return_scale"].unique().to_list() == ["supplied_abnormal_return"]
         assert result["abnormal_return_model"].unique().to_list() == [
             "market_adjusted_supplied"
         ]
@@ -435,9 +431,7 @@ class TestCaar:
         assert result.metadata["return_scale"] == "unspecified"
         assert result.metadata["event_weighting"] == "unspecified"
 
-    def test_evaluate_keeps_horizon_scale_contract_on_coarse_grid(
-        self, strong_signal
-    ):
+    def test_evaluate_keeps_horizon_scale_contract_on_coarse_grid(self, strong_signal):
         raw = strong_signal.drop("forward_return").with_columns(
             pl.when(pl.col("factor") != 0)
             .then(pl.col("factor").abs() * 2.5)


### PR DESCRIPTION
## Summary

- expose CAAR `return_scale` and `event_weighting` through `compute_caar` and `MetricResult.metadata`
- distinguish unit-sign events from factor-magnitude weighting, including positive graded intensity factors
- document cumulative CAR recovery with `EvaluationResult.forward_periods`, not coarse-grid `overlap_periods`
- preserve the existing estimator, values, p-values, and warning boundary

## Validation

- `uv run --extra dev pytest tests/test_caar.py -q` (69 passed)
- evaluate/docs contract suite (404 passed)
- `uv run --extra dev mypy factrix`
- `uv run --extra dev ruff check factrix/metrics/_primitives/_caar.py factrix/metrics/caar.py tests/test_caar.py`
- `git diff --check`

Closes #961