### PR TITLE
fix(metrics): remove FM inference fallbacks

### DIFF
--- a/docs/api/metrics/fm_beta.md
+++ b/docs/api/metrics/fm_beta.md
@@ -47,6 +47,10 @@ title: factrix.metrics.fm_beta
     raises `UserInputError`, because the obvious proxy
     $\mathrm{var}(\hat\beta_t)$ makes the multiplier $1 + t^2/T$
     identically and carries no EIV information.
+    If the supplied factor-return variance collapses to zero, the corrected
+    test is unavailable: the mean beta remains visible, while headline
+    `stat` / `p_value` are withheld and the uncorrected test is retained only
+    in explicitly named metadata fields.
 
 -   __Pooled OLS robustness check__
 
@@ -57,6 +61,9 @@ title: factrix.metrics.fm_beta
     `two_way_cluster_col`). When pooled $\hat\beta$ and FM
     $\hat\lambda$ disagree in sign, the result's `warnings` flag a
     misspecification red flag.
+    If a finite-sample two-way covariance is non-PSD, the OLS slope remains
+    descriptive but its test is withheld rather than replaced by one-way
+    inference.
 
 -   __Cross-section-robust pooled inference__
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -128,7 +128,9 @@ is emitted.
 
 - *primary*: `p_value` — NW HAC `t` on per-period λ. With
   `is_estimated_factor=True` the Shanken EIV correction is applied
-  post-hoc and the corrected `p_value` replaces the raw value.
+  post-hoc and the corrected `p_value` replaces the raw value — unless the
+  correction is unavailable, in which case both are withheld (see the
+  σ²_f ≈ 0 entry below).
 - *secondary-test* (conditional, `is_estimated_factor=True`):
   `p_value_uncorrected`, `stat_uncorrected`. These remain descriptive-only
   diagnostics when the Shanken correction is unavailable.
@@ -154,9 +156,11 @@ is emitted.
 
 - *primary*: `p_value` — single- or two-way clustered OLS `t`. When
   the cluster count G < 3 the test is short-circuited with `stat =
-  None`, `value = NaN`, and `p_value = 1.0`; the algebraic slope is not
-  exposed as a usable pooled beta when its declared covariance estimator
-  cannot be formed.
+  None`, `value = NaN`, and `p_value = 1.0`: with two clusters the sample
+  cannot support a clustered estimate, so the algebraic slope is not
+  exposed as a usable pooled beta. A non-PSD two-way covariance is the
+  other withheld-inference regime and keeps `value` — see
+  `variance_status` below.
 - Sample size: `MetricResult.n_obs` (row count entering the test).
 - *descriptive*: `n_clusters` (one-way) or `n_clusters_a`,
   `n_clusters_b`, `n_clusters_intersection` (two-way).

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -129,8 +129,9 @@ is emitted.
 - *primary*: `p_value` — NW HAC `t` on per-period λ. With
   `is_estimated_factor=True` the Shanken EIV correction is applied
   post-hoc and the corrected `p_value` replaces the raw value.
-- *secondary-test* (conditional, Shanken applied):
-  `p_value_uncorrected`, `stat_uncorrected`.
+- *secondary-test* (conditional, `is_estimated_factor=True`):
+  `p_value_uncorrected`, `stat_uncorrected`. These remain descriptive-only
+  diagnostics when the Shanken correction is unavailable.
 - *descriptive*: `n_periods`, `newey_west_lags` (the resolved HAR
   bandwidth), `hac_dof` (the effective degrees of freedom the `t` is read
   against), `overlap_periods`,
@@ -144,9 +145,10 @@ is emitted.
   `p_value` is read against the same `hac_dof` as `p_value_uncorrected`,
   so `p_value >= p_value_uncorrected` always.
 - *descriptive* (conditional, σ²_f ≈ 0): `shanken_correction` =
-  `"skipped_zero_factor_variance"` — the correction is undefined
-  when the factor-return variance collapses; the uncorrected NW
-  result is reported and `WarningCode.DEGENERATE_VARIANCE` is raised.
+  `"unavailable_zero_factor_variance"` — the correction is undefined when
+  factor-return variance collapses. The mean beta remains, but `stat` /
+  `p_value` are withheld with `WarningCode.DEGENERATE_VARIANCE`; the
+  uncorrected test stays in the explicitly named secondary fields only.
 
 #### `pooled_beta` (emits `MetricResult.name = "pooled_beta"`)
 
@@ -162,8 +164,11 @@ is emitted.
   "insufficient_clusters"`, `n_clusters` (smallest G — first-class
   `n_obs` carries the row count), `min_required` (always 3), plus
   `metric_unavailable` in `warning_codes`.
-- *descriptive* (conditional): `variance_non_psd_fallback` — names
-  the fallback path when the meat matrix is non-PSD.
+- *descriptive* (conditional): `variance_status` =
+  `"non_psd_two_way_covariance"` when the requested two-way covariance cannot
+  support a slope test. The pooled OLS slope remains available, but `stat` /
+  `p_value` are withheld with `WarningCode.DEGENERATE_VARIANCE`; factrix does
+  not substitute a one-way covariance.
 - *descriptive* (Driscoll-Kraay path, `driscoll_kraay=True`):
   `se_method` (`"driscoll_kraay"`), `n_periods` (length of the
   cross-sectional score-sum series), and `driscoll_kraay_lags` (the

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -51,6 +51,7 @@ from factrix._stats import (
     _resolve_scalar_wald_hac,
 )
 from factrix._stats.constants import MIN_PERIODS_WARN, PERSISTENT_SERIES_AUTOCORR
+from factrix._stats.core import _degenerate_t_input
 from factrix._types import (
     DEFAULT_FORWARD_PERIODS,
     EPSILON,
@@ -548,7 +549,7 @@ def _pooled_beta_driscoll_kraay(
     # ``t = 0.0 -> p = 1.0`` reported "no relationship" for a sample that fits
     # exactly, and carried no warning code - pooled_beta was the only metric
     # in the library skipping the repo's own degenerate-sample convention.
-    t_stat = float("nan") if se_slope < EPSILON else slope / se_slope
+    t_stat = float("nan") if _degenerate_t_input(se_slope, 1) else slope / se_slope
     p = _p_value_from_t(t_stat, n_periods, dof=hac_dof)
 
     warning_codes: list[str] = []
@@ -952,7 +953,7 @@ def pooled_beta(
     # ``t = 0.0 -> p = 1.0`` reported "no relationship" for a sample that fits
     # exactly, and carried no warning code - pooled_beta was the only metric
     # in the library skipping the repo's own degenerate-sample convention.
-    t_stat = float("nan") if se_slope < EPSILON else slope / se_slope
+    t_stat = float("nan") if _degenerate_t_input(se_slope, 1) else slope / se_slope
 
     p = _p_value_from_t(t_stat, df_t)
 

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -219,8 +219,9 @@ def fm_beta(
             \equiv 1 + t^2_{\mathrm{iid}}/T$ identically — an algebraic
             restatement of the $t$-stat that carries no
             errors-in-variables information about the regressor. When
-            $\sigma^2_f$ is below machine epsilon the multiplier is
-            undefined; the mean beta remains available, but the headline
+            $\sigma^2_f$ is below ``EPSILON`` (``1e-9``, not machine
+            epsilon) the multiplier is undefined; the mean beta remains
+            available, but the headline
             statistic and $p$ are withheld. The uncorrected Newey-West test
             is retained only in ``metadata["stat_uncorrected"]`` and
             ``metadata["p_value_uncorrected"]``, alongside
@@ -290,21 +291,41 @@ def fm_beta(
         >>> result.name == ""
         True
     """
-    if is_estimated_factor and factor_return_var is None:
-        raise UserInputError(
-            func_name="fm_beta",
-            field="factor_return_var",
-            value=factor_return_var,
-            expected=(
-                "the time-series variance of the factor-mimicking portfolio "
-                "return (a float) whenever is_estimated_factor=True. There is "
-                "no usable default: substituting var(β̂_t) makes the Shanken "
-                "multiplier 1 + mean(β)²/var(β̂_t) identically 1 + t²/T, which "
-                "is a restatement of the t-stat and carries no "
-                "errors-in-variables information about the regressor"
-            ),
-            docs_path=_DOCS_FM_BETA,
-        )
+    if is_estimated_factor:
+        if factor_return_var is None:
+            raise UserInputError(
+                func_name="fm_beta",
+                field="factor_return_var",
+                value=factor_return_var,
+                expected=(
+                    "the time-series variance of the factor-mimicking "
+                    "portfolio return (a float) whenever "
+                    "is_estimated_factor=True. There is no usable default: "
+                    "substituting var(β̂_t) makes the Shanken multiplier "
+                    "1 + mean(β)²/var(β̂_t) identically 1 + t²/T, which is a "
+                    "restatement of the t-stat and carries no "
+                    "errors-in-variables information about the regressor"
+                ),
+                docs_path=_DOCS_FM_BETA,
+            )
+        if not math.isfinite(factor_return_var) or factor_return_var < 0.0:
+            # Rejected at the boundary rather than folded into the σ²_f ≈ 0
+            # regime below. NaN fails ``< EPSILON``, so it would reach the
+            # multiplier as ``1 + mean(β)²/NaN`` and withhold the test while
+            # metadata still named Shanken as applied; a negative value is
+            # not a variance at all, and reporting it as "below EPSILON"
+            # would describe an invalid input as a degenerate sample.
+            raise UserInputError(
+                func_name="fm_beta",
+                field="factor_return_var",
+                value=factor_return_var,
+                expected=(
+                    "a finite, non-negative variance. A NaN or negative "
+                    "value is an invalid input, not the flat-premium regime "
+                    "the σ²_f ≈ 0 branch handles"
+                ),
+                docs_path=_DOCS_FM_BETA,
+            )
 
     betas = beta_df["beta"].drop_nulls().to_numpy()
     n = len(betas)
@@ -765,14 +786,17 @@ def pooled_beta(
         resolved test. ``overlap_periods`` is injected from the panel by
         ``evaluate``; standalone calls may pass it directly.
 
-        factrix reports ``value = NaN`` and ``stat = None`` (rather than a
-        finite slope and zero statistic) when ``G < 3`` because the
-        cluster-robust variance is undefined with too few clusters. Retaining
-        the algebraic OLS slope in the headline field would let downstream
-        aggregation treat an inference-unavailable cell as a valid pooled
-        beta; falling back to a homoskedastic SE would silently break the
-        panel-correlation guarantee that motivated using clustered SE in the
-        first place.
+        Two regimes withhold the test, and they differ in what happens to
+        ``value``. Under ``G < 3`` factrix reports ``value = NaN`` and
+        ``stat = None``: with two clusters the *sample* cannot support a
+        clustered estimate at all, so the algebraic slope is not a pooled
+        beta any downstream aggregation should average. A non-PSD two-way
+        covariance is the other case — the OLS slope is estimated exactly as
+        usual and only the finite-sample *variance* estimator failed, so
+        ``value`` stays and just ``stat`` / ``p_value`` are withheld. In
+        neither case does factrix fall back to a homoskedastic or one-way SE,
+        which would silently break the panel-correlation guarantee that
+        motivated clustering in the first place.
 
     References:
         - [Petersen (2009)][petersen-2009]. "Estimating Standard Errors
@@ -969,6 +993,22 @@ def pooled_beta(
         metadata["dropped_pairs"] = n_non_finite_dropped
 
     degenerate_codes: list[str] = []
+    if variance_status is not None:
+        # The sibling withheld-inference path in ``fm_beta`` names its cause
+        # in a message; a p-value that simply disappears should not be the
+        # quieter of the two.
+        _emit_warning(
+            WarningCode.DEGENERATE_VARIANCE,
+            "the requested two-way clustered covariance came out non-PSD in "
+            "this finite sample, so the slope variance is unavailable. The "
+            "pooled OLS slope is returned, but stat and p_value are withheld "
+            "— factrix does not substitute a one-way covariance under a "
+            "two-way method label.",
+            label="pooled_beta",
+            expected_warnings=expected_warnings,
+            warning_codes=degenerate_codes,
+            stacklevel=2,
+        )
     stat, p_out, alternative = _degenerate_test_fields(
         t_stat, p, "two-sided", metadata, degenerate_codes
     )

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -219,10 +219,11 @@ def fm_beta(
             restatement of the $t$-stat that carries no
             errors-in-variables information about the regressor. When
             $\sigma^2_f$ is below machine epsilon the multiplier is
-            undefined; the correction is skipped, the uncorrected
-            Newey-West $p$ is returned, and
-            ``WarningCode.DEGENERATE_VARIANCE`` is raised alongside
-            ``metadata["shanken_correction"]``.
+            undefined; the mean beta remains available, but the headline
+            statistic and $p$ are withheld. The uncorrected Newey-West test
+            is retained only in ``metadata["stat_uncorrected"]`` and
+            ``metadata["p_value_uncorrected"]``, alongside
+            ``WarningCode.DEGENERATE_VARIANCE``.
 
     Notes:
         Stage 2 of FM:
@@ -366,26 +367,31 @@ def fm_beta(
     if is_estimated_factor:
         sigma2_f = float(factor_return_var)  # type: ignore[arg-type]
         # σ²_f ≈ 0 means the factor premium series is flat; Shanken's
-        # denominator collapses and the correction is undefined. Skip
-        # rather than divide into EPSILON — the uncorrected NW result
-        # is the honest answer in a degenerate regime. A skipped
-        # correction is a regime switch, so it carries a warning code
-        # rather than only a metadata string.
+        # denominator collapses and the requested correction is undefined.
+        # Keep the mean beta and the uncorrected test as named diagnostics,
+        # but do not substitute that test into the headline fields.
         if sigma2_f < EPSILON:
-            metadata["shanken_correction"] = "skipped_zero_factor_variance"
+            metadata.update(
+                {
+                    "shanken_correction": "unavailable_zero_factor_variance",
+                    "p_value_uncorrected": p,
+                    "stat_uncorrected": t,
+                }
+            )
             _emit_warning(
                 WarningCode.DEGENERATE_VARIANCE,
                 f"factor_return_var={sigma2_f!r} is below "
                 f"EPSILON={EPSILON}, so the Shanken (1992) EIV multiplier "
-                f"1 + mean(β)²/σ²_f is undefined. The correction is "
-                f"skipped and the UNCORRECTED Newey-West p-value is "
-                f"returned — read it as un-adjusted for the estimated "
-                f"regressor.",
+                f"1 + mean(β)²/σ²_f is undefined. The mean beta is retained, "
+                f"but headline stat and p_value are withheld; the uncorrected "
+                f"Newey-West test is descriptive metadata only.",
                 label="fm_beta",
                 expected_warnings=expected_warnings,
                 warning_codes=warning_codes,
                 stacklevel=2,
             )
+            t = float("nan")
+            p_final = float("nan")
         else:
             c = 1.0 + (mean_beta**2) / sigma2_f
             sqrt_c = math.sqrt(c)
@@ -929,19 +935,17 @@ def pooled_beta(
 
     with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
         V = c_obs * xtx_inv @ effective_meat @ xtx_inv
-    v_slope = V[1, 1]
-    non_psd_fallback = False
-    # Two-way V can be numerically non-PSD in small samples (CGM 2011
-    # §2.2). Clipping to 0 would report SE=0 / p=1 — that looks like
-    # "accept null" but is actually "variance undefined", the opposite
-    # of honest. Cameron-Miller (2015, JHR) recommend falling back to
-    # the larger-dimension single-way V, which is always PSD.
+    v_slope = float(V[1, 1])
+    variance_status: str | None = None
+    # A finite-sample two-way covariance need not be PSD (CGM 2011 §2.3).
+    # A one-way replacement answers a different question, while clipping the
+    # negative variance to zero invents infinite evidence. Preserve the OLS
+    # slope and withhold only the unavailable two-way test.
     if v_slope < 0.0 and two_way_cluster_col is not None:
-        v_slope = float(
-            c_obs * (xtx_inv @ ((g_a / (g_a - 1)) * meat_a) @ xtx_inv)[1, 1]
-        )
-        non_psd_fallback = True
-    se_slope = float(np.sqrt(max(v_slope, 0.0)))
+        variance_status = "non_psd_two_way_covariance"
+        se_slope = float("nan")
+    else:
+        se_slope = float(np.sqrt(max(v_slope, 0.0)))
 
     # A zero clustered SE is degeneracy in the MAXIMUM-evidence direction
     # (perfect fit, zero residuals), never the null. The former
@@ -958,8 +962,8 @@ def pooled_beta(
         "method": method_desc,
         **cluster_metadata,
     }
-    if non_psd_fallback:
-        metadata["variance_non_psd_fallback"] = f"one_way_{cluster_col}"
+    if variance_status is not None:
+        metadata["variance_status"] = variance_status
     if n_non_finite_dropped:
         metadata["dropped_pairs"] = n_non_finite_dropped
 

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -543,6 +543,31 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert "variance_non_psd_fallback" not in out.metadata
         assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
 
+    def test_the_withheld_two_way_test_names_its_cause(self):
+        """A p-value that disappears should say why, as ``fm_beta`` does."""
+        rng = np.random.default_rng(7)
+        n_dates, n_assets = 3, 4
+        date_ids = np.repeat(np.arange(n_dates), n_assets)
+        asset_ids = np.tile(np.arange(n_assets), n_dates)
+        factor = rng.normal(size=n_dates * n_assets)
+        returns = (
+            0.002 * factor
+            + rng.normal(scale=0.02, size=n_dates)[date_ids]
+            + rng.normal(scale=0.02, size=n_assets)[asset_ids]
+            + rng.normal(scale=0.01, size=n_dates * n_assets)
+        )
+        panel = pl.DataFrame(
+            {
+                "date": date_ids,
+                "asset_id": asset_ids,
+                "factor": factor,
+                "forward_return": returns,
+            }
+        )
+
+        with pytest.warns(UserWarning, match="non-PSD"):
+            pooled_beta(panel, two_way_cluster_col="asset_id")
+
     def test_a_non_finite_slope_se_is_caught_by_the_guard_not_by_division(self):
         """The withheld-variance path must not depend on ``slope / nan``.
 
@@ -628,6 +653,30 @@ class TestShankenCorrection:
         # The proxy is refused because it is algebraically inert, and the
         # message has to say so — see the docstring's 1 + t^2/T identity.
         assert "1 + t" in str(err)
+
+    @pytest.mark.parametrize("bad", [float("nan"), -1.0])
+    def test_a_non_variance_factor_return_var_is_refused_at_the_boundary(self, bad):
+        """NaN and negative are invalid input, not the flat-premium regime.
+
+        REGRESSION: NaN failed the ``sigma2_f < EPSILON`` guard, reached the
+        multiplier as ``1 + mean(beta)**2 / NaN`` and withheld the test while
+        metadata still reported ``method`` as Shanken-corrected with
+        ``shanken_c = nan`` and no warning at all. A negative variance was
+        reported as "below EPSILON", describing bad input as a degenerate
+        sample.
+        """
+        from factrix._errors import UserInputError
+
+        betas = self._draw(120, 0.004, 5)
+        with pytest.raises(UserInputError) as excinfo:
+            fm_beta(
+                self._beta_df(betas),
+                is_estimated_factor=True,
+                factor_return_var=bad,
+            )
+        err = excinfo.value
+        assert err.field == "factor_return_var"
+        assert "finite, non-negative" in str(err)
 
     def test_degenerate_factor_variance_raises_a_warning_code(self):
         betas = self._draw(120, 0.004, 7)

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -512,6 +512,37 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert out.metadata["n_clusters_b"] == 2
         assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
 
+    def test_non_psd_two_way_covariance_does_not_fall_back_to_one_way(self):
+        rng = np.random.default_rng(7)
+        n_dates, n_assets = 3, 4
+        date_ids = np.repeat(np.arange(n_dates), n_assets)
+        asset_ids = np.tile(np.arange(n_assets), n_dates)
+        factor = rng.normal(size=n_dates * n_assets)
+        returns = (
+            0.002 * factor
+            + rng.normal(scale=0.02, size=n_dates)[date_ids]
+            + rng.normal(scale=0.02, size=n_assets)[asset_ids]
+            + rng.normal(scale=0.01, size=n_dates * n_assets)
+        )
+        panel = pl.DataFrame(
+            {
+                "date": date_ids,
+                "asset_id": asset_ids,
+                "factor": factor,
+                "forward_return": returns,
+            }
+        )
+
+        out = pooled_beta(panel, two_way_cluster_col="asset_id")
+
+        assert np.isfinite(out.value)
+        assert out.stat is None
+        assert out.p_value is None
+        assert out.alternative is None
+        assert out.metadata["variance_status"] == "non_psd_two_way_covariance"
+        assert "variance_non_psd_fallback" not in out.metadata
+        assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
+
 
 class TestShankenCorrection:
     """The EIV path: mandatory σ²_f, HAR df, and the degenerate regime."""
@@ -589,11 +620,15 @@ class TestShankenCorrection:
                 factor_return_var=0.0,
             )
         assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
-        assert out.metadata["shanken_correction"] == "skipped_zero_factor_variance"
-        # Skipped, so the uncorrected result stands and no Shanken key appears.
+        assert out.metadata["shanken_correction"] == "unavailable_zero_factor_variance"
         assert "shanken_c" not in out.metadata
         uncorrected = fm_beta(self._beta_df(betas))
-        assert out.p_value == pytest.approx(uncorrected.p_value)
+        assert out.value == pytest.approx(uncorrected.value)
+        assert out.stat is None
+        assert out.p_value is None
+        assert out.alternative is None
+        assert out.metadata["stat_uncorrected"] == pytest.approx(uncorrected.stat)
+        assert out.metadata["p_value_uncorrected"] == pytest.approx(uncorrected.p_value)
 
     def test_expected_warnings_silences_the_degenerate_regime(self):
         betas = self._draw(120, 0.004, 7)

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -543,6 +543,24 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert "variance_non_psd_fallback" not in out.metadata
         assert WarningCode.DEGENERATE_VARIANCE.value in out.warning_codes
 
+    def test_a_non_finite_slope_se_is_caught_by_the_guard_not_by_division(self):
+        """The withheld-variance path must not depend on ``slope / nan``.
+
+        REGRESSION: the non-PSD branch hands the SE forward as NaN, and a
+        raw ``se < EPSILON`` test is False for NaN — the withheld test then
+        survived only because dividing by NaN happens to give NaN. The
+        shared ``_degenerate_t_input`` boundary (the one ``_ols.py`` uses)
+        recognises NaN directly, so a later change to the division cannot
+        silently turn a withheld test into a reported one.
+        """
+        from factrix._stats.core import _degenerate_t_input
+        from factrix._types import EPSILON
+
+        assert (float("nan") < EPSILON) is False
+        assert _degenerate_t_input(float("nan"), 1) is True
+        assert _degenerate_t_input(0.0, 1) is True
+        assert _degenerate_t_input(1.0, 1) is False
+
 
 class TestShankenCorrection:
     """The EIV path: mandatory σ²_f, HAR df, and the degenerate regime."""


### PR DESCRIPTION
## Summary

- withhold headline FM inference when the requested Shanken correction is undefined
- retain the uncorrected Newey-West statistic and p-value only as explicitly named diagnostics
- withhold the clustered slope test when a requested two-way covariance is non-PSD
- keep both point estimates available without substituting a different inference method

No PSD projection or estimator fallback is introduced.

## Validation

- full suite: 3,654 passed, 46 skipped
- focused FM/docs suite: 254 passed
- Ruff and mypy passed
- git diff --check passed

Closes #983