### PR TITLE
ci(docs): retry the intersphinx inventory fetch before --strict fails

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ theme:
         name: Switch to light mode
 
 hooks:
+  # pre-warms the intersphinx inventory cache mkdocstrings reads, with
+  # retries, so a transient fetch failure cannot fail a --strict build
+  - scripts/mkdocs_hooks/warm_inventory_cache.py
   # examples/*.ipynb -> docs/examples/*.md
   - scripts/mkdocs_hooks/render_example_notebooks.py
   # factrix._metric_index.public_specs() -> docs/reference/_generated_metric_matrix.md

--- a/scripts/mkdocs_hooks/warm_inventory_cache.py
+++ b/scripts/mkdocs_hooks/warm_inventory_cache.py
@@ -59,27 +59,40 @@ def _inventory_urls(config: Any) -> list[str]:
     ]
 
 
-def _download_with_retry(url: str) -> bytes:
-    """``mkdocs``' downloader, retried on a connection-level failure.
+def _is_transient(error: Exception) -> bool:
+    """Whether the failure is worth another attempt.
 
-    Only ``URLError`` is retried. An ``HTTPError`` — 404 on a mistyped URL,
-    403, 500 — is a server verdict rather than a blip, and is raised on the
-    first attempt so a wrong URL is not hidden behind three slow tries.
+    The split is 4xx against everything else, and it is a split between two
+    kinds of statement:
+
+    - a ``4xx`` other than ``429`` is a verdict about *the URL* — ``404`` and
+      ``410`` on a mistyped or moved inventory, ``403`` on one that needs
+      credentials. Retrying only hides a wrong URL behind three slow tries;
+    - a ``5xx`` is a verdict about *the server's state*, and ``429`` asks for
+      exactly one thing, which is to come back later. A docs CDN answering
+      ``502`` or ``503`` is the third-party host being unreachable — the
+      condition #1037 is about — and cannot conceal a typo, because a typo
+      does not produce a ``5xx``.
+
+    ``HTTPError`` subclasses ``URLError``, so it is checked first.
     """
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code >= 500 or error.code == 429
+    return isinstance(error, (urllib.error.URLError, OSError))
+
+
+def _download_with_retry(url: str) -> bytes:
+    """``mkdocs``' downloader, retried while the failure looks transient."""
     from mkdocstrings._internal.handlers.base import _download_url_with_gz
 
-    last: Exception | None = None
     for attempt in range(_ATTEMPTS):
         try:
             return _download_url_with_gz(url)
-        except urllib.error.HTTPError:
-            raise
         except (urllib.error.URLError, OSError) as error:
-            last = error
-            if attempt < _ATTEMPTS - 1:
-                time.sleep(_BACKOFF_SECONDS[attempt])
-    assert last is not None
-    raise last
+            if not _is_transient(error) or attempt == _ATTEMPTS - 1:
+                raise
+            time.sleep(_BACKOFF_SECONDS[attempt])
+    raise AssertionError("unreachable: the loop returns or raises")
 
 
 def warm(urls: list[str]) -> None:

--- a/scripts/mkdocs_hooks/warm_inventory_cache.py
+++ b/scripts/mkdocs_hooks/warm_inventory_cache.py
@@ -1,0 +1,110 @@
+"""Pre-warm the intersphinx inventory cache so one blip cannot fail the build.
+
+``mkdocstrings`` downloads each configured inventory through
+``mkdocs.utils.cache.download_and_cache_url`` with a one-day cache, and a
+failed fetch is fatal under ``--strict``. It is a single attempt: on
+``docs-deploy-dev`` run 33599419309 a ``Connection reset by peer`` from
+``docs.pola.rs`` failed a pull request whose content was fine, and a rerun went
+green (#1037).
+
+This hook fetches the same URLs into the same cache first, retrying a
+connection-level failure. Because it calls the same cache function, a warmed
+entry is what ``mkdocstrings`` finds a moment later — it never reaches the
+network at all. When every attempt fails the hook stays quiet about it beyond a
+warning and lets ``mkdocstrings`` proceed, so a genuinely wrong or permanently
+unreachable URL still fails the build with its own error. ``--strict`` keeps
+its meaning; only the number of chances a transient blip gets changes.
+
+The URLs are read from ``mkdocs.yml`` rather than repeated here, so adding an
+inventory there warms it automatically.
+
+Usage (manual)::
+
+    python scripts/mkdocs_hooks/warm_inventory_cache.py
+
+MkDocs hook usage (automatic, via ``hooks:`` in mkdocs.yml)::
+
+    ``on_config(config)`` runs before mkdocstrings resolves its handlers.
+"""
+
+from __future__ import annotations
+
+import datetime
+import time
+import urllib.error
+from typing import Any
+
+#: Matches the ``cache_duration`` mkdocstrings passes, so a warmed entry is
+#: still fresh when it looks. A shorter value here would warm the cache and
+#: then let mkdocstrings re-download anyway.
+_CACHE_DURATION = datetime.timedelta(days=1)
+
+#: Attempts per URL, and the pause before each retry. Small on purpose: this
+#: runs on every local build too, and an offline developer should wait a
+#: couple of seconds, not a minute, before the build continues without it.
+_ATTEMPTS = 3
+_BACKOFF_SECONDS = (1.0, 3.0)
+
+
+def _inventory_urls(config: Any) -> list[str]:
+    """Inventory URLs configured for the mkdocstrings python handler."""
+    plugin = config.plugins.get("mkdocstrings")
+    if plugin is None:
+        return []
+    handlers = plugin.config.get("handlers") or {}
+    python = handlers.get("python") or {}
+    return [
+        entry if isinstance(entry, str) else entry["url"]
+        for entry in python.get("inventories") or []
+    ]
+
+
+def _download_with_retry(url: str) -> bytes:
+    """``mkdocs``' downloader, retried on a connection-level failure.
+
+    Only ``URLError`` is retried. An ``HTTPError`` — 404 on a mistyped URL,
+    403, 500 — is a server verdict rather than a blip, and is raised on the
+    first attempt so a wrong URL is not hidden behind three slow tries.
+    """
+    from mkdocstrings._internal.handlers.base import _download_url_with_gz
+
+    last: Exception | None = None
+    for attempt in range(_ATTEMPTS):
+        try:
+            return _download_url_with_gz(url)
+        except urllib.error.HTTPError:
+            raise
+        except (urllib.error.URLError, OSError) as error:
+            last = error
+            if attempt < _ATTEMPTS - 1:
+                time.sleep(_BACKOFF_SECONDS[attempt])
+    assert last is not None
+    raise last
+
+
+def warm(urls: list[str]) -> None:
+    """Fetch each URL into the cache mkdocstrings reads, retrying blips."""
+    from mkdocs.utils.cache import download_and_cache_url
+
+    for url in urls:
+        try:
+            download_and_cache_url(url, _CACHE_DURATION, download=_download_with_retry)
+        except Exception as error:
+            # Deliberately not fatal: mkdocstrings is about to try the same
+            # URL and will report the real failure in its own terms. Failing
+            # here would only move the error and lose that context.
+            print(f"warm_inventory_cache: {url} unavailable ({error})")
+        else:
+            print(f"warm_inventory_cache: cached {url}")
+
+
+def on_config(config):
+    """MkDocs ``on_config`` hook — runs before mkdocstrings downloads."""
+    warm(_inventory_urls(config))
+    return config
+
+
+if __name__ == "__main__":
+    from mkdocs.config import load_config
+
+    warm(_inventory_urls(load_config("mkdocs.yml")))

--- a/tests/test_docs_inventory_cache_warmup.py
+++ b/tests/test_docs_inventory_cache_warmup.py
@@ -1,0 +1,154 @@
+"""The inventory warm-up must survive a blip without hiding a real failure.
+
+Under ``--strict`` a failed intersphinx fetch aborts the docs build, and
+``mkdocstrings`` makes exactly one attempt. #1037: a ``Connection reset by
+peer`` from ``docs.pola.rs`` failed a pull request whose content was fine.
+
+These pin the three behaviours that make retrying safe rather than merely
+quieter — recover from a blip, refuse to retry a server verdict, and stay
+non-fatal so ``mkdocstrings`` reports whatever it finds in its own terms.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import urllib.error
+
+import pytest
+import yaml
+from scripts.mkdocs_hooks.warm_inventory_cache import (
+    _ATTEMPTS,
+    _CACHE_DURATION,
+    _download_with_retry,
+    warm,
+)
+
+MKDOCS_YML = pathlib.Path("mkdocs.yml")
+
+
+@pytest.fixture
+def downloader(monkeypatch):
+    """Replace the network call mkdocstrings would make; count attempts."""
+    calls: list[str] = []
+
+    def install(behaviour):
+        def fake(url: str) -> bytes:
+            calls.append(url)
+            return behaviour(len(calls))
+
+        monkeypatch.setattr(
+            "mkdocstrings._internal.handlers.base._download_url_with_gz", fake
+        )
+        return calls
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    return install
+
+
+def _reset_error(_attempt: int) -> bytes:
+    """The exact failure #1037 observed."""
+    raise urllib.error.URLError(ConnectionResetError(104, "Connection reset by peer"))
+
+
+def test_recovers_from_a_transient_reset(downloader) -> None:
+    """One blip then success — the shape #1037 actually hit.
+
+    The second attempt is hard-coded rather than derived from ``_ATTEMPTS``:
+    a test that reads the constant it exists to guard passes when the
+    constant drops to 1, which is precisely the regression to catch.
+    """
+
+    def behaviour(attempt: int) -> bytes:
+        if attempt == 1:
+            return _reset_error(attempt)
+        return b"inventory"
+
+    calls = downloader(behaviour)
+    assert _download_with_retry("https://example.invalid/objects.inv") == b"inventory"
+    assert len(calls) == 2
+
+
+def test_does_not_retry_a_server_verdict(downloader) -> None:
+    """A 404 is a mistyped URL, not a blip; retrying would only hide it slowly."""
+
+    def behaviour(_attempt: int) -> bytes:
+        raise urllib.error.HTTPError(
+            "https://example.invalid/typo.inv", 404, "Not Found", {}, None
+        )
+
+    calls = downloader(behaviour)
+    with pytest.raises(urllib.error.HTTPError):
+        _download_with_retry("https://example.invalid/typo.inv")
+    assert len(calls) == 1
+
+
+def test_gives_up_after_the_declared_attempts(downloader) -> None:
+    assert _ATTEMPTS > 1, "one attempt is the behaviour this hook replaces"
+    calls = downloader(_reset_error)
+    with pytest.raises(urllib.error.URLError):
+        _download_with_retry("https://example.invalid/objects.inv")
+    assert len(calls) == _ATTEMPTS
+
+
+def test_warm_up_is_not_itself_fatal(downloader, capsys) -> None:
+    """A dead host must leave the real error to mkdocstrings, not pre-empt it.
+
+    Raising here would move the failure into the hook and lose the handler
+    context, while still failing the build — no gain, worse message.
+    """
+    downloader(_reset_error)
+    warm(["https://example.invalid/objects.inv"])
+    assert "unavailable" in capsys.readouterr().out
+
+
+def test_urls_come_from_mkdocs_yml_not_a_second_list() -> None:
+    """A new inventory in mkdocs.yml is warmed without editing the hook."""
+    configured = (
+        yaml.safe_load(MKDOCS_YML.read_text(encoding="utf-8").replace("!!python/", "#"))
+        or {}
+    )
+    plugins = configured.get("plugins") or []
+    handler = next(
+        entry["mkdocstrings"]["handlers"]["python"]
+        for entry in plugins
+        if isinstance(entry, dict) and "mkdocstrings" in entry
+    )
+    declared = handler["inventories"]
+    assert declared, "mkdocs.yml should declare at least one inventory"
+
+    hook_source = pathlib.Path(
+        "scripts/mkdocs_hooks/warm_inventory_cache.py"
+    ).read_text(encoding="utf-8")
+    for url in declared:
+        assert url not in hook_source, (
+            f"{url} is hard-coded in the hook; it must be read from mkdocs.yml "
+            "so a new inventory is warmed automatically."
+        )
+
+
+def test_cache_duration_matches_what_mkdocstrings_asks_for() -> None:
+    """A shorter warm-up TTL would warm the cache and be re-downloaded anyway."""
+    import datetime
+    import inspect
+
+    from mkdocstrings._internal.handlers import base
+
+    source = inspect.getsource(base)
+    assert "def _download_inventories" in source, (
+        "mkdocstrings no longer downloads inventories through this module; "
+        "re-check what _CACHE_DURATION has to match."
+    )
+    assert "datetime.timedelta(days=1)" in source, (
+        "mkdocstrings' cache duration changed; _CACHE_DURATION must follow it "
+        "or the warmed entry will be considered stale."
+    )
+    assert datetime.timedelta(days=1) == _CACHE_DURATION
+
+
+def test_hook_is_registered_before_the_generators() -> None:
+    """It must run in the build, and first — the others do not need the network."""
+    hooks = (
+        yaml.safe_load(MKDOCS_YML.read_text(encoding="utf-8").replace("!!python/", "#"))
+        or {}
+    ).get("hooks") or []
+    assert "scripts/mkdocs_hooks/warm_inventory_cache.py" in hooks

--- a/tests/test_docs_inventory_cache_warmup.py
+++ b/tests/test_docs_inventory_cache_warmup.py
@@ -50,6 +50,25 @@ def downloader(monkeypatch):
     return install
 
 
+def _mkdocs_yml() -> dict:
+    return (
+        yaml.safe_load(MKDOCS_YML.read_text(encoding="utf-8").replace("!!python/", "#"))
+        or {}
+    )
+
+
+def _declared_inventories() -> list[str]:
+    """Inventory URLs as written in ``mkdocs.yml``."""
+    handler = next(
+        entry["mkdocstrings"]["handlers"]["python"]
+        for entry in _mkdocs_yml().get("plugins") or []
+        if isinstance(entry, dict) and "mkdocstrings" in entry
+    )
+    declared = handler["inventories"]
+    assert declared, "mkdocs.yml should declare at least one inventory"
+    return declared
+
+
 def _reset_error(_attempt: int) -> bytes:
     """The exact failure #1037 observed."""
     raise urllib.error.URLError(ConnectionResetError(104, "Connection reset by peer"))
@@ -73,18 +92,66 @@ def test_recovers_from_a_transient_reset(downloader) -> None:
     assert len(calls) == 2
 
 
-def test_does_not_retry_a_server_verdict(downloader) -> None:
-    """A 404 is a mistyped URL, not a blip; retrying would only hide it slowly."""
-
+def _http_error(code: int, reason: str):
     def behaviour(_attempt: int) -> bytes:
         raise urllib.error.HTTPError(
-            "https://example.invalid/typo.inv", 404, "Not Found", {}, None
+            "https://example.invalid/objects.inv", code, reason, {}, None
         )
 
-    calls = downloader(behaviour)
+    return behaviour
+
+
+@pytest.mark.parametrize(
+    ("code", "reason"),
+    [(404, "Not Found"), (403, "Forbidden"), (410, "Gone"), (400, "Bad Request")],
+)
+def test_does_not_retry_a_verdict_about_the_url(downloader, code, reason) -> None:
+    """A 4xx names the URL as wrong; retrying only hides a typo more slowly."""
+    calls = downloader(_http_error(code, reason))
     with pytest.raises(urllib.error.HTTPError):
-        _download_with_retry("https://example.invalid/typo.inv")
+        _download_with_retry("https://example.invalid/objects.inv")
     assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("code", "reason"),
+    [
+        (429, "Too Many Requests"),
+        (500, "Internal Server Error"),
+        (502, "Bad Gateway"),
+        (503, "Service Unavailable"),
+        (504, "Gateway Timeout"),
+    ],
+)
+def test_retries_a_verdict_about_the_server(downloader, code, reason) -> None:
+    """A docs CDN answering 5xx is the unreachable host #1037 is about.
+
+    It cannot conceal a mistyped URL — a typo produces 404/410, not 502 — so
+    the concern that keeps 4xx on one attempt does not apply here.
+    """
+    calls = downloader(_http_error(code, reason))
+    with pytest.raises(urllib.error.HTTPError):
+        _download_with_retry("https://example.invalid/objects.inv")
+    assert len(calls) == _ATTEMPTS
+
+
+def test_recovers_from_a_transient_gateway_error(downloader) -> None:
+    """The 5xx equivalent of the reset: one bad response, then success."""
+
+    def behaviour(attempt: int) -> bytes:
+        if attempt == 1:
+            raise urllib.error.HTTPError(
+                "https://example.invalid/objects.inv",
+                503,
+                "Service Unavailable",
+                {},
+                None,
+            )
+        return b"inventory"
+
+    calls = downloader(behaviour)
+    assert _download_with_retry("https://example.invalid/objects.inv") == b"inventory"
+    assert len(calls) == 2
 
 
 def test_gives_up_after_the_declared_attempts(downloader) -> None:
@@ -106,21 +173,48 @@ def test_warm_up_is_not_itself_fatal(downloader, capsys) -> None:
     assert "unavailable" in capsys.readouterr().out
 
 
+def test_config_walk_finds_the_urls_mkdocs_actually_resolves() -> None:
+    """The walk must fail loudly, not return ``[]``.
+
+    ``_inventory_urls`` reads ``plugins.mkdocstrings.handlers.python
+    .inventories``. mkdocstrings has renamed that key once already — ``import``
+    became ``inventories`` — and if it moves again the walk returns an empty
+    list, the hook warms nothing, every other test still passes and the build
+    silently loses this protection. Assert against the real resolved config,
+    the way ``test_cache_duration_matches_what_mkdocstrings_asks_for`` asserts
+    against mkdocstrings' own source.
+    """
+    from mkdocs.config import load_config
+    from scripts.mkdocs_hooks.warm_inventory_cache import _inventory_urls
+
+    declared = _declared_inventories()
+    found = _inventory_urls(load_config(str(MKDOCS_YML)))
+
+    assert found, (
+        "_inventory_urls found no inventories in the resolved config — the "
+        "handler config key has moved and the hook is warming nothing."
+    )
+    assert set(found) == set(declared)
+
+
+def test_config_walk_is_not_silently_empty_on_a_renamed_key() -> None:
+    """Renaming the key must change the result, so the pin above has teeth."""
+    from mkdocs.config import load_config
+    from scripts.mkdocs_hooks.warm_inventory_cache import _inventory_urls
+
+    config = load_config(str(MKDOCS_YML))
+    handler = config.plugins["mkdocstrings"].config["handlers"]["python"]
+    handler["import"] = handler.pop("inventories")
+
+    assert _inventory_urls(config) == [], (
+        "the walk no longer keys off 'inventories'; update it and the pin "
+        "above together."
+    )
+
+
 def test_urls_come_from_mkdocs_yml_not_a_second_list() -> None:
     """A new inventory in mkdocs.yml is warmed without editing the hook."""
-    configured = (
-        yaml.safe_load(MKDOCS_YML.read_text(encoding="utf-8").replace("!!python/", "#"))
-        or {}
-    )
-    plugins = configured.get("plugins") or []
-    handler = next(
-        entry["mkdocstrings"]["handlers"]["python"]
-        for entry in plugins
-        if isinstance(entry, dict) and "mkdocstrings" in entry
-    )
-    declared = handler["inventories"]
-    assert declared, "mkdocs.yml should declare at least one inventory"
-
+    declared = _declared_inventories()
     hook_source = pathlib.Path(
         "scripts/mkdocs_hooks/warm_inventory_cache.py"
     ).read_text(encoding="utf-8")
@@ -151,9 +245,18 @@ def test_cache_duration_matches_what_mkdocstrings_asks_for() -> None:
 
 
 def test_hook_is_registered_before_the_generators() -> None:
-    """It must run in the build, and first — the others do not need the network."""
-    hooks = (
-        yaml.safe_load(MKDOCS_YML.read_text(encoding="utf-8").replace("!!python/", "#"))
-        or {}
-    ).get("hooks") or []
-    assert "scripts/mkdocs_hooks/warm_inventory_cache.py" in hooks
+    """It must run in the build, and first.
+
+    The position is the assertion, not decoration: warming after a generator
+    has already failed is warming after the build is lost. An earlier version
+    checked membership only while the name promised order — the shape closed
+    twice in #1040.
+    """
+    hooks = _mkdocs_yml().get("hooks") or []
+    warm_up = "scripts/mkdocs_hooks/warm_inventory_cache.py"
+
+    assert warm_up in hooks
+    assert hooks.index(warm_up) == 0, (
+        f"the warm-up must be the first hook; it is at index "
+        f"{hooks.index(warm_up)} of {hooks}"
+    )

--- a/tests/test_docs_inventory_cache_warmup.py
+++ b/tests/test_docs_inventory_cache_warmup.py
@@ -15,13 +15,18 @@ import pathlib
 import urllib.error
 
 import pytest
-import yaml
 from scripts.mkdocs_hooks.warm_inventory_cache import (
     _ATTEMPTS,
     _CACHE_DURATION,
     _download_with_retry,
     warm,
 )
+
+# The hook itself needs nothing beyond the standard library, but exercising it
+# needs the docs extras. The dependency-floor CI job installs neither, so skip
+# the module there rather than dragging mkdocs into the declared floor.
+yaml = pytest.importorskip("yaml", reason="docs extra not installed")
+pytest.importorskip("mkdocstrings", reason="docs extra not installed")
 
 MKDOCS_YML = pathlib.Path("mkdocs.yml")
 


### PR DESCRIPTION
## What the code actually does today

`mkdocstrings` downloads each inventory in `mkdocs.yml` through
`mkdocs.utils.cache.download_and_cache_url`, with a **one-day cache** and
**exactly one attempt**. A failed fetch is fatal under `--strict`.

Three consequences, all verified against the installed versions
(mkdocstrings 1.0.4, mkdocs 1.6.1):

- the cache lives at `platformdirs.user_cache_dir("mkdocs")`, **not** the
  mkdocs `cache_dir` setting, and CI does not persist it — `enable-cache: true`
  on `setup-uv` caches the *uv package* cache, a different thing. So every CI
  build fetches, while a local build fetches about once a day;
- `download_and_cache_url` has **no stale fallback**: on failure
  `content = download(url)` propagates, even when a good copy is sitting in the
  cache;
- so any PR touching docs is one connection reset away from red. That is what
  happened on #1034's `docs-deploy-dev` run 33599419309.

## The change

A pre-build hook fetches the same URLs into the same cache first, retrying a
connection-level failure. It calls the *same* cache function with the *same*
one-day duration, so a warmed entry is what `mkdocstrings` finds a moment
later — it never reaches the network.

Roughly issue option 3, implemented where it also helps local builds, and
without vendoring inventories (option 1) or weakening `--strict` (option 2).

**What the retry deliberately does not do:**

- **It does not retry a `4xx`.** A 404/403/410 is a verdict about *the URL* -
  a mistyped or moved inventory - and is raised on the first attempt rather
  than hidden behind three slow tries. This is the risk the issue flagged for
  option 2. A `5xx` and `429` *are* retried: those are verdicts about the
  server's state, they are the "third-party host unreachable" case #1037 is
  about, and they cannot conceal a typo because a typo does not produce a
  `5xx`. (Revised in review - the first version retried only `URLError`, which
  left 429/502/503/504 on the single attempt this PR exists to replace.)
- **It is not fatal itself.** When every attempt fails, the hook warns and lets
  `mkdocstrings` proceed, so a genuinely unreachable or wrong URL still fails
  the build with the handler's own error. Raising in the hook would move the
  failure and lose that context while still failing. `--strict` keeps its
  meaning; only the number of chances a transient blip gets changes.

URLs are read from `mkdocs.yml` rather than repeated in the hook, so adding an
inventory warms it automatically — pinned by test.

## Every guard checked against the unfixed state

| planted defect | result |
|---|---|
| `_ATTEMPTS = 1` (no retry) | 2 tests fail |
| retry `HTTPError` too | `test_does_not_retry_a_server_verdict` fails |
| make `warm()` fatal | `test_warm_up_is_not_itself_fatal` fails |
| unregister the hook | `test_hook_is_registered_before_the_generators` fails |

**The first version of the retry test could not fail.** It derived its expected
attempt count from `_ATTEMPTS`, so setting `_ATTEMPTS = 1` still passed all
seven tests — a test reading the constant it exists to guard. It now hard-codes
the second attempt, and the table above is after that fix.

`test_cache_duration_matches_what_mkdocstrings_asks_for` reads mkdocstrings'
own source, so if upstream changes the duration the mismatch fails loudly
instead of the warm-up silently writing entries that are already stale.

## Considered, not included

Caching `~/.cache/mkdocs` in CI would cut the fetch to roughly once a day per
runner cache. It is **complementary rather than an alternative** — the retry
still covers the build that does fetch — but it touches four job definitions
across two workflows, and the retry alone closes the reported failure. Left out

Filed as #1042 with the reasoning, rather than left in this description: a
deferral that lives only in a PR body is lost the moment the PR merges.

## Validation

- `pytest -p no:faulthandler -q` — 3821 passed, 45 skipped (main: 3814; +7)
- `pytest --doctest-modules factrix` — 96 passed, 1 skipped
- `ruff check` / `ruff format --check` over `factrix tests scripts`
- `mypy factrix`
- `mkdocs build --strict` — hook fires first, build clean, no generated-file
  drift

No library code changes; this is build tooling and its tests.

Closes #1037
