### PR TITLE
fix(data): validate complete horizon stamp columns (#1050)

### DIFF
--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -130,6 +130,14 @@ metadata does not. A self-attached `forward_return` panel carries neither
 stamp and declares `forward_periods=` (and, on a coarser grid,
 `overlap_periods=`) on `evaluate`.
 
+Every present stamp must remain a non-null positive integer with one value
+over the complete panel. Public entry points reject mixed or invalid stamp
+columns before dispatch (and before `by_slice` partitions the frame), because
+otherwise row or slice order could select a different hypothesis and inference
+configuration. Evaluate different return horizons as separate panels with
+[`evaluate_horizons`](multi-horizon.md); do not concatenate their stamped rows
+into one panel.
+
 ---
 
 ## Common errors

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -82,8 +82,7 @@ from factrix._data_input import (
     _STAMP_COLUMNS,
     DataInput,
     _coerce_data,
-    _read_forward_periods_stamp,
-    _resolve_forward_periods,
+    _resolve_horizons,
     _resolve_overlap_periods,
     _validate_overlap_periods,
 )
@@ -277,8 +276,7 @@ def evaluate(
     # projection, or to_frame. A self-attached forward_return panel (no stamp)
     # must declare its horizon once via forward_periods= (path B); its
     # overlap defaults to the horizon unless declared via overlap_periods=.
-    fp = _resolve_forward_periods(data, forward_periods)
-    op = _resolve_overlap_periods(data, overlap_periods, horizon=fp)
+    fp, op = _resolve_horizons(data, forward_periods, overlap_periods)
     data = data.drop([c for c in _STAMP_COLUMNS if c in data.columns])
 
     from factrix.metrics._base import MetricBase
@@ -747,7 +745,7 @@ def sample_requirements(
         op = _resolve_overlap_periods(
             data,
             overlap_periods,
-            horizon=_read_forward_periods_stamp(data),
+            horizon=None,
             func_name="sample_requirements",
         )
     elif overlap_periods is not None:

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -102,20 +102,102 @@ def _stamp_horizons(
     )
 
 
-def _read_int_stamp(data: pl.DataFrame, column: str) -> int | None:
+def _read_int_stamp(
+    data: object,
+    column: str,
+    *,
+    func_name: str,
+) -> int | None:
+    """Read one reserved stamp after validating its complete column.
+
+    The stamps are data-level facts. Reading one row is safe only after every
+    row is known to carry the same positive integer; otherwise concatenating
+    panels at different horizons makes row order select the study's inference
+    settings and hypothesis identity.
+    """
+    if not isinstance(data, pl.DataFrame):
+        return None
     if column not in data.columns or data.height == 0:
         return None
-    return int(data[column][0])
+
+    stamp = data.get_column(column)
+    docs_path = (
+        _DOCS_FORWARD_PERIODS
+        if column == _FORWARD_PERIODS_COL
+        else _DOCS_OVERLAP_PERIODS
+    )
+    expected = (
+        "one constant, non-null positive integer on every row. Reserved "
+        "horizon stamps describe the complete panel; rebuild or de-duplicate "
+        "the panel before evaluation"
+    )
+
+    if not stamp.dtype.is_integer():
+        raise UserInputError(
+            func_name=func_name,
+            field=column,
+            value=str(stamp.dtype),
+            expected=expected,
+            docs_path=docs_path,
+        )
+
+    n_null = stamp.null_count()
+    if n_null:
+        raise UserInputError(
+            func_name=func_name,
+            field=column,
+            value=f"{n_null} null row(s) of {data.height}",
+            expected=expected,
+            docs_path=docs_path,
+        )
+
+    n_unique = stamp.n_unique()
+    if n_unique != 1:
+        preview = stamp.unique().sort().head(5).to_list()
+        raise UserInputError(
+            func_name=func_name,
+            field=column,
+            value={"n_unique": n_unique, "values_preview": preview},
+            expected=expected,
+            docs_path=docs_path,
+        )
+
+    value = int(stamp[0])
+    if value <= 0:
+        raise UserInputError(
+            func_name=func_name,
+            field=column,
+            value=value,
+            expected=expected,
+            docs_path=docs_path,
+        )
+    return value
 
 
-def _read_forward_periods_stamp(data: pl.DataFrame) -> int | None:
+def _read_horizon_stamps(
+    data: object, *, func_name: str
+) -> tuple[int | None, int | None]:
+    """Validate and read both reserved horizon columns as one data contract."""
+    return (
+        _read_int_stamp(data, _FORWARD_PERIODS_COL, func_name=func_name),
+        _read_int_stamp(data, _OVERLAP_PERIODS_COL, func_name=func_name),
+    )
+
+
+def _read_forward_periods_stamp(
+    data: object, *, func_name: str = "_read_forward_periods_stamp"
+) -> int | None:
     """Read the stamped return horizon, or ``None`` when the panel carries none."""
-    return _read_int_stamp(data, _FORWARD_PERIODS_COL)
+    forward_periods, _ = _read_horizon_stamps(data, func_name=func_name)
+    return forward_periods
 
 
-def _read_overlap_periods_stamp(data: pl.DataFrame) -> int | None:
+def _read_overlap_periods_stamp(
+    data: object, *, func_name: str = "_read_overlap_periods_stamp"
+) -> int | None:
     """Read the stamped evaluation-grid overlap, or ``None`` when absent."""
-    return _read_int_stamp(data, _OVERLAP_PERIODS_COL)
+    _, overlap_periods = _read_horizon_stamps(data, func_name=func_name)
+    return overlap_periods
 
 
 _DOCS_OVERLAP_PERIODS = "api/evaluate#forward_periods-and-overlap_periods"
@@ -150,10 +232,13 @@ def _validate_overlap_periods(declared: object, *, func_name: str) -> int:
     return declared
 
 
-def _resolve_forward_periods(
-    data: pl.DataFrame, declared: int | None, *, func_name: str = "evaluate"
+def _resolve_forward_periods_from_stamp(
+    stamp: int | None,
+    declared: int | None,
+    *,
+    func_name: str,
 ) -> int:
-    """Resolve the panel's return horizon for this evaluation.
+    """Resolve a validated forward-periods stamp against a declaration.
 
     Path A (primary): a panel built by ``compute_forward_return`` carries a
     horizon stamp — the single source of truth. Path B (escape hatch): a
@@ -162,7 +247,6 @@ def _resolve_forward_periods(
     data's overlap, not a per-metric knob). A declaration that disagrees with
     the stamp is rejected rather than silently resolved.
     """
-    stamp = _read_forward_periods_stamp(data)
     if stamp is not None:
         if declared is not None and declared != stamp:
             raise UserInputError(
@@ -194,14 +278,22 @@ def _resolve_forward_periods(
     )
 
 
-def _resolve_overlap_periods(
-    data: pl.DataFrame,
+def _resolve_forward_periods(
+    data: pl.DataFrame, declared: int | None, *, func_name: str = "evaluate"
+) -> int:
+    """Validate both stamps and resolve the panel's economic return horizon."""
+    stamp, _ = _read_horizon_stamps(data, func_name=func_name)
+    return _resolve_forward_periods_from_stamp(stamp, declared, func_name=func_name)
+
+
+def _resolve_overlap_periods_from_stamp(
+    stamp: int | None,
     declared: int | None,
     *,
     horizon: int | None,
-    func_name: str = "evaluate",
+    func_name: str,
 ) -> int:
-    """Resolve the evaluation-grid overlap inference will consume.
+    """Resolve a validated overlap-periods stamp against a declaration.
 
     Same contract as :func:`_resolve_forward_periods`: the stamp left by
     ``compute_forward_return`` is the truth and a disagreeing declaration is
@@ -214,7 +306,6 @@ def _resolve_overlap_periods(
     """
     if declared is not None:
         declared = _validate_overlap_periods(declared, func_name=func_name)
-    stamp = _read_overlap_periods_stamp(data)
     if stamp is not None:
         if declared is not None and declared != stamp:
             raise UserInputError(
@@ -250,6 +341,45 @@ def _resolve_overlap_periods(
         ),
         docs_path=_DOCS_OVERLAP_PERIODS,
     )
+
+
+def _resolve_overlap_periods(
+    data: pl.DataFrame,
+    declared: int | None,
+    *,
+    horizon: int | None,
+    func_name: str = "evaluate",
+) -> int:
+    """Validate both stamps and resolve the overlap inference will consume."""
+    forward_stamp, overlap_stamp = _read_horizon_stamps(data, func_name=func_name)
+    resolved_horizon = horizon if horizon is not None else forward_stamp
+    return _resolve_overlap_periods_from_stamp(
+        overlap_stamp,
+        declared,
+        horizon=resolved_horizon,
+        func_name=func_name,
+    )
+
+
+def _resolve_horizons(
+    data: pl.DataFrame,
+    forward_periods: int | None,
+    overlap_periods: int | None,
+    *,
+    func_name: str = "evaluate",
+) -> tuple[int, int]:
+    """Validate both stamp columns once and resolve both horizon facts."""
+    forward_stamp, overlap_stamp = _read_horizon_stamps(data, func_name=func_name)
+    horizon = _resolve_forward_periods_from_stamp(
+        forward_stamp, forward_periods, func_name=func_name
+    )
+    overlap = _resolve_overlap_periods_from_stamp(
+        overlap_stamp,
+        overlap_periods,
+        horizon=horizon,
+        func_name=func_name,
+    )
+    return horizon, overlap
 
 
 _DOCS_DATA_SCHEMA = "api/data-schema"

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -91,6 +91,11 @@ _OVERLAP_PERIODS_COL: str = "_overlap_periods"
 # the rejected set and the stripped set can never drift apart.
 _STAMP_COLUMNS: tuple[str, ...] = (_FORWARD_PERIODS_COL, _OVERLAP_PERIODS_COL)
 
+# How many distinct stamp values a rejection message enumerates. Mirrors the
+# "N of M" idiom :class:`UserInputError` already uses for candidate lists, and
+# caps what a pathological column materialises into the message.
+_STAMP_VALUE_PREVIEW: int = 5
+
 
 def _stamp_horizons(
     data: pl.DataFrame, *, forward_periods: int, overlap_periods: int
@@ -121,15 +126,15 @@ def _read_int_stamp(
         return None
 
     stamp = data.get_column(column)
-    docs_path = (
-        _DOCS_FORWARD_PERIODS
-        if column == _FORWARD_PERIODS_COL
-        else _DOCS_OVERLAP_PERIODS
-    )
+    # The complete-panel contract is stated on the data-schema page, so every
+    # rejection here links there rather than to the evaluate() argument pair a
+    # caller is not using.
+    docs_path = _DOCS_DATA_SCHEMA
     expected = (
         "one constant, non-null positive integer on every row. Reserved "
-        "horizon stamps describe the complete panel; rebuild or de-duplicate "
-        "the panel before evaluation"
+        "horizon stamps describe the complete panel; evaluate a different "
+        "return horizon as its own panel (see evaluate_horizons) rather than "
+        "concatenating stamped rows from several horizons"
     )
 
     if not stamp.dtype.is_integer():
@@ -153,11 +158,18 @@ def _read_int_stamp(
 
     n_unique = stamp.n_unique()
     if n_unique != 1:
-        preview = stamp.unique().sort().head(5).to_list()
+        # Print the values the column actually carries: the rendered line reads
+        # ``invalid _forward_periods=[1, 5]``, which is the fact the reader has
+        # to act on. Only a tail longer than the preview needs the count.
+        preview = stamp.unique().sort().head(_STAMP_VALUE_PREVIEW).to_list()
         raise UserInputError(
             func_name=func_name,
             field=column,
-            value={"n_unique": n_unique, "values_preview": preview},
+            value=(
+                preview
+                if n_unique <= _STAMP_VALUE_PREVIEW
+                else f"{preview!r} ({_STAMP_VALUE_PREVIEW} of {n_unique})"
+            ),
             expected=expected,
             docs_path=docs_path,
         )
@@ -184,18 +196,13 @@ def _read_horizon_stamps(
     )
 
 
-def _read_forward_periods_stamp(
-    data: object, *, func_name: str = "_read_forward_periods_stamp"
-) -> int | None:
-    """Read the stamped return horizon, or ``None`` when the panel carries none."""
-    forward_periods, _ = _read_horizon_stamps(data, func_name=func_name)
-    return forward_periods
+def _read_overlap_periods_stamp(data: object, *, func_name: str) -> int | None:
+    """Read the stamped evaluation-grid overlap, or ``None`` when absent.
 
-
-def _read_overlap_periods_stamp(
-    data: object, *, func_name: str = "_read_overlap_periods_stamp"
-) -> int | None:
-    """Read the stamped evaluation-grid overlap, or ``None`` when absent."""
+    Validates both stamp columns, not just the one it returns: the horizon pair
+    is one data contract, and ``func_name`` names the caller a rejection is
+    reported against, so it is required rather than defaulted to this helper.
+    """
     _, overlap_periods = _read_horizon_stamps(data, func_name=func_name)
     return overlap_periods
 
@@ -278,14 +285,6 @@ def _resolve_forward_periods_from_stamp(
     )
 
 
-def _resolve_forward_periods(
-    data: pl.DataFrame, declared: int | None, *, func_name: str = "evaluate"
-) -> int:
-    """Validate both stamps and resolve the panel's economic return horizon."""
-    stamp, _ = _read_horizon_stamps(data, func_name=func_name)
-    return _resolve_forward_periods_from_stamp(stamp, declared, func_name=func_name)
-
-
 def _resolve_overlap_periods_from_stamp(
     stamp: int | None,
     declared: int | None,
@@ -295,12 +294,13 @@ def _resolve_overlap_periods_from_stamp(
 ) -> int:
     """Resolve a validated overlap-periods stamp against a declaration.
 
-    Same contract as :func:`_resolve_forward_periods`: the stamp left by
-    ``compute_forward_return`` is the truth and a disagreeing declaration is
-    rejected. Callers that also resolve a horizon (``evaluate``) pass it as
-    ``horizon``: an unstamped panel then defaults to it, because a
-    self-attached ``forward_return`` on the full grid overlaps by exactly its
-    horizon and only a coarser grid needs ``overlap_periods=`` spelled out.
+    Same contract as :func:`_resolve_forward_periods_from_stamp`: the stamp
+    left by ``compute_forward_return`` is the truth and a disagreeing
+    declaration is rejected. Callers that also resolve a horizon
+    (``evaluate``) pass it as ``horizon``: an unstamped panel then defaults to
+    it, because a self-attached ``forward_return`` on the full grid overlaps by
+    exactly its horizon and only a coarser grid needs ``overlap_periods=``
+    spelled out.
     Callers with no horizon of their own (the ``slice_period_*`` tests) pass
     ``horizon=None``, so an unstamped panel must declare the overlap.
     """

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -13,7 +13,7 @@ from factrix._axis import (
     SpecRole,
 )
 from factrix._data_input import (
-    _OVERLAP_PERIODS_COL,
+    _read_overlap_periods_stamp,
     _validate_named_columns,
     _validate_overlap_periods,
     _validate_panel_key_columns,
@@ -329,8 +329,7 @@ class MetricBase(metaclass=MetricMeta):
             object.__setattr__(inst, "overlap_periods", overlap_periods)
         return type(self)._resolve_sample_threshold(inst)
 
-    @staticmethod
-    def _stamped_overlap_periods(data: Any) -> int | None:
+    def _stamped_overlap_periods(self, data: Any) -> int | None:
         """Read the panel's overlap horizon from the reserved stamp column.
 
         ``compute_forward_return`` stamps the horizon it built ``forward_return``
@@ -341,14 +340,7 @@ class MetricBase(metaclass=MetricMeta):
         unstamped panel (the caller's explicit argument, then the signature
         default, still applies) and for a non-frame input (series consumers).
         """
-        columns = getattr(data, "columns", None)
-        if columns is None or _OVERLAP_PERIODS_COL not in columns:
-            return None
-        stamp = data[_OVERLAP_PERIODS_COL]
-        if len(stamp) == 0:
-            return None
-        value = stamp[0]
-        return None if value is None else int(value)
+        return _read_overlap_periods_stamp(data, func_name=self.__class__.__name__)
 
     def _inject(
         self,

--- a/factrix/slicing/dispatcher.py
+++ b/factrix/slicing/dispatcher.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from factrix._codes import WarningCode, _emit_warning, _validate_expected_warnings_arg
+from factrix._data_input import _read_horizon_stamps
 from factrix._results import Warning
 from factrix.slicing._primitive import _slice_by
 
@@ -151,6 +152,10 @@ def by_slice(
     expected = _validate_expected_warnings_arg(
         expected_warnings, func_name="by_slice", docs_path=_DOCS_BY_SLICE
     )
+    # Validate the data-level horizon contract before partitioning. Otherwise
+    # each slice can carry one internally constant but mutually different stamp,
+    # hiding a mixed-horizon input from the per-slice evaluate calls.
+    _read_horizon_stamps(data, func_name="by_slice")
     sliced = _slice_by(data, by)
     label = _metric_label(metric)
     truncation = _warn_date_axis_truncation(

--- a/tests/test_horizon_stamp_validation.py
+++ b/tests/test_horizon_stamp_validation.py
@@ -1,0 +1,166 @@
+"""Reserved horizon stamps are complete-panel facts, not first-row hints."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._errors import UserInputError
+from factrix.metrics import ic, quantile_spread
+
+_STAMP_COLUMNS = ("_forward_periods", "_overlap_periods")
+
+
+@pytest.fixture
+def stamped_panel() -> pl.DataFrame:
+    raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=80, rng=1050)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=1)
+    assets = panel.get_column("asset_id").unique().sort().to_list()
+    sectors = {asset: ("a" if i % 2 else "b") for i, asset in enumerate(assets)}
+    return panel.with_columns(
+        pl.col("asset_id").replace_strict(sectors).alias("sector")
+    )
+
+
+def _replace_stamp(
+    panel: pl.DataFrame,
+    column: str,
+    values: Sequence[object],
+    *,
+    dtype: pl.DataType | type[pl.DataType],
+) -> pl.DataFrame:
+    return panel.with_columns(pl.Series(column, values, dtype=dtype))
+
+
+def _mixed_stamp(panel: pl.DataFrame, column: str) -> pl.DataFrame:
+    split = panel.height // 2
+    values = [1] * split + [5] * (panel.height - split)
+    return _replace_stamp(panel, column, values, dtype=pl.Int32)
+
+
+@pytest.mark.parametrize("column", _STAMP_COLUMNS)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_evaluate_rejects_mixed_stamps_regardless_of_row_order(
+    stamped_panel: pl.DataFrame,
+    column: str,
+    reverse: bool,
+) -> None:
+    panel = _mixed_stamp(stamped_panel, column)
+    if reverse:
+        panel = panel.reverse()
+
+    with pytest.raises(UserInputError) as excinfo:
+        fx.evaluate(
+            panel,
+            metrics={"ic": ic()},
+            factor_cols=["factor"],
+            strict=False,
+        )
+
+    assert excinfo.value.func_name == "evaluate"
+    assert excinfo.value.field == column
+    assert "constant" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("column", _STAMP_COLUMNS)
+@pytest.mark.parametrize(
+    ("values_factory", "dtype"),
+    [
+        (lambda n: [1] * (n - 1) + [None], pl.Int32),
+        (lambda n: [True] * n, pl.Boolean),
+        (lambda n: [1.0] * n, pl.Float64),
+        (lambda n: [0] * n, pl.Int32),
+        (lambda n: [-1] * n, pl.Int32),
+    ],
+    ids=["null", "bool", "float", "zero", "negative"],
+)
+def test_evaluate_rejects_invalid_stamp_columns(
+    stamped_panel: pl.DataFrame,
+    column: str,
+    values_factory: Callable[[int], list[object]],
+    dtype: pl.DataType | type[pl.DataType],
+) -> None:
+    values = values_factory(stamped_panel.height)
+    panel = _replace_stamp(stamped_panel, column, values, dtype=dtype)
+
+    with pytest.raises(UserInputError) as excinfo:
+        fx.evaluate(panel, metrics={"ic": ic()}, factor_cols=["factor"])
+
+    assert excinfo.value.func_name == "evaluate"
+    assert excinfo.value.field == column
+    assert "positive integer" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("column", _STAMP_COLUMNS)
+def test_standalone_metric_validates_both_stamp_columns(
+    stamped_panel: pl.DataFrame,
+    column: str,
+) -> None:
+    panel = _mixed_stamp(stamped_panel, column)
+
+    with pytest.raises(UserInputError) as excinfo:
+        quantile_spread(panel, n_groups=3)
+
+    assert excinfo.value.field == column
+
+
+@pytest.mark.parametrize("column", _STAMP_COLUMNS)
+def test_by_slice_rejects_mixed_stamps_before_partitioning(
+    stamped_panel: pl.DataFrame,
+    column: str,
+) -> None:
+    panel = _mixed_stamp(stamped_panel, column)
+    split = panel.height // 2
+    panel = panel.with_columns(
+        pl.Series(
+            "stamp_slice",
+            ["one"] * split + ["five"] * (panel.height - split),
+        )
+    )
+
+    with pytest.raises(UserInputError) as excinfo:
+        fx.by_slice(
+            panel,
+            ic(),
+            by="stamp_slice",
+            factor_col="factor",
+            strict=False,
+        )
+
+    assert excinfo.value.func_name == "by_slice"
+    assert excinfo.value.field == column
+
+
+@pytest.mark.parametrize("column", _STAMP_COLUMNS)
+def test_slice_inference_validates_both_stamp_columns(
+    stamped_panel: pl.DataFrame,
+    column: str,
+) -> None:
+    panel = _mixed_stamp(stamped_panel, column)
+
+    with pytest.raises(UserInputError) as excinfo:
+        fx.slice_pairwise_test(
+            panel,
+            ic(),
+            by="sector",
+            factor_col="factor",
+        )
+
+    assert excinfo.value.func_name == "slice_pairwise_test"
+    assert excinfo.value.field == column
+
+
+def test_valid_constant_stamps_preserve_existing_results(
+    stamped_panel: pl.DataFrame,
+) -> None:
+    standalone = quantile_spread(stamped_panel, n_groups=3)["factor"]
+    evaluated = fx.evaluate(
+        stamped_panel,
+        metrics={"spread": quantile_spread(n_groups=3)},
+        factor_cols=["factor"],
+    )["factor"].metrics["spread"]
+
+    assert standalone.value == evaluated.value
+    assert standalone.n_obs == evaluated.n_obs

--- a/tests/test_horizon_stamp_validation.py
+++ b/tests/test_horizon_stamp_validation.py
@@ -62,6 +62,10 @@ def test_evaluate_rejects_mixed_stamps_regardless_of_row_order(
     assert excinfo.value.func_name == "evaluate"
     assert excinfo.value.field == column
     assert "constant" in str(excinfo.value)
+    # The rejection prints the values the column actually carries, and links to
+    # the page that states the complete-panel contract.
+    assert excinfo.value.value == [1, 5]
+    assert excinfo.value.docs_url.endswith("/api/data-schema")
 
 
 @pytest.mark.parametrize("column", _STAMP_COLUMNS)
@@ -91,6 +95,26 @@ def test_evaluate_rejects_invalid_stamp_columns(
     assert excinfo.value.func_name == "evaluate"
     assert excinfo.value.field == column
     assert "positive integer" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("column", _STAMP_COLUMNS)
+def test_mixed_stamp_message_caps_the_enumerated_values(
+    stamped_panel: pl.DataFrame,
+    column: str,
+) -> None:
+    """More distinct values than the preview are summarised, not dumped."""
+    values = [i % 9 + 1 for i in range(stamped_panel.height)]
+    panel = _replace_stamp(stamped_panel, column, values, dtype=pl.Int32)
+
+    with pytest.raises(UserInputError) as excinfo:
+        fx.evaluate(
+            panel,
+            metrics={"ic": ic()},
+            factor_cols=["factor"],
+            strict=False,
+        )
+
+    assert excinfo.value.value == "[1, 2, 3, 4, 5] (5 of 9)"
 
 
 @pytest.mark.parametrize("column", _STAMP_COLUMNS)
@@ -155,6 +179,13 @@ def test_slice_inference_validates_both_stamp_columns(
 def test_valid_constant_stamps_preserve_existing_results(
     stamped_panel: pl.DataFrame,
 ) -> None:
+    """Pinning guard, not regression proof.
+
+    Unlike every other test here, this one passes on the unvalidated code as
+    well: it exists to pin that adding the complete-panel screen leaves a
+    valid single-horizon panel resolving exactly as it did before, on both the
+    ``evaluate`` and the standalone path.
+    """
     standalone = quantile_spread(stamped_panel, n_groups=3)["factor"]
     evaluated = fx.evaluate(
         stamped_panel,

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -97,24 +97,26 @@ class TestComputeForwardReturn:
     def test_stamps_overlap_horizon(self):
         from factrix._data_input import (
             _FORWARD_PERIODS_COL,
-            _read_forward_periods_stamp,
+            _read_horizon_stamps,
         )
 
         result = compute_forward_return(_make_price_data(), forward_periods=3)
         assert _FORWARD_PERIODS_COL in result.columns
-        assert _read_forward_periods_stamp(result) == 3
+        forward, _ = _read_horizon_stamps(result, func_name="compute_forward_return")
+        assert forward == 3
         # one constant value across all rows
         assert result[_FORWARD_PERIODS_COL].n_unique() == 1
 
     def test_overwrite_restamps_new_horizon(self):
         import factrix as fx
-        from factrix._data_input import _read_forward_periods_stamp
+        from factrix._data_input import _read_horizon_stamps
 
         raw = fx.datasets.make_cs_panel(n_assets=10, n_dates=60, rng=0)
         once = compute_forward_return(raw, forward_periods=1)
         changed = compute_forward_return(once, forward_periods=2, overwrite=True)
         assert changed.height > 0
-        assert _read_forward_periods_stamp(changed) == 2
+        forward, _ = _read_horizon_stamps(changed, func_name="compute_forward_return")
+        assert forward == 2
 
     def test_drops_nan_and_inf_forward_returns(self):
         dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(6)]


### PR DESCRIPTION
## Summary
- validate both reserved horizon stamp columns over the complete panel
- reject mixed, null, non-integer, zero, and negative stamps before dispatch or slicing
- share the same contract across evaluate, slicing, sample requirements, and standalone metrics

## Test plan
- [x] `python -m pytest -q -p no:faulthandler tests/test_horizon_stamp_validation.py` (21 passed)
- [x] targeted evaluate, standalone metric, sample requirements, and slicing suite (211 passed)
- [x] `ruff check factrix tests/test_horizon_stamp_validation.py`
- [x] `mypy factrix`
- [x] `pytest --doctest-modules factrix` (96 passed, 1 skipped)
- [ ] full pytest: 3816 passed / 50 skipped; 2 docs-inventory failures because this local environment cannot install `mkdocs-material` (#1061). CI installs all extras.

Closes #1050