### PR TITLE
fix(metrics): expose pooled overlap handling

### DIFF
--- a/docs/api/metrics/fm_beta.md
+++ b/docs/api/metrics/fm_beta.md
@@ -61,6 +61,11 @@ title: factrix.metrics.fm_beta
     `two_way_cluster_col`). When pooled $\hat\beta$ and FM
     $\hat\lambda$ disagree in sign, the result's `warnings` flag a
     misspecification red flag.
+    Clustered covariance does not consume the panel's `overlap_periods`;
+    metadata records the horizon with `overlap_adjustment_applied=False`.
+    To cover serial dependence from overlapping returns, cluster on an axis
+    that spans it (for example asset), use two-way clustering, or select
+    Driscoll-Kraay.
     If a finite-sample two-way covariance is non-PSD, the OLS slope remains
     descriptive but its test is withheld rather than replaced by one-way
     inference.
@@ -75,7 +80,7 @@ title: factrix.metrics.fm_beta
     bandwidth, finite-sample variance scale, and effective degrees of freedom
     as other scalar HAC restrictions in factrix. The resolved
     `driscoll_kraay_lags`, `hac_scale`, `hac_dof`, and `overlap_periods` are
-    available in metadata.
+    available in metadata, with `overlap_adjustment_applied=True`.
 
 </div>
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -162,6 +162,9 @@ is emitted.
   other withheld-inference regime and keeps `value` — see
   `variance_status` below.
 - Sample size: `MetricResult.n_obs` (row count entering the test).
+- *descriptive*: `overlap_periods` (the injected evaluation-grid horizon) and
+  `overlap_adjustment_applied`. The latter is `False` for clustered covariance,
+  which does not consume the horizon, and `True` for Driscoll-Kraay HAC.
 - *descriptive*: `n_clusters` (one-way) or `n_clusters_a`,
   `n_clusters_b`, `n_clusters_intersection` (two-way).
 - *descriptive* (conditional, short-circuit): `reason =
@@ -177,8 +180,8 @@ is emitted.
   `se_method` (`"driscoll_kraay"`), `n_periods` (length of the
   cross-sectional score-sum series), and `driscoll_kraay_lags` (the
   resolved Bartlett bandwidth), `hac_scale` (`T / (T - L - 1)`),
-  `hac_dof` (the scalar HAR reference degrees of freedom), and
-  `overlap_periods`. At 30 or more periods the DK path emits
+  and `hac_dof` (the scalar HAR reference degrees of freedom). At 30 or more
+  periods the DK path emits
   `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` when `L > T / 5`; below 30
   it emits the binding `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` without a
   redundant bandwidth echo. It short-circuits to `value = NaN` with

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -612,6 +612,7 @@ def _pooled_beta_driscoll_kraay(
         "hac_scale": hac_scale,
         "hac_dof": hac_dof,
         "overlap_periods": overlap_periods,
+        "overlap_adjustment_applied": True,
     }
     stat, p_out, alternative = _degenerate_test_fields(
         t_stat, p, "two-sided", metadata, warning_codes
@@ -708,6 +709,24 @@ def pooled_beta(
     fails is not exposed as the headline value: without a valid covariance
     estimate, downstream aggregation cannot distinguish it from a fully
     inferential pooled beta.
+
+    Args:
+        data: Panel containing the regression columns and cluster keys.
+        factor_col: Signal column used as the pooled OLS regressor.
+        return_col: Return column used as the pooled OLS response.
+        cluster_col: Primary cluster key. Defaults to the period column.
+        two_way_cluster_col: Optional second cluster key for Cameron-Gelbach-
+            Miller two-way covariance.
+        driscoll_kraay: Use cross-section-robust Driscoll-Kraay HAC covariance
+            instead of clustered covariance.
+        driscoll_kraay_lags: Optional base Bartlett bandwidth for the
+            Driscoll-Kraay path.
+        overlap_periods: Evaluation-grid overlap injected by ``evaluate`` or
+            declared on a direct call. Driscoll-Kraay uses it to resolve its
+            bandwidth, variance scale, and reference degrees of freedom.
+            Clustered covariance does not use it and records
+            ``overlap_adjustment_applied=False``.
+        expected_warnings: Warning codes expected by the study design.
 
     Formula:
         Point estimate:
@@ -985,6 +1004,8 @@ def pooled_beta(
         "stat_type": "t",
         "h0": "β=0",
         "method": method_desc,
+        "overlap_periods": overlap_periods,
+        "overlap_adjustment_applied": False,
         **cluster_metadata,
     }
     if variance_status is not None:

--- a/tests/test_fm_betas.py
+++ b/tests/test_fm_betas.py
@@ -447,6 +447,30 @@ class TestPooledClusteredSEAgainstHandComputation:
         assert out.p_value == pytest.approx(float(p_ref))
         assert out.metadata["n_clusters"] == g
 
+    @pytest.mark.parametrize("two_way_cluster_col", [None, "asset_id"])
+    def test_clustered_path_records_but_does_not_apply_overlap_adjustment(
+        self, two_way_cluster_col
+    ):
+        from factrix.metrics.fm_beta import pooled_beta
+
+        panel = self._panel()
+        short = pooled_beta(
+            panel,
+            two_way_cluster_col=two_way_cluster_col,
+            overlap_periods=1,
+        )
+        overlapping = pooled_beta(
+            panel,
+            two_way_cluster_col=two_way_cluster_col,
+            overlap_periods=21,
+        )
+
+        assert overlapping.metadata["overlap_periods"] == 21
+        assert overlapping.metadata["overlap_adjustment_applied"] is False
+        assert overlapping.value == short.value
+        assert overlapping.stat == short.stat
+        assert overlapping.p_value == short.p_value
+
     def test_one_way_too_few_clusters_hides_the_slope(self):
         panel = self._panel(n_dates=2, n_assets=15)
 

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -64,6 +64,7 @@ class TestDriscollKraayPath:
         assert res.metadata["hac_scale"] == pytest.approx(scale)
         assert res.metadata["hac_dof"] == pytest.approx(dof)
         assert res.metadata["overlap_periods"] == 5
+        assert res.metadata["overlap_adjustment_applied"] is True
 
     def test_point_estimate_matches_clustered_path(self):
         # SE method does not change the OLS slope — only its variance.
@@ -151,6 +152,8 @@ class TestDriscollKraayPath:
         res = pooled_beta(df)
         assert "se_method" not in res.metadata
         assert "clustered SE" in res.metadata["method"]
+        assert res.metadata["overlap_periods"] == 5
+        assert res.metadata["overlap_adjustment_applied"] is False
 
     def test_driscoll_kraay_p_value_degrees_of_freedom(self):
         import scipy.stats as sp_stats


### PR DESCRIPTION
## Summary

- record `overlap_periods` on clustered `pooled_beta` results and mark that the clustered covariance does not consume it
- mark the Driscoll-Kraay path as applying the overlap adjustment
- document the estimator distinction in the public docstring, metric guide, and metadata reference
- verify one-way and two-way clustered outputs are unchanged across overlap horizons

No estimator or p-value changes. Cluster dimensions may themselves span serial dependence; `overlap_periods` only directly controls the Driscoll-Kraay HAC recipe.

The existing `DEFAULT_FORWARD_PERIODS` fallback remains intentional. `pooled_beta` accepts a raw panel, where unstamped standalone calls use the project-wide default horizon; changing it to `None` would alter the Driscoll-Kraay standalone contract. This differs from `fm_beta`, which consumes an already-derived beta series.

## Verification

- `pytest -q`: 3669 passed, 46 skipped
- focused metric and documentation tests: 93 passed
- `ruff check` and `ruff format --check`
- `mypy factrix`
- `git diff --check`

## Dependency

None. The branch starts from the latest `main` and does not overlap files with #1000.

Closes #975