### PR TITLE
fix(metrics): report the HAR bandwidth the kernel ran at

### DIFF
--- a/docs/api/metrics/predictive_beta.md
+++ b/docs/api/metrics/predictive_beta.md
@@ -42,9 +42,11 @@ title: factrix.metrics.predictive_beta
     The raw OLS reference retained in metadata stays on the narrower
     Newey-West bandwidth and is labelled as uncorrected.
     Metadata reports the headline branch directly: `hac_applied=False` and
-    `har_lags=None` at `h = 1`; both switch to the resolved HAR path at
-    `h > 1`. The `method` string names the covariance that produced the
-    headline test.
+    `har_lags=None` at `h = 1`; both switch to the HAR path at `h > 1`. The
+    `method` string names the covariance that produced the headline test, and
+    `har_lags` is the bandwidth the kernel ran at — the augmented design is
+    `n_periods` rows, so a long horizon can leave it narrower than the
+    bandwidth resolved from the full series.
 
 -   __Persistent predictor diagnostic__
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -910,8 +910,11 @@ which reports `R²` for the OLS regression.
   `residual_lag1_autocorr` (lag-1 autocorrelation of the reported model's
   residuals, strided at `overlap_periods`), `newey_west_lags`,
   `overlap_periods`, `hac_applied` (whether the headline corrected test used
-  HAC), `har_lags` (the headline HAR bandwidth at `overlap_periods > 1`;
-  `None` at `h = 1`, where the corrected test is homoskedastic;
+  HAC), `har_lags` (the headline HAR bandwidth the kernel **ran at** at
+  `overlap_periods > 1` — the augmented design is `n_periods` rows and a
+  Bartlett sum cannot use a lag it has no pair for, so on a long horizon this
+  is narrower than the bandwidth resolved from the full series; `None` at
+  `h = 1`, where the corrected test is homoskedastic;
   `newey_west_lags` stays the narrow covariance bandwidth resolved for the
   uncorrected OLS reference), `alpha` (the intercept the corrected slope implies
   on the `n_obs` rows), `r_squared_ols_uncorrected`, `factor_std`,

--- a/factrix/_stats/ols.py
+++ b/factrix/_stats/ols.py
@@ -300,8 +300,17 @@ class AmihudHurvichFit(NamedTuple):
     the augmented regression's intercept: that one absorbs the innovation
     proxy and is not the intercept implied by ``beta``.
 
-    A not-computable fit fills every float with NaN, ``n_used`` with ``0``
-    and ``resid`` with an empty array.
+    ``lags_used`` is the Bartlett bandwidth the covariance was **actually**
+    computed at, which is not always the ``lags`` the caller asked for: the
+    augmented design runs on ``n_used`` rows and a kernel cannot use a lag it
+    has no observation pair for. Callers report this rather than their own
+    request, the way :func:`_ols_scalar_wald_hac` and
+    :func:`~factrix._stats.hac._driscoll_kraay_cov` already report the
+    bandwidth they ran at. It is ``0`` at ``overlap_periods = 1``, where the
+    covariance is homoskedastic and no kernel runs.
+
+    A not-computable fit fills every float with NaN, ``n_used`` and
+    ``lags_used`` with ``0`` and ``resid`` with an empty array.
     """
 
     beta: float
@@ -315,6 +324,7 @@ class AmihudHurvichFit(NamedTuple):
     alpha: float
     n_used: int
     resid: np.ndarray
+    lags_used: int
 
 
 def _amihud_hurvich_beta(
@@ -454,15 +464,20 @@ def _amihud_hurvich_beta(
         lag and the last ``h - 1`` windows to the horizon-summed proxy — and
         ``alpha`` / ``resid`` are the intercept and residual of the reported
         structural model ``y = alpha + beta·x + e`` on exactly those rows.
-        Every field is NaN (``n_used = 0``, ``resid`` empty) when the sample
-        is too short (``n < 5``) or the predictor is degenerate.
+        ``lags_used`` is the bandwidth the kernel ran at: ``lags`` is resolved
+        by the caller against the *full* series, so on a long horizon it can
+        exceed the ``n_used - 1`` lags the truncated design admits, and the
+        Bartlett sum stops there. Report ``lags_used``, not the request.
+        Every field is NaN (``n_used = 0``, ``lags_used = 0``, ``resid``
+        empty) when the sample is too short (``n < 5``) or the predictor is
+        degenerate.
     """
     y = _require_finite(y, "_amihud_hurvich_beta")
     x = _require_finite(x, "_amihud_hurvich_beta")
     n = len(y)
     nan = float("nan")
     not_computable = AmihudHurvichFit(
-        nan, nan, nan, nan, nan, nan, nan, nan, nan, 0, np.empty(0)
+        nan, nan, nan, nan, nan, nan, nan, nan, nan, 0, np.empty(0), 0
     )
     if n < 5 or len(x) != n:
         return not_computable
@@ -513,10 +528,16 @@ def _amihud_hurvich_beta(
     # the zero-lag sandwich is the HC0 form, whose own small-sample
     # under-coverage costs another 1-2pp at T = 60. HAC is kept for h > 1,
     # where the overlap is real.
+    # ``lags`` is resolved by the caller against the FULL series; the design
+    # here is ``m = n - h`` rows, so on a long horizon the request can exceed
+    # the lags this design admits. ``_ols_nw_multivariate`` clips internally;
+    # bind the same bound here so the fit can report the bandwidth that ran
+    # instead of the one that was asked for.
+    lags_used = 0 if h == 1 else max(0, min(lags, m - 1))
     if h == 1:
         beta_vec, cov, _ = _ols_homoskedastic(y[:m], design)
     else:
-        beta_vec, cov, _ = _ols_nw_multivariate(y[:m], design, lags=lags)
+        beta_vec, cov, _ = _ols_nw_multivariate(y[:m], design, lags=lags_used)
     if not np.all(np.isfinite(beta_vec)):
         return not_computable
     se_aug = float(np.sqrt(max(float(cov[1, 1]), 0.0)))
@@ -552,7 +573,7 @@ def _amihud_hurvich_beta(
     rho = float(corr_matrix[0, 1]) if np.isfinite(corr_matrix[0, 1]) else nan
     if se < EPSILON:
         return AmihudHurvichFit(
-            beta, nan, nan, se, gamma, phi, phi_c, rho, alpha, m, resid_e
+            beta, nan, nan, se, gamma, phi, phi_c, rho, alpha, m, resid_e, lags_used
         )
 
     t_stat = beta / se
@@ -560,9 +581,10 @@ def _amihud_hurvich_beta(
     # augmented SE is a Bartlett HAC one, so the t is read against the same
     # fixed-b effective df the scalar HAR path uses (``_har_dof``). This is a
     # single-restriction slope test, so the K x K Wald argument that keeps the
-    # multivariate paths on the narrow rule does not apply to it.
-    dof = float(max(m - 3, 1)) if h == 1 else _har_dof(m, lags, h)
+    # multivariate paths on the narrow rule does not apply to it. The df must
+    # read the bandwidth the kernel ran at, not the wider one requested.
+    dof = float(max(m - 3, 1)) if h == 1 else _har_dof(m, lags_used, h)
     p_value = float(2 * sp_stats.t.sf(abs(t_stat), df=dof))
     return AmihudHurvichFit(
-        beta, t_stat, p_value, se, gamma, phi, phi_c, rho, alpha, m, resid_e
+        beta, t_stat, p_value, se, gamma, phi, phi_c, rho, alpha, m, resid_e, lags_used
     )

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -147,7 +147,11 @@ def predictive_beta(
     ``overlap_periods = 1`` the corrected test uses Amihud-Hurvich's
     homoskedastic covariance; only ``overlap_periods > 1`` uses the resolved
     Newey-West HAR bandwidth. ``metadata["method"]``, ``hac_applied`` and
-    ``har_lags`` report that branch directly.
+    ``har_lags`` report that branch directly. ``har_lags`` is the bandwidth
+    the kernel ran at: the augmented design is ``n_periods`` rows and a
+    Bartlett sum cannot use a lag it has no observation pair for, so a long
+    horizon leaves it narrower than the bandwidth resolved from the full
+    series.
 
     **The correction costs power** where OLS's apparent power was partly
     its own bias: at $T=60,\ \phi=0.95,\ \rho=-0.9$ the corrected test
@@ -387,11 +391,24 @@ def predictive_beta(
             stacklevel=2,
         )
     if hac_applied and _hac_bandwidth_ill_conditioned(n, resolved_har_lags):
+        # The screen reads the RESOLVED bandwidth against the finite-pair
+        # count, which is the quantity it was calibrated on. Where the
+        # augmented design is shorter still, the kernel ran narrower than
+        # that; say so, so the text cannot contradict metadata["har_lags"].
+        narrowed = (
+            ""
+            if fit.lags_used == resolved_har_lags
+            else (
+                f" The augmented design admits only {fit.n_used - 1} lags, "
+                f"so the kernel ran at L={fit.lags_used}."
+            )
+        )
         _emit_warning(
             WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED,
             f"the resolved Bartlett bandwidth L={resolved_har_lags} exceeds "
             f"n_periods / {_MIN_PERIODS_PER_LAG} on {n} periods, so the "
-            "long-run variance rests on too few lag products to be stable.",
+            f"long-run variance rests on too few lag products to be "
+            f"stable.{narrowed}",
             label="predictive_beta",
             expected_warnings=expected_warnings,
             warning_codes=warning_codes,
@@ -498,7 +515,10 @@ def predictive_beta(
         "n_periods_finite": n,
         "residual_lag1_autocorr": resid_autocorr,
         "newey_west_lags": lags,
-        "har_lags": resolved_har_lags if hac_applied else None,
+        # The bandwidth the kernel RAN at, not the one resolved from the full
+        # series: the augmented design is ``n_periods`` rows and the Bartlett
+        # sum stops at the lags that design admits.
+        "har_lags": fit.lags_used if hac_applied else None,
         "hac_applied": hac_applied,
         "overlap_periods": overlap_periods,
         "alpha": alpha,

--- a/tests/stats/test_amihud_hurvich_bandwidth_report.py
+++ b/tests/stats/test_amihud_hurvich_bandwidth_report.py
@@ -1,0 +1,106 @@
+"""``predictive_beta`` must report the bandwidth its kernel actually used.
+
+``_resolve_har_lags`` resolves against the full finite-pair count ``n``, but
+the augmented Amihud-Hurvich design fits on ``m = n - h`` rows. At a long
+horizon ``m`` can fall below the resolved bandwidth, and the Bartlett kernel
+inside :func:`factrix._stats.ols._ols_nw_multivariate` clips to ``m - 1``.
+The metadata has to follow the kernel, the way ``_ols_scalar_wald_hac`` and
+``_driscoll_kraay_cov`` already report the bandwidth they ran at.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix._stats.ols import _amihud_hurvich_beta
+from factrix.metrics.predictive_beta import predictive_beta
+
+
+def _ts_panel(x: np.ndarray, y: np.ndarray) -> pl.DataFrame:
+    n = len(x)
+    return pl.DataFrame(
+        {
+            "date": np.arange(n),
+            "asset_id": ["A"] * n,
+            "factor": x,
+            "forward_return": y,
+        }
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+@pytest.mark.parametrize(("n", "overlap"), [(60, 42), (75, 63), (90, 63)])
+def test_reported_har_lags_never_exceeds_the_fitted_design(
+    n: int, overlap: int
+) -> None:
+    """A bandwidth wider than the design it ran on was never applied."""
+    rng = np.random.default_rng(n * 100 + overlap)
+    x = rng.standard_normal(n)
+    y = 0.1 * x + rng.standard_normal(n)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = predictive_beta(_ts_panel(x, y), overlap_periods=overlap)
+
+    assert not np.isnan(result.value), "guard the real-test path, not a short circuit"
+    har_lags = result.metadata["har_lags"]
+    n_periods = result.metadata["n_periods"]
+    assert isinstance(har_lags, int)
+    # The Bartlett kernel cannot use a lag it has no observation pair for.
+    assert har_lags <= n_periods - 1
+
+
+def test_fit_reports_the_bandwidth_the_kernel_clipped_to() -> None:
+    """``lags_used`` is the applied bandwidth, not the requested one."""
+    rng = np.random.default_rng(1041)
+    n, h = 90, 63
+    x = rng.standard_normal(n)
+    y = 0.1 * x + rng.standard_normal(n)
+
+    requested = 30
+    fit = _amihud_hurvich_beta(y, x, lags=requested, overlap_periods=h)
+
+    assert fit.n_used > 0
+    assert fit.lags_used == min(requested, fit.n_used - 1)
+    assert fit.lags_used < requested
+
+
+def test_ill_conditioned_warning_names_the_bandwidth_that_ran() -> None:
+    """Warning text and ``metadata["har_lags"]`` must not contradict."""
+    rng = np.random.default_rng(9063)
+    n, h = 90, 63
+    x = rng.standard_normal(n)
+    y = 0.1 * x + rng.standard_normal(n)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        result = predictive_beta(_ts_panel(x, y), overlap_periods=h)
+
+    har_lags = result.metadata["har_lags"]
+    bandwidth_msgs = [
+        str(w.message)
+        for w in caught
+        if "hac_bandwidth_ill_conditioned" in str(w.message)
+    ]
+    assert bandwidth_msgs, "the ill-conditioned bandwidth screen should fire here"
+    message = bandwidth_msgs[0]
+    assert f"the kernel ran at L={har_lags}" in message
+
+
+def test_short_horizon_reports_the_resolved_bandwidth_unchanged() -> None:
+    """Where the design is long enough, the requested bandwidth is the used one."""
+    rng = np.random.default_rng(7)
+    n, h = 240, 5
+    x = rng.standard_normal(n)
+    y = 0.1 * x + rng.standard_normal(n)
+
+    fit = _amihud_hurvich_beta(y, x, lags=12, overlap_periods=h)
+
+    assert fit.lags_used == 12
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = predictive_beta(_ts_panel(x, y), overlap_periods=h, newey_west_lags=12)
+    assert result.metadata["har_lags"] == 12


### PR DESCRIPTION
## Summary

`predictive_beta` resolves its Bartlett bandwidth against the full finite-pair
count `n`, then fits the Amihud-Hurvich augmented design on `m = n - h` rows.
A Bartlett sum cannot use a lag it has no observation pair for, so
`_ols_nw_multivariate` clipped to `m - 1` internally while
`metadata["har_lags"]` kept reporting the wider request.

- `AmihudHurvichFit` carries `lags_used`, the bandwidth the covariance was
  actually computed at
- `predictive_beta` reports that instead of the resolved request
- `_har_dof` reads the same value
- the ill-conditioned-bandwidth screen keeps its calibrated condition on the
  resolved bandwidth and now names the applied one when the two differ, so its
  text cannot contradict `metadata["har_lags"]`

Scope note (from review): this closes the `har_lags` contradiction only. The
same message still names `n_periods` while printing `n_periods_finite`, which
diverges from `metadata["n_periods"]` on this metric — filed as #1035 rather
than folded in, because choosing which count the message should name is a
separate wording decision from reporting the applied bandwidth.

## Reachability

Through the public API, no explicit bandwidth needed:

| n | h | reported `har_lags` | `n_periods` | bandwidth the kernel used |
|---|---|---|---|---|
| 60 | 42 | 20 | 18 | 17 |
| 60 | 50 | 20 | 10 | 9 |
| 75 | 63 | 25 | 12 | 11 |
| 90 | 63 | 30 | 27 | 26 |

Each row is a real test, not a short circuit. `n_periods=27` with
`har_lags=30` is a bandwidth wider than the sample it ran on.

## Quant impact

None. The standard error was already computed at the clipped bandwidth, so no
SE changes. `_har_dof` now reads `lags_used`, but the `n/h - 1` cap floors the
effective df at 1.0 in every currently reachable cell, so no p-value moves
either — verified across the four cells above. This corrects what is
**reported**, and removes a latent path where a future bandwidth or floor
change would silently move the df.

The sibling paths already behave this way, which is what makes this an
outlier rather than a convention: `_ols_scalar_wald_hac` resolves against
`len(y)` — the design it fits — and `_driscoll_kraay_cov` clips before it
returns `lags_used`.

## How it was found

Cross-validating the statistical kernels against `statsmodels` 0.15 and
`scipy` 1.17. The estimators themselves matched to machine precision:
Bartlett long-run variance and `K`-vector long-run covariance against
`OLS(cov_type="HAC")`, `_ols_nw_multivariate` (coefficients, HAC covariance,
residuals), `_driscoll_kraay_cov` against `cov_nw_groupsum`,
`_wald_two_way_cluster` against a CGM reference built with the corrections
and `F` reference the docstring documents, `_adf` against `adfuller`,
`_ljung_box` against `acorr_ljungbox`, `_binomial_two_sided_p` against
`binomtest`, `holm_adjusted_p` / `bhy_adjusted_p` against `multipletests`,
plus `_lag1_autocorr`, `_mann_kendall_hamed_rao` (tau against
`scipy.stats.kendalltau`), `_batch_means_se` and `_empirical_p` against
closed forms. This bandwidth report was the only discrepancy.

## Validation

- `pytest -p no:faulthandler -q` — 3795 passed, 45 skipped (main: 3789; +6 new)
- `ruff check factrix tests`
- `ruff format --check factrix tests`
- `mypy factrix`
- `mkdocs build --strict`

The six new tests fail on `main`: three on `assert har_lags <= n_periods - 1`
(`assert 30 <= 26`, `assert 25 <= 11`, `assert 20 <= 17`) and three on the
absent `lags_used` field.
