### PR TITLE
chore(warnings): align threshold messages

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -526,6 +526,9 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
   `tie_policy="ordinal"`, `FEW_ASSETS` when the median per-period
   cross-section is below `MIN_ASSETS_WARN`, and `THIN_QUANTILE_GROUPS` when
   fewer than `MIN_GROUP_ASSETS` names back each requested bucket.
+- *short-circuit*: `reason` `insufficient_assets_for_quantile_groups` reports
+  `n_obs` as the median asset count on the post-stride sample where buckets
+  are actually formed, not the raw panel universe.
 
 ### `quantile` (`factrix.metrics.quantile`)
 - `warning_codes` (conditional): `HIGH_TIE_RATIO` under `tie_policy="ordinal"`

--- a/factrix/_stats/__init__.py
+++ b/factrix/_stats/__init__.py
@@ -48,6 +48,7 @@ from factrix._stats.core import (
 )
 from factrix._stats.diagnostics import _lag1_autocorr, _ljung_box
 from factrix._stats.hac import (
+    _MIN_PERIODS_PER_LAG,
     _bartlett_lrcov,
     _driscoll_kraay_cov,
     _hac_bandwidth_ill_conditioned,
@@ -70,6 +71,7 @@ from factrix._stats.wald import _wald_p_linear
 
 __all__ = [
     "_ADF_CRITS_CONSTANT",
+    "_MIN_PERIODS_PER_LAG",
     "_adf",
     "_adf_pvalue_interp",
     "_bartlett_lrcov",

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -166,9 +166,10 @@ _INFERENCE_CODE_MESSAGE: dict[WarningCode, str] = {
         "read the p-value against a raised hurdle or lengthen the sample."
     ),
     WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED: (
-        "the resolved Bartlett bandwidth exceeds n_periods / 5 on the {n} "
-        "tested periods, so the long-run variance rests on too few lag "
-        "products to be stable. Read the p-value as indicative only."
+        "the resolved Bartlett bandwidth exceeds n_periods / "
+        "{periods_per_lag} on the {n} tested periods, so the long-run "
+        "variance rests on too few lag products to be stable. Read the "
+        "p-value as indicative only."
     ),
     WarningCode.RECT_KERNEL_NEGATIVE_VARIANCE: (
         "the rectangular-kernel HAC variance-of-mean came out negative on the "
@@ -206,13 +207,17 @@ def _emit_inference_warnings(
         MIN_PERIODS_WARN,
         PERSISTENT_SERIES_AUTOCORR,
     )
+    from factrix._stats.hac import _MIN_PERIODS_PER_LAG
 
     n = res.n_obs if res.n_obs is not None else 0
     for code in sorted(res.warnings, key=lambda c: c.value):
         template = _INFERENCE_CODE_MESSAGE.get(code)
         message = (
             template.format(
-                n=n, warn=MIN_PERIODS_WARN, autocorr=PERSISTENT_SERIES_AUTOCORR
+                n=n,
+                warn=MIN_PERIODS_WARN,
+                autocorr=PERSISTENT_SERIES_AUTOCORR,
+                periods_per_lag=_MIN_PERIODS_PER_LAG,
             )
             if template is not None
             else code.description
@@ -247,6 +252,7 @@ def _emit_scalar_har_warnings(
     thresholds or bypassing the public warning channel.
     """
     from factrix._stats.constants import MIN_PERIODS_WARN
+    from factrix._stats.hac import _MIN_PERIODS_PER_LAG
 
     warning_codes: list[str] = []
     if persistent:
@@ -264,9 +270,9 @@ def _emit_scalar_har_warnings(
     if bandwidth_ill_conditioned:
         _emit_warning(
             WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED,
-            "the resolved Bartlett bandwidth exceeds n_periods / 5 on "
-            f"{n_periods} periods, so the long-run variance rests on too few "
-            "lag products to be stable.",
+            "the resolved Bartlett bandwidth exceeds n_periods / "
+            f"{_MIN_PERIODS_PER_LAG} on {n_periods} periods, so the long-run "
+            "variance rests on too few lag products to be stable.",
             label=metric_name,
             expected_warnings=expected_warnings,
             warning_codes=warning_codes,

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -45,11 +45,12 @@ from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import (
     _hac_bandwidth_ill_conditioned,
+    _lag1_autocorr,
     _newey_west_t_test,
     _p_value_from_t,
     _resolve_scalar_wald_hac,
 )
-from factrix._stats.constants import MIN_PERIODS_WARN
+from factrix._stats.constants import MIN_PERIODS_WARN, PERSISTENT_SERIES_AUTOCORR
 from factrix._stats.core import _degenerate_t_input
 from factrix._types import (
     DEFAULT_FORWARD_PERIODS,
@@ -358,12 +359,14 @@ def fm_beta(
         overlap_periods=overlap_periods,
     )
     actual_lags = _resolve_har_lags(n, newey_west_lags, overlap_periods)
+    beta_autocorr = _lag1_autocorr(betas[:: max(overlap_periods or 1, 1)])
     if _persistent_array_beyond_horizon(betas, overlap_periods):
         _emit_warning(
             WarningCode.SERIAL_CORRELATION_DETECTED,
-            "the per-period beta series' lag-1 autocorrelation remains above "
-            f"0.3 after striding at overlap_periods={overlap_periods}. No HAC "
-            "path is calibrated "
+            "the per-period beta series has lag-1 autocorrelation "
+            f"{beta_autocorr:.2f} (> {PERSISTENT_SERIES_AUTOCORR}) after "
+            f"striding at overlap_periods={overlap_periods}. No HAC path is "
+            "calibrated "
             "in this regime — Newey-West rejects 13–17% at a nominal 5% for "
             "phi=0.6 and ~30% at 0.85 — so read the p-value against a raised "
             "hurdle (t > 3) or lengthen the sample.",

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -294,6 +294,11 @@ def monotonicity(
         (unstudentised) differences, which is what runs here. Their studentised
         variant is not implemented.
 
+        If the post-stride cross-section cannot fill ``n_groups``, the
+        short-circuit result reports ``n_obs`` as the median universe size on
+        that same non-overlapping sample. It does not report the raw-panel
+        median across periods that the buckets never use.
+
     Examples:
         >>> import factrix as fx
         >>> from factrix.preprocess import compute_forward_return

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -24,6 +24,7 @@ from factrix._codes import WarningCode, _emit_warning
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._stats import (
+    _MIN_PERIODS_PER_LAG,
     _adf,
     _hac_bandwidth_ill_conditioned,
     _lag1_autocorr,
@@ -389,8 +390,8 @@ def predictive_beta(
         _emit_warning(
             WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED,
             f"the resolved Bartlett bandwidth L={resolved_har_lags} exceeds "
-            f"n_periods / 5 on {n} periods, so the long-run variance rests "
-            "on too few lag products to be stable.",
+            f"n_periods / {_MIN_PERIODS_PER_LAG} on {n} periods, so the "
+            "long-run variance rests on too few lag products to be stable.",
             label="predictive_beta",
             expected_warnings=expected_warnings,
             warning_codes=warning_codes,

--- a/tests/stats/test_persistence_screen_beyond_horizon.py
+++ b/tests/stats/test_persistence_screen_beyond_horizon.py
@@ -169,6 +169,26 @@ def test_fm_beta_screens_the_strided_beta_series() -> None:
     assert WarningCode.SERIAL_CORRELATION_DETECTED.value not in result.warning_codes
 
 
+def test_fm_beta_warning_reports_the_measured_strided_autocorrelation() -> None:
+    rng = np.random.default_rng(1026)
+    betas = np.empty(120)
+    betas[0] = rng.standard_normal()
+    for idx in range(1, len(betas)):
+        betas[idx] = 0.9 * betas[idx - 1] + rng.standard_normal()
+    beta_df = pl.DataFrame({"date": np.arange(len(betas)), "beta": betas})
+    measured = _lag1_autocorr(betas)
+
+    with pytest.warns(UserWarning) as caught:
+        result = fm_beta(beta_df, overlap_periods=1)
+
+    code = WarningCode.SERIAL_CORRELATION_DETECTED.value
+    messages = [str(item.message) for item in caught if code in str(item.message)]
+    assert messages
+    assert f"lag-1 autocorrelation {measured:.2f}" in messages[0]
+    assert f"> {PERSISTENT_SERIES_AUTOCORR}" in messages[0]
+    assert code in result.warning_codes
+
+
 def test_persistent_factor_null_stays_calibrated_without_the_warning():
     """The quiet is honest: size on that null sits near nominal, not above it.
 

--- a/tests/test_scalar_har_warning_consistency.py
+++ b/tests/test_scalar_har_warning_consistency.py
@@ -8,7 +8,12 @@ import numpy as np
 import polars as pl
 import pytest
 from factrix._codes import WarningCode
+from factrix._stats import _MIN_PERIODS_PER_LAG
 from factrix.inference.series_mean import NeweyWest
+from factrix.metrics._helpers import (
+    _INFERENCE_CODE_MESSAGE,
+    _emit_scalar_har_warnings,
+)
 from factrix.metrics.common_asymmetry import common_asymmetry
 from factrix.metrics.common_quantile import common_quantile_spread
 from factrix.metrics.fm_beta import pooled_beta
@@ -48,6 +53,46 @@ def _pooled_panel(n: int, rng: np.random.Generator) -> pl.DataFrame:
 def _has_bandwidth_warning(result: object) -> bool:
     warning_codes = getattr(result, "warning_codes", ())
     return WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED.value in warning_codes
+
+
+def _bandwidth_messages(caught: list[warnings.WarningMessage]) -> list[str]:
+    code = WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED.value
+    return [str(item.message) for item in caught if code in str(item.message)]
+
+
+def test_bandwidth_warning_text_uses_the_policy_constant() -> None:
+    token = f"n_periods / {_MIN_PERIODS_PER_LAG}"
+    template = _INFERENCE_CODE_MESSAGE[WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED]
+    rendered = template.format(
+        n=120,
+        warn=30,
+        autocorr=0.3,
+        periods_per_lag=_MIN_PERIODS_PER_LAG,
+    )
+    assert token in rendered
+
+    with warnings.catch_warnings(record=True) as scalar_caught:
+        warnings.simplefilter("always")
+        _emit_scalar_har_warnings(
+            metric_name="test_metric",
+            subject="the test series",
+            n_periods=120,
+            overlap_periods=21,
+            persistent=False,
+            bandwidth_ill_conditioned=True,
+        )
+    scalar_messages = _bandwidth_messages(scalar_caught)
+    assert scalar_messages
+    assert all(token in message for message in scalar_messages)
+
+    rng = np.random.default_rng(1026)
+    panel = _series_panel(rng.standard_normal(120), rng.standard_normal(120))
+    with warnings.catch_warnings(record=True) as predictive_caught:
+        warnings.simplefilter("always")
+        predictive_beta(panel, overlap_periods=21)
+    predictive_messages = _bandwidth_messages(predictive_caught)
+    assert predictive_messages
+    assert all(token in message for message in predictive_messages)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- derive every touched HAC bandwidth warning from the existing `_MIN_PERIODS_PER_LAG` policy constant
- report `fm_beta`'s measured post-stride lag-1 autocorrelation beside `PERSISTENT_SERIES_AUTOCORR`
- document that monotonicity's unfillable-bucket short circuit reports the post-stride median universe actually used for bucketing
- add regression coverage for the series-inference, scalar-HAR, predictive-beta, and FM-beta message paths

This changes warning text and documentation only. HAC/persistence decisions, estimators, p-values, and the already-correct monotonicity short-circuit behavior are unchanged. The central warning-code gloss is intentionally left to #1016 after #1030, avoiding an overlapping `_codes.py` PR.

## Validation

- `ruff format --check factrix tests`
- `ruff check factrix tests`
- `mypy factrix`
- `pytest -p no:faulthandler -q` (3724 passed, 46 skipped)
- three-way merge simulation against #1028, #1029, #1030, and #1031: clean; no merge order required

Closes #1026
