### PR TITLE
refactor(stats): streamline alpha regression

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from factrix._stats.core import _degenerate_t_input
-from factrix._stats.ols import _ols_scalar_wald_hac
+from factrix._stats.ols import _ols_scalar_wald_hac_from_finite
 from factrix._types import EPSILON
 
 
@@ -56,11 +56,10 @@ def ols_alpha(
     scalar statistic. The default ``1`` (no floor) is the non-overlapping
     case.
 
-    **The trade, measured.** Both columns below predate the current scalar HAR
-    recipe and are retained because they motivated retiring the OLS SE. The
-    current recipe's measurements follow the table. Empirical size at a
-    nominal 5% under a true null (``alpha = 0``, one base factor, 4000 draws,
-    read against ``t(n - k)``):
+    **The trade, measured.** The table records why the OLS SE was retired;
+    measurements for the current scalar HAR recipe follow it. Empirical size
+    at a nominal 5% under a true null (``alpha = 0``, one base factor, 4000
+    draws):
 
     | residuals | OLS | HAC (narrow rule, superseded) |
     |---|---|---|
@@ -113,8 +112,10 @@ def ols_alpha(
     version returned, which claimed the factor added exactly nothing.
 
     Raises:
-        ValueError: ``candidate`` or ``base_matrix`` holds a non-finite
-            value. ``np.linalg.lstsq`` does not raise on NaN input — it
+        ValueError: ``base_matrix`` is not a two-dimensional
+            ``(n_obs, n_base_factors)`` array, or ``candidate`` /
+            ``base_matrix`` holds a non-finite value. ``np.linalg.lstsq``
+            does not raise on NaN input — it
             returns a NaN solution, so an unguarded NaN became a NaN alpha
             and a NaN t far from the cause. The guard lives in the kernel
             rather than at the call sites: ``spanning`` filtered before all
@@ -125,6 +126,11 @@ def ols_alpha(
     """
     candidate = np.asarray(candidate, dtype=float)
     base_matrix = np.asarray(base_matrix, dtype=float)
+    if base_matrix.ndim != 2:
+        raise ValueError(
+            "ols_alpha: base_matrix must be 2-D (n_obs, n_base_factors); "
+            "reshape(-1, 1) a single factor."
+        )
     if candidate.size and not np.all(np.isfinite(candidate)):
         raise ValueError("ols_alpha: candidate must be finite (no NaN / inf).")
     if base_matrix.size and not np.all(np.isfinite(base_matrix)):
@@ -137,19 +143,28 @@ def ols_alpha(
     ones = np.ones((n_obs, 1))
     X = np.hstack([ones, base_matrix]) if base_matrix.shape[1] > 0 else ones
 
-    try:
-        beta, _, _, _ = np.linalg.lstsq(X, candidate, rcond=None)
-    except np.linalg.LinAlgError:
-        # Rank-deficient design (collinear base factors, or a base factor
-        # equal to the candidate). The fit does not exist, so neither does
-        # alpha: NaN rather than 0.0, which would read as "this factor adds
-        # exactly nothing" -- a decisive claim from a failed computation.
-        return _OLSResult(alpha=float("nan"), alpha_t=float("nan"))
+    # The HAC kernel already returns the OLS coefficients and residuals. Use
+    # that fit as the common path instead of solving the same design once via
+    # ``lstsq`` and again via ``(X'X)^-1 X'y`` inside the kernel.
+    hac = _ols_scalar_wald_hac_from_finite(
+        candidate, X, overlap_periods=overlap_periods
+    )
+    beta = hac.beta
+    resid = hac.resid
+
+    if not np.all(np.isfinite(beta)):
+        # The inverse-based kernel refuses a singular or saturated design,
+        # while ``lstsq`` can still supply the minimum-norm descriptive fit.
+        # Preserve that long-standing point-estimate contract, but the NaN
+        # HAC covariance below continues to withhold its t-statistic.
+        try:
+            beta, _, _, _ = np.linalg.lstsq(X, candidate, rcond=None)
+        except np.linalg.LinAlgError:
+            return _OLSResult(alpha=float("nan"), alpha_t=float("nan"))
+        resid = candidate - X @ beta
 
     alpha = float(beta[0])
     betas = [float(b) for b in beta[1:]]
-
-    resid = candidate - X @ beta
 
     ss_res = float(np.dot(resid, resid))
     centered = candidate - np.mean(candidate)
@@ -177,10 +192,6 @@ def ols_alpha(
             df_resid=dof,
         )
 
-    # The shared entry point owns bandwidth resolution and the matching
-    # finite-sample scale, so a new rank-one OLS consumer cannot apply only
-    # part of the scalar HAR contract.
-    hac = _ols_scalar_wald_hac(candidate, X, overlap_periods=overlap_periods)
     se_alpha = float(np.sqrt(max(hac.covariance[0, 0], 0.0)))
 
     if _degenerate_t_input(se_alpha, 1):

--- a/factrix/_stats/ols.py
+++ b/factrix/_stats/ols.py
@@ -158,6 +158,16 @@ def _ols_nw_multivariate(
     """
     y = _require_finite(y, "_ols_nw_multivariate")
     X = _require_finite(X, "_ols_nw_multivariate")
+    return _ols_nw_multivariate_from_finite(y, X, lags=lags)
+
+
+def _ols_nw_multivariate_from_finite(
+    y: np.ndarray,
+    X: np.ndarray,
+    *,
+    lags: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Fit :func:`_ols_nw_multivariate` after the caller validated input."""
     n, k = X.shape
     not_computable = (np.full(k, np.nan), np.full((k, k), np.nan), np.zeros(n))
     if len(y) != n or n < k + 1:
@@ -219,10 +229,32 @@ def _ols_scalar_wald_hac(
     shared warning policy, including suppression below the common warning
     floor.
     """
+    # Keep the historical error label from the kernel while routing the
+    # validated arrays through the shared fit below. ``ols_alpha`` uses that
+    # fit directly after its field-specific validation, avoiding a second
+    # full-array finiteness scan.
+    y = _require_finite(y, "_ols_nw_multivariate")
+    X = _require_finite(X, "_ols_nw_multivariate")
+    return _ols_scalar_wald_hac_from_finite(
+        y,
+        X,
+        lags=lags,
+        overlap_periods=overlap_periods,
+    )
+
+
+def _ols_scalar_wald_hac_from_finite(
+    y: np.ndarray,
+    X: np.ndarray,
+    *,
+    lags: int | None = None,
+    overlap_periods: int | None = None,
+) -> _ScalarWaldHacFit:
+    """Fit :func:`_ols_scalar_wald_hac` after caller-side validation."""
     resolved_lags, variance_scale, dof = _resolve_scalar_wald_hac(
         len(y), lags, overlap_periods
     )
-    beta, covariance, resid = _ols_nw_multivariate(y, X, lags=resolved_lags)
+    beta, covariance, resid = _ols_nw_multivariate_from_finite(y, X, lags=resolved_lags)
     return _ScalarWaldHacFit(
         beta=beta,
         covariance=covariance * variance_scale,

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -534,6 +534,26 @@ class TestOlsAlphaFiniteContract:
         result = ols_alpha(candidate, np.empty((len(candidate), 0)))
         assert result.alpha == pytest.approx(float(np.mean(candidate)))
 
+    def test_one_dimensional_base_matrix_is_rejected(self):
+        from factrix._ols import ols_alpha
+
+        candidate, base = self._design()
+        with pytest.raises(ValueError, match="2-D"):
+            ols_alpha(candidate, base[:, 0])
+
+    def test_regular_fit_does_not_solve_twice(self, monkeypatch):
+        from factrix._ols import ols_alpha
+
+        candidate, base = self._design()
+
+        def fail_lstsq(*_args, **_kwargs):
+            raise AssertionError("regular fits must reuse the HAC kernel fit")
+
+        monkeypatch.setattr(np.linalg, "lstsq", fail_lstsq)
+        result = ols_alpha(candidate, base)
+        assert math.isfinite(result.alpha)
+        assert math.isfinite(result.alpha_t)
+
 
 class TestAlphaTIsHac:
     """``alpha_t`` divides by a Newey-West HAC SE, not the homoskedastic OLS SE.


### PR DESCRIPTION
## Summary

- reuse the scalar HAR kernel coefficients and residuals instead of solving the same alpha regression twice
- retain the minimum-norm descriptive fit only when the inverse-based HAC kernel refuses a singular or saturated design
- avoid a duplicate full-array finiteness scan while preserving field-specific errors
- reject one-dimensional base matrices with an actionable shape error
- remove duplicate wording from the alpha calibration docstring

## Scope decision

This keeps the optimization local to ols_alpha. It does not add a prepared-design cache to greedy selection: the measured remaining waste is only a few milliseconds per typical selection run and a cache would enlarge the private estimator API without changing results.

## Timing

Minimum of 5 runs, 200 calls each in the repo virtual environment:

- n=120, k=2: about 72 microseconds per call (issue baseline about 197)
- n=1000, k=10: about 668 microseconds per call (issue baseline about 1098)

## Validation

- 78 focused spanning and scalar-HAR consumer tests passed
- Ruff passed
- mypy passed (83 source files)
- diff check passed

## Merge order

This PR is stacked on #979. Merge #979 first, then retarget or merge this PR.

Closes #968
Closes #969