### PR TITLE
fix(metrics): make FM inference contracts explicit

### DIFF
--- a/docs/api/metrics/fm_beta.md
+++ b/docs/api/metrics/fm_beta.md
@@ -47,6 +47,10 @@ title: factrix.metrics.fm_beta
     raises `UserInputError`, because the obvious proxy
     $\mathrm{var}(\hat\beta_t)$ makes the multiplier $1 + t^2/T$
     identically and carries no EIV information.
+    If the supplied factor-return variance collapses to zero, the corrected
+    test is unavailable: the mean beta remains visible, while headline
+    `stat` / `p_value` are withheld and the uncorrected test is retained only
+    in explicitly named metadata fields.
 
 -   __Pooled OLS robustness check__
 
@@ -57,6 +61,11 @@ title: factrix.metrics.fm_beta
     `two_way_cluster_col`). When pooled $\hat\beta$ and FM
     $\hat\lambda$ disagree in sign, the result's `warnings` flag a
     misspecification red flag.
+    `overlap_periods` is recorded but not consumed on clustered paths because
+    dependence is defined by the declared cluster dimensions. If a
+    finite-sample two-way covariance is non-PSD, the OLS slope remains
+    descriptive but its test is withheld rather than replaced by one-way
+    inference.
 
 -   __Cross-section-robust pooled inference__
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -119,8 +119,9 @@ is emitted.
 - *primary*: `p_value` — NW HAC `t` on per-period λ. With
   `is_estimated_factor=True` the Shanken EIV correction is applied
   post-hoc and the corrected `p_value` replaces the raw value.
-- *secondary-test* (conditional, Shanken applied):
-  `p_value_uncorrected`, `stat_uncorrected`.
+- *secondary-test* (conditional, `is_estimated_factor=True`):
+  `p_value_uncorrected`, `stat_uncorrected`. These remain descriptive-only
+  diagnostics when the Shanken correction is unavailable.
 - *descriptive*: `n_periods`, `newey_west_lags` (the resolved HAR
   bandwidth), `hac_dof` (the effective degrees of freedom the `t` is read
   against), `overlap_periods`,
@@ -134,9 +135,11 @@ is emitted.
   `p_value` is read against the same `hac_dof` as `p_value_uncorrected`,
   so `p_value >= p_value_uncorrected` always.
 - *descriptive* (conditional, σ²_f ≈ 0): `shanken_correction` =
-  `"skipped_zero_factor_variance"` — the correction is undefined
-  when the factor-return variance collapses; the uncorrected NW
-  result is reported and `WarningCode.DEGENERATE_VARIANCE` is raised.
+  `"unavailable_zero_factor_variance"` — the correction is undefined
+  when the factor-return variance collapses. The mean beta remains the point
+  estimate, but `stat` / `p_value` are withheld and
+  `WarningCode.DEGENERATE_VARIANCE` is raised; the uncorrected test stays in
+  the explicitly named secondary fields only.
 
 #### `pooled_beta` (emits `MetricResult.name = "pooled_beta"`)
 
@@ -147,13 +150,19 @@ is emitted.
   cannot be formed.
 - Sample size: `MetricResult.n_obs` (row count entering the test).
 - *descriptive*: `n_clusters` (one-way) or `n_clusters_a`,
-  `n_clusters_b`, `n_clusters_intersection` (two-way).
+  `n_clusters_b`, `n_clusters_intersection` (two-way), `overlap_periods`, and
+  `overlap_periods_consumed` (`False` on clustered paths, where cluster
+  dimensions define dependence; `True` on Driscoll-Kraay, where the value
+  floors bandwidth and caps effective df).
 - *descriptive* (conditional, short-circuit): `reason =
   "insufficient_clusters"`, `n_clusters` (smallest G — first-class
   `n_obs` carries the row count), `min_required` (always 3), plus
   `metric_unavailable` in `warning_codes`.
-- *descriptive* (conditional): `variance_non_psd_fallback` — names
-  the fallback path when the meat matrix is non-PSD.
+- *descriptive* (conditional): `variance_status` =
+  `"non_psd_two_way_covariance"` when the requested two-way covariance cannot
+  support a slope test. The pooled OLS slope remains available, but `stat` /
+  `p_value` are withheld with `WarningCode.DEGENERATE_VARIANCE`; factrix does
+  not substitute a one-way covariance.
 - *descriptive* (Driscoll-Kraay path, `driscoll_kraay=True`):
   `se_method` (`"driscoll_kraay"`), `n_periods` (length of the
   cross-sectional score-sum series), and `driscoll_kraay_lags` (the
@@ -163,7 +172,9 @@ is emitted.
   `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` when `L > T / 5`; below 30
   it emits the binding `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` without a
   redundant bandwidth echo. It short-circuits to `value = NaN` with
-  `reason = "insufficient_periods"` below 3. An explicit
+  `reason = "insufficient_periods"` below 3, or
+  `reason = "singular_pooled_design_matrix"` when a sufficient-period design
+  remains singular. An explicit
   `driscoll_kraay_lags` replaces the automatic base
   but cannot undercut the overlap floor or exceed the estimability cap.
 

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -52,7 +52,6 @@ from factrix._stats import (
 )
 from factrix._stats.constants import MIN_PERIODS_WARN, PERSISTENT_SERIES_AUTOCORR
 from factrix._types import (
-    DEFAULT_FORWARD_PERIODS,
     EPSILON,
     MIN_FM_PERIODS_HARD,
     MIN_FM_PERIODS_WARN,
@@ -219,10 +218,11 @@ def fm_beta(
             restatement of the $t$-stat that carries no
             errors-in-variables information about the regressor. When
             $\sigma^2_f$ is below machine epsilon the multiplier is
-            undefined; the correction is skipped, the uncorrected
-            Newey-West $p$ is returned, and
-            ``WarningCode.DEGENERATE_VARIANCE`` is raised alongside
-            ``metadata["shanken_correction"]``.
+            undefined; the mean beta remains available, but the headline
+            statistic and $p$ are withheld. The uncorrected Newey-West test
+            is retained only in ``metadata["stat_uncorrected"]`` and
+            ``metadata["p_value_uncorrected"]``, alongside
+            ``WarningCode.DEGENERATE_VARIANCE``.
 
     Notes:
         Stage 2 of FM:
@@ -366,26 +366,31 @@ def fm_beta(
     if is_estimated_factor:
         sigma2_f = float(factor_return_var)  # type: ignore[arg-type]
         # σ²_f ≈ 0 means the factor premium series is flat; Shanken's
-        # denominator collapses and the correction is undefined. Skip
-        # rather than divide into EPSILON — the uncorrected NW result
-        # is the honest answer in a degenerate regime. A skipped
-        # correction is a regime switch, so it carries a warning code
-        # rather than only a metadata string.
+        # denominator collapses and the requested correction is undefined.
+        # Keep the mean beta and the uncorrected test as named diagnostics,
+        # but do not substitute that test into the headline fields.
         if sigma2_f < EPSILON:
-            metadata["shanken_correction"] = "skipped_zero_factor_variance"
+            metadata.update(
+                {
+                    "shanken_correction": "unavailable_zero_factor_variance",
+                    "p_value_uncorrected": p,
+                    "stat_uncorrected": t,
+                }
+            )
             _emit_warning(
                 WarningCode.DEGENERATE_VARIANCE,
                 f"factor_return_var={sigma2_f!r} is below "
                 f"EPSILON={EPSILON}, so the Shanken (1992) EIV multiplier "
-                f"1 + mean(β)²/σ²_f is undefined. The correction is "
-                f"skipped and the UNCORRECTED Newey-West p-value is "
-                f"returned — read it as un-adjusted for the estimated "
-                f"regressor.",
+                f"1 + mean(β)²/σ²_f is undefined. The mean beta is retained, "
+                f"but headline stat and p_value are withheld; the uncorrected "
+                f"Newey-West test is descriptive metadata only.",
                 label="fm_beta",
                 expected_warnings=expected_warnings,
                 warning_codes=warning_codes,
                 stacklevel=2,
             )
+            t = float("nan")
+            p_final = float("nan")
         else:
             c = 1.0 + (mean_beta**2) / sigma2_f
             sqrt_c = math.sqrt(c)
@@ -491,7 +496,7 @@ def _pooled_beta_driscoll_kraay(
     cluster_col: str,
     two_way_cluster_col: str | None,
     lags: int | None,
-    overlap_periods: int,
+    overlap_periods: int | None,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
     r"""Driscoll-Kraay (1998) cross-section-robust SE path for ``pooled_beta``.
@@ -584,6 +589,7 @@ def _pooled_beta_driscoll_kraay(
         "hac_scale": hac_scale,
         "hac_dof": hac_dof,
         "overlap_periods": overlap_periods,
+        "overlap_periods_consumed": True,
     }
     stat, p_out, alternative = _degenerate_test_fields(
         t_stat, p, "two-sided", metadata, warning_codes
@@ -644,10 +650,31 @@ def pooled_beta(
     two_way_cluster_col: str | None = None,
     driscoll_kraay: bool = False,
     driscoll_kraay_lags: int | None = None,
-    overlap_periods: int = DEFAULT_FORWARD_PERIODS,
+    overlap_periods: int | None = None,
     expected_warnings: tuple[str, ...] = (),
 ) -> MetricResult:
     r"""Pooled ordinary least squares (OLS) with clustered SE — robustness check against FM.
+
+    Args:
+        data: Panel containing the factor, forward return, and cluster columns.
+        factor_col: Factor column used as the pooled OLS regressor.
+        return_col: Return column used as the pooled OLS response.
+        cluster_col: Primary cluster dimension. It is also the period axis for
+            the Driscoll-Kraay score series.
+        two_way_cluster_col: Optional second cluster dimension for the
+            Cameron-Gelbach-Miller two-way covariance.
+        driscoll_kraay: Use Driscoll-Kraay cross-section-robust HAC inference
+            instead of clustered covariance.
+        driscoll_kraay_lags: Optional Bartlett bandwidth for the
+            Driscoll-Kraay score series.
+        overlap_periods: Forward-return overlap horizon. The
+            Driscoll-Kraay path consumes it as a bandwidth floor and
+            effective-df cap. Clustered covariance does not use it because
+            dependence is defined by the declared cluster dimensions; that
+            path records the value as metadata only. Defaults to ``None`` for
+            standalone calls; ``evaluate`` injects the panel stamp.
+        expected_warnings: Warning codes whose per-run ``UserWarning`` echo
+            should be suppressed while preserving the structured record.
 
     Clustering on date alone catches contemporaneous cross-sectional
     dependence but misses asset-level persistence; on asset alone the
@@ -756,7 +783,14 @@ def pooled_beta(
         estimability cap. ``metadata["driscoll_kraay_lags"]``,
         ``metadata["hac_scale"]`` and ``metadata["hac_dof"]`` report the
         resolved test. ``overlap_periods`` is injected from the panel by
-        ``evaluate``; standalone calls may pass it directly.
+        ``evaluate``; standalone calls may pass it directly. Metadata records
+        it on both paths and sets ``overlap_periods_consumed`` to distinguish
+        the Driscoll-Kraay bandwidth input from the clustered-path audit value.
+
+        A finite-sample two-way covariance can be non-PSD. In that case the
+        pooled OLS slope remains descriptive, but ``stat`` and ``p_value`` are
+        withheld with ``DEGENERATE_VARIANCE``. factrix does not silently
+        replace the requested two-way covariance with one-way inference.
 
         factrix reports ``value = NaN`` and ``stat = None`` (rather than a
         finite slope and zero statistic) when ``G < 3`` because the
@@ -929,19 +963,17 @@ def pooled_beta(
 
     with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
         V = c_obs * xtx_inv @ effective_meat @ xtx_inv
-    v_slope = V[1, 1]
-    non_psd_fallback = False
-    # Two-way V can be numerically non-PSD in small samples (CGM 2011
-    # §2.2). Clipping to 0 would report SE=0 / p=1 — that looks like
-    # "accept null" but is actually "variance undefined", the opposite
-    # of honest. Cameron-Miller (2015, JHR) recommend falling back to
-    # the larger-dimension single-way V, which is always PSD.
+    v_slope = float(V[1, 1])
+    variance_status: str | None = None
+    # A finite-sample two-way covariance need not be PSD (CGM 2011 §2.3).
+    # A one-way replacement answers a different question, while clipping the
+    # negative variance to zero invents infinite evidence. Preserve the OLS
+    # slope and withhold only the unavailable two-way test.
     if v_slope < 0.0 and two_way_cluster_col is not None:
-        v_slope = float(
-            c_obs * (xtx_inv @ ((g_a / (g_a - 1)) * meat_a) @ xtx_inv)[1, 1]
-        )
-        non_psd_fallback = True
-    se_slope = float(np.sqrt(max(v_slope, 0.0)))
+        variance_status = "non_psd_two_way_covariance"
+        se_slope = float("nan")
+    else:
+        se_slope = float(np.sqrt(max(v_slope, 0.0)))
 
     # A zero clustered SE is degeneracy in the MAXIMUM-evidence direction
     # (perfect fit, zero residuals), never the null. The former
@@ -956,10 +988,12 @@ def pooled_beta(
         "stat_type": "t",
         "h0": "β=0",
         "method": method_desc,
+        "overlap_periods": overlap_periods,
+        "overlap_periods_consumed": False,
         **cluster_metadata,
     }
-    if non_psd_fallback:
-        metadata["variance_non_psd_fallback"] = f"one_way_{cluster_col}"
+    if variance_status is not None:
+        metadata["variance_status"] = variance_status
     if n_non_finite_dropped:
         metadata["dropped_pairs"] = n_non_finite_dropped
 

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -512,6 +512,37 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert out.metadata["n_clusters_b"] == 2
         assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
 
+    def test_non_psd_two_way_covariance_does_not_fall_back_to_one_way(self):
+        rng = np.random.default_rng(7)
+        n_dates, n_assets = 3, 4
+        date_ids = np.repeat(np.arange(n_dates), n_assets)
+        asset_ids = np.tile(np.arange(n_assets), n_dates)
+        factor = rng.normal(size=n_dates * n_assets)
+        returns = (
+            0.002 * factor
+            + rng.normal(scale=0.02, size=n_dates)[date_ids]
+            + rng.normal(scale=0.02, size=n_assets)[asset_ids]
+            + rng.normal(scale=0.01, size=n_dates * n_assets)
+        )
+        panel = pl.DataFrame(
+            {
+                "date": date_ids,
+                "asset_id": asset_ids,
+                "factor": factor,
+                "forward_return": returns,
+            }
+        )
+
+        out = pooled_beta(panel, two_way_cluster_col="asset_id")
+
+        assert np.isfinite(out.value)
+        assert out.stat is None
+        assert out.p_value is None
+        assert out.alternative is None
+        assert out.metadata["variance_status"] == "non_psd_two_way_covariance"
+        assert "variance_non_psd_fallback" not in out.metadata
+        assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
+
 
 class TestShankenCorrection:
     """The EIV path: mandatory σ²_f, HAR df, and the degenerate regime."""
@@ -589,11 +620,15 @@ class TestShankenCorrection:
                 factor_return_var=0.0,
             )
         assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
-        assert out.metadata["shanken_correction"] == "skipped_zero_factor_variance"
-        # Skipped, so the uncorrected result stands and no Shanken key appears.
+        assert out.metadata["shanken_correction"] == "unavailable_zero_factor_variance"
         assert "shanken_c" not in out.metadata
         uncorrected = fm_beta(self._beta_df(betas))
-        assert out.p_value == pytest.approx(uncorrected.p_value)
+        assert out.value == pytest.approx(uncorrected.value)
+        assert out.stat is None
+        assert out.p_value is None
+        assert out.alternative is None
+        assert out.metadata["stat_uncorrected"] == pytest.approx(uncorrected.stat)
+        assert out.metadata["p_value_uncorrected"] == pytest.approx(uncorrected.p_value)
 
     def test_expected_warnings_silences_the_degenerate_regime(self):
         betas = self._draw(120, 0.004, 7)

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -54,7 +54,7 @@ def _se(result) -> float:
 class TestDriscollKraayPath:
     def test_metadata_marks_se_method(self):
         df = _common_factor_panel(n_dates=60, n_assets=12, rho=0.3)
-        res = pooled_beta(df, driscoll_kraay=True)
+        res = pooled_beta(df, driscoll_kraay=True, overlap_periods=5)
         assert res.metadata["se_method"] == "driscoll_kraay"
         assert "Driscoll-Kraay" in res.metadata["method"]
         assert res.metadata["n_periods"] == 60
@@ -64,6 +64,7 @@ class TestDriscollKraayPath:
         assert res.metadata["hac_scale"] == pytest.approx(scale)
         assert res.metadata["hac_dof"] == pytest.approx(dof)
         assert res.metadata["overlap_periods"] == 5
+        assert res.metadata["overlap_periods_consumed"] is True
 
     def test_point_estimate_matches_clustered_path(self):
         # SE method does not change the OLS slope — only its variance.
@@ -105,6 +106,19 @@ class TestDriscollKraayPath:
         assert res.p_value == 1.0
         assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
 
+    def test_singular_design_has_its_own_reason(self):
+        df = _common_factor_panel(n_dates=12, n_assets=10, rho=0.2).with_columns(
+            pl.lit(1.0).alias("factor")
+        )
+
+        res = pooled_beta(df, driscoll_kraay=True)
+
+        assert np.isnan(res.value)
+        assert res.stat is None
+        assert res.p_value == 1.0
+        assert res.metadata["reason"] == "singular_pooled_design_matrix"
+        assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
+
     def test_mutually_exclusive_with_two_way_cluster(self):
         df = _common_factor_panel(n_dates=40, n_assets=10, rho=0.2)
         with pytest.raises(ValueError, match="mutually exclusive"):
@@ -138,6 +152,15 @@ class TestDriscollKraayPath:
         res = pooled_beta(df)
         assert "se_method" not in res.metadata
         assert "clustered SE" in res.metadata["method"]
+        assert res.metadata["overlap_periods"] is None
+        assert res.metadata["overlap_periods_consumed"] is False
+
+    def test_clustered_path_records_but_does_not_consume_overlap(self):
+        df = _common_factor_panel(n_dates=60, n_assets=12, rho=0.3)
+        res = pooled_beta(df, overlap_periods=21)
+
+        assert res.metadata["overlap_periods"] == 21
+        assert res.metadata["overlap_periods_consumed"] is False
 
     def test_driscoll_kraay_p_value_degrees_of_freedom(self):
         import scipy.stats as sp_stats


### PR DESCRIPTION
## Summary

- make pooled overlap metadata observable and consume it only on the Driscoll-Kraay path
- pin the sufficient-period singular Driscoll-Kraay design to its dedicated short-circuit reason
- withhold headline Shanken inference when factor-return variance collapses
- stop replacing a non-PSD two-way clustered covariance with one-way inference
- document and test the public result contracts

## Inference behavior

The FM mean beta and pooled OLS slope remain available as descriptive point estimates when the requested covariance cannot support a test. Headline stat and p_value are withheld; explicitly named uncorrected diagnostics or variance status remain in metadata. No uncalibrated PSD projection is introduced.

## Validation

- 3624 passed, 46 skipped
- Ruff passed
- mypy passed (83 source files)
- diff check passed

## Merge order

This PR is stacked on #979. Merge #979 first, then retarget or merge this PR.

Closes #975
Closes #976
Closes #983