### PR TITLE
test(metrics): pin DK singular failure reason

### DIFF
--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -105,6 +105,19 @@ class TestDriscollKraayPath:
         assert res.p_value == 1.0
         assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
 
+    def test_singular_design_has_its_own_reason(self):
+        df = _common_factor_panel(n_dates=12, n_assets=10, rho=0.2).with_columns(
+            pl.lit(1.0).alias("factor")
+        )
+
+        res = pooled_beta(df, driscoll_kraay=True)
+
+        assert np.isnan(res.value)
+        assert res.stat is None
+        assert res.p_value == 1.0
+        assert res.metadata["reason"] == "singular_pooled_design_matrix"
+        assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
+
     def test_mutually_exclusive_with_two_way_cluster(self):
         df = _common_factor_panel(n_dates=40, n_assets=10, rho=0.2)
         with pytest.raises(ValueError, match="mutually exclusive"):


### PR DESCRIPTION
## Summary

- verify that a sufficient-period but singular pooled design reaches the Driscoll-Kraay covariance path
- pin reason=singular_pooled_design_matrix separately from the n_periods < 3 insufficient_periods short-circuit
- confirm the unavailable result contract (NaN value, no stat, conservative p sentinel, metric_unavailable)

## Finding

The current runtime behavior is correct; the regression was an untested contract rather than an active calculation bug. No production change is needed.

## Dependency / merge order

No functional dependency and no overlapping files with #993-#996. It can merge at any point. Merging after #993 is recommended only to keep the review queue ordered; #993's pooled-beta changes occur after the singular covariance branch and do not alter this result.

## Validation

- 23 focused Driscoll-Kraay tests passed
- Ruff passed
- git diff --check passed
- full main suite was already green in #996 immediately before this test-only change

Closes #976