### PR TITLE
docs(inference): align compute signature

### DIFF
--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -8,7 +8,8 @@ metric accept?" is answered per-metric (e.g. ``ic`` accepts
 ``NON_OVERLAPPING`` / ``NEWEY_WEST``).
 
 The namespace is scoped to the **series-mean** family
-(``compute(data, *, value_col, overlap_periods)``). Slice / panel methods
+(``compute(data, *, value_col, overlap_periods, alternative="two-sided")``).
+Slice / panel methods
 keep their multivariate compute in ``factrix.slicing`` until they move
 onto the same ``metric(inference=...)`` path; they are deliberately not
 listed here to avoid re-creating a heterogeneous discovery surface.

--- a/factrix/inference/_base.py
+++ b/factrix/inference/_base.py
@@ -30,7 +30,8 @@ class Inference(Protocol):
 
     Implementations are frozen dataclasses that additionally carry a
     ``compute`` whose signature is fixed per target shape (series-mean
-    members share ``compute(data, *, value_col, overlap_periods)``).
+    members share ``compute(data, *, value_col, overlap_periods,
+    alternative="two-sided")``).
     ``compute`` is intentionally absent here — see module docstring.
     """
 

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -263,8 +263,8 @@ def _spread_significance_with_inference(
     member needs every period (it corrects or resamples the dependence
     itself) or takes the pre-strided series (it sub-samples, and the metric's
     panel-stride already did that). The chosen series then goes through the
-    ordinary ``compute(data, value_col=..., overlap_periods=...)`` call, the
-    same polymorphic path ``ic`` uses.
+    ordinary ``compute(data, value_col=..., overlap_periods=...,
+    alternative=...)`` call, the same polymorphic path ``ic`` uses.
 
     A pre-strided series is handed over with ``overlap_periods=1``: the
     metric's panel-stride already broke the MA(h-1) overlap, and re-striding


### PR DESCRIPTION
## Summary
- update the series-mean `compute` signature in the base protocol documentation
- align the inference namespace and spread helper descriptions with `alternative`
- keep the runtime API unchanged

## Validation
- `.venv\Scripts\python.exe -m ruff check factrix/inference/_base.py factrix/inference/__init__.py factrix/metrics/_helpers.py`
- `.venv\Scripts\python.exe -m pytest tests/inference/test_series_mean.py tests/test_quantile.py -q` (96 passed)

## Dependencies and merge order
None. This branch is based directly on `origin/main`, shares no files with #993-#997, and may be merged in any order relative to them.

Closes #990