### PR TITLE
fix(metrics): reject invalid event baseline prices

### DIFF
--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -46,6 +46,14 @@ title: factrix.metrics.event_horizon
     [confounded-event note](../../reference/metric-applicability.md#confounded-event-handling)
     on within-asset event clustering.
 
+!!! warning "Invalid prices withdraw the curve"
+    `event_around_return` needs a finite unconditional bar-return baseline.
+    Any observed non-finite or non-positive `price` invalidates that baseline,
+    so the metric returns `value=NaN`, an empty `per_offset`, and
+    `WarningCode.METRIC_UNAVAILABLE` with `reason="invalid_price_data"`.
+    Missing (`null`) observations remain allowed on ragged panels; fix invalid
+    observed prices rather than interpreting a contaminated finite hit rate.
+
 ## Use cases
 
 <div class="grid cards" markdown>

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -469,7 +469,11 @@ Pre/post-event return profile; descriptive.
   as events accumulate), `interpretation`. `reason` is set to
   `no_pre_event_offset_with_enough_events` and `value` is `NaN` when no
   negative offset cleared the 5-event floor — `0.0` there was the *best*
-  possible score for a quantity never computed.
+  possible score for a quantity never computed. An observed non-finite or
+  non-positive price instead withdraws the entire curve with
+  `reason=invalid_price_data`, `per_offset={}`, and
+  `WarningCode.METRIC_UNAVAILABLE`; `n_invalid_prices` reports the offending
+  row count. Null prices remain valid missing data on a ragged panel.
 - `p_value` is `None` — no hypothesis test runs, and no offset carries a
   `p`: the headline `value` is the pre-event leakage score and per-horizon
   `hit_rate` is a raw fraction of positive signed returns. Offsets overlap

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -31,6 +31,7 @@ from factrix._types import DDOF, EPSILON
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _densify_on_period_grid,
+    _finite_expr,
     _short_circuit_output,
     _warn_ragged_event_grid,
 )
@@ -46,14 +47,18 @@ __all__ = [
 _EH_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
 
-def _unconditional_bar_return(data: pl.DataFrame, price_col: str) -> float:
+def _unconditional_bar_return(
+    data: pl.DataFrame, price_col: str
+) -> tuple[float | None, int]:
     """Mean single-bar return across the whole panel, per asset then pooled.
 
     The pre-event offsets are single-bar returns, so an asset that drifts up
     0.1% a bar has pre-event means of 0.1% with no information leakage at all.
     Subtracting this baseline makes the leakage score measure what its name
-    says. Returns ``0.0`` when it cannot be computed, which leaves the score
-    exactly as it was.
+    says. Returns ``None`` when it cannot be computed. A non-finite or
+    non-positive observed price invalidates the baseline rather than being
+    silently dropped: otherwise a contaminated denominator can manufacture
+    an infinite baseline and a finite-looking hit rate.
 
     The bar is one step on the panel's period grid, matching the offsets it is
     subtracted from: on a ragged panel a step across an asset's missing periods
@@ -61,18 +66,23 @@ def _unconditional_bar_return(data: pl.DataFrame, price_col: str) -> float:
     baseline.
     """
     if price_col not in data.columns or "asset_id" not in data.columns:
-        return 0.0
-    dense, _ = _densify_on_period_grid(data)
-    rets = (
-        dense.with_columns(
-            (pl.col(price_col) / pl.col(price_col).shift(1).over("asset_id") - 1).alias(
-                "_bar_ret"
-            )
-        )["_bar_ret"]
-        .drop_nulls()
-        .drop_nans()
+        return None, 0
+
+    price = pl.col(price_col).cast(pl.Float64, strict=False)
+    invalid_price = pl.col(price_col).is_not_null() & (
+        ~_finite_expr(price_col) | (price <= EPSILON).fill_null(False)
     )
-    return float(rets.mean()) if len(rets) else 0.0  # type: ignore[arg-type]
+    n_invalid_prices = data.filter(invalid_price).height
+    if n_invalid_prices:
+        return None, n_invalid_prices
+
+    dense, _ = _densify_on_period_grid(data)
+    rets = dense.with_columns(
+        (pl.col(price_col) / pl.col(price_col).shift(1).over("asset_id") - 1).alias(
+            "_bar_ret"
+        )
+    ).filter(_finite_expr("_bar_ret"))["_bar_ret"]
+    return (float(rets.mean()), 0) if len(rets) else (None, 0)  # type: ignore[arg-type]
 
 
 @metric(
@@ -114,9 +124,9 @@ def event_around_return(
 
     Returns:
         MetricResult with per-offset stats in metadata. When price data is
-        unavailable, returns a short-circuit MetricResult (``value=NaN``,
-        ``metadata["reason"]="no_price_data"``) so all metrics share a
-        single return contract.
+        unavailable or the unconditional baseline cannot be computed from
+        valid positive prices, returns a short-circuit MetricResult
+        (``value=NaN``) so all metrics share a single return contract.
 
     Notes:
         For each offset ``k``: ``mean, median, p25, p75, hit_rate``
@@ -203,12 +213,31 @@ def event_around_return(
             per_offset={},
         )
 
+    n_events = event_rets.select("date", "asset_id").n_unique()
+    # Unconditional mean single-bar return across the whole panel: the baseline
+    # every offset is measured against. A bad observed price invalidates the
+    # whole baseline; dropping only its affected return would silently change
+    # the estimand and still publish a finite-looking hit rate.
+    baseline, n_invalid_prices = _unconditional_bar_return(data, price_col)
+    if baseline is None:
+        reason = (
+            "invalid_price_data" if n_invalid_prices else "no_finite_baseline_returns"
+        )
+        return _short_circuit_output(
+            "event_around_return",
+            reason,
+            descriptive=True,
+            n_obs=n_events,
+            n_obs_axis="events",
+            n_events=n_events,
+            n_invalid_prices=n_invalid_prices,
+            baseline_bar_return=None,
+            per_offset={},
+        )
+
     per_offset: dict[int, dict] = {}
     pre_leakage_vals: list[float] = []
     pre_leakage_se: list[float] = []
-    # Unconditional mean single-bar return across the whole panel: the baseline
-    # every offset is measured against.
-    baseline = _unconditional_bar_return(data, price_col)
 
     for k in offsets:
         subset = event_rets.filter(pl.col("offset") == k)
@@ -261,8 +290,6 @@ def event_around_return(
     # here broke the uniform column in to_frame() for no reason — the count is
     # already in per_offset. One event contributes one row per offset, so the
     # row count is not it; the distinct event count is.
-    n_events = event_rets.select("date", "asset_id").n_unique()
-
     warning_codes: list[str] = []
     _warn_ragged_event_grid(
         "event_around_return", data, warning_codes, expected_warnings=expected_warnings

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -190,6 +190,24 @@ class TestEventAroundReturn:
         assert result.n_obs == 0
         assert result.n_obs_axis == "events"
 
+    def test_zero_price_withholds_contaminated_baseline(self, event_data):
+        poisoned = event_data.with_row_index("_row").with_columns(
+            pl.when(pl.col("_row") == 0)
+            .then(0.0)
+            .otherwise(pl.col("price"))
+            .alias("price")
+        )
+
+        result = event_around_return(poisoned.drop("_row"))
+
+        assert math.isnan(result.value)
+        assert result.p_value is None
+        assert result.metadata["reason"] == "invalid_price_data"
+        assert result.metadata["n_invalid_prices"] == 1
+        assert result.metadata["baseline_bar_return"] is None
+        assert result.metadata["per_offset"] == {}
+        assert fx.WarningCode.METRIC_UNAVAILABLE.value in result.warning_codes
+
 
 class TestEventMetricThroughEvaluate:
     def test_price_survives_dag_projection(self, event_data):


### PR DESCRIPTION
## Summary

- reject non-finite, non-positive, and near-zero observed prices before estimating the unconditional event baseline
- withdraw the descriptive curve with NaN, an empty per-offset result, metric_unavailable, and an explicit invalid_price_data reason
- retain event and invalid-price counts for diagnosis, while continuing to allow nulls on ragged panels
- document the invalid-price contract and add a zero-price regression test

## Why

A zero denominator previously produced an infinite baseline because Polars drop_nans does not remove infinity. Comparing finite event returns with that baseline then yielded a plausible-looking hit rate instead of declaring the metric unavailable. Dropping only the affected return would silently change the baseline sample, so this PR conservatively withholds the whole curve.

## Validation

- 3688 passed, 46 skipped
- ruff check .
- ruff format --check factrix tests
- mypy factrix

## Merge order

No logical dependency on #1020 or #1021. This branch is based on current main, including #1018, and can be merged independently.

Closes #1008