### PR TITLE
fix(metrics): align degenerate result contracts (#1013)

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -188,7 +188,7 @@ is emitted.
   `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` when `L > T / 5`; below 30
   it emits the binding `WarningCode.UNRELIABLE_SE_SHORT_PERIODS` without a
   redundant bandwidth echo. It short-circuits to `value = NaN` with
-  `reason = "insufficient_periods"` below 3. An explicit
+  `reason = "insufficient_pooled_periods"` below 3. An explicit
   `driscoll_kraay_lags` replaces the automatic base
   but cannot undercut the overlap floor or exceed the estimability cap.
 
@@ -1080,8 +1080,10 @@ producing `MetricResult`s rather than bare floats.
 ## Short-circuit envelope
 
 Every metric falls back to a uniform short-circuit `MetricResult`
-when input data fails the metric's preconditions (insufficient
-sample, no events, degenerate signal, …). The fallback shape is:
+when input data fails the metric's preconditions (for example, an
+insufficient sample or missing input). A defined point estimate whose
+hypothesis test degenerates keeps its `value` and instead withholds only
+`stat`, `p_value`, and `alternative`. The short-circuit shape is:
 
 - `value = float("nan")`, `stat = None`, `significance = ""`.
 - `MetricResult.n_obs: int | None` — first-class sample size the
@@ -1089,7 +1091,7 @@ sample, no events, degenerate signal, …). The fallback shape is:
   actually available). Populated when the short-circuit knows the
   number; `None` otherwise.
 - `metadata["reason"]: str` names the short-circuit branch (e.g.
-  `"insufficient_periods"`, `"no_events"`,
+  `"insufficient_ic_periods"`, `"no_return_column"`,
   `"not_applicable_discrete_signal"`, `"insufficient_clusters"`).
 - `MetricResult.p_value = 1.0` — conservative scalar default for callers
   reading the field directly (descriptive short-circuits use `None`).

--- a/factrix/metrics/caar.py
+++ b/factrix/metrics/caar.py
@@ -820,7 +820,7 @@ def bmp_z(
     if len(events) == 0:
         return _short_circuit_output(
             "bmp_z",
-            "no_events",
+            "insufficient_events",
             n_obs=0,
             n_obs_axis="events",
             min_required=1,

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -137,7 +137,12 @@ def clustering_hhi(
     n_events = len(events)
 
     sc = _enforce_min_floor(
-        clustering_hhi, "clustering_hhi", n_events, "insufficient_events", axis="events"
+        clustering_hhi,
+        "clustering_hhi",
+        n_events,
+        "insufficient_events",
+        axis="events",
+        descriptive=True,
     )
     if sc is not None:
         return sc

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -444,7 +444,7 @@ def common_beta_profile(
         common_beta_profile,
         "common_beta_profile",
         n,
-        "no_asset_beta_observations",
+        "insufficient_asset_beta_observations",
         axis="assets",
         descriptive=True,
     )
@@ -565,8 +565,9 @@ def common_beta_r_squared(
         common_beta_r_squared,
         "common_beta_r_squared",
         n,
-        "no_asset_r_squared_observations",
+        "insufficient_asset_r_squared_observations",
         axis="assets",
+        descriptive=True,
     )
     if sc is not None:
         return sc
@@ -828,6 +829,7 @@ def common_beta_sign_consistency(
         n,
         "insufficient_assets_for_sign_consistency",
         axis="assets",
+        descriptive=True,
     )
     if sc is not None:
         return sc

--- a/factrix/metrics/corrado_rank.py
+++ b/factrix/metrics/corrado_rank.py
@@ -22,14 +22,13 @@ from factrix._stats import _calc_t_stat
 from factrix._types import (
     DDOF,
     DEFAULT_FORWARD_PERIODS,
-    EPSILON,
     MIN_EVENTS_HARD,
     MIN_EVENTS_WARN,
 )
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     _attach_abnormal_return,
-    _degenerate_metric_output,
+    _degenerate_test_fields,
     _enforce_min_floor,
     _event_sample_threshold,
     _is_sparse_magnitude_weighted,
@@ -409,29 +408,24 @@ def corrado_rank(
     mean_u = float(np.mean(u_bar))
     std_u = float(np.std(u_bar, ddof=DDOF))
 
-    if std_u < EPSILON:
-        return _degenerate_metric_output(
-            n_obs=n_event_periods,
-            n_obs_axis="events",
-            alternative_requested="greater",
-            std_u=std_u,
-            n_events=n_events,
-            n_event_periods=n_event_periods,
-        )
-
     z = _calc_t_stat(mean_u, std_u, n_event_periods)
     # One-sided: u_bar is already direction-adjusted by sign(factor), so
     # z > 0 signals genuine directional skill and z < 0 signals a factor that
     # anti-predicts — a two-sided p would read the latter as "significant".
     p = float(sp_stats.norm.sf(z))
+    if np.isnan(z):
+        metadata["std_u"] = std_u
+    stat, p_out, alternative = _degenerate_test_fields(
+        z, p, "greater", metadata, warning_codes
+    )
 
     return MetricResult(
-        p_value=p,
-        alternative="greater",
+        p_value=p_out,
+        alternative=alternative,
         value=mean_u,
         n_obs=n_event_periods,
         n_obs_axis="events",
-        stat=z,
+        stat=stat,
         warning_codes=tuple(warning_codes),
         metadata=metadata,
     )

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -42,7 +42,7 @@ from factrix._types import (
 )
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
-    _degenerate_metric_output,
+    _degenerate_test_fields,
     _enforce_min_floor,
     _estimate_within_date_icc,
     _finite_expr,
@@ -233,40 +233,6 @@ def directional_hit_rate(
     )
     var_s = var_p_hat - var_p_star
 
-    # Degenerate: one-signed predictions or realisations collapse P* to 1
-    # and drive var_s to (numerically) zero or below — S_n is undefined.
-    if var_s <= 0.0:
-        return _degenerate_metric_output(
-            n_obs=n,
-            n_obs_axis="pairs",
-            alternative_requested="greater",
-            p_correct=p_correct,
-            p_up_pred=p_x,
-            p_up_real=p_y,
-        )
-
-    s_n = (p_correct - p_star) / np.sqrt(var_s)
-
-    # Cross-sectional correlation: pooling every (date, asset) trial as
-    # independent over-states the effective sample because same-date returns
-    # share shocks. Deflate S_n by the Kolari-Pynnönen (2010) factor built from
-    # the within-date ICC of the sign-hit indicator — the same correction
-    # bmp_z applies to clustered SARs. A single-asset series has no within-date
-    # cross-section (one trial per date), so r̂ is undefined and S_n is left
-    # exact (the canonical PT setting).
-    hit_by_date = paired.select(
-        pl.col("date"),
-        (pl.col("_x_sign") == pl.col("_y_sign")).cast(pl.Float64).alias("_hit"),
-    )
-    r_hat, n_eff, _ = _estimate_within_date_icc(hit_by_date, "_hit")
-    if r_hat is not None and n_eff > 1.0:
-        s_stat = s_n * _kp_cluster_scale(r_hat, n_eff)
-        kolari_pynnonen_applied = True
-    else:
-        s_stat = s_n
-        kolari_pynnonen_applied = False
-    p = float(sp_stats.norm.sf(s_stat))
-
     warning_codes: list[str] = []
     warn_code = _warn_below_floor(
         directional_hit_rate,
@@ -293,10 +259,52 @@ def directional_hit_rate(
         "p_expected": p_star,
         "p_up_pred": p_x,
         "p_up_real": p_y,
-        "kolari_pynnonen_r": r_hat,
-        "kolari_pynnonen_n_eff": n_eff,
-        "kolari_pynnonen_applied": kolari_pynnonen_applied,
     }
+
+    # Degenerate: one-signed predictions or realisations collapse P* to 1
+    # and drive var_s to (numerically) zero or below — S_n is undefined.
+    if var_s <= 0.0:
+        stat, p, alternative = _degenerate_test_fields(
+            float("nan"), float("nan"), "greater", metadata, warning_codes
+        )
+        return MetricResult(
+            value=p_correct,
+            p_value=p,
+            alternative=alternative,
+            n_obs=n,
+            n_obs_axis="pairs",
+            stat=stat,
+            metadata=metadata,
+            warning_codes=tuple(warning_codes),
+        )
+
+    s_n = (p_correct - p_star) / np.sqrt(var_s)
+
+    # Cross-sectional correlation: pooling every (date, asset) trial as
+    # independent over-states the effective sample because same-date returns
+    # share shocks. Deflate S_n by the Kolari-Pynnönen (2010) factor built from
+    # the within-date ICC of the sign-hit indicator — the same correction
+    # bmp_z applies to clustered SARs. A single-asset series has no within-date
+    # cross-section (one trial per date), so r̂ is undefined and S_n is left
+    # exact (the canonical PT setting).
+    hit_by_date = paired.select(
+        pl.col("date"),
+        (pl.col("_x_sign") == pl.col("_y_sign")).cast(pl.Float64).alias("_hit"),
+    )
+    r_hat, n_eff, _ = _estimate_within_date_icc(hit_by_date, "_hit")
+    if r_hat is not None and n_eff > 1.0:
+        s_stat = s_n * _kp_cluster_scale(r_hat, n_eff)
+        kolari_pynnonen_applied = True
+    else:
+        s_stat = s_n
+        kolari_pynnonen_applied = False
+    p = float(sp_stats.norm.sf(s_stat))
+
+    metadata.update(
+        kolari_pynnonen_r=r_hat,
+        kolari_pynnonen_n_eff=n_eff,
+        kolari_pynnonen_applied=kolari_pynnonen_applied,
+    )
     if kolari_pynnonen_applied:
         metadata["stat_uncorrected"] = float(s_n)
         metadata["method"] = (

--- a/factrix/metrics/event_quality.py
+++ b/factrix/metrics/event_quality.py
@@ -738,7 +738,12 @@ def profit_factor(
     n = len(events)
 
     sc = _enforce_min_floor(
-        profit_factor, "profit_factor", n, "insufficient_events", axis="events"
+        profit_factor,
+        "profit_factor",
+        n,
+        "insufficient_events",
+        axis="events",
+        descriptive=True,
     )
     if sc is not None:
         return sc
@@ -903,6 +908,7 @@ def event_skewness(
         n,
         "insufficient_events",
         axis="events",
+        descriptive=True,
         overlap_periods=overlap_periods,
     )
     if sc is not None:
@@ -994,6 +1000,7 @@ def signal_density(
             n_obs=n_events,
             n_obs_axis="events",
             min_required=2,
+            descriptive=True,
         )
 
     # Per-asset: count events and date span. Every asset with at least one

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -529,9 +529,9 @@ def _pooled_beta_driscoll_kraay(
     sandwiched with ``(X'X)⁻¹``. The scalar restriction uses the project's
     calibrated HAR bandwidth, finite-sample variance scale and effective
     degrees of freedom. Short-circuits with
-    ``value=NaN`` / ``stat=None`` / ``p=1.0`` below
-    ``_MIN_DK_PERIODS_HARD`` periods (HAC undefined), mirroring the clustered
-    ``G < 3`` guard.
+    ``value=NaN`` / ``stat=None`` / ``p=1.0`` with
+    ``reason="insufficient_pooled_periods"`` below ``_MIN_DK_PERIODS_HARD``
+    periods (HAC undefined), mirroring the clustered ``G < 3`` guard.
     """
     from factrix._stats.hac import _driscoll_kraay_cov as _dk_cov
 
@@ -540,7 +540,7 @@ def _pooled_beta_driscoll_kraay(
     if n_periods < _MIN_DK_PERIODS_HARD:
         return _short_circuit_output(
             "pooled_beta",
-            "insufficient_periods",
+            "insufficient_pooled_periods",
             n_obs=n_obs,
             n_obs_axis="pairs",
             n_periods=n_periods,
@@ -1115,7 +1115,11 @@ def fm_beta_sign_consistency(
     betas = beta_df["beta"].drop_nulls().drop_nans().to_numpy()
     n = len(betas)
     sc = _enforce_min_floor(
-        fm_beta_sign_consistency, "fm_beta_sign_consistency", n, "no_beta_observations"
+        fm_beta_sign_consistency,
+        "fm_beta_sign_consistency",
+        n,
+        "insufficient_fm_beta_observations",
+        descriptive=True,
     )
     if sc is not None:
         return sc

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -164,6 +164,7 @@ def mfe_mae(
         return _short_circuit_output(
             "mfe_mae",
             "no_price_data",
+            descriptive=True,
             mfe_mae_ratio=float("nan"),
             n_events=0,
         )
@@ -190,6 +191,7 @@ def mfe_mae(
         n_events,
         "insufficient_events",
         axis="events",
+        descriptive=True,
         warning_codes=tuple(warning_codes),
         mfe_mae_ratio=float("nan"),
         n_events=n_events,

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -308,12 +308,13 @@ def rank_turnover(
     if len(all_dates) < min_required:
         return _short_circuit_output(
             "rank_turnover",
-            "insufficient_dates",
+            "insufficient_rank_turnover_periods",
             n_obs=len(all_dates),
             n_obs_axis="periods",
             min_required=min_required,
             overlap_periods=overlap_periods,
             rebalance_lag=lag,
+            descriptive=True,
         )
 
     # WHY: polars ``rank()`` sorts NaN *last*, i.e. treats it as larger than
@@ -362,13 +363,14 @@ def rank_turnover(
     if rc_per_date.height < 2:
         return _short_circuit_output(
             "rank_turnover",
-            "insufficient_periods",
+            "insufficient_rank_turnover_periods",
             n_obs=rc_per_date.height,
             n_obs_axis="periods",
             min_required=2,
             overlap_periods=overlap_periods,
             rebalance_lag=lag,
             quantile=quantile,
+            descriptive=True,
         )
 
     rc_arr = rc_per_date["rc"].to_numpy()
@@ -568,9 +570,10 @@ def notional_turnover(
         notional_turnover,
         "notional_turnover",
         len(dates),
-        "insufficient_dates",
+        "insufficient_notional_turnover_periods",
         overlap_periods=overlap_periods,
         rebalance_lag=lag,
+        descriptive=True,
     )
     if sc is not None:
         return sc
@@ -656,6 +659,7 @@ def notional_turnover(
             overlap_periods=overlap_periods,
             rebalance_lag=lag,
             n_groups=n_groups,
+            descriptive=True,
         )
 
     turnover_arr = per_date["turnover"].to_numpy()

--- a/tests/stats/test_degenerate_guard_polarity.py
+++ b/tests/stats/test_degenerate_guard_polarity.py
@@ -42,7 +42,6 @@ _FX007_BASELINE = Counter(
         ("factrix/metrics/_helpers.py", "denom < EPSILON"): 1,
         ("factrix/metrics/common_beta.py", "float(np.std(x)) < EPSILON"): 1,
         ("factrix/metrics/common_beta.py", "var_total <= EPSILON * EPSILON"): 1,
-        ("factrix/metrics/corrado_rank.py", "std_u < EPSILON"): 1,
         ("factrix/metrics/fm_beta.py", "sigma2_f < EPSILON"): 1,
         ("factrix/metrics/ic.py", "std_ic < EPSILON"): 1,
         ("factrix/metrics/predictive_beta.py", "x_std < EPSILON"): 1,

--- a/tests/test_caar.py
+++ b/tests/test_caar.py
@@ -576,6 +576,7 @@ class TestBmpTest:
         )
         result = bmp_z(df)
         assert math.isnan(result.value)
+        assert result.metadata["reason"] == "insufficient_events"
 
     def test_uses_price_for_vol(self, strong_signal):
         result = bmp_z(strong_signal)

--- a/tests/test_common_betas.py
+++ b/tests/test_common_betas.py
@@ -340,7 +340,7 @@ class TestCommonBetaProfile:
         result = common_beta_profile(betas)
         assert np.isnan(result.value)
         assert result.p_value is None
-        assert result.metadata["reason"] == "no_asset_beta_observations"
+        assert result.metadata["reason"] == "insufficient_asset_beta_observations"
 
     def test_negative_neutral_epsilon_rejected(self):
         with pytest.raises(ValueError, match="neutral_epsilon"):

--- a/tests/test_corrado_rank.py
+++ b/tests/test_corrado_rank.py
@@ -95,6 +95,25 @@ class TestOneSidedPValue:
         assert result.p_value == sp_stats.norm.sf(result.stat)
 
 
+class TestDegenerateVariance:
+    def test_keeps_the_defined_mean_rank_when_only_the_test_is_undefined(self):
+        n = 300
+        factor = np.zeros(n)
+        factor[np.arange(70, n, 20)] = 1.0
+        result = corrado_rank(
+            _panel(np.zeros(n), factor),
+            overlap_periods=1,
+            expected_warnings=tuple(code.value for code in WarningCode),
+        )
+
+        assert result.value == pytest.approx(0.0)
+        assert result.stat is None
+        assert result.p_value is None
+        assert result.alternative is None
+        assert result.metadata["signal_status"] == "degenerate_zero_variance"
+        assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
+
+
 class TestNonFiniteReturns:
     """Ranks must be formed over finite returns only."""
 

--- a/tests/test_directional_hit_rate.py
+++ b/tests/test_directional_hit_rate.py
@@ -126,7 +126,7 @@ class TestShortCircuits:
         x = np.abs(rng.normal(size=100)) + 0.1  # all positive
         y = rng.normal(size=100)
         result = directional_hit_rate(_ts_panel(x, y), overlap_periods=1)
-        assert math.isnan(result.value)
+        assert result.value == pytest.approx(float(np.mean(y > 0)))
         assert result.p_value is None
         assert result.metadata["signal_status"] == "degenerate_zero_variance"
         assert "reason" not in result.metadata

--- a/tests/test_evaluation_grid.py
+++ b/tests/test_evaluation_grid.py
@@ -288,7 +288,7 @@ class TestStaleStampHintIsTimeAxisOnly:
         )
         out = rank_turnover(panel, overlap_periods=5)
         assert out.n_obs_axis == "periods"
-        assert out.metadata["reason"] == "insufficient_dates"
+        assert out.metadata["reason"] == "insufficient_rank_turnover_periods"
         assert "compute_forward_return(..., dates=" in out.metadata["hint"]
 
     def test_asset_axis_short_circuit_does_not_carry_the_hint(self):

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -101,7 +101,7 @@ class TestDriscollKraayPath:
         res = pooled_beta(df, driscoll_kraay=True)
         assert np.isnan(res.value)
         assert res.stat is None
-        assert res.metadata["reason"] == "insufficient_periods"
+        assert res.metadata["reason"] == "insufficient_pooled_periods"
         assert res.metadata["n_periods"] == 2
         assert res.p_value == 1.0
         assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes

--- a/tests/test_short_circuit_contract_consistency.py
+++ b/tests/test_short_circuit_contract_consistency.py
@@ -1,0 +1,175 @@
+"""Cross-metric contracts for descriptive and sample-shortfall results."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from datetime import datetime
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._errors import InsufficientSampleError, UserInputError
+from factrix._results import MetricResult
+from factrix.metrics.clustering_hhi import clustering_hhi
+from factrix.metrics.common_beta import (
+    common_beta_profile,
+    common_beta_r_squared,
+    common_beta_sign_consistency,
+)
+from factrix.metrics.event_quality import event_skewness, profit_factor, signal_density
+from factrix.metrics.fm_beta import fm_beta_sign_consistency
+from factrix.metrics.mfe_mae import mfe_mae
+from factrix.metrics.tradability import notional_turnover, rank_turnover
+
+
+def _panel(*, event: bool = False, n_assets: int = 3, n_dates: int = 1) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "date": [
+                datetime(2024, 1, day + 1)
+                for day in range(n_dates)
+                for _ in range(n_assets)
+            ],
+            "asset_id": [f"A{i}" for _ in range(n_dates) for i in range(n_assets)],
+            "factor": [1.0 if event else 0.0] * n_assets * n_dates,
+            "forward_return": [0.01] * n_assets * n_dates,
+        }
+    )
+
+
+def _empty_frame(**schema: pl.DataType) -> pl.DataFrame:
+    return pl.DataFrame(schema=schema)
+
+
+CaseFactory = Callable[[], MetricResult]
+
+
+@pytest.mark.parametrize(
+    ("factory", "reason", "error_type"),
+    [
+        pytest.param(
+            lambda: clustering_hhi(_panel()),
+            "insufficient_events",
+            InsufficientSampleError,
+            id="clustering_hhi",
+        ),
+        pytest.param(
+            lambda: signal_density(_panel()),
+            "insufficient_events",
+            InsufficientSampleError,
+            id="signal_density",
+        ),
+        pytest.param(
+            lambda: profit_factor(_panel(event=True)),
+            "insufficient_events",
+            InsufficientSampleError,
+            id="profit_factor",
+        ),
+        pytest.param(
+            lambda: event_skewness(_panel(event=True)),
+            "insufficient_events",
+            InsufficientSampleError,
+            id="event_skewness",
+        ),
+        pytest.param(
+            lambda: mfe_mae(
+                _empty_frame(
+                    date=pl.Datetime("ms"),
+                    asset_id=pl.String,
+                    mfe=pl.Float64,
+                    mae=pl.Float64,
+                )
+            ),
+            "no_price_data",
+            UserInputError,
+            id="mfe_mae",
+        ),
+        pytest.param(
+            lambda: mfe_mae(
+                pl.DataFrame(
+                    {
+                        "date": [datetime(2024, 1, 1)],
+                        "asset_id": ["A"],
+                        "mfe": [0.1],
+                        "mae": [-0.1],
+                    }
+                )
+            ),
+            "insufficient_events",
+            InsufficientSampleError,
+            id="mfe_mae_thin_events",
+        ),
+        pytest.param(
+            lambda: rank_turnover(_panel()),
+            "insufficient_rank_turnover_periods",
+            InsufficientSampleError,
+            id="rank_turnover",
+        ),
+        pytest.param(
+            lambda: rank_turnover(_panel(event=True, n_dates=5)),
+            "insufficient_rank_turnover_periods",
+            InsufficientSampleError,
+            id="rank_turnover_no_rank_dispersion",
+        ),
+        pytest.param(
+            lambda: notional_turnover(_panel(n_assets=10)),
+            "insufficient_notional_turnover_periods",
+            InsufficientSampleError,
+            id="notional_turnover",
+        ),
+        pytest.param(
+            lambda: notional_turnover(_panel(n_assets=4, n_dates=5), rebalance_lag=1),
+            "insufficient_assets_for_quantile_groups",
+            InsufficientSampleError,
+            id="notional_turnover_unfilled_groups",
+        ),
+        pytest.param(
+            lambda: common_beta_profile(
+                _empty_frame(asset_id=pl.String, beta=pl.Float64)
+            ),
+            "insufficient_asset_beta_observations",
+            InsufficientSampleError,
+            id="common_beta_profile",
+        ),
+        pytest.param(
+            lambda: common_beta_r_squared(
+                _empty_frame(asset_id=pl.String, r_squared=pl.Float64)
+            ),
+            "insufficient_asset_r_squared_observations",
+            InsufficientSampleError,
+            id="common_beta_r_squared",
+        ),
+        pytest.param(
+            lambda: common_beta_sign_consistency(
+                _empty_frame(asset_id=pl.String, beta=pl.Float64)
+            ),
+            "insufficient_assets_for_sign_consistency",
+            InsufficientSampleError,
+            id="common_beta_sign_consistency",
+        ),
+        pytest.param(
+            lambda: fm_beta_sign_consistency(
+                _empty_frame(date=pl.Datetime("ms"), beta=pl.Float64)
+            ),
+            "insufficient_fm_beta_observations",
+            InsufficientSampleError,
+            id="fm_beta_sign_consistency",
+        ),
+    ],
+)
+def test_descriptive_short_circuits_share_shape_reason_and_exception(
+    factory: CaseFactory,
+    reason: str,
+    error_type: type[Exception],
+) -> None:
+    result = factory()
+
+    assert math.isnan(result.value)
+    assert result.p_value is None
+    assert result.alternative is None
+    assert result.stat is None
+    assert result.metadata["reason"] == reason
+
+    with pytest.raises(error_type):
+        fx._enforce_strict({"metric": result})

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -55,14 +55,14 @@ class TestComputeRankTurnover:
         ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
         result = rank_turnover(df)
         assert math.isnan(result.value)
-        assert result.metadata["reason"] == "insufficient_dates"
+        assert result.metadata["reason"] == "insufficient_rank_turnover_periods"
 
     def test_insufficient_dates_for_horizon(self):
         """2·h + 1 dates is the minimum for SE to be defined."""
         df = _panel(4, ["A", "B", "C"], lambda t, a: ord(a) + t)
         result = rank_turnover(df, overlap_periods=2)
         assert math.isnan(result.value)
-        assert result.metadata["reason"] == "insufficient_dates"
+        assert result.metadata["reason"] == "insufficient_rank_turnover_periods"
         assert result.metadata["min_required"] == 5
 
     def test_non_overlapping_skips_intermediate_noise(self):
@@ -239,7 +239,7 @@ class TestNotionalTurnover:
         df = _panel(1, self.TEN_ASSETS, lambda t, a: ord(a))
         result = notional_turnover(df, n_groups=5)
         assert math.isnan(result.value)
-        assert result.metadata["reason"] == "insufficient_dates"
+        assert result.metadata["reason"] == "insufficient_notional_turnover_periods"
 
     def test_validation(self):
         df = _panel(3, self.TEN_ASSETS, lambda t, a: ord(a))


### PR DESCRIPTION
## Summary

- preserve `corrado_rank` and `directional_hit_rate` point estimates when only their inference variance degenerates
- make descriptive metric short-circuits return no hypothesis-test fields
- normalize sample-shortfall reasons so strict mode raises `InsufficientSampleError` consistently
- align period reason tokens with metric-scoped project vocabulary and document the contract

## Quant and API impact

The estimands and normal-path statistics are unchanged. Degenerate inference now withholds only `stat`, `p_value`, and `alternative` when the point estimate remains defined. Descriptive short-circuits no longer resemble failed two-sided tests, and renamed `insufficient_*` reasons intentionally correct strict-mode exception routing.

This is a pre-1.0 return-shape and exception-class correction. The repository's current changelog policy keeps `CHANGELOG.md` as an index, so the migration detail lives here and in the reference contract.

## Validation

- `ruff format --check factrix tests`
- `ruff check factrix tests`
- `mypy factrix`
- `pytest -p no:faulthandler` — 3722 passed, 46 skipped

Closes #1013