### PR TITLE
fix(metrics): exclude degenerate non-tests

### DIFF
--- a/docs/api/metrics/directional_hit_rate.md
+++ b/docs/api/metrics/directional_hit_rate.md
@@ -46,10 +46,11 @@ title: factrix.metrics.directional_hit_rate
     its sign before testing). Observations are sub-sampled at stride
     `overlap_periods` so overlapping forward-return windows do not
     inflate the statistic; degenerate samples (one-signed predictions or
-    realisations) short-circuit to `NaN`. `inspect_data()` also blocks
+    realisations) return `NaN` with `DEGENERATE_VARIANCE` and no hypothesis
+    test. `inspect_data()` also blocks
     obviously one-sided factor signs up front, so bulk discovery does not
-    advertise `directional_hit_rate` as clean when runtime would hit
-    `degenerate_directional_variance`.
+    advertise `directional_hit_rate` as clean when runtime would find a
+    degenerate directional variance.
 
 </div>
 

--- a/docs/guides/choosing-metric.md
+++ b/docs/guides/choosing-metric.md
@@ -54,8 +54,8 @@ apply unchanged.
 
 An always-positive magnitude target (realised volatility, turnover) is not
 a drop-in replacement: both sign-test metrics assume `return_col` can be
-negative. `directional_hit_rate` short-circuits with
-`degenerate_directional_variance`; `event_hit_rate` has no such guard and
+negative. `directional_hit_rate` returns `NaN` with `DEGENERATE_VARIANCE`;
+`event_hit_rate` has no such guard and
 silently degrades to counting positive-factor events. Use `ic` or
 `monotonicity` instead — both are rank-based and test factor level against
 target magnitude directly, with no sign assumption.

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -121,6 +121,9 @@ is emitted.
 
 - *descriptive*: `mean_ic`, `std_ic`, `n_periods`, `tie_ratio`, `min_assets_per_period` / `warn_assets_per_period` when the upstream IC series carries per-period asset counts.
 - *warning*: `WarningCode.FEW_ASSETS` when retained per-period IC cross-sections are below `MIN_IC_ASSETS_WARN`.
+- *degenerate*: a zero IC-series standard deviation returns `value=NaN`
+  with `WarningCode.DEGENERATE_VARIANCE`; it is not a hypothesis and does
+  not enter multiple-testing families.
 
 ### `fm_beta` family (`factrix.metrics.fm_beta`)
 
@@ -291,6 +294,8 @@ Boehmer-Musumeci-Poulsen standardised-abnormal-return cross-sectional
   `overlap_periods` (the spacing stride),
   `n_events_overlapping` / `n_events_sampled` (removed by, and surviving,
   the spacing pass; a non-zero removal fires `EVENT_WINDOW_OVERLAP`).
+- *degenerate*: a zero standard deviation of the event-period mean ranks
+  returns `value=NaN` with `WarningCode.DEGENERATE_VARIANCE` and no test.
 
 ### `positive_rate` (`factrix.metrics.positive_rate`)
 
@@ -323,6 +328,9 @@ Pesaran-Timmermann `z` statistic (`stat_type="z"`), tested one-sided.
   `kolari_pynnonen_applied` (whether the Kolari-Pynnönen deflation fired).
 - *descriptive* (conditional, adjustment applied): `stat_uncorrected`
   (the raw `S_n` before the cross-sectional-correlation deflation).
+- *degenerate*: one-signed predictions or realisations that collapse the
+  Pesaran-Timmermann variance return `value=NaN` with
+  `WarningCode.DEGENERATE_VARIANCE` and no test.
 
 ### `directional_pair_accuracy` (`factrix.metrics.directional_pair_accuracy`)
 
@@ -891,9 +899,10 @@ which reports `R²` for the OLS regression.
 - *warning*: `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` when the scalar HAR
   bandwidth satisfies `L > T / 5` on at least 30 finite periods. Below 30,
   `UNRELIABLE_SE_SHORT_PERIODS` owns the regime without a duplicate warning.
+- *degenerate*: zero factor variance returns `value=NaN` with
+  `WarningCode.DEGENERATE_VARIANCE` and no test.
 - *short-circuit*: `reason` `insufficient_predictive_periods`,
-  `degenerate_factor_variance`, `no_amihud_hurvich_fit`,
-  `no_factor_column`, or `no_return_column`. The
+  `no_amihud_hurvich_fit`, `no_factor_column`, or `no_return_column`. The
   `insufficient_predictive_periods` floor is a pre-flight gate on
   `n_periods_finite`, before the augmented design trims its rows.
   `no_amihud_hurvich_fit` retains `beta_ols_uncorrected` as a descriptive

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -846,8 +846,8 @@ def _evaluate_applicability(
     if spec.name == "directional_hit_rate" and factor_sign_one_sided:
         blockers.append(
             "one-sided directional signal: sign(factor) has only one non-zero "
-            "side, so directional_hit_rate would short-circuit "
-            "degenerate_directional_variance at run time; center, threshold, "
+            "side, so directional_hit_rate would return degenerate_variance "
+            "at run time; center, threshold, "
             "or encode a true two-sided directional signal before using this "
             "metric"
         )

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -580,6 +580,36 @@ def _no_signal_zero_variance(
 DEGENERATE_SIGNAL_STATUS = "degenerate_zero_variance"
 
 
+def _degenerate_metric_output(
+    *,
+    n_obs: int,
+    n_obs_axis: SampleAxis,
+    alternative_requested: PValueAlternative | None = None,
+    **metadata: object,
+) -> MetricResult:
+    """Return the canonical shape for an undefined degenerate metric.
+
+    Use this when zero dispersion makes the point estimate itself undefined.
+    Unlike :func:`_short_circuit_output`, this is not a data or configuration
+    shortage: no ``reason`` or inert p-value is fabricated. The warning code
+    keeps the non-test out of multiple-testing families, while ``strict=True``
+    correctly leaves a data-dependent degeneracy in the returned result.
+    """
+    metadata["signal_status"] = DEGENERATE_SIGNAL_STATUS
+    if alternative_requested is not None:
+        metadata["alternative_requested"] = alternative_requested
+    return MetricResult(
+        value=float("nan"),
+        p_value=None,
+        alternative=None,
+        n_obs=n_obs,
+        n_obs_axis=n_obs_axis,
+        stat=None,
+        metadata=metadata,
+        warning_codes=(WarningCode.DEGENERATE_VARIANCE.value,),
+    )
+
+
 def _degenerate_test_fields(
     stat: float,
     p_value: float,

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -29,6 +29,7 @@ from factrix._types import (
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _attach_abnormal_return,
+    _degenerate_metric_output,
     _enforce_min_floor,
     _event_sample_threshold,
     _is_sparse_magnitude_weighted,
@@ -191,7 +192,8 @@ def corrado_rank(
         sit on them) — the same floor ``caar`` applies to its own event-period
         series, and ``WarningCode.FEW_EVENTS`` fires in
         ``[MIN_EVENTS_HARD, MIN_EVENTS_WARN)``; and
-        ``"degenerate_rank_variance"`` when ``std(U_bar_d) < EPSILON``.
+        a result with ``DEGENERATE_VARIANCE`` and no hypothesis test when
+        ``std(U_bar_d) < EPSILON``.
 
     References:
         - [Corrado (1989)][corrado-1989]. "A Nonparametric Test for
@@ -399,12 +401,10 @@ def corrado_rank(
     std_u = float(np.std(u_bar, ddof=DDOF))
 
     if std_u < EPSILON:
-        return _short_circuit_output(
-            "corrado_rank",
-            "degenerate_rank_variance",
-            alternative="greater",
+        return _degenerate_metric_output(
             n_obs=n_event_periods,
             n_obs_axis="events",
+            alternative_requested="greater",
             std_u=std_u,
             n_events=n_events,
             n_event_periods=n_event_periods,

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -42,6 +42,7 @@ from factrix._types import (
 )
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _degenerate_metric_output,
     _enforce_min_floor,
     _estimate_within_date_icc,
     _finite_expr,
@@ -235,12 +236,10 @@ def directional_hit_rate(
     # Degenerate: one-signed predictions or realisations collapse P* to 1
     # and drive var_s to (numerically) zero or below — S_n is undefined.
     if var_s <= 0.0:
-        return _short_circuit_output(
-            "directional_hit_rate",
-            "degenerate_directional_variance",
-            alternative="greater",
+        return _degenerate_metric_output(
             n_obs=n,
             n_obs_axis="pairs",
+            alternative_requested="greater",
             p_correct=p_correct,
             p_up_pred=p_x,
             p_up_real=p_y,

--- a/factrix/metrics/ic.py
+++ b/factrix/metrics/ic.py
@@ -50,6 +50,7 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _DROP_STATS_COL,
     TIE_RATIO_WARN_THRESHOLD,
+    _degenerate_metric_output,
     _degenerate_test_fields,
     _emit_inference_warnings,
     _enforce_min_floor,
@@ -509,9 +510,9 @@ def ic_ir(
     std_ic = float(ic_vals.std())  # type: ignore[arg-type]
 
     if std_ic < EPSILON:
-        return _short_circuit_output(
-            "ic_ir",
-            "degenerate_ic_variance",
+        return _degenerate_metric_output(
+            n_obs=n,
+            n_obs_axis="periods",
             std_ic=std_ic,
         )
 

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -45,6 +45,7 @@ from factrix._types import (
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _degenerate_metric_output,
     _degenerate_test_fields,
     _enforce_min_floor,
     _finite_expr,
@@ -285,11 +286,10 @@ def predictive_beta(
     y = paired[return_col].to_numpy().astype(np.float64)
     x_std = float(np.std(x, ddof=DDOF))
     if x_std < EPSILON:
-        return _short_circuit_output(
-            "predictive_beta",
-            "degenerate_factor_variance",
+        return _degenerate_metric_output(
             n_obs=n,
             n_obs_axis="periods",
+            alternative_requested="two-sided",
             factor_std=x_std,
         )
 

--- a/tests/test_bhy.py
+++ b/tests/test_bhy.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import warnings
+from datetime import date, timedelta
 
 import numpy as np
 import polars as pl
 import pytest
+from factrix import _enforce_strict
 from factrix._errors import UserInputError
-from factrix._multi_factor import BhyResult, bhy
+from factrix._multi_factor import BhyResult, _is_inactive_hypothesis, bhy
 from factrix._results import MetricResult
+from factrix.metrics.corrado_rank import corrado_rank
+from factrix.metrics.directional_hit_rate import directional_hit_rate
+from factrix.metrics.ic import ic_ir
+from factrix.metrics.predictive_beta import predictive_beta
 
 from .conftest import make_result, make_spec
 
@@ -152,6 +158,69 @@ def test_degenerate_variance_results_are_dropped_from_family():
 
     assert out.n_tests == {(): 1}
     assert [r.factor for r in out.survivors] == ["valid"]
+
+
+def _degenerate_metric_result(metric: str) -> MetricResult:
+    n = 100
+    dates = [date(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+    series = pl.DataFrame({"date": dates, "ic": np.full(n, 0.3)})
+    timeseries = pl.DataFrame(
+        {
+            "date": dates,
+            "asset_id": ["A"] * n,
+            "factor": np.ones(n),
+            "forward_return": np.arange(n, dtype=float),
+        }
+    )
+    directional = timeseries.with_columns(
+        pl.Series("forward_return", np.tile([-1.0, 1.0], n // 2))
+    )
+
+    event_factor = np.zeros(300)
+    event_return = np.zeros(300)
+    event_idx = np.arange(70, 300, 30)
+    event_factor[event_idx] = 1.0
+    event_return[event_idx] = 1.0
+    events = pl.DataFrame(
+        {
+            "date": [date(2020, 1, 1) + timedelta(days=i) for i in range(300)],
+            "asset_id": ["A"] * 300,
+            "factor": event_factor,
+            "forward_return": event_return,
+            "abnormal_return": event_return,
+        }
+    )
+    if metric == "ic_ir":
+        return ic_ir(series)
+    if metric == "corrado_rank":
+        return corrado_rank(events, expected_warnings=("few_events",))
+    if metric == "directional_hit_rate":
+        return directional_hit_rate(directional, overlap_periods=1)
+    return predictive_beta(timeseries, overlap_periods=1, adf_threshold=None)
+
+
+@pytest.mark.parametrize(
+    "metric", ["ic_ir", "corrado_rank", "directional_hit_rate", "predictive_beta"]
+)
+def test_metric_degeneracies_are_inactive_and_strict_safe(metric: str) -> None:
+    """Producer contracts, rather than reason parsing, identify non-tests."""
+    output = _degenerate_metric_result(metric)
+    make_spec(metric)
+    result = make_result(
+        factor="flat",
+        p=output.p_value,
+        metric=metric,
+        value=output.value,
+        metadata=output.metadata,
+        warning_codes=output.warning_codes,
+    )
+
+    assert _is_inactive_hypothesis(result, metric)
+    _enforce_strict({metric: output})
+
+    valid = make_result(factor="valid", p=0.01, metric=metric)
+    screened = bhy([valid, result], metrics=[metric], q=0.05)[metric]
+    assert screened.n_tests == {(): 1}
 
 
 def test_expand_over_forward_periods_partitions_by_horizon():

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -127,7 +127,10 @@ class TestShortCircuits:
         y = rng.normal(size=100)
         result = directional_hit_rate(_ts_panel(x, y), overlap_periods=1)
         assert math.isnan(result.value)
-        assert result.metadata["reason"] == "degenerate_directional_variance"
+        assert result.p_value is None
+        assert result.metadata["signal_status"] == "degenerate_zero_variance"
+        assert "reason" not in result.metadata
+        assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
         assert result.n_obs_axis == "pairs"
 
     def test_missing_return_column(self):

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -365,7 +365,7 @@ class TestDeclaredPeriodsFloorsVisible:
         assert da.usable is False
         assert da in info.unusable
         assert any("one-sided directional signal" in b for b in da.blockers)
-        assert any("degenerate_directional_variance" in b for b in da.blockers)
+        assert any("degenerate_variance" in b for b in da.blockers)
 
     def test_top_concentration_declares_periods_floors(self):
         from factrix._types import (

--- a/tests/test_predictive_beta.py
+++ b/tests/test_predictive_beta.py
@@ -121,7 +121,10 @@ class TestPredictiveBetaShortCircuits:
         y = np.arange(MIN_PERIODS_HARD, dtype=float)
         result = predictive_beta(_ts_panel(x, y), overlap_periods=1)
         assert math.isnan(result.value)
-        assert result.metadata["reason"] == "degenerate_factor_variance"
+        assert result.p_value is None
+        assert result.metadata["signal_status"] == "degenerate_zero_variance"
+        assert "reason" not in result.metadata
+        assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
         assert result.n_obs == MIN_PERIODS_HARD
 
     def test_missing_return_column(self) -> None:


### PR DESCRIPTION
## Summary
- normalize four zero-dispersion paths to the canonical degenerate result shape
- withhold fabricated p-values and mark the outputs with degenerate_variance
- prove each producer is excluded from BHY families and remains safe under strict evaluation
- align pre-flight and user documentation with the result contract

The fix is producer-side only. It does not broaden BHY reason parsing or retain the former dual taxonomy.

## Verification
- full suite: 3689 passed, 46 skipped
- relevant contract/docs suite: 183 passed
- final inspect/BHY/docs suite: 136 passed
- Ruff, mypy, and git diff --check passed

## Dependency
None. This branch is based directly on main including #1004 and does not depend on PR #1018.

Closes #1006