### PR TITLE
fix(metrics): state the short-circuit metadata contract, judge keys per side

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -978,7 +978,7 @@ Hard constraints — violating these breaks the API contract:
    `False` / an explicit failure state) unless the metric documents, at that
    branch, that the key describes the attempt instead. FX008 in
    `tests/stats/test_short_circuit_flag_polarity.py` lints the decidable
-   half — a `*_applied` / `*_adjusted` / `*_corrected` / `*_flipped` key
+   half — a `*_applied` / `*_adjusted` / `*_flipped` key
    reporting a stage as having run — on the same baseline shape as FX007.
    The contract itself is
    [Which auxiliary keys a short circuit may carry](../reference/stat-keys-by-metric.md#which-auxiliary-keys-a-short-circuit-may-carry).

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -972,6 +972,16 @@ Hard constraints — violating these breaks the API contract:
    `tests/stats/test_degenerate_guard_polarity.py` rejects new bare
    comparisons and carries the pre-existing sites as a baseline — that
    baseline is a migration ledger, not a bug list.
+   A short circuit runs no kernel, so its `metadata` may state anything true
+   about the input, the configuration or the attempt, but a key that would
+   describe the withheld result is neutralised (`NaN` / `None` / empty /
+   `False` / an explicit failure state) unless the metric documents, at that
+   branch, that the key describes the attempt instead. FX008 in
+   `tests/stats/test_short_circuit_flag_polarity.py` lints the decidable
+   half — a `*_applied` / `*_adjusted` / `*_corrected` / `*_flipped` key
+   reporting a stage as having run — on the same baseline shape as FX007.
+   The contract itself is
+   [Which auxiliary keys a short circuit may carry](../reference/stat-keys-by-metric.md#which-auxiliary-keys-a-short-circuit-may-carry).
 6. Family declaration is explicit: a screening verb's input list is one family, optionally split per bucket via `expand_over` where the API supports it. Shared resolution enforces (a) the result identity `(factor, forward_periods, *sorted(params.items()))` is unique across the input — every `params` entry joins it automatically, while `metadata` never does, (b) `expand_over` names come only from `EvaluationResult.params` (or the built-in `forward_periods`), never the factor and never a `metadata` key, (c) formal p-values are populated before procedures read them. Cross-metric BHY adds the metric label to the hypothesis identity; cross-metric partial conjunction keeps the predeclared metric count fixed under insufficient endpoints. Mixed horizons warn so the caller confirms whether selection is pooled or predeclared per horizon.
 7. A metric whose effective sample is below its own hard floor raises `InsufficientSampleError` under `strict=True` (per metric, per axis, on the effective post-stride/post-drop sample — not a global `T` rule); metrics never silently produce a result on under-sampled data. NW HAC bandwidths read `overlap_periods` and never fall below `h - 1`; scalar series means and rank-one contrasts use the wider calibrated `3(h - 1)` floor, while multi-restriction Wald paths retain the Hansen-Hodrick floor.
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -936,16 +936,21 @@ which reports `R²` for the OLS regression.
     the metric short-circuits rather than substituting the biased OLS slope,
     and `metadata["reason"]` is `no_amihud_hurvich_fit`.
 
-    On that branch `hac_applied` and `har_lags` describe the covariance
-    branch and bandwidth **resolved for the attempt**, not a kernel that ran;
+    Each key on that payload is judged on its own side of the
+    [short-circuit envelope](#which-auxiliary-keys-a-short-circuit-may-carry),
+    not as one "inference" bundle:
+
+    | key | side | value |
+    |---|---|---|
+    | `har_lags`, `newey_west_lags` | resolved for the attempt | the resolved bandwidth |
+    | `beta_ols_uncorrected`, `factor_std` | measured before the bail | the measurement |
+    | `hac_applied`, `stambaugh_adjusted` | claims a stage ran | `False` |
+
     `beta_ols_uncorrected` is the uncorrected slope the metric declined to
-    publish as the headline. This is the documented exception the
-    [short-circuit envelope](#which-auxiliary-keys-a-short-circuit-may-carry)
-    allows, taken instead of neutralising: `hac_applied = False` implies
-    `har_lags = None` on every computed result, so neutralising the pair here
-    would make the branch indistinguishable from an `h = 1` success rather
-    than merely uninformative. `stambaugh_adjusted` stays `False` because it
-    describes the headline value, and there is none.
+    publish as the headline. The `(hac_applied=False, har_lags=<int>)` pair
+    that results is unreachable on any computed result — an impossible
+    combination a consumer can detect, rather than a plausible one that reads
+    as a completed fit.
 
     As the envelope says, branch on `reason` before reading these keys.
 - *warning*: `WarningCode.PERSISTENT_REGRESSOR` when the ADF p-value exceeds
@@ -1187,16 +1192,27 @@ that point is worth reporting.
 - **Keys that would describe the withheld result** are neutralised — `NaN`
   (`mfe_mae`'s `mfe_mae_ratio`), `None` (`event_around_return`'s
   `baseline_bar_return`), empty (`per_offset`), `False` (`predictive_beta`'s
-  `stambaugh_adjusted`, `oos_decay`'s `sign_flipped`), or an explicit failure
-  state (`oos_decay`'s `status = "VETOED"`) — **or** the metric documents, at
-  that branch, that they describe the attempt rather than a result.
-  `predictive_beta`'s `no_amihud_hurvich_fit` is the one branch that takes the
-  second route, because neutralising its pair would reuse a sentinel that
-  already means `h = 1`.
+  `hac_applied` and `stambaugh_adjusted`, `oos_decay`'s `sign_flipped`), or an
+  explicit failure state (`oos_decay`'s `status = "VETOED"`).
+
+The two sides are judged **per key, never per branch**.
+`predictive_beta`'s `no_amihud_hurvich_fit` is the worked example: `har_lags`
+stays affirmative because resolving the bandwidth really happened, while
+`hac_applied` — a past-tense claim that the HAC covariance was computed — goes
+to `False`. The resulting `(hac_applied=False, har_lags=<int>)` pair is
+unreachable on any computed result, and that is the point: an impossible
+combination is detectable, where a plausible one reads as a completed fit.
+
+A branch may instead document that a withheld-result key describes the
+attempt, but only where neutralising is **impossible or destroys
+information** — not where it is merely less convenient — and the branch must
+say which applies. No metric currently needs this; the bar is written down so
+a future case is argued rather than assumed.
 
 The mechanically decidable half is linted: FX008 in
-`tests/stats/test_short_circuit_flag_polarity.py` rejects a new
-`*_applied` / `*_adjusted` / `*_corrected` / `*_flipped` key that reports a
-stage as having run on a short-circuit payload, and carries the documented
-exception as a baseline. Whether a value-bearing key was neutralised is a
+`tests/stats/test_short_circuit_flag_polarity.py` rejects a
+`*_applied` / `*_adjusted` / `*_flipped` key that reports a
+stage as having run on a short-circuit payload. Its baseline of documented
+exceptions is empty, so the rule holds without carve-outs. Whether a
+value-bearing key was neutralised is a
 semantic question no lint settles; this section is the contract for it.

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -914,10 +914,7 @@ which reports `R²` for the OLS regression.
   kernel **ran at** — the augmented design is `n_periods` rows and a
   Bartlett sum cannot use a lag it has no pair for, so on a long horizon this
   is narrower than the bandwidth resolved from the full series; `None` at
-  `h = 1`, where the corrected test is homoskedastic. One exception: on the
-  `no_amihud_hurvich_fit` short circuit no kernel runs at all, and the value
-  is the bandwidth resolved for the attempt. `None` is not reused there
-  because it already means `h = 1`;
+  `h = 1`, where the corrected test is homoskedastic;
   `newey_west_lags` stays the narrow covariance bandwidth resolved for the
   uncorrected OLS reference), `alpha` (the intercept the corrected slope implies
   on the `n_obs` rows), `r_squared_ols_uncorrected`, `factor_std`,
@@ -930,6 +927,27 @@ which reports `R²` for the OLS regression.
   `ar1_phi_corrected_explosive` (`ar1_phi_corrected >= 1` — the corrected
   AR(1) coefficient is deliberately not clamped, because clamping it
   re-opens the bias the correction exists to close).
+
+!!! note "`no_amihud_hurvich_fit`: the inference keys describe the attempt"
+
+    This metric's headline is the Amihud-Hurvich augmented regression, not
+    plain OLS. When that regression cannot be fitted — most reachably when a
+    long `overlap_periods` leaves the horizon-summed design under five rows —
+    the metric short-circuits rather than substituting the biased OLS slope,
+    and `metadata["reason"]` is `no_amihud_hurvich_fit`.
+
+    On that branch `hac_applied` and `har_lags` describe the covariance
+    branch and bandwidth **resolved for the attempt**, not a kernel that ran;
+    `beta_ols_uncorrected` is the uncorrected slope the metric declined to
+    publish as the headline. This is the documented exception the
+    [short-circuit envelope](#which-auxiliary-keys-a-short-circuit-may-carry)
+    allows, taken instead of neutralising: `hac_applied = False` implies
+    `har_lags = None` on every computed result, so neutralising the pair here
+    would make the branch indistinguishable from an `h = 1` success rather
+    than merely uninformative. `stambaugh_adjusted` stays `False` because it
+    describes the headline value, and there is none.
+
+    As the envelope says, branch on `reason` before reading these keys.
 - *warning*: `WarningCode.PERSISTENT_REGRESSOR` when the ADF p-value exceeds
   `adf_threshold`, **or** `stambaugh_bias_channel` exceeds `0.7`, **or**
   `ar1_phi_corrected_explosive`. The channel trigger is the one that
@@ -1153,5 +1171,32 @@ hypothesis test degenerates keeps its `value` and instead withholds only
   descriptive — emitted only on the short-circuit branch that
   needed it; consumers should branch on `reason` before reading.
 
-The auxiliary `metadata` keys listed in the per-metric subsections
-above are *not* present on the short-circuit path.
+### Which auxiliary keys a short circuit may carry
+
+A short circuit runs no kernel, so the contract is about what a key can
+truthfully *say*, not about which keys appear. Auxiliary keys are common on
+these payloads: a branch usually bails partway, and what it established up to
+that point is worth reporting.
+
+- **Keys describing the input, the configuration, or the attempt** carry their
+  real values. Configuration echoes (`n_groups`, `tie_policy`,
+  `rebalance_lag`, `overlap_periods`, `weights_lagged`), settings resolved for
+  the attempt (`newey_west_lags`), and measurements taken before the bail
+  (`factor_std`, `tie_ratio`, `n_events`, `beta_ols_uncorrected`) are all true
+  statements about work that actually happened.
+- **Keys that would describe the withheld result** are neutralised — `NaN`
+  (`mfe_mae`'s `mfe_mae_ratio`), `None` (`event_around_return`'s
+  `baseline_bar_return`), empty (`per_offset`), `False` (`predictive_beta`'s
+  `stambaugh_adjusted`, `oos_decay`'s `sign_flipped`), or an explicit failure
+  state (`oos_decay`'s `status = "VETOED"`) — **or** the metric documents, at
+  that branch, that they describe the attempt rather than a result.
+  `predictive_beta`'s `no_amihud_hurvich_fit` is the one branch that takes the
+  second route, because neutralising its pair would reuse a sentinel that
+  already means `h = 1`.
+
+The mechanically decidable half is linted: FX008 in
+`tests/stats/test_short_circuit_flag_polarity.py` rejects a new
+`*_applied` / `*_adjusted` / `*_corrected` / `*_flipped` key that reports a
+stage as having run on a short-circuit payload, and carries the documented
+exception as a baseline. Whether a value-bearing key was neutralised is a
+semantic question no lint settles; this section is the contract for it.

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -151,9 +151,19 @@ def predictive_beta(
     the kernel ran at: the augmented design is ``n_periods`` rows and a
     Bartlett sum cannot use a lag it has no observation pair for, so a long
     horizon leaves it narrower than the bandwidth resolved from the full
-    series. The one exception is the ``no_amihud_hurvich_fit`` short circuit,
-    where no kernel runs and the value is the bandwidth resolved for the
-    attempt; ``None`` is not reused there because it already means ``h = 1``.
+    series.
+
+    **On the ``no_amihud_hurvich_fit`` short circuit the inference keys
+    describe the attempt, not a result.** No kernel runs there, so
+    ``hac_applied`` and ``har_lags`` report the covariance branch and
+    bandwidth *resolved for* the attempt, and ``beta_ols_uncorrected`` is the
+    slope the metric declined to publish as a headline. This is the exception
+    the short-circuit envelope permits in place of neutralising:
+    ``hac_applied = False`` implies ``har_lags = None`` on every computed
+    result, so neutralising the pair would make the branch indistinguishable
+    from an ``h = 1`` success rather than merely uninformative.
+    ``stambaugh_adjusted`` stays ``False`` — it describes the headline value,
+    and there is none. Branch on ``metadata["reason"]`` before reading them.
 
     The ``HAC_BANDWIDTH_ILL_CONDITIONED`` message names
     ``n_periods_finite``, not ``n_periods``. This metric is the one place the

--- a/factrix/metrics/predictive_beta.py
+++ b/factrix/metrics/predictive_beta.py
@@ -153,17 +153,22 @@ def predictive_beta(
     horizon leaves it narrower than the bandwidth resolved from the full
     series.
 
-    **On the ``no_amihud_hurvich_fit`` short circuit the inference keys
-    describe the attempt, not a result.** No kernel runs there, so
-    ``hac_applied`` and ``har_lags`` report the covariance branch and
-    bandwidth *resolved for* the attempt, and ``beta_ols_uncorrected`` is the
-    slope the metric declined to publish as a headline. This is the exception
-    the short-circuit envelope permits in place of neutralising:
-    ``hac_applied = False`` implies ``har_lags = None`` on every computed
-    result, so neutralising the pair would make the branch indistinguishable
-    from an ``h = 1`` success rather than merely uninformative.
-    ``stambaugh_adjusted`` stays ``False`` — it describes the headline value,
-    and there is none. Branch on ``metadata["reason"]`` before reading them.
+    **On the ``no_amihud_hurvich_fit`` short circuit each key is judged on
+    its own side of the envelope**, not as one "inference" bundle:
+
+    - ``har_lags`` and ``newey_west_lags`` are *resolved quantities*. The
+      resolution really ran, so the bandwidth reported is the one the kernel
+      would have used — attempt side, kept.
+    - ``beta_ols_uncorrected`` and ``factor_std`` were *measured before the
+      bail* — kept, and the former is the slope the metric declined to
+      publish as a headline.
+    - ``hac_applied`` and ``stambaugh_adjusted`` are past-tense claims that a
+      stage of the inference ran. Neither did, so both are ``False``. The
+      resulting ``(hac_applied=False, har_lags=<int>)`` pair is unreachable
+      on any computed result — an impossible combination a consumer can
+      detect, rather than a plausible one that reads as a completed fit.
+
+    Branch on ``metadata["reason"]`` before reading any of them.
 
     The ``HAC_BANDWIDTH_ILL_CONDITIONED`` message names
     ``n_periods_finite``, not ``n_periods``. This metric is the one place the
@@ -354,8 +359,16 @@ def predictive_beta(
             overlap_periods=overlap_periods,
             factor_std=x_std,
             newey_west_lags=lags,
+            # ``har_lags`` is attempt-side: the resolution really ran, and the
+            # bandwidth it produced is what the kernel would have used.
+            # ``hac_applied`` is a past-tense claim that the HAC covariance
+            # was computed, and no kernel ran here at all, so it neutralises
+            # alongside ``stambaugh_adjusted`` below. The resulting
+            # ``(False, <int>)`` pair is unreachable on any computed result -
+            # an impossible combination a consumer can detect, rather than the
+            # plausible ``(True, <int>)`` that reads as a completed fit.
             har_lags=resolved_har_lags if hac_applied else None,
-            hac_applied=hac_applied,
+            hac_applied=False,
             stambaugh_adjusted=False,
             beta_ols_uncorrected=beta_ols,
         )

--- a/tests/stats/test_predictive_beta_metadata_contract.py
+++ b/tests/stats/test_predictive_beta_metadata_contract.py
@@ -6,11 +6,11 @@ Two contracts, both split out of the review of #1034:
   up (#1035). ``predictive_beta`` is the only metric whose ``n_periods`` is the
   truncated augmented-design row count rather than the count the screen reads,
   so the bare token sends a reader to the wrong number;
-- the ``no_amihud_hurvich_fit`` short circuit runs no kernel, so its
-  ``har_lags`` is the bandwidth resolved for the *attempt*. #1034 tightened the
-  documented contract to "the bandwidth the kernel ran at", which that branch
-  cannot satisfy; the value is kept and the exception is documented instead of
-  overloading the ``None``-means-``h = 1`` sentinel (#1036).
+- the ``no_amihud_hurvich_fit`` short circuit runs no kernel, so each of its
+  keys is judged on its own side of the envelope (#1036, #1039). ``har_lags``
+  is attempt-side and keeps the resolved bandwidth — ``None`` there would
+  overload the ``h = 1`` sentinel — while ``hac_applied`` claims a stage ran
+  and neutralises to ``False``.
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ import pytest
 from factrix.metrics.predictive_beta import predictive_beta
 
 STAT_KEYS_DOCS = Path("docs/reference/stat-keys-by-metric.md")
+_MISSING = object()
 
 
 def _ts_panel(x: np.ndarray, y: np.ndarray) -> pl.DataFrame:
@@ -75,8 +76,8 @@ class TestIllConditionedMessageNamesALookupableKey:
         assert "n_periods /" not in message
 
 
-class TestShortCircuitBandwidthIsTheAttemptedOne:
-    """#1036: no kernel runs there, so the contract states the exception."""
+class TestShortCircuitKeysAreJudgedPerSide:
+    """#1036 / #1039: attempt-side keys stay, stage claims neutralise."""
 
     @pytest.mark.parametrize(("n", "h"), [(20, 19), (20, 16), (22, 18)])
     def test_short_circuit_keeps_the_resolved_bandwidth(self, n: int, h: int) -> None:
@@ -91,26 +92,52 @@ class TestShortCircuitBandwidthIsTheAttemptedOne:
     def test_short_circuit_pair_is_unreachable_on_a_computed_result(
         self, n: int, h: int
     ) -> None:
-        """#1039: why the attempt keys are not neutralised here.
+        """#1039: each key judged on its own side, and the pair is impossible.
 
-        On every computed result ``hac_applied = False`` implies
-        ``har_lags = None``. Keeping both affirmative leaves the branch
-        distinguishable; neutralising only ``hac_applied`` would produce a
-        pair no computed result can, and neutralising both would reproduce an
-        ``h = 1`` success exactly.
+        ``har_lags`` is attempt-side — resolving the bandwidth really
+        happened — so it stays. ``hac_applied`` claims a stage ran, and none
+        did, so it neutralises. The resulting pair cannot occur on a computed
+        result, which is what makes it detectable rather than plausible.
         """
         short_circuit, _ = _run(n, h, seed=n * 10 + h)
         h1, _ = _run(240, 1, seed=11)
         computed, _ = _run(240, 5, seed=7)
 
-        assert short_circuit.metadata["hac_applied"] is True
+        assert short_circuit.metadata["hac_applied"] is False
         assert isinstance(short_circuit.metadata["har_lags"], int)
 
-        # The success-path invariant this branch must not collide with.
+        # Every computed result pairs hac_applied=False with har_lags=None,
+        # so (False, <int>) names this branch and nothing else.
         assert h1.metadata["hac_applied"] is False
         assert h1.metadata["har_lags"] is None
         assert computed.metadata["hac_applied"] is True
         assert isinstance(computed.metadata["har_lags"], int)
+
+    def test_short_circuit_stays_distinguishable_from_an_h1_success(self) -> None:
+        """The collision the first design feared does not exist.
+
+        Neutralising ``hac_applied`` was rejected on the grounds that it would
+        make this branch read as an ``h = 1`` success. It does not:
+        ``stambaugh_adjusted`` is neutralised one keyword earlier in the same
+        call and is ``True`` on every computed result, so it separates the two
+        on its own — before ``reason``, ``value`` and the absent keys are even
+        consulted.
+        """
+        short_circuit, _ = _run(20, 19, seed=190)
+        h1, _ = _run(240, 1, seed=11)
+
+        assert short_circuit.metadata["stambaugh_adjusted"] is False
+        assert h1.metadata["stambaugh_adjusted"] is True
+
+        differing = {
+            key
+            for key in set(short_circuit.metadata) | set(h1.metadata)
+            if short_circuit.metadata.get(key, _MISSING)
+            != h1.metadata.get(key, _MISSING)
+        }
+        assert "stambaugh_adjusted" in differing
+        assert "reason" in differing
+        assert math.isnan(short_circuit.value) and not math.isnan(h1.value)
 
     def test_h1_still_reports_no_bandwidth(self) -> None:
         result, _ = _run(240, 1, seed=11)
@@ -118,13 +145,12 @@ class TestShortCircuitBandwidthIsTheAttemptedOne:
         assert not math.isnan(result.value)
         assert result.metadata["har_lags"] is None
 
-    def test_docs_state_the_branch_contract(self) -> None:
-        """The exception is stated once for the branch, not per key."""
+    def test_docs_state_the_per_key_rule(self) -> None:
+        """The envelope states the rule; the branch is its worked example."""
         docs = STAT_KEYS_DOCS.read_text(encoding="utf-8")
-        assert "no_amihud_hurvich_fit" in docs
-        assert "the inference keys describe the attempt" in docs
-        # ...and the envelope it is an exception to states the general rule.
         assert "Which auxiliary keys a short circuit may carry" in docs
+        assert "per key, never per branch" in docs
+        assert "no_amihud_hurvich_fit" in docs
 
     def test_docs_do_not_repeat_at_at(self) -> None:
         """Typo introduced by #1034's wording; folded in here per review.

--- a/tests/stats/test_predictive_beta_metadata_contract.py
+++ b/tests/stats/test_predictive_beta_metadata_contract.py
@@ -87,17 +87,44 @@ class TestShortCircuitBandwidthIsTheAttemptedOne:
         assert result.metadata["reason"] == "no_amihud_hurvich_fit"
         assert isinstance(result.metadata["har_lags"], int)
 
+    @pytest.mark.parametrize(("n", "h"), [(20, 19), (20, 16), (22, 18)])
+    def test_short_circuit_pair_is_unreachable_on_a_computed_result(
+        self, n: int, h: int
+    ) -> None:
+        """#1039: why the attempt keys are not neutralised here.
+
+        On every computed result ``hac_applied = False`` implies
+        ``har_lags = None``. Keeping both affirmative leaves the branch
+        distinguishable; neutralising only ``hac_applied`` would produce a
+        pair no computed result can, and neutralising both would reproduce an
+        ``h = 1`` success exactly.
+        """
+        short_circuit, _ = _run(n, h, seed=n * 10 + h)
+        h1, _ = _run(240, 1, seed=11)
+        computed, _ = _run(240, 5, seed=7)
+
+        assert short_circuit.metadata["hac_applied"] is True
+        assert isinstance(short_circuit.metadata["har_lags"], int)
+
+        # The success-path invariant this branch must not collide with.
+        assert h1.metadata["hac_applied"] is False
+        assert h1.metadata["har_lags"] is None
+        assert computed.metadata["hac_applied"] is True
+        assert isinstance(computed.metadata["har_lags"], int)
+
     def test_h1_still_reports_no_bandwidth(self) -> None:
         result, _ = _run(240, 1, seed=11)
 
         assert not math.isnan(result.value)
         assert result.metadata["har_lags"] is None
 
-    def test_docs_state_the_short_circuit_exception(self) -> None:
-        """The tightened ``har_lags`` contract must carry its one exception."""
+    def test_docs_state_the_branch_contract(self) -> None:
+        """The exception is stated once for the branch, not per key."""
         docs = STAT_KEYS_DOCS.read_text(encoding="utf-8")
         assert "no_amihud_hurvich_fit" in docs
-        assert "the bandwidth resolved for the attempt" in docs
+        assert "the inference keys describe the attempt" in docs
+        # ...and the envelope it is an exception to states the general rule.
+        assert "Which auxiliary keys a short circuit may carry" in docs
 
     def test_docs_do_not_repeat_at_at(self) -> None:
         """Typo introduced by #1034's wording; folded in here per review.

--- a/tests/stats/test_short_circuit_flag_polarity.py
+++ b/tests/stats/test_short_circuit_flag_polarity.py
@@ -116,6 +116,33 @@ def test_fx008_baseline_is_current() -> None:
     )
 
 
+def _stage_flag_list_sentence() -> str:
+    """The one sentence of the ``_STAGE_FLAG`` comment that states the reach.
+
+    Scoped deliberately. Searching the whole file would let a name deleted
+    from the list keep passing because it also appears in the planted-module
+    string further down — the same drift from the other side.
+    """
+    own_source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    block = own_source.rsplit("_STAGE_FLAG = ", 1)[0]
+    comment = " ".join(
+        line.removeprefix("#:").strip()
+        for line in block.splitlines()
+        if line.startswith("#:")
+    )
+    match = re.search(r"(It matches \w+ names.*?)\s+—\s+so the grammar", comment)
+    assert match is not None, (
+        "could not find the 'It matches N names ... — so the grammar' sentence "
+        "in the _STAGE_FLAG comment; keep it in a form this guard can read."
+    )
+    return match.group(1)
+
+
+def _listed_names(sentence: str) -> set[str]:
+    """Double-backticked names inside that sentence."""
+    return set(re.findall(r"``([a-z0-9_]+)``", sentence))
+
+
 def test_fx008_docstring_count_matches_the_grammar() -> None:
     """The stated reach must equal the measured one.
 
@@ -145,14 +172,18 @@ def test_fx008_docstring_count_matches_the_grammar() -> None:
     assert stated is not None, (
         f"grammar now matches {len(matched)} names; extend the word map."
     )
-    own_source = pathlib.Path(__file__).read_text(encoding="utf-8")
-    assert f"matches {stated} names" in own_source, (
+    sentence = _stage_flag_list_sentence()
+    assert f"matches {stated} names" in sentence, (
         f"the grammar matches {len(matched)} names ({stated}); the comment on "
         f"_STAGE_FLAG states a different count."
     )
-    # ...and every name the comment lists is one the grammar really matches.
-    for name in matched:
-        assert name in own_source, f"{name} matches but is not listed"
+    # Set equality, both directions: a matched name missing from the list and
+    # a listed name the grammar no longer matches are the same defect from
+    # opposite sides, and each produces a list contradicting its own count.
+    assert _listed_names(sentence) == matched, (
+        f"listed but not matched: {sorted(_listed_names(sentence) - matched)}; "
+        f"matched but not listed: {sorted(matched - _listed_names(sentence))}"
+    )
 
 
 def test_fx008_detects_a_planted_violation(tmp_path: pathlib.Path) -> None:

--- a/tests/stats/test_short_circuit_flag_polarity.py
+++ b/tests/stats/test_short_circuit_flag_polarity.py
@@ -1,18 +1,21 @@
 """Regression lint for did-this-stage-run flags on short-circuit payloads.
 
 A short circuit runs no kernel, so a flag reporting that a stage of the
-inference *was applied* cannot be affirmative there without a documented
-exception. ``predictive_beta``'s own short circuit is the illustration: it
-neutralises ``stambaugh_adjusted`` to ``False`` and, one keyword later,
-reports ``hac_applied`` as ``True``.
+inference *was applied* cannot be affirmative there. ``predictive_beta`` is
+what prompted this: its short circuit neutralised ``stambaugh_adjusted`` to
+``False`` and, one keyword later, reported ``hac_applied`` as ``True`` — the
+same claim about a different stage, decided two different ways inside one
+call.
 
-FX008 records the sites that legitimately stay affirmative — each with the
-reason it does — and rejects any new one, the same migration-ledger shape as
-FX007 in ``test_degenerate_guard_polarity``. It deliberately checks only the
-mechanically decidable half of the short-circuit envelope: a key whose *name*
-says a stage ran. Whether a value-bearing key such as ``mfe_mae_ratio`` was
-neutralised is a semantic question the envelope documents but no lint can
-settle.
+FX008 carries a baseline of documented exceptions in the migration-ledger
+shape of FX007 in ``test_degenerate_guard_polarity``. The baseline is empty,
+so the rule currently holds without carve-outs; the mechanism stays for a
+future case that clears the envelope's bar.
+
+It deliberately checks only the mechanically decidable half of the
+short-circuit envelope: a key whose *name* says a stage ran. Whether a
+value-bearing key such as ``mfe_mae_ratio`` was neutralised is a semantic
+question the envelope documents and no lint can settle.
 """
 
 from __future__ import annotations
@@ -32,28 +35,34 @@ _SHORT_CIRCUIT_HELPERS = frozenset(
 
 #: Keys whose name asserts that a stage of the *inference* ran. Deliberately a
 #: suffix grammar rather than a hand-list: a new ``*_applied`` flag is exactly
-#: the case this lint exists to catch. Data-preparation verbs (``*_lagged``)
-#: stay out — ``quantile_spread_vw``'s ``weights_lagged`` echoes the
-#: ``lag_weights`` parameter, so it describes the caller's configuration
-#: rather than a stage of the withheld inference, and is affirmative on every
-#: branch by design.
-_STAGE_FLAG = re.compile(r"^[a-z0-9_]*_(applied|adjusted|corrected|flipped)$")
+#: the case this lint exists to catch. It matches nine names across the
+#: package today — ``hac_applied``, ``stambaugh_adjusted``,
+#: ``kolari_pynnonen_applied``, ``calendar_time_se_applied``,
+#: ``overlap_adjustment_applied``, ``event_clustering_adjusted``,
+#: ``mean_adjusted``, ``sign_flipped`` — so the grammar has real reach beyond
+#: the site that prompted it.
+#:
+#: Two verb families are excluded on purpose:
+#:
+#: - ``*_lagged`` is data preparation, not inference. ``quantile_spread_vw``'s
+#:   ``weights_lagged`` echoes the ``lag_weights`` parameter, so it describes
+#:   the caller's configuration and is affirmative on every branch by design.
+#: - ``*_corrected`` matches ``ar1_phi_corrected``, which is a float — the
+#:   bias-corrected AR(1) coefficient — not a did-this-run flag, and is
+#:   legitimately attempt-side because the AR(1) fit precedes the bail.
+#:   Including it would force a baseline entry for something that is not a
+#:   flag the first time a short circuit reports it.
+_STAGE_FLAG = re.compile(r"^[a-z0-9_]*_(applied|adjusted|flipped)$")
 
 #: Sites that stay affirmative on purpose, with the reason each is sound.
 #: A migration ledger, not a bug list — an entry leaves when the branch stops
 #: needing it, and ``test_fx008_baseline_is_current`` fails if one goes stale.
-_FX008_BASELINE: dict[tuple[str, str], str] = {
-    (
-        "factrix/metrics/predictive_beta.py",
-        "hac_applied",
-    ): (
-        "no_amihud_hurvich_fit documents its inference keys as describing the "
-        "attempt, not a result: har_lags is the bandwidth resolved for it and "
-        "hac_applied the covariance branch it would have taken. Neutralising "
-        "to False would make the pair identical to an h = 1 success, reusing "
-        "a sentinel that already means something else."
-    ),
-}
+#:
+#: **Currently empty**, and that is the point: the rule holds everywhere
+#: without a carve-out. Adding an entry needs the envelope's bar — that
+#: neutralising the key is impossible or destroys information, not merely
+#: less convenient — argued at the branch that adds it.
+_FX008_BASELINE: dict[tuple[str, str], str] = {}
 
 
 def _flag_kwargs(path: pathlib.Path) -> list[tuple[str, str]]:

--- a/tests/stats/test_short_circuit_flag_polarity.py
+++ b/tests/stats/test_short_circuit_flag_polarity.py
@@ -35,7 +35,7 @@ _SHORT_CIRCUIT_HELPERS = frozenset(
 
 #: Keys whose name asserts that a stage of the *inference* ran. Deliberately a
 #: suffix grammar rather than a hand-list: a new ``*_applied`` flag is exactly
-#: the case this lint exists to catch. It matches nine names across the
+#: the case this lint exists to catch. It matches eight names across the
 #: package today — ``hac_applied``, ``stambaugh_adjusted``,
 #: ``kolari_pynnonen_applied``, ``calendar_time_se_applied``,
 #: ``overlap_adjustment_applied``, ``event_clustering_adjusted``,
@@ -114,6 +114,45 @@ def test_fx008_baseline_is_current() -> None:
         f"FX008: baseline entries no longer present in the source: {sorted(stale)}. "
         "Remove them so the ledger keeps describing the code."
     )
+
+
+def test_fx008_docstring_count_matches_the_grammar() -> None:
+    """The stated reach must equal the measured one.
+
+    This shipped wrong once: the count stayed at ``nine`` after ``*_corrected``
+    left the grammar, contradicting the list beside it. Measuring it here is
+    the same rule this lint exists to enforce, one layer up — a stated number
+    has to be the number the code produces.
+    """
+    matched = {
+        node.value if isinstance(node, ast.Constant) else node.arg
+        for path in sorted(PACKAGE_DIR.rglob("*.py"))
+        if not path.stem.startswith("llms")
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and _STAGE_FLAG.match(node.value)
+        )
+        or (
+            isinstance(node, ast.keyword)
+            and node.arg is not None
+            and _STAGE_FLAG.match(node.arg)
+        )
+    }
+    words = {8: "eight", 9: "nine", 10: "ten", 11: "eleven", 12: "twelve"}
+    stated = words.get(len(matched))
+    assert stated is not None, (
+        f"grammar now matches {len(matched)} names; extend the word map."
+    )
+    own_source = pathlib.Path(__file__).read_text(encoding="utf-8")
+    assert f"matches {stated} names" in own_source, (
+        f"the grammar matches {len(matched)} names ({stated}); the comment on "
+        f"_STAGE_FLAG states a different count."
+    )
+    # ...and every name the comment lists is one the grammar really matches.
+    for name in matched:
+        assert name in own_source, f"{name} matches but is not listed"
 
 
 def test_fx008_detects_a_planted_violation(tmp_path: pathlib.Path) -> None:

--- a/tests/stats/test_short_circuit_flag_polarity.py
+++ b/tests/stats/test_short_circuit_flag_polarity.py
@@ -1,0 +1,135 @@
+"""Regression lint for did-this-stage-run flags on short-circuit payloads.
+
+A short circuit runs no kernel, so a flag reporting that a stage of the
+inference *was applied* cannot be affirmative there without a documented
+exception. ``predictive_beta``'s own short circuit is the illustration: it
+neutralises ``stambaugh_adjusted`` to ``False`` and, one keyword later,
+reports ``hac_applied`` as ``True``.
+
+FX008 records the sites that legitimately stay affirmative — each with the
+reason it does — and rejects any new one, the same migration-ledger shape as
+FX007 in ``test_degenerate_guard_polarity``. It deliberately checks only the
+mechanically decidable half of the short-circuit envelope: a key whose *name*
+says a stage ran. Whether a value-bearing key such as ``mfe_mae_ratio`` was
+neutralised is a semantic question the envelope documents but no lint can
+settle.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+from collections import Counter
+
+PACKAGE_DIR = pathlib.Path("factrix")
+
+#: Helpers that build a short-circuit ``MetricResult``. Keyword arguments to
+#: these become ``metadata`` on a result that carries no estimate.
+_SHORT_CIRCUIT_HELPERS = frozenset(
+    {"_short_circuit_output", "_enforce_min_floor", "_enforce_scaled_floor"}
+)
+
+#: Keys whose name asserts that a stage of the *inference* ran. Deliberately a
+#: suffix grammar rather than a hand-list: a new ``*_applied`` flag is exactly
+#: the case this lint exists to catch. Data-preparation verbs (``*_lagged``)
+#: stay out — ``quantile_spread_vw``'s ``weights_lagged`` echoes the
+#: ``lag_weights`` parameter, so it describes the caller's configuration
+#: rather than a stage of the withheld inference, and is affirmative on every
+#: branch by design.
+_STAGE_FLAG = re.compile(r"^[a-z0-9_]*_(applied|adjusted|corrected|flipped)$")
+
+#: Sites that stay affirmative on purpose, with the reason each is sound.
+#: A migration ledger, not a bug list — an entry leaves when the branch stops
+#: needing it, and ``test_fx008_baseline_is_current`` fails if one goes stale.
+_FX008_BASELINE: dict[tuple[str, str], str] = {
+    (
+        "factrix/metrics/predictive_beta.py",
+        "hac_applied",
+    ): (
+        "no_amihud_hurvich_fit documents its inference keys as describing the "
+        "attempt, not a result: har_lags is the bandwidth resolved for it and "
+        "hac_applied the covariance branch it would have taken. Neutralising "
+        "to False would make the pair identical to an h = 1 success, reusing "
+        "a sentinel that already means something else."
+    ),
+}
+
+
+def _flag_kwargs(path: pathlib.Path) -> list[tuple[str, str]]:
+    """``(key, unparsed value)`` for every stage flag on a short-circuit call."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: list[tuple[str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name not in _SHORT_CIRCUIT_HELPERS:
+            continue
+        for keyword in node.keywords:
+            if keyword.arg and _STAGE_FLAG.match(keyword.arg):
+                found.append((keyword.arg, ast.unparse(keyword.value)))
+    return found
+
+
+def _affirmative_sites() -> Counter[tuple[str, str]]:
+    """Stage flags passed a value that is not a literal ``False`` / ``None``."""
+    sites: Counter[tuple[str, str]] = Counter()
+    for path in sorted(PACKAGE_DIR.rglob("*.py")):
+        if path.stem.startswith("llms"):
+            continue
+        for key, value in _flag_kwargs(path):
+            if value in {"False", "None"}:
+                continue
+            sites[(path.as_posix(), key)] += 1
+    return sites
+
+
+def test_fx008_no_new_affirmative_stage_flag() -> None:
+    """Lint FX008: a new stage flag must be neutral on a short circuit."""
+    unexpected = {site for site in _affirmative_sites() if site not in _FX008_BASELINE}
+    assert not unexpected, (
+        "FX008: a short circuit runs no kernel, so a flag naming a stage of "
+        "the inference cannot report that it was applied. Pass False (or "
+        "None), or add the site to _FX008_BASELINE with the reason its "
+        "branch documents the value as describing the attempt. New sites: "
+        f"{sorted(unexpected)}"
+    )
+
+
+def test_fx008_baseline_is_current() -> None:
+    """A baseline entry that no longer matches a site is stale."""
+    stale = set(_FX008_BASELINE) - set(_affirmative_sites())
+    assert not stale, (
+        f"FX008: baseline entries no longer present in the source: {sorted(stale)}. "
+        "Remove them so the ledger keeps describing the code."
+    )
+
+
+def test_fx008_detects_a_planted_violation(tmp_path: pathlib.Path) -> None:
+    """The lint must fail on the shape it exists to reject."""
+    module = tmp_path / "metric.py"
+    module.write_text(
+        """
+def metric():
+    return _short_circuit_output(
+        "m", "no_fit", overlap_adjustment_applied=True, sign_flipped=False
+    )
+""",
+        encoding="utf-8",
+    )
+    flags = dict(_flag_kwargs(module))
+
+    assert flags["overlap_adjustment_applied"] == "True"
+    assert flags["sign_flipped"] == "False"
+
+
+def test_fx008_ignores_flags_on_normal_results() -> None:
+    """Only short-circuit payloads are in scope; a real fit may report True."""
+    module = pathlib.Path("factrix/metrics/predictive_beta.py")
+
+    # The success path reports the correction it applied, affirmatively.
+    assert '"stambaugh_adjusted": True' in module.read_text(encoding="utf-8")
+    # ...and that emission is not a short-circuit call, so FX008 never sees it.
+    assert ("stambaugh_adjusted", "True") not in _flag_kwargs(module)


### PR DESCRIPTION
Designed as a general rule rather than a `predictive_beta` patch: #1039 is the
fourth instance in a row of the same shape (#1034, #1035, #1036), so the
remedy is the contract, not the fourth patch.

**Revised after review** — the first version granted `predictive_beta` a
documented exception on a premise that turned out to be false. See *What
changed after review* at the end.

## The rule

> A short-circuit payload may state anything true about the **input**, the
> **configuration**, or the **attempt**. A key that would describe the
> **withheld result** is neutralised — `NaN` / `None` / empty / `False` / an
> explicit failure state.
>
> The two sides are judged **per key, never per branch**.

This *describes* what the library already does:

| metric | key | short-circuit value |
|---|---|---|
| `mfe_mae` | `mfe_mae_ratio` | `float("nan")` |
| `event_around_return` | `baseline_bar_return` / `per_offset` | `None` / `{}` |
| `oos_decay` | `status` / `sign_flipped` | `"VETOED"` / `False` |
| `predictive_beta` | `stambaugh_adjusted` | `False` |
| **`predictive_beta`** | **`hac_applied`** | **`True` → `False`** |

The last two are keyword arguments to the *same* `_short_circuit_output` call:
the same claim about two different stages, decided two different ways.

A branch may instead document that a withheld-result key describes the
attempt, but only where neutralising is **impossible or destroys
information** — not merely less convenient — and must say which applies. No
metric currently needs it; the bar is written down so a future case is argued
rather than assumed.

## The envelope doc was false library-wide

`stat-keys-by-metric.md` ended its short-circuit section with:

> The auxiliary `metadata` keys listed in the per-metric subsections above are
> *not* present on the short-circuit path.

An AST sweep finds **39 call sites across 17 metric modules** passing keys
outside its allowlist (the reviewer's independent sweep, under a stricter
allowlist, found 71/23 — different line, same conclusion). Almost all are
harmless configuration echoes. The sentence described a rule the code does not
follow, and drew the line in the wrong place: the real split is
input-vs-withheld-result, not auxiliary-vs-not. Rewritten.

That is the larger half of this PR, and why the fix is not a one-liner.

## `predictive_beta`, judged per key

| key | side | value |
|---|---|---|
| `har_lags`, `newey_west_lags` | resolved for the attempt — the resolution ran | the resolved bandwidth |
| `beta_ols_uncorrected`, `factor_std` | measured before the bail | the measurement |
| `hac_applied`, `stambaugh_adjusted` | claims a stage ran | `False` |

`(hac_applied=False, har_lags=<int>)` is unreachable on any computed result.
That is the argument *for* it: an impossible combination is detectable, where
the plausible `(True, <int>)` reads as a completed fit. `hac_applied` has no
consumers outside `predictive_beta` and its own tests.

## FX008

Lints the mechanically decidable half: an `*_applied` / `*_adjusted` /
`*_flipped` key reporting a stage as having run on a short-circuit payload.
FX007's migration-ledger shape — baseline plus a staleness check.

- **The baseline is empty**, so the rule holds with no carve-outs.
- Verified to fire: planting `hac_applied=True` back into `predictive_beta`
  fails FX008 and names the site.
- The grammar matches eight names across the package, not just the one that
  prompted it.
- `*_corrected` was dropped after review: it matched `ar1_phi_corrected`, a
  float (the bias-corrected AR(1) coefficient), not a did-this-run flag, and
  legitimately attempt-side. `*_lagged` stays out too — `weights_lagged`
  echoes the `lag_weights` parameter.
- What a lint cannot decide — whether `mfe_mae_ratio` was neutralised — is
  stated in the envelope instead, and the lint's docstring says it does not
  cover that half.

## What changed after review

The first version kept `hac_applied=True` under a documented exception,
arguing that neutralising the pair would make the branch indistinguishable
from an `h = 1` success. **That premise was false.** Comparing the payloads
key by key: 27 differ, **0 share a value**. `stambaugh_adjusted` — neutralised
one keyword earlier in the same call, `True` on every computed result —
separates them on its own.

With the premise gone, the rule decides the case without an exception: the
first version had bundled `har_lags` and `hac_applied` as "the inference
keys" when the rule operates per key. `test_short_circuit_stays_distinguishable_from_an_h1_success`
pins the refutation so the premise cannot quietly return.

An earlier draft of this description cited `CLAUDE.md` as independent support
for the exception route. It is not: those sections are uncommitted and were
written this session as a codification of #1034/#1035/#1036/#1039 themselves,
so citing them was the same judgment restated. Removed.

## Validation

- `pytest -p no:faulthandler -q` — 3813 passed, 45 skipped (main: 3805; +8)
- `pytest --doctest-modules factrix` — 96 passed, 1 skipped
- `ruff check` / `ruff format --check` / `mypy factrix`
- `mkdocs build --strict`, no generated-file drift

One metadata **value** changes: `hac_applied` on `no_amihud_hurvich_fit`,
`True` → `False`. No estimator, statistic or p-value changes.

Closes #1039