### PR TITLE
fix(stats): harden bootstrap invalid draws (#1017)

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -91,6 +91,13 @@ contrasts, not a sidecar to a primary value.
 | [`breakeven_cost`][factrix.metrics.tradability.breakeven_cost] | none — descriptive | — | breakeven one-way cost (bps) |
 | [`net_spread`][factrix.metrics.tradability.net_spread] | none — descriptive | — | net spread (per-period return) |
 
+### Bootstrap resample counts — `StationaryBootstrap` metrics
+
+`n_resamples` is the requested draw count retained for exact replay with
+`seed`. `n_resamples_used` is the number of finite studentized roots that
+enter the empirical p-value. It can be smaller than `n_resamples`; keeping
+both preserves reproducibility while exposing the p-value denominator.
+
 ### `alternative_requested` — every metric, degenerate path only
 
 A metric that withholds its test on a degenerate sample returns

--- a/docs/reference/statistical-methods.md
+++ b/docs/reference/statistical-methods.md
@@ -130,6 +130,12 @@ procedures.
 Entry points that turn resamples into a p-value or interval use
 `n_resamples` and `rng` consistently.
 
+For `STATIONARY_BOOTSTRAP`, result metadata keeps the requested draw count in
+`n_resamples` so `seed` can reproduce the run. `n_resamples_used` reports the
+finite studentized roots that actually enter the empirical p-value; invalid
+roots are excluded from both its denominator and `p_value_mc_se`. If none are
+usable, the p-value is unavailable rather than `1.0`.
+
 | Entry point | Default `n_resamples` | Enforces the 199 floor | Reports resolved seed |
 |---|---:|---:|---:|
 | `STATIONARY_BOOTSTRAP` on admitted metrics | 999 | Yes | In metric metadata |

--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -166,10 +166,9 @@ def _empirical_p(n_extreme: int, n_resamples: int) -> tuple[float, float]:
         n_resamples: ``B``, the number of resamples the count is out of.
 
     Returns:
-        ``(p_value, p_value_mc_se)``. Callers are gated entry points, so
-        ``B >= BOOTSTRAP_RESAMPLES_FLOOR`` and ``p`` is confined to
-        ``[1/(B+1), 1]``; no clamping or zero-guard is needed, and none is
-        done.
+        ``(p_value, p_value_mc_se)``. For a positive resample count, ``p``
+        is confined to ``[1/(B+1), 1]``; callers handle an empty usable
+        set before entering this helper.
     """
     p = (n_extreme + 1.0) / (n_resamples + 1.0)
     return float(p), float(np.sqrt(p * (1.0 - p) / n_resamples))
@@ -512,12 +511,13 @@ def _block_bootstrap_diff_p(
 
     Returns:
         ``(p_value, metadata)`` — p in ``[1/(B+1), 1]``; metadata
-        records the resolved (fractional) block length, ``n_resamples``,
-        whether the root was studentized, the Monte-Carlo SE of the
-        reported p (``p_value_mc_se``), and the resolved seed (so the run
-        is reproducible from the logged metadata even when the caller
-        passed ``rng=None``) — ``None`` when the caller supplied a
-        ``Generator``.
+        records the resolved (fractional) block length, requested draw count
+        (``n_resamples``), count entering the reported p
+        (``n_resamples_used``), whether the root was studentized, the
+        Monte-Carlo SE of the reported p (``p_value_mc_se``), and the
+        resolved seed (so the run is reproducible from the logged metadata
+        even when the caller passed ``rng=None``) — ``None`` when the caller
+        supplied a ``Generator``.
 
         A series too short to test (``n < 2``) returns ``p = nan`` with
         ``block_length = nan`` and ``n_resamples = 0``. NaN rather than
@@ -542,6 +542,7 @@ def _block_bootstrap_diff_p(
         return float("nan"), {
             "block_length": float("nan"),
             "n_resamples": 0,
+            "n_resamples_used": 0,
             "studentized": False,
             "p_value_mc_se": float("nan"),
             "seed": seed_used,
@@ -596,10 +597,14 @@ def _block_bootstrap_diff_p(
         extreme = _count_extreme(boot_means, observed, alternative)
         n_used = int(n_resamples)
 
-    p, p_mc_se = _empirical_p(extreme, n_used)
+    if n_used == 0:
+        p = p_mc_se = float("nan")
+    else:
+        p, p_mc_se = _empirical_p(extreme, n_used)
     metadata: dict[str, float | int | str | None] = {
         "block_length": L,
         "n_resamples": int(n_resamples),
+        "n_resamples_used": n_used,
         "studentized": studentized,
         "p_value_mc_se": p_mc_se,
         "seed": seed_used,

--- a/factrix/slicing/period_inference.py
+++ b/factrix/slicing/period_inference.py
@@ -811,10 +811,16 @@ def _wald_bootstrap_omnibus(
     mean, so the contrasts are null). Keeps the ``"bootstrap"`` omnibus
     bootstrap-native — consistent with the pairwise path — rather than
     falling back to the χ² asymptotics the ``"analytic"`` path uses.
-    Returns ``(W, p)``; ``(nan, nan)`` on a singular middle matrix (no
-    test — see ``_stats.wald._NOT_COMPUTABLE``).
+    Returns ``(W, p)``; ``(nan, nan)`` on non-finite inputs or a singular
+    middle matrix (no test — see ``_stats.wald._NOT_COMPUTABLE``).
     """
     middle = restriction @ np.diag(variances) @ restriction.T
+    if (
+        not np.all(np.isfinite(obs_means))
+        or not np.all(np.isfinite(boot))
+        or not np.all(np.isfinite(middle))
+    ):
+        return float("nan"), float("nan")
     try:
         middle_inv = np.linalg.inv(middle)
     except np.linalg.LinAlgError:

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -262,6 +262,7 @@ class TestStationaryBootstrap:
         assert set(result.metadata) == {
             "block_length",
             "n_resamples",
+            "n_resamples_used",
             "p_value_mc_se",
             "seed",
             "studentized",
@@ -270,7 +271,10 @@ class TestStationaryBootstrap:
         # resolved block length at the overlap horizon, so a replay without
         # it reproduces a different (shorter-block) bootstrap.
         p_replay, _ = _block_bootstrap_diff_p(
-            series, overlap_periods=5, rng=result.metadata["seed"]
+            series,
+            overlap_periods=5,
+            n_resamples=result.metadata["n_resamples"],
+            rng=result.metadata["seed"],
         )
         assert result.p_value == p_replay
         assert result.metadata["block_length"] >= 5

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -159,6 +159,7 @@ class TestStudentizedDiffP:
         assert isinstance(meta["seed"], int)
         assert meta["seed"] >= 0
         assert meta["n_resamples"] == 199
+        assert 0 < meta["n_resamples_used"] <= 199
 
     def test_explicit_seed_reproducible(self):
         diff = np.array([0.3, -0.1, 0.4, -0.2, 0.1, 0.05, -0.15, 0.2, 0.0, 0.1])
@@ -166,6 +167,39 @@ class TestStudentizedDiffP:
         p2, m2 = _block_bootstrap_diff_p(diff, n_resamples=199, rng=123)
         assert p1 == p2
         assert m1["seed"] == m2["seed"] == 123
+
+    def test_metadata_counts_only_resamples_used_by_p(self):
+        """A normal finite sample can drop roots; metadata exposes that denominator."""
+        diff = np.array([0.1, -0.2, 0.3, -0.1, 0.2, 0.0, -0.05, 0.15])
+        p_value, metadata = _block_bootstrap_diff_p(diff, n_resamples=199, rng=0)
+
+        assert metadata["n_resamples"] == 199
+        n_used = metadata["n_resamples_used"]
+        assert 0 < n_used < 199
+        smoothed_extreme = p_value * (n_used + 1) - 1
+        assert smoothed_extreme == pytest.approx(round(smoothed_extreme))
+        assert metadata["p_value_mc_se"] == pytest.approx(
+            np.sqrt(p_value * (1.0 - p_value) / n_used)
+        )
+
+    def test_zero_usable_resamples_withholds_p(self, monkeypatch):
+        """Zero valid bootstrap-t roots admit no inference, not p=1."""
+        import factrix._stats.bootstrap as bootstrap
+
+        def fake_batch_means_se(values, _block_length):
+            if values.ndim == 1:
+                return np.array([1.0])
+            return np.full(values.shape[0], np.nan)
+
+        monkeypatch.setattr(bootstrap, "_batch_means_se", fake_batch_means_se)
+        p_value, metadata = _block_bootstrap_diff_p(
+            np.arange(10.0), n_resamples=3, rng=0
+        )
+
+        assert math.isnan(p_value)
+        assert metadata["n_resamples"] == 3
+        assert metadata["n_resamples_used"] == 0
+        assert math.isnan(metadata["p_value_mc_se"])
 
     def test_stationary_auto_block_length_is_not_discretized(self):
         """The stationary L is a geometric MEAN, so it must stay fractional.
@@ -212,6 +246,7 @@ class TestStudentizedDiffP:
         assert math.isnan(p)
         assert math.isnan(meta["block_length"])
         assert meta["n_resamples"] == 0
+        assert meta["n_resamples_used"] == 0
         assert meta["studentized"] is False
 
     def test_short_series_still_rejects_unknown_alternative(self):

--- a/tests/test_slice_period_joint_test.py
+++ b/tests/test_slice_period_joint_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 
 import factrix as fx
+import numpy as np
 import polars as pl
 import pytest
 from factrix import slice_period_joint_test, slice_period_pairwise_test
@@ -157,6 +158,21 @@ def test_bootstrap_reproducible_under_seed() -> None:
     a = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng=42)
     b = slice_period_joint_test(df, ic(), by="regime", factor_col="factor", rng=42)
     assert a["stat"][0] == b["stat"][0]
+
+
+def test_bootstrap_omnibus_withholds_nonfinite_input() -> None:
+    """An undefined Wald matrix cannot become the minimum empirical p."""
+    from factrix.slicing.period_inference import _wald_bootstrap_omnibus
+
+    stat, p_value = _wald_bootstrap_omnibus(
+        np.array([0.1, -0.1]),
+        np.array([[0.0, 0.1, -0.1], [0.0, -0.1, 0.1]]),
+        np.array([1e-4, np.nan]),
+        np.array([[1.0, -1.0]]),
+    )
+
+    assert math.isnan(stat)
+    assert math.isnan(p_value)
 
 
 def test_rejects_bare_class() -> None:


### PR DESCRIPTION
## Summary

- withhold the date-disjoint bootstrap omnibus when its observed means, draws, or Wald matrix are non-finite, instead of converting an undefined statistic into the minimum empirical p-value
- report both requested bootstrap draws (`n_resamples`) and valid studentized roots (`n_resamples_used`), so runs remain reproducible and the p-value denominator is auditable
- return an unavailable p-value when no studentized roots are usable

## Evidence

The resample-drop path is reachable with ordinary finite input: an existing 8-period fixture requested 199 draws but produced 183 usable studentized roots under a fixed seed. The p-value already used the smaller denominator; only metadata incorrectly reported 199 as if every draw entered the test.

## Compatibility

This PR has no runtime dependency on #1028. A three-way merge simulation with #1028 completed without conflicts, and the combined tree passed its strengthened metadata guard (27 tests), so either PR may merge first.

## Validation

- `python -m pytest -p no:faulthandler` (3725 passed, 46 skipped)
- focused bootstrap, inference, RNG, and metadata-contract tests (198 passed)
- `python -m ruff format --check factrix tests`
- `python -m ruff check factrix tests`
- `python -m mypy factrix`
- `git diff --check`

Closes #1017