### PR TITLE
refactor(metrics)!: remove duplicate period metadata

### DIFF
--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -296,27 +296,32 @@ def _spread_significance_with_inference(
     panel-stride feeds ``strided_spread`` for the common path; the full
     series is built (h× more bucketing) only when the requested member
     declares it consumes one. ``full_spread`` is ``None`` otherwise; a
-    missing one where the member needed it degrades to the strided
-    non-overlap path defensively and is flagged ``inference_overridden``.
+    missing one where the member needs it is an internal contract violation,
+    not permission to run a different estimator.
     """
     from factrix._stats.constants import MIN_ASSETS_WARN
-    from factrix.inference import NON_OVERLAPPING
 
-    use_full = inference.consumes_full_series and full_spread is not None
-    member: NonOverlapping | NeweyWest | StationaryBootstrap = (
-        inference if use_full else NON_OVERLAPPING
-    )
+    use_full = inference.consumes_full_series
+    if use_full and full_spread is None:
+        raise RuntimeError(
+            f"{metric_name}: {inference.summary} requires the full spread series"
+        )
+    member = inference
     data = full_spread if use_full else strided_spread
-    assert data is not None  # narrowed by use_full
+    assert data is not None  # full_spread narrowed by the guard above
     res = member.compute(
         data, value_col="spread", overlap_periods=overlap_periods if use_full else 1
     )
-    n_tested = res.n_obs if res.n_obs is not None else 0
+    if res.n_obs is None or res.estimate is None:
+        raise RuntimeError(
+            f"{metric_name}: {member.summary} returned an incomplete inference result"
+        )
+    n_tested = res.n_obs
     # ``value`` must describe the sample the test ran on, and the member that
     # ran is the only thing that knows what that sample was — a sub-sampling
     # member tested the survivors of its own stride. So the headline estimate
     # is always the member's, on every path.
-    mean_spread = res.estimate if res.estimate is not None else float("nan")
+    mean_spread = res.estimate
 
     extra: dict[str, object]
     if use_full:
@@ -324,12 +329,6 @@ def _spread_significance_with_inference(
     else:
         extra = {}
         _surface_inference_run_metadata(res, extra)
-        if inference.consumes_full_series:
-            # Requested a member that needs the full series but none was
-            # supplied — surface the degradation rather than report the
-            # strided non-overlap t under the requested method's name.
-            extra["inference_requested"] = inference.summary
-            extra["inference_overridden"] = True
     code_list: list[str] = []
     _emit_inference_warnings(
         res,
@@ -351,11 +350,9 @@ def _spread_significance_with_inference(
             stacklevel=3,
         )
     codes = tuple(code_list)
-    # ``method`` / ``stat_type`` describe the member that actually ran, not
-    # the one that was asked for: an ``inference_overridden`` degradation runs
-    # the non-overlap t and must say so, and a member whose ``stat`` is not a
-    # t-ratio (the bootstrap reports the observed mean under an empirical p)
-    # must not be read against a t-distribution.
+    # ``method`` / ``stat_type`` describe the member that ran. A member whose
+    # ``stat`` is not a t-ratio (the bootstrap reports the observed mean under
+    # an empirical p) must not be read against a t-distribution.
     return (
         mean_spread,
         res.stat,

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -235,13 +235,25 @@ def _spread_significance_with_inference(
     n_assets: int,
     metric_name: str,
     expected_warnings: tuple[str, ...] = (),
-) -> tuple[float, float, float, str, str, dict[str, object], tuple[str, ...]]:
+) -> tuple[
+    float,
+    float,
+    float,
+    str,
+    str,
+    int,
+    dict[str, object],
+    tuple[str, ...],
+]:
     """Single headline-significance chokepoint shared by every spread metric.
 
-    Returns ``(value, stat, p_value, method, stat_type, extra_metadata,
-    warning_codes)`` where ``value`` is the mean-spread point estimate over
-    the series the chosen member actually tested: the full overlapping series for a member
-    that consumes one, the strided series otherwise.
+    Returns ``(value, stat, p_value, method, stat_type, n_tested,
+    extra_metadata, warning_codes)`` where ``value`` is the mean-spread point
+    estimate over the series the chosen member actually tested: the full
+    overlapping series for a member that consumes one, the strided series
+    otherwise. ``n_tested`` stays an internal routing value so consumers can
+    expose it under their canonical ``n_periods`` key without adding a second
+    public metadata name.
 
     Both ``quantile_spread`` and ``k_spread`` route here so the policy lives
     in one place, and the routing is the member's own declaration rather than
@@ -318,10 +330,6 @@ def _spread_significance_with_inference(
             # strided non-overlap t under the requested method's name.
             extra["inference_requested"] = inference.summary
             extra["inference_overridden"] = True
-    # ``n_periods_tested`` is the sample the stat / p / value describe: the
-    # full overlapping series on one path, the strided series on the other.
-    extra["n_periods_tested"] = n_tested
-
     code_list: list[str] = []
     _emit_inference_warnings(
         res,
@@ -354,6 +362,7 @@ def _spread_significance_with_inference(
         res.p_value,
         member.summary,
         member.test,
+        n_tested,
         extra,
         codes,
     )

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -450,7 +450,7 @@ def k_spread(
     # names, not the universe-wide unique asset count (see
     # ``_median_per_date_count``).
     median_xs = _median_per_date_count(clean)
-    mean_spread, t, p, sig_method, sig_stat_type, sig_extra, sig_codes = (
+    mean_spread, t, p, sig_method, sig_stat_type, n, sig_extra, sig_codes = (
         _spread_significance_with_inference(
             inference,
             strided_spread=strided_series,
@@ -461,18 +461,6 @@ def k_spread(
             expected_warnings=expected_warnings,
         )
     )
-    # Sample the headline stat/p actually ran on: full overlapping series under
-    # HAC, strided otherwise. ``value``/``stat``/``p_value``/``n_obs`` all
-    # describe it.
-    n = int(
-        cast(
-            int,
-            sig_extra.get(
-                "n_periods_tested", sig_extra.get("n_periods_full", n_strided)
-            ),
-        )
-    )
-
     mean_dispersion = _finite_mean(series["xs_dispersion"])
     mean_top = _finite_mean(series["top_return"])
     mean_bottom = _finite_mean(series["bottom_return"])

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -439,9 +439,6 @@ def _quantile_spread_from_series(
             expected_warnings=expected_warnings,
         )
     )
-    # Sample the headline stat/p actually ran on: the full overlapping series on
-    # the HAC path, the strided one otherwise. ``value``/``stat``/``p_value``/
-    # ``n_obs`` must all describe it.
     # Long/short decomposition (spread = long_alpha + short_alpha)
     long_arr = _finite_values(
         series["top_return"] - series["universe_return"]

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -428,7 +428,7 @@ def _quantile_spread_from_series(
     clean_full_series = (
         full_series.filter(_finite_expr("spread")) if full_series is not None else None
     )
-    mean_spread, t, p, sig_method, sig_stat_type, sig_extra, sig_codes = (
+    mean_spread, t, p, sig_method, sig_stat_type, n, sig_extra, sig_codes = (
         _spread_significance_with_inference(
             inference,
             strided_spread=strided_series,
@@ -442,15 +442,6 @@ def _quantile_spread_from_series(
     # Sample the headline stat/p actually ran on: the full overlapping series on
     # the HAC path, the strided one otherwise. ``value``/``stat``/``p_value``/
     # ``n_obs`` must all describe it.
-    n = int(
-        cast(
-            int,
-            sig_extra.get(
-                "n_periods_tested", sig_extra.get("n_periods_full", n_strided)
-            ),
-        )
-    )
-
     # Long/short decomposition (spread = long_alpha + short_alpha)
     long_arr = _finite_values(
         series["top_return"] - series["universe_return"]
@@ -846,22 +837,23 @@ def quantile_spread_vw(
         ).select("date", pl.col("spread_vw").alias("spread"))
         full_series = full_series.filter(_finite_expr("spread"))
 
-    mean_spread, t, p, sig_method, sig_stat_type, sig_extra, sig_codes = (
-        _spread_significance_with_inference(
-            inference,
-            strided_spread=strided_series,
-            full_spread=full_series,
-            overlap_periods=overlap_periods,
-            n_assets=n_assets,
-            metric_name="quantile_spread_vw",
-            expected_warnings=expected_warnings,
-        )
-    )
-    n_tested = int(
-        cast(
-            int,
-            sig_extra.get("n_periods_tested", sig_extra.get("n_periods_full", n)),
-        )
+    (
+        mean_spread,
+        t,
+        p,
+        sig_method,
+        sig_stat_type,
+        n_tested,
+        sig_extra,
+        sig_codes,
+    ) = _spread_significance_with_inference(
+        inference,
+        strided_spread=strided_series,
+        full_spread=full_series,
+        overlap_periods=overlap_periods,
+        n_assets=n_assets,
+        metric_name="quantile_spread_vw",
+        expected_warnings=expected_warnings,
     )
     metadata: dict[str, object] = {
         "n_periods": n_tested,

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -888,7 +888,7 @@ class TestValueWeightedInference:
         assert hac.metadata["method"] == NEWEY_WEST.summary
         # value is the full-sample mean on the HAC path, the strided mean
         # otherwise — both describe the sample the headline ran on.
-        assert hac.metadata["n_periods_tested"] == hac.n_obs
+        assert hac.metadata["n_periods"] == hac.n_obs
 
     def test_pair_shares_the_inference_allowlist(self):
         panel = self._panel()

--- a/tests/test_spread_inference_dispatch.py
+++ b/tests/test_spread_inference_dispatch.py
@@ -20,6 +20,7 @@ tolerance to loosen.
 from __future__ import annotations
 
 import factrix as fx
+import polars as pl
 import pytest
 from factrix._errors import IncompatibleInferenceError
 from factrix._results import MetricResult
@@ -30,6 +31,7 @@ from factrix.inference import (
     StationaryBootstrap,
 )
 from factrix.inference.series_mean import HANSEN_HODRICK
+from factrix.metrics._helpers import _spread_significance_with_inference
 from factrix.metrics.k_spread import k_spread
 from factrix.metrics.quantile import quantile_spread, quantile_spread_vw
 from factrix.preprocess import compute_forward_return
@@ -102,6 +104,19 @@ def _run(metric_name: str, panel, inference) -> MetricResult:
             inference=inference,
         )
     return k_spread(panel, overlap_periods=OVERLAP_PERIODS, inference=inference)
+
+
+def test_full_series_member_rejects_missing_full_series():
+    """An internal routing error must not change the requested estimator."""
+    with pytest.raises(RuntimeError, match="requires the full spread series"):
+        _spread_significance_with_inference(
+            NEWEY_WEST,
+            strided_spread=pl.DataFrame({"spread": [0.01, -0.02, 0.03]}),
+            full_spread=None,
+            overlap_periods=5,
+            n_assets=80,
+            metric_name="quantile_spread",
+        )
 
 
 @pytest.mark.parametrize(("metric_name", "inference_name"), sorted(GOLDEN))

--- a/tests/test_spread_inference_dispatch.py
+++ b/tests/test_spread_inference_dispatch.py
@@ -142,14 +142,15 @@ def test_hansen_hodrick_rejected(panel, metric_name):
 @pytest.mark.parametrize(
     "metric_name", ["quantile_spread", "quantile_spread_vw", "k_spread"]
 )
-def test_stat_type_names_the_member_that_ran(
+def test_member_stat_type_and_sample_metadata(
     panel, metric_name, inference_name, expected_stat_type
 ):
-    """``stat_type`` follows the member, as it already does on ``ic``.
+    """Inference identity and the canonical tested-sample count stay aligned.
 
     The bootstrap's ``stat`` is the observed mean under an empirical p, not
     a t-ratio, so reporting ``"t"`` there would invite reading it against a
-    t-distribution.
+    t-distribution. ``n_periods`` is the sole public metadata alias for
+    ``n_obs`` across every spread metric and inference member.
     """
     inference = {
         "NON_OVERLAPPING": NON_OVERLAPPING,
@@ -158,6 +159,7 @@ def test_stat_type_names_the_member_that_ran(
     }[inference_name]
     result = _run(metric_name, panel, inference)
     assert result.metadata["stat_type"] == expected_stat_type
+    assert result.metadata["n_periods"] == result.n_obs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- remove the duplicate public tested-period metadata alias from all spread metrics
- return the tested sample count directly from the shared inference helper
- remove dead fallback chains in quantile_spread, quantile_spread_vw, and k_spread
- reject missing full-series input instead of silently changing NW/bootstrap to non-overlap inference
- reject incomplete inference results instead of inventing `n_obs=0` or `estimate=NaN`
- pin `n_periods == n_obs` across all three spread metrics and all three supported inference members

## Breaking change
Spread metric results no longer expose `metadata[n_periods_tested]`. Use `metadata[n_periods]` or `n_obs`.

The repository's pre-1.0 changelog policy keeps detailed migration notes in GitHub PRs/releases, so this branch does not add a conflicting Unreleased section or bump the version.

## Validation
- 121 focused spread, quantile, k-spread, and metadata-doc tests passed for the metadata removal
- 98 spread inference, quantile, and k-spread tests passed after the invariant checks
- Ruff format/check passed
- mypy passed for 83 source files
- no `n_periods_tested` references remain under factrix, tests, or docs

Closes #970