### PR TITLE
fix(inference): reject unknown alternatives

### DIFF
--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -38,6 +38,7 @@ from typing import Literal
 
 import numpy as np
 
+from factrix._stats.core import _validate_p_value_alternative
 from factrix._types import EPSILON, PValueAlternative
 
 #: Refusal floor for every entry point that exposes a user-settable resample
@@ -511,6 +512,7 @@ def _block_bootstrap_diff_p(
         for the null, and the former sentinel also broke the documented
         ``block_length >= 1`` invariant for anyone reading the metadata.
     """
+    _validate_p_value_alternative(alternative, func_name="_block_bootstrap_diff_p")
     diff = np.asarray(diff, dtype=float)
     # A NaN would make ``centred`` all-NaN, every ``|boot| >= |obs|`` test
     # False and the reported p collapse to ``1 / (B + 1)`` — the *strongest*

--- a/factrix/_stats/core.py
+++ b/factrix/_stats/core.py
@@ -8,10 +8,31 @@ heteroskedasticity-and-autocorrelation-consistent (HAC) t-tests in ``factrix._st
 
 from __future__ import annotations
 
+from typing import get_args
+
 import numpy as np
 from scipy import stats as sp_stats
 
+from factrix._errors import UserInputError
 from factrix._types import DDOF, EPSILON, PValueAlternative
+
+_P_VALUE_ALTERNATIVES: tuple[str, ...] = get_args(PValueAlternative)
+
+
+def _validate_p_value_alternative(
+    alternative: object,
+    *,
+    func_name: str,
+) -> None:
+    """Reject a runtime value outside :class:`PValueAlternative`."""
+    if alternative not in _P_VALUE_ALTERNATIVES:
+        raise UserInputError(
+            func_name=func_name,
+            field="alternative",
+            value=alternative,
+            candidates=_P_VALUE_ALTERNATIVES,
+            docs_path="reference/statistical-methods",
+        )
 
 
 def _degenerate_t_input(std: float, n: int) -> bool:
@@ -99,6 +120,7 @@ def _p_value_from_t(
             (:func:`factrix._stats.hac._har_dof`). Returns 1.0 if the
             resolved ``dof`` is below 1.
     """
+    _validate_p_value_alternative(alternative, func_name="_p_value_from_t")
     dof = n - 1 if dof is None else dof
     if dof < 1:
         return 1.0

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -164,8 +164,10 @@ class NonOverlapping:
         alternative: PValueAlternative = "two-sided",
     ) -> InferenceResult:
         from factrix._stats import _p_value_from_t, _t_stat_from_array
+        from factrix._stats.core import _validate_p_value_alternative
         from factrix.metrics._helpers import _sample_non_overlapping
 
+        _validate_p_value_alternative(alternative, func_name=type(self).__name__)
         # Stride on the *calendar* (every h-th unique date) before dropping
         # non-finite rows, so a dropped observation cannot shift the sampling
         # phase; striding the cleaned row index would silently re-align the
@@ -276,7 +278,9 @@ class NeweyWest:
             _newey_west_t_test,
             _resolve_har_lags,
         )
+        from factrix._stats.core import _validate_p_value_alternative
 
+        _validate_p_value_alternative(alternative, func_name=type(self).__name__)
         vals = _clean_series(data, value_col).to_numpy()
         n = len(vals)
         newey_west_lags = _resolve_har_lags(n, None, overlap_periods) if n >= 2 else 0
@@ -364,7 +368,9 @@ class HansenHodrick:
         alternative: PValueAlternative = "two-sided",
     ) -> InferenceResult:
         from factrix._stats import _hansen_hodrick_t_test
+        from factrix._stats.core import _validate_p_value_alternative
 
+        _validate_p_value_alternative(alternative, func_name=type(self).__name__)
         vals = _clean_series(data, value_col).to_numpy()
         n = len(vals)
         t_stat, p_value, _, clamped = _hansen_hodrick_t_test(
@@ -509,7 +515,9 @@ class StationaryBootstrap:
         alternative: PValueAlternative = "two-sided",
     ) -> InferenceResult:
         from factrix._stats.bootstrap import _block_bootstrap_diff_p
+        from factrix._stats.core import _validate_p_value_alternative
 
+        _validate_p_value_alternative(alternative, func_name=type(self).__name__)
         vals = _clean_series(data, value_col).to_numpy()
         n = len(vals)
         p_value, boot_metadata = _block_bootstrap_diff_p(

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -18,6 +18,7 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix._codes import WarningCode
+from factrix._errors import UserInputError
 from factrix._stats import (
     _hansen_hodrick_t_test,
     _har_dof,
@@ -143,6 +144,29 @@ def test_series_mean_members_honor_predeclared_tail(member, sign: float) -> None
     favored = "greater" if sign > 0 else "less"
     opposed = "less" if sign > 0 else "greater"
     assert p[favored] < p["two-sided"] < p[opposed]
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        NON_OVERLAPPING,
+        NEWEY_WEST,
+        HansenHodrick(),
+        StationaryBootstrap(n_resamples=199, rng=0),
+    ],
+)
+def test_series_mean_members_reject_unknown_alternative(member) -> None:
+    with pytest.raises(UserInputError) as exc_info:
+        member.compute(
+            _series_df(np.arange(20.0)),
+            value_col="ic",
+            overlap_periods=1,
+            alternative="grater",  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.func_name == type(member).__name__
+    assert exc_info.value.field == "alternative"
+    assert exc_info.value.suggestions == ("greater",)
 
 
 class TestNeweyWest:

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -6,6 +6,7 @@ import math
 
 import numpy as np
 import pytest
+from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
     _block_bootstrap_diff_p,
     _politis_white_block_length,
@@ -201,6 +202,13 @@ class TestStudentizedDiffP:
         assert math.isnan(meta["block_length"])
         assert meta["n_resamples"] == 0
         assert meta["studentized"] is False
+
+    def test_short_series_still_rejects_unknown_alternative(self):
+        with pytest.raises(UserInputError, match="greater"):
+            _block_bootstrap_diff_p(
+                np.array([0.5]),
+                alternative="grater",  # type: ignore[arg-type]
+            )
 
     def test_p_floor_smoothing(self):
         # p should never be exactly 0 (Davison-Hinkley smoothing).

--- a/tests/test_significance.py
+++ b/tests/test_significance.py
@@ -4,6 +4,7 @@ import math
 
 import numpy as np
 import pytest
+from factrix._errors import UserInputError
 from factrix._stats import (
     _calc_t_stat,
     _p_value_from_t,
@@ -56,6 +57,11 @@ class TestTStatFromArray:
     def test_constant_non_zero_array(self):
         # The reported shape: every observation identical and non-zero.
         assert math.isnan(_t_stat_from_array(np.full(10, 0.03)))
+
+
+def test_p_value_rejects_unknown_alternative_before_short_sample_fallback():
+    with pytest.raises(UserInputError, match="greater"):
+        _p_value_from_t(0.0, 1, "grater")  # type: ignore[arg-type]
 
 
 class TestSignificanceMarker:


### PR DESCRIPTION
## Summary

- reject unknown p-value alternatives at every series-mean inference entry point
- guard analytic and bootstrap kernels so invalid tails cannot fall through to two-sided logic
- validate before short-sample exits and provide typo suggestions through UserInputError

## Validation

- 3659 passed, 46 skipped
- Ruff passed
- mypy passed
- git diff --check passed

Closes #989