### PR TITLE
fix(metadata): align documented contracts (#1014)

### DIFF
--- a/docs/api/metrics/clustering_hhi.md
+++ b/docs/api/metrics/clustering_hhi.md
@@ -19,7 +19,7 @@ title: factrix.metrics.clustering_hhi
     ---
 
     Read `value` (Herfindahl-Hirschman index (HHI) on the event-period histogram) and
-    `metadata["effective_n_periods"]` $= 1 / \mathrm{HHI}$. High HHI →
+    `metadata["n_periods_effective"]` $= 1 / \mathrm{HHI}$. High HHI →
     the events that exist are concentrated on few of the dates that have
     events. **This is one axis of three, and not the one the
     Kolari-Pynnönen adjustment acts on**: HHI is invariant to how many assets
@@ -60,7 +60,7 @@ title: factrix.metrics.clustering_hhi
 
     diag = clustering_hhi(panel)
     print(diag.value,
-          diag.metadata["effective_n_periods"],
+          diag.metadata["n_periods_effective"],
           diag.metadata["hhi_normalized"],
           diag.metadata["events_per_period_mean"],
           diag.metadata["share_events_in_bursts"])

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -101,16 +101,31 @@ normal path `MetricResult.alternative` already records it, so a second copy
 would read as a degeneracy marker. Metrics that expose no `alternative`
 knob record `"two-sided"` here, which is what they ran.
 
+### Drop-stat schema — metrics that filter an upstream sample
+
+Metrics that discard unusable observations expose the same five descriptive
+keys for the affected axis:
+
+- Period axis: `n_periods_in`, `n_periods_out`, `dropped_periods`,
+  `drop_rate`, `drop_reason`.
+- Asset axis: `n_assets_in`, `n_assets_out`, `dropped_assets`, `drop_rate`,
+  `drop_reason`.
+
+The `*_in` and `*_out` counts describe the sample before and after filtering;
+`dropped_*` is their difference. `drop_reason` is `None` when nothing was
+dropped. `WarningCode.EXCESSIVE_PERIOD_DROPS` and
+`WarningCode.EXCESSIVE_ASSET_DROPS` direct users to these fields.
+
 ## Per-metric schemas
 
 ### `ic` family (`factrix.metrics.ic`)
 
 #### `ic`
 
-- *primary*: `p_value` — test on the per-period IC series, from the configured `inference`: a `t`-test on a non-overlapping stride of `overlap_periods` (default), a Newey-West HAC `t`-test, or a stationary-bootstrap empirical `p`.
+- *primary*: `p_value` — test on the per-period IC series, from the configured `inference`: a `t`-test on a non-overlapping stride of `overlap_periods` (default), a Newey-West HAC `t`-test, or a stationary-bootstrap empirical *p*.
 - *descriptive*: `n_periods` (the sample the `value` / `stat` / `p_value` describe — the strided subsample under `NonOverlapping`, the full series under `NeweyWest` / `StationaryBootstrap`; equals `n_obs`), `n_periods_full` and `mean_ic_full` (the full per-period series, for reference), `overlap_periods`, `tie_ratio` (median across periods), `min_assets_per_period` / `warn_assets_per_period` when the upstream IC series carries per-period asset counts, `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`), `h0` (`"mu=0"`), and `method`.
 - *descriptive* (conditional, `NeweyWest`): `newey_west_lags` (resolved Bartlett bandwidth) and `hac_dof` (the effective degrees of freedom the `t` is read against; `None` when the sample is too short to run the kernel).
-- *descriptive* (conditional, `StationaryBootstrap`): `n_resamples` and `seed` (the resolved seed, reported even when not supplied, so an unseeded run stays reproducible; `null` when a `numpy.random.Generator` was supplied — that stream is the caller's to reproduce), `p_value_mc_se` (Monte-Carlo SE of the empirical `p`), `block_length` (the resolved Politis-White mean block length) and `studentized`. See [Resampling knobs](statistical-methods.md#resampling-knobs).
+- *descriptive* (conditional, `StationaryBootstrap`): `n_resamples` and `seed` (the resolved seed, reported even when not supplied, so an unseeded run stays reproducible; `null` when a `numpy.random.Generator` was supplied — that stream is the caller's to reproduce), `p_value_mc_se` (Monte-Carlo SE of the empirical *p*), `block_length` (the resolved Politis-White mean block length) and `studentized`. See [Resampling knobs](statistical-methods.md#resampling-knobs).
 - *warning*: `WarningCode.FEW_ASSETS` when retained per-period IC cross-sections are below `MIN_IC_ASSETS_WARN`; `WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED` under `NeweyWest` when the resolved bandwidth exceeds `n_periods / 5`.
 - *short-circuit*: `reason` `insufficient_ic_periods` (too few periods) carries `min_required`; `insufficient_ic_assets` (every cross-section below `MIN_IC_ASSETS_HARD`, so no per-period IC survived — common on one-valid-pair panels) carries `min_assets_required`.
 
@@ -375,9 +390,8 @@ Same shape as `positive_rate` (exact binomial, `stat` = hit count).
   `sign_base_rate_source` (`non_event_rows`, or `assumed_symmetric` when
   there are too few non-event rows to estimate it), `n_base_rate_rows`.
 - *descriptive*: `kolari_pynnonen_r` / `kolari_pynnonen_n_eff` /
-  `kolari_pynnonen_r_source` / `kolari_pynnonen_applied` /
-  `kolari_pynnonen_scaling` / `stat_uncorrected` (the within-period clustering
-  estimate and the deflator),
+  `kolari_pynnonen_r_source` / `kolari_pynnonen_applied` (the within-period
+  clustering estimate and whether the deflator ran),
   `n_events` (events surviving the non-overlap spacing pass —
   the binomial `n`), `n_hits`, `n_events_dropped_non_finite`
   (events with a non-finite return / factor, excluded from `n`),
@@ -390,6 +404,8 @@ Same shape as `positive_rate` (exact binomial, `stat` = hit count).
   size at h = 1 / 5 / 21 on 20 assets, nominal 5%),
   `n_events_overlapping` / `n_events_sampled` (removed by, and surviving,
   the spacing pass; a non-zero removal fires `EVENT_WINDOW_OVERLAP`).
+- *descriptive* (conditional, clustering adjustment applied):
+  `kolari_pynnonen_scaling`, `stat_uncorrected`.
 
 #### `event_ic`
 
@@ -474,7 +490,7 @@ Pre/post-event return profile; descriptive.
   unconditional mean single-bar return, subtracted so a trending asset does
   not read as leaky), `leakage_null_scale` (`≈ 0.8 × mean se` — what the
   headline is worth under *no* leakage, since `E|x̄| > 0` always and shrinks
-  as events accumulate), `interpretation`. `reason` is set to
+  as events accumulate). `reason` is set to
   `no_pre_event_offset_with_enough_events` and `value` is `NaN` when no
   negative offset cleared the 5-event floor — `0.0` there was the *best*
   possible score for a quantity never computed. An observed non-finite or
@@ -488,6 +504,9 @@ Pre/post-event return profile; descriptive.
   each other within an event and, unlike the event significance tests, this
   metric applies no non-overlap sampling across events, so the curve is a
   shape to read rather than a test to interpret.
+- Interpret a larger headline value as more potential pre-event leakage. It
+  is the mean absolute single-bar excess return across eligible pre-event
+  offsets, not a cumulative pre-event CAR.
 
 ### `monotonicity` (`factrix.metrics.monotonicity`)
 
@@ -557,7 +576,7 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
   behind the `few_assets` diagnostic), `tie_ratio`, `tie_policy`,
   `stat_type` (the test actually run: `"t"` under `NonOverlapping` /
   `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`), `method`.
-- *descriptive*: `n_periods_in`, `n_periods_out`, `n_dropped`,
+- *descriptive*: `n_periods_in`, `n_periods_out`, `dropped_periods`,
   `drop_rate`, `drop_reason` — the null/NaN-drop bookkeeping on the
   **strided** spread series (`n_periods_in` also appears on the
   no-surviving-periods short-circuit).
@@ -572,14 +591,24 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
 
 #### `quantile_spread_vw`
 
-Value-weighted variant. Same metadata shape as `quantile_spread` —
-including `median_cross_section`, `n_periods_strided`, `stat_type` (the test actually run: `"t"` under `NonOverlapping` / `NeweyWest`, `"bootstrap-mean"` under `StationaryBootstrap`)
-and whatever the selected inference member contributes — plus a `weights_lagged` flag
-indicating whether the weighting input was lagged before the join
-(descriptive). It takes the same `inference=` knob off the same
+Value-weighted variant. It takes the same `inference=` knob off the same
 allowlist as `quantile_spread`, so the equal-weighted / value-weighted
 pair is tested the same way on the same date set; under `NEWEY_WEST` the
 VW leg gives up the first date, whose lagged weight does not exist.
+
+- *descriptive*: `n_periods`, `n_periods_strided`, `median_cross_section`,
+  `n_groups`, `overlap_periods`, `method`, `stat_type`, `h0`, `tie_ratio`,
+  `tie_policy`, `weights_lagged`, `n_periods_in`, `n_periods_out`,
+  `dropped_periods`, `drop_rate`, `drop_reason`.
+- *descriptive* (conditional, full-series inference): `n_periods_full` plus
+  the selected inference member's metadata (`newey_west_lags` / `hac_dof`,
+  or `n_resamples` / `seed` / `p_value_mc_se` / `block_length` /
+  `studentized`).
+
+`weights_lagged` records whether the weighting input was lagged before the
+join. Unlike `quantile_spread`, the value-weighted metric does not emit
+long/short attribution tests.
+
 It also carries the same thin-cross-section diagnostics — `few_assets`
 on the median per-period finite-factor count and `thin_quantile_groups`
 off the shared bucket threshold. Both were previously absent: the metric
@@ -654,6 +683,8 @@ not reject at any sample size. See
   pairs the cutoff selected, and how many of those were excluded from
   both the HHI and `n_top` for a non-finite weight),
   `warning_codes` (conditional).
+- *descriptive* (conditional, one-signed `abs_factor` input):
+  `n_positive_factor_values`, `n_negative_factor_values`.
 
 ### `clustering` (`factrix.metrics.clustering_hhi`)
 
@@ -664,12 +695,12 @@ is invariant to how many assets fire per date and is bounded below by `1/D`,
 so it cannot answer "do my events cluster?" on its own — read it with the two
 companions.
 
-- *descriptive*: `n_events`, `n_event_periods`, `effective_n_periods`
+- *descriptive*: `n_events`, `n_event_periods`, `n_periods_effective`
   (`1/HHI`), `hhi_normalized` (`(HHI - 1/D)/(1 - 1/D)`; `0` when every event
   date carries the same count, **including** under perfect cross-sectional
   clustering), `events_per_period_mean` (Kish effective cluster size — the
-  cross-sectional axis, and the same `n_eff` the Kolari-Pynnönen deflator
-  consumes), `max_events_per_period`, `share_events_in_bursts` (share of
+  cross-sectional axis, and the same $n_{\mathrm{eff}}$ the Kolari-Pynnönen deflator
+  consumes), `events_per_period_max`, `share_events_in_bursts` (share of
   events whose same-asset predecessor sits within `cluster_window` periods on
   the full panel calendar — the temporal axis), `cluster_window`.
 
@@ -878,8 +909,8 @@ which reports `R²` for the OLS regression.
 - *descriptive* (Stambaugh correction): `stambaugh_adjusted` (True on every
   computed result), `beta_ols_uncorrected`, `stambaugh_bias_estimate`
   (`beta_ols_uncorrected - value`), `ar1_phi`,
-  `ar1_phi_corrected`, `innovation_corr` (`rho_hat`),
-  `stambaugh_bias_channel` (`|rho_hat * phi_corrected|`),
+  `ar1_phi_corrected`, `innovation_corr` ($\hat\rho$),
+  `stambaugh_bias_channel` ($|\hat\rho \phi_{corrected}|$),
   `ar1_phi_corrected_explosive` (`ar1_phi_corrected >= 1` — the corrected
   AR(1) coefficient is deliberately not clamped, because clamping it
   re-opens the bias the correction exists to close).
@@ -996,7 +1027,7 @@ scale and the kernel's fixed-`b` effective `ν`.
   a constant return); `value` is kept.
 - *secondary-test* (conditional, Method B ran):
   `method_b`, `stat_type_method_b`, `beta_pos`, `beta_neg`,
-  `p_wald_slopes`.
+  `p_wald_slopes`, `h0_method_b` (`"beta_pos = beta_neg"`).
 - *warning codes* (conditional): `serial_correlation_detected` (per-period
   factor persistent once strided at `overlap_periods`),
   `unreliable_se_short_periods` (fewer than 30 periods after that stride),
@@ -1013,7 +1044,7 @@ scale and the kernel's fixed-`b` effective `ν`.
 - *primary*: `p_value` — Wald F on `H₀: β_top = β_bottom` from an OLS fit
   on bucket dummies. A single restriction, so it takes the scalar HAR
   reference (`_resolve_scalar_wald_hac`): finite-sample `F_{1, ν}` at the
-  kernel's fixed-`b` effective `ν`. `stat` /
+  kernel's fixed-$b$ effective `ν`. `stat` /
   `p_value` are `None` with `degenerate_variance` when the contrast's HAC
   variance collapses (e.g. identical bucket means every period); `value`
   is kept.

--- a/factrix/metrics/clustering_hhi.py
+++ b/factrix/metrics/clustering_hhi.py
@@ -103,7 +103,7 @@ def clustering_hhi(
         observation: null and NaN factors are excluded rather than counted
         as events (a bare ``factor != 0`` predicate is True for NaN in
         polars as in numpy).
-        ``effective_n_periods`` $= 1 / \mathrm{HHI}$;
+        ``n_periods_effective`` $= 1 / \mathrm{HHI}$;
         ``hhi_normalized`` $= (\mathrm{HHI} - 1/D) / (1 - 1/D)$ rescales
         to $[0, 1]$ — 0 when every event date carries the same number of
         events, including under perfect cross-sectional clustering.
@@ -202,10 +202,10 @@ def clustering_hhi(
         metadata={
             "n_events": n_events,
             "n_event_periods": n_dates,
-            "effective_n_periods": effective_n,
+            "n_periods_effective": effective_n,
             "hhi_normalized": hhi_normalized,
             "events_per_period_mean": events_per_period_mean,
-            "max_events_per_period": int(counts.max()),
+            "events_per_period_max": int(counts.max()),
             "share_events_in_bursts": share_events_in_bursts,
             "cluster_window": cluster_window,
         },

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -314,10 +314,5 @@ def event_around_return(
                 else None
             ),
             **({"reason": leakage_reason} if leakage_reason else {}),
-            "interpretation": (
-                "value = mean over pre-event offsets of |mean single-bar "
-                "signed return| (not a cumulative pre-event CAR); "
-                "high = potential leakage"
-            ),
         },
     )

--- a/factrix/metrics/k_spread.py
+++ b/factrix/metrics/k_spread.py
@@ -325,9 +325,9 @@ def k_spread(
         count under ``NEWEY_WEST`` and ``STATIONARY_BOOTSTRAP``;
         ``metadata["n_periods_strided"]`` always carries the non-overlap
         count and ``metadata["n_periods_full"]`` the overlapping one on
-        either full-series path. The ``n_dropped`` / ``n_periods_in`` /
-        ``n_periods_out`` keys describe the null-drop on the strided
-        series.
+        either full-series path. The ``dropped_periods`` /
+        ``n_periods_in`` / ``n_periods_out`` keys describe the null-drop
+        on the strided series.
 
     References:
         [Hansen-Hodrick 1980][hansen-hodrick-1980]: overlapping-return

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -252,7 +252,8 @@ def quantile_spread(
           always present so the two are comparable.
         - ``metadata["n_periods_full"]``: the overlapping sample
           (``NEWEY_WEST`` / ``STATIONARY_BOOTSTRAP`` paths only).
-        - ``metadata["n_dropped"]`` / ``n_periods_in`` / ``n_periods_out``:
+        - ``metadata["dropped_periods"]`` / ``n_periods_in`` /
+          ``n_periods_out``:
           the null- and NaN-drop bookkeeping on the **strided** series.
 
         **Non-finite observations.** Every series column consumed here is

--- a/tests/test_clustering_hhi.py
+++ b/tests/test_clustering_hhi.py
@@ -35,6 +35,7 @@ class TestEventSelection:
         result = clustering_hhi(_panel(_event_rows(20, 2)))
         assert result.metadata["n_events"] == 40
         assert result.metadata["n_event_periods"] == 20
+        assert result.metadata["n_periods_effective"] == pytest.approx(20.0)
         assert result.value == pytest.approx(1 / 20)
 
     def test_nan_factor_is_not_an_event(self):
@@ -107,7 +108,7 @@ class TestTheAxesHhiCannotSee:
         # The companion measure is not blind.
         assert one.metadata["events_per_period_mean"] == pytest.approx(1.0)
         assert many.metadata["events_per_period_mean"] == pytest.approx(20.0)
-        assert many.metadata["max_events_per_period"] == 20
+        assert many.metadata["events_per_period_max"] == 20
 
     def test_events_per_period_mean_feeds_the_kp_adjustment(self):
         # It is the same n_eff the deflator consumes, so the diagnostic and the

--- a/tests/test_docs_stat_keys_by_metric.py
+++ b/tests/test_docs_stat_keys_by_metric.py
@@ -20,6 +20,7 @@ import re
 
 import pytest
 from factrix._metric_index import public_specs
+from factrix.metrics._helpers import _drop_stat_keys
 
 METRICS_DIR = pathlib.Path("factrix/metrics")
 DOCS_PAGE = pathlib.Path("docs/reference/stat-keys-by-metric.md")
@@ -33,6 +34,7 @@ _KEY_BULLET = re.compile(
     re.M,
 )
 _BACKTICK_TOKEN = re.compile(r"`([a-z][a-z0-9_]*)`")
+_KEY_TOKEN = re.compile(r"[a-z][a-z0-9_]*")
 
 _COMMON_KEYS: frozenset[str] = frozenset(
     {"p_value", "stat_type", "h0", "method", "reason"}
@@ -69,14 +71,77 @@ def _public_metric_modules() -> list[pathlib.Path]:
     return sorted(p for p in METRICS_DIR.glob("*.py") if not p.stem.startswith("_"))
 
 
-def _dict_string_keys(node: ast.AST) -> set[str]:
+def _dict_string_keys(
+    node: ast.AST,
+    bindings: dict[str, set[str]] | None = None,
+) -> set[str]:
+    if isinstance(node, ast.IfExp):
+        return _dict_string_keys(node.body, bindings) | _dict_string_keys(
+            node.orelse, bindings
+        )
     if not isinstance(node, ast.Dict):
         return set()
-    return {
-        k.value
-        for k in node.keys
-        if isinstance(k, ast.Constant) and isinstance(k.value, str)
-    }
+    keys: set[str] = set()
+    for key, value in zip(node.keys, node.values, strict=True):
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            keys.add(key.value)
+        elif key is None and isinstance(value, ast.Name) and bindings is not None:
+            keys |= bindings.get(value.id, set())
+    return keys
+
+
+def _dict_bindings(tree: ast.AST) -> dict[str, set[str]]:
+    """Resolve local dict literals, unpacking, and keyword ``update`` calls."""
+    bindings: dict[str, set[str]] = {}
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            targets: list[ast.Name] = []
+            value: ast.AST | None = None
+            if isinstance(node, ast.Assign):
+                targets = [
+                    target for target in node.targets if isinstance(target, ast.Name)
+                ]
+                value = node.value
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Subscript)
+                        and isinstance(target.value, ast.Name)
+                        and isinstance(target.slice, ast.Constant)
+                        and isinstance(target.slice.value, str)
+                    ):
+                        bound = bindings.setdefault(target.value.id, set())
+                        before = len(bound)
+                        bound.add(target.slice.value)
+                        changed |= len(bound) != before
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                targets = [node.target]
+                value = node.value
+            if value is not None:
+                resolved = _dict_string_keys(value, bindings)
+                for target in targets:
+                    before = len(bindings.setdefault(target.id, set()))
+                    bindings[target.id] |= resolved
+                    changed |= len(bindings[target.id]) != before
+
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            if node.func.attr != "update" or not isinstance(node.func.value, ast.Name):
+                continue
+            target = node.func.value.id
+            resolved: set[str] = set()
+            for arg in node.args:
+                resolved |= _dict_string_keys(arg, bindings)
+                if isinstance(arg, ast.Name):
+                    resolved |= bindings.get(arg.id, set())
+            resolved |= {kw.arg for kw in node.keywords if kw.arg is not None}
+            before = len(bindings.setdefault(target, set()))
+            bindings[target] |= resolved
+            changed |= len(bindings[target]) != before
+    return bindings
 
 
 def _is_metadata_name(node: ast.AST) -> bool:
@@ -95,6 +160,7 @@ def _emitted_metadata_keys(path: pathlib.Path) -> set[str]:
       — each kwarg name is splatted into ``metadata`` by the helper.
     """
     tree = ast.parse(path.read_text(encoding="utf-8"))
+    bindings = _dict_bindings(tree)
     keys: set[str] = set()
 
     for node in ast.walk(tree):
@@ -102,16 +168,21 @@ def _emitted_metadata_keys(path: pathlib.Path) -> set[str]:
             # MetricResult(..., metadata={...})
             for kw in node.keywords:
                 if kw.arg == "metadata":
-                    keys |= _dict_string_keys(kw.value)
+                    keys |= _dict_string_keys(kw.value, bindings)
+                    if isinstance(kw.value, ast.Name):
+                        keys |= bindings.get(kw.value.id, set())
             # metadata.update({...})
             func = node.func
             if (
                 isinstance(func, ast.Attribute)
                 and func.attr == "update"
                 and _is_metadata_name(func.value)
-                and node.args
             ):
-                keys |= _dict_string_keys(node.args[0])
+                for arg in node.args:
+                    keys |= _dict_string_keys(arg, bindings)
+                    if isinstance(arg, ast.Name):
+                        keys |= bindings.get(arg.id, set())
+                keys |= {kw.arg for kw in node.keywords if kw.arg is not None}
             # _short_circuit_output(name, reason, k1=v1, k2=v2, ...)
             if isinstance(func, ast.Name) and func.id == "_short_circuit_output":
                 keys.update(
@@ -123,13 +194,13 @@ def _emitted_metadata_keys(path: pathlib.Path) -> set[str]:
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if _is_metadata_name(target):
-                    keys |= _dict_string_keys(node.value)
+                    keys |= _dict_string_keys(node.value, bindings)
         if (
             isinstance(node, ast.AnnAssign)
             and _is_metadata_name(node.target)
             and node.value is not None
         ):
-            keys |= _dict_string_keys(node.value)
+            keys |= _dict_string_keys(node.value, bindings)
         if (
             isinstance(node, ast.Subscript)
             and _is_metadata_name(node.value)
@@ -161,14 +232,72 @@ def test_metadata_keys_documented(path: pathlib.Path, docs_text: str) -> None:
     )
 
 
-def _shared_source() -> str:
-    """Source text of the internal modules that assemble metric metadata."""
-    return "\n".join(
-        p.read_text(encoding="utf-8")
+def _shared_literal_keys() -> set[str]:
+    """Quoted key tokens in internal metadata builders plus dynamic drop keys."""
+    keys = set(_drop_stat_keys("periods")) | set(_drop_stat_keys("assets"))
+    paths = (
+        p
         for p in sorted(pathlib.Path("factrix").rglob("*.py"))
         if p.stem.startswith("_")
         or p.parent.name in {"_primitives", "inference", "_stats"}
     )
+    for path in paths:
+        keys |= _literal_keys(path)
+    return keys
+
+
+def _literal_keys(path: pathlib.Path) -> set[str]:
+    """Return identifier-shaped string literals, never bare variable names."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _KEY_TOKEN.fullmatch(node.value)
+    }
+
+
+def test_shared_drop_stat_keys_documented(docs_text: str) -> None:
+    missing = sorted(
+        key
+        for axis in ("periods", "assets")
+        for key in _drop_stat_keys(axis)
+        if f"`{key}`" not in docs_text
+    )
+    assert not missing, f"shared drop-stat keys missing from {DOCS_PAGE}: {missing}"
+
+
+def test_metadata_scan_follows_local_dict_updates(tmp_path: pathlib.Path) -> None:
+    module = tmp_path / "metric.py"
+    module.write_text(
+        """
+def metric():
+    method_b = {}
+    method_b.update(h0_method_b="beta_pos = beta_neg")
+    metadata = {**method_b}
+    return MetricResult(metadata=metadata)
+""",
+        encoding="utf-8",
+    )
+
+    assert "h0_method_b" in _emitted_metadata_keys(module)
+
+
+def test_metadata_scan_does_not_treat_local_names_as_keys(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = tmp_path / "metric.py"
+    module.write_text(
+        """
+def metric():
+    n_dropped = 3
+    return MetricResult(metadata={"dropped_periods": n_dropped})
+""",
+        encoding="utf-8",
+    )
+
+    assert _emitted_metadata_keys(module) == {"dropped_periods"}
 
 
 def _documented_keys(section: str) -> set[str]:
@@ -182,7 +311,7 @@ def _documented_keys(section: str) -> set[str]:
 def test_documented_keys_still_exist_in_code(docs_text: str) -> None:
     """Every key the page names must still appear in the metric's sources."""
     name_to_stem = {spec.name: stem for stem, spec in public_specs()}
-    shared = _shared_source()
+    shared = _shared_literal_keys()
 
     sections = re.split(r"^#### ", docs_text, flags=re.M)[1:]
     stale: list[str] = []
@@ -195,11 +324,14 @@ def test_documented_keys_still_exist_in_code(docs_text: str) -> None:
         if stem is None:
             stale.append(f"{name}: documented but not a registered metric")
             continue
-        sources = (METRICS_DIR / f"{stem}.py").read_text(encoding="utf-8") + shared
+        metric_path = METRICS_DIR / f"{stem}.py"
+        emitted = (
+            _emitted_metadata_keys(metric_path) | _literal_keys(metric_path) | shared
+        )
         stale += [
             f"{name}: `{key}` is documented but no longer in factrix sources"
             for key in sorted(_documented_keys(section))
-            if not re.search(rf"\b{key}\b", sources)
+            if key not in emitted
         ]
     assert not stale, (
         f"{DOCS_PAGE} names metadata keys the code no longer carries:\n  "

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -141,6 +141,7 @@ class TestEventAroundReturn:
         result = event_around_return(event_data)
         assert result is not None
         assert "per_offset" in result.metadata
+        assert "interpretation" not in result.metadata
 
     def test_descriptive_no_p_value(self, event_data):
         # Descriptive multi-horizon summary: no hypothesis test runs, so the


### PR DESCRIPTION
## Summary

- align the metadata reference with the keys emitted by quantile, concentration, event, and inference metrics
- normalize clustering metadata to `n_periods_effective` and `events_per_period_max`, and keep the event-return interpretation in documentation instead of every result payload
- strengthen the metadata drift guard for shared drop-stat schemas, local dictionary updates, and dynamic helper-generated keys

## API impact

- renames two pre-1.0 clustering metadata keys for project-wide naming consistency
- removes the constant `interpretation` field from `event_around_return` metadata; the same guidance remains in the reference documentation
- does not change any estimator or statistical calculation

## Validation

- `python -m pytest -p no:faulthandler` (3725 passed, 46 skipped)
- `python -m ruff format --check factrix tests`
- `python -m ruff check factrix tests`
- `python -m mypy factrix`
- `git diff --check`

## Local docs environment

`mkdocs build --strict` was not rerun locally because this Windows `.venv` could not complete the `mkdocs-material` file-install phase after dependency resolution. The focused documentation contract tests pass; the clean docs runner can perform the site build.

Closes #1014