### PR TITLE
docs: align regression inference contracts

### DIFF
--- a/docs/api/metrics/predictive_beta.md
+++ b/docs/api/metrics/predictive_beta.md
@@ -34,12 +34,13 @@ title: factrix.metrics.predictive_beta
 
     ---
 
-    The headline bias-corrected slope test uses the project's scalar HAR
-    recipe: bandwidth
-    `min(max(1.3 * sqrt(T), 3 * (overlap_periods - 1)), ceil(T / 3))`,
-    finite-sample variance scale `T / (T - L - 1)`, and effective degrees
-    of freedom. The raw OLS reference retained in metadata stays on the
-    narrower Newey-West bandwidth and is labelled as uncorrected.
+    At `overlap_periods > 1`, the headline bias-corrected slope test uses
+    the project's scalar HAR bandwidth and effective degrees of freedom.
+    Its Amihud-Hurvich generated-regressor covariance does not apply the
+    separate finite-sample variance scale used by scalar Wald consumers.
+    At `overlap_periods = 1` it uses the original homoskedastic covariance.
+    The raw OLS reference retained in metadata stays on the narrower
+    Newey-West bandwidth and is labelled as uncorrected.
 
 -   __Persistent predictor diagnostic__
 

--- a/docs/api/metrics/spanning.md
+++ b/docs/api/metrics/spanning.md
@@ -45,7 +45,8 @@ title: factrix.metrics.spanning
     the GRS 1989 $F$). Standard tool for "does this factor add anything
     beyond the existing model?" (Barillas-Shanken 2017). Pass
     `overlap_periods=h` when the spreads are built on $h$-period
-    overlapping returns, so the Bartlett bandwidth is floored at $h-1$.
+    overlapping returns. The resulting rank-one alpha test follows the
+    shared [scalar HAR contract](../../reference/statistical-methods.md#hac-families).
 
 -   __Base factors are required__
 
@@ -175,12 +176,12 @@ title: factrix.metrics.spanning
 
     ---
 
-    Newey-West (NW) heteroskedasticity-and-autocorrelation-consistent
-    (HAC) $t$ on the alpha, with the bandwidth
-    $L=\max(\mathrm{auto\_bartlett}(T), h-1)$ — the same kernel
-    discipline `fm_beta` and `ic` use.
+    The rank-one alpha restriction uses the project's shared scalar HAR
+    bandwidth, finite-sample variance scale, and effective degrees of
+    freedom. The centralized formula also distinguishes this path from
+    multi-restriction Wald tests.
 
-    [reference/statistical-methods →](../../reference/statistical-methods.md)
+    [reference/statistical-methods →](../../reference/statistical-methods.md#hac-families)
 
 -   __Metric applicability reference__
 

--- a/factrix/metrics/spanning.py
+++ b/factrix/metrics/spanning.py
@@ -238,11 +238,11 @@ def spanning_alpha(
             so the metric short-circuits (see Returns).
         overlap_periods: Overlap horizon of the spread series. Spreads built
             from ``h``-period overlapping forward returns carry MA(``h-1``)
-            residual autocorrelation, so the HAC bandwidth is floored at
-            ``h - 1``. Leave at ``1`` for genuinely non-overlapping spreads
-            (the output of ``compute_spread_series``, which strides to the
-            rebalance schedule). ``evaluate`` injects the panel's stamped
-            horizon; a standalone call declares it.
+            residual autocorrelation, so this value is passed to the shared
+            scalar rank-one HAC resolver. Leave at ``1`` for genuinely
+            non-overlapping spreads (the output of ``compute_spread_series``,
+            which strides to the rebalance schedule). ``evaluate`` injects
+            the panel's stamped horizon; a standalone call declares it.
         expected_warnings: Warning codes the caller declares; a declared code
             is still recorded, the ``UserWarning`` echo is silenced.
 
@@ -281,33 +281,13 @@ def spanning_alpha(
         \qquad t = 1, \dots, T,
         $$
 
-        and test $H_0: \alpha = 0$ against a two-sided alternative with
-
-        $$
-        t_\alpha = \frac{\hat\alpha}{\mathrm{SE}_{\mathrm{NW}}(\hat\alpha)},
-        \qquad
-        \mathrm{SE}_{\mathrm{NW}}(\hat\alpha) =
-        \sqrt{\bigl[(X'X)^{-1} \hat S_L (X'X)^{-1}\bigr]_{0,0}},
-        $$
-
-        where $X = [\mathbf{1}, f_1, \dots, f_K]$ and $\hat S_L$ is the
-        Bartlett-kernel HAC score covariance
-
-        $$
-        \hat S_L = \hat\Omega_0 + \sum_{j=1}^{L}
-            \Bigl(1 - \tfrac{j}{L+1}\Bigr)(\hat\Omega_j + \hat\Omega_j'),
-        \qquad
-        \hat\Omega_j = \sum_t x_t \hat\varepsilon_t\,
-                       \hat\varepsilon_{t-j} x_{t-j}' .
-        $$
-
-        The bandwidth is
-        $L = \max(\mathrm{auto\_bartlett}(T),\, h - 1)$ with
-        $h = $ ``overlap_periods`` — the [Newey-West (1994)][newey-west-1994]
-        automatic rule floored against the
-        [Hansen-Hodrick (1980)][hansen-hodrick-1980] overlap horizon, the same
-        rule ``fm_beta`` and ``ic`` apply. $p$ is read against
-        $t(T - 1 - K)$.
+        and test $H_0: \alpha = 0$ against a two-sided alternative. Because
+        this is one restriction, its Bartlett bandwidth, finite-sample
+        variance scale, and effective reference degrees of freedom come from
+        :func:`factrix._stats.hac._resolve_scalar_wald_hac`. This scalar HAR
+        contract is distinct from the narrow multi-restriction Wald rule; the
+        centralized formula and path map live in
+        ``reference/statistical-methods``.
 
         A rejection means the candidate's spread carries return the base set
         does not span. $\hat\alpha$ is on the same per-period scale as the

--- a/tests/test_docs_inference_contracts.py
+++ b/tests/test_docs_inference_contracts.py
@@ -1,0 +1,26 @@
+"""Keep public regression-inference descriptions aligned with their consumers."""
+
+from pathlib import Path
+
+SPANNING_SOURCE = Path("factrix/metrics/spanning.py")
+SPANNING_DOCS = Path("docs/api/metrics/spanning.md")
+PREDICTIVE_DOCS = Path("docs/api/metrics/predictive_beta.md")
+
+
+def test_spanning_docs_delegate_to_the_scalar_har_contract() -> None:
+    source = SPANNING_SOURCE.read_text(encoding="utf-8")
+    docs = SPANNING_DOCS.read_text(encoding="utf-8")
+
+    assert "_resolve_scalar_wald_hac" in source
+    assert "statistical-methods.md#hac-families" in docs
+    for stale_claim in ("auto_bartlett", "T - 1 - K", "floored at $h-1$"):
+        assert stale_claim not in source
+        assert stale_claim not in docs
+
+
+def test_predictive_docs_do_not_claim_the_scalar_wald_variance_scale() -> None:
+    docs = PREDICTIVE_DOCS.read_text(encoding="utf-8")
+
+    assert "scalar HAR bandwidth and effective degrees of freedom" in docs
+    assert "does not apply the\n    separate finite-sample variance scale" in docs
+    assert "T / (T - L - 1)" not in docs


### PR DESCRIPTION
## Summary
- make spanning_alpha delegate its public HAC description to the shared scalar rank-one contract
- correct predictive_beta documentation to match the Amihud-Hurvich covariance actually used
- add focused drift guards for both public contracts

## Validation
- 34 focused metric and contract tests passed
- 428 documentation tests passed, 46 skipped
- Ruff check and format passed

Closes #965
Closes #973