### PR TITLE
fix(metrics): name the metadata key the bandwidth screen reads

### DIFF
--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -910,11 +910,14 @@ which reports `R²` for the OLS regression.
   `residual_lag1_autocorr` (lag-1 autocorrelation of the reported model's
   residuals, strided at `overlap_periods`), `newey_west_lags`,
   `overlap_periods`, `hac_applied` (whether the headline corrected test used
-  HAC), `har_lags` (the headline HAR bandwidth the kernel **ran at** at
-  `overlap_periods > 1` — the augmented design is `n_periods` rows and a
+  HAC), `har_lags` (at `overlap_periods > 1`, the headline HAR bandwidth the
+  kernel **ran at** — the augmented design is `n_periods` rows and a
   Bartlett sum cannot use a lag it has no pair for, so on a long horizon this
   is narrower than the bandwidth resolved from the full series; `None` at
-  `h = 1`, where the corrected test is homoskedastic;
+  `h = 1`, where the corrected test is homoskedastic. One exception: on the
+  `no_amihud_hurvich_fit` short circuit no kernel runs at all, and the value
+  is the bandwidth resolved for the attempt. `None` is not reused there
+  because it already means `h = 1`;
   `newey_west_lags` stays the narrow covariance bandwidth resolved for the
   uncorrected OLS reference), `alpha` (the intercept the corrected slope implies
   on the `n_obs` rows), `r_squared_ols_uncorrected`, `factor_std`,

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -151,7 +151,14 @@ def predictive_beta(
     the kernel ran at: the augmented design is ``n_periods`` rows and a
     Bartlett sum cannot use a lag it has no observation pair for, so a long
     horizon leaves it narrower than the bandwidth resolved from the full
-    series.
+    series. The one exception is the ``no_amihud_hurvich_fit`` short circuit,
+    where no kernel runs and the value is the bandwidth resolved for the
+    attempt; ``None`` is not reused there because it already means ``h = 1``.
+
+    The ``HAC_BANDWIDTH_ILL_CONDITIONED`` message names
+    ``n_periods_finite``, not ``n_periods``. This metric is the one place the
+    two diverge — the screen is calibrated on the finite pairs, while
+    ``n_periods`` counts the truncated augmented design.
 
     **The correction costs power** where OLS's apparent power was partly
     its own bias: at $T=60,\ \phi=0.95,\ \rho=-0.9$ the corrected test
@@ -405,10 +412,15 @@ def predictive_beta(
         )
         _emit_warning(
             WarningCode.HAC_BANDWIDTH_ILL_CONDITIONED,
+            # Name ``n_periods_finite``, not ``n_periods``. This metric is the
+            # one place the two diverge: ``n_periods`` is the truncated
+            # augmented design's row count, while the screen reads the finite
+            # pairs. A bare "n_periods" sends a reader to a number that cannot
+            # reproduce the comparison the message states.
             f"the resolved Bartlett bandwidth L={resolved_har_lags} exceeds "
-            f"n_periods / {_MIN_PERIODS_PER_LAG} on {n} periods, so the "
-            f"long-run variance rests on too few lag products to be "
-            f"stable.{narrowed}",
+            f"n_periods_finite / {_MIN_PERIODS_PER_LAG} on the {n} finite "
+            f"pairs, so the long-run variance rests on too few lag products "
+            f"to be stable.{narrowed}",
             label="predictive_beta",
             expected_warnings=expected_warnings,
             warning_codes=warning_codes,

--- a/tests/stats/test_predictive_beta_metadata_contract.py
+++ b/tests/stats/test_predictive_beta_metadata_contract.py
@@ -16,6 +16,7 @@ Two contracts, both split out of the review of #1034:
 from __future__ import annotations
 
 import math
+import re
 import warnings
 from pathlib import Path
 
@@ -99,6 +100,15 @@ class TestShortCircuitBandwidthIsTheAttemptedOne:
         assert "the bandwidth resolved for the attempt" in docs
 
     def test_docs_do_not_repeat_at_at(self) -> None:
-        """Typo introduced by #1034's wording; folded in here per review."""
+        """Typo introduced by #1034's wording; folded in here per review.
+
+        The literal ``"ran at at"`` never appeared: #1034 shipped
+        ``the kernel **ran at** at``, with the emphasis markers between the
+        two words. A bare-substring guard passed while the typo was live, so
+        match across the markup instead.
+        """
         docs = STAT_KEYS_DOCS.read_text(encoding="utf-8")
-        assert "ran at at" not in docs
+        doubled = re.compile(r"\bat(?:\*+|_+|`+|\s)*\s+at\b")
+        assert not doubled.search(docs), (
+            f"doubled 'at' in {STAT_KEYS_DOCS}: {doubled.search(docs).group()!r}"
+        )

--- a/tests/stats/test_predictive_beta_metadata_contract.py
+++ b/tests/stats/test_predictive_beta_metadata_contract.py
@@ -1,0 +1,104 @@
+"""``predictive_beta`` metadata must be reproducible from the keys it names.
+
+Two contracts, both split out of the review of #1034:
+
+- the ill-conditioned-bandwidth warning has to name the key a reader can look
+  up (#1035). ``predictive_beta`` is the only metric whose ``n_periods`` is the
+  truncated augmented-design row count rather than the count the screen reads,
+  so the bare token sends a reader to the wrong number;
+- the ``no_amihud_hurvich_fit`` short circuit runs no kernel, so its
+  ``har_lags`` is the bandwidth resolved for the *attempt*. #1034 tightened the
+  documented contract to "the bandwidth the kernel ran at", which that branch
+  cannot satisfy; the value is kept and the exception is documented instead of
+  overloading the ``None``-means-``h = 1`` sentinel (#1036).
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+from factrix.metrics.predictive_beta import predictive_beta
+
+STAT_KEYS_DOCS = Path("docs/reference/stat-keys-by-metric.md")
+
+
+def _ts_panel(x: np.ndarray, y: np.ndarray) -> pl.DataFrame:
+    n = len(x)
+    return pl.DataFrame(
+        {
+            "date": np.arange(n),
+            "asset_id": ["A"] * n,
+            "factor": x,
+            "forward_return": y,
+        }
+    ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+
+def _run(n: int, h: int, seed: int):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(n)
+    y = 0.1 * x + rng.standard_normal(n)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        result = predictive_beta(_ts_panel(x, y), overlap_periods=h)
+    return result, [str(w.message) for w in caught]
+
+
+class TestIllConditionedMessageNamesALookupableKey:
+    """#1035: the count printed must be the value under the key named."""
+
+    @pytest.mark.parametrize(("n", "h"), [(90, 63), (60, 42), (120, 21)])
+    def test_message_count_matches_the_metadata_key_it_names(
+        self, n: int, h: int
+    ) -> None:
+        result, messages = _run(n, h, seed=n * 100 + h)
+        assert not math.isnan(result.value)
+        bandwidth = [m for m in messages if "hac_bandwidth_ill_conditioned" in m]
+        assert bandwidth, "the bandwidth screen should fire in this regime"
+        message = bandwidth[0]
+
+        assert "n_periods_finite /" in message
+        assert f"on the {result.metadata['n_periods_finite']} finite pairs" in message
+
+    def test_message_does_not_send_a_reader_to_the_truncated_row_count(self) -> None:
+        """``n_periods`` is the augmented design's rows; the screen reads neither."""
+        result, messages = _run(90, 63, seed=9063)
+        message = next(m for m in messages if "hac_bandwidth_ill_conditioned" in m)
+
+        assert result.metadata["n_periods"] != result.metadata["n_periods_finite"]
+        assert "n_periods /" not in message
+
+
+class TestShortCircuitBandwidthIsTheAttemptedOne:
+    """#1036: no kernel runs there, so the contract states the exception."""
+
+    @pytest.mark.parametrize(("n", "h"), [(20, 19), (20, 16), (22, 18)])
+    def test_short_circuit_keeps_the_resolved_bandwidth(self, n: int, h: int) -> None:
+        """Pinned deliberately: ``None`` there would overload the ``h = 1`` sentinel."""
+        result, _ = _run(n, h, seed=n * 10 + h)
+
+        assert math.isnan(result.value)
+        assert result.metadata["reason"] == "no_amihud_hurvich_fit"
+        assert isinstance(result.metadata["har_lags"], int)
+
+    def test_h1_still_reports_no_bandwidth(self) -> None:
+        result, _ = _run(240, 1, seed=11)
+
+        assert not math.isnan(result.value)
+        assert result.metadata["har_lags"] is None
+
+    def test_docs_state_the_short_circuit_exception(self) -> None:
+        """The tightened ``har_lags`` contract must carry its one exception."""
+        docs = STAT_KEYS_DOCS.read_text(encoding="utf-8")
+        assert "no_amihud_hurvich_fit" in docs
+        assert "the bandwidth resolved for the attempt" in docs
+
+    def test_docs_do_not_repeat_at_at(self) -> None:
+        """Typo introduced by #1034's wording; folded in here per review."""
+        docs = STAT_KEYS_DOCS.read_text(encoding="utf-8")
+        assert "ran at at" not in docs

--- a/tests/test_scalar_har_warning_consistency.py
+++ b/tests/test_scalar_har_warning_consistency.py
@@ -92,7 +92,15 @@ def test_bandwidth_warning_text_uses_the_policy_constant() -> None:
         predictive_beta(panel, overlap_periods=21)
     predictive_messages = _bandwidth_messages(predictive_caught)
     assert predictive_messages
-    assert all(token in message for message in predictive_messages)
+    # ``predictive_beta`` names ``n_periods_finite``, not ``n_periods``: it is
+    # the one metric whose ``metadata["n_periods"]`` is the truncated
+    # augmented-design row count rather than the count this screen reads, so
+    # the shared token would send a reader to the wrong key (see the metadata
+    # contract tests in ``tests/stats``). What has to hold everywhere is that
+    # the policy constant is interpolated rather than written out by hand.
+    policy_token = f"/ {_MIN_PERIODS_PER_LAG}"
+    assert all(policy_token in message for message in predictive_messages)
+    assert all("n_periods_finite /" in message for message in predictive_messages)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scalar_har_warning_consistency.py
+++ b/tests/test_scalar_har_warning_consistency.py
@@ -96,11 +96,12 @@ def test_bandwidth_warning_text_uses_the_policy_constant() -> None:
     # the one metric whose ``metadata["n_periods"]`` is the truncated
     # augmented-design row count rather than the count this screen reads, so
     # the shared token would send a reader to the wrong key (see the metadata
-    # contract tests in ``tests/stats``). What has to hold everywhere is that
-    # the policy constant is interpolated rather than written out by hand.
-    policy_token = f"/ {_MIN_PERIODS_PER_LAG}"
-    assert all(policy_token in message for message in predictive_messages)
-    assert all("n_periods_finite /" in message for message in predictive_messages)
+    # contract tests in ``tests/stats``). Keep it as ONE token rather than two
+    # ``in`` checks: split checks no longer verify that the constant is the
+    # divisor *of that key*, and would pass a message carrying the two halves
+    # in unrelated places.
+    predictive_token = f"n_periods_finite / {_MIN_PERIODS_PER_LAG}"
+    assert all(predictive_token in message for message in predictive_messages)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Two contracts left open by the review of #1034, fixed together because they are
adjacent and both touch the same `har_lags` documentation sentence.

## #1035 — the message named a key that gives a different number

`predictive_beta` emitted:

    the resolved Bartlett bandwidth L=30 exceeds n_periods / 5 on 90 periods, ...

with `metadata["n_periods"] == 27` and `metadata["n_periods_finite"] == 90`. A
reader who looked up the key the message named could not reproduce the `90 / 5`
comparison. This metric is the only place the two counts diverge: `n_periods`
is the truncated augmented design's row count, while the screen is calibrated
on the finite pairs.

The message now names `n_periods_finite`. **The firing condition is
unchanged** — `_hac_bandwidth_ill_conditioned(n, resolved_har_lags)` still
reads the finite-pair count, because moving the screen onto the truncated
design is a recalibration rather than a reporting fix.

## #1036 — the short circuit runs no kernel

#1034 tightened `har_lags` to "the bandwidth the kernel ran at". The
`no_amihud_hurvich_fit` short circuit cannot satisfy that, since no kernel runs
there at all. Per the issue's recommended option, the value is kept as the
bandwidth resolved for the attempt and the exception is documented, rather than
reusing `None` — which already means `h = 1` and would be overloaded. The
behaviour is now pinned by test so it cannot drift silently in either
direction.

No new metadata key: `metadata["reason"]` is already the machine-readable
signal for this branch, and the issue scoped "which keys every short circuit
should populate" as out of boundary.

## Test that had to change

`test_bandwidth_warning_text_uses_the_policy_constant` asserted that *every*
bandwidth message carries the literal `n_periods / 5`. Its real intent is that
`_MIN_PERIODS_PER_LAG` is interpolated rather than hand-written — the key name
was an incidental assumption, and #1035 is precisely the finding that the
assumption is wrong for this metric. The shared `_INFERENCE_CODE_MESSAGE`
template and `_emit_scalar_har_warnings` keep the full token; `predictive_beta`
is asserted to carry the interpolated constant *and* to name
`n_periods_finite`, so the check did not get weaker.

Flagging it explicitly because loosening an existing consistency test is the
kind of change that deserves a second opinion.

## Also

The doubled "ran at at" that #1034 introduced in `stat-keys-by-metric.md`,
folded in here per the review rather than spending its own CI cycle.

## Validation

- `pytest -p no:faulthandler -q` — 3805 passed, 45 skipped (main: 3795; +10 new)
- `pytest --doctest-modules factrix` — 96 passed, 1 skipped
- `ruff check` / `ruff format --check` / `mypy factrix`
- `mkdocs build --strict`, no generated-file drift

Five of the ten new tests fail on `main`: three on the message naming
`n_periods` where the printed count is `n_periods_finite`, one on the bare
`n_periods /` token, and one on the absent short-circuit doc sentence. The
other five pin behaviour that is already correct and must stay that way.

Closes #1035
Closes #1036