### PR TITLE
refactor(stats): centralize bootstrap tail count

### DIFF
--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -417,6 +417,19 @@ def _stationary_block_indices(
     return idx
 
 
+def _count_extreme(
+    draws: np.ndarray,
+    observed: float,
+    alternative: PValueAlternative,
+) -> int:
+    """Count bootstrap draws at least as extreme as the observed statistic."""
+    if alternative == "greater":
+        return int(np.sum(draws >= observed))
+    if alternative == "less":
+        return int(np.sum(draws <= observed))
+    return int(np.sum(np.abs(draws) >= abs(observed)))
+
+
 def _block_bootstrap_diff_p(
     diff: np.ndarray,
     *,
@@ -577,20 +590,10 @@ def _block_bootstrap_diff_p(
         )
         observed_t = observed / se_observed
         roots = boot_t[usable]
-        if alternative == "greater":
-            extreme = int(np.sum(roots >= observed_t))
-        elif alternative == "less":
-            extreme = int(np.sum(roots <= observed_t))
-        else:
-            extreme = int(np.sum(np.abs(roots) >= abs(observed_t)))
+        extreme = _count_extreme(roots, observed_t, alternative)
         n_used = int(usable.sum())
     else:
-        if alternative == "greater":
-            extreme = int(np.sum(boot_means >= observed))
-        elif alternative == "less":
-            extreme = int(np.sum(boot_means <= observed))
-        else:
-            extreme = int(np.sum(np.abs(boot_means) >= abs(observed)))
+        extreme = _count_extreme(boot_means, observed, alternative)
         n_used = int(n_resamples)
 
     p, p_mc_se = _empirical_p(extreme, n_used)

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -9,6 +9,7 @@ import pytest
 from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
     _block_bootstrap_diff_p,
+    _count_extreme,
     _politis_white_block_length,
     _stationary_block_indices,
 )
@@ -123,6 +124,16 @@ class TestStationaryBlockIndices:
         rng = np.random.default_rng()
         with pytest.raises(ValueError, match="invalid block_length"):
             _stationary_block_indices(30, 5, mean_block_length=200.0, rng=rng)
+
+
+class TestTailCount:
+    @pytest.mark.parametrize(
+        ("alternative", "expected"),
+        [("greater", 2), ("less", 2), ("two-sided", 2)],
+    )
+    def test_ties_count_as_extreme(self, alternative, expected):
+        draws = np.array([1.0, 2.0, 3.0])
+        assert _count_extreme(draws, 2.0, alternative) == expected
 
 
 class TestStudentizedDiffP:
@@ -295,6 +306,20 @@ class TestStudentizedRoot:
         """A zero-dispersion series leaves no SE to divide by."""
         _, meta = _block_bootstrap_diff_p(np.full(40, 2.0), n_resamples=99, rng=0)
         assert meta["studentized"] is False
+
+    @pytest.mark.parametrize(
+        ("alternative", "expected_p"),
+        [("greater", 0.01), ("less", 1.0), ("two-sided", 0.01)],
+    )
+    def test_raw_mean_fallback_respects_alternative(self, alternative, expected_p):
+        p, meta = _block_bootstrap_diff_p(
+            np.full(40, 2.0),
+            n_resamples=99,
+            alternative=alternative,
+            rng=0,
+        )
+        assert meta["studentized"] is False
+        assert p == pytest.approx(expected_p)
 
     @pytest.mark.parametrize(("n", "phi"), [(120, 0.5), (500, 0.8)])
     def test_size_beats_the_unstudentized_root(self, n, phi):


### PR DESCRIPTION
## Summary

- centralize greater, less, and two-sided bootstrap extreme counting
- reuse the same helper for studentized and raw-mean fallback paths
- pin inclusive tie handling and raw-fallback alternatives with regression tests

The #989 alternative validation remains at `_block_bootstrap_diff_p` entry so invalid values are rejected before the `n < 2` early return. This is an internal behavior-preserving refactor with no API or numerical contract change.

## Verification

- `pytest -q`: 3676 passed, 46 skipped
- focused bootstrap tests: 72 passed
- `ruff check`: passed
- `ruff format --check`: passed
- `mypy factrix`: passed
- `git diff --check`: passed

## Dependency

None. This branch starts from the latest `main`, including #1000 and #1001, and no other PR is currently open.

Closes #992