### PR TITLE
ci(docs): persist the mkdocs inventory cache across runs

### DIFF
--- a/.github/workflows/docs-deploy-dev.yml
+++ b/.github/workflows/docs-deploy-dev.yml
@@ -41,6 +41,22 @@ jobs:
           version: "0.8.x"
           enable-cache: true
 
+      # mkdocstrings caches each intersphinx inventory for one day, but at
+      # platformdirs.user_cache_dir("mkdocs") rather than the mkdocs cache_dir
+      # setting, so setup-uv's enable-cache does not cover it and every run
+      # would otherwise fetch (#1042). The key rotates daily to match that TTL:
+      # a fixed key would be restored past its expiry, re-downloaded anyway,
+      # and never re-saved, which is the same as having no cache from day two.
+      - name: Inventory cache key
+        id: inventory-cache-key
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore mkdocs inventory cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/mkdocs
+          key: mkdocs-inventories-${{ runner.os }}-${{ steps.inventory-cache-key.outputs.day }}
+
       - name: Install docs dependencies
         run: uv sync --frozen --python 3.12 --extra docs
 
@@ -68,6 +84,22 @@ jobs:
         with:
           version: "0.8.x"
           enable-cache: true
+
+      # mkdocstrings caches each intersphinx inventory for one day, but at
+      # platformdirs.user_cache_dir("mkdocs") rather than the mkdocs cache_dir
+      # setting, so setup-uv's enable-cache does not cover it and every run
+      # would otherwise fetch (#1042). The key rotates daily to match that TTL:
+      # a fixed key would be restored past its expiry, re-downloaded anyway,
+      # and never re-saved, which is the same as having no cache from day two.
+      - name: Inventory cache key
+        id: inventory-cache-key
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore mkdocs inventory cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/mkdocs
+          key: mkdocs-inventories-${{ runner.os }}-${{ steps.inventory-cache-key.outputs.day }}
 
       - name: Install docs dependencies
         run: uv sync --frozen --python 3.12 --extra docs

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -33,6 +33,22 @@ jobs:
           version: "0.8.x"
           enable-cache: true
 
+      # mkdocstrings caches each intersphinx inventory for one day, but at
+      # platformdirs.user_cache_dir("mkdocs") rather than the mkdocs cache_dir
+      # setting, so setup-uv's enable-cache does not cover it and every run
+      # would otherwise fetch (#1042). The key rotates daily to match that TTL:
+      # a fixed key would be restored past its expiry, re-downloaded anyway,
+      # and never re-saved, which is the same as having no cache from day two.
+      - name: Inventory cache key
+        id: inventory-cache-key
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore mkdocs inventory cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/mkdocs
+          key: mkdocs-inventories-${{ runner.os }}-${{ steps.inventory-cache-key.outputs.day }}
+
       - name: Install docs dependencies
         run: uv sync --frozen --python 3.12 --extra docs
 
@@ -76,6 +92,22 @@ jobs:
         with:
           version: "0.8.x"
           enable-cache: true
+
+      # mkdocstrings caches each intersphinx inventory for one day, but at
+      # platformdirs.user_cache_dir("mkdocs") rather than the mkdocs cache_dir
+      # setting, so setup-uv's enable-cache does not cover it and every run
+      # would otherwise fetch (#1042). The key rotates daily to match that TTL:
+      # a fixed key would be restored past its expiry, re-downloaded anyway,
+      # and never re-saved, which is the same as having no cache from day two.
+      - name: Inventory cache key
+        id: inventory-cache-key
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore mkdocs inventory cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/mkdocs
+          key: mkdocs-inventories-${{ runner.os }}-${{ steps.inventory-cache-key.outputs.day }}
 
       - name: Install docs dependencies
         run: uv sync --frozen --python 3.12 --extra docs

--- a/tests/test_docs_inventory_cache_warmup.py
+++ b/tests/test_docs_inventory_cache_warmup.py
@@ -12,6 +12,7 @@ non-fatal so ``mkdocstrings`` reports whatever it finds in its own terms.
 from __future__ import annotations
 
 import pathlib
+import re
 import urllib.error
 
 import pytest
@@ -258,23 +259,40 @@ def test_cache_duration_matches_what_mkdocstrings_asks_for() -> None:
 def test_ci_cache_path_is_the_one_mkdocs_writes_to() -> None:
     """#1042: the workflows hard-code a path; pin it to the library's own.
 
-    The YAML cannot be executed here, but the assumption it encodes can:
-    ``download_and_cache_url`` writes under
-    ``platformdirs.user_cache_dir("mkdocs")``, so if mkdocs changes the
-    appname the cache step silently stops covering anything and every CI
-    build quietly goes back to fetching.
+    The chain is ``mkdocs.utils.cache.download_and_cache_url`` ->
+    ``mkdocs_get_deps.cache.download_and_cache_url`` ->
+    ``platformdirs.user_cache_dir(<appname>)``. Both halves have to come from
+    the library: writing the appname here would pin ``platformdirs``' layout
+    for a literal string, and a rename to ``"mkdocs-get-deps"`` upstream would
+    leave this passing while the CI cache covered nothing — the exact failure
+    this exists to prevent.
     """
-    platformdirs = pytest.importorskip("platformdirs")
+    import inspect
+
+    pytest.importorskip("platformdirs")
+    import mkdocs.utils.cache
+    import mkdocs_get_deps.cache
     from platformdirs.unix import Unix
 
-    # The runners are ubuntu-latest, so the Unix implementation is the one
-    # that decides. Asserted rather than assumed, because this host is not it.
-    linux_path = Unix(appname="mkdocs").user_cache_dir
-    assert linux_path.replace("\\", "/").endswith("/.cache/mkdocs"), (
-        f"platformdirs now resolves mkdocs' cache to {linux_path}; the "
-        f"workflows cache {_CI_CACHE_PATH} and would cover nothing."
+    assert "mkdocs_get_deps" in inspect.getsource(mkdocs.utils.cache), (
+        "mkdocs no longer delegates its URL cache to mkdocs_get_deps; "
+        "re-derive where the inventories are written."
     )
-    assert platformdirs.user_cache_dir("mkdocs")
+    source = inspect.getsource(mkdocs_get_deps.cache)
+    appnames = re.findall(r"user_cache_dir\(\s*[\"']([^\"']+)[\"']", source)
+    assert len(appnames) == 1, (
+        f"expected exactly one user_cache_dir appname in mkdocs_get_deps."
+        f"cache; found {appnames}. The cache location has been restructured."
+    )
+
+    # The runners are ubuntu-latest, so the Unix implementation is the one
+    # that decides. Asserted rather than assumed: this host is Windows and
+    # resolves the same appname somewhere else entirely.
+    linux_path = Unix(appname=appnames[0]).user_cache_dir
+    assert linux_path.replace("\\", "/").endswith(_CI_CACHE_PATH.lstrip("~")), (
+        f"mkdocs_get_deps caches under {linux_path!r} on Linux; the workflows "
+        f"cache {_CI_CACHE_PATH} and would cover nothing."
+    )
 
 
 @pytest.mark.parametrize("workflow", _WORKFLOWS, ids=lambda p: p.name)
@@ -294,6 +312,17 @@ def test_every_mkdocs_build_job_caches_the_inventories(workflow: pathlib.Path) -
 
     for name, spec in building.items():
         steps = spec["steps"]
+
+        # ``~/.cache/mkdocs`` is the Linux layout. On macOS the same appname
+        # resolves to ``~/Library/Caches/mkdocs``, so a job moved to a macOS
+        # runner would cache a directory nothing writes to — the step would
+        # still be there, still green, and cover nothing.
+        assert "ubuntu" in str(spec.get("runs-on", "")), (
+            f"{workflow}::{name} runs on {spec.get('runs-on')!r}; "
+            f"{_CI_CACHE_PATH} is the Linux cache layout and would not be the "
+            "directory mkdocs writes to there."
+        )
+
         cache = [
             i
             for i, step in enumerate(steps)

--- a/tests/test_docs_inventory_cache_warmup.py
+++ b/tests/test_docs_inventory_cache_warmup.py
@@ -30,6 +30,17 @@ pytest.importorskip("mkdocstrings", reason="docs extra not installed")
 
 MKDOCS_YML = pathlib.Path("mkdocs.yml")
 
+#: Workflows whose jobs run ``mkdocs build`` and therefore need the cache.
+_WORKFLOWS = (
+    pathlib.Path(".github/workflows/docs-deploy-dev.yml"),
+    pathlib.Path(".github/workflows/link-check.yml"),
+)
+
+#: The path the CI cache step declares. It has to be the directory
+#: ``download_and_cache_url`` actually writes to on the runner, which is
+#: ``platformdirs.user_cache_dir("mkdocs")`` — Linux ``~/.cache/mkdocs``.
+_CI_CACHE_PATH = "~/.cache/mkdocs"
+
 
 @pytest.fixture
 def downloader(monkeypatch):
@@ -242,6 +253,63 @@ def test_cache_duration_matches_what_mkdocstrings_asks_for() -> None:
         "or the warmed entry will be considered stale."
     )
     assert datetime.timedelta(days=1) == _CACHE_DURATION
+
+
+def test_ci_cache_path_is_the_one_mkdocs_writes_to() -> None:
+    """#1042: the workflows hard-code a path; pin it to the library's own.
+
+    The YAML cannot be executed here, but the assumption it encodes can:
+    ``download_and_cache_url`` writes under
+    ``platformdirs.user_cache_dir("mkdocs")``, so if mkdocs changes the
+    appname the cache step silently stops covering anything and every CI
+    build quietly goes back to fetching.
+    """
+    platformdirs = pytest.importorskip("platformdirs")
+    from platformdirs.unix import Unix
+
+    # The runners are ubuntu-latest, so the Unix implementation is the one
+    # that decides. Asserted rather than assumed, because this host is not it.
+    linux_path = Unix(appname="mkdocs").user_cache_dir
+    assert linux_path.replace("\\", "/").endswith("/.cache/mkdocs"), (
+        f"platformdirs now resolves mkdocs' cache to {linux_path}; the "
+        f"workflows cache {_CI_CACHE_PATH} and would cover nothing."
+    )
+    assert platformdirs.user_cache_dir("mkdocs")
+
+
+@pytest.mark.parametrize("workflow", _WORKFLOWS, ids=lambda p: p.name)
+def test_every_mkdocs_build_job_caches_the_inventories(workflow: pathlib.Path) -> None:
+    """A job that builds without the cache fetches on every run.
+
+    Checks position too: restoring after the build would cache nothing the
+    build could have used.
+    """
+    jobs = (yaml.safe_load(workflow.read_text(encoding="utf-8")) or {})["jobs"]
+    building = {
+        name: spec
+        for name, spec in jobs.items()
+        if any("mkdocs build" in str(step.get("run", "")) for step in spec["steps"])
+    }
+    assert building, f"{workflow} no longer runs mkdocs build; drop this check"
+
+    for name, spec in building.items():
+        steps = spec["steps"]
+        cache = [
+            i
+            for i, step in enumerate(steps)
+            if step.get("uses", "").startswith("actions/cache")
+            and str(step.get("with", {}).get("path", "")) == _CI_CACHE_PATH
+        ]
+        assert cache, f"{workflow}::{name} builds docs without the inventory cache"
+
+        build = next(
+            i
+            for i, step in enumerate(steps)
+            if "mkdocs build" in str(step.get("run", ""))
+        )
+        assert cache[0] < build, (
+            f"{workflow}::{name} restores the cache after the build that needs it"
+        )
 
 
 def test_hook_is_registered_before_the_generators() -> None:


### PR DESCRIPTION
The complementary half of #1041, split out at review so it would not be
bundled into a PR that closed a different problem.

## Why CI fetches every time

`mkdocstrings` already caches each intersphinx inventory for one day — but at
`platformdirs.user_cache_dir("mkdocs")`, **not** the mkdocs `cache_dir`
setting, so `setup-uv`'s `enable-cache: true` (which caches the *uv package*
cache) does not cover it.

That asymmetry is why #1037 never reproduced locally: a local build fetches
about once a day, every CI build fetches.

Restoring `~/.cache/mkdocs` takes most builds off the network entirely.
#1041's retry still covers the build that does fetch, so the two compose: a red
build now needs a cache miss **and** three consecutive failures.

## The key rotates daily — that is the design, not a detail

`actions/cache` saves only on a miss. A fixed key would be restored past
`mkdocstrings`' one-day expiry, re-downloaded anyway, and never re-saved —
identical to having no cache from day two. Rotating the key on the UTC date
matches the TTL, so the first build of a day warms and saves, and the rest of
the day reads it.

**No `restore-keys`**, unlike the lychee cache beside it in `link-check.yml`.
A restored older entry is stale by construction and re-downloaded regardless,
so falling back to one would be an inert line rather than a saving. Called out
because it is a deliberate deviation from the neighbouring style.

Applied to all four jobs that run `mkdocs build`: `docs-deploy-dev`'s `build`
and `build-main`, `link-check`'s `pr` and `scheduled`.

## The YAML cannot be executed here; its assumptions can

Both are pinned, in the file that already pins `_CACHE_DURATION` against
mkdocstrings' own source:

- `test_ci_cache_path_is_the_one_mkdocs_writes_to` asserts `~/.cache/mkdocs`
  against `platformdirs`' **Unix** implementation — the one the runners use,
  asserted rather than assumed because the dev host resolves somewhere else
  entirely. If mkdocs changes the appname this fails loudly instead of the
  cache silently covering nothing.
- `test_every_mkdocs_build_job_caches_the_inventories` walks both workflows and
  requires every job running `mkdocs build` to restore that exact path
  **before** the build.

| planted defect | result |
|---|---|
| remove the cache from one job | 1 failure |
| point it at `.cache` (the mkdocs `cache_dir` — the wrong directory) | 1 failure |
| move the restore after the build | 2 failures |

## Validation

- `pytest -p no:faulthandler -q` — 3847 passed, 45 skipped (main: 3844; +3)
- `ruff check` / `ruff format --check`
- `mkdocs build --strict` clean
- both workflows re-parsed as YAML after editing, and step order asserted
  programmatically rather than by reading the diff

No library code, docs or `mkdocs.yml` changes. This PR touches two workflow
files and one test module.

Closes #1042