### PR TITLE
docs(common-beta): clarify calendar-time terminology

### DIFF
--- a/docs/api/metrics/common_beta.md
+++ b/docs/api/metrics/common_beta.md
@@ -44,7 +44,9 @@ title: factrix.metrics.common_beta
     Stage 2 of BJS tests $H_0: \mathbb{E}[\beta] = 0$ across assets. The
     headline standard error combines the Newey-West variance of the
     equal-weight portfolio slope with cross-asset beta dispersion. This
-    calendar-time term retains shared residual shocks that an iid
+    [calendar-time](../../reference/glossary.md#calendar-time-portfolio) term
+    names the `CS_THEN_TS` aggregation order, not a calendar interval; it
+    retains shared residual shocks that an iid
     $\mathrm{std}(\beta)/\sqrt{N}$ reference discards.
 
     A hand-built beta table has no underlying panel from which to recover the

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -117,6 +117,27 @@ specific contracts that apply when factrix routes here.
 
 ## Other terms
 
+### calendar-time portfolio
+
+An aggregation order from the event-study literature: form a cross-asset
+portfolio in each observed period, then test the portfolio's time series. It
+contrasts with event-time alignment. For `common_beta`, this is factrix's
+`CS_THEN_TS` order: the equal-weight portfolio slope is estimated on the
+panel's own distinct-period grid before cross-asset beta dispersion is added.
+
+"Calendar-time" is a literature label, not a time unit. The implementation
+does not inspect calendar intervals, assume a cadence, or perform date
+arithmetic. See [Fama (1998)][fama-1998] for the portfolio convention and
+[Period grid, not calendar](../development/architecture.md#period-grid-not-calendar)
+for factrix's time-axis contract.
+
+### event-time
+
+An alignment order: observations are indexed by their offset from an event
+rather than first being pooled into a portfolio for each observed panel
+period. "Event-time" likewise names a design, not a time unit; offsets and
+windows in factrix still count periods on the panel's own grid.
+
 ### mainstream metric
 
 The headline mean-significance test conventionally used for a

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -927,18 +927,21 @@ which reports `R²` for the OLS regression.
 #### `common_beta`
 
 - *primary*: `p_value` — `t` on the cross-asset mean of the per-asset OLS
-  β, with the calendar-time SE: `SE² = V_EW + τ̂²/N`, where `V_EW` is the
+  β, with the [calendar-time SE](glossary.md#calendar-time-portfolio):
+  `SE² = V_EW + τ̂²/N`, where `V_EW` is the
   Newey-West(`h−1`) variance of the equal-weight portfolio's slope on the
   factor (the mean beta is that slope on a rectangular panel) and `τ̂²` is
   the cross-sectional beta variance in excess of the per-asset estimation
   noise. The textbook iid `std(β)/√N` understates the SE without bound when
   assets share a residual component (44.8% size at N=8, ρ=0.5); the
   Kolari-Pynnönen factor it briefly used instead had zero power once the
-  true betas were dispersed.
+  true betas were dispersed. Here calendar-time names the `CS_THEN_TS`
+  aggregation order; the calculation reads only the panel's period grid.
 - *descriptive*: `n_assets`, `beta_std`, `median_beta`,
   `calendar_time_se_applied`, and — when it applied — `ew_portfolio_beta`
   (the equal-weight portfolio slope, equal to `value` on a rectangular
-  panel), `ew_portfolio_beta_se`, `ew_portfolio_periods` (dates behind it),
+  panel), `ew_portfolio_beta_se`, `ew_portfolio_periods` (shared panel
+  periods),
   `beta_dispersion_excess` (`τ̂²`), `dof` (Welch-Satterthwaite df across the
   two variance components) and `stat_uncorrected` (the iid `t`).
   `calendar_time_se_source` records `unavailable_hand_built_frame` (no

--- a/factrix/metrics/_primitives/_common_betas.py
+++ b/factrix/metrics/_primitives/_common_betas.py
@@ -161,13 +161,14 @@ def compute_common_betas(
     Returns:
         Dict mapping each factor name to a DataFrame with columns
         ``asset_id, beta, alpha, t_stat, r_squared, n_periods`` sorted by
-        ``asset_id``, three broadcast calendar-time columns —
+        ``asset_id``, three broadcast calendar-time columns (the literature's
+        per-period portfolio aggregation term, not a calendar interval) —
         ``ew_portfolio_beta`` / ``ew_portfolio_beta_var`` (the equal-weight
         portfolio's slope on the factor and its Newey-West variance, the
         sampling variance ``common_beta`` tests the mean beta with — see
         :func:`_ew_portfolio_slope`; ``null`` when they cannot be estimated)
-        and ``ew_portfolio_periods`` (dates behind them) — plus a broadcast
-        ``_drop_stats`` carrier column on the
+        and ``ew_portfolio_periods`` (shared panel periods behind them) — plus
+        a broadcast ``_drop_stats`` carrier column on the
         assets axis (see :func:`_attach_drop_stats`) so cross-asset consumers
         can surface how much of the universe was silently dropped. An asset is
         emitted only with at least ``MIN_COMMON_BETA_PERIODS_HARD`` **finite**

--- a/factrix/metrics/common_beta.py
+++ b/factrix/metrics/common_beta.py
@@ -78,6 +78,12 @@ def _calendar_time_se(
 ) -> tuple[float, int] | None:
     r"""Standard error and df of the mean beta from the calendar-time portfolio.
 
+    ``Calendar-time`` is the literature's aggregation-order term: form a
+    cross-asset portfolio each panel period, then test that portfolio's time
+    series, rather than align observations in event time. In factrix this is
+    ``CS_THEN_TS`` on the panel's own period grid; no calendar interval enters
+    the calculation ([Fama (1998)][fama-1998]).
+
     Reads ``ew_portfolio_beta_var`` — the Newey-West($h-1$) variance of the
     equal-weight portfolio's slope on the factor, measured by
     :func:`~factrix.metrics._primitives._common_betas.compute_common_betas`


### PR DESCRIPTION
## Summary

- define `calendar-time portfolio` once in the glossary as an aggregation order, not a time unit
- clarify that `common_beta` implements `CS_THEN_TS` on the panel's own period grid and performs no calendar arithmetic
- replace `dates behind them` with the actual shared-period count contract
- add the paired `event-time` glossary boundary so both literature terms are distinguished from cadence

The existing metadata keys and literature terminology remain unchanged. This is documentation-only; estimator, standard error, degrees of freedom, and warning behavior are untouched. The terminology follows the portfolio convention discussed by [Fama (1998)](https://doi.org/10.1016/S0304-405X(98)00026-9).

## Validation

- `ruff format --check factrix tests`
- `ruff check factrix tests`
- `mypy factrix`
- `pytest -p no:faulthandler -q` (3722 passed, 46 skipped)
- `rg dates-behind factrix docs` has no matches (query used with the words separated)
- three-way merge simulation against #1028, #1029, and #1030: clean; no merge order required

Closes #1015
