### PR TITLE
chore(hooks): report a gate that could not run as not run (#1048)

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -106,6 +106,16 @@ to each clone.
 | `commit-msg` | Commit-message and contributor-trailer policy |
 | `pre-push` | Strict docs build for docs-relevant paths, mypy for package paths, and release-note checks where applicable |
 
+The `pre-push` gates run through `uv run`, which resolves the environment of
+the directory the push is issued from. A **git worktree** has no environment of
+its own, so the gates fall back to the main checkout's `.venv`; where neither
+can start a tool the hook says the gate *did not run* and lets the push
+through, rather than reporting it as a gate failure. Nothing was measured in
+that case, and CI still runs the same check on the pull request — but if you
+want the local feedback back, `uv sync --extra docs` inside the worktree gives
+it one of its own. Reach for `git push --no-verify` only when you mean to skip
+gates that *can* run; it drops all of them, including the release-note check.
+
 Run the lint stage directly with:
 
 ```bash

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -45,6 +45,49 @@ MYPY_PATH_RE='^factrix/.*\.py$'
 needs_mkdocs=0
 needs_mypy=0
 
+# Resolve a command that can actually START a gate tool, printing its words
+# separated by ``|``; return 1 when no environment here can.
+#
+# WHY resolve before running: ``uv run`` resolves the environment of the
+# directory it is invoked from, and a git worktree has none - it exits
+# ``Failed to spawn: mkdocs / program not found`` without mkdocs ever
+# starting. Reporting that as "mkdocs build --strict failed" sends the reader
+# hunting a docs defect that does not exist, and the way out of it is
+# ``--no-verify``, which drops every other gate along with the one that could
+# not run (#1048). The probe costs one ``uv run`` spawn per gate (about 2.7s
+# once the environment is synced); that is the price of the two outcomes
+# staying distinguishable.
+_gate_command() {
+    tool=$1
+    if command -v uv >/dev/null 2>&1 &&
+        uv run --quiet -- "$tool" --version >/dev/null 2>&1; then
+        printf 'uv|run|--quiet|--|%s' "$tool"
+        return 0
+    fi
+    # A worktree shares the main checkout's ``.git``, so the environment the
+    # gate would have used over there is the one to fall back to.
+    common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+    root=${common%/.git}
+    for py in "$root/.venv/bin/python" "$root/.venv/Scripts/python.exe"; do
+        if [ -x "$py" ] && "$py" -c "import $tool" >/dev/null 2>&1; then
+            printf '%s|-m|%s' "$py" "$tool"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Say that the gate DID NOT RUN, which is not the statement that the gate
+# failed, and do not block on it: nothing was measured, so there is no finding
+# to act on, and CI runs the same check on the pull request.
+_gate_unavailable() {
+    printf '\n' >&2
+    printf 'pre-push: %s did not run - no environment here can start it.\n' "$1" >&2
+    printf 'Nothing was measured, so this is not a gate failure. CI still checks it\n' >&2
+    printf 'on the pull request.\n' >&2
+    printf 'From a git worktree: uv sync --extra docs, or push from the main checkout.\n\n' >&2
+}
+
 # Emit ``<local_ref> <local_sha> <remote_ref> <remote_sha>`` lines in
 # Git's pre-push stdin format. Only the two SHA fields are read below,
 # so the ref fields are placeholders when synthesised.
@@ -124,28 +167,38 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 done < <(_ref_lines)
 
 if [ "$needs_mkdocs" -eq 1 ]; then
-    tmp=$(mktemp -d)
-    # WHY: ``--site-dir`` to a tempdir keeps the working tree clean
-    # and avoids any race with a running ``mkdocs serve``.
-    trap 'rm -rf "$tmp"' EXIT
-    printf 'pre-push: running mkdocs build --strict (docs-relevant paths touched)...\n' >&2
-    if ! uv run mkdocs build --strict --site-dir "$tmp" >/dev/null 2>&1; then
-        printf '\n' >&2
-        printf 'pre-push blocked: mkdocs build --strict failed.\n' >&2
-        printf 'Re-run for the full error: uv run mkdocs build --strict\n' >&2
-        printf 'Bypass: git push --no-verify\n\n' >&2
-        exit 1
+    if ! gate=$(_gate_command mkdocs); then
+        _gate_unavailable "mkdocs build --strict"
+    else
+        IFS='|' read -r -a mkdocs_cmd <<<"$gate"
+        tmp=$(mktemp -d)
+        # WHY: ``--site-dir`` to a tempdir keeps the working tree clean
+        # and avoids any race with a running ``mkdocs serve``.
+        trap 'rm -rf "$tmp"' EXIT
+        printf 'pre-push: running mkdocs build --strict (docs-relevant paths touched)...\n' >&2
+        if ! "${mkdocs_cmd[@]}" build --strict --site-dir "$tmp" >/dev/null 2>&1; then
+            printf '\n' >&2
+            printf 'pre-push blocked: mkdocs build --strict failed.\n' >&2
+            printf 'Re-run for the full error: %s build --strict\n' "${mkdocs_cmd[*]}" >&2
+            printf 'Bypass: git push --no-verify\n\n' >&2
+            exit 1
+        fi
     fi
 fi
 
 if [ "$needs_mypy" -eq 1 ]; then
-    printf 'pre-push: running mypy factrix (factrix/*.py touched)...\n' >&2
-    if ! uv run mypy factrix >/dev/null 2>&1; then
-        printf '\n' >&2
-        printf 'pre-push blocked: mypy factrix failed.\n' >&2
-        printf 'Re-run for the full error: uv run mypy factrix\n' >&2
-        printf 'Bypass: git push --no-verify\n\n' >&2
-        exit 1
+    if ! gate=$(_gate_command mypy); then
+        _gate_unavailable "mypy factrix"
+    else
+        IFS='|' read -r -a mypy_cmd <<<"$gate"
+        printf 'pre-push: running mypy factrix (factrix/*.py touched)...\n' >&2
+        if ! "${mypy_cmd[@]}" factrix >/dev/null 2>&1; then
+            printf '\n' >&2
+            printf 'pre-push blocked: mypy factrix failed.\n' >&2
+            printf 'Re-run for the full error: %s factrix\n' "${mypy_cmd[*]}" >&2
+            printf 'Bypass: git push --no-verify\n\n' >&2
+            exit 1
+        fi
     fi
 fi
 

--- a/tests/test_pre_push_gate_runner.py
+++ b/tests/test_pre_push_gate_runner.py
@@ -1,0 +1,137 @@
+"""A gate that could not run must not be reported as a gate that failed.
+
+#1048: ``scripts/hooks/pre-push`` shells out to ``uv run mkdocs`` / ``uv run
+mypy``. From a git worktree ``uv run`` resolves no environment — it exits with
+``Failed to spawn: mkdocs`` — and the hook printed ``pre-push blocked: mkdocs
+build --strict failed`` although mkdocs never started. That is the repo's own
+"report what ran, not what was asked for" rule inverted, on its own tooling,
+and its practical cost is a standing ``--no-verify`` habit that disables every
+other gate along with the one that could not run.
+
+The tests drive the real hook under a stub ``uv`` so the three outcomes stay
+distinguishable: could not run (skip, non-blocking), ran and failed (blocked),
+ran and passed (silent).
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+
+import pytest
+
+HOOK = pathlib.Path("scripts/hooks/pre-push").resolve()
+
+#: What ``uv run`` prints from a worktree with no synced environment.
+_SPAWN_ERROR = "error: Failed to spawn: `mkdocs`\\n  Caused by: program not found"
+
+bash = shutil.which("bash")
+pytestmark = pytest.mark.skipif(bash is None, reason="POSIX shell not available")
+
+
+def _write_stub(path: pathlib.Path, body: str) -> None:
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _repo(tmp_path: pathlib.Path, touched: str) -> tuple[pathlib.Path, str, str]:
+    """A one-commit repo whose commit touches ``touched``, plus the ref pair."""
+    repo = tmp_path / "repo"
+    (repo / pathlib.Path(touched).parent).mkdir(parents=True, exist_ok=True)
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    subprocess.run(["git", "init", "-q", str(repo)], check=True, capture_output=True)
+    run("config", "user.email", "t@example.com")
+    run("config", "user.name", "t")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    run("add", "seed.txt")
+    run("commit", "-qm", "seed")
+    base = run("rev-parse", "HEAD").stdout.strip()
+    (repo / touched).write_text("x = 1\n", encoding="utf-8")
+    run("add", touched)
+    run("commit", "-qm", "touch the gated path")
+    head = run("rev-parse", "HEAD").stdout.strip()
+    return repo, base, head
+
+
+def _run_hook(
+    repo: pathlib.Path, base: str, head: str, stub_dir: pathlib.Path
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": f"{stub_dir}{os.pathsep}{os.environ['PATH']}",
+        "PRE_COMMIT_FROM_REF": base,
+        "PRE_COMMIT_TO_REF": head,
+    }
+    assert bash is not None
+    return subprocess.run(
+        [bash, str(HOOK)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("gate", "touched"),
+    [("mkdocs", "docs/page.md"), ("mypy", "factrix/mod.py")],
+)
+def test_a_gate_that_cannot_run_is_not_reported_as_a_failed_gate(
+    tmp_path: pathlib.Path, gate: str, touched: str
+) -> None:
+    """The #1048 defect: no environment can run the tool, so it never ran."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(stub_dir / "uv", f'printf "{_SPAWN_ERROR}\\n" >&2; exit 1')
+
+    repo, base, head = _repo(tmp_path, touched)
+    result = _run_hook(repo, base, head, stub_dir)
+
+    assert result.returncode == 0, (
+        f"an unrunnable gate must not block the push:\n{result.stderr}"
+    )
+    assert "blocked" not in result.stderr, (
+        f"the hook claimed a gate failed that never ran:\n{result.stderr}"
+    )
+    # The message has to say which gate was skipped and that CI still covers it,
+    # as one statement: a bare "skipped" reads as "nothing to do here".
+    assert gate in result.stderr
+    assert "did not run" in result.stderr
+    assert "CI still checks" in result.stderr
+
+
+def test_a_gate_that_ran_and_failed_still_blocks(tmp_path: pathlib.Path) -> None:
+    """False-positive guard: the skip path must not swallow a real failure."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    # Resolvable — the probe succeeds — but the build itself fails.
+    _write_stub(
+        stub_dir / "uv",
+        'case "$*" in *--version*) exit 0 ;; *) echo "boom" >&2; exit 1 ;; esac',
+    )
+
+    repo, base, head = _repo(tmp_path, "docs/page.md")
+    result = _run_hook(repo, base, head, stub_dir)
+
+    assert result.returncode == 1
+    assert "blocked" in result.stderr
+    assert "did not run" not in result.stderr
+
+
+def test_a_gate_that_ran_and_passed_says_nothing(tmp_path: pathlib.Path) -> None:
+    """The other false-positive guard: a healthy environment is not a skip."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(stub_dir / "uv", "exit 0")
+
+    repo, base, head = _repo(tmp_path, "docs/page.md")
+    result = _run_hook(repo, base, head, stub_dir)
+
+    assert result.returncode == 0
+    assert "blocked" not in result.stderr
+    assert "did not run" not in result.stderr


### PR DESCRIPTION
Closes #1048.

The pre-push gates shell out to `uv run mkdocs` / `uv run mypy`. `uv run`
resolves the environment of the directory it is invoked from, and a git
worktree has none:

```
$ uv run mkdocs build --strict          # inside a worktree
error: Failed to spawn: `mkdocs`
  Caused by: program not found
```

The hook reported that as `pre-push blocked: mkdocs build --strict failed`.
mkdocs never started. It is this repo's own "report what ran, not what was
asked for" rule inverted, on its own tooling — and the practical cost is worse
than the confusion, because the way out is `--no-verify`, which drops every
other gate along with the one that could not run. #1047 was pushed that way.

## What changed

The runner is resolved **before** the gate runs:

1. `uv run` when it can actually start the tool — the normal main-checkout
   case, so the auto-sync against the lock is kept;
2. otherwise the main checkout's `.venv`, which a worktree shares a `.git`
   with. This is the part that makes a worktree push *work*, not merely fail
   more clearly;
3. otherwise the gate is reported as **did not run** and does not block.
   Nothing was measured, so there is no finding to act on, and CI runs the same
   check on the pull request.

Cost: one `uv run` spawn per gate for the probe, about 2.7s once the
environment is synced. The probe syncs a `.venv` into the worktree as a side
effect — the old code did the same the moment it called `uv run`, so that is
not new.

## Verification

**This PR was pushed from a worktree with the gates enabled** — no
`--no-verify`:

```
CHANGELOG polish + mkdocs --strict + mypy................................Passed
```

A pass is not proof on its own, since the skip path also lets a push through,
so I checked which branch ran. Invoking the hook by hand over the same range in
the worktree prints `pre-push: running mkdocs build --strict ...` and exits 0 —
the gate ran. Both `uv run` probes fail there (`program not found`) and the
main checkout's `.venv` is what served it, i.e. branch 2. mypy correctly did
not run: this branch touches no `factrix/**/*.py`.

`tests/test_pre_push_gate_runner.py` drives the real hook under a stub `uv` in
a throwaway git repo and separates the three outcomes:

| case | expected | on the unfixed hook |
|---|---|---|
| nothing can start the tool | exit 0, "did not run", no "blocked" | **fails** — exit 1, "mkdocs build --strict failed" |
| runner starts it, gate fails | exit 1, "blocked" | passes (false-positive guard) |
| runner starts it, gate passes | exit 0, silent | passes (false-positive guard) |

The first case is parametrised over both gates and is the regression test; the
other two exist so the skip path cannot be widened into swallowing a real
failure. Suite `3855 passed / 45 skipped`, ruff and format clean.

`docs/development/contributing.md` gains the worktree behaviour and a note that
`--no-verify` is for skipping gates that *can* run.

## Not done

The hook file is CRLF in the working tree (no `.gitattributes` pins
`scripts/hooks/*` to `eol=lf`). It works under Git Bash today and is a separate
question from this issue, so it is left alone rather than folded in.
