### PR TITLE
fix(quantile): label leg test alternative

### DIFF
--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -33,7 +33,10 @@ title: factrix.metrics.quantile
     Test $H_0: \mathbb{E}[\text{spread}] = 0$ on the non-overlap
     spread series, with the long-vs-short alpha decomposition
     (`top - universe`, `universe - bottom`) attached so callers can
-    attribute the spread to long-side vs short-side excess.
+    attribute the spread to long-side vs short-side excess. The headline
+    accepts a directional `alternative`; the two leg p-values remain
+    two-sided and report `metadata["leg_alternative"] = "two-sided"` because
+    a directional hypothesis about their sum does not constrain each leg.
 
 -   __Value-weighted spread for capacity diagnostics__
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -514,6 +514,10 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 - *secondary-test*: `short_alpha`, `short_stat`, `short_p_value`,
   `short_significance` — short-leg attribution, on
   `n_periods_short_leg` observations.
+- *secondary-test*: `leg_alternative` — always `"two-sided"` for both leg
+  p-values, independent of the headline `alternative`. The headline tests the
+  sum `long_alpha + short_alpha`; a directional hypothesis about that sum does
+  not imply that each component has the same direction.
 - *descriptive*: `n_periods` (**the sample the headline test ran on**,
   equal to `n_obs`: the strided series under `NON_OVERLAPPING`, the full
   overlapping series under `NEWEY_WEST` / `STATIONARY_BOOTSTRAP`),

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -231,6 +231,9 @@ def quantile_spread(
         ``top_return - universe_return`` and ``universe_return -
         bottom_return`` regardless of ``inference`` — it attributes the
         spread to long-side vs short-side excess, it is not the headline H0.
+        Leg p-values are always two-sided and metadata records
+        ``leg_alternative="two-sided"``. A directional hypothesis about the
+        sum does not imply that both component means have that direction.
         Each leg is tested on its own finite sample (``n_periods_long_leg``
         / ``n_periods_short_leg``), which can be shorter than the spread
         sample when only one bucket was empty on a date.
@@ -480,6 +483,7 @@ def _quantile_spread_from_series(
         "short_stat": t_short,
         "short_p_value": p_short,
         "short_significance": _significance_marker(p_short),
+        "leg_alternative": "two-sided",
         "tie_ratio": tie_ratio,
         "tie_policy": tie_policy,
         **sig_extra,

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -8,6 +8,7 @@ import polars as pl
 import pytest
 from factrix._codes import WarningCode
 from factrix._errors import IncompatibleInferenceError
+from factrix._stats import _p_value_from_t
 from factrix.inference import NEWEY_WEST
 from factrix.inference.series_mean import HANSEN_HODRICK
 from factrix.metrics.quantile import (
@@ -120,6 +121,24 @@ class TestQuantileSpread:
             assert "long_stat" in result.metadata
             assert "short_stat" in result.metadata
             assert result.p_value is not None
+
+    def test_leg_tests_label_their_two_sided_alternative(self, noisy_panel):
+        result = quantile_spread(
+            noisy_panel,
+            overlap_periods=1,
+            n_groups=5,
+            alternative="greater",
+        )["factor"]
+        metadata = result.metadata
+
+        assert result.alternative == "greater"
+        assert metadata["leg_alternative"] == "two-sided"
+        for leg in ("long", "short"):
+            stat = metadata[f"{leg}_stat"]
+            n_obs = metadata[f"n_periods_{leg}_leg"]
+            assert metadata[f"{leg}_p_value"] == pytest.approx(
+                _p_value_from_t(stat, n_obs, "two-sided")
+            )
 
     def test_constant_factor_returns_explicit_no_signal(self):
         rng = np.random.default_rng(12)


### PR DESCRIPTION
## Summary

- record leg_alternative=two-sided beside quantile spread leg p-values
- keep leg tests independent from the directional headline hypothesis
- document the headline/leg distinction in the API and statistical-key reference

## Statistical rationale

The headline tests the sum long_alpha + short_alpha. A directional hypothesis about that sum does not imply that both component means share the same direction, so the attribution tests remain two-sided and now state that contract explicitly.

## Validation

- 3654 passed, 46 skipped
- Ruff passed
- mypy passed
- docs example/reference tests passed
- git diff --check passed

Closes #991