### PR TITLE
docs: streamline documentation structure (#966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,12 @@
 # Changelog
 
-Detailed changelog entries are not maintained for the current pre-1.0
-development line.
+Detailed entries are not maintained for the current pre-1.0 line. Reconstructing
+rapid historical API and architecture changes now would risk presenting an
+incomplete upgrade guide as authoritative.
 
-factrix moved quickly and several large API, documentation, and architecture changes landed between tags before the release-note process was reliable. Reconstructing those notes after the fact would be expensive and would risk presenting incomplete or mis-bucketed history as authoritative upgrade guidance.
-
-For that reason, this file intentionally does **not** list detailed entries for
-pre-1.0 releases or current unreleased work. Exact historical source snapshots
-remain available through git tags and commit history; the index below lists only
-the pre-1.0 versions that have GitHub release entries.
-
-The changelog will be maintained from `v1.0.0` onward, when the public API is
-expected to be stable enough for release notes to serve as a trustworthy upgrade
-guide.
+Git tags and commit history remain the source for exact pre-1.0 snapshots. The
+index below lists releases with GitHub release entries; detailed changelog
+maintenance starts at `v1.0.0`, when the public API is expected to be stable.
 
 ## Historical pre-1.0 GitHub releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,4 +11,4 @@ may assume a constant stride or a bar frequency.
 Wording rule for code, docstrings, warnings, docs, issues and PRs: say
 **periods**. Never days / trading days / weeks / month-ends in a contract-level
 statement; concrete cadences appear only in explicitly labelled examples.
-Source of truth: `docs/development/architecture.md` § "Period grid, not calendar".
+Source of truth: [Period grid, not calendar](docs/development/architecture.md#period-grid-not-calendar).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,7 @@ python scripts/setup_dev.py   # installs the pre-commit framework hooks
 uv run pytest
 ```
 
-Hooks are declared in `.pre-commit-config.yaml`. Refresh their pinned
-versions with `uv run pre-commit autoupdate`; the ruff `rev` must be bumped
-together with the `ruff==` pin in `pyproject.toml` (a test enforces it).
-
-For release checks, sync every declared extra — the suite exercises the
-optional pandas / pyarrow path, and a partial sync leaves it broken:
-
-```bash
-uv sync --frozen --all-extras
-```
-
-## Development Cycle
+## Development cycle
 
 ```bash
 git checkout -b feat/<short-desc>
@@ -36,12 +25,12 @@ git push origin feat/<short-desc>
 gh pr create
 ```
 
-## Before Opening a PR
+## Before opening a PR
 
 - Keep the change scoped and include tests for new metrics, result fields, or API parameters.
 - Run `uv run pytest` locally.
 - Use `cz commit` for Conventional Commits.
 - Do not append commit signature trailers unless a future DCO policy explicitly
   requires them.
-- For metrics, docs, release flow, hooks, changelog policy, and pre-1.0 rules,
-  use the full contributing guide.
+- Follow the [full contributing guide](docs/development/contributing.md) for
+  testing, documentation, hooks, release flow, and project conventions.

--- a/README.md
+++ b/README.md
@@ -35,52 +35,23 @@
 
 <p align="center"><a href="https://awwesomeman.github.io/factrix/latest/"><b>📖 Full documentation</b></a></p>
 
-## Where factrix fits
+## What factrix does
 
-**Does this factor possess predictive edge?**
+factrix is a Polars-native toolkit for testing whether a candidate factor has
+predictive evidence. It provides factor-type-specific tests for
+cross-sectional, event, and common factors, and rejects metric/data
+combinations that do not apply.
 
-factrix is the first Polars-native Python toolkit that picks the right statistical test for each factor type. Cross-sectional, event, common factor — each gets the tests that fit its data-generating process. The full scope comparison against neighbouring libraries is in [Where factrix fits](https://awwesomeman.github.io/factrix/latest/where-factrix-fits/).
+- **Inference built for factor data** — overlap-aware standard errors,
+  persistence diagnostics, and event-study methods.
+- **Batch screening** — false-discovery-rate control for testing many factors.
+- **Structured results** — estimates, p-values, metadata, and warnings remain
+  separate instead of being collapsed into one score.
 
-```
-factor construction  →  factrix (inference)  →  strategy construction  →  backtest  →  live trading
-                            ▲ you are here
-```
-
-For each candidate factor factrix answers — *is the predictive power real?* — and corrects for multiple testing when you screen at scale. Kill fakes before they cost you a backtest.
-
-### Why factrix?
-
-- **Type-routed evaluation** — Information Coefficient + Fama-MacBeth for cross-sectional factors; Cumulative Average Abnormal Return for events.
-- **Financial statistics built in** — autocorrelation-robust standard errors (Newey-West), overlapping-forward-return correction, persistent-predictor flagging (Stambaugh bias), and false-discovery-rate control across batches (Benjamini-Hochberg-Yekutieli).
-- **Polars-native** — modern Polars alternative to the pandas-based alphalens.
-
-factrix stops at the inference — primary test plus diagnostic battery. It does not size positions, model slippage, optimise weights, or compose alphas; those belong to the later stages of the pipeline.
-
-### Is factrix the right tool?
-
-| You want to… | Use this |
-|---|---|
-| Inference on a factor (cross-sectional / event / common factor) | **factrix** |
-| Screen many factors with multiple-testing correction | **factrix** |
-| Backtest with positions / slippage / margin | [zipline-reloaded][zipline], [backtrader][backtrader], [bt][bt], [vectorbt][vectorbt], [nautilus_trader][nautilus] |
-| Optimise portfolio weights | [skfolio][skfolio], [riskfolio-lib][riskfolio] |
-| Returns-level tear-sheet (P&L diagnostics) | [pyfolio-reloaded][pyfolio], [QuantStats][quantstats] |
-| Familiar cross-sectional tear-sheet | [alphalens-reloaded][alphalens] |
-| End-to-end machine-learning pipeline | [qlib][qlib] |
-| Deflated / probabilistic Sharpe today (commercial) | [mlfinlab][mlfinlab] |
-
-[alphalens]: https://github.com/stefan-jansen/alphalens-reloaded
-[vectorbt]: https://github.com/polakowo/vectorbt
-[zipline]: https://github.com/stefan-jansen/zipline-reloaded
-[backtrader]: https://github.com/mementum/backtrader
-[bt]: https://github.com/pmorissette/bt
-[nautilus]: https://github.com/nautechsystems/nautilus_trader
-[skfolio]: https://skfolio.org/
-[riskfolio]: https://github.com/dcajasn/Riskfolio-Lib
-[pyfolio]: https://github.com/stefan-jansen/pyfolio-reloaded
-[quantstats]: https://github.com/ranaroussi/quantstats
-[qlib]: https://github.com/microsoft/qlib
-[mlfinlab]: https://github.com/hudson-and-thames/mlfinlab
+factrix covers factor inference and screening. Portfolio construction,
+backtesting, and execution remain downstream; see
+[Where factrix fits](https://awwesomeman.github.io/factrix/latest/where-factrix-fits/)
+for the scope boundary and neighbouring tools.
 
 ## Installation
 
@@ -92,16 +63,16 @@ uv add factrix
 
 See the [installation guide](https://awwesomeman.github.io/factrix/latest/getting-started/install/) for version pinning and development setup.
 
-## Typical usage
-
-**Single factor — IC evaluation**
+## Quickstart
 
 ```python
 import factrix as fx
 from factrix.metrics import ic
 
-raw   = fx.datasets.make_cs_panel(n_assets=100, n_dates=500, ic_target=0.08, rng=2024)
-data  = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+raw = fx.datasets.make_cs_panel(
+    n_assets=100, n_dates=500, ic_target=0.08, rng=2024
+)
+data = fx.preprocess.compute_forward_return(raw, forward_periods=5)
 
 results = fx.evaluate(
     data,
@@ -112,24 +83,31 @@ results = fx.evaluate(
 res = results["factor"]
 ic_res = res.metrics["ic"]
 
-print('ic_mean =', round(ic_res.value, 4))
-print('p_value =', round(ic_res.p_value, 4))
+print("ic_mean =", round(ic_res.value, 4))
+print("p_value =", round(ic_res.p_value, 4))
 ```
 
-More scenarios, runnable end to end:
+The minimum input is a long Polars frame keyed by `date` and `asset_id`, with
+a factor column and `forward_return`. Read the returned `p_value` together with
+the result's sample metadata and warnings; the
+[quickstart](https://awwesomeman.github.io/factrix/latest/getting-started/quickstart/)
+shows the complete result shape.
 
-- [Quickstart](https://awwesomeman.github.io/factrix/latest/getting-started/quickstart/) — same example, plus `.to_dict()` output and warnings.
+## Next steps
+
+- [Preparing data](https://awwesomeman.github.io/factrix/latest/guides/preparing-data/) — validate and align your own panel.
+- [Choosing a metric](https://awwesomeman.github.io/factrix/latest/guides/choosing-metric/) — map a research question to a metric.
 - [Multi-factor screening](https://awwesomeman.github.io/factrix/latest/examples/multi_factor_screening/) — BHY false-discovery-rate control across candidate factors.
 - [Multi-horizon evaluation](https://awwesomeman.github.io/factrix/latest/api/multi-horizon/) — sweeping `forward_periods` with `evaluate_horizons`.
-- [PANEL vs TIMESERIES](https://awwesomeman.github.io/factrix/latest/guides/panel-timeseries/) — single-asset evaluation with `predictive_beta`.
+- [Panel vs timeseries](https://awwesomeman.github.io/factrix/latest/guides/panel-timeseries/) — understand data-shape dispatch.
 
 ## Documentation
 
-- [**Get Started**](https://awwesomeman.github.io/factrix/latest/) — install, quickstart, where factrix fits
-- [**User Guide**](https://awwesomeman.github.io/factrix/latest/guides/) — concepts and conventions, how-to (preparing data, choosing a metric, panel vs timeseries, reading results, slice analysis), examples
-- [**API Reference**](https://awwesomeman.github.io/factrix/latest/api/) — entry points, results, lookup tables, per-metric pages
-- [**Development**](https://awwesomeman.github.io/factrix/latest/development/contributing/) — contributing, design notes
-- [**Release Notes**](https://awwesomeman.github.io/factrix/latest/development/changelog/) — changelog
+- [**Get started**](https://awwesomeman.github.io/factrix/latest/) — installation and quickstart
+- [**User guide**](https://awwesomeman.github.io/factrix/latest/guides/) — concepts, how-to guides, examples, and reference tables
+- [**API reference**](https://awwesomeman.github.io/factrix/latest/api/) — entry points, result types, and per-metric pages
+- [**Development**](https://awwesomeman.github.io/factrix/latest/development/contributing/) — contribution and design guidance
+- [**Release notes**](https://awwesomeman.github.io/factrix/latest/development/changelog/) — changelog
 
 ## License
 

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -231,7 +231,7 @@ derivation are automatically resolved at dispatch time.
 
 <div class="grid cards" markdown>
 
--   __Timeseries-mode conventions__
+-   __Common-factor regression conventions__
 
     ---
 

--- a/docs/api/metrics/common_asymmetry.md
+++ b/docs/api/metrics/common_asymmetry.md
@@ -10,11 +10,11 @@ title: factrix.metrics.common_asymmetry
 
 <hr>
 
-!!! info "Timeseries-mode conventions"
+!!! info "Common-factor regression conventions"
     Plain stage-1 SE rationale and the `forward_periods` vs
     `signal_horizon` bias framing apply here as for the rest of the
     Common × Continuous family. See
-    [Timeseries-mode conventions](../../reference/ts-mode-conventions.md).
+    [Common-factor regression conventions](../../reference/ts-mode-conventions.md).
 
 ## Use cases
 
@@ -128,7 +128,7 @@ title: factrix.metrics.common_asymmetry
 
     [reference/statistical-methods →](../../reference/statistical-methods.md)
 
--   __Timeseries-mode conventions__
+-   __Common-factor regression conventions__
 
     ---
 

--- a/docs/api/metrics/common_beta.md
+++ b/docs/api/metrics/common_beta.md
@@ -14,12 +14,12 @@ title: factrix.metrics.common_beta
 
 <hr>
 
-!!! info "Timeseries-mode conventions"
+!!! info "Common-factor regression conventions"
     Stage-1 per-asset ordinary least squares (OLS) uses **plain SE**, not heteroskedasticity-and-autocorrelation-consistent (HAC) — the dominant
     bias under a persistent predictor is Stambaugh coefficient bias,
     which HAC does not address. Non-overlap resampling is **not**
     applied (stage-1 runs on the full overlapping series). See
-    [Timeseries-mode conventions](../../reference/ts-mode-conventions.md)
+    [Common-factor regression conventions](../../reference/ts-mode-conventions.md)
     for the full rationale.
 
 ## Use cases
@@ -213,7 +213,7 @@ allocation rule.
 
     [api/by-slice →](../by-slice.md)
 
--   __Timeseries-mode conventions__
+-   __Common-factor regression conventions__
 
     ---
 

--- a/docs/api/metrics/common_quantile.md
+++ b/docs/api/metrics/common_quantile.md
@@ -10,11 +10,11 @@ title: factrix.metrics.common_quantile
 
 <hr>
 
-!!! info "Timeseries-mode conventions"
+!!! info "Common-factor regression conventions"
     Plain stage-1 SE rationale and the `forward_periods` vs
     `signal_horizon` bias framing apply here as for the rest of the
     Common × Continuous family. See
-    [Timeseries-mode conventions](../../reference/ts-mode-conventions.md).
+    [Common-factor regression conventions](../../reference/ts-mode-conventions.md).
 
 ## Use cases
 
@@ -127,7 +127,7 @@ title: factrix.metrics.common_quantile
 
     [reference/statistical-methods →](../../reference/statistical-methods.md)
 
--   __Timeseries-mode conventions__
+-   __Common-factor regression conventions__
 
     ---
 

--- a/docs/api/metrics/event_quality.md
+++ b/docs/api/metrics/event_quality.md
@@ -61,7 +61,8 @@ title: factrix.metrics.event_quality
     (`value = NaN`). `event_skewness` reports the Fisher-
     corrected skewness of the `signed_car` distribution, descriptively:
     `p_value` and `stat` are always `None` because no pooled test of that
-    third moment is calibrated here (statistical-methods section 6).
+    third moment is calibrated here (see
+    [Inference calibration and limitations](../../reference/inference-calibration.md#event-skewness-has-no-calibrated-test)).
     Useful for screening fat-right-tail vs symmetric event payoffs.
 
 -   __Firing frequency__

--- a/docs/api/metrics/trend.md
+++ b/docs/api/metrics/trend.md
@@ -30,16 +30,17 @@ title: factrix.metrics.trend
 
     Median pairwise slope $\mathrm{median}\{(y_j - y_i)/(j - i): i <
     j\}$ has a 29.3 % breakdown point — absorbs IC outliers (e.g. COVID-
-    era spikes) that would dominate an ordinary least squares (OLS) slope. The trade-off is the
-    SE recovered from the rank-CI is approximate, not asymptotically
-    exact.
+    era spikes) that would dominate an ordinary least squares (OLS) slope.
+    Theil-Sen supplies magnitude and a descriptive interval; Hamed-Rao
+    Mann-Kendall supplies the test statistic and p-value.
 
 -   __Unit-root pre-check on the input__
 
     ---
 
-    `adf_threshold` (default 0.10, the Stock-Watson cutoff) drives an
-    augmented Dickey-Fuller (ADF) persistence diagnostic on the input series. Above the cutoff
+    `adf_threshold` (default 0.10, a conventional practitioner cutoff) drives
+    an augmented Dickey-Fuller (ADF) persistence diagnostic on the strided
+    tested series. Above the cutoff
     the slope null is rejected at inflated rates regardless of the
     true trend; the slope value is still returned but
     `metadata["unit_root_suspected"] = True` flags it for sceptical
@@ -122,7 +123,7 @@ title: factrix.metrics.trend
     ---
 
     Theil-Sen breakdown point, ADF persistence diagnostic (MacKinnon
-    response surface), and the rank-CI to approximate-$t$ recovery.
+    response surface), and Hamed-Rao Mann-Kendall inference.
 
     [reference/statistical-methods →](../../reference/statistical-methods.md)
 

--- a/docs/api/slice-test.md
+++ b/docs/api/slice-test.md
@@ -137,15 +137,19 @@ same per-slice per-date series but **do not** inner-join — each slice is
 treated as an independent sample with block-diagonal cross-slice
 covariance. A two-valued `method` flag selects the estimator:
 
-| `method` | Per-slice SE | Pairwise `p_adj` | Best for |
+| `method` | Per-slice SE | Pairwise `p_adj` | Finite-sample note |
 |---|---|---|---|
-| `"bootstrap"` (default) | Independent stationary block bootstrap (Politis-White automatic block length) | Romano-Wolf step-down | Short regimes (T ≈ 30-80); never invalid |
-| `"analytic"` | Per-slice Newey-West HAC, Welch-style pairwise contrast | Holm step-down | Long spans (T ≳ 100); fast, deterministic |
+| `"bootstrap"` (default) | Independent stationary block bootstrap (Politis-White automatic block length) | Romano-Wolf step-down | Avoids a closed-form normal reference, but over-rejects in the measured `K=5` short-slice cells |
+| `"analytic"` | Per-slice Newey-West HAC, Welch-style pairwise contrast | Holm step-down | Fast and deterministic; better calibrated for measured `K=5` pairwise contrasts |
 
 Under `method="bootstrap"` both take `n_resamples=` (default 999, floored
 at 199) and `rng=` — the library-wide resampling knobs, see
 [Resampling knobs](../reference/statistical-methods.md#resampling-knobs).
 `"analytic"` ignores both.
+
+Neither method is uniformly better in small samples. See
+[Joint period tests on short slices](../reference/inference-calibration.md#joint-period-test-on-short-slices-known-over-rejection)
+before interpreting a short-regime omnibus or choosing the pairwise path.
 
 Each slice's per-period series must clear the metric's own sample floor,
 resolved at the panel's stamped or declared `overlap_periods` — the same

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,24 +1,19 @@
 ---
-title: factrix Architecture
+title: factrix architecture
 ---
 
-Current-state snapshot of the public API surface and internal layout.
+Current-state reference for internal contracts, dispatch, and module layout.
+Use it as a lookup page rather than a start-to-finish guide. User-facing scope
+lives in [Where factrix fits](../where-factrix-fits.md); callable details live
+in the [API reference](../api/index.md).
 
 ---
 
 ## Positioning
 
-**factrix is a factor-signal validator, not a backtest engine.**
-
-The library produces a single canonical p-value (`MetricResult.p_value`) and
-its explicit tested tail (`MetricResult.alternative`) per
-factor per `(scope, density, structure)` cell from the cell's mainstream
-metric (information coefficient (IC) / FM-λ / CAAR / TS-β). Dense
-time-series mainstream metrics use Newey-West (NW)
-heteroskedasticity-and-autocorrelation-consistent (HAC) inference; CAAR uses
-event-period-indexed non-overlap sampling on the event-period series. Realistic execution simulation,
-tradability proxies, and portfolio construction are out of scope — feed
-screened factors into Zipline / Backtrader / `vectorbt` downstream.
+factrix is a factor-inference and screening library, not a backtest engine.
+Each metric keeps its estimate, tested tail, p-value, metadata, and warnings
+explicit; downstream portfolio and execution state stays outside the package.
 
 ---
 
@@ -94,25 +89,18 @@ The dispatch runs through a Directed Acyclic Graph (DAG) executor on a closed `l
 
 ## Public API surface
 
-Primary public entry points:
+The public surface has four layers:
 
-| Symbol | Purpose |
-|--------|---------|
-| `fx.evaluate(panel, metrics=...)` | Dispatch to the metrics applicable to the factor's cell |
-| `fx.multi_factor.bhy(results, *, metrics, expand_over=(), q=0.05)` | Benjamini-Hochberg-Yekutieli (BHY) false discovery rate (FDR) correction; one declared family per call (optionally split per-bucket via `expand_over`) |
-| `fx.multi_factor.bhy_across_metrics(results, *, metrics, expand_over=(), q=0.05)` | One pooled BHY family over factor × metric hypotheses, optionally partitioned by predeclared contexts |
-| `fx.multi_factor.partial_conjunction(results, *, metrics, min_pass, expand_over, ...)` | Factor confirmation in at least `min_pass` predeclared contexts |
-| `fx.multi_factor.partial_conjunction_across_metrics(results, *, metrics, min_pass, q=0.05)` | Factor confirmation on at least `min_pass` predeclared metric endpoints |
-| `fx.multi_factor.bhy_hierarchical(results, *, metrics, group, q=0.05)` | Two-stage FDR screening across and within predeclared groups |
+1. `evaluate` and `evaluate_horizons` build factor results.
+2. `by_slice`, slice tests, and `compare` inspect or contrast those results.
+3. `multi_factor` procedures apply declared-family FDR and partial-conjunction
+   rules.
+4. Result dataclasses, enums, errors, and discovery helpers expose the stable
+   contracts used by all three layers.
 
-Plus introspection / error / enum re-exports:
-
-- `fx.FactorScope`, `fx.FactorDensity` — user-facing axes
-- `fx.WarningCode` — structured result codes
-- `fx.FactrixError`, `fx.IncompatibleAxisError`, `fx.IncompatibleInferenceError`,
-  `fx.InsufficientSampleError`, `fx.UserInputError` — exception hierarchy (see § Error UX contract)
-
-`__version__` is sourced from `pyproject.toml` (Commitizen-managed).
+The [API reference](../api/index.md) is the source for current signatures and
+the complete entry-point list. `__version__` is sourced from
+`pyproject.toml` and managed by Commitizen.
 
 ---
 
@@ -971,7 +959,7 @@ Hard constraints — violating these breaks the API contract:
 4. The DAG executor is the single dispatch path. `DagExecutor` topologically orders specs by `MetricSpec.requires` (raising `CycleError` on cycles), runs `batchable=True` producers once per factor batch and `batchable=False` consumers once per factor, and short-circuits a downstream consumer with a NaN `MetricResult` + `WarningCode.UPSTREAM_UNAVAILABLE` rather than invoking it on missing upstream data.
 5. `MetricResult.p_value` is the single canonical p-value read path — `EvaluationResult.to_frame()` / `to_dict()`, `compare`, and the BHY family resolver all read it; the p-value lives only on the field and is not duplicated into `metadata`. A formal p-value and `alternative` (`two-sided` / `greater` / `less`) must be present together; p-values are finite and in `[0, 1]`. `warnings` flag interpretation risk but never rebind it.
 6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over` where the API supports it. Shared resolution enforces (a) the result identity `(factor, forward_periods, *sorted(params.items()))` is unique across the input — every `params` entry joins it automatically, while `metadata` never does, (b) `expand_over` names come only from `EvaluationResult.params` (or the built-in `forward_periods`), never the factor and never a `metadata` key, (c) formal p-values are populated before procedures read them. Cross-metric BHY adds the metric label to the hypothesis identity; cross-metric partial conjunction keeps the predeclared metric count fixed under insufficient endpoints. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
-7. A metric whose effective sample is below its own hard floor raises `InsufficientSampleError` under `strict=True` (per metric, per axis, on the effective post-stride/post-drop sample — not a global `T` rule); metrics never silently produce a result on under-sampled data. NW HAC lag selection on overlapping forward returns floors at `forward_periods - 1` (the Hansen-Hodrick floor) so serial correlation from overlap is not under-counted.
+7. A metric whose effective sample is below its own hard floor raises `InsufficientSampleError` under `strict=True` (per metric, per axis, on the effective post-stride/post-drop sample — not a global `T` rule); metrics never silently produce a result on under-sampled data. NW HAC bandwidths read `overlap_periods` and never fall below `h - 1`; scalar series means and rank-one contrasts use the wider calibrated `3(h - 1)` floor, while multi-restriction Wald paths retain the Hansen-Hodrick floor.
 
 For the user-facing field walk of `EvaluationResult` (and its
 `metrics` mapping), see
@@ -988,49 +976,6 @@ from disk.
 
 Run: `uv run pytest`
 
-### Docs SSOT strategy — MetricSpec drives generated tables
-
-`docs/reference/metric-pipelines.md` does not contain a hand-written
-matrix. The matrix is generated at build time from the same typed
-`MetricSpec` registry that runtime discovery uses.
-
-**How it works:**
-
-- Each public metric callable declares its cell and aggregation through
-  `@metric`, producing a `MetricSpec`.
-- `scripts/mkdocs_hooks/gen_metric_matrix.py` (a MkDocs `hooks:` entry) reads
-  `factrix._metric_index.public_specs()`, groups specs by module / cell /
-  aggregation, and writes
-  `docs/reference/_generated_metric_matrix.md` before each docs build.
-- `scripts/mkdocs_hooks/gen_metric_name_index.py` reads the same spec set and
-  writes `docs/reference/_generated_metric_name_index.md`.
-- `metric-pipelines.md` includes the generated file via
-  `--8<-- "docs/reference/_generated_metric_matrix.md"` (pymdownx.snippets).
-
-**CI coverage (`tests/test_docs_matrix.py`):**
-
-- Every public metric module registers at least one public `MetricSpec`.
-- `_generated_metric_matrix.md` exists and is non-empty (skipped if absent,
-  so CI that only runs pytest without a prior build does not false-positive).
-- The generated matrix and name-index files match the live renderers, catching
-  stale generated docs after registry changes.
-
-**Why the registry rather than hand-written tables:** the same source of truth
-now serves runtime discovery (`list_metrics()` / `metrics_summary()`), dispatch
-validation, and the rendered reference tables. Adding or changing a metric in
-one place updates both the API and the docs on the next build, and CI catches
-generated-file drift.
-
-### Example docs SSOT strategy - notebooks render MkDocs pages
-
-Worked example recipes use the executable notebook as the source of truth:
-`examples/*.ipynb` renders to `docs/examples/*.md` during the docs build via
-`scripts/mkdocs_hooks/render_example_notebooks.py`.
-
-The generated markdown files stay committed so GitHub and local docs reads do
-not require running MkDocs first. Drift is caught in two places:
-
-- `tests/test_example_notebook_docs.py` compares committed example pages with
-  the live notebook renderer.
-- `.github/workflows/docs-deploy-dev.yml` runs `mkdocs build --strict`, then
-  `git diff --exit-code` on the generated example pages.
+Documentation source-of-truth and generation rules live in
+[Documentation conventions](documentation.md#sources-of-truth), so this page
+can remain focused on runtime architecture.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -2,978 +2,170 @@
 title: Contributing to factrix
 ---
 
-This document describes the factrix development workflow. factrix is a
-public repository with a single maintainer, so this guide covers the
-**development workflow and its pitfalls** rather than OSS contributor
-conventions (licensing / DCO / CLA).
+This page covers the development workflow. Use the companion references for
+[documentation conventions](documentation.md), the
+[release process](release-process.md), and current
+[architecture contracts](architecture.md).
 
----
-
-## 1. Development setup
-
-Clone the factrix repo directly into its own venv:
+## Development setup
 
 ```bash
 git clone https://github.com/awwesomeman/factrix.git
 cd factrix
 uv sync --extra dev
-uv run pytest        # confirm baseline is green
+python scripts/setup_dev.py
+uv run pytest
 ```
 
-factrix is developed and tested as a standalone package. A consuming
-project (a research workspace, a notebook, a pipeline) depends on it the
-way it depends on any other library — an exact PyPI version or a git tag —
-and is never edited from inside that project; see
-[Versioning and release](#7-versioning-and-release-semver--release) for the pinning policy.
+`pyproject.toml` and `uv.lock` define the environment. Do not install packages
+directly into `.venv`; use `uv add`, update the project metadata, and commit the
+lockfile change together.
 
----
+### Extras
 
-## 2. Environment setup
+| Command | Purpose |
+|---|---|
+| `uv sync` | Runtime dependencies only |
+| `uv sync --extra dev` | Tests, lint, typing, and commit tooling |
+| `uv sync --extra docs` | MkDocs and API-documentation tooling |
+| `uv sync --extra pandas` | pandas/pyarrow input adapter |
+| `uv sync --extra jupyter` | Notebook environment |
+| `uv sync --frozen --all-extras` | Full CI or release verification |
 
-factrix uses **uv** to manage the Python venv and lockfile.
-`pyproject.toml` and `uv.lock` are the sole authority—do not use
-`pip install` to drop anything directly into `.venv/`.
+The named `all` extra is the optional runtime bundle; it does not include the
+development and docs toolchains. Use `--all-extras` when every declared extra
+is required.
 
-Python is pinned to **3.12+** (defined by `requires-python` in
-`pyproject.toml`).
-
-### Dependencies and extras
-Use `--extra` to add or drop modules per development needs:
-
-```bash
-uv sync                              # core only (polars, numpy, scipy)
-uv sync --extra dev                  # +pytest, commitizen, etc. (required to write code)
-uv sync --extra pandas               # +pandas / pyarrow (factrix.adapt on pandas input)
-uv sync --extra jupyter              # +jupyter / jupyterlab / ipywidgets (notebooks)
-uv sync --extra docs                 # +mkdocs-material, mkdocstrings, mike (build the site)
-uv sync --frozen --all-extras        # local CI / release checks (see the release-train drift audit)
-```
-
-The declared extras are `pandas`, `jupyter`, `dev`, `docs`, and `all` (where
-`all == factrix[jupyter]`).
-
-!!! note "`dev` and `docs` are separate from `all`"
-    `all` only pulls in the `jupyter` extra — the toolchain (`dev`) and
-    docs-build (`docs`) extras are deliberately kept separate from the named
-    `all` extra. Use `--all-extras` when you really want every declared extra:
-
-    ```bash
-    uv sync --all-extras              # every declared extra
-    ```
-
-### Common environment commands
-```bash
-uv run <cmd>         # run inside the venv (e.g. uv run pytest)
-uv add <pkg>         # add dep, sync pyproject + uv.lock
-uv lock --upgrade    # upgrade lock to the latest within current pyproject constraints
-```
-
-### Windows test notes
-
-On Windows consoles, prefer UTF-8 mode for tests that read Markdown or
-render diagnostics with non-ASCII characters:
+On Windows, enable UTF-8 for Markdown and diagnostic tests if the console does
+not already do so:
 
 ```powershell
 $env:PYTHONUTF8="1"
 .\.venv\Scripts\python.exe -m pytest -q -p no:faulthandler
 ```
 
-Timezone-aware Polars tests also need Python timezone data available
-for `ZoneInfo("UTC")` / UTC conversions. Run `uv sync --extra dev`
-from the repo lockfile before testing; if a local environment was
-manually altered and timezone tests fail with missing timezone data,
-resync the environment instead of patching tests.
+`uv sync` installs factrix in editable mode. Restart a Jupyter kernel after
+changing module imports, dataclasses, or module-level constants; autoreload is
+not sufficient for those changes.
 
-### Editable install and Jupyter
+## Git hooks
 
-`uv sync` installs factrix in editable mode, so source changes reach
-`import factrix` immediately — with the usual Jupyter exceptions:
+`python scripts/setup_dev.py` installs the `pre-commit`, `commit-msg`, and
+`pre-push` stages declared in `.pre-commit-config.yaml`. Installation is local
+to each clone.
 
-- Function body changes → caught by `%autoreload 2`
-- `__init__.py` imports / dataclass definitions / module-level
-  constants → **restart the kernel**
+| Stage | Checks |
+|---|---|
+| `pre-commit` | Ruff lint and format checks for staged Python/notebook changes |
+| `commit-msg` | Commit-message and contributor-trailer policy |
+| `pre-push` | Strict docs build for docs-relevant paths, mypy for package paths, and release-note checks where applicable |
 
-When in doubt, restart the kernel.
-
-### Git hooks
-
-Hooks are managed by the [pre-commit](https://pre-commit.com/) framework;
-`.pre-commit-config.yaml` at the repo root declares them and
-`scripts/hooks/` holds the two repo-local hook scripts. Run once after a
-fresh clone:
-
-```bash
-python scripts/setup_dev.py
-```
-
-The script runs `pre-commit install` for the `pre-commit`, `commit-msg`
-and `pre-push` stages. Idempotent — re-running just rewrites the same
-shims; aborts (non-zero exit) if `core.hooksPath` is set at all, since it
-would shadow the installed hooks and a contributor's dotfiles-managed hook
-surface must not be silently overwritten. The installation is per-clone
-and local; it does not propagate across machines, so every clone / new
-machine must run the script once. `git worktree` instances share
-`.git/hooks` with their primary clone, so one
-run at the primary clone covers every worktree under it.
-
-`pre-commit` — when staged changes include `*.py` / `*.ipynb`, runs
-`ruff check` + `ruff format --check`. Both gate rather than rewrite: a
-hook run never mutates your files. CI's `lint` job runs the same
-`uv run pre-commit run --all-files --hook-stage pre-commit`, so local and
-CI cannot drift. Fail → blocks the commit; fix-then-commit, or use
-`git commit --no-verify` to bypass. Scoped to staged files, so commits
-touching only YAML / Markdown / .txt don't trigger.
-
-`commit-msg` — rejects `Co-Authored-By: Claude <...@anthropic.com>`
-trailers, which GitHub would surface on the repo's contributor graph.
-
-`pre-push` — for `v1.0.0+` release commits (`chore(release): vX.Y.Z`),
-checks that the `## vX.Y.Z` section in `CHANGELOG.md` has ≥ 25 non-blank
-lines. Below threshold → blocks the push, forcing you to add WHY narrative
-(BREAKING migration, behavioural direction, motivation) before pushing. Pre-1.0
-release commits skip this gate; see the [Pre-1.0 version guide](#pre-10-version-guide). It
-also runs `mkdocs build --strict` when the push touches docs-relevant paths and
-`uv run mypy factrix` when it touches `factrix/**/*.py`. To bypass:
-`git push --no-verify`.
-
-Adjust the threshold (per-shell):
-
-```bash
-CHANGELOG_MIN_LINES=10 git push
-```
-
-Run any stage by hand without committing:
+Run the lint stage directly with:
 
 ```bash
 uv run pre-commit run --all-files --hook-stage pre-commit
 ```
 
-Maintenance: `uv run pre-commit autoupdate` bumps each `rev` to the
-latest upstream tag. The ruff `rev` must stay equal to the `ruff==` pin
-in `pyproject.toml` — that pin is the source of truth, so bump it to
-match in the same commit. `tests/test_precommit_ruff_pin.py` fails when
-the two diverge.
+When updating hook versions, run `uv run pre-commit autoupdate`. Keep the Ruff
+hook revision equal to the `ruff==` development pin in `pyproject.toml`; a test
+enforces the match.
 
-Rationale: see [Versioning and release](#7-versioning-and-release-semver--release) for release-note and pre-1.0 policy.
-
----
-
-## 3. Development cycle (branch → test → commit → push → PR)
+## Development workflow
 
 ```bash
-# 1. Branch off main (do not commit directly to main)
-git checkout main && git pull
-git checkout -b <type>/<short-desc>     # e.g. feat/redundancy-heatmap
+git switch main
+git pull --ff-only origin main
+git switch -c <type>/<short-description>
 
-# 2. Develop + run tests frequently
-# ...edit...
-uv run pytest                            # must be all green before commit
-uv run pytest tests/test_<file>.py -v   # focus on a single module for fast iteration
+# edit and test
+uv run pytest tests/test_<area>.py -v
+uv run pytest
 
-# 3. Commit (Conventional Commits + interactive generation)
-git add <specific-files>                 # avoid -A
-cz commit                                # Commitizen produces standard format
-
-# 4. Push + open PR
-git push origin feat/redundancy-heatmap
-gh pr create --title "..." --body "..."
-
-# 5. After CI is green, merge (currently solo → squash-merge or rebase-merge)
-gh pr merge --squash
+git add <specific-files>
+cz commit
+git push -u origin <type>/<short-description>
+gh pr create
 ```
 
-!!! warning "Do not run `cz bump` after merge"
-    Versions and tags follow the [release-train cadence](#release-cadence--release-train) — a single
-    release fires after several PRs accumulate. Follow the Pre-1.0 version guide
-    in the [Pre-1.0 version guide](#pre-10-version-guide) for pre-1.0 PR narrative and changelog behavior.
+Use lowercase, hyphenated branches under `feat/`, `fix/`, `docs/`,
+`refactor/`, or `chore/`. Do not commit directly to `main`.
 
-### Branch naming
+Commits follow Conventional Commits. Keep the subject concise and use the body
+for the reason and behavioural effect. Do not add AI co-author or
+`Signed-off-by` trailers unless a future repository policy explicitly requires
+them.
 
-`<type>/<short-desc>`, all lowercase with hyphens:
+Open one pull request for one reviewable concern. The PR body should contain a
+short summary, the verification performed, and `Closes #<issue>` when it
+resolves an issue. Version bumps and tags follow the independent
+[release process](release-process.md), not each merged PR.
 
-- `feat/...` — new feature
-- `fix/...` — bug fix
-- `refactor/...` — refactor (no behavioural change)
-- `docs/...` — documentation
-- `chore/...` — packaging / CI / lockfile maintenance
+## Testing rules
 
-### Commit message
+- Use synthetic fixtures from `tests/conftest.py` or `factrix.datasets`; tests
+  do not read private or live market data.
+- Add tests for new metrics, public result fields, parameters, error paths, and
+  documented warnings.
+- Characterise statistical size separately from ordinary unit behaviour. A
+  reduced-replication guard can pin a measured band, while the larger sweep is
+  documented in [Inference calibration](../reference/inference-calibration.md).
+- Run focused tests while iterating, then the full suite before opening a PR.
+- Do not bypass hooks or tests to make a branch appear green.
 
-The project follows **Commitizen** + **Conventional Commits**.
-**Always use `cz commit` for interactive commits**—it validates title
-length and other rules automatically.
-
-**Reminders**:
-- Description length `< 50 chars`
-- Body uses `-` bullets, recording only "why" + "what"—do not restate
-  the diff; aim for `< 72 chars` per line
-- No AI co-author signature, no emoji, no trailing period
-- Do not append commit signature trailers unless a future DCO policy explicitly
-  requires them
-
----
-
-## 4. Docs sync boundary (Source of Truth)
-
-After editing `factrix/`, the table below tells you which `docs/`
-files auto-update and which need manual maintenance.
-
-### Auto-sync pipelines
-
-| Source (SSOT) | Docs target | Mechanism |
-|---|---|---|
-| `factrix/**/*.py` docstrings | `:::` directives in `docs/api/**/*.md` | mkdocstrings plugin |
-| `factrix._metric_index.public_specs()` | `docs/reference/_generated_metric_matrix.md`, `docs/reference/_generated_metric_name_index.md` | hooks: `scripts/mkdocs_hooks/gen_metric_matrix.py`, `scripts/mkdocs_hooks/gen_metric_name_index.py` |
-| `factrix._codes.WarningCode.description` | `docs/reference/_generated_warning_codes.md` | hook: `scripts/mkdocs_hooks/gen_code_descriptions.py` |
-| `factrix/llms*.txt` | site root `llms*.txt` | hook: `scripts/mkdocs_hooks/sync_llms_txt.py` |
-
-#### Docstring `Examples:` — runnable, copy-paste ready
-
-Every page-primary callable reachable from the API Reference nav carries an
-`Examples:` block in its docstring.
-The docstring is the single source of truth — `.md` pages do not
-duplicate runnable examples, only document things the example
-cannot show (output schemas, attribute tables, semantic intent).
-
-Convention:
-
-- Section header is `Examples:` (plural, Google style).
-- Source uses `>>>` doctest prompt syntax. The Material copy button
-  is configured (via `docs/javascripts/copy-strip-pycon.js`) to
-  strip `>>>` prompts and expected-output lines from the clipboard
-  payload, so readers can copy a `pycon` block straight into a
-  REPL or script.
-- Show **call shape**, not fragile output. Lines starting with
-  `>>>` carry the educational value; expected-output lines (lines
-  without `>>>`) are reserved for values stable across BLAS / numpy
-  / polars / Python versions.
-- Avoid concrete floating-point values, DataFrame / array reprs, or
-  multi-line text reprs as expected output. If a value must be
-  shown, prefer structural facts (enum value, integer length,
-  boolean from `isinstance`).
-- Setup is self-contained — construct any required panel inline via
-  `fx.datasets.make_cs_panel(...)` + `compute_forward_return(...)`
-  so the snippet runs verbatim with no surrounding fixtures.
-
-Examples blocks are CI-verified. The `doctest` job in
-`.github/workflows/test.yml` runs `pytest --doctest-modules
-factrix/` on every PR; option flags (`ELLIPSIS`,
-`NORMALIZE_WHITESPACE`) live in `[tool.pytest.ini_options]
-doctest_optionflags` so individual Examples carry no
-`# doctest:` directives. A renamed symbol, changed signature,
-or dropped import that breaks an Example surfaces on the same
-PR as the change.
-
-Page-level demo admonitions (`## Worked example`, `!!! example`
-blocks) are reserved for end-to-end demos that intentionally show
-something the docstring cannot — typically a longer
-synthetic-panel walk-through with `EvaluationResult.warnings` output or a
-cross-cell config recipe table. They do not echo the docstring
-example.
-
-#### Examples - notebook SSOT + generated MkDocs pages
-
-`examples/*.ipynb` files at repo root are the executable source of truth for
-worked example recipes. The `docs/examples/*.md` pages are generated by
-`scripts/mkdocs_hooks/render_example_notebooks.py` during `mkdocs build` and
-must not be edited directly.
-
-New example convention:
-
-- Write or update `examples/<name>.ipynb` first. Match the shape of the existing
-  recipes: a top-level title, narrative blocks (`Factor type` / `Use this when`
-  / `What it tests` / `Output to read` where useful), numbered step sections,
-  runnable code cells, and short illustrative output blocks only when they help
-  interpretation.
-- Do **not** print `fx.__version__` or include trailing
-  `print("<name>: ok")` smoke tests in visible notebook cells. Those lines render
-  into the docs and invite drift on every release.
-- Regenerate the derived markdown with
-  `python scripts/mkdocs_hooks/render_example_notebooks.py` or `mkdocs build`.
-  `tests/test_example_notebook_docs.py` and the docs workflow fail when the
-  generated pages are stale.
-
-### Docs that still need manual maintenance
-
-- `docs/api/**/*.md`: each contains a hand-written 2–5 line
-  narrative intro plus a `:::` directive; new public metrics require a
-  new file plus a `nav:` entry in `mkdocs.yml`
-- `docs/getting-started/`, `docs/guides/`, `docs/development/`, the
-  homepage `index.md`, and per-section `index.md`: pure narrative
-- `docs/reference/metric-pipelines.md`, `statistical-methods.md`,
-  `warning-codes.md`, `bibliography.md`: narrative roll-ups (not
-  matrices)
-
-### Nav classification principle
-
-Pages are placed in the nav by **what reading task they serve**, not by
-which folder they happen to live in. Four shapes carry the whole site:
-
-- **symbol-centric** — one mkdocstrings page per public callable / class.
-  Lives under `API reference`. Reader knows the name, wants signature +
-  semantics. (`evaluate`, `bhy`, `EvaluationResult`, every `metrics/<x>.md`.)
-- **question-centric** — answers a "how do I do X?" task with a short
-  walk-through. Lives under `User guide` > `How-to`. Title is the
-  question, body is the recipe. (`Choosing a metric`,
-  `Panel vs timeseries`, `Preparing data`.)
-- **lookup** — pure table or reverse-index, scanned not read. Lives
-  under `User guide` > `Reference tables`. Ordered by quant scan
-  frequency, not alphabetically. (`Metrics applicability`, `Stat keys`,
-  `Warning codes`.)
-- **migration** — deprecation notes, rename recipes, BREAKING upgrade
-  paths. Belongs to the `Release notes` register. Linked from the
-  CHANGELOG entry that retired the surface; not given its own nav slot
-  unless ≥ 3 active migration pages accumulate (single-member groups
-  read as navigation cruft).
-
-#### Folder path and nav placement are decoupled
-
-The on-disk path under `docs/` is **never** changed to match a nav
-move. mike publishes versioned URLs from the file path, and external
-links (issue references, downstream notebooks, search indexes) pin to
-that URL — relocating `docs/api/metrics/ic.md` to
-`docs/guides/ic.md` would 404 every link captured before the
-move. Nav is the editorial layer; folders are the URL contract. When
-re-classifying a page, change only the `mkdocs.yml` entry; leave the
-file where it is.
-
-#### Title casing and acronym rules
-
-Nav labels and page `title:` frontmatter follow sentence case: only the
-first word, proper nouns, and code identifiers used as proper nouns
-take a capital. Tab labels (`Get started`, `User guide`, `API
-reference`, `Release notes`) follow the same rule.
-
-- **Acronyms in nav labels are spelled out** (`Timeseries-mode
-  conventions`, `Validating allocation signals`)
-  with no parenthetical short form. The short form is redundant for
-  domain readers and mis-leading for newcomers; first-use expansion is
-  the page's first paragraph or the `Glossary` entry, not the sidebar.
-- **Universal technical acronyms are an exception** — `API` is not
-  expanded.
-- **Code identifiers do not appear in CAPS in nav labels.** DataStructure enum
-  values (`DataStructure.PANEL` / `DataStructure.TIMESERIES`) become `Panel` / `Timeseries`
-  in nav; reach for backticks inside body prose when the literal
-  identifier matters. Dataclass / class names inside `Results` (e.g.
-  `MetricResult`, `EvaluationResult`) keep PascalCase because that node *is*
-  the mkdocstrings spec page for the symbol — the title is the symbol.
-
-### Nav structure conventions
-
-The mkdocs nav follows a **pure-label** policy: every group label in
-`mkdocs.yml` is a non-clickable organising heading; every entry with
-content is an explicit leaf with a sidebar label. `navigation.indexes`
-is intentionally disabled so the visual contract is "label = heading,
-leaf = page, never both".
-
-When adding a new section or hub page:
-
-- Group labels carry no page reference. They look like `- Concepts:`
-  followed by an indented list of leaves.
-- Hub or overview pages (e.g. `api/metrics/index.md`) appear as an
-  explicit leaf with label `Overview` as the first child of their
-  group: `- Overview: api/metrics/index.md`.
-- Leaf labels are unique within their sidebar branch — never reuse the
-  parent group's name as a leaf label.
-
-This keeps `mkdocs build --strict` green and the sidebar legible without
-clicking through to discover affordance.
-
----
-
-## 5. Drift management
-
-Documentation, generated reference material, and example notebooks drift
-away from the code they describe. The project's working policy:
-**automate symbol-level drift, leave narrative/conceptual drift to
-review, and run a manual half-hour pass at every release-train cut.**
-The framing below is heuristic — when a new "should I add a test for
-this drift?" question arises, judge it by whether the cost of
-automating exceeds the cost of missing.
-
-### 5.1 Automated drift checks
-
-Enforced by tests and CI — a regression fails the PR build.
-
-| Drift class | Enforced by |
-|---|---|
-| Generated docs freshness (metric matrix, name index, warning-code table) | `tests/test_docs_matrix.py`, plus the `git diff --exit-code` step in `.github/workflows/docs-deploy-dev.yml` |
-| Public-surface mention coverage in `factrix/llms-full.txt` | `tests/test_docs_llms.py` |
-| Public-surface mention coverage across all docs pages | `tests/test_docs_pages.py` |
-| Hand-authored `python` fences on every docs page execute against the current API | `tests/test_docs_examples.py` |
-| Every public metric module has a docs page whose `members:` mirrors its `__all__` | `tests/test_metric_api_members_match_all.py` (module list derived from `factrix/metrics/`) |
-| README quickstart end-to-end | `tests/test_readme_quickstart.py` |
-| mkdocs nav / link integrity | `uv run mkdocs build --strict` (run in `.github/workflows/docs-deploy-dev.yml`) |
-| Type-checking gate (`mypy factrix`) | `uv run mypy factrix` (lint job in `.github/workflows/test.yml`) |
-
-### 5.2 Drift left to human review
-
-Deliberately not automated, because machine-judgement cost > miss cost:
-
-- **Architecture narrative vs current code design**
-  (`docs/development/architecture.md`) — accuracy hinges on whether the
-  prose still captures the *spirit* of the design; a string match
-  cannot judge that.
-- **Conceptual / explanatory text in guides**
-  (`docs/guides/*.md`, `docs/getting-started/*.md`) — wording quality
-  and pedagogical ordering are reviewer calls; a stale phrasing often
-  parses fine.
-- **Editorial choices in `factrix/llms-full.txt`** — depth of context,
-  ordering, and what to omit are agent-UX decisions, not symbol
-  coverage (which [Automated drift checks](#51-automated-drift-checks) already enforces).
-
-Rule of thumb: if the drift can be detected by a string match or a
-function call, automate it; if catching it requires reading prose for
-meaning, leave it to release-train review.
-
-### 5.3 Release-train drift audit
-
-Before running a release bump (see [Versioning and release](#7-versioning-and-release-semver--release)), run this checklist on `main`:
+The baseline local checks are:
 
 ```bash
-# 1. Search for symbols retired this release cycle that may have leaked back in.
-#    Build PATTERN from the breaking changes since the last tag (the `!`-marked
-#    commits and the CHANGELOG's breaking entries). It is rebuilt every cycle,
-#    not inherited — a pattern that survives past its removal only adds noise.
-git grep -nE "$PATTERN"
-
-# 2. Sync the release-check toolchain from locked project metadata. All
-#    extras, not just dev + docs: the full suite expects the optional
-#    ``pandas`` / ``pyarrow`` path installed (CI runs the no-pandas floor
-#    separately), and dropping the extra leaves a dangling
-#    ``site-packages/pandas/`` that imports without ``DataFrame``.
-uv sync --frozen --all-extras
-
-# 3. Lint, formatting, and typing — mirrors the CI lint job.
-uv run ruff check .
-uv run ruff format --check .
+uv run pre-commit run --all-files --hook-stage pre-commit
 uv run mypy factrix
-
-# 4. Full test suite — covers every automated drift check.
-uv run pytest -q
-
-# 5. Doctests — mirrors the CI doctest job.
-uv run pytest --doctest-modules factrix/
-
-# 6. Strict docs build — surfaces broken nav, links, and generated-file drift.
-uv run mkdocs build --strict
-
-# 7. Public-surface coverage spot-check (also run by step 4; explicit run
-#    is cheap and isolates failures).
-uv run pytest tests/test_docs_llms.py tests/test_docs_pages.py -q
-
-# 8. Package build — mirrors the CI wheel build job.
-uv build --python 3.12
-
-# 9. Review release-note policy before changelog edits:
-#    - the versioning and release section of this file
-#    - the top of CHANGELOG.md
-```
-
-A failure on any step is a release blocker — fix on `main` (or revert
-the offending PR) before bumping.
-
-### 5.4 Type-checking conventions
-
-`uv run mypy factrix` is enforced in CI. Three recurring patterns:
-
-- Polars scalar aggregations (`.median() / .mean() / .std() / .quantile() / .item()`) annotate as a broad union; suppress per call site with `# type: ignore[arg-type]`. `warn_unused_ignores = true` self-cleans these if stubs improve.
-- Polars schema dicts typed `dict[str, pl.DataType]` need **instances** (`pl.String()`), not class references (`pl.String`). Both work at runtime; only instances satisfy the annotation.
-- scipy / pandas: routed through `[[tool.mypy.overrides]] ignore_missing_imports = true`. New stub-less third-party deps must extend that override.
-
-For hand-written nested dicts (e.g. per-regime / per-horizon stats), prefer a `TypedDict` over scattered suppressions — those errors point at a typing gap, not a Polars one.
-
-### 5.5 Design proposals — use issues, not files
-
-New design proposals go in a **GitHub issue** (label: `design`), not a markdown file under `docs/plans/`. Issues give threaded discussion, edit history, cross-links to PRs / commits, and zero file-maintenance overhead. The `docs/plans/archive/` directory is the frozen legacy plan corpus — read-only history; never add to it.
-
-Exceptions where a file-form plan still earns its keep:
-
-- Multi-thousand-line specs with heavy LaTeX / diagrams that strain GitHub markdown
-- Plans that go through ≥3 numbered revisions where commit history of the file itself is the record
-
-In those cases, file under `docs/plans/active/<short-slug>.md` and open a tracking issue that links to it. Once shipped or superseded, the same PR that lands the work deletes the file and records the outcome on the tracking issue; the archive stays frozen.
-
----
-
-## 6. Testing rules
-
-### Synthetic fixtures only
-
-**factrix tests must not load real market data**—every fixture must be
-constructed programmatically in `tests/conftest.py` or the test module
-itself, using numpy / polars. This invariant lets tests run in any
-environment (CI / new machine / fresh clone) and prevents the repo
-from being polluted with data.
-
-Pattern (see `tests/conftest.py`):
-
-```python title="Illustrative"
-@pytest.fixture
-def clean_panel():
-    rng = np.random.default_rng(42)
-    return pl.DataFrame({
-        "date": [...],
-        "asset_id": [...],
-        "factor_value": rng.normal(size=n),
-        "forward_return": rng.normal(size=n) * 0.01,
-    })
-```
-
-### New features require tests
-
-A new metric, `MetricSpec` field, result field, or API parameter must come with
-a matching test in the same PR. Review should block the PR if tests are missing.
-
-### CI must be green
-
-`.github/workflows/test.yml` runs the full pytest suite on every push
-/ PR. **A red PR must not merge**—fix first, then continue.
-
-### Docstring style boundary — Google sections, ruff for everything else
-
-The project's style policy is split between two complementary but distinct conventions; conflating them invites drift.
-
-- **Code formatting and structure** (line length, naming, imports, indentation, formatter tool) follows PEP 8 and the Black / ruff defaults configured in `pyproject.toml [tool.ruff]`. The selector set (`E/W/F/I/B/UP/SIM/RUF/D`, with `D` scoped to the Google convention via `[tool.ruff.lint.pydocstyle]` and six codes ignored) and 88-character line length there are the source of truth.
-- **Docstring format** follows the griffe / mkdocstrings interpretation of Google section convention, because the mkdocstrings python handler is configured for `docstring_style: google` (see `mkdocs.yml`). Recognised section headers — the complete set this project commits to — are colon-terminated and ordered per the "Section order" subsection below. Dataclasses use `Attributes:` in place of `Args:`. `References:` is a project-local extension — griffe handles it via fallthrough rather than as a strict Google section, so it is listed here so future contributors do not "fix" it away.
-- **Structured sections vs admonitions.** Two visually similar groups are not interchangeable: structured sections expect `Type: description` entries (`Args:`, `Returns:`, `Yields:`, `Raises:`, `Warns:`, `Attributes:`); admonitions accept free-form prose under a heading (`Note:`, `Warning:`, `Tip:`, `Important:`, `Caution:`). `Warns:` lists `WarningClass: msg` entries (paired with `warnings.warn` call sites); `Warning:` is a free-form caveat block. Same distinction applies in principle to `Notes:` vs `Note:`, though `Notes:` is the project default for multi-paragraph commentary. Use the plural / structured form when the content is a typed list; use the singular / admonition form for prose caveats.
-- **The Google Python Style Guide as a whole is not adopted.** Its 80-character line limit, single-quote string preference, and yapf formatter conflict with the ruff configuration above and do not apply. Only the docstring section convention is taken from Google.
-
-NumPy-style underline sections (`Parameters\n----------`) and Sphinx field lists (`:param x:` / `:returns:`) are not parsed by the Google handler and render as plain prose under generic headings. Convert on sight.
-
-`Examples:` blocks are covered by `pytest --doctest-modules` in CI. Any sweep touching `Examples:` must keep them runnable; non-runnable illustrative code belongs in `.md` under the intent-layer policy below, not in docstrings.
-
-**Narrative subsection headings** (`Algorithm:`, `Formula:`, `Construction:`, `Aggregation:`, `Scale:`, `Steps:`, `Invariants:`, `Reported:`, etc.) are permitted as in-body prose subsection labels — they sit before the structured-section block, are griffe-rendered as generic colon-terminated headings rather than typed admonitions, and document the algorithm / math / pipeline structure that does not belong in `Notes:`. They are not part of the recognised structured-section set listed above and have no canonical ordering among themselves; place each where it best explains the docstring's flow. Reach for one only when the content is a self-contained explanatory block; otherwise keep it in body prose.
-
-### Module docstring layering — navigation vs implementation
-
-Module-level and function-level docstrings carry different roles. The split is structural, not stylistic.
-
-- **Module docstring** holds navigation + cross-module context only:
-    - A one-to-three-sentence TL;DR of what the module is for and which entry point / public surface consumes it.
-    - When the module hosts several callables sharing one theoretical frame (e.g. `_stats/bootstrap.py` covering stationary + fixed schemes): a brief inventory naming each public callable with a one-line distinguishing characteristic.
-    - Non-obvious sibling-module relationships when the boundary matters (e.g. `_stats/bootstrap.py` supplies private block-index primitives to public `factrix.stats.bootstrap`).
-- **Function / class / method docstring** holds the implementation contract: `Args:` → `Returns:` → `Yields:` → `Attributes:` → `Raises:` → `Warns:` → `Notes:` → `References:` → `Examples:` (see the "Section order" subsection below for the canonical sequence).
-- The module docstring does **not** hold parameter contracts, return shape, pipeline `Notes:`, runnable `Examples:`, or implementation rationale.
-
-#### Section order — body prose before structured sections
-
-Within any docstring (module-level or function-level), free-form body prose comes before all structured Google sections. The canonical order follows NumPy / numpydoc convention (factrix imports NumPy-only sections such as `Notes:` / `References:` / `See Also:`, so the trailing-section order aligns with the broader convention rather than Google's narrower spec): summary line → body prose → `Args:` → `Returns:` → `Yields:` → `Receives:` → `Other Parameters:` → `Raises:` → `Warns:` → `See Also:` → `Notes:` → `References:` → `Examples:`. `Examples:` sits last. The same rule applies to attribute-bearing classes (`Attributes:` sits with `Args:` / `Returns:` and accepts no trailing prose). The arrow is a strict total order — no two sections are interchangeable, even when conceptually paired (e.g. `Args:` always precedes `Returns:` in source even though both describe input/output). griffe / napoleon also accept `Warnings:` as a synonym for the `Warns:` structured section header; in this project the structured section header is `Warns:` only. Unrelated occurrences of the word — MkDocs Material admonitions (`!!! warning`), markdown headings, or body-prose English — are out of scope for this rule.
-
-Putting `Notes:` or `References:` mid-text — between the summary and the rest of the prose, with prose still appearing below the heading — breaks the rendered metric page: the admonition box jumps above the function inventory, severing the reader's eye-path from summary to body.
-
-#### `References:` placement — by callable count
-
-Placement is driven by how many public callables the module hosts, not by paper-vs-module scope. The rule matches the rendered metric / API page: `::: factrix.metrics.<x>` with several `members:` produces one page with multiple function sections, and reader UX differs by layout.
-
-- **Single-callable module** (e.g. `corrado.py`, most `metrics/*.py` files that host one public function): `References:` lives only on the function. No module-level References — would just duplicate the function block above it on the rendered page.
-- **Multi-callable module** (e.g. `caar.py` with `compute_caar` / `caar` / `bmp_z`; `factrix.stats.multiple_testing` with the Benjamini-Hochberg-Yekutieli (BHY) family): module docstring carries a short-form `References:` overview listing the key papers covering the module's topic; each function then carries its own `References:` block with inline full citations for the specific paper driving that function's algorithm. Same paper appearing at both module-overview and function-detail levels is accepted here — they serve different reader animations on the same page.
-- **Private `_stats/*` modules**: source-only. Inline full citation at module level is fine since these are not rendered to user-facing pages.
-
-Format in every case: Google `References:` (colon-terminated heading, indented body), not NumPy underline (`References\n----------`).
-
-#### Inline citation form — bullet list + autorefs hyperlink + full text
-
-`References:` entries are markdown bullet list items, uniformly — one paper or many, every entry starts with `- `. Each entry's author-year prefix is an autorefs reference-style link to the catalog; the rest of the citation follows as plain text on continuation lines indented to align under the link.
-
-```
-References:
-    - [MacKinlay (1997)][mackinlay-1997]. "Event Studies in Economics
-      and Finance." Journal of Economic Literature, 35(1), 13–39.
-```
-
-This serves two animations without compromising either:
-
-- Reader who does not click — sees the full citation inline (author, year, title, journal, volume, pages) and never needs to leave the page.
-- Reader who clicks the author-year link — jumps to `bibliography.md#mackinlay-1997` to read the paper's role in factrix and cross-metric usage.
-
-Short-form module-level overviews on multi-callable modules can drop the trailing full-citation text (the link + title is enough at the overview layer):
-
-```
-References:
-    - [MacKinlay (1997)][mackinlay-1997], "Event Studies in Economics
-      and Finance."
-    - [Boehmer, Musumeci & Poulsen (1991)][boehmer-musumeci-poulsen-1991],
-      "Event-study methodology under conditions of event-induced
-      variance."
-```
-
-The uniform bullet form keeps every `References:` block visually identical regardless of paper count and removes the failure mode of forgetting blank-line separators when a second paper is added. The slug must match an anchor declared in `docs/reference/bibliography.md`; missing anchors produce an mkdocs `--strict` warning.
-
-#### Inline-prose citations — same hyperlink, hyphenated author form
-
-Paper citations appearing inside docstring prose (`Notes:`, argument descriptions, narrative paragraphs — not inside a `References:` block) use the same autorefs-linked shape with hyphenated multi-author surnames:
-
-```
-Shanken (1992) shows ...               # avoid (bare text — not clickable)
-[Shanken (1992)][shanken-1992] shows ...                                   # ok
-[Newey-West (1987)][newey-west-1987] HAC ...                               # ok (hyphenated)
-[Cameron-Gelbach-Miller (2011)][cameron-gelbach-miller-2011] two-way ...   # ok (hyphenated)
-```
-
-Conventions split by layer:
-
-- **Bibliography heading** (`bibliography.md`): formal `Author & Author (Year)` with ampersand (matches the paper's title-page citation, APA-style).
-- **Anchor ID**: lowercase hyphenated `author-author-year`.
-- **Docstring link text** (both `References:` bullets and inline prose): hyphenated `Author-Author (Year)` — consistent with how factrix's prose names the *method* (Newey-West estimator, Hansen-Hodrick SE, Fama-MacBeth regression) and with how `bibliography.md`'s own intro example reads (`[Newey-West 1987][newey-west-1987]`).
-
-Conversion rules when migrating from a bare citation: `&` and `and` in the visible text become hyphens; commas in 3+ author lists also become hyphens (`Black, Jensen & Scholes (1972)` → `[Black-Jensen-Scholes (1972)][black-jensen-scholes-1972]`); single-author citations stay single (`MacKinlay (1997)` → `[MacKinlay (1997)][mackinlay-1997]`). Year stays parenthesised.
-
-The rule applies uniformly to module-level docstrings and to public symbol (function / class / method) docstrings. It does **not** apply to Python `# comments` or to runtime string values (`WarningCode` descriptions, `"method": "..."` dict literals, `refs=(...)` tuples on registry calls) — those render outside the mkdocs autorefs pipeline and the link would not resolve.
-
-#### `bibliography.md` as catalog, not single SSOT
-
-`docs/reference/bibliography.md` is a **catalog page**, not the SSOT for citation metadata: every cited paper appears there once with its full citation, an anchor, and a paragraph on the paper's role in factrix. It serves three roles:
-
-- Aggregated browse view ("which papers does factrix cite").
-- Anchor target for inline `References:` hyperlinks inside docstrings.
-- Anchor provider for cross-page links from guides / how-tos using the autorefs form `[Corrado 1989][corrado-1989]`.
-
-The hyperlinks are an enhancement, not a dependency: if `bibliography.md` is removed, inline citations still carry the full metadata inline — only the link targets would 404. When updating a citation (typo, DOI), update the catalog entry and each inline copy that carries the full text.
-
-#### `Notes:` rule — function self-contained
-
-Function docstrings are self-sufficient. If a function's behaviour is only intelligible with one sentence of module-level frame, **copy that sentence into the function `Notes:`** rather than forcing the reader to scroll up. Duplication cost is less than reading-context-break cost.
-
-Module-level `Notes:` exists only when no single function carries the canonical pipeline — rare in factrix, since most modules host one canonical function per metric.
-
-### Markdown code-block intent layers — runnable vs illustrative
-
-Code blocks under `docs/api/**/*.md` carry two distinct intents; verify which layer a block belongs to before editing.
-
-- **Runnable** — `pycon` blocks injected from docstring `Examples:` via mkdocstrings autodoc. Self-contained imports, no unbound names, no fragile output; the rendered page exposes a copy button that strips `>>>` and expected-output lines, so blocks must remain paste-ready Python.
-- **Illustrative** — hand-authored `python` fenced blocks that use unbound names (e.g. `panel_large`, `regime_labels`) to communicate semantic intent, plus ASCII / DataFrame layouts that document output schema. Deliberately not runnable; visual lookup value beats setup faithfulness. Do not "fix" these into runnable form — confirm the intent first.
-
-`tests/test_docs_examples.py` executes every hand-authored `python` fence on `README.md` and every docs page, in page order, sharing one namespace per page. **Any exception fails the page** — a `NameError` from an unbound name, a `TypeError` from a stale keyword, an `AttributeError` from a removed helper, a `KeyError` from a renamed metadata key, a polars column error from an outdated schema.
-
-An illustrative block therefore has to say so, on its own fence — open it with <code>&#96;&#96;&#96;python title="Illustrative"</code> instead of a bare <code>&#96;&#96;&#96;python</code>. A declared block is compiled (it must still parse) but never executed, and the marker renders as a caption above the block, so the reader learns the same thing the harness does. `title=` is the only marker that works: a bare word (`python illustrative`) or an unknown key (`python exec="false"`) makes `pymdownx.superfences` drop the block to inline code. Declared blocks are not unchecked — `tests/test_docs_pages.py` still resolves every `factrix.*` symbol they name — and each one gets its own case in `test_illustrative_block_compiles`, so a `-v` run prints the full inventory of what was not executed.
-
-Reach for the marker only after a minimal setup has been ruled out: two lines of `fx.datasets.make_cs_panel(...)` + `fx.preprocess.compute_forward_return(...)` turn many placeholder blocks into real coverage. Blocks must be side-effect free (no file I/O, no plotting). `docs/examples/*.md` are rendered from `examples/*.ipynb` — fix the notebook and re-render.
-
-### Metric docstring style
-
-Docstrings in `factrix/metrics/*.py` are the **authoritative source**
-for each metric's "exact formula / algorithm". Overall doc partitioning
-(what goes where) is in the README "Where to look next" table—single
-source, not restated here. Format:
-
-1. **TL;DR first line** — one sentence describing what the metric
-   measures, optionally with a short formula
-   (e.g. `IC_IR = mean(IC) / std(IC).`)
-2. **Formula**:
-   - **Single-line formula** → inline, format `value = <expr>`
-   - **Multi-line algorithms / sandwich SE / non-trivial procedures** →
-     `Formula:` block with indented equations, so anyone scanning
-     `help()` gets readable display math
-3. **Args / Returns** blocks (Google-style)
-4. **Short-circuit conditions** as a final paragraph (which inputs
-   short-circuit to NaN, what `metadata["reason"]` reports)
-5. Paper citations under a `References:` block (optional; only complex
-   methods need it, simple diagnostics don't)
-
-Examples (inline formula): `common_beta.common_beta_sign_consistency`
-Examples (Formula block): `fm_beta.pooled_beta`,
-`_helpers._sample_non_overlapping`
-
-### LLM agent reference sync
-
-The SSOT lives in `factrix/llms.txt` and `factrix/llms-full.txt`
-(shipped with the wheel; an mkdocs hook mirrors them to the site root
-at build time). Their content overlaps with the mkdocs site partially
-but **neither is the SSOT for the other**—agents need density and
-humans need progressive disclosure; the structural targets are
-mutually exclusive, so both tracks are maintained.
-
-When any of the following ships, sync `factrix/llms*.txt` in the same
-PR. CI validates public-symbol coverage and resolvable references; review owns
-ordering, omissions, and agent-UX quality.
-
-- Additions / removals to `factrix/__init__.py` `__all__`
-- Public API signature changes (factory, `evaluate`, `bhy`,
-  `EvaluationResult`)
-- `WarningCode` additions, renames, or description rewrites
-- DataStructure dispatch rules or canonical data schema changes
-
-PR self-check:
-
-```bash
-uv run pytest tests/test_docs_llms.py tests/test_docs_pages.py -q
+uv run pytest
+uv run pytest --doctest-modules factrix
 uv run mkdocs build --strict
 ```
 
-If the content grows substantially, keep the `cl100k` token count under 8000.
+Use `uv sync --frozen --all-extras` before the complete run so optional adapter
+tests do not execute against a partially installed pandas/pyarrow environment.
 
-### Docs callout conventions
+## Python and API changes
 
-Use mkdocs-material admonitions to elevate content that breaks from the
-surrounding flow (different audience or different urgency). Default to
-plain prose; reach for a callout only when the elevation earns it.
-
-- `!!! abstract "Answers"` — top-of-page scope statement on reference pages.
-- `!!! warning` — gotcha / data-validity precondition the reader must check first; surface invariants whose violation breaks the analysis silently.
-- `!!! note` — orthogonal context that helps but isn't required (e.g. mode-axis edge cases).
-- `!!! info` — contract / convention block (e.g. event-study contracts, TS-mode conventions).
-- `!!! example` — minimal worked code that surrounding prose references.
-- `??? note "..."` (collapsible) — long content for a subset of readers (derivations, full enum tables).
-- `> **Input contract** — …` (blockquote, two lines) — appears only on raw-data `(data, ...)` entry points (`docs/api/evaluate.md`), placed between the frontmatter and the autodoc block. Format: one short sentence naming the four-column floor + a link to [Data schema](../api/data-schema.md). Other API pages consume pre-computed artefacts (`EvaluationResult` / `BhyResult` / `MetricResult`) and do not carry the callout.
-
-Apply opportunistically: when you touch a page for any other reason and a paragraph already qualifies, hoist it. Do not retrofit pages just to add admonitions.
-
-### Autodoc target — top-level path for `__all__` symbols
-
-For each `::: <target>` directive in `docs/api/`, the target dotted path matches the symbol's canonical user-facing import:
-
-- Symbol in `factrix.__all__` → top-level path (`::: factrix.evaluate`, `::: factrix.by_slice`). Do not target the submodule that physically defines it (e.g. `factrix.slicing.dispatcher` with `members: [by_slice]`) — submodule-target with member filter renders the *submodule* as the page h1 and buries the documented symbol below.
-- Symbol reached only via a submodule path → submodule path (`::: factrix.preprocess.compute_forward_return`, `::: factrix.metrics.ic` with `members: [ic, ic_ir]`, `::: factrix.datasets.make_cs_panel`). The submodule path is the canonical import.
-
-mkdocstrings cross-references (`[X][factrix.<...>.X]`) and intra-doc anchor links (`page.md#factrix.<...>.X`) follow the same rule — the path inside the brackets matches the autodoc target. Changing one without the other breaks the cross-ref.
-
-### Autodoc options — globals + per-block deviations
-
-`mkdocs.yml` carries the page-primary defaults for mkdocstrings (`show_root_heading: true`, `show_root_full_path: true`, `show_root_toc_entry: true`, `heading_level: 1`, `separate_signature: true`, `show_signature_annotations: true`, `show_source: false`, `merge_init_into_class: true`, `docstring_style: google`). Every `::: factrix.<X>` block in `docs/api/**` inherits these.
-
-Per-block `options:` should carry **only deviations** from the globals. Common deviations:
-
-- Secondary block on a page (e.g. `BhyResult` on `bhy.md`, individual error classes on `errors.md`): `show_root_toc_entry: false`, `heading_level: 3` or `4`.
-- Dataclass page where the class name is already in the frontmatter title: `show_root_heading: false`.
-- Module-level block with a curated function list: `members: [...]`, optionally `show_root_members_full_path: true`.
-
-Bare `::: factrix.<X>` is the canonical form for page-primary function / dataclass blocks; do not duplicate globals.
-
-### Page-shape conventions — when to add `## Use cases` / `## Worked example`
-
-These two sections appear on pages whose primary purpose is to show the reader *how to call the API*. They are content shapes for workflow-oriented pages — not a universal requirement.
-
-- **Expected on callable entry points.** Function pages under `docs/api/` whose page subject is a callable the user invokes directly. Includes the entry-point callables listed in the API nav and every metric page under `docs/api/metrics/`.
-- **Not expected** on:
-    - Dataclass / container pages (`evaluation-results.md`, which documents `EvaluationResult` / `MetricResult` / `Warning`) — these describe a return type, not a workflow.
-    - Reference / taxonomy / hub pages (`errors.md`, `data-schema.md`, `api/index.md`, `multi-horizon.md`, `metrics/index.md`, the cell-grouped metrics index pages) — content shape is a table or a concept, not a call.
-    - Namespace / module pages (`stats.md`, `datasets.md`) — content shape is a catalogue of members.
-
-A page that legitimately does not need these sections carries no marker — silence is the policy default. Pages in the "expected" category that currently lack the sections are accepted as a backfill debt rather than a defect.
-
-### Terminology — functional names, not stage labels
-
-Code (`factrix/**/*.py` docstrings + module headers) and published docs (`docs/**/*.md` excluding `docs/plans/`) describe behaviour by **what a function does**, not by **which planning tier it lives in**. Stage labels — `Layer-A` / `Layer-B`, `first / second layer`, `Phase 1` / `P1`, `curated wrapper`, `dispatcher vs wrapper` as a tier pair — belong only to GitHub issues / labels / milestones, where they can be renamed as the roadmap shifts.
-
-Reason: planning labels drift on the issue tracker (`P1` → `P0` after triage, `Phase 1` → `v1` after milestone rename, `Layer-B` → `slice-test function` after the feature lands), but a docstring or `architecture.md` paragraph is bound to a release. The two timescales pull apart; the docstring becomes wrong without ever being touched. Additionally, AI agents reading a body that says `P1 contract` will copy that label into downstream files and amplify the drift.
-
-The slicing subsystem is the worked example of the rule:
-
-| Stage-label phrasing (avoid) | Functional phrasing (use) |
-|---|---|
-| `Layer-A` / first-layer dispatcher | **slice dispatcher** — describes partitioning by label + applying a metric per slice (`by_slice`) |
-| `Layer-B` / second-layer / curated wrapper (inference path) | **slice-test function** / **inference function** — describes the cross-slice estimator + multiple-testing pipeline (`slice_pairwise_test` / `slice_joint_test`) |
-| `Layer-B` Estimator | **selection-only Estimator** — identity handles under `factrix.stats` (`WaldNWCluster` / `WaldTwoWayCluster` / `DriscollKraay`); their numerics live in the `_stats` kernels and the slice-test / pooled-beta procedures that consume them |
-| `EvaluationResult.to_frame()` renderer layer | **renderer** — result-side method; no separate tier implied |
-
-The rule is functional, not lexical — `dispatcher`, `function`, and `wrapper` are fine on their own when they describe what the function does. It is the **pairing** as a tier label (`dispatcher` vs `curated wrapper` as the two levels of the slicing system) that drifts; the same word as a behavioural noun is stable. Describe the specification by its content when a docstring needs to point at one, rather than `Layer-B (#NNN)` — the `Layer-B` tier label drifts, and an issue number does not belong in source either.
-
-#### Two-register convention: "verb" vs "function" / "entry point"
-
-User-facing surface uses **function** when referring to one specific callable,
-and **entry point** when referring to the public callables grouped as entry
-points in the API nav. Design-issue bodies and RFC comments may keep **verb** as
-RFC vocabulary — that register is internal to design discussion and does not
-propagate to user docs. When sweeping prose from a design issue into a guide or
-docstring, translate `verb` → `function` (or rephrase to name the specific
-callable) as part of the move.
-
-User-facing surface covers `docs/**/*.md`, README, docstrings, CHANGELOG, **and
-the error contract** — the structured attributes on `UserInputError` (and any
-future user-facing exception) belong to the user-facing register. The
-failing-function slot is named `func_name`, not `verb`, on every error class
-users can catch and read. Internal source may use different local variable names
-while populating the error; the rule is about what the user sees on the caught
-exception.
-
----
-
-## 7. Versioning and release (SemVer & Release)
-
-factrix is currently in **pre-1.0** (v0.x.x). The operational policy for API
-stability, docs wording, and release notes lives in the Pre-1.0 version guide
-below.
-
-**The project uses Commitizen for fully automated bump and changelog
-generation, paired with the release-train cadence: PRs merge whenever,
-but releases (bump + tag) are scheduled independently.**
-
-### Pre-1.0 version guide
-
-Until `v1.0.0`, treat published docs as a current-state manual, not a
-version-by-version history.
-
-- Public API may break in MINOR bumps. Consumers should pin an exact
-  version or tag, not a SemVer range.
-- PR descriptions carry the reviewable WHY / migration narrative. Do not add
-  detailed per-release entries to `CHANGELOG.md` during the pre-1.0 line.
-- `CHANGELOG.md` remains a policy note plus historical GitHub-release index.
-  Do not backfill pre-1.0 entries unless each entry is audited against its tag.
-- From `v1.0.0` onward, resume the maintained `## [Unreleased]` flow and freeze
-  release notes into version headings at release time.
-- Published mkdocs pages and docstrings describe the current public surface.
-  Do not write backward-looking version sentences such as "removed in v0.12.0",
-  "added in v0.13.0", or "since v0.x" in guides, API pages, reference pages, or
+- Public functions and classes use type annotations and Google-style
   docstrings.
-- `pre-push` enforces polished `CHANGELOG.md` release sections only for
-  `v1.0.0+` release commits. Pre-1.0 release commits skip that gate.
+- `data` names a DataFrame-like input; reserve `df_*` for degrees of freedom.
+- A new metric registers one `MetricSpec`; do not add a parallel applicability
+  or routing table.
+- A formal p-value and `alternative` must be published together through
+  `MetricResult.p_value`; metadata must not duplicate the canonical p-value.
+- Public metric names describe the statistic. Avoid `_test` suffixes, and add
+  a method token when several estimators produce the same concept.
 
-Exceptions:
+For the complete dispatch, result, guard, and naming invariants, see
+[Architecture](architecture.md). For user-visible prose, citations, examples,
+and generated pages, see [Documentation conventions](documentation.md).
 
-- `CHANGELOG.md` may keep its historical release index.
-- This contributing guide may describe the pre-1.0 documentation and release
-  policy itself.
-- Issue / PR text may mention exact historical versions when needed for review
-  or release coordination.
+## Design proposals
 
-### Release cadence — release train
+`architecture.md` describes the current state, not design history. Use a
+GitHub issue for a proposed behavioural or architectural change, record the
+decision and definition of done there, and link the implementing PR. Update the
+architecture page only when the current contract changes.
 
-PRs and releases are decoupled:
+The files under `docs/plans/archive/` are frozen historical plans and are not
+published. Do not create a new plan file for ordinary development work; use an
+issue unless the design genuinely requires a long-lived external artifact.
 
-- **PR cadence**: high-frequency, atomic. Do **not** bump or tag after
-  merge.
-- **Release cadence**: low-frequency, aggregated. A release fires when
-  any of the following holds:
-  - ≥ 3 user-facing `feat:` / `fix:` accumulated
-  - ≥ 2 weeks since the last tag
-  - An urgent downstream bug fix (a one-off PATCH may ship
-    immediately)
-  - A named version is needed for a person / demo
+## Communication and language
 
-### Release workflow
+Issues, pull requests, commit messages, changelog entries, package docstrings,
+and published docs use English. Planning archives may remain bilingual because
+they are excluded from the site.
 
-```bash
-# 1. On main, ensure latest
-git checkout main && git pull
+Small decisions belong in the PR rationale. Invariant-level changes must also
+update the relevant architecture section. If a decision changes a public
+contract, state the migration path explicitly.
 
-# 2. Verify CI is green and local release checks pass
-#    See the release-train drift audit above.
+## Licensing
 
-# 3. Auto-bump and tag
-# cz derives the level from commits since the last tag (feat=MINOR, fix=PATCH),
-# updates pyproject.toml, and auto-commits + tags. Follow the Pre-1.0 version
-# guide above until v1.0.0.
-uv run cz bump
-
-# 4. If this is v1.0.0 or later, maintain CHANGELOG.md manually (or via
-#    cz bump --changelog) and polish the release section. If polishing after
-#    the release commit, amend and re-tag:
-git commit --amend --no-edit
-git tag -d v<X.Y.Z> && git tag v<X.Y.Z>
-
-# 5. Push the release commit and annotated tag
-git push origin main --follow-tags
-
-```
-
-### CHANGELOG entry convention
-
-See the Pre-1.0 version guide above for changelog behavior before `v1.0.0`.
-From `v1.0.0` onward, changelog entries should link via **PR number** (`(#PR)`)
-because the PR carries the diff / review / discussion that downstream upgraders
-need when triaging a change.
-
-CHANGELOG paragraphs and bullets are not hard-wrapped: each paragraph is one
-line, and each bullet is one line. The 72-character wrap convention applies to
-commit messages, not to CHANGELOG prose; GitHub Release notes treat single
-newlines as `<br>`, so source-level wrapping leaks into the rendered output.
-
-### BC change reminders
-
-Example: `breakeven_cost` / `net_spread` were renamed from
-`overlap_periods` to `holding_periods`. This
-kind of rename is a BC change. When using `cz commit`, the developer must
-select Breaking Change and **explicitly write the migration path** in the
-prompt (old → new names, affected fields). The Pre-1.0 version guide
-above defines where that upgrade text lives before `v1.0.0`; from
-`v1.0.0` onward, carry it into the maintained changelog entry.
-
----
-
-## 8. Architecture / design decisions
-
-Before a new feature or large change, read:
-
-- `docs/development/architecture.md` — current snapshot of the package
-  (positioning, public API, metric-spec dispatch, result contract, invariants)
-- `CHANGELOG.md` and the Pre-1.0 version guide in this file — release-note
-  policy and historical index expectations
-
-`docs/development/architecture.md` describes the **current state**, not
-the design history. For "why is it designed this way" process records,
-see the closed `design`-labelled GitHub issues and the linked PRs; the
-frozen pre-issue plan corpus lives under `docs/plans/archive/`.
-
-### Metric naming conventions
-
-Two rules when adding or renaming a public metric. They exist to fix
-real confusion, not to enforce a uniform grammar — most existing names
-are fine as-is.
-
-1. **No `_test` suffix for statistical tests.** In Python `_test` reads
-   as a pytest utility, not a production metric. Name by the output
-   statistic instead (e.g. a z-test → `bmp_z`); the academic test name
-   lives in the docstring.
-2. **One concept, many estimators → every variant carries a method
-   token.** When the same quantity is computed by different methods,
-   each metric name must include its method (`fm_beta_sign_consistency`
-   vs `common_beta_sign_consistency`, `fm_beta` vs `common_beta` vs
-   `pooled_beta`). A bare name with no token is ambiguous about which
-   estimator it is. Conversely, a family prefix (`event_`, `ts_`) is
-   only warranted when a bare-name sibling exists or the prefix names
-   the defining methodology — not merely to restate the input domain.
-
----
-
-## 9. Asking questions / decision communication
-
-Self-use repo for the author + AI agents, so there is no issue
-template / discussion board. Decision-record channels:
-
-- **Small changes**: PR description spells out the why and any BC
-- **Large changes / architectural decisions**: open a GitHub design issue
-  (see [Design proposals](#55-design-proposals--use-issues-not-files)). Use a file-form plan only for the exceptions listed there,
-  and link it from the issue / PR.
-- **Invariant-level rule changes**: update the `Invariants` section in
-  `docs/development/architecture.md`
-
----
-
-## 10. Style — single language
-
-All issue / PR titles + bodies, commit messages, CHANGELOG entries,
-and any content under `factrix/` and `docs/` (excluding `docs/plans/`)
-is written in **English**. Internal planning notes under `docs/plans/`
-may remain bilingual; they are excluded from the published mkdocs site
-via `mkdocs.yml` `exclude_docs`.
-
-Rationale: mixed-language content fragments full-text search
-(`gh issue list`, GitHub search, `git log`), splits visual flow in
-notification emails, and burdens readers who must context-switch
-mid-paragraph. The choice of language is not prescribed by tooling—the
-repo settled on English to align with the public docstring surface,
-README, and CHANGELOG.
-
----
-
-## 11. Licensing and contribution terms
-
-This project is released under the [Apache License 2.0](https://github.com/awwesomeman/factrix/blob/main/LICENSE).
-
-**Inbound = Outbound**: per Apache-2.0 §5, any content you submit to
-this repo (PRs, patches, issue-attached code, etc.) is **deemed
-licensed back to the project under the same Apache-2.0 terms**, unless
-you explicitly state otherwise at submission time. Before opening a
-PR, confirm:
-
-- You hold the right to license that code (self-authored, or sourced
-  under an Apache-2.0-compatible licence)
-- When citing third-party code, mark the original licence in the file
-  header or PR description
-- Patent-encumbered algorithms (e.g. methods you or your organisation
-  hold patents on) must be disclosed proactively in the PR description
-
-Code under strong copyleft (GPL/AGPL etc.) is not accepted into the
-main code tree, since it would propagate licence obligations onto
-downstream users.
+factrix is licensed under Apache-2.0. Contributions are licensed to the project
+under the same terms unless the contributor states otherwise. Submit only code
+you have the right to license, identify third-party sources and licences, and
+disclose relevant patent claims. Strong-copyleft code is not accepted into the
+main package because it would change downstream obligations.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -48,6 +48,52 @@ $env:PYTHONUTF8="1"
 changing module imports, dataclasses, or module-level constants; autoreload is
 not sufficient for those changes.
 
+### Environment troubleshooting
+
+Each clone normally owns its `.venv`; another project does not mix packages
+into it. The uv download cache is shared by default, so a reported cache error
+can affect more than one clone without implying that their environments were
+combined.
+
+When several toolchains are needed on a development machine, install them in
+one sync and retain existing extras:
+
+```bash
+uv sync --inexact --extra dev --extra docs
+```
+
+On a centrally managed Windows machine, use the organisation-approved Python
+and certificate profile. A typical invocation with an existing system Python
+is:
+
+```powershell
+py -m uv --system-certs --no-python-downloads sync `
+  --inexact --extra dev --extra docs
+```
+
+Use this diagnostic order instead of repeatedly restarting an installation:
+
+1. Confirm the interpreter and environment with
+   `.\.venv\Scripts\python.exe -c "import sys; print(sys.executable); print(sys.prefix)"`.
+2. Run `py -m uv pip check --python .\.venv\Scripts\python.exe` and inspect
+   `py -m uv cache dir` when uv reports cache or package-metadata errors.
+3. If dependency resolution has finished but the process shows no sustained
+   CPU, disk, or network activity for about a minute, stop it and investigate
+   proxy, certificate, antivirus, or endpoint file-scanning controls. Waiting
+   longer does not repair an idle finalisation step.
+4. When uv names a damaged cache package, remove only that package with
+   `py -m uv cache clean <package>`, then run one sync. Do not clear unrelated
+   caches or run concurrent repair attempts.
+5. If imports succeed but package metadata or plugin discovery is missing,
+   treat `.venv` as incomplete. Recreate only the repository-local environment
+   through the approved setup rather than editing `site-packages` manually.
+
+Do not disable TLS verification or endpoint security to make an install pass.
+Use system certificates, an approved package mirror, or an administrator-
+managed exception for the project environment and cache paths. Clean CI can
+provide an independent verification gate, but it does not make a partially
+installed local environment healthy.
+
 ## Git hooks
 
 `python scripts/setup_dev.py` installs the `pre-commit`, `commit-msg`, and

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -1,0 +1,171 @@
+---
+title: Documentation conventions
+---
+
+This page defines how factrix documentation is organised, generated, and
+reviewed. The project style takes precedence; otherwise prefer clear, direct
+technical prose and separate pages by the reader's task.
+
+## Information architecture
+
+The navigation classifies content by how it is read, not by its source folder:
+
+| Page type | Reader task | Examples |
+|---|---|---|
+| Concepts | Understand the mental model or scope | Concepts, Where factrix fits, Panel vs timeseries |
+| How-to | Complete a specific task | Preparing data, Choosing a metric, Reading results |
+| Example | Follow an end-to-end runnable workflow | Multi-factor screening, Stock factor evaluation |
+| Method reference | Check assumptions, formulas, conventions, or calibration | Statistical methods, Inference calibration |
+| Lookup reference | Scan a table or reverse index | Metric applicability, Stat keys, Warning codes |
+| API reference | Look up a public symbol's signature and semantics | `evaluate`, `ic`, `EvaluationResult` |
+| Development | Change or release the project | Architecture, Contributing, this page |
+
+Do not move a file merely to match its navigation section. Published URLs are
+versioned and may be linked from notebooks, issues, and search indexes;
+`mkdocs.yml` is the editorial layer.
+
+Keep the navigation shallow. Group labels are non-clickable headings, and hub
+pages appear as an explicit `Overview` leaf. Page and nav titles use sentence
+case. Public identifiers keep their exact spelling (`fm_beta`, not
+`fama_macbeth`); expand uncommon acronyms in body prose, not sidebar labels.
+
+## Sources of truth
+
+| Source | Published target | Synchronisation |
+|---|---|---|
+| Public Python docstrings | `docs/api/**/*.md` `:::` blocks | mkdocstrings at build time |
+| `factrix._metric_index.public_specs()` | Generated metric matrix and name index | MkDocs hooks |
+| `WarningCode.description` | Generated warning-code descriptions | MkDocs hook |
+| `examples/*.ipynb` | `docs/examples/*.md` | Notebook-render hook |
+| `factrix/llms*.txt` | Site-root LLM snapshots | MkDocs hook |
+| `CHANGELOG.md` | `docs/development/changelog.md` | Snippet include |
+
+Do not hand-edit generated tables or example Markdown. Edit the registry,
+warning description, notebook, or root changelog, then regenerate through a
+strict docs build. Generated Markdown stays committed so repository readers do
+not need MkDocs to see it.
+
+Narrative pages, API-page introductions, navigation entries, and cross-links
+remain manually maintained. A code change is not complete until those pages
+match the public behaviour.
+
+## API and docstring layers
+
+Docstrings are the callable-level contract. They explain parameters, return
+values, raised errors, statistical notes, examples, and citations needed to
+use that symbol correctly. API Markdown pages add only page-level orientation,
+use cases, or links; do not restate the generated parameter schema.
+
+Use Google-style sections in this order when present:
+
+1. Summary and body prose.
+2. `Args`, `Returns`, and `Raises`.
+3. `Notes` for assumptions, statistical contracts, and non-obvious design
+   choices.
+4. `References`.
+5. `Examples`.
+
+A function must remain understandable without following a citation. Put the
+claim and its practical implication in `Notes`, then cite the source. Use a
+short authored bibliography label that resolves to
+[`bibliography.md`](../reference/bibliography.md); the bibliography is a
+catalog, while the docstring remains the local source of behavioural truth.
+
+Module docstrings provide navigation and family-wide conventions. Do not copy
+an entire callable contract into both the module and function. When a rule is
+shared across many modules, document it once on a reference page and link to
+it from the local docstrings.
+
+## Examples and code blocks
+
+Python blocks are executable by default. They must run in document order with
+the current public API and use deterministic synthetic data where randomness
+matters.
+
+Use an illustrative block only when external state or a deliberately omitted
+object prevents execution:
+
+````markdown
+```python title="Illustrative"
+# Sketch that depends on caller-owned data.
+```
+````
+
+Illustrative code still has to parse. Prefer a runnable example over a sketch;
+do not mark stale code illustrative merely to bypass validation.
+
+Notebook examples are the source of truth for multi-step tutorials. Keep short
+single-call examples in docstrings or API pages and link to the notebook for a
+complete workflow.
+
+## Writing style
+
+- Lead with the reader's outcome or the contract, then explain why.
+- Keep one main idea per paragraph and put its distinguishing information in
+  the first sentence.
+- Use descriptive headings and a consistent heading hierarchy.
+- Prefer direct verbs and concrete nouns over roadmap or implementation-tier
+  labels.
+- Say **periods** for contract-level horizons, windows, and lags. Calendar
+  cadences belong only in clearly labelled examples.
+- Define a specialised acronym on first use. Keep universal API identifiers
+  and literal code names exact.
+- Use lists for steps and parallel alternatives; use tables for repeated field
+  comparisons, not ordinary prose.
+- Use meaningful link text. Avoid “click here,” bare paths, and links whose
+  label does not describe the destination.
+- Avoid superlatives and competitor claims that require continuous market
+  monitoring. State verifiable scope differences instead.
+
+Long lookup catalogs are acceptable when their headings and generated indexes
+support scanning. Long narrative pages are a signal to separate concepts,
+procedures, and evidence—not a rule to split at a fixed line count.
+
+## Metric and statistical pages
+
+Per-metric API pages answer:
+
+- what the metric estimates;
+- what input and cell it accepts;
+- the inference unit and null hypothesis, when present;
+- how to read `value`, `stat`, `p_value`, `n_obs`, metadata, and warnings;
+- where the cross-cutting method and calibration evidence live.
+
+Keep general estimator contracts in
+[Statistical methods](../reference/statistical-methods.md) and empirical null
+measurements in
+[Inference calibration](../reference/inference-calibration.md). Do not turn a
+method reference into a chronological lab notebook; retain the measured range,
+null design, known limit, and producing test, and leave obsolete intermediate
+attempts in git history or the design issue.
+
+## Drift checks
+
+Run the checks that match the edited layer:
+
+```bash
+uv run python scripts/mkdocs_hooks/gen_metric_matrix.py
+uv run python scripts/mkdocs_hooks/gen_metric_name_index.py
+uv run python scripts/mkdocs_hooks/gen_code_descriptions.py
+uv run python scripts/mkdocs_hooks/render_example_notebooks.py
+uv run pytest tests/test_docs_pages.py tests/test_docs_paths.py
+uv run pytest tests/test_docs_examples.py tests/test_docs_bibliography.py
+uv run mkdocs build --strict
+```
+
+The full test suite also checks public symbols, generated matrices, notebook
+drift, warning descriptions, bibliography anchors, metric API members, and LLM
+snapshots. A strict MkDocs build catches rendered navigation and anchor errors
+that source-only checks cannot reproduce.
+
+## Review checklist
+
+- Does each page serve one reader task?
+- Is information repeated because two entry points need a short orientation,
+  or because two files are accidentally acting as the source of truth?
+- Are assumptions, inference unit, defaults, and finite-sample limits stated
+  without overclaiming?
+- Do links use stable relative paths and meaningful labels?
+- Are long tables lookup material, and are long narratives split by purpose?
+- Do examples, generated files, API pages, and docstrings match the current
+  code?

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,0 +1,102 @@
+---
+title: Release process
+---
+
+Releases are cut from `main` after the selected pull requests are reviewed and
+merged. A feature or fix PR does not bump the version, create a tag, or edit a
+release solely because it landed.
+
+## Pre-1.0 policy
+
+Until `v1.0.0`, public API changes may ship in a minor release. Consumers
+should pin an exact version or tag.
+
+Published docs describe the current public surface. Do not add historical
+“added in” or “removed in” prose to guides, references, or docstrings; put the
+reviewable reason and migration path in the issue and pull request.
+
+`CHANGELOG.md` remains a policy note and index of pre-1.0 GitHub releases.
+Detailed maintained entries start at `v1.0.0`; do not reconstruct earlier
+entries unless each statement is audited against its tag.
+
+## Release cadence
+
+Pull requests are small and frequent; releases aggregate them. Cut a release
+when the accumulated user-facing change justifies a new version, a named build
+is needed, or an urgent downstream fix cannot wait. The maintainer chooses the
+release point after reviewing the merged change set.
+
+For pre-1.0 versions:
+
+- Use a minor bump for a planned batch that changes or adds public behaviour.
+- Use a patch bump for a compatible correction to the current minor line.
+- Keep the version, tag, GitHub release, and published docs label identical.
+
+## Release audit
+
+Start from a clean, current `main` and install every declared extra:
+
+```bash
+git switch main
+git pull --ff-only origin main
+uv sync --frozen --all-extras
+```
+
+Then run the checks mirrored by CI:
+
+```bash
+uv run pre-commit run --all-files --hook-stage pre-commit
+uv run mypy factrix
+uv run pytest
+uv run pytest --doctest-modules factrix
+uv run mkdocs build --strict
+uv build
+```
+
+Before bumping, also review:
+
+- removed or renamed symbols and their migration path;
+- docs and LLM snapshots for retired terminology;
+- generated metric, warning, and example pages for drift;
+- optional pandas/pyarrow adapter coverage;
+- the exact commits since the previous tag and their Conventional Commit
+  types.
+
+Do not reuse a removal-search pattern from an older release. Build it from the
+current change set so the audit remains signal rather than accumulated noise.
+
+## Bump, tag, and publish
+
+Commitizen derives the bump from commits since the previous tag and updates the
+configured version locations:
+
+```bash
+uv run cz bump
+git push origin main --follow-tags
+```
+
+Inspect the generated release commit and tag before pushing. The tag must point
+to the release commit on `main`; do not create a release branch solely for the
+bump.
+
+Create the GitHub release from the pushed tag and publish the matching version
+of the docs. Release notes should lead with behavioural changes and migration
+information, not a raw commit list.
+
+From `v1.0.0` onward, maintain `## [Unreleased]` and freeze it into a versioned
+section at release time. Changelog entries link to the pull request because it
+contains the reviewed diff and rationale.
+
+## Breaking changes
+
+A breaking change must state:
+
+- the old and new public names or behaviour;
+- affected inputs, outputs, and serialized fields;
+- a concrete migration example;
+- whether the change alters calculation, inference, or only presentation.
+
+Select the breaking-change option in the Conventional Commit workflow so the
+release tool can derive the correct version. Before `v1.0.0`, the PR is the
+primary migration record; after `v1.0.0`, carry the same concise guidance into
+the maintained changelog and GitHub release.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -2,51 +2,36 @@
 title: Concepts
 ---
 
-This page introduces the core mental model and architecture of `factrix`.
+This page introduces the user-facing mental model of `factrix`.
 
 ## Core workflow
 
-The standard research workflow in `factrix` is divided into three distinct phases:
+The standard workflow has three phases:
 
 ```
 1. inspect_data (Pre-flight) ──▶ 2. evaluate (DAG Evaluation) ──▶ 3. bhy (FDR Screening)
 ```
 
-### 1. `inspect_data` (Pre-flight)
-Before executing computationally intensive metrics, you scan your input data. 
-Calling `inspect_data(data)` returns a `DataInspection` object. It detects data properties (number of assets, periods, and sparsity) and evaluates them against the statistical requirements of every registered metric. This partitions the metrics into three tiers:
-- **`usable`**: The data satisfies all sample size and structural requirements.
-- **`degraded`**: The metric can run, but results may carry a warning due to a smaller sample size.
-- **`unusable`**: The sample is too thin to compute the metric (running it will short-circuit to `NaN`).
+### 1. `inspect_data` (pre-flight)
 
-### 2. `evaluate` (DAG Evaluation)
-Once you select your metrics, you run the evaluation. 
-`evaluate()` takes your data, a dictionary of metric instances, and a list of factor columns. Under the hood, a **Directed Acyclic Graph (DAG) executor** resolves all metric dependencies, optimizes the execution sequence, and returns a `dict` of `EvaluationResult` objects keyed by factor column (one per factor).
+`inspect_data(data)` detects asset count, period count, density, and other
+properties before evaluation. It groups registered metrics as `usable`,
+`degraded`, or `unusable`, so you can identify sample and structure problems
+before running a large metric set.
 
-### 3. `bhy` (FDR Screening)
-If you are screening multiple candidate factors, you must correct for multiple testing to control false discoveries.
-Passing the list of `EvaluationResult` objects to `fx.multi_factor.bhy` applies the Benjamini-Hochberg-Yekutieli (BHY) step-up procedure. This controls the False Discovery Rate (FDR) under arbitrary dependency, returning the subset of factors that truly possess predictive edge.
+### 2. `evaluate` (evaluation)
 
----
+`evaluate()` takes the data, a mapping of metric instances, and factor columns.
+It validates metric applicability and returns an `EvaluationResult` mapping
+keyed by factor column.
 
-## The execution DAG: specs, dependencies, and batching
+### 3. `bhy` (FDR screening)
 
-The DAG executor relies on specific metadata attached to each metric class:
-
-### `MetricSpec`
-Every metric declares a `MetricSpec` as its single source of truth (SSOT). The spec defines:
-- **`cell`**: The target data scope and density the metric applies to.
-- **`aggregation`**: How cross-sectional and time-series reductions compose.
-- **`requires`**: The upstream intermediate data dependencies.
-- **`batchable`**: Whether the metric can process multiple factors in a single operation.
-
-### `requires` (Dependency Injection)
-Metrics do not always compute directly from raw panels. For example, the Information Coefficient (`ic`) statistic does not consume the raw asset returns directly; it requires the per-period time-series of ICs. 
-The `ic` spec declares `requires={"ic_df": compute_ic}`. The DAG executor detects this, schedules `compute_ic` to run first, and injects its output into the `ic` metric.
-
-### `batchable` (Shared Computations)
-Many upstream calculations (like sorting, grouping, or ranking assets to compute ICs or quantiles) are identical across all factor candidates. 
-If a spec is marked `batchable=True`, the executor runs it once across all factors in the batch, significantly reducing overhead compared to looping through each factor individually.
+When you screen multiple candidate factors, pass their results to
+`fx.multi_factor.bhy`. The Benjamini-Hochberg-Yekutieli (BHY) procedure
+controls the false discovery rate (FDR) under arbitrary dependence and returns
+the factors that survive the declared screen. It does not prove that a factor
+has economic value or will survive portfolio costs.
 
 ---
 
@@ -61,9 +46,19 @@ An evaluation cell is defined by three orthogonal axes:
 | **DataStructure** | `PANEL` / `TIMESERIES` | Derived from the asset count at evaluate-time: `PANEL` for `n_assets >= 2`, and `TIMESERIES` for `n_assets == 1`. |
 
 `SPARSE` is a zero-encoded event contract, not a generic discrete-factor
-label. The detector counts explicit `0` values over non-null factor cells:
-nulls are missing values, not non-events. If missing upstream rows should
-mean "no event", fill them to `0`; if the research question is event-study
-shaped, map the event-of-interest into `{0, R}` before using sparse metrics.
+label. Explicit zero means no event; null means missing. Map an event factor to
+`{0, R}` before using sparse metrics.
 
-A metric's cell declares which `DataStructure` it applies to. A `PANEL`-cell metric needs a cross-section, so on `n_assets == 1` data — `Individual × Continuous` (`ic`, `fm_beta`) or `Common × Continuous` (`common_beta`) — `evaluate` raises `IncompatibleAxisError` (or returns NaN + `structure_mismatch` under `strict=False`). Single-asset dense data uses `predictive_beta` for the direct HAC predictive-regression slope and `directional_hit_rate` for sign prediction. Single-asset sparse data is served by `(*, SPARSE, *)` metrics. Two-column diagnostics (`positive_rate`, `oos_decay`, `ic_trend`) remain standalone `(date, value)` tools, and in `evaluate()` they are layered on panel IC series rather than raw single-asset dense panels.
+The data-structure axis determines whether a requested metric has the
+cross-section it needs:
+
+| Input | Use |
+|---|---|
+| Multiple assets, dense individual factor | `ic`, `fm_beta`, and cross-sectional diagnostics |
+| Multiple assets, dense common factor | `common_beta` and common-factor diagnostics |
+| One asset, dense factor | `predictive_beta` and sign diagnostics |
+| Sparse factor, one or many assets | Event metrics whose specification admits the detected structure |
+
+For sample guards, strict-mode behaviour, and the full dispatch matrix, see
+[Panel vs timeseries](../guides/panel-timeseries.md). For dependency resolution
+and batching internals, see [Architecture](../development/architecture.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,78 +71,26 @@ contain sporadic missing or non-finite values.
 
 ---
 
-## Research question → metric mapping
+## Choose metrics
 
-In `factrix`, rather than constructing a central config object, you pass metric instances imported from `factrix.metrics` directly to the `metrics` parameter of `fx.evaluate()`.
+Pass metric instances from `factrix.metrics` directly to the `metrics`
+parameter of `evaluate()`; there is no central configuration object.
 
 To learn how to choose the right metrics and configure them, see [Choosing a metric](../guides/choosing-metric.md) and [Concepts](concepts.md).
 
 ---
 
-## `EvaluationResult.to_dict()` and warnings
+## Read the result
 
-Calling `.to_dict()` on the returned `EvaluationResult` returns a flat, JSON-friendly representation of the results, including evaluation metadata, statistics, and any active warnings:
+Read a metric's `value` and `p_value` together with `n_obs`, metadata, and
+the enclosing result's warnings. A small p-value is not sufficient evidence
+when the result also reports a persistence, overlap, clustering, or thin-sample
+warning.
 
-```json
-{
-  "factor": "factor",
-  "cell": {
-    "scope": "individual",
-    "density": "dense",
-    "structure": "panel"
-  },
-  "forward_periods": 5,
-  "overlap_periods": 5,
-  "n_periods": 494,
-  "n_pairs": 49400,
-  "n_assets": 100,
-  "params": {},
-  "metadata": {},
-  "metrics": {
-    "ic": {
-      "value": 0.07221,
-      "p_value": 2.367e-12,
-      "alternative": "two-sided",
-      "stat": 12.79,
-      "n_obs": 494,
-      "n_obs_axis": "periods",
-      "is_applicable": true,
-      "reason": null,
-      "metadata": {
-        "n_periods": 494,
-        "n_periods_full": 494,
-        "mean_ic_full": 0.07221,
-        "overlap_periods": 5,
-        "stat_type": "t",
-        "h0": "mu=0",
-        "method": "Newey-West HAC t-test",
-        "tie_ratio": 0.0,
-        "min_assets_per_period": 100,
-        "warn_assets_per_period": 10,
-        "n_periods_in": 494,
-        "n_periods_out": 494,
-        "dropped_periods": 0,
-        "drop_rate": 0.0,
-        "drop_reason": null
-      }
-    }
-  },
-  "warnings": [],
-  "plan": "1. compute_ic [batchable]\n2. ic [per-factor] requires=compute_ic"
-}
-```
-
-The most common warnings include:
-
-- `UNRELIABLE_SE_SHORT_PERIODS` — the effective (post-stride) sample is under `MIN_PERIODS_WARN` (= 30); the SE is unstable. (Falling below the metric's *hard* floor raises `InsufficientSampleError` under `strict=True`. The floor is per metric and per axis, checked on the effective sample — read `exc.axis` before assuming it is the time axis.)
-- `PERSISTENT_REGRESSOR` — the predictive regressor sits in a regime the corrected test is less well sized in: an augmented Dickey-Fuller (ADF) $p$-value above the configured threshold (default 0.10), a strong measured Stambaugh channel, or a bias-corrected AR(1) coefficient at or above one. Raised by `predictive_beta` / `trend` / `fm_beta`, not by `ic`.
-- `OVERLAPPING_PREDICTIVE_INFERENCE` — `predictive_beta` uses overlapping forward-return windows (`overlap_periods > 1`), where its corrected HAC test remains oversized in the measured null grid. The estimate and p-value are returned; use a raised hurdle and an `h = 1` or non-overlapping sensitivity check.
-- `EVENT_WINDOW_OVERLAP` — event windows overlap on the same asset.
-- `SERIAL_CORRELATION_DETECTED` — the tested per-period series is persistent beyond the overlap horizon: lag-1 autocorrelation above `PERSISTENT_SERIES_AUTOCORR` on the series strided at `overlap_periods`. The MA(h-1) structure of overlapping forward returns is absorbed by the HAC bandwidth floor and does not fire this; what does is persistence the stride cannot remove, and no HAC or bootstrap path is calibrated there, so read the p-value against a raised hurdle.
-
-For the full enum and the trigger conditions for each `WarningCode`, see [Reference § Warning codes](../reference/warning-codes.md).
-
-For exception classes (`InsufficientSampleError`, `IncompatibleAxisError`, `UserInputError`, ...) and their catch patterns, see [Errors](../api/errors.md).
+`EvaluationResult.to_dict()` returns the complete result as a flat,
+JSON-friendly mapping. See [Reading results](../guides/reading-results.md) for
+the field-by-field contract, [Warning codes](../reference/warning-codes.md) for
+trigger conditions, and [Errors](../api/errors.md) for strict-mode failures.
 
 ---
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,7 +8,7 @@ Step-by-step guides for common factrix workflows:
 - **Picking the right metric for your research question** — [Choosing a metric](choosing-metric.md)
 - **Data structure dispatch (PANEL ↔ TIMESERIES) and the `n_assets == 1` special path** — [Panel vs timeseries](panel-timeseries.md)
 - **Reading EvaluationResult, MetricResult, and FDR results** — [Reading results](reading-results.md)
-- **False Discovery Rate (FDR) control across a factor batch (BHY / partial conjunction / hierarchical)** — [BHY FDR screening](../api/bhy.md)
+- **False Discovery Rate (FDR) control across a factor batch** — [Multi-factor screening example](../examples/multi_factor_screening.md)
 - **Choosing evidence for allocation signals without turning factrix into a portfolio optimizer** — [Validating allocation signals](validating-allocation-signals.md)
 - **Bounding peak memory when screening 100–1000+ factors (caller-side batched loop)** — [Large-scale evaluation and memory protection](large-scale-evaluation.md)
 - **Slicing one metric by an attached label column (sector / regime / universe / ADV bucket)** — [Slice analysis](slice-analysis.md)

--- a/docs/guides/panel-timeseries.md
+++ b/docs/guides/panel-timeseries.md
@@ -4,7 +4,7 @@ title: Panel vs timeseries
 
 !!! abstract "Answers"
     What `DataStructure.PANEL` vs `DataStructure.TIMESERIES` mean, when each is dispatched, and the sample-guard contract for each.
-    For the conventions table (column names, alignment), see [Timeseries-mode conventions](../reference/ts-mode-conventions.md).
+    For stage-1 regressions inside common-factor panel metrics, see [Common-factor regression conventions](../reference/ts-mode-conventions.md).
     For the `evaluate()` entry point, see [`evaluate`](../api/evaluate.md).
     For sample-guard error surfacing (`InsufficientSampleError`, `IncompatibleAxisError`), see [Errors](../api/errors.md).
 

--- a/docs/guides/validating-allocation-signals.md
+++ b/docs/guides/validating-allocation-signals.md
@@ -36,7 +36,7 @@ contract; none of the derivations are restated here.
 
 | Research question / stage | Primary evidence | Supplementary or robustness evidence | Do not infer |
 |---|---|---|---|
-| Cross-sectional asset ranking | [`ic`](../api/metrics/ic.md) or [`fm_beta`](../api/metrics/fm_beta.md) over a [declared hypothesis family](#declare-selection-families), read against the [persistent-series caveat](../reference/statistical-methods.md#persistence-beyond-the-overlap-horizon-no-hac-or-bootstrap-path-is-calibrated) | [`k_spread`](../api/metrics/k_spread.md), [`monotonicity`](../api/metrics/monotonicity.md), [`directional_pair_accuracy`](../api/metrics/directional_pair_accuracy.md), [`ic_ir`](../api/metrics/ic.md) stability | That one diagnostic passing promotes the candidate |
+| Cross-sectional asset ranking | [`ic`](../api/metrics/ic.md) or [`fm_beta`](../api/metrics/fm_beta.md) over a [declared hypothesis family](#declare-selection-families), read against the [persistent-series caveat](../reference/inference-calibration.md#persistence-beyond-the-overlap-horizon) | [`k_spread`](../api/metrics/k_spread.md), [`monotonicity`](../api/metrics/monotonicity.md), [`directional_pair_accuracy`](../api/metrics/directional_pair_accuracy.md), [`ic_ir`](../api/metrics/ic.md) stability | That one diagnostic passing promotes the candidate |
 | Single-asset time-series predictability | [`predictive_beta`](../api/metrics/predictive_beta.md) | [Persistence](../reference/statistical-methods.md#4-persistence-diagnostics-under-near-unit-root-predictors) and sample diagnostics, `PERSISTENT_REGRESSOR` in [warning codes](../reference/warning-codes.md) | That the slope is cross-sectional ranking evidence |
 | Regime robustness | [`by_slice`](../api/by-slice.md), [`slice_period_pairwise_test`](../api/slice-test.md) contrasts, effect sizes | [`slice_period_joint_test`](../api/slice-test.md) where it is calibrated — `K = 2`, or `K >= 3` on longer slices | That a declared `short_slice_joint_test` corrected the p-value, or that a short-slice joint p is an admission gate |
 | Candidate redundancy | Correlation and fixed-base [`spanning_alpha`](../api/metrics/spanning.md) | Economic reading of the residual alpha | That `greedy_forward_selection` t-stats are post-selection inference |
@@ -49,7 +49,7 @@ The boundaries the table compresses, each owned by the page it links to:
   the estimator, the p-value, or the sample requirement
   ([warning contract](../api/slice-test.md#warning-contract-slice_period_joint_test)).
 - A regime joint test on short slices with `K >= 3` carries a
-  [disclosed over-rejection](../reference/statistical-methods.md#joint-period-test-on-short-slices-known-over-rejection),
+  [disclosed over-rejection](../reference/inference-calibration.md#joint-period-test-on-short-slices-known-over-rejection),
   and declaring `short_slice_joint_test` as expected does not calibrate that
   p-value, so it stays robustness evidence rather than an admission gate.
 - `spanning_alpha` is a fixed-base incremental-information / redundancy

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,38 +4,34 @@ title: factrix
 
 <h3 align="center"><b>Tests one factor. Screens a thousand.</b></h3>
 
-**Does this factor possess predictive edge?**
+**Does this factor have predictive value?**
 
-factrix is the first Polars-native Python toolkit that picks the right statistical test for each factor type. Cross-sectional, event, common factor — each gets the tests that fit its data-generating process.
+factrix is a Polars-native toolkit for factor inference and batch screening.
+It provides methods for cross-sectional, event, and common factors while
+keeping estimates, p-values, diagnostics, and warnings explicit.
 
 [![GitHub](https://img.shields.io/badge/GitHub-factrix-blue?logo=github)](https://github.com/awwesomeman/factrix)
 
-## What ships
-
-factrix exposes a small set of functions organised by category:
-
-- **Compute** — `evaluate`, `evaluate_horizons`
-- **Screening (false discovery rate (FDR))** — `bhy`, `partial_conjunction`, `bhy_hierarchical`, `bhy_across_metrics`, `partial_conjunction_across_metrics`
-- **Inference (no FDR)** — `slice_pairwise_test`, `slice_joint_test` (cross-sectional slices), `slice_period_pairwise_test`, `slice_period_joint_test` (date-disjoint slices)
-- **Descriptive view** — `by_slice`, `compare`
-- **Introspection** — `list_metrics`, `inspect_data`
-
-See the [API reference landing](api/index.md) for the function-flow graph, edge conventions, and the full entry-point table with category, signature summary, and when-to-reach-for guidance.
-
----
-
-## Quick links
+## Start here
 
 | If you want | Go to |
 |---|---|
-| **Prepare your own data** | [Preparing data](guides/preparing-data.md) |
-| **Pick the right metric** | [Choosing a metric](guides/choosing-metric.md) |
-| **Install and run a smoke test** | [Installation](getting-started/install.md) · [Quickstart](getting-started/quickstart.md) |
-| **Understand the three-axis design** (scope / signal / metric) | [Concepts](getting-started/concepts.md) |
-| **Compare factrix against alphalens / qlib / peers** | [Where factrix fits](where-factrix-fits.md) |
-| **Screen a batch of factors with Benjamini-Hochberg-Yekutieli (BHY)** | [BHY FDR screening](api/bhy.md) |
-| **Slice any metric by regime / universe / sector** | [Slice analysis](guides/slice-analysis.md) |
-| **Look up formulas and applicability** | [Metric applicability](reference/metric-applicability.md) |
-| **Read every public symbol** | [API reference](api/index.md) |
-| **Browse runnable notebooks** | [Examples](examples/index.md) |
-| **Read the internal architecture** | [Architecture](development/architecture.md) |
+| Install and run a complete example | [Installation](getting-started/install.md) · [Quickstart](getting-started/quickstart.md) |
+| Prepare and validate a panel | [Preparing data](guides/preparing-data.md) |
+| Match a research question to a metric | [Choosing a metric](guides/choosing-metric.md) |
+| Understand factor types and dispatch | [Concepts](getting-started/concepts.md) · [Panel vs timeseries](guides/panel-timeseries.md) |
+| Read estimates, metadata, and warnings | [Reading results](guides/reading-results.md) |
+| Screen many factors with FDR control | [Multi-factor screening](examples/multi_factor_screening.md) |
+| Look up a metric or public symbol | [Metric applicability](reference/metric-applicability.md) · [API reference](api/index.md) |
+| Decide whether factrix fits your workflow | [Where factrix fits](where-factrix-fits.md) |
+
+## Workflow
+
+1. Prepare a long Polars frame on a consistent period grid.
+2. Choose metrics that match the factor scope, density, and data structure.
+3. Run `evaluate()` and inspect each metric's estimate, sample metadata, and warnings.
+4. When screening a family of candidates, apply the multi-factor FDR helpers.
+
+The [API reference](api/index.md) lists every entry point. Contributors should
+start with the [development guide](development/contributing.md) and
+[architecture](development/architecture.md).

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -498,9 +498,10 @@ Clustering-adjustment option on factrix's BMP-style test. K-P scale
 the single-event-day BMP $z$ by
 $\sqrt{(1 - \hat r)/(1 + (N_{\mathrm{eff}}-1)\,\hat r)}$; factrix pools
 SARs across event periods, so it applies only the design-effect part
-$1/\sqrt{1 + (N_{\mathrm{eff}}-1)\,\hat r}$ (see *Statistical methods*
-§6 for why the $(1 - \hat r)$ numerator does not apply to a pooled
-variance). Recommended when factrix's event-period clustering HHI
+$1/\sqrt{1 + (N_{\mathrm{eff}}-1)\,\hat r}$ (see
+[Statistical methods](statistical-methods.md#bmp-standardised-ar) for why the
+$(1 - \hat r)$ numerator does not apply to a pooled variance). Recommended
+when factrix's event-period clustering HHI
 diagnostic flags high concentration.
 
 ### Shrout & Fleiss (1979)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -112,7 +112,7 @@ Note that factrix `TIMESERIES` mode does **not** mean Alphalens'
 "time-series of cross-sectional means" (that is per-date aggregation
 of a `PANEL`); the two collide on the word *time-series* and disagree
 on what is aggregated. See
-[Timeseries-mode conventions](ts-mode-conventions.md) for the
+[Common-factor regression conventions](ts-mode-conventions.md) for the
 specific contracts that apply when factrix routes here.
 
 ## Other terms
@@ -215,7 +215,7 @@ is realised. Aligning `evaluate()`'s `forward_periods` with
 `signal_horizon` is the regime where the synthetic IC / drift is
 calibrated; mismatched horizons induce IC decay (synthetic) and bias
 (in TIMESERIES mode — see
-[Timeseries-mode conventions § Non-overlap](ts-mode-conventions.md#non-overlap-convention)).
+[Common-factor regression conventions § Non-overlap](ts-mode-conventions.md#non-overlap-convention)).
 
 ### `non-overlapping` returns
 

--- a/docs/reference/inference-calibration.md
+++ b/docs/reference/inference-calibration.md
@@ -1,0 +1,170 @@
+---
+title: Inference calibration and limitations
+---
+
+This page records empirical null-size measurements, deliberate departures from
+textbook estimators, and regimes where factrix p-values are not calibrated. It
+is evidence for the contracts in [Statistical methods](statistical-methods.md),
+not a promise that one simulation design covers every user dataset.
+
+Sizes below are rejection rates at a nominal 5% unless stated otherwise.
+Characterisation tests rerun selected cells at lower replication counts to
+detect material drift; the larger research sweeps remain documented here.
+
+## Coverage contract
+
+Every registered metric that can publish a non-null `p_value` must appear on
+this page with either a measured size result or an explicit gap. A source-based
+test enforces names, not a claim that every path is calibrated.
+
+| Family | Covered p-value metrics |
+|---|---|
+| Series means and spreads | `ic`, `quantile_spread`, `quantile_spread_vw`, `k_spread`, `fm_beta` |
+| Predictive and panel regressions | `predictive_beta`, `spanning_alpha`, `common_asymmetry`, `common_quantile_spread`, `pooled_beta`, `common_beta` |
+| Event inference | `caar`, `bmp_z`, `corrado_rank`, `event_hit_rate`, `event_ic` |
+| Direction, order, and trend | `directional_hit_rate`, `monotonicity`, `positive_rate`, `ic_trend` |
+
+## HAC family calibration
+
+The same overlapping input reaches different references depending on the rank
+of the restriction. The ranges are intentionally kept beside the path rather
+than repeated throughout the method guide.
+
+| Path | Measured null size | Interpretation |
+|---|---:|---|
+| Scalar series mean with `NEWEY_WEST` | 3.9–7.3% over `T ∈ {60,120,240,500}`, `h ∈ {1,5,21}`; 5.4–8.1% on AR(0.6) at `h=1` | Calibrated to mildly liberal on the measured grid; conservative when `h` is declared on a non-overlapping series |
+| `NON_OVERLAPPING` mean, including `ic`, `caar`, and spread metrics | 4.5–5.4% on measured overlap nulls | Removes mechanical overlap; does not remove persistence beyond the stride |
+| `predictive_beta`, `h=1` | 4.3–5.5% at regressor persistence `ρ=0`; 6.2–8.3% in the strongest measured Stambaugh cells | Amihud-Hurvich path is characterised at one-period horizons |
+| `predictive_beta`, `h>1` | **7.5–14.5%** | Known oversized overlapping-regression HAC regime |
+| Rank-one `common_*` contrasts | 3.3–8.0% on non-persistent common-factor nulls; 7.3–16.3% on persistent input | Scalar reference fixes the ordinary overlap case; persistence remains a warning regime |
+| `spanning_alpha` rank-one contrast | 5.7–11.7% on the measured overlapping-sum spread null | Uses the scalar reference, but the upper measured cells remain mildly oversized |
+| Date-aligned multi-restriction slice Wald tests | 8–9% for `K=5` on 50–90 periods per slice | Known short-slice over-rejection; converges near 5.5% around 150 periods |
+| `pooled_beta` Driscoll-Kraay | **1.7–9.1%** on its persistent-regressor, cross-sectionally correlated, overlapping-return panel grid | The scalar HAR reference reduced the former path's 4.9–23.2% range; the low-overlap-dependence cells can be conservative |
+
+The scalar recipe combines three factrix-specific choices: a `3(h - 1)`
+overlap floor, variance scale `T/(T-L-1)`, and effective degrees of freedom
+bounded by `T/h - 1`. These move together. Applying only the wider lag floor
+while keeping an ordinary reference made rank-one regressions worse in the
+measured cells.
+
+Producing tests include `tests/stats/test_hac_overlap_size.py`,
+`test_overlap_floor_size.py`, `test_scalar_wald_overlap_size.py`,
+`test_driscoll_kraay_size.py`, and `tests/test_stambaugh_bias.py`.
+
+### Single-restriction Wald contrasts
+[](){ #single-restriction-wald }
+
+`common_asymmetry`, `common_quantile_spread`, and `spanning_alpha` each test
+one linear restriction. Treating them like a multi-restriction Wald matrix
+left the two common-factor metrics 10–34% oversized at `h > 1`. Moving the
+bandwidth, finite-sample scale, and reference together to the scalar recipe
+put every non-persistent common-factor cell at or below 8.0%.
+
+The correction is not a persistence cure. At `T=60, h=5`, a common factor
+with `φ=0.9` still produced 13.0% and 16.3% rejection rates for the two
+metrics. `serial_correlation_detected` identifies that regime. Increasing a
+raw lag override does not repair the reference.
+
+### Shanken correction on `fm_beta`
+
+On a true-null panel, the measured uncorrected versus Shanken rejection rates
+were 7.3/7.3%, 3.3/3.3%, 4.3/4.0%, and 6.0/6.0% over
+`(T,h)={(120,1),(120,5),(240,1),(240,5)}`. Under the null the estimated
+premium approaches zero and the multiplicative correction approaches one, so
+near-equality is expected. This table characterises size; it does not measure
+power or the omitted additive term in the simplified single-factor variance.
+
+## Persistence beyond the overlap horizon
+
+[](){ #persistence-beyond-the-overlap-horizon }
+
+The persistence screen reads lag-1 autocorrelation on the series after the
+`overlap_periods` stride. Reading the raw series would flag the MA(`h - 1`)
+structure that the stride or kernel was designed to handle.
+
+On a directly constructed persistent per-period signal, the measured ranges
+were:
+
+| Lag-1 persistence | Plain t | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` |
+|---:|---:|---:|---:|
+| 0 | 7–9% | 7–9% | 7–9% |
+| 0.6 | 32–34% | 13–17% | 12–19% |
+| 0.85 | 55–61% | 32–34% | 20–32% |
+
+No member is calibrated in the strongest rows. Switching from analytic to
+bootstrap inference changes the number but does not resolve the model failure.
+Use a raised hurdle, redesign the sample, or fit a model that explicitly
+handles the persistence. A screen estimated close to the 10-period floor is
+itself noisy; always read `n_obs`.
+
+Andrews-Monahan AR(1) prewhitening is measured behind a private flag. It
+substantially reduces moderate-persistence excess on univariate mean paths but
+does not rescue near-unit-root input and is not implemented for every vector
+or regression kernel. Keeping it private avoids implying a library-wide
+correction that has not been calibrated.
+
+## Spread and rank-based paths
+
+| Metric or path | Measured result | Main limit |
+|---|---|---|
+| Spread-series `STATIONARY_BOOTSTRAP` | 4.8–9.0% on the iid-factor grid; 3.7–10.0% on the persistent-factor overlap grid | Long-horizon cells can be mildly liberal while NW becomes conservative |
+| `monotonicity` stationary-bootstrap MR test | 2.0–7.3% over `T ∈ {120,240}`, `h ∈ {1,5}`, factor persistence `φ ∈ {0,0.9}` | Calibrated to conservative on the measured grid |
+| `positive_rate` exact binomial | 2.3–4.7% in most cells; one IC-pipeline cell measured 8.0% at `n=240` | Exact-binomial discreteness is conservative at short `n`; the 8% cell is within two Monte Carlo SE of the iid cell, not evidence that every cell is at or below nominal |
+| `directional_hit_rate` Pesaran-Timmermann with period deflation | 3.0–7.7% on the measured panel grid | Same-period dependence must remain visible in the event-period metadata |
+| `ic_trend` strided Hamed-Rao Mann-Kendall | 1.7–5.3% over `T ∈ {60,120,240}`, `h ∈ {1,5}` | Strong residual persistence and unit-root input remain warning regimes |
+| `common_beta` calendar-time cross-asset t | 2.0–7.3% on the measured common-factor panel grid | A hand-built beta table cannot recover the calendar-time variance and falls back to the iid cross-asset reference |
+
+Producing tests include `test_spread_bootstrap_size.py`,
+`test_monotonicity_size.py`, `test_positive_rate_size.py`,
+`test_directional_hit_rate_size.py`, `test_ic_trend_size.py`, and
+`test_common_beta_size.py` under `tests/stats/`.
+
+## Event-study paths
+
+`caar` and `corrado_rank` infer on event periods; `bmp_z` infers on valid
+events and uses distinct event periods to assess clustering and sample
+reliability. Their `n_obs` values are therefore not interchangeable.
+
+| Path | Characterisation | Limit |
+|---|---|---|
+| `caar` non-overlapping event-period t | Falls in the 4.5–5.4% non-overlap band on the measured null | Event-induced variance motivates the standardised read |
+| `bmp_z` with design-effect deflation | About 7% on the sign-aligned shared-shock null; around 10% at 8 effective event periods, around 7% at 15, clearing near 30 | Residual size follows distinct event periods, not raw events; heavy skew at long horizons can bias standardised abnormal returns |
+| `corrado_rank` | 6% on the same sign-aligned null | Rank robustness does not create power from few event periods |
+| `event_hit_rate` | 7% on the sign-aligned null | Uses the same-period dependence adjustment; still thin with few event periods |
+| `event_ic` | Covered by the shared clustering characterisation and dedicated clustered-inference tests | A pooled event correlation remains sensitive to the effective event-period count |
+
+### `event_skewness` has no calibrated test
+[](){ #event-skewness-no-calibrated-test }
+[](){ #event-skewness-has-no-calibrated-test }
+
+The withdrawn D'Agostino path failed on both non-normal signed returns and
+sign-aligned same-period shocks. On two panel nulls with only about 1.5 events
+per event period, it rejected 19.0% and 23.3%; on a sign-aligned clustered
+null it rejected 30.3%. Applying the event design-effect deflator barely moved
+the first failure and drove the last to 0.0%, so no single adjustment
+calibrated both. `event_skewness` is descriptive and publishes no p-value.
+
+## Joint period test on short slices: known over-rejection
+[](){ #joint-period-test-on-short-slices-known-over-rejection }
+
+For date-disjoint slices, `slice_period_joint_test` with `K ≥ 3` and fewer
+than roughly 150 periods per slice is not a reliably sized omnibus test. At
+`K=5`, measured size is 8–9% for the analytic path and about 12% for the
+bootstrap path at the short end. The bootstrap inherits noisy per-slice
+variance estimates; it is not automatically safer because the sample is
+short.
+
+For pairwise contrasts, both methods were near nominal at `K=3, T=60`
+(5.8% bootstrap, 5.4% analytic Holm). At `K=5`, analytic Holm measured
+5.7–6.7% versus 7.4–8.5% for the bootstrap/Romano-Wolf path. Prefer analytic
+pairwise contrasts or longer slices in that regime. The default remains a
+compatibility choice, not a claim that bootstrap dominates finite samples.
+
+## Uneven evaluation grids
+
+The main size tables use a constant stride. Scalar series-mean paths were also
+checked on one uneven `(20, 20, 40)`-spaced grid: `NON_OVERLAPPING` measured
+5.8% and `NEWEY_WEST` 5.5%. Regression HAC, multi-restriction Wald, ADF,
+rolling, event-window, and adjacent-period paths have not been comprehensively
+recalibrated on uneven grids. `uneven_evaluation_grid` is therefore a design
+warning, not a claim that every method is invalid or valid there.

--- a/docs/reference/metric-pipelines.md
+++ b/docs/reference/metric-pipelines.md
@@ -8,11 +8,11 @@ title: Metric pipelines
     For output schema and metadata keys, see [Stat keys by metric](stat-keys-by-metric.md).
     For the research-question → metric mapping, see [Choosing a metric](../guides/choosing-metric.md).
 
-Cross-module index of every module under `factrix/metrics/`. Use this
-page to pick the existing aggregation pattern a new metric should
-match, or to mechanically check that a candidate metric satisfies the
-[Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) discipline](statistical-methods.md) the rest of the suite
-follows.
+Cross-module index of every module under `factrix/metrics/`. Use it to trace
+how a metric aggregates observations and which inference procedure it reports.
+Contributors adding a metric should also follow the
+[documentation conventions](../development/documentation.md) and
+[architecture contracts](../development/architecture.md).
 
 The matrix lists **all** metric modules — both the metrics
 [`evaluate()`](../api/evaluate.md) runs for each cell

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -65,7 +65,7 @@ contrasts, not a sidecar to a primary value.
 | [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | Pesaran-Timmermann `z` (one-sided) | `p_value` | directional hit rate ∈ [0, 1] |
 | [`event_hit_rate`][factrix.metrics.event_quality.event_hit_rate] | binomial test (or normal `z`) | `p_value` | hit rate ∈ [0, 1] |
 | [`event_ic`][factrix.metrics.event_quality.event_ic] | Fisher-transformed Spearman `z` | `p_value` | Spearman ρ |
-| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | none — descriptive (the D'Agostino skew test is withdrawn, section 6) | — | Fisher skewness |
+| [`event_skewness`][factrix.metrics.event_quality.event_skewness] | none — descriptive ([the D'Agostino skew test is withdrawn](inference-calibration.md#event-skewness-no-calibrated-test)) | — | Fisher skewness |
 | [`profit_factor`][factrix.metrics.event_quality.profit_factor] | none — descriptive | — | gains / \|losses\| |
 | [`signal_density`][factrix.metrics.event_quality.signal_density] | none — descriptive | — | mean bars per event |
 | [`event_around_return`][factrix.metrics.event_horizon.event_around_return] | none — descriptive | — | mean leakage score |
@@ -396,7 +396,7 @@ event panel carries with no clustering at all (19.0% and 23.3% at a nominal
 shock and a factor sign. The sibling clustering deflation repairs neither —
 it moves the first to 17.7% / 22.7% and over-corrects the second to 0.0%.
 The size table and both null definitions are in
-[statistical-methods section 6](statistical-methods.md#event-skewness-no-calibrated-test).
+[inference calibration](inference-calibration.md#event-skewness-has-no-calibrated-test).
 Test the direction of an event payoff with `event_hit_rate` / `event_ic` /
 `bmp_z`, which stay sized on both.
 
@@ -595,7 +595,7 @@ near it — the null diversification ratio is ~0.91 on a Gaussian factor
 with `abs_factor` weights, and the measured rejection rate is 0 of 300
 draws at a nominal 5% at both 10 and 48 tested periods, so the p could
 not reject at any sample size. See
-[§6 of the statistical-methods reference](statistical-methods.md#6-known-simplifications-deliberately-retained).
+[inference-calibration reference](inference-calibration.md#coverage-contract).
 
 - *descriptive*: `method`, `mean_n_top`, `ratio_eff_to_total`, `tie_ratio`,
   `weight_by`, `q_top` (requested top fraction; per period the bucket is
@@ -786,7 +786,7 @@ calibrated (4.3–5.5% at `rho = 0`, 6.2–8.3% in the strongest Stambaugh
 cells). At `h > 1` it is not — 7.5–14.5%, present at `rho = 0` for every
 `phi`, and plain OLS-NW carries the same excess. That is the
 overlapping-regression HAC problem, not the Stambaugh channel; see the
-[known-oversized regimes table](statistical-methods.md#hac-families).
+[HAC family calibration](inference-calibration.md#hac-family-calibration).
 
 The correction also costs power where OLS's apparent power was partly its
 own bias: at `T = 60, phi = 0.95, rho = -0.9` the corrected test rejects

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -3,1438 +3,286 @@ title: Statistical methods
 ---
 
 !!! note "Audience"
-    This page assumes working familiarity with applied econometrics
-    (heteroskedasticity-and-autocorrelation-consistent (HAC) SE, false discovery rate (FDR) control, near-unit-root inference). If you are
-    looking for a first-pass orientation to factrix output, start at
-    [Quickstart](../getting-started/quickstart.md) and
-    [Concepts](../getting-started/concepts.md); return here when you
-    need the discipline-level rationale behind a specific metric.
+    This page assumes familiarity with applied econometrics. For a first
+    result, start with [Quickstart](../getting-started/quickstart.md). For
+    empirical size measurements and known finite-sample limits, use
+    [Inference calibration and limitations](inference-calibration.md).
 
-Cross-cutting statistical disciplines that govern multiple metrics in
-factrix. This page sits **above** the per-metric API pages: it
-describes the five discipline lines that recur across cells, explains
-the variant of each that factrix implements, and points at the
-[bibliography](bibliography.md) anchor for the source treatment.
+This page defines the cross-cutting statistical contracts shared by factrix
+metrics. Per-metric formulas, parameters, and return schemas remain on the
+[Metrics API pages](../api/metrics/index.md).
 
-For per-metric formulae and signatures see the
-[Metrics API pages](../api/metrics/index.md). For the design choices
-behind which disciplines factrix does *not* implement, see
-[Development § Design notes](../development/design-notes.md).
-
-The five sections are the only first-class disciplines in factrix:
-
-1. **HAC SE under overlapping returns** — Newey-West with a
-   deterministic bandwidth rule.
-2. **Multiple-testing under dependence** — Benjamini-Yekutieli FDR,
-   not Bonferroni.
-3. **Robust scale and outlier handling** — MAD-based winsorisation
-   with the consistency factor; Theil-Sen for slope.
-4. **Persistence diagnostics under near-unit-root predictors** —
-   augmented Dickey-Fuller (ADF) flag, no auto-correction.
-5. **Event-study cross-sectional inference** — CAAR cross-event $t$,
-   BMP-style standardised AR, Corrado rank.
-
-!!! note "Every estimator here is frequency-agnostic"
-    No estimator in factrix reads the calendar (the library-wide principle:
-    [Period grid, not calendar](../development/architecture.md#period-grid-not-calendar)). `date` is only an ordering
-    key, and every window, lag, horizon and stride (`forward_periods`,
-    `estimation_window`, `window`, Bartlett lags, block lengths) is a count
-    of **periods on the panel's own distinct-date grid**, i.e. of whatever
-    interval one period represents. There is no annualisation factor, no
-    trading-day constant and no date arithmetic anywhere in the library, and
-    the grid may be unevenly spaced. Where a docstring says "one period" it
-    means one distinct date; "within-period" means "among the rows sharing
-    one timestamp", whatever that timestamp's granularity. The
-    caller owns frequency consistency between the factor, the return and
-    the price column — see
-    [Preparing data](../guides/preparing-data.md).
-
----
+!!! note "Periods, not calendar time"
+    Every horizon, lag, stride, and window counts periods on the panel's own
+    distinct-date grid. No method infers frequency or annualises from a date.
+    See [Period grid, not calendar](../development/architecture.md#period-grid-not-calendar).
 
 ## 1. HAC SE under overlapping returns
 [](){ #nw-hac }
 
-When forward returns span `h > 1` periods, consecutive observations
-inherit MA(`h − 1`) structure. Two standard responses, with different
-trade-offs: Newey-West (NW) HAC corrects SE on the full series at the cost of a
-kernel choice and asymptotic-Gaussian inference, while non-overlapping
-sampling preserves an exact-distribution `t` at the cost of a factor
-of `h` in effective sample size. factrix exposes both — non-overlap
-as the default for the mainstream metrics, NW HAC as an explicit
-sibling.
-When NW HAC is selected, factrix uses the
-[Newey-West 1987][newey-west-1987] Bartlett kernel with a
-deterministic bandwidth. The full path-to-family map is the table in
-[section 6](#hac-families).
+An `h`-period forward return makes adjacent observations share up to `h - 1`
+periods. factrix exposes three series-mean approaches. None removes economic
+persistence that remains after the overlap horizon.
 
-There are **two** bandwidth rules, and the split is by **restriction
-count**, not by whether the fit is univariate: a scalar statistic (a series
-mean, or a rank-one regression contrast) and a $K \ge 2$ Wald statistic
-degrade in opposite directions under a wide kernel (see
-[section 6](#hac-families) for the full path table).
-
-- **Scalar series-mean HAR $t$-test** (`ic` / `quantile_spread` /
-  `quantile_spread_vw` / `k_spread` under `NeweyWest`, `fm_beta` stage 2) —
-  `_resolve_har_lags`:
-  $$
-  L = \min\!\left(\max\!\left(1.3\sqrt{T},\; 3(h - 1)\right),\; \lceil T/3 \rceil\right)
-  $$
-  read against effective degrees of freedom
-  $\nu = \max\!\left(\min\!\left(1.5T/L - 1,\; T/h - 1\right),\; 1\right)$,
-  with the SE carrying a $T/(T - L - 1)$ finite-sample scale.
-- **Single-restriction regression contrasts** (`spanning_alpha`,
-  `common_quantile_spread`, `common_asymmetry`, `_ols.py`) —
-  `_resolve_scalar_wald_hac`: the *same* recipe as the scalar series mean,
-  applied to $R\beta$ with $R$ of rank one. A rank-one contrast is a scalar
-  statistic, so it inherits that calibration; the bandwidth, the
-  $T/(T-L-1)$ variance scale and the effective $\nu$ move together.
-- **Multi-restriction / cluster-mean Wald paths** (the slice Wald tests) —
-  `_resolve_nw_lags`:
-  $$
-  L = \max\!\left(\text{auto\_bartlett}(T),\; h - 1\right)
-  $$
-  where $\text{auto\_bartlett}(T) = \max\!\left(1,\; \lfloor 4 \cdot (T/100)^{2/9} \rfloor\right)$ per Newey-West (1994),
-  read against $F_{r,\,T-1}$. A $K$-restriction Wald statistic inverts a
-  $K \times K$ HAC matrix and degrades under the wide kernel that helps a
-  scalar one, so this family keeps the narrow rule (section 6).
-
-with $h$ = `overlap_periods` — the overlap of adjacent observations on the
-evaluation grid, stamped by `compute_forward_return` (equal to
-`forward_periods` on the full grid, derived from `dates=` on a coarser one).
-The $1.3\sqrt{T}$ base is
-[LLSW (2018)][llsw-2018]'s HAR recommendation; `auto_bartlett` is the
-[Newey-West 1994][newey-west-1994] automatic Bartlett bandwidth; the
-$h - 1$ term is the [Hansen-Hodrick 1980][hansen-hodrick-1980] overlap
-floor that ensures the kernel covers the MA(`h − 1`) structure of
-overlapping returns. factrix takes the maximum so the bandwidth is
-always at least large enough to absorb the overlap.
-
-Both bandwidth rules and the effective-df cap $T/h - 1$ read
-`overlap_periods`, not the return horizon. On the full grid the two are
-equal; on a coarser evaluation grid built with
-`compute_forward_return(..., dates=)` the overlap is the derived
-`1 + max_i #\{j : 0 < \mathrm{idx}(j) - \mathrm{idx}(i) < h\}`
-([Evaluating on a coarser grid](../api/preprocess.md#evaluating-on-a-coarser-grid)).
-**Disclosure:** the size tables in this section were measured on regular
-grids (a constant stride, overlap equal to the horizon). On an unevenly
-spaced evaluation grid the scalar series-mean paths were re-checked at the
-derived overlap — `NonOverlapping` 5.8% and `NeweyWest` 5.5% at a nominal 5%
-on the `(20, 20, 40)`-spaced grid in
-`tests/stats/test_uneven_grid_overlap_size.py` — but the Amihud-Hurvich
-path of `predictive_beta` and the $K$-restriction Wald paths have not been
-re-measured there, and the $T/h - 1$ cap is less conservative on a
-sub-sampled panel by construction. Such a grid is disclosed at source:
-`compute_forward_return(..., dates=)` fires
-[`uneven_evaluation_grid`](warning-codes.md) when adjacent kept rows are not
-a constant number of periods apart. The paths that read a constant spacing
-into the grid they are handed are
-
-- the regression HAC tests — `predictive_beta`, `spanning_alpha`, and the
-  $K$-restriction Wald / slice period joint tests;
-- the ADF and autocorrelation persistence screens;
-- event-study estimation windows and offsets;
-- adjacent-period metrics — turnover, rank autocorrelation, rolling windows.
-
-The remedy is the caller's: pass `dates=` at a constant stride on the panel's
-period grid if those paths must be calibrated; factrix does not resample.
-Switching `inference=` is not that remedy — on an uneven grid
-`overlap_periods` is the *maximum* overlap, so `NonOverlapping` strides at
-that maximum and discards more of the series than it would on a
-constant-stride grid, while `NeweyWest`'s $1.3\sqrt{T}$ base bandwidth is
-insensitive to the unevenness and keeps the full series; that is sample
-efficiency, not calibration.
-
-#### Three departures from the textbook HAR form
-
-Each is a factrix choice, not a published one, kept because it is
-load-bearing for measured size on overlapping horizons. The counterpart
-statements live in `factrix._stats.hac`'s docstring Notes.
-
-| Piece | Standard | What factrix does | Why | Measured consequence |
-|---|---|---|---|---|
-| Overlap floor | $h - 1$ (Hansen-Hodrick consistency floor) | $3(h-1)$ | At $L = h-1$ the Bartlett weight sends the lag-$(h{-}1)$ autocovariance to $1/h$, so the kernel discards most of the overlap covariance it exists to capture; at $3(h-1)$ the mean weight across the MA band is ≈0.83 rather than ≈0.5. | $T{=}240$, $h{=}21$: size 10.1% → 6.0% (40000 replications, seed 20260828; re-run at a reduced replication count by `tests/stats/test_overlap_floor_size.py`). Floor moved alone, the other two rows held at what factrix does today. |
-| SE scale | none (textbook is $\sqrt{\text{LRV}/T}$); Stata's `newey` scales by $T/(T-k)$ with $k$ = **regressor count**, never the bandwidth | $T/(T - L - 1)$ | Self-derived white-noise demeaning-bias correction: in-sample demeaning biases each $\hat\gamma_j$ by ≈$-\gamma_0/T$, giving $\mathbb{E}[\widehat{\text{LRV}}] \approx \gamma_0(1 - (L+1)/T)$, which this undoes exactly. | $h{=}5$: 8.2–9.6% → 6.2–6.7%. Partly double-counts with the fixed-$b$ reference (whose KV limit already embeds demeaning), so $h{=}1$ iid cells come out slightly *under*-sized (4.3–4.7% at $T \le 120$). |
-| Effective df | LLSW's `harreg.ado` uses $\lceil 1.5T/S \rceil$ | $\min(1.5T/L - 1,\; T/h - 1)$ | The $-1$ is a sub-one-df small-sample conservatism. The $T/h - 1$ cap is self-derived: an $h$-period overlapping series carries at most $T/h$ independent observations however the kernel is tuned. | Cap: $T{=}60$, $h{=}21$ size 12.2% → 4.3%. Cost: passing `forward_periods` on a series with *less* dependence than $h$ implies makes the test markedly conservative — measured 0.2% ($T{=}60$), 2.1% ($T{=}120$), 3.5% ($T{=}240$) on iid input at $h{=}21$. |
-
-Producing module: `tests/stats/test_hac_overlap_size.py` re-measures the
-three pieces only as one contrast — the current recipe against the
-pre-fix recipe that swapped all three at once. The per-piece cells above
-are not re-measured by any committed module except where a cell names
-one.
-
-Two choices factrix deliberately did not adopt:
-
-- The data-adaptive plug-in of [Newey-West 1994][newey-west-1994] is
-  not used. Its sampling variability defeats the point of having a
-  reproducible reported SE; the deterministic Newey-West rule is
-  adequate at typical research `T` and is auditable.
-- The prewhitening refinement of
-  [Andrews-Monahan 1992][andrews-monahan-1992] is also not used.
-  Same reason: deterministic outputs over marginal efficiency.
-
-The [White 1980][white-1980] HC0 sandwich estimator is the
-heteroskedasticity-only ancestor of NW and is mentioned in metric
-docstrings as background, not implemented separately.
-
-For the FM-cell, the NW HAC sits at stage 2
-([Fama-MacBeth 1973][fama-macbeth-1973]). When the Stage-1 regressor
-is itself an estimated quantity (rolling β, PCA score, ML predictor),
-[`fm_beta(is_estimated_factor=True)`](../api/metrics/fm_beta.md)
-applies the [Shanken (1992)][shanken-1992] single-factor case of the
-errors-in-variables correction, scaling SE by
-$\sqrt{1 + \hat\lambda^2 / \sigma^2_f}$ (Shanken's general multi-factor
-multiplicative term $1 + \lambda'\Sigma_f^{-1}\lambda$ collapses to
-$1 + \hat\lambda^2 / \sigma^2_f$ when there is one factor). The full
-Shanken variance has an additional $+\sigma^2_f / T$ term that factrix
-omits: at finite $T$ the omission **understates** the EIV inflation
-and so **overstates** the resulting $t$. The simplification is honest
-only when $T$ is large enough that the dropped term is negligible.
-
-`factor_return_var` is **required** under `is_estimated_factor=True`;
-omitting it raises `UserInputError`. There is no default because the
-only readily-available substitute, $\mathrm{var}(\hat\beta_t)$, makes the
-multiplier $1 + \overline{\beta}^2 / \mathrm{var}(\hat\beta_t) \equiv
-1 + t^2_{\mathrm{iid}} / T$ identically — an algebraic restatement of the
-$t$-stat that carries no errors-in-variables information about the
-regressor at all. When $\sigma^2_f$ collapses below machine epsilon the
-multiplier is undefined; factrix skips the correction, returns the
-uncorrected Newey-West $p$, and raises
-`WarningCode.DEGENERATE_VARIANCE` rather than switching silently.
-
-The corrected $t$ is read against the **same** effective degrees of
-freedom $\nu$ as the uncorrected one (`metadata["hac_dof"]`), so
-$c \ge 1$ translates into $p_{\text{Shanken}} \ge p_{\text{uncorrected}}$
-on any given series. Reading it against $T - 1$ instead would widen the
-reference distribution far enough to more than undo the $\sqrt{c}$ SE
-inflation and make the "conservative" correction return the *smaller*
-$p$.
-
-Default versus paired t-test is a separate choice: the mainstream
-metrics (`ic`, `caar`) use **non-overlapping resampling** as the
-default rather than NW HAC.
-[](){ #non-overlap-default }
-NW is exposed as an explicit sibling
-(`ic(inference=fx.inference.NEWEY_WEST)`) for callers who prefer the HAC route. Resampling has
-the advantage of exact rather than asymptotic-Gaussian inference at
-the cost of a factor of `h` in effective sample size; users with long
-panels often prefer NW.
-
-When the non-overlapping effective sample (`n / overlap_periods`) is
-thin, `ic` surfaces `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` on the
-returned result — the post-stride series is too short for a reliable
-`t`. Switching to `ic(inference=fx.inference.NEWEY_WEST)` keeps every
-observation and recovers test power in that regime. The guidance is
-one-directional: a thin non-overlapping sample is a reason to move to
-NW, but an ample sample is **not** a reason to move back — both methods
-are valid there and `ic` never changes the method for you.
-
-### NW vs HH-1980 vs Hodrick-1992 — when to use which
-
-The first three procedures target overlap-induced SE distortion; the
-stationary bootstrap targets the same distortion plus the normal-
-approximation assumption all three analytic methods still make:
-
-| Procedure | Mechanism | Strengths | Weaknesses | Where factrix uses it |
-|---|---|---|---|---|
-| **Newey-West (1987)** | Bartlett-kernel HAC on the full overlapping series, bandwidth `L = max(bandwidth_base, h−1)`. | Simple, deterministic, asymptotically valid for arbitrary autocorrelation up to `L`. | Asymptotic Gaussian — finite-sample size distortion when `h/T` is non-trivial; bandwidth rule is conservative. | `ic` / `quantile_spread` / `quantile_spread_vw` / `k_spread` (with `NeweyWest` inference), `fm_beta` stage 2, `common_quantile_spread`, `common_asymmetry`, `spanning_alpha`, the slice Wald tests. |
-| **Hansen-Hodrick (HH) (1980)** | A generalized method of moments (GMM)-style HAC estimator with a rectangular kernel truncated at `h−1`; the canonical reference for overlap-aware long-horizon SEs. | Targets the MA(`h−1`) residual structure overlap induces. | Rectangular kernel can yield a non-PSD covariance matrix in finite samples; still asymptotic. | **Research-only.** Implemented as `factrix.inference.series_mean.HANSEN_HODRICK` (rectangular-kernel SE → t-statistic → two-sided p-value) and usable standalone via `HANSEN_HODRICK.compute(...)`, but deliberately in **no** metric's `applicable_inference` allowlist — passing it to a metric raises `IncompatibleInferenceError` — and for that reason not re-exported from `factrix.inference`. Also borrows the `h−1` lag idea as a floor on the NW bandwidth above. |
-| **Hodrick (1992) "1B"** | Reverse-regression: regress one-period return on the predictor sum `X_t = Σ x_{t-j}` over the last `h` periods. | Size-correct in finite samples even at large `h/T`; no bandwidth choice. | Coefficient interpretation differs — `β` is the response to a cumulative-predictor stimulus (MA on the RHS) rather than a long-horizon forecast slope (MA on the LHS in the standard form); not a drop-in replacement for the canonical `β`. | **Not implemented**. Cited as the right tool when overlap is severe; the `Individual × Continuous` cell side-steps the issue with non-overlapping resampling instead. |
-| **Stationary bootstrap (Politis-Romano 1994)** | Block-resamples the series (geometric block length, Politis-White 2004 automatic selection), centred under `H0`, studentizes both the observed and the resampled root by a batch-means SE at the same block length, and reports the empirical two-sided p from the resampled `t` ratios. | No normality or asymptotic-variance assumption at all — valid when the IC/return distribution is heavy-tailed or skewed enough that NW's / HH's Gaussian p-value is itself suspect. | Heavier to compute (resampling, not closed-form); the reported `stat` is the observed mean rather than the root the p is computed from. On a zero-dispersion sample there is no block SE to divide by, and the kernel falls back to the raw-mean root — reported as `metadata["studentized"] = False` and `degenerate_variance`. | Exposed as `factrix.inference.STATIONARY_BOOTSTRAP` on `ic`, `quantile_spread`, `quantile_spread_vw` and `k_spread` — every one of them dispatches the member polymorphically, and the spread series carries its own measured size table (§6). |
-
-Practical rule of thumb:
-
-- `h ≤ 1`: NW with the Andrews rule is fine; the HH-1980 floor is
-  inactive.
-- `1 < h, h/T ≤ 0.05`: NW + HH-1980 floor is the factrix default; the
-  finite-sample bias is small enough.
-- `h/T > 0.05`: prefer non-overlapping resampling (`ic`, `caar`
-  defaults) over NW. If a slope estimate is needed and resampling
-  burns too much sample, Hodrick-1992 1B is the literature-preferred
-  alternative; pre-compute externally.
-- Distribution itself in doubt (heavy tails, skew) regardless of `h/T`:
-  prefer `STATIONARY_BOOTSTRAP` over any of the analytic methods above —
-  it is the only one of the four that does not assume asymptotic
-  normality.
-
-### Which metrics take `inference=`, and which take a raw lag knob
-
-Two different surfaces set the HAC bandwidth, and which one a metric
-offers is decided by whether that metric's series has a **measured size
-table**, not by convenience:
-
-| Metric | Bandwidth surface | Why |
+| Method | Dependence treatment | Reference and main trade-off |
 |---|---|---|
-| `ic`, `quantile_spread`, `quantile_spread_vw`, `k_spread` | `inference=` (allowlist: `NON_OVERLAPPING`, `NEWEY_WEST`, `STATIONARY_BOOTSTRAP`) | Headline test is "average an overlapping per-date series, test `mean != 0`". The IC series and the spread series each carry their own measured size table (this section and §6), so each member is admitted on the strength of it, and the bandwidth is chosen for the caller by the member. |
-| `fm_beta`, `predictive_beta`, `common_quantile_spread`, `common_asymmetry` | raw `newey_west_lags` | These are estimator-specific regression paths rather than interchangeable series-mean tests. `None` (the default and calibrated setting) resolves the project's applicable rule; an explicit integer is an unvetted research override. |
-| `pooled_beta` | raw `driscoll_kraay_lags` | Driscoll-Kraay is a two-dimensional (period × asset) sandwich, not an `inference` member. Its default is calibrated on its own pooled-panel DGP; an explicit integer replaces the automatic base but cannot undercut the overlap floor or estimability cap. |
-| `spanning_alpha`, the slice Wald tests | neither | Bandwidth is fully determined by `overlap_periods` through `_resolve_nw_lags`; there is no caller knob to mis-set. |
+| `NON_OVERLAPPING` | Keep observations at least `overlap_periods` apart | Student-t reference on the strided series. Mechanical overlap is removed; the reference is exact only under iid normality. It spends roughly a factor of `h` in sample size. |
+| `NEWEY_WEST` | Bartlett-kernel heteroskedasticity-and-autocorrelation-consistent (HAC) variance on the full series | Retains observations but uses an asymptotic HAC reference and a calibrated deterministic bandwidth. |
+| `STATIONARY_BOOTSTRAP` | Stationary block resampling with an automatically selected mean block length | Avoids a parametric-normal reference for the series mean, but still requires stationarity or weak dependence, a suitable block length, and an adequate sample. It is a second read for long series with distributional doubt, not a rescue for a short series. |
 
-An `inference=` allowlist is reserved for metrics whose tested per-period
-series supports interchangeable inference members. Regression estimators
-keep their estimator-specific lag surface even after own-DGP calibration;
-the raw knob is deliberately raw and does not pretend that a caller override
-is a vetted choice.
+`NON_OVERLAPPING` is the default for the mainstream series-mean metrics. The
+caller can select the other admitted members explicitly; factrix never switches
+the requested method in response to a warning.
+[](){ #non-overlap-default }
 
----
+### Newey-West bandwidth families
+
+The bandwidth depends on the rank of the tested restriction, not simply on
+whether a regression has multiple coefficients.
+
+For a scalar series mean or rank-one regression contrast, factrix uses
+
+$$
+L = \min\!\left(\max\!\left(1.3\sqrt{T},\;3(h-1)\right),\;\lceil T/3\rceil\right),
+$$
+
+scales the variance by $T/(T-L-1)$, and reads the statistic against
+
+$$
+\nu = \max\!\left(\min\!\left(1.5T/L-1,\;T/h-1\right),\;1\right).
+$$
+
+The $1.3\sqrt{T}$ term follows [LLSW (2018)][llsw-2018]; the overlap floor
+extends the [Hansen-Hodrick (1980)][hansen-hodrick-1980] coverage requirement.
+The wider `3(h - 1)` floor, finite-sample scale, and effective degrees of
+freedom are factrix calibration choices rather than textbook Newey-West.
+
+Multi-restriction Wald tests instead use
+$L=\max(\text{auto_bartlett}(T), h-1)$ and an F reference. A wide kernel can
+degrade the inversion of a multi-restriction HAC matrix, so the scalar recipe
+does not transfer to this family.
+
+### HAC path map
+[](){ #hac-families }
+
+| Path | Bandwidth and reference |
+|---|---|
+| `ic`, `quantile_spread`, `quantile_spread_vw`, `k_spread` with `NEWEY_WEST`; `fm_beta` stage 2 | Scalar series-mean recipe and $t_\nu$ |
+| `spanning_alpha`, `common_quantile_spread`, `common_asymmetry`, single-restriction OLS contrasts | Scalar rank-one recipe and $t_\nu$ or $F_{1,\nu}$ |
+| `predictive_beta`, `h > 1` | Scalar bandwidth and effective-df reference after the Amihud-Hurvich correction |
+| `pooled_beta` | Driscoll-Kraay covariance over period-level score sums, using the scalar HAR bandwidth, variance scale, and $t_\nu$ reference; it is not a series-mean covariance |
+| Cross-sectional slice Wald tests | Narrow multi-restriction bandwidth and $F$ reference |
+| Date-disjoint `slice_period_*_test` | Per-slice NW variances for `method="analytic"`; independent stationary bootstrap draws for `method="bootstrap"` |
+
+See [HAC family calibration](inference-calibration.md#hac-family-calibration)
+for measured size bands and known oversized regimes.
+
+### Which metrics expose `inference=`
+
+`ic`, `quantile_spread`, `quantile_spread_vw`, and `k_spread` expose the
+closed allowlist `NON_OVERLAPPING`, `NEWEY_WEST`, and
+`STATIONARY_BOOTSTRAP`. Each member was measured on the relevant IC or spread
+series before admission.
+
+Other metrics keep estimator-specific parameters instead:
+
+| Metric family | Surface |
+|---|---|
+| `fm_beta`, `predictive_beta`, `common_quantile_spread`, `common_asymmetry` | `newey_west_lags`; `None` selects the documented rule, while an integer is an uncalibrated research override |
+| `pooled_beta` | `driscoll_kraay_lags`; `None` selects the calibrated rule, while an integer replaces the automatic base but cannot undercut the overlap floor or estimability cap |
+| `spanning_alpha` and slice Wald tests | Bandwidth determined from `overlap_periods`; no caller lag knob |
 
 ## 2. Multiple-testing under dependence
 [](){ #bhy }
 
-!!! tip "Canonical reference"
-    For when to use Benjamini-Hochberg-Yekutieli (BHY), family partitioning, and worked screening recipes, see [BHY screening](../api/bhy.md). This section is the underlying theorem and assumptions.
+The literature names two step-up procedures three ways:
 
-!!! note "BH / BY / BHY — three names, two procedures"
-    The literature uses three labels that map to two distinct procedures:
+- **BH** is the [Benjamini-Hochberg (1995)][benjamini-hochberg-1995]
+  procedure. Its FDR guarantee assumes independence or positive regression
+  dependence on a subset (PRDS).
+- **BY** is the [Benjamini-Yekutieli (2001)][benjamini-yekutieli-2001]
+  arbitrary-dependence procedure. It divides the BH threshold by
+  $c(m)=\sum_{i=1}^{m}1/i$.
+- **BHY** is common quant shorthand for the BY procedure. factrix follows
+  that convention in the function name `bhy()`.
 
-    - **BH** — [Benjamini & Hochberg (1995)][benjamini-hochberg-1995]. Original FDR step-up; requires independence or positive regression dependence on a subset (PRDS) among the test statistics.
-    - **BY** — [Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]. Generalises BH to arbitrary dependence by dividing the threshold by $c(m) = \sum_{i=1}^{m} 1/i$. **This is the procedure factrix's `multi_factor.bhy()` implements mathematically.**
-    - **BHY** — quant / factor-research shorthand (e.g. [Harvey-Liu-Zhu 2016][harvey-liu-zhu-2016]) for the BY-2001 procedure, naming all three authors of the BH/BY lineage. Pure statistics / biostatistics literature (R `mutoss`, `sgof`, etc.) uses **BY** for the same procedure.
+Factor-test dependence is usually difficult to prove to be PRDS. factrix
+therefore uses the BY/BHY threshold when a family must be valid under arbitrary
+dependence. Bonferroni also remains valid under arbitrary dependence, but it
+controls the family-wise error rate (FWER), a stricter and usually more
+conservative target than FDR; its conservatism does not come from assuming
+independence.
 
-    factrix follows the quant convention: the function is `bhy()`, the abbreviation in prose is `BHY`, the full form on first use is `Benjamini-Hochberg-Yekutieli`. Paper-citation links (`[Benjamini & Yekutieli (2001)][benjamini-yekutieli-2001]`) still point at the actual two-author paper because that is the work being cited.
-
-Factor pools are dependent by construction: 200 momentum variants on
-the same return panel correlate, and a Bonferroni step that assumes
-independence over-corrects. factrix's `multi_factor.bhy` wrapper
-implements [Benjamini-Yekutieli 2001][benjamini-yekutieli-2001] FDR
-control with the dependence correction $c(m) = \sum_{i=1}^{m} 1/i$ —
-valid under arbitrary positive or negative dependence at the cost of
-a $1/\ln m$ shrinkage relative to plain Benjamini-Hochberg (BH).
-
-[Benjamini-Hochberg 1995][benjamini-hochberg-1995] BH is *not* the
-default because the typical factor-pool dependence violates its positive regression dependence on a subset (PRDS)
-assumption; factrix offers BHY as the safe choice and surfaces the
-adjusted `q`-values rather than a binary pass/fail at a fixed `α`.
-
-Three positions on multiple testing that the literature has converged
-on and factrix takes:
-
-- The [Harvey-Liu-Zhu 2016][harvey-liu-zhu-2016] case for raising
-  t-thresholds is taken seriously. Single-factor pre-registered comparisons default to $t \geq 2.0$
-  but exposes the BHY-adjusted `q` so users can apply a stricter
-  threshold for new factor proposals.
-- The [Harvey 2017][harvey-2017] case against ad-hoc p-hacking is the
-  reason factrix runs registered procedures with fixed pipelines —
-  the lag rule, the sample guards, the resampling stride are not
-  user-tunable per call.
-- The [White 2000][white-2000] reality-check and
-  [Hansen 2005][hansen-2005] SPA family are *not* implemented. The
-  cost of bootstrap-based data-snooping correction is high relative
-  to the BHY recipe under realistic `m`, and the empirical
-  disagreement is concentrated in the marginal cases where neither is
-  decisive (see [Design notes § BHY rather than
-  Bayesian](../development/design-notes.md#5-bhy-rather-than-bayesian-multiple-testing)).
-
-Greedy forward selection (`greedy_forward_selection`) inflates t-stats
-by selection and is documented as **not for inference**. The PoSI
-literature ([Berk-Brown-Buja-Zhang-Zhao 2013][berk-brown-buja-zhang-zhao-2013],
-[Leeb-Pötscher 2005][leeb-potscher-2005]) gives the rigorous
-correction; factrix does not implement it because the function is
-intended as a diagnostic, not a hypothesis test.
-
+The declared hypothesis family is part of the analysis. Placeholder results
+are excluded rather than treated as p-values, and separate economic questions
+should not be pooled merely to increase `m`. See
+[BHY screening](../api/bhy.md) for family construction and hierarchical
+procedures.
 
 ### Resampling knobs
 
-Every entry point that turns a resample count into a reported p or
-interval takes the same two knobs under the same names, with the same
-default and the same refusal floor.
+Entry points that turn resamples into a p-value or interval use
+`n_resamples` and `rng` consistently.
 
-| Entry point | `n_resamples` default | resolved `seed` reported as | Floor enforced | Reports `p_value_mc_se` |
-|---|---|---|---|---|
-| `ic(inference=StationaryBootstrap(...))` | 999 | `metadata["seed"]` | yes | yes (`metadata`) |
-| `monotonicity(...)` | 999 | `metadata["seed"]` | yes | yes (`metadata`) |
-| `bootstrap_mean_ci(...)` | 999 | not reported (returns an interval) | yes | no (returns an interval, not a p) |
-| `slice_period_pairwise_test` / `slice_period_joint_test` (`method="bootstrap"`) | 999 | the `seed` output column | yes | no (see below) |
-| `stationary_bootstrap_resamples(...)` | 999 | not reported (returns draws) | **no** | no (returns draws, not inference) |
+| Entry point | Default `n_resamples` | Enforces the 199 floor | Reports resolved seed |
+|---|---:|---:|---:|
+| `STATIONARY_BOOTSTRAP` on admitted metrics | 999 | Yes | In metric metadata |
+| `monotonicity` | 999 | Yes | In metric metadata |
+| `bootstrap_mean_ci` | 999 | Yes | No; returns an interval |
+| `slice_period_pairwise_test` / `slice_period_joint_test` with `method="bootstrap"` | 999 | Yes | In the result column |
+| `stationary_bootstrap_resamples` | 999 | No; returns draws, not inference | No |
 
-The floor is `BOOTSTRAP_RESAMPLES_FLOOR = 199` and a lower count raises
-`UserInputError`. A Davison-Hinkley smoothed p lives on the `1/(B+1)`
-grid, so `B` should be chosen with `α·(B + 1)` an integer
-([Davidson-MacKinnon 2000][davidson-mackinnon-2000]): 199 / 399 / 999 at
-the conventional levels. 199 is the smallest such grid point — below it
-the p resolves no finer than 0.005 — and the default 999 is
-[Politis-White (2004)][politis-white-2004]'s recommendation for two-sided
-5% work. `stationary_bootstrap_resamples` sits outside the floor
-deliberately: it returns draws and claims no inference on them.
+A smoothed empirical p-value lies on the `1/(B + 1)` grid. Values such as
+199, 399, and 999 align common significance levels with that grid; 999 gives
+roughly 0.001 resolution. The Monte Carlo standard error
+$\sqrt{p(1-p)/B}$ describes resampling noise, not uncertainty in the factor
+estimate. Automatic block-length selection is a separate operation; it does
+not determine the number of resamples.
 
-`p_value_mc_se` is `sqrt(p(1-p)/B)`, the binomial SE of the resampling
-draw itself — how far the reported p would move on a re-run with a
-different seed, not a statistical SE of the estimate. At `B = 999` and
-p near 0.05 it is ~0.7pp, so 0.043 and 0.058 are one draw apart. It
-shrinks only as `1/sqrt(B)`; no amount of data shrinks it. The period
-slice tests do **not** report it: their `p_adj` is a Romano-Wolf
-step-down adjustment, not a single binomial draw, so the formula does
-not apply.
+`rng` accepts an integer, `None`, or `numpy.random.Generator`. An integer is
+reproducible and reported unchanged. `None` draws and reports an integer seed.
+A generator is advanced in place and reports no seed because the caller owns
+the stream.
 
-`rng` takes the same three types everywhere — including
-`datasets.make_*`, which reports nothing:
+## 3. Robust scale and trend handling
 
-- an **`int`** reproduces the run and is reported back unchanged;
-- **`None`** (the default) draws a 32-bit int from system entropy and
-  reports it, so an unseeded run is still reproducible after the fact;
-- a **`numpy.random.Generator`** is used as-is and *advanced* by the
-  call, so two calls on one generator draw differently while two
-  generators built from the same seed agree. That is the numpy / scipy
-  `rng=` semantics, and it is what a nested or large-scale simulation
-  running off one stream needs. The reported seed is then `None`: the
-  stream is the caller's, so only the caller can reproduce the draw.
+For each period, `mad_winsorize` clips a factor to
 
-Anything else raises `UserInputError`. The period slice tests carry the
-report in a `seed` output column, which is null under
-`method="analytic"` (that path draws nothing).
+$$
+\text{centre} \pm n_{\text{MAD}}\,b_n\,1.4826\,\operatorname{MAD},
+$$
 
----
+where the centre can be the median (default) or mean. The MAD itself is always
+computed about the median. `1.4826` gives asymptotic Gaussian consistency;
+the Croux-Rousseeuw $b_n$ factor corrects finite-cross-section bias. This
+keeps small cross-sections from receiving a materially narrower band solely
+because raw MAD is biased downward.
 
-## 3. Robust scale and outlier handling
+Sn and Qn have higher Gaussian efficiency than MAD, but require more pairwise
+order-statistic machinery. factrix keeps the simpler MAD contract and applies
+the explicit finite-sample correction instead.
 
-factrix preprocesses cross-sectional factor exposures with
-**MAD-based winsorisation**: per period, clip values to
-$\text{median} \pm k \cdot \mathrm{MAD} \cdot 1.4826$. The $1.4826$ factor restores Gaussian
-consistency of the median absolute deviation as a scale estimator
-([Hampel 1974][hampel-1974] is the canonical reference popularising
-MAD as a scale estimator; textbook treatment in
-[Huber 1981][huber-1981]). This avoids letting the same outlier that
-breaks a sample mean break the scale estimator that gates its
-treatment.
+`ic_trend` pairs two rank-based quantities:
 
-Theil-Sen slope is used for the trend metric (`ic_trend`) for the
-same reason. The estimator computes the median pairwise slope
-([Sen 1968][sen-1968]) and inherits a 29.3% breakdown point; the
-SE recovered from the rank-based confidence interval is approximate,
-not asymptotically exact, which is the trade-off factrix accepts in
-return for not letting a single COVID-era information coefficient (IC) spike dominate the slope.
+- Theil-Sen supplies the trend magnitude and descriptive confidence interval.
+- Hamed-Rao Mann-Kendall supplies `stat` and `p_value` after non-overlapping
+  sampling.
 
-Two robust-scale choices factrix did not adopt:
-
-- The Sn / Qn estimators of [Rousseeuw-Croux 1993][rousseeuw-croux-1993]
-  have higher Gaussian efficiency than MAD. The factrix winsorisation
-  pipeline keeps MAD because the small efficiency gain does not
-  justify the extra complexity at the boundaries (Sn / Qn need
-  sorted-pair lookups; MAD is a single median).
-- The stationary block bootstrap of
-  [Politis-Romano 1994][politis-romano-1994] is cited as the proper
-  way to recover SE under serial dependence when an analytical kernel
-  is not available. factrix's parametric NW HAC is preferred because
-  it is deterministic; the bootstrap is left to external packages
-  (`arch`).
-
-The influence-function framework that places robust-scale and
-breakdown-point reasoning on a common conceptual map is
-[Hampel 1974][hampel-1974].
-
----
+The p-value is not backed out of the Theil-Sen interval. A constant series
+returns the zero slope while withholding `stat` and `p_value` with a
+degenerate-variance warning.
 
 ## 4. Persistence diagnostics under near-unit-root predictors
 
-Predictive regressions with persistent regressors carry the
-[Stambaugh 1999][stambaugh-1999] bias: when the regressor's
-innovation correlates with the dependent return innovation, ordinary least squares (OLS) $\hat\beta$
-carries a finite-sample bias of order $O(1/T)$ that does not vanish
-at conventional research sample sizes ($\hat\beta$ is consistent
-asymptotically, but the bias is large enough to flip inference at
-$T \approx 10\text{–}30$ years of monthly data). The textbook corrections
-([Campbell-Yogo 2006][campbell-yogo-2006] Bonferroni Q,
-[Phillips-Magdalinos 2009][phillips-magdalinos-2009] /
-[Kostakis-Magdalinos-Stamatogiannis 2015][kostakis-magdalinos-stamatogiannis-2015]
-IVX) are out of factrix's lean-dependency scope.
+Persistent predictive regressors can carry finite-sample coefficient bias
+([Stambaugh 1999][stambaugh-1999]). HAC changes the variance estimate; it does
+not remove that coefficient bias. `predictive_beta` therefore applies the
+Amihud-Hurvich correction unconditionally and reports the raw OLS slope in
+metadata. The persistence warning describes the remaining inference regime;
+it is not the switch that decides whether the correction runs.
 
-factrix's response is **flag, do not fix**: `ic_trend(adf_threshold=
-0.10)` runs an Augmented Dickey-Fuller test on the input series
-([Dickey-Fuller 1979][dickey-fuller-1979], [Said-Dickey 1984][said-dickey-1984]
-ARMA extension). When the ADF p-value exceeds `0.10` —
-[Stock-Watson 1988][stock-watson-1988] practitioner cutoff — the
-metadata records `unit_root_suspected=True` and the slope significance
-is annotated with that caveat. The slope value itself is still
-returned; the caller decides whether to trust it.
+At `overlap_periods > 1`, the corrected predictive-slope test remains oversized
+on the measured null grid. `overlapping_predictive_inference` makes that limit
+explicit on every such result. Use the estimate as an effect size, raise the
+evidentiary hurdle for its p-value, and compare a one-period or genuinely
+non-overlapping design. factrix does not silently substitute IVX,
+Bonferroni-Q, or another model-dependent estimator.
 
-The lag order of the augmentation is selected by AIC over
-$0 \ldots \lfloor 12 (T/100)^{1/4} \rfloor$ ([Schwert 1989][schwert-1989]
-ceiling) on a common estimation sample, then refitted on the full sample —
-the `statsmodels.tsa.stattools.adfuller(autolag="AIC")` procedure. The
-series this is applied to carry MA($h-1$) autocorrelation from overlapping
-forward returns, so the un-augmented $\text{lags}=0$ regression (the
-earlier default) is mis-sized. Pass `lags=` explicitly to `_adf` to fix
-the order.
+For `ic_trend`, non-overlapping sampling happens before Theil-Sen,
+Mann-Kendall, the augmented Dickey-Fuller (ADF) screen, and residual
+autocorrelation diagnostics. The ADF test therefore reads the strided tested
+series, not the raw MA(`h - 1`) overlap. Its lag order is selected by AIC up to
+the Schwert ceiling. The default `adf_threshold=0.10` is a conventional
+practitioner cutoff, not a direct prescription from Stock-Watson (1988).
 
-The ADF p-value is interpolated from
-[MacKinnon 1996][mackinnon-1996] response-surface critical values for
-the constant-only specification (`_adf_pvalue_interp`); the upper tail
-uses Fuller's $\tau_\mu$ points ($-0.44$ / $-0.07$ / $0.23$ / $0.60$ at
-90 / 95 / 97.5 / 99%). The interpolation accuracy is ~±0.02 — ample for
-the qualitative "is this a unit root" decision the threshold drives.
+A series that remains autocorrelated after the stride can still make HAC,
+bootstrap, or Mann-Kendall p-values optimistic. factrix raises
+`serial_correlation_detected`; changing inference member does not make that
+regime calibrated. See [Persistence beyond the overlap
+horizon](inference-calibration.md#persistence-beyond-the-overlap-horizon).
 
-Overlapping multi-period returns inherit MA(`h − 1`) autocorrelation
-([Richardson-Stock 1989][richardson-stock-1989]), which the NW lag
-floor in section 1 absorbs. The persistence diagnostic in this
-section is on the *input* series itself, not the residual structure
-captured by HAC.
-
-For per-asset β regressions in `compute_common_betas`, factrix
-deliberately retains plain OLS SE rather than HAC.
+For stage-1 per-asset regressions inside common-factor metrics, factrix keeps
+plain OLS standard errors. Adding HAC there would not correct Stambaugh bias and
+would imply robustness the coefficient estimator does not provide.
 [](){ #stage1-plain-se }
-The Stambaugh bias arises from the predictor's persistence, not from
-SE estimation, and HAC fixes only the SE while leaving the coefficient
-bias untouched. Adding HAC there would advertise robustness factrix
-does not deliver.
 
----
+## 5. Event-study inference
 
-## 5. Event-study cross-sectional inference
+Event metrics differ in their inference unit. Compare `n_obs` only after
+checking `n_obs_axis` and the metric metadata.
 
-The `individual_sparse` cell aggregates per-event abnormal returns
-across assets. Three estimators are exposed, each making a different
-assumption about the cross-event distribution. A fourth pooled statistic —
-the skewness of the signed event returns — is reported descriptively only;
-see [event_skewness](#event-skewness-no-calibrated-test) in section 6.
+| Metric | Inference unit | Test and dependence treatment | `n_obs` |
+|---|---|---|---:|
+| `caar` | Event periods | Mean signed abnormal return on a non-overlapping event-period series; Student-t reference | Sampled event periods |
+| `bmp_z` | Valid event rows | Standardised abnormal returns; per-asset event overlap removal plus optional within-period design-effect deflation | Valid events |
+| `corrado_rank` | Event periods | Signed within-asset ranks collapsed by event period; z reference on the event-period series | Event periods |
+| `event_hit_rate` / `event_ic` | Event rows with period clustering adjustment | Metric-specific test with the same-period design effect where applicable | Metric-specific event count; inspect `n_event_periods` separately |
 
-### CAAR cross-event t
+### CAAR event-period t
 [](){ #caar-cross-event-t }
 
-Default for `caar`. Per event period, take the cross-sectional mean of
-$\text{abnormal return} \times \text{factor}$ across event rows — the
-abnormal return, not the raw one, so the asset's own drift over the
-estimation window does not enter the signed CAR; the resulting
-CAAR series is greedily subsampled by `date_ordinal` so consecutive
-kept event periods are at least `overlap_periods` periods apart,
-then tested with a standard $t$ on the sampled mean. `n_obs` is the
-non-overlap event-period count, not the raw event count or full calendar
-length. Specification follows [Brown-Warner 1985][brown-warner-1985].
-The test is correctly sized under no event-induced variance; under variance
-inflation around the event period it is mis-specified — the documented
-motivation for switching to the BMP-style estimator below.
+`caar` forms a per-event-period cross-sectional mean of signed abnormal
+returns, samples event periods at the declared overlap stride, and tests the
+sampled mean. It is not a raw-event-count t-test. Event-induced variance can
+invalidate the simple reference, which motivates reading `bmp_z` alongside it.
 
-### BMP standardised AR
+### BMP-style standardised abnormal returns
 [](){ #bmp-standardised-ar }
 
-`bmp_z`. Standardises each event's abnormal return by its
-estimation-window standard deviation before taking the cross-event
-mean, restoring size under event-induced variance
-([Boehmer-Musumeci-Poulsen 1991][boehmer-musumeci-poulsen-1991]).
-factrix's implementation is a **BMP-style simplification**: by
-default it uses mean-adjusted abnormal returns and omits the original
-BMP prediction-error correction, so results do not match a textbook
-BMP implementation byte-for-byte. The strict denominator is
-available via `bmp_z(..., include_prediction_error_variance=True)`
-when the textbook form is required.
+`bmp_z` standardises each valid event by its estimation-window volatility.
+The default is a documented BMP-style simplification; set
+`include_prediction_error_variance=True` for the constant textbook
+prediction-error factor. Same-period dependence is estimated with an ANOVA
+ICC(1) and a design-effect deflator. The result reports both valid events and
+distinct event periods because the latter controls the residual small-sample
+limit under clustering.
 
-### Corrado nonparametric rank
+The published Kolari-Pynnönen statistic also includes a `(1 - r)` numerator
+for variance estimated within one event date. factrix pools standardised
+abnormal returns across event periods, so that between-period variance is
+already present; applying the numerator again would deflate the statistic
+twice.
+
+### Corrado rank
 [](){ #corrado-rank }
 
-`corrado_rank`. Replaces each asset's abnormal returns with their uniform
-rank over that asset's **full sample series** — not a rank within the
-(estimation ∪ event) window — averages each event period's ranks into
-one observation, then runs the $z$ on that event-period series
-([Corrado 1989][corrado-1989]). Robust to extreme returns,
-non-normality, cross-asset heteroscedasticity, and **same-period event
-clustering** — the last because collapsing each date first puts the
-within-period correlation into the denominator, which is what makes this
-the honest fallback when `clustering_hhi` says `caar`'s $t$ cannot be
-trusted. `n_obs` therefore counts event *periods*, and a factor firing on
-fewer than `MIN_EVENTS_HARD` periods short-circuits rather than estimating
-a time-series SD from a handful of points — the same floor `caar` applies
-to its own event-period series.
+`corrado_rank` replaces abnormal returns with signed within-asset ranks and
+collapses them by event period before inference. It is the distribution-robust
+read when standardised abnormal returns are sensitive to skew or extreme
+returns.
 
-factrix adds the direction adjustment of
-[Corrado-Zivney 1992][corrado-zivney-1992] for two-sided signed signals —
-the rank itself is signed by $\text{sign}(\text{factor})$ before
-aggregation, not the underlying return.
-
-The denominator follows the *intent* of Corrado's eq. (5) (time-series SD
-of a cross-sectional mean) rather than its literal form: Corrado's design
-is event-time aligned so every date's cross-section is the full universe,
-whereas a calendar-time sparse panel has thin event periods against full
-non-event ones. Taking the SD over all periods there would understate the
-relevant dispersion several-fold, so it is taken over the event-period
-series, whose scale matches the numerator by construction.
-
-## 6. Known simplifications (deliberately retained)
-
-This section records the estimator simplifications kept deliberately, and the
-calibration measurements that map each test to the HAC family and reference
-distribution it actually uses. Each is intentional and has been reviewed; the
-record exists so the choices are not re-litigated.
-
-### Within-period clustering: ANOVA ICC(1) and the design-effect deflator
-
-`_estimate_within_date_icc` (feeds the clustering deflation in `bmp_z` and
-`directional_hit_rate`) is the one-way random-effects ANOVA estimator
-$\hat r = (\text{MSB} - \text{MSW}) / (\text{MSB} + (n_0 - 1)\,\text{MSW})$
-([Shrout-Fleiss 1979][shrout-fleiss-1979] ICC(1), Donner-Koval $n_0$ for
-unbalanced periods), clipped to $[0, 1]$. An earlier version used the raw
-between/total ratio $\operatorname{Var}(\bar x_d) / (\operatorname{Var}(\bar x_d) +
-\hat\sigma^2_w)$; because $\mathbb{E}[\operatorname{Var}(\bar x_d)] = \sigma^2_b +
-\sigma^2_w / n$, that ratio converges to $1/(n+1)$ under **independence** and
-the deflator fired at full strength on unclustered data (empirical size
-$\approx 1\%$ at nominal 5%).
-
-The deflator itself is the Kish design effect $1/\sqrt{1 + (n_0 - 1)\hat r}$,
-i.e. [Kolari-Pynnönen 2010][kolari-pynnonen-2010] **without** the $(1 - \bar r)$
-numerator. K-P's numerator corrects a cross-sectional variance estimated on a
-*single* event day (which under clustering estimates only $\sigma^2(1 - \bar
-r)$). factrix pools SARs / hit indicators across many event periods, so the pooled
-variance already contains the between-date component; applying $(1 - \bar r)$
-on top would double-count. Choosing the design-effect form is the
-engine-specific decision; the textbook K-P form is correct for the single-day
-BMP setting it was derived in.
-
-### `event_skewness`: no calibrated test for the third moment
+### Event skewness is descriptive
 [](){ #event-skewness-no-calibrated-test }
 
-`event_skewness` reports the Fisher skewness of the sampled signed
-abnormal returns and **no p-value or test statistic**. It used to publish
-D'Agostino's skew-test $z$ and its two-sided $p$ whenever
-`n_events >= 20`; that test is withdrawn as uncalibrated. It has no
-calibrated pooled form here for two independent reasons, and the
-same-period clustering deflation `event_hit_rate` and `event_ic` apply
-repairs neither.
+`event_skewness` reports Fisher skewness without `stat` or `p_value`. A pooled
+D'Agostino test was removed because non-normal signed returns and same-period
+shocks break it in different directions; a single clustering deflator did not
+calibrate both. Use `caar`, `bmp_z`, `corrado_rank`, `event_hit_rate`, or
+`event_ic` for a declared directional hypothesis.
 
-The measured null size, at a nominal 5%, 300 replications per cell, base
-seed 20260830 + replication. The deflated column routes the $z$ through
-the design effect of the per-event standardised cubed deviation
-$((x_i - \bar x)/s)^3$, whose mean is $g_1$ — the same helper the sibling
-event tests use on their own per-event score. Three nulls:
+## 6. Calibration and known limitations
+[](){ #6-known-simplifications-deliberately-retained }
 
-- **Panel** — `make_event_panel(n_assets=50, post_event_drift_bps=0,
-  event_rate=0.02, signal_horizon=5)` through
-  `compute_forward_return(forward_periods=5)`, read by
-  `event_skewness(overlap_periods=5)`. Events land independently, so an
-  event period holds 1.55 events on average.
-- **Sign-randomised clustered** — 50 events on each of 20 shared event
-  periods, one shared shock per period added to every event's return, and
-  each event's factor sign drawn independently per asset.
-- **Sign-aligned clustered** — 40 assets, 400 periods, returns
-  $r_{t,i} = \delta_t + \varepsilon_{t,i}$ with $\delta_t,
-  \varepsilon_{t,i} \sim N(0, 0.01^2)$ compounded into a price series; all
-  40 assets fire together on 20 randomly chosen periods, and every event
-  on a period carries **one common factor sign** drawn for that period.
-  This is the auditor's construction; it is the same shared-shock
-  mechanism as the row above with the sign randomisation removed.
+The full size tables, known oversized regimes, and test provenance now live on
+[Inference calibration and limitations](inference-calibration.md). The split
+keeps method contracts scannable without hiding the evidence behind them.
 
-| Null | Events per event period | Excess kurtosis of signed CAR | SD of the null $z$ | Size, D'Agostino $z$ | Size, $z$ deflated for clustering |
-|---|---|---|---|---|---|
-| Panel, 252 periods | 1.55 | +0.63 | 1.31 | **19.0%** | **17.7%** |
-| Panel, 504 periods | 1.52 | +0.95 | 1.50 | **23.3%** | **22.7%** |
-| Panel, `n_assets=1`, 2000 periods | 1.00 | −0.29 | 0.92 | 3.0% | 3.0% |
-| Sign-randomised clustered, 50 events per period | 50.0 | −0.08 | 1.13 | 4.7% | 2.0% |
-| Sign-aligned clustered, 40 events per period | 40.0 | −0.09 | 2.04 | **30.3%** | **0.0%** |
+Useful direct links:
 
-**Failure one: non-normal signed CARs, with no clustering needed.**
-D'Agostino's test assumes the sample is normal under the null and derives
-$\operatorname{Var}(g_1) = 6/n$ from that; leptokurtic input inflates the
-true variance of $m_3 / m_2^{3/2}$ above it, and the null $z$ comes out
-over-dispersed by exactly the factor the size implies. The two panel rows
-break the test at 19.0% and 23.3% while averaging 1.55 events per event
-period — near enough no clustering at all — and the deflation moves them
-barely, to 17.7% and 22.7%. On this null the within-period correlation of
-the cubed-deviation score is near zero by construction: signing by
-$\operatorname{sign}(\text{factor})$ enters a shared period shock with an
-asset-random sign, so a common shock moves the cubed deviations
-symmetrically and leaves no between-period variance for the ICC to find.
-The sign-randomised clustered row is the control — maximal clustering,
-near-zero excess kurtosis, correctly sized at 4.7%, and over-deflated to
-2.0% for its trouble.
-
-**Failure two: same-period shocks with sign-aligned events.** Remove the
-sign randomisation and the shared shock no longer cancels. The sign-aligned
-row rejects 30.3% at a nominal 5% with excess kurtosis of −0.09 — a pure
-dependence failure, with none of the non-normality that drives the panel
-rows. Here the deflator does grip (estimated ICC 0.30, mean Kish scale
-0.286), but it does not restore size: it drives the rejection rate to
-**0.0%**, trading a 6x over-rejection for a test with no power at all.
-
-The two failures pull in opposite directions — a deflator strong enough to
-touch the sign-aligned row annihilates it, and one weak enough to leave the
-sign-randomised control alone does nothing for the panel rows, which are
-not a dependence problem in the first place. factrix therefore has no
-calibrated pooled test for the skewness of sampled event returns, and does
-not manufacture one by tuning a deflator against whichever null it happens
-to be measured on. Read `value` as the descriptive shape of the event
-return distribution, and test the direction of the payoff with
-`event_hit_rate`, `event_ic`, `caar` or `bmp_z` — all of which stay sized
-on the mechanism that breaks hardest here. On the sign-aligned null, same
-300 replications: `bmp_z` 7.0% (71.3% with `kolari_pynnonen_adjust=False`,
-which is the deflator doing exactly the job it was built for, on a
-statistic whose failure *is* a shared mean shift), `event_hit_rate` 7.0%,
-`corrado_rank` 6.0%. `tests/stats/test_event_skewness_size.py` re-runs the
-252-period and sign-aligned cells at a cut replication count.
-
-### Which HAC family a test is in
-[](){ #hac-families }
-
-After the HAR calibration work, the same overlapping $h$-period input can
-reach two different bandwidth rules and three different reference
-distributions depending on which test consumes it. This table is the map;
-sizes are at a nominal 5% on a true null.
-
-| Path | Bandwidth | Reference distribution | Measured size |
-|---|---|---|---|
-| `ic` / `quantile_spread` / `quantile_spread_vw` / `k_spread` (`NEWEY_WEST`), `fm_beta` stage 2 — scalar series mean | `_resolve_har_lags`: $\min(\max(1.3\sqrt T, 3(h{-}1)), \lceil T/3\rceil)$, SE scaled by $T/(T{-}L{-}1)$ | $t_\nu$, $\nu = \min(1.5T/L - 1,\ T/h - 1)$ | 3.9–7.3% over $T \in \{60,120,240,500\} \times h \in \{1,5,21\}$; 5.4–8.1% on AR(0.6) input at $h=1$; 0.2–3.5% (conservative) when `forward_periods` is passed on a series that is not actually overlapping |
-| `ic` / `caar` / `quantile_spread` under `NON_OVERLAPPING` — strided mean | none (stride $h$, no kernel) | $t_{n_{\text{strided}}-1}$ | 4.5–5.4% in every overlapping cell measured; 32% on AR(0.6) input at $h=1$, which striding cannot touch |
-| `predictive_beta` — single-restriction slope, $h = 1$ | none: Amihud-Hurvich's homoskedastic $s^2(X'X)^{-1}$ | $t_{m-3}$ | 4.3–5.5% at $\rho = 0$; 6.2–8.3% in the strongest Stambaugh cells |
-| `predictive_beta` — single-restriction slope, $h > 1$ | `_resolve_har_lags` | $t_\nu$ via `_har_dof` | **7.5–14.5%** — known-oversized, see below |
-| `spanning_alpha`, `common_quantile_spread`, `common_asymmetry`, `_ols.py` — single-restriction regression contrast | `_resolve_scalar_wald_hac`: the scalar HAR recipe (bandwidth, $T/(T{-}L{-}1)$ scale, effective $\nu$) | $t_\nu$ / $F_{1,\,\nu}$ | 3.3–8.0% for the two `common_*` metrics on the non-persistent common-factor null across $T \in \{60,120,240\} \times h \in \{1,5,21\}$; 5.7–11.7% for `spanning_alpha` on an overlapping-sum spread null; **7.3–16.3%** on a persistent ($\phi = 0.9$) common factor, flagged — see below |
-| `pooled_beta` — pooled OLS slope under a Driscoll-Kraay (1998) sandwich | `_resolve_scalar_wald_hac` on the $T$ cross-sectionally summed score vectors: overlap-aware HAR bandwidth and $T/(T-L-1)$ covariance scale | $t_\nu$, $\nu = \min(1.5T/L - 1,\ T/h - 1)$ | **1.7–9.1%** across its own persistent-regressor, cross-sectionally correlated, overlapping-return panel grid, versus **4.9–23.2%** under the former auto-bandwidth / $t_{T-1}$ path; the low end is conservative, see below |
-| The slice Wald tests (`slice_joint_test`, `slice_pairwise_test`) — cluster-mean Wald | `_resolve_nw_lags`: $\max(\text{auto\_bartlett}(T), h-1)$ | $F_{r,\,T-1}$ | **8–9%** for the $K = 5$ joint test on 50–90-period slices. The pairwise contrasts are calibrated at $K \le 3$ (5.8% bootstrap / 5.4% Holm at $K = 3$, $T = 60$) but not at $K = 5$, where the bootstrap path runs 7.4–8.5% against Holm's 5.7–6.7% |
-
-Producing modules: `tests/stats/test_hac_overlap_size.py` for the scalar
-series-mean rows, `tests/test_stambaugh_bias.py` for the `predictive_beta`
-rows, `tests/stats/test_driscoll_kraay_size.py` for the reduced-replication
-DK regression check, and `tests/test_slice_period_joint_test.py` for the
-slice-test band in the last row.
-
-The Driscoll-Kraay row was measured on its **own** estimator rather than
-assuming that the scalar series-mean results transfer. The null panel has
-20 assets (plus a 50-asset check), a factor AR coefficient in `{0, 0.8}`,
-common and idiosyncratic factor and return innovations, and overlapping
-$h$-period return shocks; 1,000 replications per cell use seed
-`20260831 + rep`. The DK sandwich remains the standard cross-sectional
-score-sum estimator. Only its scalar slope test's bandwidth, finite-sample
-scale, and reference degrees of freedom change:
-
-| $T$ | $h$ | $\phi_x$ | return / factor common share | former | calibrated |
-|---:|---:|---:|---:|---:|---:|
-| 60 | 1 | 0.0 | 0.0 / 0.0 | 6.5% | 3.7% |
-| 60 | 5 | 0.8 | 0.5 / 0.3 | 15.7% | 6.9% |
-| 120 | 5 | 0.8 | 0.5 / 0.3 | 13.5% | 7.6% |
-| 120 | 21 | 0.0 | 0.5 / 0.3 | 5.2% | 1.7% |
-| 120 | 21 | 0.8 | 0.5 / 0.3 | 23.2% | 4.7% |
-| 240 | 21 | 0.8 | 0.5 / 0.3 | 20.3% | 4.9% |
-| 120 | 5 | 0.8 | 0.8 / 0.8 | 13.8% | 9.1% |
-
-The non-persistent $h=21$ cell shows the cost of treating the declared
-overlap horizon as binding when the score sequence carries less dependence:
-the correction can be conservative. The last cell is the deliberately severe
-dependence check. Together they are why the documentation reports a range
-rather than claiming exact 5% size. Large bandwidths still emit
-`hac_bandwidth_ill_conditioned`; fewer than 30 periods still emit
-`unreliable_se_short_periods`.
-
-Two of these rows are **known-oversized regimes rather than calibrated
-ones**, and are disclosed rather than corrected:
-
-- The slice Wald tests keep the narrow bandwidth deliberately. A wide
-  bandwidth on a $K \times K$ HAC matrix read against $\chi^2$ /
-  $F$ critical values is exactly the case fixed-$b$ theory says needs
-  Kiefer-Vogelsang / LLSW $F$-type critical values — moving them to the HAR
-  rule measured *worse* (the $K = 5$ slice test goes from 8–9% to 21% at 50
-  periods per slice; re-checked on a second null at 300 replications, seed
-  `20260830 + rep`, where the wide floor takes it from 22.3% to 47.0% at 50
-  periods per slice and $h = 5$). The narrow rule is the lesser evil until
-  fixed-$b$ Wald critical values are implemented. The *single*-restriction
-  contrasts are a different statistic and moved the other way — see
-  "Single-restriction Wald contrasts" below.
-- `predictive_beta` at $h > 1$ is the single-restriction case, so it does
-  use the HAR rule; that took it from 10–19% to 7.5–14.5%, not to 5%. The
-  excess is present at $\rho = 0$ for every $\phi$ and plain OLS-NW carries
-  it too, so it is the overlapping-regression HAC problem rather than
-  anything about the Stambaugh correction. Re-measured on the
-  independent-regressor null used for the split above (iid $h$-period
-  overlapping returns, an AR($\phi$) regressor drawn independently of them;
-  300 replications, seed `20260830 + rep`): 9.7 / 6.3 / 5.3% at
-  $\phi = 0$ and 15.0 / 15.7 / 12.0% at $\phi = 0.9$ for $h = 5$ and
-  $T \in \{60, 120, 240\}$ — the same band, and unchanged by the split,
-  because this path already resolved its headline bandwidth through
-  `_resolve_har_lags`. Its uncorrected-OLS reference slope, which does read
-  `_resolve_nw_lags`, measures 4.0–16.0% at $\phi = 0$ and 7.7–36.7% at
-  $\phi = 0.9$ and gets *worse* under a wide floor with no matching
-  reference (9.0 → 17.3% at $T = 60$, $h = 5$); it stays on the narrow rule,
-  reported as the pre-correction reference it is.
-
-The residual anti-conservatism on **persistent** input is a property of the
-Bartlett kernel rather than of any one metric, so every row above inherits
-it. Measured on the `spanning_alpha` path (true null, one base factor, 4000
-draws):
-
-| residuals | $n=60$ | $n=120$ | $n=240$ |
-|---|---|---|---|
-| iid | 0.071 | 0.065 | 0.054 |
-| AR(0.6) | 0.185 | 0.135 | 0.115 |
-
-The AR column converges slowly enough to matter at realistic sample
-lengths. A finite-sample fix (fixed-$b$ critical values for the Wald paths,
-or Andrews-Monahan prewhitening) would change every HAC $p$-value in the
-library and is a project rather than a patch. Read HAC $p$-values near the
-threshold as optimistic when the input is persistent — the `persistence`
-diagnostic in section 4 flags exactly that case.
-
-### Single-restriction Wald contrasts: the restriction-count split
+- [HAC family calibration](inference-calibration.md#hac-family-calibration)
 
 [](){ #single-restriction-wald }
 
-`common_asymmetry`, `common_quantile_spread` and `spanning_alpha` all test
-**one** linear restriction on an ordinary least squares (OLS) fit —
-$\beta_{\text{long}} + \beta_{\text{short}} = 0$, $\beta_{\text{top}} =
-\beta_{\text{bottom}}$, $\alpha = 0$. They used to share the narrow
-`_resolve_nw_lags` rule with the $K$-restriction slice tests on the grounds
-that both are *multivariate fits*. The grouping was wrong: what degrades
-under a wide kernel is the $K \times K$ matrix inversion, and a rank-one
-contrast has none. Measured on the common-factor null below, the narrow rule
-left both `common_*` metrics 10–34% oversized at $h > 1$ and **not**
-shrinking with $T$.
+- [Single-restriction Wald contrasts](inference-calibration.md#single-restriction-wald)
 
-The null: one AR($\phi$) factor broadcast to 50 assets from a random stream
-independent of the prices, `ic_target=0`, so every rejection is a false one.
-300 replications per cell, seed `20260830 + rep`; Monte-Carlo standard error
-about 1.3pp. Rejection rate at a nominal 5%, narrow rule → shipped rule:
+[](){ #joint-period-test-on-short-slices-known-over-rejection }
 
-| metric | $\phi$ | $T=60$, $h=1$ | $h=5$ | $h=21$ | $T=120$, $h=1$ | $h=5$ | $h=21$ | $T=240$, $h=1$ | $h=5$ | $h=21$ |
-|---|---|---|---|---|---|---|---|---|---|---|
-| `common_asymmetry` | 0.0 | 8.0 → 5.7 | 15.3 → 8.0 | 34.0 → 5.7 | 3.3 → 3.3 | 10.7 → 3.3 | 23.7 → 7.7 | 4.0 → 5.0 | 10.0 → 5.7 | 16.0 → 7.7 |
-| `common_asymmetry` | 0.9 | 10.3 → 9.0 | 19.3 → 13.0 | 41.0 → 7.3 | 5.0 → 4.3 | 12.7 → 6.7 | 28.3 → 8.7 | 4.0 → 4.3 | 9.7 → 6.0 | 17.3 → 8.3 |
-| `common_quantile_spread` | 0.0 | 7.7 → 5.0 | 9.7 → 5.7 | 16.3 → 0.0 | 7.7 → 6.7 | 7.7 → 5.0 | 10.3 → 2.7 | 7.3 → 3.7 | 6.3 → 4.0 | 7.7 → 2.0 |
-| `common_quantile_spread` | 0.9 | 13.0 → 14.3 | 21.0 → 16.3 | 42.3 → 9.3 | 9.7 → 7.3 | 18.7 → 14.7 | 30.7 → 11.0 | 7.0 → 5.7 | 12.0 → 7.7 | 13.0 → 8.0 |
+- [Joint period tests on short slices](inference-calibration.md#joint-period-test-on-short-slices-known-over-rejection)
 
-Every $\phi = 0$ cell now sits at or below 8.0%, and the $h = 21$ column —
-the worst regime under the old rule — is the one the change helps most.
+[](){ #persistence-beyond-the-overlap-horizon-no-hac-or-bootstrap-path-is-calibrated }
 
-`spanning_alpha`, on a null of two independent AR($\phi$) series summed over
-$h$ periods (same replication count and seed stream), moves the same way:
-9.0 → 6.0, 18.7 → 9.3 and 46.0 → 11.7% at $T = 60$ and $h \in \{1, 5, 21\}$
-for $\phi = 0$, and 50.0 → 29.3, 50.3 → 30.3, 60.0 → 21.7% at $\phi = 0.9$.
-That null is deliberately harsh — a spread series that *is* an overlapping
-sum of a near-unit-root process — and the $\phi = 0.9$ column is the
-persistent regime no path here is calibrated for, not a claim about the
-metric on ordinary input. `spanning_alpha` runs the same two screens as the
-two `common_*` metrics, on the **regressand**: the candidate spread is the
-series whose long-run variance the alpha standard error estimates. Post-fix
-size and the share of draws carrying a code, on the same null and grid:
+- [Persistence beyond the overlap horizon](inference-calibration.md#persistence-beyond-the-overlap-horizon)
 
-| $\phi$ | | $T=60$, $h=1$ | $h=5$ | $h=21$ | $T=120$, $h=1$ | $h=5$ | $h=21$ | $T=240$, $h=1$ | $h=5$ | $h=21$ |
-|---|---|---|---|---|---|---|---|---|---|---|
-| 0.0 | size | 6.0 | 9.3 | 11.7 | 5.7 | 7.7 | 11.7 | 5.7 | 8.0 | 9.7 |
-| 0.0 | flagged | 1.3 | 8.3 | 100 | 0.0 | 4.0 | 100 | 0.0 | 0.7 | 6.0 |
-| 0.9 | size | 29.3 | 30.3 | 21.7 | 19.0 | 21.3 | 15.3 | 18.0 | 17.0 | 12.7 |
-| 0.9 | flagged | 100 | 77.7 | 100 | 100 | 92.0 | 100 | 100 | 100 | 27.3 |
-
-Every $\phi = 0.9$ cell is flagged on at least 27% of draws and most on
-100%, against 0–8.3% of the calibrated $\phi = 0$ cells at $h \le 5$. One
-cell is genuinely uncovered and disclosed rather than gated: $\phi = 0$,
-$T = 240$, $h = 21$ measures 9.7% with 11 independent observations — above
-the shortage floor, and with no persistence left after the stride. That is
-the residual overlapping-regression HAC excess `predictive_beta` carries at
-$h > 1$ for the same reason. `predictive_beta` now emits
-`overlapping_predictive_inference` for that known regime; the two `common_*`
-metrics do not, because their non-persistent grid is generally calibrated
-and this is one isolated residual cell rather than their defining regime.
-
-**What moving only the overlap floor would have done.** The narrow rule's
-$h - 1$ floor is the [Hansen-Hodrick (1980)][hansen-hodrick-1980]
-consistency floor, and widening it alone to $3(h-1)$ — the change the
-scalar series-mean path made — measures *worse* here, not better:
-`common_quantile_spread` at $\phi = 0$ goes 9.7 → 16.0% ($T=60$, $h=5$) and
-16.3 → 35.7% ($T=60$, $h=21$); `common_asymmetry` at $\phi = 0.9$ goes
-41.0 → 55.7% ($T=60$, $h=21$). A wide Bartlett kernel read against $T-k$
-degrees of freedom is exactly the fixed-$b$ case: the bandwidth and the
-reference distribution have to move together, which is why
-`_resolve_scalar_wald_hac` returns the scale and the effective $\nu$
-alongside the lag count rather than a lag count alone.
-
-**The cost.** The fixed-$b$ reference is a genuinely higher hurdle, at
-$h = 1$ as much as at $h > 1$: on a $T = 800$ split-slope alternative that
-the narrow rule rejected at $p \approx 0.045$, the shipped rule reports
-$p \approx 0.080$. That is the LLSW size-power trade the scalar series-mean
-path already pays, now paid consistently by every scalar statistic in the
-library.
-
-**What it does not fix, and what is flagged instead.** Two regimes survive:
-
-- *A factor persistent beyond the overlap horizon* ($\phi = 0.9$ column
-  above, 13.0–16.3% at $T = 60$). Both metrics now run the same lag-1 screen
-  on the strided per-period factor that the series-mean members run on their
-  tested series, and emit `serial_correlation_detected`. On the null above
-  it fires on 100% of the $\phi = 0.9$, $h = 1$ draws and 51–93% of the
-  $h = 5$ draws, against 0–8% of the $\phi = 0$ draws.
-- *Too few independent periods.* At $h = 21$ the strided sample falls below
-  `MIN_SERIES_PERIODS_HARD` (10) for $T \le 240$, so the persistence screen
-  withholds itself; the metrics emit `unreliable_se_short_periods` on the
-  effective count $T / h$ instead, exactly as `predictive_beta` does. The
-  two codes partition the regime rather than overlap.
-
-All three metrics run both screens — the two `common_*` on the per-period
-factor, `spanning_alpha` on the candidate spread it regresses.
-
-Neither number was tuned to reach a target. `tests/stats/test_scalar_wald_overlap_size.py`
-re-runs the contrast on a cheaper null at a cut replication count.
-
-### Shanken EIV correction on `fm_beta`: measured size
-
-Rejection frequency at a nominal 5% on a true null —
-`make_cs_panel(ic_target=0.0)`, 50 assets, 300 replications per cell,
-seed 20260830 + replication. $\sigma^2_f$ is the variance of the panel's
-own realised long-short forward return (top-minus-bottom quintile,
-equal-weighted, computed from the same panel), which is what a caller
-holding the traded spread would supply.
-
-| $T$ | $h$ | uncorrected | Shanken |
-|---|---|---|---|
-| 120 | 1 | 7.3% | 7.3% |
-| 120 | 5 | 3.3% | 3.3% |
-| 240 | 1 | 4.3% | 4.0% |
-| 240 | 5 | 6.0% | 6.0% |
-
-Under the null $\overline{\beta} \to 0$, so $c \to 1$ and the correction is
-close to inert: the row simply inherits the scalar series-mean size of the
-HAR path in the table above. That is the intended shape — the correction
-costs no size on a true null and only shrinks $t$ where a premium is
-actually estimated. Producing module:
-`tests/stats/test_fm_beta_shanken_size.py`, which re-measures the same
-grid at a reduced replication count.
-
-### Joint period test on short slices: known over-rejection
-
-`slice_period_joint_test` with `K ≥ 3` slices shorter than ~150 periods
-over-rejects on a true null — measured 8–9% at a nominal 5% for `K = 5`
-with 50–90-period slices, converging to ~5.5% by `T = 150`; `K = 2` is
-calibrated throughout. The cause is the per-slice Bartlett HAC variance
-estimate, whose effective degrees of freedom at `T = 50` are ≈ 21 rather
-than `T − 1`: with the *true* variances the same Wald statistic rejects
-3.8%, so neither the aggregation nor the `F` reference is at fault. The
-bootstrap path inherits the same noise (12% at `K = 5`, `T = 50`).
-Andrews-Monahan prewhitening, the Newey-West (1994) plug-in bandwidth, a
-Hotelling-style `F` on the HAC effective df, and a Satterthwaite ν on
-that df were each measured; none calibrates the iid short-slice case
-(prewhitening is the right tool for *autocorrelated* input — see the HAC
-size sweep tracker). The function warns in this regime and the
-characterisation test in `tests/test_slice_period_joint_test.py` pins the
-measured band; the pairwise contrasts on the same
-slices are the better-calibrated read, but how much better depends on $K$.
-At $K = 3$, $T = 60$ they sit at 5.8% (bootstrap) and 5.4% (Holm). At
-$K = 5$ the bootstrap path is itself oversized — 8.1 / 8.5 / 7.4% at
-$T = 50 / 60 / 150$ — while the analytic Holm path holds at
-6.7 / 5.8 / 5.7% (1000 replications). The Romano-Wolf primitive is not the
-cause: on the same null it rejects 4.45%. The excess enters through the
-*per-pair* bootstrap p feeding it, which is already 6.0–6.2% at $K = 2$.
-**At $K = 5$, read the analytic pairwise path**; the two agree closely
-enough at $K \le 3$ that either serves.
-
-### Persistence *beyond the overlap horizon*: no HAC or bootstrap path is calibrated
-
-Every mean test on a per-period series (`ic` under any inference member,
-the spread metrics, `fm_beta`) is measured on a true null against the
-series' own persistence (`build_autocorrelated_ic_panel`, nominal 5%):
-
-| lag-1 φ | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` | plain *t* |
-|---|---|---|---|
-| 0 | 7–9% | 7–9% | 7–9% |
-| 0.6 | 13–17% | 12–19% | 32–34% |
-| 0.85 | 32–34% | 20–32% | 55–61% |
-
-Above φ ≈ 0.3 the Bartlett kernel's small-sample understatement of the
-long-run variance is no longer a nuisance but the dominant term, and the
-block bootstrap inherits it. This is the well-documented short-sample
-behaviour of Newey-West, not a factrix defect, and the field's response
-is not a different kernel: report the *t* against a raised hurdle
-([Harvey, Liu & Zhu (2016)][harvey-liu-zhu-2016]: *t* > 3) or lengthen
-the sample.
-
-#### What the screen reads, and why it is the strided series
-
-factrix raises `WarningCode.SERIAL_CORRELATION_DETECTED` above
-`PERSISTENT_SERIES_AUTOCORR` (0.3) so the regime above is never silent.
-The number it screens is lag-1 autocorrelation **on the series strided at
-`overlap_periods`** — first observation of each block, the same stride
-`NON_OVERLAPPING` runs its *t*-test on — not on the full overlapping
-series.
-
-The distinction is the whole content of the screen. Overlapping *h*-period
-forward returns carry an MA(*h*−1) structure by construction: lag-1
-autocorrelation near 1 − 1/*h*, lag-*h* near zero. That is precisely what
-the HAC bandwidth floor `3(h − 1)` and the bootstrap block-length floor
-`overlap_periods` exist to absorb, and the size tables below show they do.
-A lag-1 read on the unstrided series therefore fires on the everyday
-overlapping case — where the paths *are* calibrated — and says nothing
-about the regime where they are not. Measured on the persistent-factor
-null below (300 replications, φ = 0.9), an unstrided lag-1 screen fires on
-99–100% of draws at *h* ∈ {5, 21} while the measured size stays at
-3.7–9.0%; the strided screen fires on 0–9% of the same draws.
-
-Whether a factor is persistent is not itself the question. A per-asset
-AR(φ) factor makes the *IC series* persistent only through the
-forward-return overlap: measured lag-1 rises to 0.61–0.81 at *h* ∈ {5, 21}
-while lag-*h* stays at −0.02 to −0.11, the MA(*h*−1) signature. What the
-screen is for is a series that stays autocorrelated once the overlap is
-strided away — a drifting signal level, a slow-moving regime — and there
-the stride cannot help and neither can the kernel.
-
-#### The `ic` pipeline: measured size and screen firing rate
-
-True-null rejection rates at a nominal 5% for `ic` under each inference
-member, on two nulls. Both are
-`make_cs_panel(n_assets=50, ic_target=0.0, signal_horizon=h)` with
-`n_dates = T + h`, `compute_forward_return(forward_periods=h)` and
-`overlap_periods=h`; they differ only in `factor_persistence` — φ = 0 is
-the iid-per-period factor, φ = 0.9 a per-asset AR(0.9) factor independent
-of returns, which is what makes the overlap mechanism bite at all. 300
-replications per cell, seed `20260830 + rep`, `n_resamples=499`.
-Monte-Carlo standard error is ~1.3pp per cell. `T` counts periods on the
-evaluation grid before the stride. "screen" is the fraction of draws
-raising `serial_correlation_detected`; it is a property of the series, so
-it is identical across the three members.
-
-Null: **iid factor** (`factor_persistence=0.0`)
-
-| T | h | `NON_OVERLAPPING` | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` | screen |
-|---|---|---|---|---|---|
-| 60 | 1 | 0.047 | 0.057 | 0.057 | 0.003 |
-| 60 | 5 | 0.043 | 0.060 | 0.080 | 0.047 |
-| 60 | 21 | — | 0.003 | 0.053 | 0.000 |
-| 120 | 1 | 0.050 | 0.040 | 0.053 | 0.000 |
-| 120 | 5 | 0.060 | 0.030 | 0.043 | 0.053 |
-| 120 | 21 | — | 0.023 | 0.100 | 0.000 |
-| 240 | 1 | 0.053 | 0.053 | 0.060 | 0.000 |
-| 240 | 5 | 0.053 | 0.063 | 0.067 | 0.010 |
-| 240 | 21 | 0.033 | 0.027 | 0.043 | 0.060 |
-
-Null: **persistent factor** (`factor_persistence=0.9`)
-
-| T | h | `NON_OVERLAPPING` | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` | screen |
-|---|---|---|---|---|---|
-| 60 | 1 | 0.020 | 0.037 | 0.030 | 0.000 |
-| 60 | 5 | 0.040 | 0.060 | 0.083 | 0.067 |
-| 60 | 21 | — | 0.010 | 0.040 | 0.000 |
-| 120 | 1 | 0.063 | 0.073 | 0.063 | 0.000 |
-| 120 | 5 | 0.073 | 0.063 | 0.067 | 0.030 |
-| 120 | 21 | — | 0.067 | 0.077 | 0.000 |
-| 240 | 1 | 0.060 | 0.053 | 0.060 | 0.000 |
-| 240 | 5 | 0.080 | 0.087 | 0.090 | 0.020 |
-| 240 | 21 | 0.057 | 0.060 | 0.070 | 0.080 |
-
-`NON_OVERLAPPING` at `T ∈ {60, 120}, h = 21` has no rejection rate: `ic`
-refuses the panel at its stride-scaled periods floor (`metric_unavailable`)
-rather than testing ~3 effective periods.
-
-Both nulls read the same way, which is the point: the persistent factor
-moves no member outside the band the iid factor already sits in
-(`NEWEY_WEST` 0.3–8.7%, `STATIONARY_BOOTSTRAP` 3.0–10.0%), and the screen
-stays quiet on both. The `NEWEY_WEST` floor cells (0.3% at `T = 60,
-h = 21`, 2.3% at `T = 120, h = 21`) are the documented long-horizon
-conservatism of the HAR effective df `T/h − 1`, not a persistence effect —
-they are as low on the iid null as on the persistent one.
-
-The screen is **withheld** below `MIN_SERIES_PERIODS_HARD` (10) strided
-observations — the library's floor for estimating a series statistic on
-the periods axis, the same one `NON_OVERLAPPING`'s post-stride sample is
-gated on. A lag-1 autocorrelation read off three to nine observations is
-noise: the estimator's standard error there is 0.3–0.6 and a sample value
-above `PERSISTENT_SERIES_AUTOCORR` is common under independence, so the
-code would be reporting the shortage of periods rather than any
-persistence, which is `UNRELIABLE_SE_SHORT_PERIODS`'s job. That is why
-the `h = 21` screen column reads 0.000 at `T ∈ {60, 120}` on both nulls:
-`T/h` is 3–6 observations there and nothing is estimated.
-
-`T = 240, h = 21` clears the floor at 12 strided observations and still
-fires on 6.0% (iid factor) / 8.0% (persistent factor) of draws. That is
-the residual small-sample noise of a lag-1 estimate at *n* = 12, where the
-estimator's own standard error is ~0.29 against a 0.3 threshold — equal on
-both nulls, so it is not persistence. Read a
-`serial_correlation_detected` on a strided series near the floor as weak
-evidence and check `n_obs`.
-
-#### A series that really is persistent beyond the horizon
-
-Constructed directly rather than through the overlap: a per-period
-factor→return signal level following a zero-mean AR(φ) across the grid, 50
-assets, `overlap_periods=1`, so the IC series is AR(φ) with no overlap
-component at all. 300 replications, seed `20260830 + rep`, nominal 5%.
-
-| φ | T | plain *t* (`NON_OVERLAPPING`) | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` | screen |
-|---|---|---|---|---|---|
-| 0.6 | 60 | 0.340 | 0.103 | 0.153 | 0.947 |
-| 0.6 | 120 | 0.267 | 0.067 | 0.067 | 1.000 |
-| 0.6 | 240 | 0.347 | 0.073 | 0.073 | 1.000 |
-| 0.9 | 60 | 0.653 | 0.273 | 0.213 | 0.997 |
-| 0.9 | 120 | 0.623 | 0.193 | 0.143 | 1.000 |
-| 0.9 | 240 | 0.630 | 0.143 | 0.097 | 1.000 |
-
-This is the regime the code names, and the screen fires on 94.7–100% of
-draws in it. Note that lengthening the sample does not fix the plain *t*
-here — 34.7% at `T = 240` — because the persistence, not the sample size,
-is what the OLS SE is missing.
-
-Measured but deliberately **not** adopted: the Newey-West (1994) plug-in
-bandwidth (worse than the fixed rule on iid input), longer Bartlett
-bandwidths (no change on real overlapping series), and the Hansen-Hodrick
-flat kernel (matches NW on real overlapping series; no PSD guarantee).
-**Default is plain Newey-West; Andrews-Monahan prewhitening is measured
-and available, not on.** Neither estimator is right everywhere. Plain
-Newey-West at the automatic bandwidth understates the long-run variance
-of a persistent series at the sample sizes factor research works with
-(AR(0.6): 50% of the truth at `n = 50`, 61% at `n = 150`), so a drifting
-IC or spread series produces a *t* that looks one to three times as
-significant as the evidence warrants. [Andrews-Monahan
-(1992)][andrews-monahan-1992] AR(1) prewhitening — strip the drift
-component before the kernel sees it, then recolour — removes most of that
-but not all of it, and none of it near a unit root. It is implemented
-behind a private flag on `_newey_west_se` (the univariate mean-SE kernel
-behind `NEWEY_WEST` and `fm_beta`) so both estimators are measured and
-pinned side by side.
-
-The default stays plain Newey-West because **matching published
-factor-research numbers is a core use of this library**, and the
-convention in that literature is plain Newey-West with a lag rule; the
-tool ecosystem is split (R's `sandwich::NeweyWest` defaults prewhitening
-on, statsmodels and Stata's `newey` do not implement it). This is a
-convention choice, not a correctness claim — and it follows a line every
-deliberate deviation in factrix has respected so far: BHY, the sample
-floors and the persistence screen are all *additive* (they warn or
-refuse); none silently moves a number a user is comparing to a paper.
-Prewhitening by default would have been the first to cross it, on
-exactly the input users most often compare. What the default gets wrong
-on persistent input is therefore surfaced by `SERIAL_CORRELATION_DETECTED`
-rather than corrected. Against the plain Bartlett estimate (nominal 5%):
-
-| input | n | plain Bartlett | prewhitened |
-|---|---|---|---|
-| iid | 50 / 240 | 8.3% / 5.9% | 9.3% / 6.0% |
-| AR(0.6), pure | 60 / 240 | 15.6% / 11.5% | 8.4% / 5.0% |
-| AR(0.85), pure | 240 | 27.5–28.9% | 8.9–10.6% |
-| IC fixture, φ = 0 (its own baseline) | 240 | 9.2% | 9.2% |
-| IC fixture, φ = 0.6 | 240 | 14.4% | 8.0% |
-| IC fixture, φ = 0.85 | 240 | 32.8% | 15.6% |
-| real overlapping IC, h=5 | 240 / 480 | 5.2% / 8.8% | 5.2% / 8.4% |
-
-The prewhitened-versus-plain bands above are pinned as characterisation
-bands in `tests/stats/test_prewhitening.py`.
-
-Two independent implementations agree on every row above. Read the IC
-fixture against its *own* φ = 0 baseline of 9.2% (a property of the
-fixture — 40-name cross-sections and a non-normal IC — not of
-persistence): prewhitening removes the persistence-driven excess entirely
-at φ = 0.6 (8.0% is below baseline) and ~73% of it at φ = 0.85
-(0.236 → 0.064 over baseline). On pure AR(1) input it returns Newey-West
-to its iid baseline outright. On iid and real overlapping input the two
-estimates are indistinguishable, so the change is confined to the regime
-it targets.
-
-**What prewhitening does not do.** Near a unit root the AR(1) fit is
-biased down (φ̂ ≈ 0.96 at true φ = 0.99), so the ±0.97 clip never bites
-and the recolouring stays bounded (SE ratio 1.7–3.0×) — there is no
-over-correction risk, but there is also no rescue: pure AR(1), n = 240,
-prewhitened rejects 17% at φ = 0.95, 50% at 0.99, and 99.8% at a true
-unit root, the same as plain Bartlett. No kernel change — this one or
-any future one — relaxes `SERIAL_CORRELATION_DETECTED`: a user who knows
-the kernel was improved will assume a persistent series is handled.
-Should the default ever change, the multivariate `_nw_hac_vector_mean`
-and the regression kernels `_ols_nw_slope_t` / `_ols_nw_multivariate`
-would need their own measurement first — a vector series needs a VAR(1)
-fit and regression scores a different derivation.
-
-### Stationary bootstrap on the spread series: measured size
-
-`ic`'s size table is a table of the *IC* series. A long-short spread
-series is a different object — a cross-sectional bucket difference, not a
-rank correlation — so admitting `STATIONARY_BOOTSTRAP` to
-`quantile_spread` / `quantile_spread_vw` / `k_spread` needed its own
-measurement rather than an inherited one.
-
-True-null rejection rates at a nominal 5% on `quantile_spread`, measured
-on `make_cs_panel(n_assets=50, ic_target=0.0)` with
-`compute_forward_return(forward_periods=h)` and `overlap_periods=h`. `T`
-counts periods on the evaluation grid before the stride. Each table
-states its null; both use base seed 20260830 and `n_resamples=499`.
-
-Null: **iid factor** (`factor_persistence=0.0`, the default) — 500
-replications per cell, Monte-Carlo standard error ~1.0pp.
-
-| T | h | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` |
-|---|---|---|---|
-| 60 | 1 | 0.074 | 0.082 |
-| 60 | 5 | 0.036 | 0.066 |
-| 60 | 21 | — | — |
-| 120 | 1 | 0.056 | 0.052 |
-| 120 | 5 | 0.054 | 0.072 |
-| 120 | 21 | 0.024 | 0.090 |
-| 240 | 1 | 0.046 | 0.048 |
-| 240 | 5 | 0.076 | 0.080 |
-| 240 | 21 | 0.036 | 0.068 |
-
-Null: **persistent factor** (`factor_persistence=0.9`, per-asset AR(0.9)
-independent of returns) — 300 replications per cell, seed
-`20260830 + rep`, Monte-Carlo standard error ~1.3pp. This is the null
-under which the forward-return overlap actually shows up in the spread
-series: with an iid factor, consecutive periods' spreads share return
-windows but draw independent weights, so the overlap barely propagates.
-"screen" is the fraction of draws raising `serial_correlation_detected`.
-
-| T | h | `NEWEY_WEST` | `STATIONARY_BOOTSTRAP` | screen |
-|---|---|---|---|---|
-| 60 | 1 | 0.027 | 0.037 | 0.003 |
-| 60 | 5 | 0.083 | 0.083 | 0.063 |
-| 60 | 21 | — | — | — |
-| 120 | 1 | 0.060 | 0.057 | 0.003 |
-| 120 | 5 | 0.067 | 0.090 | 0.023 |
-| 120 | 21 | 0.077 | 0.100 | 0.000 |
-| 240 | 1 | 0.047 | 0.050 | 0.000 |
-| 240 | 5 | 0.083 | 0.080 | 0.003 |
-| 240 | 21 | 0.043 | 0.067 | 0.047 |
-
-`T = 60, h = 21` is not measurable on either null: the metric refuses that
-panel at its stride-scaled periods floor (`metric_unavailable`) rather
-than testing ~2 effective periods, so there is no rejection rate to
-report.
-
-The persistent-factor null moves nothing outside the iid-factor bands
-(`NEWEY_WEST` 2.7–8.3% against 2.4–7.6%, `STATIONARY_BOOTSTRAP`
-3.7–10.0% against 4.8–9.0%; every difference is inside two Monte-Carlo
-standard errors), and the screen stays quiet — the 4.7–7.3% at `h = 21` is
-the small-sample false-positive floor of a 3–11-observation strided
-sample, present on the iid null too.
-
-The bootstrap is calibrated-to-slightly-liberal across every measurable
-cell (4.8–9.0%) and never worse than the short-sample distortion already
-documented for the *t*. `NEWEY_WEST` is tighter at `h = 1` and
-conservative at long horizons (2.4–3.6% at `h = 21`), where the HAR
-effective df `T/h - 1` spends most of the sample. Neither dominates; both
-are reported, and the choice is the routing question the next section
-answers. A reduced-replication re-run of two cells guards the numbers in
-`tests/stats/test_spread_bootstrap_size.py`.
-
-### `monotonicity`: measured size of the Patton-Timmermann MR bootstrap
-
-True-null rejection rates at a nominal 5% for the MR statistic's
-stationary-bootstrap p. Null: `make_cs_panel(n_assets=50, ic_target=0.0,
-factor_persistence=φ)` → `compute_forward_return(forward_periods=h)`,
-`overlap_periods=h`, `n_groups=5`, `n_resamples=499`. `T` counts periods
-on the evaluation grid before the stride. 300 replications per cell, seed
-`20260830 + rep`, Monte-Carlo standard error ~1.3pp.
-
-| T | h | φ = 0 | φ = 0.9 |
-|---|---|---|---|
-| 120 | 1 | 0.037 | 0.033 |
-| 120 | 5 | 0.020 | 0.027 |
-| 240 | 1 | 0.073 | 0.060 |
-| 240 | 5 | 0.050 | 0.033 |
-
-Calibrated-to-conservative throughout (2.0–7.3%), and the persistent
-factor moves nothing outside the iid band — every difference is inside two
-Monte-Carlo standard errors. The conservatism at `h = 5` is the expected
-cost of the block bootstrap's block-length floor at `overlap_periods`
-absorbing the MA(*h*−1) overlap. A reduced-replication re-run guards the
-numbers in `tests/stats/test_monotonicity_size.py`.
-
-### `directional_hit_rate`: measured size of the Pesaran-Timmermann test
-
-True-null rejection rates at a nominal 5% for the PT statistic $S_n$ with
-the Kolari-Pynnönen within-period deflation applied (it fires on every
-cell of this grid — the null panel is a cross-section, so the pooled
-`(date, asset)` trials are not independent). Same null and seed scheme as
-the table above; 300 replications per cell, Monte-Carlo standard error
-~1.3pp.
-
-| T | h | φ = 0 | φ = 0.9 |
-|---|---|---|---|
-| 120 | 1 | 0.043 | 0.053 |
-| 120 | 5 | 0.030 | 0.047 |
-| 240 | 1 | 0.040 | 0.067 |
-| 240 | 5 | 0.060 | 0.077 |
-
-Calibrated across the grid (3.0–7.7%). The persistent-factor column runs
-slightly hotter than the iid one at `T = 240` (6.7% and 7.7% against 4.0%
-and 6.0%), but the gap is within two Monte-Carlo standard errors and the
-worst cell is still inside the 7–9% short-sample band every other
-per-period path in this document sits in. The deflation is what keeps it
-there: the raw pooled $S_n$ treats 50 same-date names as 50 independent
-trials. A reduced-replication re-run guards the numbers in
-`tests/stats/test_directional_hit_rate_size.py`.
-
-### `positive_rate`: measured size of the exact binomial test, and its discreteness
-
-True-null rejection rates at a nominal 5% for the two-sided exact
-binomial test against `H0: p = 0.5`. Two nulls, both at
-`overlap_periods=1` so `n` is the series length directly; 300
-replications per cell, seed `20260830 + rep`, Monte-Carlo standard error
-~1.3pp.
-
-- **iid Gaussian series** — `value ~ N(0, 1)`, the textbook null the exact
-  test is derived against.
-- **IC-series pipeline** — the per-period Spearman IC of
-  `make_cs_panel(n_assets=50, ic_target=0.0)` at `forward_periods=1`, i.e.
-  the series a caller actually feeds it after `compute_ic`.
-
-| n | iid Gaussian series | IC-series pipeline |
-|---|---|---|
-| 60 | 0.027 | 0.023 |
-| 120 | 0.030 | 0.040 |
-| 240 | 0.047 | 0.080 |
-
-Both columns sit at or below nominal, which is the *expected* behaviour
-and not a defect: the binomial distribution is discrete, so at most `n`
-the attainable two-sided level nearest 5% from below is materially under
-it — the exact test spends whatever is left over as conservatism. That is
-the deliberate trade recorded in the function's docstring (the
-normal-approximation `z` attains 5% by *over*-rejecting: `n=20, 15 hits`
-gives `p=0.025` against the exact `0.041`). Read a `positive_rate` p as a
-conservative bound, and do not calibrate a power study against a nominal
-5% at short `n`. The IC-series column's 8.0% at `n = 240` is the one cell
-above nominal and is inside two Monte-Carlo standard errors of the iid
-column. A reduced-replication re-run guards the numbers in
-`tests/stats/test_positive_rate_size.py`.
-
-### Coverage of the size tables
-
-Every `p_value` factrix publishes has a measured size somewhere in this
-section. A test
-(`tests/stats/test_section6_covers_every_p_value_path.py`) enumerates the
-metrics whose `MetricResult` can carry a non-`None` `p_value` and fails if
-any is missing from this section, so a new inference path cannot be added
-without either measuring it or naming it here.
-
-The two entries below were the last gap; both are now measured.
-
-**`common_asymmetry` and `common_quantile_spread`.** A COMMON-scope null
-found both Wald p-values over-rejecting at
-`h > 1` in a way that did *not* shrink with `T`. The cause was the
-bandwidth `_resolve_nw_lags` gave them: an overlap floor of
-`overlap_periods - 1`, against the `3(h - 1)` the scalar series-mean HAR
-path uses, so the MA(*h*−1) structure an overlapping forward return
-carries by construction was absorbed at the minimum admissible bandwidth.
-Both metrics test a *single* linear restriction and have since been moved
-off that rule onto the scalar HAR recipe; the post-fix sizes are tabled in
-[Single-restriction Wald contrasts](#single-restriction-wald) and are not
-repeated here. Read that section for what their `p_value` is worth at
-`overlap_periods > 1`: calibrated on a non-persistent common factor, still
-oversized when the common factor is itself persistent, which is what
-`serial_correlation_detected` flags.
-
-### `common_beta`: measured size of the calendar-time cross-asset $t$
-
-True-null rejection rates at a nominal 5% for `common_beta`'s
-cross-asset $t$ on $\mathbb{E}[\beta]$, on the COMMON-scope null the
-metric's cell describes: one AR($\varphi$) factor series broadcast to
-every asset, drawn from an RNG stream independent of the
-`make_cs_panel(n_assets=50, ic_target=0.0)` prices, so every true
-per-asset $\beta$ is zero while the assets keep the cross-sectional
-return correlation the panel generates. 300 replications per cell, seed
-`20260830 + rep` (factor stream `20260830 + 10000 + rep`), Monte-Carlo
-standard error ~1.3pp. `T` counts periods on the evaluation grid and `h`
-is `forward_periods`, passed through as `overlap_periods`.
-
-| T | h | φ = 0 | φ = 0.9 |
-|---|---|---|---|
-| 60 | 1 | 0.067 | 0.057 |
-| 60 | 5 | 0.073 | 0.033 |
-| 120 | 1 | 0.060 | 0.067 |
-| 120 | 5 | 0.067 | 0.027 |
-| 240 | 1 | 0.053 | 0.047 |
-| 240 | 5 | 0.053 | 0.020 |
-
-Calibrated across the grid (2.0–7.3%), with the worst cells at the short
-end where the Newey-West variance $V_{\mathrm{EW}}$ of the equal-weight
-portfolio slope rests on fewest periods. The calendar-time SE is what
-holds it there: the iid cross-asset $t$ the docstring keeps as
-`metadata["stat_uncorrected"]` is the one this null breaks, because 50
-assets loading on one shared regressor do not supply 50 independent
-betas. The persistent-factor column is the *conservative* direction at
-`h = 5` (3.3 / 2.7 / 2.0% against 7.3 / 6.7 / 5.3%) — a φ = 0.9 regressor
-read through an overlapping forward return leaves more serial dependence
-for the Newey-West kernel to pick up, so the SE widens. A
-reduced-replication re-run guards the numbers in
-`tests/stats/test_common_beta_size.py`. This is the panel-null companion
-to the synthetic-regime measurements in the function's own docstring
-(equicorrelated returns at fixed $T$, varying $N$ and $\rho$); neither
-covers a hand-built beta table, which falls back to the iid $t$ and says
-so in `metadata["calendar_time_se_applied"]`.
-
-### `ic_trend`: measured size of the Mann-Kendall trend test
-
-True-null rejection rates at a nominal 5% for `ic_trend`. The series is
-the per-period Spearman IC of `make_cs_panel(n_assets=50,
-ic_target=0.0)` through `compute_ic`, so the IC has no time trend to
-find; `factor_persistence` supplies the second null. The test runs on the
-non-overlapping subsample at stride `overlap_periods`, so the `h = 5`
-rows test roughly `T / 5` observations. 300 replications per cell, seed
-`20260830 + rep`, Monte-Carlo standard error ~1.3pp.
-
-| T | h | φ = 0 | φ = 0.9 |
-|---|---|---|---|
-| 60 | 1 | 0.040 | 0.030 |
-| 60 | 5 | 0.017 | 0.047 |
-| 120 | 1 | 0.043 | 0.050 |
-| 120 | 5 | 0.033 | 0.053 |
-| 240 | 1 | 0.017 | 0.047 |
-| 240 | 5 | 0.033 | 0.047 |
-
-Calibrated-to-conservative throughout (1.7–5.3%), and unlike the
-per-period mean paths in §1 the persistent factor moves nothing outside
-the iid band: factor persistence carries into the *level* of the
-per-period IC, not into a drift in it, and the Hamed-Rao variance
-correction absorbs the serial dependence the IC series does carry. Two
-things the table does not license. It is measured with the ADF gate at
-its default `adf_threshold=0.10`, on a null that is trend-free but also
-stationary — a unit-root input is the regime the gate exists for
-(`PERSISTENT_REGRESSOR`), and no size here speaks to it. And it is a
-*size* table only: the Theil-Sen slope's robustness is what recommends it
-over OLS, not a power advantage, and nothing above measures power. A
-reduced-replication re-run guards the numbers in
-`tests/stats/test_ic_trend_size.py`.
-
-### Which path to read: a routing guide from the size measurements
-
-The measurements above and in §1 say where each inference path is
-calibrated and where it is not. This table turns them into the choice a
-user faces after a warning fires — *keep the path, switch member, or
-change the sample*. None of these rows changes a default: every deliberate
-deviation in factrix is additive (it warns or refuses), so the routing is
-the reader's, not the library's. Sizes are true-null rejection rates at a
-nominal 5%; sample sizes count periods on the evaluation grid after the
-`overlap_periods` stride.
-
-| Input regime | What you see | What the measurements say | Read / do |
-|---|---|---|---|
-| Overlapping `forward_periods` panel, per-period series not persistent once strided (the everyday case) | No warning | `NEWEY_WEST` 5–9% on real overlapping IC (h = 5, n = 240 / 480: 5.2% / 8.8%); `NON_OVERLAPPING` calibrated. On the persistent-factor null, where the overlap actually propagates into the per-period series, `ic` measures NW 1–8.7% and the bootstrap 3–9% across `T × h`, and the screen fires on 0–9% of draws (tables above). | Keep the default member. |
-| Persistent per-period series (lag-1 φ ≥ 0.3 on the *strided* tested series) | `serial_correlation_detected` | No path is calibrated. On an AR(φ) per-period IC series at `h = 1`: plain *t* 26.7–34.7%, NW 6.7–10.3%, bootstrap 6.7–15.3% at φ = 0.6, and 62.3–65.3% / 14.3–27.3% / 9.7–21.3% at φ = 0.9 (table above); the screen fires on 94.7–100% of those draws. | Do **not** switch member; it moves the number without fixing it. Read the *t* against a raised hurdle (*t* > 3) or lengthen the sample — at φ = 0.6 the plain *t* is still 34.7% at `T = 240`, so more periods alone is not enough either. A coarser `overlap_periods` stride under `NON_OVERLAPPING` helps mechanically where the horizon allows it — the strided sample sits at φ^h, and AR(0.6) strided at h = 21 measures 4.5%. |
-| Fewer than `MIN_SERIES_PERIODS_HARD` (10) periods after the stride | No `serial_correlation_detected` — the screen is withheld | A lag-1 autocorrelation estimated from 3–9 observations is noise, so the screen reports nothing rather than report the shortage of periods as persistence; measured firing rate at `h = 21, T ∈ {60, 120}` is 0.000 on both nulls. Just above the floor it is still weak: 12 strided observations at `T = 240, h = 21` fire on 6.0% / 8.0% of draws, equally on the iid and persistent nulls. | Read `unreliable_se_short_periods` and `n_obs` — the periods shortage, not the persistence, is what the sample is telling you. Lengthen the history or shorten the horizon. |
-| Short strided series (fewer than ~120 periods after the stride) | `unreliable_se_short_periods`, or nothing on a moderately short series | The *t* / NW branch runs 7–9%. A block-bootstrap p is *worse* here — the spread metrics' former automatic bootstrap branch (`_block_bootstrap_diff_p`, kernel-isolated on iid input) measured 13.6% at n = 12, 9.8% at 30, 7.4% at 60, reaching 5.2% only by 120 — and the strided series is short exactly when the horizon is long. The spread-series table above says the same at the short end: 8.2% at T = 60, h = 1. | Stay on the analytic *t* / NW. Do not reach for the bootstrap to rescue a short sample; shorten the stride or lengthen the history instead. |
-| `predictive_beta` with `overlap_periods > 1` | `overlapping_predictive_inference` | The bias-corrected slope test remains 7.5–14.5% oversized at a nominal 5%, including independent-regressor nulls. This is separate from Stambaugh bias and residual persistence. | Keep the returned estimate for effect size, but read the p-value against a raised hurdle and compare `h = 1` or a genuinely non-overlapping design. |
-| Long strided series (≥ ~120 periods) whose distribution is in doubt (heavy tails, skew) | No warning | On iid input `STATIONARY_BOOTSTRAP` sits at the same 7–9% baseline as NW (φ = 0 row above) — it buys no *size*. On the spread series it measures 4.8–9.0% across the grid above, with its worst cell at the long horizon (9.0% at T = 120, h = 21) where NW is conservative instead (2.4%). Its case is distributional: it is the only member that does not assume asymptotic normality of the mean (§1). | Read `STATIONARY_BOOTSTRAP` alongside the analytic p — on `ic` and on all three spread metrics, which admit it on the strength of the table above — when tails or skew are the doubt. A documented option, not a default. |
-| Heavy-tailed *and* short | `unreliable_se_short_periods` | The *t* is size-robust to tails — 3–4% on t(3) input, i.e. conservative — while the small-n bootstrap is not (6–14%). | Keep the *t*. Tails are not a reason to bootstrap a short series. |
-| Thin cross-section (few names per leg) | `few_assets` | Each leg mean rests on a handful of names: a noisier estimate, not a differently-distributed one. The automatic bootstrap switch this once triggered rejected 8–20% against the *t*'s 7–9% and keyed on the wrong axis; it was removed. | Keep the requested member; read `n_assets` and treat the spread as fragile. |
-| Overlapping panel scored by `common_asymmetry` / `common_quantile_spread`, per-period factor persistent once strided | `serial_correlation_detected` | The single-restriction HAR reference takes both metrics to 3.3–8.0% on a non-persistent common factor across `T × h`, but a φ = 0.9 common factor leaves them at 13.0% / 16.3% at `T = 60, h = 5`, clearing by `T = 240` (6.0% / 7.7%). The screen fires on 51–100% of those draws and on 0–8% of the calibrated ones. | Read the p against a raised hurdle or lengthen the sample. Changing `newey_west_lags` does not fix it — the bandwidth is not what is wrong. |
-| `common_asymmetry` / `common_quantile_spread` with fewer than 10 periods after the `overlap_periods` stride | `unreliable_se_short_periods` | The effective sample, not the raw period count, is what the HAC standard error rests on: at `T = 120, h = 21` five independent observations carry a bandwidth-40 kernel. The persistence screen withholds itself there for the same reason. | Shorten the horizon or lengthen the history; the p carries little information at that effective count. |
-| Joint test on K ≥ 3 short slices | `slice_period_joint_test` warning | 8–9% for K = 5 on 50–90-period slices, converging by T ≈ 150; the bootstrap path inherits it (12%). K = 2 is calibrated throughout. | Read the pairwise contrasts on the same slices rather than the joint p, or lengthen the slices — at `K = 3` either pairwise path is calibrated (5.8% bootstrap / 5.4% Holm), at `K = 5` take the analytic Holm path (5.7–6.7%) over the bootstrap one (7.4–8.5%). |
-| Few event periods after the stride | `few_events` | Power-thin, not size-inflated for `caar` / `corrado_rank`; `bmp_z` is ~10% at 8 effective periods, ~7% at 15, clearing by ~30. | Read borderline p-values cautiously; extend the event history rather than switching estimator — all three count the same event periods. |
-| 3–19 portfolio periods in `top_concentration` | `borderline_portfolio_periods` | `top_concentration` publishes no p at any sample size — the withdrawn one-sided `t` against `ratio ≥ 0.5` never rejected, because the null diversification ratio is ~0.91 (0 of 300 draws at both 10 and 48 tested periods). The code is about the precision of the mean, not a test. | Read `value` and `ratio_eff_to_total` as a noisy mean over few periods; lengthen the history before comparing panels. |
-| Overlapping panel read through `common_asymmetry` / `common_quantile_spread` at `overlap_periods > 1` | No warning | Both metrics now take the scalar HAR recipe rather than the Wald family's `overlap_periods - 1` bandwidth floor, and their post-fix sizes are tabled in [Single-restriction Wald contrasts](#single-restriction-wald). What remains is the persistent-common-factor regime in the row above, not the horizon itself. | Read the p normally; where `serial_correlation_detected` fires, raise the hurdle or lengthen the sample. |
-
-Two rules fall out of the table. A *size* problem driven by persistence or
-a short sample is not fixed by changing the inference member — the
-analytic and bootstrap paths inherit the same small-sample distortion —
-so the honest response is a raised hurdle or more periods. A
-*distribution* problem on a long series is the one case where the
-bootstrap earns its cost — as a second read, not a better-sized one — and
-it is offered there rather than routed to automatically because a default
-that silently moves a number is the line every other deviation in this
-library has stayed behind.
-
----
-
-## 7. Missing-value convention (null vs NaN)
-
-polars distinguishes `null` (missing) from float `NaN` (a value), and
-`drop_nulls` / `mean` / `std` / `sum` / `rank` do **not** skip NaN — a NaN
-propagates through a mean, ranks above every finite value, and compares
-`False` to everything (so `x > 0` counts it as a miss and `x != 0` as an
-event). pandas users are used to `skipna=True` hiding this; there is no such
-switch in polars, so factrix fixes one convention across the library:
-
-1. **Producers drop and record.** A per-period primitive (`compute_ic`,
-   `compute_caar`, the quantile bucketing, the beta primitives) drops a
-   non-finite input row or an undefined per-period statistic (e.g. the
-   Spearman $\rho$ of a constant cross-section, which `pl.corr` returns as
-   NaN) at the boundary, and reports the count through `_drop_stats` /
-   `n_*_dropped` metadata so the shrinkage is visible.
-2. **Consumers use `drop_nulls().drop_nans()`.** Every series consumer treats
-   NaN exactly like null: it is a missing observation, never a value. The
-   headline `value`, `stat`, `p_value` and `n_obs` are computed on the same
-   surviving sample.
-3. **Kernels refuse non-finite input.** `factrix._stats` primitives
-   (`_newey_west_*`, `_hansen_hodrick_*`, `_block_bootstrap_diff_p`) raise
-   `ValueError` on NaN / inf — scipy's `nan_policy="raise"` semantics — rather
-   than emit a NaN statistic or, worse, a spuriously small $p$ (an all-NaN
-   bootstrap centring makes every `|boot| >= |obs|` comparison `False` and the
-   empirical $p$ collapses to $1/(B+1)$).
-
-The alternative — pandas-style silent `skipna` inside every reduction — was
-rejected because it hides sample shrinkage from the reader and would still
-leave `rank` / comparison semantics wrong. Imputing NaN to 0 was rejected
-because a zero is a *value* (it pulls means toward zero and hit rates down).
-
+For null versus NaN handling, use the canonical
+[Data schema](../api/data-schema.md) and
+[Preparing data](../guides/preparing-data.md#6-missing-data) guidance.

--- a/docs/reference/ts-mode-conventions.md
+++ b/docs/reference/ts-mode-conventions.md
@@ -1,5 +1,5 @@
 ---
-title: Timeseries-mode conventions
+title: Common-factor regression conventions
 ---
 
 !!! tip "Canonical reference"

--- a/docs/where-factrix-fits.md
+++ b/docs/where-factrix-fits.md
@@ -2,513 +2,106 @@
 title: Where factrix fits
 ---
 
-This page expands the design philosophy, walks through the pipeline
-and internals, draws scope boundaries, compares against same-purpose
-peers, shows adjacent-tool integration, and discloses honest
-weaknesses.
+factrix sits between factor construction and strategy construction. It tests
+whether a candidate signal has predictive evidence and, when many candidates
+are screened together, controls the false discovery rate (FDR). It does not
+turn that evidence into positions or a backtest.
 
-## 1. What factrix is
+[](){ #1-what-factrix-is }
 
-factrix is a **factor inference surface**: given a candidate factor and
-a forward return, it answers *is the predictive power real?* and
-returns a structured profile of evidence — rather than applying one
-uniform formula to every factor.
+## Scope
 
-Three factor types each get a mainstream test fitted to their
-data-generating process:
+factrix routes metrics by factor scope, signal density, and data structure.
+The caller chooses the research question and metrics; factrix validates that
+the requested metrics apply to the supplied data.
 
-- **Cross-sectional factors** — Information Coefficient (IC) and
-  Fama-MacBeth (FM), both with Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent (HAC) standard errors and a
-  Hansen-Hodrick lag floor for overlapping forward returns.
-- **Event factors** — Cumulative Average Abnormal Return (CAAR) on
-  the event-date series with grid-aware non-overlap inference, plus
-  overlap and clustering diagnostics for crowded event schedules.
-- **Common factors** — a factor whose realisation is shared across
-  the cross-section in a given period (Fama-French market / size /
-  value, or a macro variable). factrix tests these as a panel
-  exposure across the asset cross-section (`n_assets >= 2`); a single asset
-  has no cross-section to aggregate over, so these metrics raise on
-  `n_assets == 1` data.
+| Factor type | Typical question | Mainstream evidence |
+|---|---|---|
+| Cross-sectional | Do higher-ranked assets earn different forward returns? | Information Coefficient (IC), Fama-MacBeth regression, and spread diagnostics |
+| Event | Do sparse signals precede abnormal returns? | Cumulative Average Abnormal Return (CAAR), standardised abnormal returns, and rank tests |
+| Common | Does one shared factor explain the cross-section? | Cross-asset beta and conditional-response diagnostics |
 
-Each type also runs a multi-metric *diagnostic battery* — never
-collapsed into a single score. This is a deliberate design choice,
-not an oversight. A composite score becomes its own optimisation
-target the moment it ships (Goodhart 1984), and weighted aggregation
-across heterogeneous nulls implicitly prices each null
-(DeMiguel-Garlappi-Uppal 2009; Harvey 2017). See
-[design notes §1](development/design-notes.md#1-no-composite-factor-score)
-and
-[§7](development/design-notes.md#7-per-metric-registered-procedures-rather-than-a-unified-test)
-for the full citation chain.
-
-## 2. Where factrix sits
-
-### 2.1 Ecosystem pipeline
-
-factrix is **Stage 1** of a multi-stage workflow. It is not a
-competitor to portfolio construction, backtesting, or execution
-tools — it sits upstream of them and produces the input they assume.
+`evaluate()` returns a mapping keyed by factor name. Each
+`EvaluationResult` keeps metric results, warnings, the detected cell, and
+sample metadata separate. factrix does not collapse heterogeneous tests into
+a composite score.
 
 ```mermaid
 flowchart LR
-    DATA[Raw data] --> CONSTR[Factor construction<br/>zipline Pipeline · self-roll]
-    CONSTR --> FX[<b>factrix inference</b><br/>Stage 1 — kill fakes]
-    FX --> PORT[Strategy construction<br/>skfolio · PyPortfolioOpt · riskfolio-lib]
-    PORT --> BT[Backtest<br/>vectorbt · zipline-reloaded · bt]
-    BT --> LIVE[Live trading<br/>lumibot · nautilus_trader]
+    DATA[Data and factor construction] --> FX[<b>factrix</b><br/>inference and screening]
+    FX --> PORT[Strategy and portfolio construction]
+    PORT --> BT[Backtest and execution]
     classDef here fill:#3670A0,color:#fff,stroke:#234060,stroke-width:2px;
     class FX here
 ```
 
-### 2.2 factrix internals
-
-Inside factrix the call graph is small. Long-format `data` (the
-`(date, asset_id, factor, forward_return)` floor) plus a
-`metrics={label: metric()}` dict and `factor_cols` enter `evaluate()`.
-Each metric instance carries a `MetricSpec` whose `cell`
-(`FactorScope` × `FactorDensity` × `DataStructure`) decides whether it
-applies to the detected data shape; the DAG executor runs batchable
-stage-1 producers once across the factor batch and per-factor consumers
-once per factor, and returns a `list[EvaluationResult]` — one per
-factor, each holding a read-only `Mapping[str, MetricResult]` of
-per-metric outputs plus a flat `list[Warning]`. The list flows into
-`multi_factor.bhy(results, metrics=[...])` for cross-test false
-discovery rate (FDR) control, which returns the surviving factors.
-
-```mermaid
-flowchart LR
-    DATA[Long data<br/>date · asset_id · factor · forward_return] --> EVAL[evaluate<br/>metrics · factor_cols]
-    METRICS[metrics dict<br/>label → metric instance] --> EVAL
-    EVAL --> DISP{Cell-routed<br/>applicability}
-    DISP -->|individual · dense| CS[IC · FM beta<br/>+ diagnostics]
-    DISP -->|individual · sparse| EV[CAAR<br/>+ diagnostics]
-    DISP -->|common · dense| CO[common_beta<br/>+ diagnostics]
-    DISP -->|common · sparse| DUM[CAAR<br/>+ event diagnostics]
-    CS --> RES[EvaluationResult<br/>metrics · warnings · cell]
-    EV --> RES
-    CO --> RES
-    DUM --> RES
-    RES --> BHY[multi_factor.bhy<br/>FDR within family]
-    BHY --> SURV[Surviving factors]
-```
-
-The dispatch arrow is the single line that distinguishes factrix
-from peers that apply one uniform formula across factor types
-(see [§4](#4-same-purpose-peers)). For the field-order walk of the
-`EvaluationResult` shown in the graph — `metrics`, `warnings`, `cell`,
-and the rest — see [Reading results](guides/reading-results.md).
-
-## 3. Out of scope (use these libraries instead)
-
-What factrix deliberately does **not** do, and the canonical tool for
-each. This is a commitment, not a TODO. To expand factrix scope,
-update
-[ARCHITECTURE.md Invariants](development/architecture.md#invariants)
-first.
-
-| Out of scope | Use instead |
-|---|---|
-| Portfolio optimisation (MVO / HRP / risk parity) | [skfolio](https://skfolio.org/), [PyPortfolioOpt](https://github.com/robertmartin8/PyPortfolioOpt), [riskfolio-lib](https://github.com/dcajasn/Riskfolio-Lib), cvxpy |
-| ML signal layer | xgboost + shap |
-| Regime detection methodology (HMM / threshold) | [hmmlearn](https://hmmlearn.readthedocs.io/), self-roll |
-| Structural break detection (Chow / Bai-Perron) | [ruptures](https://centre-borelli.github.io/ruptures-docs/) |
-| GARCH / wild-bootstrap SE | [arch](https://github.com/bashtage/arch) |
-| Persistent-predictor auto-correction (IVX / Stambaugh) | [arch](https://github.com/bashtage/arch), R `ivx` (factrix flags via augmented Dickey-Fuller (ADF); does not auto-correct) |
-| Backtest / execution / slippage / margin | [vectorbt](https://github.com/polakowo/vectorbt), [bt](https://github.com/pmorissette/bt), [zipline-reloaded](https://github.com/stefan-jansen/zipline-reloaded), backtrader |
-| Intraday / HFT (tick-level) | dedicated tooling |
-| Cross-factor signal combiner | self-roll, scikit-learn |
-| Composite factor scoring across dimensions | [AlphaEval](https://github.com/LeoDingggg/AlphaEval) (different design philosophy — see [§4.4](#44-alphaeval)) |
-| Deflated / probabilistic / Haircut Sharpe | [mlfinlab](https://github.com/hudson-and-thames/mlfinlab) (commercial); roadmap gap for factrix — see [§7](#7-honest-weaknesses) |
-| Cross-sectional factor *construction* DSL | [zipline-reloaded Pipeline](https://github.com/stefan-jansen/zipline-reloaded); factrix consumes Pipeline output |
-| Returns-level tear-sheet (downstream of factrix) | [pyfolio-reloaded](https://github.com/stefan-jansen/pyfolio-reloaded) |
-
-### 3.1 Rationale for the controversial rows
-
-Three rows surprise readers most often. Their rationale is anchored
-in design notes rather than restated here.
-
-**Composite factor scoring** — rejected for the reason a single
-weighted score becomes its own target the instant it ships
-(Goodhart 1984), and weighted aggregation across heterogeneous
-nulls implicitly prices each null without disclosing the price.
-factrix exposes per-metric pass/fail and keeps the user in the
-inference loop. See
-[design notes §1](development/design-notes.md#1-no-composite-factor-score).
-
-**ML signal layer** — out of scope as a deliberate boundary. The
-signal-generation problem is well served by xgboost + shap, and
-folding model fit into factrix would change the page's hero claim
-from "inference on a hypothesised factor" to "inference on a fitted
-model" — those need different statistical machinery (cross-validation
-schemes, leakage tests). qlib already covers the integrated
-pipeline; we leave that branch to qlib.
-
-**Persistent-predictor flagging only, not auto-correction** —
-when the cross-sectional or time-series predictor is highly
-persistent (ADF p-value above the configured threshold; default 0.10),
-factrix raises
-`PERSISTENT_REGRESSOR` and notes that the beta estimate may carry
-Stambaugh (1999) bias. It does not silently swap in IVX
-(Phillips-Magdalinos), Stambaugh-correction, or sign-restricted
-inference, because the right correction depends on the
-researcher's economic prior — IVX assumes a near-unit-root
-predictor; Stambaugh requires a specified innovation-correlation
-sign. Auto-correcting would mask the modelling choice. Reach for
-[arch](https://github.com/bashtage/arch) or R `ivx` when the flag
-fires.
-
-## 4. Same-purpose peers
-
-Six peers occupy the *factor-evaluation / hypothesis-test* space.
-Each subsection follows the same shape: positioning, where the peer
-wins, where factrix wins, and the user profile that should pick the
-peer instead. Code side-by-side snippets are not included here yet;
-they will land once the migration examples are validated against the
-same input panel both ways.
-
-### 4.1 alphalens-reloaded
-
-**Positioning** — alphalens-reloaded is the canonical pandas
-tear-sheet for cross-sectional factors; the `get_clean_factor_and_
-forward_returns` → `create_full_tear_sheet` flow is the vocabulary
-most working quants recognise on sight. factrix targets the same
-*hypothesis-test* slot but extends past CS-only and past
-pandas-bound performance.
-
-**Where alphalens wins**
-
-- Tear-sheet vocabulary every quant recognises; fastest path to a
-  publishable chart pack from a notebook.
-- pandas-native — drops into existing notebooks without a polars
-  conversion step.
-- Six years of community examples and Stack Overflow answers.
-
-**Where factrix wins**
-
-- IC inference uses NW HAC with a Hansen-Hodrick lag floor for
-  overlapping forward returns; alphalens applies a naive
-  `scipy.stats.ttest_1samp` on the IC time series ([source](https://github.com/stefan-jansen/alphalens-reloaded)),
-  which is biased when forward windows overlap.
-- Multiple-testing correction (Benjamini-Hochberg-Yekutieli (BHY)) is built into the screening
-  surface; alphalens has no batch-level FDR control by design.
-- Type-routed dispatch — alphalens is CS-only by design; factrix
-  also covers event and common-factor hypotheses without the user
-  re-implementing the test machinery.
-
-**When to pick alphalens instead** — you have a single CS factor,
-your existing toolchain is pandas-only, and the tear-sheet
-vocabulary matters more than the inference rigour.
-
-### 4.2 qlib factor layer
-
-**Positioning** — qlib is a full alpha → model → backtest → live
-platform. Its factor-evaluation surface (`qlib.contrib.eva.alpha`)
-is a thin utility under that platform, not the product.
-
-**Where qlib wins**
-
-- Industrial-scale data layer with caching and an integrated
-  backtest engine — pick qlib when you want one tool for the whole
-  pipeline.
-- Alpha158 / Alpha360 baselines and RD-Agent integration give an
-  ML-first research workflow.
-- Largest active community among peers in this list.
-
-**Where factrix wins**
-
-- qlib's `calc_ic` / `calc_all_ic` apply uniform IC + Rank-IC
-  across **every** factor regardless of type ([source](https://github.com/microsoft/qlib/blob/main/qlib/contrib/eva/alpha.py)).
-  factrix dispatches IC, FM, CAAR, or ts-β by factor type.
-- factrix is decoupled from any data store, signal-mining DSL, or
-  backtest engine. You can drop it into an existing pipeline; qlib
-  expects you to adopt its data layout.
-- factrix ships per-metric NW HAC, BHY FDR, and persistent-predictor
-  flagging as first-class outputs of `evaluate()`; in qlib these
-  live in scattered helper functions or are absent.
-
-**When to pick qlib instead** — you want one integrated platform
-covering data → factor → ML model → backtest → live, and the
-opinionated qlib data store is acceptable.
-
-### 4.3 linearmodels
-
-**Positioning** — linearmodels (Kevin Sheppard, statsmodels core)
-is the reference Python implementation of panel econometrics:
-HAC kernels (Bartlett / Parzen / QS with auto-bandwidth),
-clustered SE, and a correctly-implemented Fama-MacBeth
-second-stage SE. It is a primitive, not a framework.
-
-**Where linearmodels wins**
-
-- Best-in-class HAC and clustered SE coverage; correct FM
-  second-stage variance (most homebrew loops are wrong by a
-  constant factor).
-- Maintained by an econometrics-credible author with frequent
-  releases.
-
-**Where factrix wins**
-
-- linearmodels is a panel-econometrics toolkit; it has no factor
-  tear-sheet, no IC surface, no event-study path, no batch
-  multiple-testing layer. The user must already have a panel and
-  know which test to run.
-- factrix uses `arch` for HAC kernels (Kevin Sheppard maintains
-  both `arch` and `linearmodels`; their HAC implementations are
-  functionally equivalent) and treats FM as one routed metric
-  among several. You are not asked to assemble the workflow.
-
-**When to pick linearmodels instead** — you only need correct
-Fama-MacBeth standard errors on a panel you have already
-constructed, and you do not need IC, CAAR, BHY, or any of the
-inference surfaces.
-
-### 4.4 AlphaEval
-
-**Positioning** — AlphaEval ([repo](https://github.com/LeoDingggg/AlphaEval))
-is a *post-processing ranker for formula-mined alphas*: input
-qlib expression-DSL formulas, compose them via `WeightCalculator`,
-score the composite across five dimensions including an
-OpenAI-LLM-as-judge for "financial logic". Its target user mines
-1000 GP/GA formulas and needs to rank them.
-
-This is the design path factrix considered and rejected with
-literature backing — see
-[design notes §1](development/design-notes.md#1-no-composite-factor-score)
-and
-[§7](development/design-notes.md#7-per-metric-registered-procedures-rather-than-a-unified-test).
-
-**Where AlphaEval wins**
-
-- Purpose-built for formula-mining workflows; LLM-judged
-  "financial logic" dimension is unique.
-- Composite ranker is the right tool when the input is a *pool*
-  of mined alphas rather than a small set of hypothesised
-  factors.
-
-**Where factrix wins**
-
-- factrix evaluates one factor (or batch with FDR) against an
-  explicit null and surfaces per-metric pass/fail rather than a
-  weighted scalar. The two libraries answer different questions.
-- Composite scoring becomes its own optimisation target the
-  moment it ships (Goodhart 1984); per-metric inference keeps the
-  null distributions distinct.
-
-**When to pick AlphaEval instead** — you mine formula alphas
-with GP/GA and need to rank thousands by an aggregate score for
-downstream selection.
-
-### 4.5 eventstudy
-
-**Positioning** — `eventstudy` is the only dedicated event-study
-Python package. It implements the standard parametric / BMP /
-Patell tests on event windows. The package self-describes as
-alpha-quality with a frequently-changing API.
-
-**Where eventstudy wins**
-
-- BMP / Patell standardised tests for event-window inference are
-  shipped with vocabulary that matches MacKinlay (1997).
-
-**Where factrix wins**
-
-- factrix integrates event-date CAAR with grid-aware non-overlap
-  inference plus overlap and clustering diagnostics; eventstudy treats
-  events in isolation.
-- Event inference lives in the same `EvaluationResult` shape as CS and
-  common-factor inferences; one pipeline screens all three with
-  shared FDR control.
-
-**When to pick eventstudy instead** — you only do M&A or
-earnings event studies in isolation and do not need integration
-with cross-sectional or macro work.
-
-### 4.6 mlfinlab
-
-**Positioning** — mlfinlab is the López de Prado reference
-implementation of deflated / probabilistic / Haircut Sharpe,
-PBO via combinatorial CV, BHY-adjusted p-values, and a
-structural-break suite (Chow / CUSUM / SADF). It went
-commercial in 2022; the public PyPI package was removed and the
-public repo has been dormant since 2021-12.
-
-**Where mlfinlab wins**
-
-- The only library shipping deflated / probabilistic / Haircut
-  Sharpe end-to-end. If your firm has the licence, this is the
-  shortest path to those metrics.
-
-**Where factrix wins**
-
-- Open source (Apache-2.0); `pip install factrix` works.
-- Active maintenance with tagged releases and reviewable PR narratives during the pre-1.0 line.
-- Deflated Sharpe / PSR is on the factrix roadmap and is the
-  highest-priority OSS gap; see [§7](#7-honest-weaknesses).
-
-**When to pick mlfinlab instead** — your firm pays for the
-licence and you need deflated Sharpe today.
-
-## 5. Adjacent tools and integration
-
-The tools below are not peers; they sit upstream, downstream, or
-underneath factrix. The point of this section is to make the
-integration surface explicit so factrix reads as a citizen of the
-ecosystem rather than a walled garden.
-
-### 5.1 Per-tool role
-
-| Tool | Role relative to factrix |
-|---|---|
-| [zipline-reloaded Pipeline](https://github.com/stefan-jansen/zipline-reloaded) | Upstream CS factor *construction* DSL; factrix consumes Pipeline output |
-| [arch](https://github.com/bashtage/arch) | Reference HAC kernel implementation; factrix depends on it, does not reimplement |
-| [statsmodels](https://www.statsmodels.org/) | General econometrics primitives (regression / time-series); used internally |
-| [empyrical-reloaded](https://github.com/stefan-jansen/empyrical-reloaded) | Low-level return-stat primitives (Sharpe, Sortino, drawdown); dependency layer |
-| [pyfolio-reloaded](https://github.com/stefan-jansen/pyfolio-reloaded) | Downstream returns-level tear-sheet; consumes strategy P&L, not factor signal |
-| [vectorbt](https://github.com/polakowo/vectorbt) | Stage 3 parameter-grid backtest engine; pairs with factrix BHY for honest workflow |
-| [skfolio](https://skfolio.org/) / [PyPortfolioOpt](https://github.com/robertmartin8/PyPortfolioOpt) / [riskfolio-lib](https://github.com/dcajasn/Riskfolio-Lib) | Stage 2 strategy construction (portfolio optimisation); consume factrix-validated factors as input |
-
-### 5.2 Integration sketches
-
-Stage 1 → factrix: zipline Pipeline outputs a pandas MultiIndex
-`(date, asset)`, which converts to the polars panel factrix
-expects in two lines.
-
-```python title="Illustrative"
-import polars as pl
-import factrix as fx
-from factrix.preprocess import compute_forward_return
-
-# zipline_out: pandas DataFrame with MultiIndex (date, asset),
-# columns include the factor value and the realised return.
-panel = pl.from_pandas(zipline_out.reset_index())
-panel = compute_forward_return(panel, forward_periods=5)
-
-from factrix.metrics import ic
-results = fx.evaluate(panel, factor_cols=["factor"], metrics={"ic": ic()})
-ic_p = results["factor"].metrics["ic"].p_value
-```
-
-factrix → Stage 2: surviving factors after BHY feed a portfolio
-optimiser.
-
-```python title="Illustrative"
-import factrix as fx
-from factrix.metrics import ic
-
-# Each panel carries its factor under a distinct column name
-# ("momentum_12" / "value" / ...); evaluate stamps each result's
-# `factor` from factor_cols so identities stay unique without manual surgery.
-results = []
-for name, p in panels.items():
-    res = fx.evaluate(p, factor_cols=[name], metrics={"ic": ic()})
-    results.extend(res.values())
-
-bhy_ic = fx.multi_factor.bhy(results, metrics=["ic"], q=0.05)["ic"]
-
-# bhy_ic.survivors is a list[EvaluationResult]; pass the underlying factor
-# panels to skfolio / PyPortfolioOpt / riskfolio-lib as Stage 2 input
-```
-
-The integration story matters because it answers the implicit
-"what do I do with the inference" question — factrix is an
-intermediate stage, not an endpoint.
-
-## 6. When factrix is NOT the right tool
-
-If you are not at the inference / screening stage, factrix is the
-wrong tool. The chart below routes you to the canonical
-alternative for each adjacent stage. Construction (upstream) is
-intentionally not branched: readers reach this chart asking
-*given I have a factor, what do I do next*, not *how do I build
-one*.
-
-```mermaid
-flowchart TD
-    A[What stage of the alpha pipeline?] --> F[Inference / screening on a factor]
-    A --> W[Optimise weights for trusted factors]
-    A --> E[Backtest or deploy a strategy]
-    A --> R[Returns-level tear-sheet on a P&L series]
-    F --> FX[<b>factrix</b>]
-    W --> WX[skfolio · PyPortfolioOpt · riskfolio-lib]
-    E --> EX[zipline-reloaded · backtrader · bt · vectorbt · nautilus_trader]
-    R --> RX[pyfolio-reloaded · QuantStats]
-```
-
-## 7. Honest weaknesses
-
-This section is the disclosure surface. It is meant to be cited
-verbatim by skeptical readers — soft-pedalling the gaps would be
-self-defeating once they read the source.
-
-### 7.1 Capability matrix and roadmap
-
-| Capability | factrix today | Closest peer | Status / roadmap |
-|---|---|---|---|
-| CS IC/IR tear-sheet | yes | alphalens (legacy, pandas) | parity on visualization vocabulary |
-| Event CAAR | yes | eventstudy (alpha-quality) / linearmodels (manual) | event-date CAAR with non-overlap inference out of the box |
-| Macro panel | yes | linearmodels (manual) | packaged macro-factor evaluation surface |
-| Multi-test FDR (BHY) | yes | mlfinlab (commercial-gated) | only OSS implementation post-mlfinlab paywall |
-| NW HAC | yes | linearmodels / arch | depend on `arch`, do not reimplement |
-| Type-routed mainstream metric (CS / Event / Macro) | yes | none | factrix's core differentiation |
-| **Deflated Sharpe / PSR / PBO** | **no** | mlfinlab (commercial-gated) | **roadmap priority** — most painful OSS gap |
-| ML pipeline integration | no (out of scope) | qlib | document interop; leave to qlib |
-| Live trading / execution | no (out of scope) | lumibot / nautilus_trader | document boundary; leave out |
-
-### 7.2 Non-capability weaknesses
-
-- **Smaller community** compared with alphalens / qlib — factrix is a newer
-  project with fewer Stack Overflow answers. Expect to read source
-  for edge cases that alphalens has been asked about for six years.
-- **No published replication of a canonical anomaly study yet** —
-  a factor-zoo skeptic will ask whether factrix's conclusions agree
-  with the published record on a known-good factor. That
-  replication is on the roadmap and is a credibility gap until it
-  ships.
+For the data-shape taxonomy, see [Concepts](getting-started/concepts.md). For
+the internal dispatch and execution model, see
+[Architecture](development/architecture.md).
+
+## Boundaries
+
+Use factrix when the unit of analysis is a factor hypothesis. Use a downstream
+or specialised tool when the unit is a portfolio, order, fitted machine-learning
+model, or return series.
+
+| Need | factrix | Use instead |
+|---|---:|---|
+| Factor-type-aware inference | Yes | — |
+| FDR control across candidate factors | Yes | — |
+| Data validation and applicability checks | Yes | — |
+| Factor construction DSL | No | [zipline-reloaded Pipeline](https://zipline.ml4trading.io/) or your research pipeline |
+| Portfolio optimisation | No | [skfolio](https://skfolio.org/), [PyPortfolioOpt](https://pyportfolioopt.readthedocs.io/), or [riskfolio-lib](https://riskfolio-lib.readthedocs.io/) |
+| Strategy backtesting and execution | No | [vectorbt](https://vectorbt.dev/), [zipline-reloaded](https://zipline.ml4trading.io/), [bt](https://pmorissette.github.io/bt/), or an execution engine |
+| Return-series tear sheets | No | [pyfolio-reloaded](https://pyfolio.ml4trading.io/) or [QuantStats](https://github.com/ranaroussi/quantstats) |
+| Machine-learning model training | No | [Qlib](https://github.com/microsoft/qlib), scikit-learn, or your model pipeline |
+| Persistent-predictor correction | No; factrix warns | A model chosen for the research design, such as IVX or a Stambaugh correction |
+
+These are scope boundaries, not roadmap promises. Adding a new inference
+method can fit factrix; adding portfolio or execution state changes the
+library's purpose.
+
+## Related tools
+
+The tools below overlap with part of the workflow but answer different primary
+questions. The comparison stays at the level of documented product scope; it
+does not rank communities, maintenance activity, or implementation quality.
+
+| Tool | Primary use | Choose it when |
+|---|---|---|
+| [alphalens-reloaded](https://github.com/stefan-jansen/alphalens-reloaded) | Cross-sectional factor statistics, plots, and tear sheets | You want the established Alphalens workflow and visual vocabulary for a pandas factor dataset |
+| [linearmodels](https://bashtage.github.io/linearmodels/) | Panel, instrumental-variable, system, and asset-pricing estimators | You already know the econometric model and need lower-level estimator or covariance control |
+| [eventstudy](https://github.com/LemaireJean-Baptiste/eventstudy) | Focused financial event-study analysis | Your workflow is an isolated event study rather than a mixed factor-screening pipeline |
+| [Qlib](https://github.com/microsoft/qlib) | An AI-oriented quantitative platform spanning data, models, backtests, and execution | You want an integrated research platform rather than an inference-only component |
+| [AlphaEval](https://github.com/GAIR-NLP/AlphaEval) | Evaluation of mined alpha formulas | Your main problem is ranking or analysing a large formula-mining output |
+| [mlfinlab](https://github.com/hudson-and-thames/mlfinlab) | Commercial financial-machine-learning tooling | You need methods available in that licensed suite, such as its backtest-overfitting tools |
+
+No single row is a drop-in substitute for every factrix factor type. It is also
+reasonable to use these tools together: for example, construct a factor in a
+research platform, validate it with factrix, then send surviving factors to a
+portfolio optimiser and backtest engine.
+
+## Design trade-offs
+
+- **No composite factor score.** A single score hides the null hypothesis and
+  the price assigned to each diagnostic. factrix keeps results separate; see
+  [Design notes](development/design-notes.md#1-no-composite-factor-score).
+- **Warnings do not silently change estimators.** Persistence, thin samples,
+  event clustering, and uneven grids remain visible in the result. The caller
+  decides whether to change the sample or method.
+- **Calibration has explicit limits.** Statistical defaults are measured on
+  documented nulls, but not every finite-sample regime is calibrated. See
+  [Statistical methods](reference/statistical-methods.md) and the linked
+  validation evidence before interpreting a borderline p-value.
+- **Factor evidence is not strategy evidence.** A predictive factor can still
+  fail after turnover, costs, capacity limits, and portfolio constraints. Those
+  questions belong downstream.
 
 ## Next steps
 
-If this page resolved the fit question and you want to run factrix:
-
-- [Quickstart](getting-started/quickstart.md) — 30-second example from a raw panel to a `p_value` readout.
-- [Concepts](getting-started/concepts.md) — the three-axis taxonomy and the metric dispatch underneath the routing examples above.
-- [Choosing a metric](guides/choosing-metric.md) — research-question to metric mapping for the five scenarios in §2.
-
-If you want to compare factrix to a specific peer before installing, the [§4 same-purpose peers](#4-same-purpose-peers) table is the densest summary on this page.
-
-## 8. Citations
-
-The methodological choices on this page anchor in the following
-sources. The full bibliography lives in
-[reference/bibliography.md](reference/bibliography.md); this
-section names the most load-bearing ones.
-
-- [**Goodhart (1984)**](reference/bibliography.md#goodhart-1984) —
-  *Monetary Theory and Practice*. Origin of the Goodhart's-law
-  argument used by design-notes §1.
-- [**DeMiguel, Garlappi & Uppal (2009)**](reference/bibliography.md#demiguel-garlappi-uppal-2009) —
-  "Optimal versus naive diversification." *Review of Financial
-  Studies*. Equal-weight beats optimised under estimation error;
-  cited in the no-composite position.
-- [**Harvey (2017)**](reference/bibliography.md#harvey-2017) —
-  "Presidential address: The scientific outlook in financial
-  economics." *Journal of Finance*. Argues for pre-registered
-  per-metric audit trails over unified statistics.
-- **Bailey & López de Prado (2014)** — "The Deflated Sharpe
-  Ratio." *Journal of Portfolio Management*. Roadmap target for
-  the §7 PSR row. (Not yet in bibliography; will land alongside
-  the Deflated-Sharpe roadmap work.)
-- [**Harvey, Liu & Zhu (2016)**](reference/bibliography.md#harvey-liu-zhu-2016) —
-  "…and the cross-section of expected returns." *Review of
-  Financial Studies*. Multiple-testing inflation in the factor
-  zoo; motivates BHY.
-- [**Hou, Xue & Zhang (2020)**](reference/bibliography.md#hou-xue-zhang-2020) —
-  "Replicating anomalies." *Review of Financial Studies*. The
-  replication context for the §7.2 weakness disclosure.
-- [**Brown & Warner (1985)**](reference/bibliography.md#brown-warner-1985) —
-  "Using daily stock returns: The case of event studies."
-  *Journal of Financial Economics*. The canonical event-study
-  reference behind CAAR.
-- [**MacKinlay (1997)**](reference/bibliography.md#mackinlay-1997) —
-  "Event studies in economics and finance." *Journal of
-  Economic Literature*. Vocabulary used in
-  [§1](#1-what-factrix-is) and [§4.5](#45-eventstudy).
+- [Quickstart](getting-started/quickstart.md) — run an end-to-end evaluation.
+- [Choosing a metric](guides/choosing-metric.md) — map a hypothesis to a metric.
+- [Reading results](guides/reading-results.md) — interpret estimates, metadata,
+  and warnings.
+- [Validating allocation signals](guides/validating-allocation-signals.md) —
+  carry inference forward without treating it as portfolio optimisation.

--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -73,7 +73,7 @@ def ols_alpha(
     On the case the retired assumption was written for — iid, genuinely
     non-overlapping — HAC costs 1–2 points of size, the usual small-sample
     HAC noise every other HAC path in factrix carries and
-    ``statistical-methods`` §6 discloses. On the case the assumption was
+    ``inference-calibration`` discloses. On the case the assumption was
     silently covering, the OLS SE rejects at **33%** and does not improve
     with more data, because it is estimating the wrong quantity: the
     autocorrelation is in the residuals, and more of them does not help.
@@ -92,7 +92,7 @@ def ols_alpha(
     9.0 -> 6.0%, 18.7 -> 9.3% and 46.0 -> 11.7% at ``n = 60`` for
     ``h = 1, 5, 21``, and 50.0 -> 29.3%, 50.3 -> 30.3%, 60.0 -> 21.7% on
     the ``phi = 0.9`` version of the same null. The persistent column stays
-    the uncalibrated regime ``statistical-methods`` section 6 discloses;
+    the uncalibrated regime ``inference-calibration`` discloses;
     spanning has no persistence screen of its own, so read it there.
 
     An earlier version used the OLS SE on the stated assumption that

--- a/factrix/_stats/hac.py
+++ b/factrix/_stats/hac.py
@@ -225,7 +225,7 @@ def _resolve_scalar_wald_hac(
     13.0% / 16.3% at ``T = 60, h = 5``, converging to 6.0% / 7.7% by
     ``T = 240``. That regime is flagged
     (:attr:`~factrix._codes.WarningCode.SERIAL_CORRELATION_DETECTED`)
-    rather than corrected — see ``statistical-methods`` section 6.
+    rather than corrected — see ``reference/inference-calibration``.
     """
     resolved = _resolve_har_lags(n, lags, overlap_periods)
     remaining = n - resolved - 1
@@ -317,7 +317,7 @@ def _newey_west_se(
     published numbers is a core use of this library, and R's
     ``sandwich::NeweyWest`` is the only mainstream tool that defaults it
     on (statsmodels and Stata do not). The flag exists so the
-    characterisation tests and ``statistical-methods`` section 6 can pin
+    characterisation tests and ``reference/inference-calibration`` can pin
     what prewhitening would and would not buy; every library path uses
     the default.
 

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -17,7 +17,8 @@ Which metrics expose ``inference=``
 -----------------------------------
 A selectable ``inference`` is offered **only** to the metrics whose
 headline test is "average an overlapping per-date series and test
-``mean != 0``" — currently ``ic``, ``quantile_spread`` and ``k_spread``.
+``mean != 0``" — currently ``ic``, ``quantile_spread``,
+``quantile_spread_vw`` and ``k_spread``.
 There the choice between non-overlap sub-sampling and a HAC SE genuinely
 changes the standard error, so it is the caller's to make.
 
@@ -33,9 +34,11 @@ design, not an omission:
 - **Per-asset time-series** (``common_beta``) — its own SE.
 - **Fixed-distribution tests** (``directional_hit_rate`` is
   Pesaran-Timmermann, ``positive_rate`` is a binomial) — no SE to choose.
-- **Descriptive diagnostics** (``oos_decay``, ``concentration``,
-  ``trend`` = Theil-Sen, ``common_asymmetry``) — no single headline H0, or an
-  estimator-specific CI.
+- **Descriptive diagnostics** (``oos_decay``, ``concentration``) — no
+  headline hypothesis test.
+- **Estimator-specific tests** (``trend`` pairs Theil-Sen magnitude with a
+  Mann-Kendall p-value; ``common_asymmetry`` tests a regression contrast) —
+  fixed inference dictated by the metric.
 
 Closed-union policy
 -------------------
@@ -71,7 +74,7 @@ The allowlist is a **vetting record, not a dispatch table**. Every
 could in principle run any series-mean member. What the allowlist says is
 which members have been *measured on that metric's series*: the IC series
 and the long-short spread series have different distributions, so each
-carries its own size table (see ``reference/statistical-methods``) and
+carries its own size table (see ``reference/inference-calibration``) and
 each admits a member only on the strength of it.
 
 ``HansenHodrick`` is research-only
@@ -82,9 +85,10 @@ The reason is statistical, not structural: its rectangular kernel has no
 PSD guarantee and can clamp a negative variance (see
 ``WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE``), so the vetted HAC is
 ``NeweyWest``'s PSD-guaranteed Bartlett kernel. ``StationaryBootstrap``
-*is* admitted everywhere the family is offered — it makes no
-asymptotic-variance assumption at all, so it is the recommended read when
-a series is too short or too heavy-tailed for a HAC member to be trusted.
+*is* admitted everywhere the family is offered. It avoids a parametric-normal
+reference for the series mean, but still depends on stationarity, weak
+dependence, block-length choice, and an adequate sample. Use it as a second
+read on a long series with distributional doubt, not as a short-sample rescue.
 
 Because no metric can accept it, ``HansenHodrick`` / ``HANSEN_HODRICK``
 are **not** re-exported here: a name on ``fx.inference.*`` reads as

--- a/factrix/metrics/common_asymmetry.py
+++ b/factrix/metrics/common_asymmetry.py
@@ -133,7 +133,7 @@ def common_asymmetry(
         Both restrictions are rank one, so both take the scalar HAR recipe
         (:func:`~factrix._stats.hac._resolve_scalar_wald_hac`): bandwidth,
         ``T / (T - L - 1)`` variance scale and fixed-``b`` effective degrees
-        of freedom together. See ``statistical-methods`` section 6 for the
+        of freedom together. See ``inference-calibration`` for the
         measured size and for the two regimes it does not fix, which this
         metric reports as ``serial_correlation_detected`` (per-period factor
         persistent once strided) and ``unreliable_se_short_periods`` (fewer

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -211,7 +211,7 @@ def common_beta(
         the mean of the per-asset slopes; both are reported. On a
         COMMON-scope panel null the test measures 2.0-7.3% across
         $T \in \{60, 120, 240\}$ and $h \in \{1, 5\}$
-        (``statistical-methods`` section 6).
+        (``reference/inference-calibration``).
 
     References:
         [Black-Jensen-Scholes 1972][black-jensen-scholes-1972]:

--- a/factrix/metrics/common_quantile.py
+++ b/factrix/metrics/common_quantile.py
@@ -138,8 +138,7 @@ def common_quantile_spread(
         variance scale and the fixed-``b`` effective degrees of freedom come
         from :func:`~factrix._stats.hac._resolve_scalar_wald_hac` — the same
         recipe the scalar series-mean HAR t-test uses, and the one this
-        metric's size table is measured on (``statistical-methods``
-        section 6). A
+        metric's size table is measured on (``inference-calibration``). A
         ``Spearman(0..K-1, beta)`` rank-monotonicity diagnostic across
         buckets is reported alongside.
 

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -855,7 +855,7 @@ def event_skewness(
         descriptive shape of the event return distribution and test
         direction with ``event_hit_rate`` / ``event_ic`` / ``bmp_z``,
         which are calibrated on both. The full size table is in
-        ``docs/reference/statistical-methods.md`` section 6.
+        ``docs/reference/inference-calibration.md``.
 
         Events with a non-finite ``return_col`` / ``factor_col`` are
         dropped before the moments are taken and counted in

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -264,8 +264,9 @@ def spanning_alpha(
         :attr:`~factrix.WarningCode.SERIAL_CORRELATION_DETECTED` when it stays
         autocorrelated after the ``overlap_periods`` stride, and
         :attr:`~factrix.WarningCode.UNRELIABLE_SE_SHORT_PERIODS` when that
-        strided sample falls below ten periods. See ``statistical-methods``
-        section 6 for the measured size and firing rates.
+        strided sample falls below ten periods. See
+        ``reference/inference-calibration`` for the measured size and firing
+        rates.
 
     Notes:
         The [Huberman-Kandel (1987)][huberman-kandel-1987] mean-variance

--- a/factrix/metrics/trend.py
+++ b/factrix/metrics/trend.py
@@ -124,7 +124,8 @@ def ic_trend(
             but significance should be read with scepticism.
 
     Returns:
-        MetricResult with value = slope, t_stat from Theil-Sen confidence interval.
+        MetricResult with the Theil-Sen slope as ``value`` and the
+        Hamed-Rao Mann-Kendall ``tau`` / p-value as ``stat`` / ``p_value``.
 
     Notes:
         Theil-Sen median pairwise slope: ``slope = median{(y_j - y_i) /
@@ -140,7 +141,7 @@ def ic_trend(
         ``WarningCode.PERSISTENT_REGRESSOR`` rather than sitting in
         metadata alone. On a trend-free IC series the Mann-Kendall p
         measures 1.7-5.3% at a nominal 5% over ``T`` in 60/120/240 and
-        ``h`` in 1/5 (``statistical-methods`` section 6).
+        ``h`` in 1/5 (``reference/inference-calibration``).
 
         **Two corrections for serial dependence.** Striding does ~99% of
         the work; Hamed-Rao handles the residual persistence that
@@ -226,9 +227,9 @@ def ic_trend(
         informational and no longer drives the p.
 
         factrix uses Theil-Sen rather than OLS because its 29.3% breakdown
-        point absorbs information coefficient (IC) outliers (e.g. COVID-era spikes) that would
-        dominate an OLS slope; the trade-off is the SE recovered from the
-        rank-CI is approximate, not asymptotically exact.
+        point absorbs information coefficient (IC) outliers (e.g. COVID-era
+        spikes) that would dominate an OLS slope. The confidence interval is
+        descriptive; Mann-Kendall supplies the inferential reference.
 
     References:
         [Sen 1968][sen-1968]: Theil-Sen median pairwise slope.

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -33,17 +33,15 @@ standard-error / p estimator:
   block-bootstrapped (stationary blocks, Politis-White automatic block
   length); pairwise multiplicity is **Romano-Wolf** step-down
   (bootstrap-native, exploits the joint dependence through shared
-  slices). Never invalid: asymptotically valid *and* small-sample robust
-  (the block length absorbs serial autocorrelation, i.e. built-in HAC).
-  The right default for short regimes (T ≈ 30-80) where HAC asymptotics
-  are unreliable.
+  slices). This avoids a closed-form normal reference but is not uniformly
+  small-sample robust: the measured ``K=5`` short-slice cells over-reject.
 - ``"analytic"`` (opt-in) — each slice mean carries a Newey-West HAC
   variance; pairwise contrasts are Welch-style unequal-variance, the
   omnibus is a block-diagonal Wald χ²; pairwise multiplicity is **Holm**
   (no bootstrap distribution, so Romano-Wolf is unavailable). Faster,
-  deterministic, closed-form — choose it when T is large enough for HAC
-  asymptotics (rule of thumb T ≳ 100): decade sub-samples, pre/post,
-  in/out-of-sample.
+  deterministic, closed-form. It is also the better-calibrated pairwise
+  read at ``K=5`` in the measured short-slice grid; see
+  ``reference/inference-calibration``.
 
 The ``p_adj`` correction family is decided *internally* by ``method``
 (bootstrap → Romano-Wolf, analytic → Holm); there is deliberately no
@@ -386,9 +384,9 @@ def slice_period_pairwise_test(
         method: ``"bootstrap"`` (default) runs an independent stationary
             block bootstrap per slice with Romano-Wolf step-down ``p_adj``;
             ``"analytic"`` runs Newey-West HAC per slice with Welch-style
-            pairwise contrasts and Holm ``p_adj``. Use ``"bootstrap"`` for
-            short regimes (T ≈ 30-80); ``"analytic"`` for long spans
-            (T ≳ 100) when you want speed / determinism.
+            pairwise contrasts and Holm ``p_adj``. Neither dominates every
+            finite sample: at ``K=5`` the measured short-slice grid favours
+            the analytic Holm path. See ``reference/inference-calibration``.
         overlap_periods: The evaluation-grid overlap the sample floor (and,
             under ``method="analytic"``, the per-slice HAC bandwidth) resolve
             at. Normally omitted — :func:`factrix.preprocess.compute_forward_return`
@@ -400,9 +398,9 @@ def slice_period_pairwise_test(
         n_resamples: ``B`` for the ``"bootstrap"`` path (ignored by
             ``"analytic"``). Must be at least ``BOOTSTRAP_RESAMPLES_FLOOR``
             — the shared floor every factrix entry point reporting an
-            inference drawn from resamples enforces. The default 999 is
-            [Politis-White (2004)][politis-white-2004]'s recommendation for
-            two-sided 5% work.
+            inference drawn from resamples enforces. The default 999 gives
+            an empirical p-value grid of roughly 0.001; automatic block-length
+            selection is a separate Politis-White step.
         rng: Reproducibility seed for the ``"bootstrap"`` path
             (ignored by ``"analytic"``). ``None`` draws from system
             entropy and the resolved int is reported in the ``seed``
@@ -802,9 +800,9 @@ def slice_period_joint_test(
     methods share the same Wald quadratic form; they differ in how the null
     is referenced, mirroring the pairwise path: ``"analytic"`` uses an
     ``F_{K-1, ν}`` reference with a Satterthwaite ``ν``, while ``"bootstrap"`` calibrates the
-    statistic against its own block-bootstrap null (so a short-regime
-    omnibus stays small-sample robust instead of leaning on χ²
-    asymptotics). Useful for **regime analysis**: a single test of "does
+    statistic against its own block-bootstrap null. The bootstrap path is
+    still known to over-reject in the measured ``K=5`` short-slice cells.
+    Useful for **regime analysis**: a single test of "does
     this factor's edge differ across regimes at all?" before drilling into
     pairs.
 
@@ -829,9 +827,9 @@ def slice_period_joint_test(
         n_resamples: ``B`` for the ``"bootstrap"`` path (ignored by
             ``"analytic"``). Must be at least ``BOOTSTRAP_RESAMPLES_FLOOR``
             — the shared floor every factrix entry point reporting an
-            inference drawn from resamples enforces. The default 999 is
-            [Politis-White (2004)][politis-white-2004]'s recommendation for
-            two-sided 5% work.
+            inference drawn from resamples enforces. The default 999 gives
+            an empirical p-value grid of roughly 0.001; automatic block-length
+            selection is a separate Politis-White step.
         rng: Reproducibility seed for the ``"bootstrap"`` path
             (ignored by ``"analytic"``). ``None`` draws from system
             entropy and the resolved int is reported in the ``seed``

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,6 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
-    - navigation.expand
     - navigation.top
     - navigation.path
     - search.suggest
@@ -147,13 +146,11 @@ nav:
       - Concepts:
           - Overview: getting-started/concepts.md
           - Where factrix fits: where-factrix-fits.md
-          - Statistical methods: reference/statistical-methods.md
-          - Timeseries-mode conventions: reference/ts-mode-conventions.md
+          - Panel vs timeseries: guides/panel-timeseries.md
       - How-to:
           - Overview: guides/index.md
           - Preparing data: guides/preparing-data.md
           - Choosing a metric: guides/choosing-metric.md
-          - Panel vs timeseries: guides/panel-timeseries.md
           - Reading results: guides/reading-results.md
           - Validating allocation signals: guides/validating-allocation-signals.md
           - Observability: guides/observability.md
@@ -165,12 +162,15 @@ nav:
           - Overview: examples/index.md
           - Multi-factor screening: examples/multi_factor_screening.md
           - Stock factor evaluation: examples/stock_factor_evaluation.md
-      - Reference tables:
+      - Methods and reference:
+          - Statistical methods: reference/statistical-methods.md
+          - Inference calibration and limitations: reference/inference-calibration.md
+          - Common-factor regression conventions: reference/ts-mode-conventions.md
           - Glossary: reference/glossary.md
-          - Metrics applicability: reference/metric-applicability.md
-          - Stat keys: reference/stat-keys-by-metric.md
+          - Metric applicability: reference/metric-applicability.md
+          - Stat keys by metric: reference/stat-keys-by-metric.md
           - Warning codes: reference/warning-codes.md
-          - Metrics pipelines: reference/metric-pipelines.md
+          - Metric pipelines: reference/metric-pipelines.md
           - Bibliography: reference/bibliography.md
   - API reference:
       - Overview: api/index.md
@@ -202,7 +202,7 @@ nav:
           - Individual continuous:
               - Overview: api/metrics/individual-continuous.md
               - ic: api/metrics/ic.md
-              - fama_macbeth: api/metrics/fm_beta.md
+              - fm_beta: api/metrics/fm_beta.md
               - quantile: api/metrics/quantile.md
               - k_spread: api/metrics/k_spread.md
               - monotonicity: api/metrics/monotonicity.md
@@ -215,8 +215,8 @@ nav:
               - event_quality: api/metrics/event_quality.md
               - event_horizon: api/metrics/event_horizon.md
               - mfe_mae: api/metrics/mfe_mae.md
-              - clustering: api/metrics/clustering_hhi.md
-              - corrado: api/metrics/corrado_rank.md
+              - clustering_hhi: api/metrics/clustering_hhi.md
+              - corrado_rank: api/metrics/corrado_rank.md
           - Common sparse:
               - Overview: api/metrics/common-sparse.md
           - Common continuous:
@@ -231,7 +231,7 @@ nav:
               - directional_pair_accuracy: api/metrics/directional_pair_accuracy.md
               - predictive_beta: api/metrics/predictive_beta.md
               - trend: api/metrics/trend.md
-              - oos: api/metrics/oos_decay.md
+              - oos_decay: api/metrics/oos_decay.md
       - Supporting modules:
           - stats: api/stats.md
           - datasets: api/datasets.md
@@ -240,5 +240,7 @@ nav:
       - Architecture: development/architecture.md
       - Design notes: development/design-notes.md
       - Contributing: development/contributing.md
+      - Documentation conventions: development/documentation.md
+      - Release process: development/release-process.md
   - Release notes:
       - Changelog: development/changelog.md

--- a/tests/stats/test_driscoll_kraay_size.py
+++ b/tests/stats/test_driscoll_kraay_size.py
@@ -3,7 +3,7 @@
 The panel null combines a persistent regressor, cross-sectional common shocks,
 and overlapping forward returns. It pins the regression-specific calibration
 behind the public ``pooled_beta`` path without turning the test suite into the
-full 1,000-replication research run documented in statistical-methods.md.
+full 1,000-replication research run documented in inference-calibration.md.
 """
 
 from __future__ import annotations

--- a/tests/stats/test_event_skewness_size.py
+++ b/tests/stats/test_event_skewness_size.py
@@ -5,7 +5,7 @@ two-sided ``p``. The test has no calibrated pooled form, for two
 independent reasons, and the same-period clustering deflation
 ``event_hit_rate`` / ``event_ic`` apply repairs neither. Full table (300
 replications per cell, base seed 20260830) in
-``reference/statistical-methods`` section 6.
+``reference/inference-calibration``.
 
 1. **Non-normal signed CARs, no clustering needed.** On the null event
    panel — ``make_event_panel`` with ``post_event_drift_bps=0``,

--- a/tests/stats/test_inference_calibration_covers_every_p_value_path.py
+++ b/tests/stats/test_inference_calibration_covers_every_p_value_path.py
@@ -1,13 +1,13 @@
-"""Coverage guard: every metric that publishes a ``p_value`` is named in §6.
+"""Coverage guard: every p-value metric is named in the calibration reference.
 
-factrix's standing rule is that only *measured* inference paths are
-exposed. §6 of ``docs/reference/statistical-methods.md`` is where a path's
-size measurement — or an explicit statement that it has none yet — lives,
-so a metric that can return a non-``None`` ``p_value`` and is absent from
-§6 is an undocumented inference path, not merely a documentation gap.
+factrix's standing rule is that every exposed inference path is measured or
+explicitly disclosed as unmeasured. ``docs/reference/inference-calibration.md``
+is where that evidence or gap lives, so a metric that can return a non-``None``
+``p_value`` and is absent from the page is an undocumented inference path, not
+merely a documentation gap.
 
 The metric side is derived from source rather than from a hand-kept list,
-so a new p-emitting metric fails this test until §6 accounts for it. For
+so a new p-emitting metric fails this test until the page accounts for it. For
 each registered metric the scan walks its own function body for a
 ``MetricResult(...)`` whose ``p_value`` keyword is anything other than the
 literal ``None``; a metric that constructs no ``MetricResult`` itself
@@ -21,20 +21,12 @@ from __future__ import annotations
 
 import ast
 import pathlib
-import re
 
 import pytest
 from factrix._metric_index import public_specs
 
 METRICS_DIR = pathlib.Path("factrix/metrics")
-DOCS_PAGE = pathlib.Path("docs/reference/statistical-methods.md")
-
-
-def _section_6() -> str:
-    text = DOCS_PAGE.read_text(encoding="utf-8")
-    match = re.search(r"^## 6\..*?(?=^## 7\.)", text, re.M | re.S)
-    assert match, "section 6 not found — has the page been renumbered?"
-    return match.group(0)
+DOCS_PAGE = pathlib.Path("docs/reference/inference-calibration.md")
 
 
 def _module_functions(stem: str) -> dict[str, ast.FunctionDef]:
@@ -110,10 +102,10 @@ def test_the_scan_finds_a_plausible_number_of_p_value_paths():
 
 
 @pytest.mark.parametrize("metric_name", _p_value_metrics())
-def test_section_6_names_every_p_value_metric(metric_name):
-    assert f"`{metric_name}`" in _section_6(), (
-        f"{metric_name} publishes a p_value but §6 of "
+def test_calibration_reference_names_every_p_value_metric(metric_name):
+    text = DOCS_PAGE.read_text(encoding="utf-8")
+    assert f"`{metric_name}`" in text, (
+        f"{metric_name} publishes a p_value but "
         f"{DOCS_PAGE} does not name it. Every exposed inference path needs "
-        "a size measurement there, or an explicit statement that it has "
-        "none yet."
+        "a size measurement there or an explicit unmeasured disclosure."
     )

--- a/tests/stats/test_persistence_screen_beyond_horizon.py
+++ b/tests/stats/test_persistence_screen_beyond_horizon.py
@@ -8,8 +8,7 @@ bandwidth floor and the bootstrap block-length floor absorb, and which an
 unstrided lag-1 read would flag as a calibration failure it is not.
 
 Two nulls pin the two halves of that claim, at cut replication counts
-against the full grids recorded in ``reference/statistical-methods``
-section 6:
+against the full grids recorded in ``reference/inference-calibration``:
 
 * a per-asset AR(0.9) factor with overlapping returns — persistent factor,
   persistent *unstrided* IC series, nothing left after the stride: the

--- a/tests/stats/test_scalar_wald_overlap_size.py
+++ b/tests/stats/test_scalar_wald_overlap_size.py
@@ -5,7 +5,7 @@ restriction on an OLS fit, so they resolve their HAC reference through
 ``_resolve_scalar_wald_hac`` (the scalar HAR recipe) rather than through the
 ``max(auto_bartlett(T), h - 1)`` rule the K-restriction Wald paths keep.
 
-On the common-factor null of ``statistical-methods`` section 6 (300
+On the common-factor null of ``inference-calibration`` (300
 replications, seed ``20260830 + rep``) the change measures, at a nominal 5%:
 
 | metric | phi | T, h | narrow rule | shipped rule |

--- a/tests/stats/test_spread_bootstrap_size.py
+++ b/tests/stats/test_spread_bootstrap_size.py
@@ -6,7 +6,7 @@ admitting the member to ``quantile_spread`` / ``quantile_spread_vw`` /
 ``k_spread`` rests on its own measurement. The full 3x3 grid
 (``T`` in {60, 120, 240} x ``h`` in {1, 5, 21}, 500 replications per cell,
 ``n_resamples=499``, base seed 20260830) is recorded in
-``reference/statistical-methods`` section 6; measured there, the bootstrap
+``reference/inference-calibration``; measured there, the bootstrap
 rejects 4.8-9.0% at a nominal 5% across every measurable cell and
 ``NEWEY_WEST`` 2.4-7.6%.
 

--- a/tests/test_docs_allocation_boundaries.py
+++ b/tests/test_docs_allocation_boundaries.py
@@ -35,10 +35,9 @@ LINK_TARGETS = (
     "../reference/statistical-methods.md#2-multiple-testing-under-dependence",
     "../reference/statistical-methods.md"
     "#4-persistence-diagnostics-under-near-unit-root-predictors",
-    "../reference/statistical-methods.md"
+    "../reference/inference-calibration.md"
     "#joint-period-test-on-short-slices-known-over-rejection",
-    "../reference/statistical-methods.md"
-    "#persistence-beyond-the-overlap-horizon-no-hac-or-bootstrap-path-is-calibrated",
+    "../reference/inference-calibration.md#persistence-beyond-the-overlap-horizon",
     "../api/slice-test.md#warning-contract-slice_period_joint_test",
 )
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -7,7 +7,7 @@ only live symbols and still call them with a keyword that no longer exists,
 and nothing short of executing the block catches that.
 
 Execution contract (matches the "Runnable" / "Illustrative" split in
-``docs/development/contributing.md``):
+``docs/development/documentation.md``):
 
 * Every ``python`` fence on a page runs, in order, in one shared namespace —
   later blocks may build on earlier ones, as the prose reads. Any exception
@@ -130,7 +130,7 @@ def _run_page(text: str) -> list[_BlockFailure]:
     return failures
 
 
-# README.md is the one authored page outside docs/ with a python fence; the
+# README.md is the one authored page outside docs/ with a Python fence; the
 # quickstart it carries is the first snippet any user runs, and it lives under
 # the same rule as the docs pages — including the marker, which GitHub's
 # renderer ignores as trailing info-string text.


### PR DESCRIPTION
## Summary

- make the root and site entry pages task-first, remove repeated scope and setup prose, and clarify navigation boundaries
- separate statistical method contracts from empirical calibration evidence, while correcting stale inference descriptions across API pages and docstrings
- split maintainer guidance into contributing, documentation, and release references, and add bounded uv environment diagnostics without changing existing public URLs

## Verification

- `python -m pre_commit run --all-files --hook-stage pre-commit`
- `python -m mypy factrix`
- `python -m pytest -q -p no:faulthandler` (3613 passed, 46 skipped)
- `python -m pytest --doctest-modules factrix -q -p no:faulthandler` (96 passed, 1 skipped)
- focused documentation and inference-calibration contract tests (473 passed, 46 skipped)
- environment-troubleshooting documentation checks (251 passed, 46 skipped)
- GitHub strict MkDocs build and rendered-link check

The local strict build was blocked by this workstation's interrupted `mkdocs-material` installation and endpoint file scanning; the clean Linux CI build supplies the rendered-site gate.

Closes #966
