### PR TITLE
refactor(stats): reuse alpha HAC fit

### DIFF
--- a/factrix/_ols.py
+++ b/factrix/_ols.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from factrix._stats.core import _degenerate_t_input
-from factrix._stats.ols import _ols_scalar_wald_hac
+from factrix._stats.ols import _ols_scalar_wald_hac_from_finite
 from factrix._types import EPSILON
 
 
@@ -142,19 +142,26 @@ def ols_alpha(
     ones = np.ones((n_obs, 1))
     X = np.hstack([ones, base_matrix]) if base_matrix.shape[1] > 0 else ones
 
-    try:
-        beta, _, _, _ = np.linalg.lstsq(X, candidate, rcond=None)
-    except np.linalg.LinAlgError:
-        # Rank-deficient design (collinear base factors, or a base factor
-        # equal to the candidate). The fit does not exist, so neither does
-        # alpha: NaN rather than 0.0, which would read as "this factor adds
-        # exactly nothing" -- a decisive claim from a failed computation.
-        return _OLSResult(alpha=float("nan"), alpha_t=float("nan"))
+    # Reuse the coefficients and residuals already formed for the HAC
+    # covariance instead of solving the same regular design twice.
+    hac = _ols_scalar_wald_hac_from_finite(
+        candidate, X, overlap_periods=overlap_periods
+    )
+    beta = hac.beta
+    resid = hac.resid
+
+    if not np.all(np.isfinite(beta)):
+        # The inverse-based kernel refuses a singular or saturated design,
+        # while ``lstsq`` can still supply the minimum-norm descriptive fit.
+        # Preserve that point estimate, but keep the formal test withheld.
+        try:
+            beta, _, _, _ = np.linalg.lstsq(X, candidate, rcond=None)
+        except np.linalg.LinAlgError:
+            return _OLSResult(alpha=float("nan"), alpha_t=float("nan"))
+        resid = candidate - X @ beta
 
     alpha = float(beta[0])
     betas = [float(b) for b in beta[1:]]
-
-    resid = candidate - X @ beta
 
     ss_res = float(np.dot(resid, resid))
     centered = candidate - np.mean(candidate)
@@ -182,10 +189,6 @@ def ols_alpha(
             df_resid=dof,
         )
 
-    # The shared entry point owns bandwidth resolution and the matching
-    # finite-sample scale, so a new rank-one OLS consumer cannot apply only
-    # part of the scalar HAR contract.
-    hac = _ols_scalar_wald_hac(candidate, X, overlap_periods=overlap_periods)
     se_alpha = float(np.sqrt(max(hac.covariance[0, 0], 0.0)))
 
     if _degenerate_t_input(se_alpha, 1):

--- a/factrix/_stats/ols.py
+++ b/factrix/_stats/ols.py
@@ -158,6 +158,16 @@ def _ols_nw_multivariate(
     """
     y = _require_finite(y, "_ols_nw_multivariate")
     X = _require_finite(X, "_ols_nw_multivariate")
+    return _ols_nw_multivariate_from_finite(y, X, lags=lags)
+
+
+def _ols_nw_multivariate_from_finite(
+    y: np.ndarray,
+    X: np.ndarray,
+    *,
+    lags: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Fit :func:`_ols_nw_multivariate` after caller-side validation."""
     n, k = X.shape
     not_computable = (np.full(k, np.nan), np.full((k, k), np.nan), np.zeros(n))
     if len(y) != n or n < k + 1:
@@ -219,10 +229,32 @@ def _ols_scalar_wald_hac(
     shared warning policy, including suppression below the common warning
     floor.
     """
+    # Preserve the kernel's historical error label while allowing a caller
+    # with a more specific validation contract to reuse the finite-input fit.
+    y = _require_finite(y, "_ols_nw_multivariate")
+    X = _require_finite(X, "_ols_nw_multivariate")
+    return _ols_scalar_wald_hac_from_finite(
+        y,
+        X,
+        lags=lags,
+        overlap_periods=overlap_periods,
+    )
+
+
+def _ols_scalar_wald_hac_from_finite(
+    y: np.ndarray,
+    X: np.ndarray,
+    *,
+    lags: int | None = None,
+    overlap_periods: int | None = None,
+) -> _ScalarWaldHacFit:
+    """Fit :func:`_ols_scalar_wald_hac` after caller-side validation."""
     resolved_lags, variance_scale, dof = _resolve_scalar_wald_hac(
         len(y), lags, overlap_periods
     )
-    beta, covariance, resid = _ols_nw_multivariate(y, X, lags=resolved_lags)
+    beta, covariance, resid = _ols_nw_multivariate_from_finite(
+        y, X, lags=resolved_lags
+    )
     return _ScalarWaldHacFit(
         beta=beta,
         covariance=covariance * variance_scale,

--- a/factrix/_stats/ols.py
+++ b/factrix/_stats/ols.py
@@ -252,9 +252,7 @@ def _ols_scalar_wald_hac_from_finite(
     resolved_lags, variance_scale, dof = _resolve_scalar_wald_hac(
         len(y), lags, overlap_periods
     )
-    beta, covariance, resid = _ols_nw_multivariate_from_finite(
-        y, X, lags=resolved_lags
-    )
+    beta, covariance, resid = _ols_nw_multivariate_from_finite(y, X, lags=resolved_lags)
     return _ScalarWaldHacFit(
         beta=beta,
         covariance=covariance * variance_scale,

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -541,6 +541,19 @@ class TestOlsAlphaFiniteContract:
         result = ols_alpha(candidate, np.empty((len(candidate), 0)))
         assert result.alpha == pytest.approx(float(np.mean(candidate)))
 
+    def test_regular_fit_reuses_hac_coefficients(self, monkeypatch):
+        from factrix._ols import ols_alpha
+
+        candidate, base = self._design()
+
+        def fail_lstsq(*_args, **_kwargs):
+            raise AssertionError("regular fits must reuse the HAC kernel fit")
+
+        monkeypatch.setattr(np.linalg, "lstsq", fail_lstsq)
+        result = ols_alpha(candidate, base)
+        assert math.isfinite(result.alpha)
+        assert math.isfinite(result.alpha_t)
+
 
 class TestAlphaTIsHac:
     """``alpha_t`` divides by a Newey-West HAC SE, not the homoskedastic OLS SE.


### PR DESCRIPTION
## Summary

- reuse the scalar HAC kernel's coefficients and residuals on regular `ols_alpha` fits
- avoid the duplicate finiteness scan after `ols_alpha` has validated its inputs
- retain `lstsq` only when the inverse-based HAC kernel cannot form a fit, preserving the existing descriptive alpha while withholding invalid inference
- add a regression test proving the regular path no longer calls `lstsq`

The candidate-invariant prepared-design cache suggested in the issue is intentionally out of scope: the remaining work is small, and introducing cache state/API would add complexity without evidence that it is needed.

## Verification

- `pytest -q`: 3668 passed, 46 skipped
- focused OLS/spanning tests: 72 passed
- `ruff check factrix/_ols.py factrix/_stats/ols.py tests/test_spanning.py`
- `mypy factrix`
- point-estimate comparison against `np.linalg.lstsq`: max alpha difference `5.7e-16`

Local best-of-5 timing (200 calls, Windows/Python 3.13):

| shape | issue baseline | this PR |
|---|---:|---:|
| n=120, k=2 | 197 us/call | 70 us/call |
| n=1000, k=10 | 1098 us/call | 747 us/call |

## Dependency

None. This branch starts directly from the latest `main`, including merged #999, and can be merged independently.

Closes #968