### PR TITLE
fix(stats): validate ols_alpha base shape

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -56,11 +56,10 @@ def ols_alpha(
     scalar statistic. The default ``1`` (no floor) is the non-overlapping
     case.
 
-    **The trade, measured.** Both columns below predate the current scalar HAR
-    recipe and are retained because they motivated retiring the OLS SE. The
-    current recipe's measurements follow the table. Empirical size at a
-    nominal 5% under a true null (``alpha = 0``, one base factor, 4000 draws,
-    read against ``t(n - k)``):
+    **The trade, measured.** The table records the comparison that motivated
+    retiring the OLS SE; current scalar HAR measurements follow it. Empirical
+    size at a nominal 5% under a true null (``alpha = 0``, one base factor,
+    4000 draws):
 
     | residuals | OLS | HAC (narrow rule, superseded) |
     |---|---|---|
@@ -113,7 +112,8 @@ def ols_alpha(
     version returned, which claimed the factor added exactly nothing.
 
     Raises:
-        ValueError: ``candidate`` or ``base_matrix`` holds a non-finite
+        ValueError: ``base_matrix`` is not a 2-D ``(n_obs, n_base_factors)``
+            array, or ``candidate`` / ``base_matrix`` holds a non-finite
             value. ``np.linalg.lstsq`` does not raise on NaN input — it
             returns a NaN solution, so an unguarded NaN became a NaN alpha
             and a NaN t far from the cause. The guard lives in the kernel
@@ -125,6 +125,11 @@ def ols_alpha(
     """
     candidate = np.asarray(candidate, dtype=float)
     base_matrix = np.asarray(base_matrix, dtype=float)
+    if base_matrix.ndim != 2:
+        raise ValueError(
+            "ols_alpha: base_matrix must be 2-D (n_obs, n_base_factors); "
+            "reshape(-1, 1) a single factor."
+        )
     if candidate.size and not np.all(np.isfinite(candidate)):
         raise ValueError("ols_alpha: candidate must be finite (no NaN / inf).")
     if base_matrix.size and not np.all(np.isfinite(base_matrix)):

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -518,6 +518,13 @@ class TestOlsAlphaFiniteContract:
         with pytest.raises(ValueError, match="base_matrix must be finite"):
             ols_alpha(candidate, base)
 
+    def test_one_dimensional_base_matrix_raises(self):
+        from factrix._ols import ols_alpha
+
+        candidate, base = self._design()
+        with pytest.raises(ValueError, match="base_matrix must be 2-D"):
+            ols_alpha(candidate, base[:, 0])
+
     def test_clean_input_is_unaffected(self):
         from factrix._ols import ols_alpha
 


### PR DESCRIPTION
## Summary
- reject non-2-D `base_matrix` inputs with an actionable `ValueError`
- document the shape contract and cover the 1-D regression case
- remove repeated historical HAC wording while preserving the calibration measurements

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_spanning.py -q` (38 passed)
- `.venv\Scripts\python.exe -m ruff check factrix/_ols.py tests/test_spanning.py`
- `.venv\Scripts\python.exe -m mypy factrix`
- `.venv\Scripts\python.exe -m pytest -q` (3654 passed, 46 skipped)

## Dependencies and merge order
None relative to open PRs #993-#998. This branch is based directly on `origin/main` and shares no files with them, so it may be merged in any order.

Open issue #968 also targets `factrix/_ols.py`; handle it only after this PR is merged and rebuild it from the updated `main` rather than running both changes in parallel.

Closes #969