### PR TITLE
fix(event): preserve complete price paths (#1051)

### DIFF
--- a/docs/api/data-schema.md
+++ b/docs/api/data-schema.md
@@ -110,6 +110,13 @@ projected per factor before a metric's keyword arguments are known, so a
 `inspect_data` reports `quantile_spread_vw` as unusable, with a blocker naming
 the column, on a panel that has no `market_cap`.
 
+For event paths, a `price` column on the evaluation panel can only cover that
+panel's retained rows. Pass the original full panel separately as
+[`evaluate(..., price_data=raw)`](evaluate.md#full-price-data-for-event-paths)
+when preprocessing removed the forward-return tail or selected a coarser
+evaluation grid. `data` owns events and return samples; `price_data` owns only
+the complete price grid.
+
 ## Reserved columns
 
 [`compute_forward_return`](preprocess.md) stamps two constant `Int32`
@@ -158,10 +165,10 @@ Full error taxonomy and recovery patterns: [Errors](errors.md).
 The canonical pipeline from raw price/event data to evaluate-ready panel:
 
 ```
-raw price panel  ──compute_forward_return(h)──▶  (date, asset_id, factor, forward_return)
-                                                           │
-                                                           ▼
-                                                        evaluate / by_slice / ...
+raw panel ──compute_forward_return(h)──▶ evaluation + forward-return sample
+    └──────────────── price_data ────────────────┐
+                                                 ▼
+                                           evaluate(...)
 ```
 
 Pre-attachment helpers live in [`factrix.preprocess`](preprocess.md); synthetic panels in [`factrix.datasets`](datasets.md). Wide-format multi-factor inputs are handled by passing the column names through `factor_cols=` on a single `evaluate` call rather than by reshaping the panel.

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -17,6 +17,50 @@ title: factrix.evaluate
 
 <hr>
 
+## Full price data for event paths
+
+`compute_forward_return` returns the evaluation panel: it removes rows whose
+forward return cannot be formed and, with `dates=`, keeps only the chosen
+evaluation dates. Those rows are the correct sample for return metrics, but
+they are not a complete price path. A later event offset or MFE/MAE window can
+need prices from the removed tail or from dates between evaluations.
+
+Keep the three grids separate by passing the original panel as `price_data`:
+
+```python
+import factrix as fx
+
+raw = fx.datasets.make_event_panel(n_assets=50, n_dates=400, rng=7)
+panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+result = fx.evaluate(
+    panel,
+    price_data=raw,
+    metrics={
+        "path": fx.metrics.event_around_return(offsets=[-1, 6, 12, 24]),
+        "excursion": fx.metrics.mfe_mae(),
+    },
+    factor_cols=["factor"],
+    strict=False,
+)["factor"]
+```
+
+| Input/grid | Owns | Never contributes to |
+|---|---|---|
+| `price_data` price grid | Complete per-asset prices used by offsets, excursion windows, and the event baseline | Forward-return samples, sample floors, or factor routing |
+| `data` evaluation grid | Eligible event dates and the rows selected by `dates=` | Prices outside the returned panel |
+| Finite `data.forward_return` rows | Return estimates and their effective sample | Extending an event price path |
+
+`price_data` must contain unique `(date, asset_id)` keys plus `price`; its key
+dtypes must exactly match `data`. Extra columns are ignored, so the event and
+factor authority cannot silently move to the side panel. If `price_data` is
+omitted, event paths continue to use `data.price` for backward compatibility.
+`evaluate_horizons` already owns the raw panel and forwards it automatically.
+
+This is an additive API in the pre-1.0 line: existing calls keep their prior
+behavior. Migrate event-path calls that preprocess returns by retaining `raw`
+and adding `price_data=raw`; no change is needed for return-only metrics.
+
 ## `forward_periods=` and `overlap_periods=`
 
 Both are properties of the data, normally read from the stamps

--- a/docs/api/evaluate.md
+++ b/docs/api/evaluate.md
@@ -54,12 +54,46 @@ result = fx.evaluate(
 `price_data` must contain unique `(date, asset_id)` keys plus `price`; its key
 dtypes must exactly match `data`. Extra columns are ignored, so the event and
 factor authority cannot silently move to the side panel. If `price_data` is
-omitted, event paths continue to use `data.price` for backward compatibility.
-`evaluate_horizons` already owns the raw panel and forwards it automatically.
+omitted, event paths continue to use `data.price`.
 
-This is an additive API in the pre-1.0 line: existing calls keep their prior
-behavior. Migrate event-path calls that preprocess returns by retaining `raw`
-and adding `price_data=raw`; no change is needed for return-only metrics.
+### Offsets and windows are counted on the grid that supplies them
+
+`offsets=` and `window=` are counts of periods on the price grid the path walk
+reads. Without `price_data` that grid is `data`'s own distinct dates; with
+`price_data` it is the price panel's. When the two grids differ, the same
+argument therefore spans a different amount of the sample, and the excursion or
+offset it measures changes with it.
+
+Measured on a panel whose evaluation grid keeps every tenth period of the price
+grid, `mfe_mae(window=3)`:
+
+| Grid the walk read | Median MFE |
+|---|---|
+| `data` evaluation grid (no `price_data`) | 0.1272 |
+| `price_data` price grid | 0.0120 |
+
+Three evaluation periods reach ten times further than three price periods, so
+the coarser grid reports the larger excursion. Neither number is wrong; they
+answer different questions. State the grid you mean, and scale `window=` and
+`offsets=` to it.
+
+### Behaviour change (pre-1.0)
+
+This is **not** an additive API. `evaluate_horizons` owns the raw panel and now
+forwards it as `price_data` on every call, so an existing `evaluate_horizons`
+run that includes `event_around_return` or `mfe_mae` changes value: event paths
+gain the tail and the between-evaluation periods that were previously
+unreachable, and offsets and windows are re-based onto the raw grid as above.
+Return-only metrics are unaffected.
+
+Migrate by deciding which grid each event-path argument counts on:
+
+- `evaluate_horizons` callers: re-read `offsets=` and `window=` against the raw
+  panel's grid. Where the evaluation grid was the intended unit, pass the
+  already-preprocessed panel to `evaluate` instead.
+- `evaluate` callers who preprocess returns themselves: retain `raw` and add
+  `price_data=raw` to get the complete paths; no change is needed for
+  return-only metrics.
 
 ## `forward_periods=` and `overlap_periods=`
 

--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -49,10 +49,36 @@ title: factrix.metrics.event_horizon
 !!! warning "Invalid prices withdraw the curve"
     `event_around_return` needs a finite unconditional bar-return baseline.
     Any observed non-finite or non-positive `price` invalidates that baseline,
-    so the metric returns `value=NaN`, an empty `per_offset`, and
+    so the metric returns `value=NaN`, audited `per_offset` entries, and
     `WarningCode.METRIC_UNAVAILABLE` with `reason="invalid_price_data"`.
     Missing (`null`) observations remain allowed on ragged panels; fix invalid
     observed prices rather than interpreting a contaminated finite hit rate.
+
+## Complete price paths and censoring audit
+
+An evaluation panel produced by `compute_forward_return` has a shorter tail
+than its raw price input. Pass that raw panel as `price_data` so an event that
+remains eligible can still reach every available offset:
+
+```python
+import factrix as fx
+from factrix.metrics.event_horizon import event_around_return
+
+raw = fx.datasets.make_event_panel(n_assets=50, n_dates=400, rng=7)
+panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+out = fx.evaluate(
+    panel,
+    price_data=raw,
+    metrics={"path": event_around_return(offsets=[-1, 6, 12, 24])},
+    factor_cols=["factor"],
+    strict=False,
+)["factor"].metrics["path"]
+```
+
+Each `per_offset[k]` reports `eligible`, `computed`, `censored`, and a
+`censor_reasons` count mapping. Reasons distinguish an out-of-grid offset,
+missing entry/exit price, invalid denominator, missing asset, and missing price
+column. `n` remains the computed count used for the summary statistic.
 
 ## Use cases
 

--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -75,6 +75,14 @@ out = fx.evaluate(
 )["factor"].metrics["path"]
 ```
 
+`offsets=` are counts of periods on the grid the walk reads: the evaluation
+panel's own distinct dates without `price_data`, the price panel's grid with
+it. Passing `price_data` therefore re-bases every offset, and an offset chosen
+for a coarse evaluation grid reaches a different distance on the raw grid. See
+[Offsets and windows are counted on the grid that supplies them](../evaluate.md#offsets-and-windows-are-counted-on-the-grid-that-supplies-them);
+`evaluate_horizons` forwards its raw panel automatically, so its existing
+`event_around_return` results change accordingly.
+
 Each `per_offset[k]` reports `eligible`, `computed`, `censored`, and a
 `censor_reasons` count mapping. Reasons distinguish an out-of-grid offset,
 missing entry/exit price, invalid denominator, missing asset, and missing price

--- a/docs/api/metrics/mfe_mae.md
+++ b/docs/api/metrics/mfe_mae.md
@@ -63,6 +63,26 @@ with `evaluate(..., expected_warnings=("ragged_period_grid",))` to silence the
 echo — the code is still recorded — or reindex the panel onto a common grid
 before calling.
 
+## Complete price paths and censored events
+
+When the evaluation panel came from `compute_forward_return`, pass the raw
+panel as `evaluate(..., price_data=raw)` (or as `price_data=` on the direct
+`compute_mfe_mae` call). Event eligibility stays on the evaluation panel;
+excursion and estimation windows walk the full price grid.
+
+`compute_mfe_mae` now retains one row per eligible event. Computable rows carry
+`path_status="computed"`; rows with no usable path carry null excursions,
+`path_status="censored"`, and a `censor_reason`. The aggregate metadata reports
+`n_events_eligible`, `n_events_computed`, `n_events_censored`, and reason
+counts. To reproduce the pre-0.33 valid-only table, filter explicitly:
+
+```python title="Illustrative"
+computed = per_event.filter(pl.col("path_status") == "computed")
+```
+
+This row-retention change is a pre-1.0 MINOR-level contract change; pin 0.32.x
+if downstream code assumes every producer row has finite excursions.
+
 ## Choosing a function
 
 | Goal                                                                | Function           |

--- a/docs/api/metrics/mfe_mae.md
+++ b/docs/api/metrics/mfe_mae.md
@@ -46,8 +46,15 @@ title: factrix.metrics.mfe_mae
 
 ## Windows are counted on the panel's period grid
 
-`window` and `estimation_window` are counts of periods on the panel's own
-distinct-date grid, not counts of an asset's rows. Each event asset is laid
+`window` and `estimation_window` are counts of periods on the grid of the
+panel the walk reads, not counts of an asset's rows. Without `price_data` that
+is the evaluation panel's own distinct-date grid; with `price_data` it is the
+price panel's, so the same `window=` spans a different amount of the sample
+whenever the two grids differ. Measured on a panel whose evaluation grid keeps
+every tenth period of the price grid, `window=3` gives a median MFE of 0.1272
+read on the evaluation grid and 0.0120 read on the price grid. Both are
+correct for the grid they were counted on; scale `window=` to the grid you are
+passing. Each event asset is laid
 onto the full grid before the excursion is walked, so on a ragged panel — an
 asset missing periods the other names have — the excursion spans exactly
 `window` grid periods and the missing periods count as missing observations
@@ -68,7 +75,19 @@ before calling.
 When the evaluation panel came from `compute_forward_return`, pass the raw
 panel as `evaluate(..., price_data=raw)` (or as `price_data=` on the direct
 `compute_mfe_mae` call). Event eligibility stays on the evaluation panel;
-excursion and estimation windows walk the full price grid.
+excursion and estimation windows walk the full price grid, and are counted in
+periods of that grid.
+
+`evaluate_horizons` forwards its raw panel automatically, so an existing
+`evaluate_horizons` run that includes `mfe_mae` changes value: the excursion
+reaches periods it could not previously see, and `window=` is re-based onto the
+raw grid. See
+[Offsets and windows are counted on the grid that supplies them](../evaluate.md#offsets-and-windows-are-counted-on-the-grid-that-supplies-them).
+
+A panel that carries no event at all short-circuits with
+`reason="no_events"`; a panel with events but no price column reports
+`reason="no_price_data"` alongside one `missing_price_column` censored row per
+event. The two conditions never share a reason.
 
 `compute_mfe_mae` now retains one row per eligible event. Computable rows carry
 `path_status="computed"`; rows with no usable path carry null excursions,

--- a/docs/api/preprocess.md
+++ b/docs/api/preprocess.md
@@ -87,6 +87,12 @@ long for the panel, or price data leaves no finite forward returns after
 filtering, the function raises [`UserInputError`](errors.md) instead of
 returning an empty panel.
 
+The returned rows are the **forward-return sample**, not a complete price
+history. Event offsets and MFE/MAE windows may need the dropped tail even when
+their event row remains in the sample. Preserve the raw panel and pass it as
+`evaluate(panel, price_data=raw, ...)`; see
+[Full price data for event paths](evaluate.md#full-price-data-for-event-paths).
+
 `winsorize_forward_return` clips `forward_return` by per-date quantiles.
 Its bounds must satisfy `0 <= lower <= upper <= 1`; invalid ordering,
 out-of-range values, non-numeric values, and `bool` bounds raise

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -489,6 +489,11 @@ is `clustering_hhi`).
 
 Pre/post-event return profile; descriptive.
 
+- *censor audit*: `n_events_eligible` counts events selected from the
+  evaluation grid before path availability is checked. Every `per_offset`
+  member reports `eligible`, `computed`, `censored`, and `censor_reasons`;
+  its `n` remains an alias for `computed`.
+
 - *descriptive*: `n_events` (distinct `(date, asset)` events behind the
   curve — also `n_obs`, axis `events`; one event contributes one row per
   offset, so this is not the row count), `per_offset` (dict
@@ -502,7 +507,7 @@ Pre/post-event return profile; descriptive.
   negative offset cleared the 5-event floor — `0.0` there was the *best*
   possible score for a quantity never computed. An observed non-finite or
   non-positive price instead withdraws the entire curve with
-  `reason=invalid_price_data`, `per_offset={}`, and
+  `reason=invalid_price_data`, audited `per_offset` entries, and
   `WarningCode.METRIC_UNAVAILABLE`; `n_invalid_prices` reports the offending
   row count. Null prices remain valid missing data on a ragged panel.
 - `p_value` is `None` — no hypothesis test runs, and no offset carries a
@@ -730,6 +735,9 @@ Descriptive; no test.
 - *descriptive* (conditional, when σ-normalised inputs available):
   `mfe_z_p50`, `mae_z_p25`, `mfe_mae_ratio_z`, `mfe_mae_ratio_z_status`,
   `n_events_z`.
+- *censor audit*: `n_events_eligible`, `n_events_computed`,
+  `n_events_censored`, and `censor_reasons`. Only computed paths enter the
+  summary and its sample floor; `n_events` aliases `n_events_computed`.
 - `p_value` is `None` — descriptive metric, no hypothesis test.
 ### `oos` (`factrix.metrics.oos_decay`)
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -82,6 +82,7 @@ from factrix._data_input import (
     _STAMP_COLUMNS,
     DataInput,
     _coerce_data,
+    _coerce_price_data,
     _resolve_horizons,
     _resolve_overlap_periods,
     _validate_overlap_periods,
@@ -131,6 +132,7 @@ from factrix.slicing import (
 def evaluate(
     data: DataInput,
     *,
+    price_data: DataInput | None = None,
     metrics: "dict[str, MetricBase]",
     factor_cols: list[str],
     forward_periods: int | None = None,
@@ -153,6 +155,14 @@ def evaluate(
             attached via :func:`factrix.preprocess.compute_forward_return`.
             ``price`` is optional — consumed by event-study metrics which
             short-circuit to NaN when it is absent.
+        price_data: Optional complete price panel containing exactly alignable
+            ``date``, ``asset_id``, and ``price`` columns. Use the raw panel
+            here when event path metrics must reach prices that
+            :func:`factrix.preprocess.compute_forward_return` dropped from
+            ``data`` (its forward-return tail, or dates outside a coarser
+            evaluation grid). ``data`` remains the sole owner of events and
+            the forward-return sample; extra columns on ``price_data`` are
+            ignored. Key dtypes must match ``data`` exactly.
         metrics: ``dict[str, Metric]`` mapping a caller-chosen label to a
             metric **instance** from :mod:`factrix.metrics` (e.g.
             ``{"ic_5d": ic(), "spread": quantile_spread(n_groups=5)}``).
@@ -268,6 +278,7 @@ def evaluate(
     _validate_factor_cols_not_stamps(cols)
     data = _coerce_data(data)
     _validate_baseline_columns(data)
+    price_data = _coerce_price_data(price_data, data=data)
     _validate_factor_cols_on_data(data, cols)
     _validate_factor_cols_numeric(data, cols)
 
@@ -368,6 +379,7 @@ def evaluate(
             density=density,
             forward_periods=fp,
             overlap_periods=op,
+            price_data=price_data,
             expected_warnings=expected,
             kwargs_by_metric=node_kwargs,
         )
@@ -410,6 +422,11 @@ def evaluate_horizons(
     ``forward_periods + 1`` rows per asset and stamps the horizon), so a
     horizon cannot be re-derived from an already-attached panel. This
     wrapper exists to make that rebuild-per-horizon loop hard to get wrong.
+
+    The raw panel is also forwarded to each inner :func:`evaluate` call as
+    ``price_data``. Event offsets and MFE/MAE windows therefore retain the
+    complete price grid even though each horizon's forward-return panel has a
+    shorter tail (and may use a coarser evaluation grid via ``dates=``).
 
     Identity of a swept result is the composite ``(factor, forward_periods)``,
     not a unique scalar factor key — so the return is a flat
@@ -494,6 +511,7 @@ def evaluate_horizons(
         )
         per_factor = evaluate(
             panel,
+            price_data=raw,
             metrics=metrics,
             factor_cols=factor_cols,
             strict=strict,

--- a/factrix/_dag.py
+++ b/factrix/_dag.py
@@ -180,6 +180,7 @@ class DagExecutor:
         density: FactorDensity,
         forward_periods: int,
         overlap_periods: int,
+        price_data: pl.DataFrame | None = None,
         expected_warnings: tuple[str, ...] = (),
         kwargs_by_metric: Mapping[str, Mapping[str, Any]] | None = None,
     ) -> dict[str, EvaluationResult]:
@@ -233,6 +234,7 @@ class DagExecutor:
                 node.spec,
                 kwargs_by_metric.get(nid, {}),
                 overlap_periods,
+                price_data=price_data,
                 expected_warnings=expected_warnings,
             )
 
@@ -298,6 +300,7 @@ class DagExecutor:
         kwargs: Mapping[str, Any],
         overlap_periods: int,
         *,
+        price_data: pl.DataFrame | None = None,
         expected_warnings: tuple[str, ...] = (),
     ) -> Callable[..., dict[str, Any]]:
         """Return the spec's unified batch dispatcher.
@@ -305,10 +308,10 @@ class DagExecutor:
         Registry ``MetricBase`` classes expose ``__call_batch__`` directly
         (bound to a configured instance); bare ``fn_resolver`` callables are
         wrapped through the same :func:`_dispatch_batch` so both paths share
-        one dispatch body. ``overlap_periods`` (the data's stamped evaluation-grid overlap
-        horizon) and ``expected_warnings`` (the caller's study-level
-        declaration, consumed by bodies that echo a ``UserWarning``) are
-        injected into whichever callables declare them.
+        one dispatch body. ``overlap_periods`` (the data's stamped
+        evaluation-grid overlap horizon), ``expected_warnings`` (the caller's
+        study-level declaration), and the optional complete ``price_data``
+        panel are injected into whichever callables declare them.
         """
         import functools
 
@@ -321,6 +324,7 @@ class DagExecutor:
                 fn(**kw).__call_batch__,
                 overlap_periods=overlap_periods,
                 expected_warnings=expected_warnings,
+                price_data=price_data,
             )
 
         bare: Callable[..., Any] = fn
@@ -330,6 +334,8 @@ class DagExecutor:
             inj["overlap_periods"] = overlap_periods
         if "expected_warnings" in bare_params:
             inj["expected_warnings"] = expected_warnings
+        if "price_data" in bare_params:
+            inj["price_data"] = price_data
 
         def handle(
             data: pl.DataFrame,

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -562,3 +562,56 @@ def _coerce_data(data: DataInput, *, func_name: str = "evaluate") -> pl.DataFram
     raise TypeError(
         f"data must be pl.DataFrame or pl.LazyFrame; got {type(data).__name__}."
     )
+
+
+def _coerce_price_data(
+    price_data: DataInput | None,
+    *,
+    data: pl.DataFrame,
+    func_name: str = "evaluate",
+    price_col: str = "price",
+) -> pl.DataFrame | None:
+    """Validate an optional full price panel against an evaluation panel.
+
+    ``data`` owns events and the forward-return sample; ``price_data`` owns
+    only the complete price grid used by path metrics. Keeping the inputs
+    separate prevents price-only tail rows from entering return metrics while
+    still making those rows available to event offsets and excursion windows.
+    """
+    if price_data is None:
+        return None
+
+    prices = _coerce_data(price_data, func_name=func_name)
+    required = ("date", "asset_id", price_col)
+    missing = [column for column in required if column not in prices.columns]
+    if missing:
+        raise UserInputError(
+            func_name=func_name,
+            field="price_data",
+            value=list(prices.columns),
+            expected=(
+                "a full price panel containing date, asset_id, and "
+                f"{price_col!r}; "
+                f"missing {missing!r}"
+            ),
+            docs_path=_DOCS_DATA_SCHEMA,
+        )
+
+    for column in ("date", "asset_id"):
+        data_dtype = data.schema[column]
+        price_dtype = prices.schema[column]
+        if price_dtype != data_dtype:
+            raise UserInputError(
+                func_name=func_name,
+                field=f"price_data.{column}",
+                value=str(price_dtype),
+                expected=(
+                    f"the same dtype as data.{column} ({data_dtype}) so event "
+                    "keys align exactly; cast the price panel explicitly"
+                ),
+                docs_path=_DOCS_DATA_SCHEMA,
+            )
+
+    # Extra columns, including factor values, have no authority on this path.
+    # Projecting here makes that ownership structural rather than conventional.
+    return prices.select(required)

--- a/factrix/_data_input.py
+++ b/factrix/_data_input.py
@@ -23,7 +23,7 @@ polars throughout) and avoids hiding the pd → pl copy inside every
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 import polars.selectors as cs
@@ -384,6 +384,27 @@ def _resolve_horizons(
 
 _DOCS_DATA_SCHEMA = "api/data-schema"
 
+# Which panel a structural guard is running on. Both panels carry the same
+# (date, asset_id) contract; they differ in what a breach of it does next.
+PanelRole = Literal["data", "price_data"]
+
+_DUPLICATE_KEY_EXPECTED: dict[PanelRole, str] = {
+    "data": (
+        "one row per (date, asset_id). The forward return shifts by "
+        "row position within an asset, so a duplicate makes the "
+        "'next period' the same date's twin and fabricates a 0.0 "
+        "return. De-duplicate first, e.g. "
+        "data.unique(subset=['date', 'asset_id'], keep='first')"
+    ),
+    "price_data": (
+        "one row per (date, asset_id) in price_data. A period holding two "
+        "prices leaves the event offset and the excursion walk unable to say "
+        "which one the event entered at, and the duplicate also shifts every "
+        "later period of that asset off the price grid. De-duplicate first, "
+        "e.g. price_data.unique(subset=['date', 'asset_id'], keep='first')"
+    ),
+}
+
 
 def _validate_panel_key_columns(data: object, *, func_name: str) -> None:
     """Reject a direct raw-panel metric call whose frame lacks the key columns.
@@ -455,7 +476,7 @@ def _validate_named_columns(
 
 
 def _normalize_panel(
-    data: pl.DataFrame, *, func_name: str = "evaluate"
+    data: pl.DataFrame, *, func_name: str = "evaluate", role: PanelRole = "data"
 ) -> pl.DataFrame:
     """Enforce the panel's structural contract once, at the boundary.
 
@@ -487,6 +508,13 @@ def _normalize_panel(
     changed here — the shift-based producers sort themselves, and reordering
     every caller's frame at the gate would be a surprise that buys nothing.
 
+    ``role`` names which panel is being normalised. The guards are the
+    same for both, but the *consequence* a duplicate key has is not: the
+    evaluation panel fabricates a forward return, while a price panel
+    leaves the excursion walk unable to say which of two prices the
+    event entered at. A message that states the wrong consequence sends
+    the reader to the wrong column.
+
     Raises:
         UserInputError: ``date`` is not a temporal dtype, or ``(date,
             asset_id)`` is not unique.
@@ -515,15 +543,9 @@ def _normalize_panel(
         if n_duplicated:
             raise UserInputError(
                 func_name=func_name,
-                field="(date, asset_id)",
+                field="(date, asset_id)" if role == "data" else "price_data",
                 value=f"{n_duplicated} duplicated row(s) of {data.height}",
-                expected=(
-                    "one row per (date, asset_id). The forward return shifts by "
-                    "row position within an asset, so a duplicate makes the "
-                    "'next period' the same date's twin and fabricates a 0.0 "
-                    "return. De-duplicate first, e.g. "
-                    "data.unique(subset=['date', 'asset_id'], keep='first')"
-                ),
+                expected=_DUPLICATE_KEY_EXPECTED[role],
                 docs_path=_DOCS_DATA_SCHEMA,
             )
 
@@ -541,7 +563,9 @@ def _is_pandas_dataframe(obj: object) -> bool:
     return type(obj).__module__.split(".", 1)[0] == "pandas"
 
 
-def _coerce_data(data: DataInput, *, func_name: str = "evaluate") -> pl.DataFrame:
+def _coerce_data(
+    data: DataInput, *, func_name: str = "evaluate", role: PanelRole = "data"
+) -> pl.DataFrame:
     """Coerce ``DataInput`` to eager ``pl.DataFrame`` and normalise it.
 
     ``pl.LazyFrame`` is collected immediately. ``pd.DataFrame`` is
@@ -550,9 +574,9 @@ def _coerce_data(data: DataInput, *, func_name: str = "evaluate") -> pl.DataFram
     the single structural gate every public entry point shares.
     """
     if isinstance(data, pl.DataFrame):
-        return _normalize_panel(data, func_name=func_name)
+        return _normalize_panel(data, func_name=func_name, role=role)
     if isinstance(data, pl.LazyFrame):
-        return _normalize_panel(data.collect(), func_name=func_name)
+        return _normalize_panel(data.collect(), func_name=func_name, role=role)
     if _is_pandas_dataframe(data):
         raise TypeError(
             "data must be pl.DataFrame or pl.LazyFrame; got pandas DataFrame. "
@@ -581,7 +605,7 @@ def _coerce_price_data(
     if price_data is None:
         return None
 
-    prices = _coerce_data(price_data, func_name=func_name)
+    prices = _coerce_data(price_data, func_name=func_name, role="price_data")
     required = ("date", "asset_id", price_col)
     missing = [column for column in required if column not in prices.columns]
     if missing:

--- a/factrix/metrics/_base.py
+++ b/factrix/metrics/_base.py
@@ -23,10 +23,13 @@ from factrix._metric_index import Cell, MetricSpec, SampleThreshold
 # Parameters that ``evaluate`` injects at dispatch rather than the user
 # configuring per metric: ``overlap_periods`` comes from the data's overlap
 # stamp, ``expected_warnings`` from the caller's study-level declaration on
-# ``evaluate``. On metrics whose body declares them they remain dataclass
+# ``evaluate``, and ``price_data`` from its optional full price panel. On
+# metrics whose body declares them they remain dataclass
 # fields, kept out of the user-facing ``_param_names`` so neither shows up as
 # a configured knob on ``spec()`` / ``_params()``.
-_INJECTED_PARAMS: frozenset[str] = frozenset({"overlap_periods", "expected_warnings"})
+_INJECTED_PARAMS: frozenset[str] = frozenset(
+    {"overlap_periods", "expected_warnings", "price_data"}
+)
 
 # The injected param the public constructor refuses. ``overlap_periods`` is a
 # property of the *data* — the panel's own overlap horizon — so a per-metric
@@ -36,7 +39,7 @@ _INJECTED_PARAMS: frozenset[str] = frozenset({"overlap_periods", "expected_warni
 # :ref:`the contract <expected-warnings-contract>` in the module docstring of
 # ``factrix.metrics``), and both the constructor and the direct-call form take
 # it, with ``evaluate`` overriding it at dispatch with the study-level value.
-_REJECTED_PARAMS: frozenset[str] = frozenset({"overlap_periods"})
+_REJECTED_PARAMS: frozenset[str] = frozenset({"overlap_periods", "price_data"})
 
 
 def _log_exception_once(
@@ -136,6 +139,18 @@ class MetricMeta(type):
             from factrix._errors import UserInputError
 
             name = offending[0]
+            if name == "price_data":
+                raise UserInputError(
+                    func_name=cls.__name__,
+                    field=name,
+                    value=type(supplied[name]).__name__,
+                    expected=(
+                        "run-level price data passed to evaluate(), or to the "
+                        "direct-call form with the event panel as its first "
+                        "argument"
+                    ),
+                    docs_path="api/evaluate#full-price-data-for-event-paths",
+                )
             raise UserInputError(
                 func_name=cls.__name__,
                 field=name,
@@ -211,7 +226,8 @@ class MetricBase(metaclass=MetricMeta):
     # Params dispatch injects rather than the user configuring per metric:
     # ``overlap_periods`` (read from the data, rejected at the constructor) and
     # ``expected_warnings`` (the study-level declaration; the constructor and
-    # the direct call both take it, ``evaluate`` overrides it). Both are kept
+    # direct call both take it, ``evaluate`` overrides it), and ``price_data``
+    # (the complete path panel). All are kept
     # out of ``_param_names`` and injected at dispatch into the metrics whose
     # ``_impl`` declares them. Empty for a metric that takes neither.
     _injected_param_names: ClassVar[tuple[str, ...]] = ()
@@ -346,6 +362,7 @@ class MetricBase(metaclass=MetricMeta):
         self,
         overlap_periods: int | None,
         expected_warnings: tuple[str, ...] | None = None,
+        price_data: Any | None = None,
     ) -> dict[str, Any]:
         """Dispatch-time injected kwargs for ``_impl``.
 
@@ -360,6 +377,7 @@ class MetricBase(metaclass=MetricMeta):
         supplied = {
             "overlap_periods": overlap_periods,
             "expected_warnings": expected_warnings,
+            "price_data": price_data,
         }
         return {
             name: (
@@ -406,6 +424,7 @@ class MetricBase(metaclass=MetricMeta):
         *args: Any,
         overlap_periods: int | None = None,
         expected_warnings: tuple[str, ...] | None = None,
+        price_data: Any | None = None,
         **kwargs: Any,
     ) -> Any:
         """Evaluate the metric on a single input (one factor's view / upstream)."""
@@ -434,9 +453,19 @@ class MetricBase(metaclass=MetricMeta):
             # class of mistake as a mis-typed ``asset_id`` and fails the same
             # way, instead of reaching a polars expression or being answered
             # with a NaN "insufficient data" envelope.
+            named_columns = self._named_column_params()
+            price_columns: dict[str, Any] = {}
+            if price_data is not None and "price_col" in named_columns:
+                price_columns["price_col"] = named_columns.pop("price_col")
             _validate_named_columns(
                 args[0],
-                self._named_column_params(),
+                named_columns,
+                func_name=self.__class__.__name__,
+                docs_path=self._docs_path(),
+            )
+            _validate_named_columns(
+                price_data,
+                price_columns,
                 func_name=self.__class__.__name__,
                 docs_path=self._docs_path(),
             )
@@ -451,7 +480,7 @@ class MetricBase(metaclass=MetricMeta):
                 *args,
                 **{
                     **self._params(),
-                    **self._inject(overlap_periods, expected_warnings),
+                    **self._inject(overlap_periods, expected_warnings, price_data),
                     **kwargs,
                 },
             )
@@ -474,6 +503,7 @@ class MetricBase(metaclass=MetricMeta):
         upstream: dict[str, dict[str, Any]],
         overlap_periods: int | None = None,
         expected_warnings: tuple[str, ...] | None = None,
+        price_data: Any | None = None,
     ) -> dict[str, Any]:
         """Run this metric across a factor batch; return ``{factor: output}``.
 
@@ -484,7 +514,7 @@ class MetricBase(metaclass=MetricMeta):
         ``batchable`` (whole panel), ``requires`` (consume upstream), plain
         (thin view) — are unified in :func:`_dispatch_batch`.
         """
-        inj = self._inject(overlap_periods, expected_warnings)
+        inj = self._inject(overlap_periods, expected_warnings, price_data)
         if self.requires:
 
             def run_batch() -> dict[str, Any]:

--- a/factrix/metrics/_primitives/_event_returns.py
+++ b/factrix/metrics/_primitives/_event_returns.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
+import numpy.typing as npt
 import polars as pl
+from typing_extensions import TypedDict
 
 from factrix._axis import (
     Aggregation,
@@ -11,9 +13,170 @@ from factrix._axis import (
     OutputShape,
     SpecRole,
 )
+from factrix._data_input import DataInput, _coerce_price_data
 from factrix._metric_index import cell
 from factrix._types import EPSILON
 from factrix.metrics._decorators import metric
+
+
+class EventOffsetAuditEntry(TypedDict):
+    eligible: int
+    computed: int
+    censored: int
+    censor_reasons: dict[str, int]
+
+
+type EventOffsetAudit = dict[int, EventOffsetAuditEntry]
+
+
+def _empty_event_returns(date_dtype: pl.DataType) -> pl.DataFrame:
+    return pl.DataFrame(
+        schema={
+            "offset": pl.Int32,
+            "date": date_dtype,
+            "asset_id": pl.String,
+            "signed_return": pl.Float64,
+            "sign": pl.Float64,
+        }
+    )
+
+
+def _record_censor(audit: EventOffsetAudit, offset: int, reason: str) -> None:
+    entry = audit[offset]
+    entry["censored"] += 1
+    reasons = entry["censor_reasons"]
+    reasons[reason] = reasons.get(reason, 0) + 1
+
+
+def _compute_event_returns_with_audit(
+    data: pl.DataFrame,
+    *,
+    price_data: pl.DataFrame | None,
+    offsets: list[int],
+    factor_col: str,
+    price_col: str,
+) -> tuple[pl.DataFrame, EventOffsetAudit]:
+    """Compute valid event-offset rows and account for every omitted row."""
+    date_dtype = data.schema["date"]
+    sorted_events = data.sort(["asset_id", "date"]).filter(pl.col(factor_col) != 0)
+    audit: EventOffsetAudit = {
+        offset: {
+            "eligible": sorted_events.height,
+            "computed": 0,
+            "censored": 0,
+            "censor_reasons": {},
+        }
+        for offset in offsets
+    }
+    if sorted_events.is_empty():
+        return _empty_event_returns(date_dtype), audit
+
+    paths = data if price_data is None else price_data
+    if price_col not in paths.columns:
+        for offset in offsets:
+            audit[offset]["censored"] = sorted_events.height
+            audit[offset]["censor_reasons"] = {
+                "missing_price_column": sorted_events.height
+            }
+        return _empty_event_returns(date_dtype), audit
+
+    sorted_paths = paths.sort(["asset_id", "date"])
+    grid_idx = {
+        date: index
+        for index, date in enumerate(sorted_paths["date"].unique().sort().to_list())
+    }
+    n_grid = len(grid_idx)
+    event_assets = set(sorted_events["asset_id"].unique().to_list())
+    asset_prices: dict[object, npt.NDArray[np.float64]] = {}
+    for asset_id, asset_frame in sorted_paths.partition_by(
+        "asset_id", as_dict=True, maintain_order=True
+    ).items():
+        key = asset_id[0]
+        if key not in event_assets:
+            continue
+        prices = np.full(n_grid, np.nan, dtype=np.float64)
+        positions = np.fromiter(
+            (grid_idx[date] for date in asset_frame["date"].to_list()),
+            dtype=np.int64,
+            count=asset_frame.height,
+        )
+        prices[positions] = asset_frame[price_col].to_numpy().astype(np.float64)
+        asset_prices[key] = prices
+
+    rows: list[dict[str, object]] = []
+    for row in sorted_events.iter_rows(named=True):
+        asset_id = row["asset_id"]
+        event_date = row["date"]
+        direction = np.sign(row[factor_col])
+        idx = grid_idx.get(event_date)
+        event_prices = asset_prices.get(asset_id)
+
+        for offset in offsets:
+            reason: str | None = None
+            if idx is None:
+                reason = "event_date_not_on_price_grid"
+            elif event_prices is None:
+                reason = "asset_not_in_price_data"
+            elif offset > 0:
+                entry_idx = idx + 1
+                exit_idx = idx + 1 + offset
+                if entry_idx >= n_grid or exit_idx >= n_grid:
+                    reason = "offset_out_of_bounds"
+                else:
+                    entry_price = event_prices[entry_idx]
+                    exit_price = event_prices[exit_idx]
+                    if not np.isfinite(entry_price):
+                        reason = "missing_entry_price"
+                    elif entry_price < EPSILON:
+                        reason = "invalid_entry_price"
+                    elif not np.isfinite(exit_price):
+                        reason = "missing_exit_price"
+                    else:
+                        signed_return = float(
+                            direction * (exit_price / entry_price - 1)
+                        )
+            else:
+                bar_idx = idx + offset
+                previous_idx = bar_idx - 1
+                if bar_idx < 0 or previous_idx < 0 or bar_idx >= n_grid:
+                    reason = "offset_out_of_bounds"
+                else:
+                    bar_price = event_prices[bar_idx]
+                    previous_price = event_prices[previous_idx]
+                    if not np.isfinite(previous_price):
+                        reason = "missing_previous_price"
+                    elif previous_price < EPSILON:
+                        reason = "invalid_previous_price"
+                    elif not np.isfinite(bar_price):
+                        reason = "missing_offset_price"
+                    else:
+                        signed_return = float(
+                            direction * (bar_price / previous_price - 1)
+                        )
+
+            if reason is not None:
+                _record_censor(audit, offset, reason)
+                continue
+            audit[offset]["computed"] += 1
+            rows.append(
+                {
+                    "offset": offset,
+                    "date": event_date,
+                    "asset_id": asset_id,
+                    "signed_return": signed_return,
+                    "sign": float(direction),
+                }
+            )
+
+    if not rows:
+        return _empty_event_returns(date_dtype), audit
+    return (
+        pl.DataFrame(rows).with_columns(
+            pl.col("offset").cast(pl.Int32),
+            pl.col("date").cast(date_dtype),
+        ),
+        audit,
+    )
 
 
 @metric(
@@ -28,6 +191,7 @@ from factrix.metrics._decorators import metric
 def compute_event_returns(
     data: pl.DataFrame,
     *,
+    price_data: DataInput | None = None,
     offsets: list[int] | None = None,
     factor_col: str = "factor",
     price_col: str = "price",
@@ -85,102 +249,34 @@ def compute_event_returns(
     panel's drift, in :func:`~factrix.metrics.event_horizon.event_around_return`)
     can sign the baseline the same way instead of subtracting ``+mu`` from a
     return that carries ``-mu``.
+
+    Args:
+        data: Evaluation panel owning event dates and factor values.
+        price_data: Optional complete ``date, asset_id, price`` panel. When
+            supplied, offsets walk this price grid while events still come
+            only from ``data``. This preserves tail and between-evaluation-date
+            prices removed by ``compute_forward_return``.
+        offsets: Period-grid offsets to compute.
+        factor_col: Event factor column on ``data``.
+        price_col: Price column on the selected price panel.
+
+    Returns:
+        One row per computed event-offset pair. Censored pairs remain omitted
+        from this low-level table; :func:`event_around_return` reports their
+        eligible, computed, censored, and reason counts per offset.
     """
-    if offsets is None:
-        offsets = [-6, -3, -1, 1, 6, 12, 24]
-
-    date_dtype = data.schema["date"]
-    empty_schema = {
-        "offset": pl.Int32,
-        "date": date_dtype,
-        "asset_id": pl.String,
-        "signed_return": pl.Float64,
-        "sign": pl.Float64,
-    }
-
-    if price_col not in data.columns:
-        return pl.DataFrame(schema=empty_schema)  # type: ignore[arg-type]
-
-    sorted_df = data.sort(["asset_id", "date"])
-    events = sorted_df.filter(pl.col(factor_col) != 0)
-
-    if len(events) == 0:
-        return pl.DataFrame(schema=empty_schema)  # type: ignore[arg-type]
-
-    # Offsets are counted on the panel's distinct-date grid, not on the asset's
-    # own rows: an asset missing periods that others have would otherwise step
-    # over the hole as though it were one period, so its "k periods after the
-    # event" price would sit further out on the grid than every other name's.
-    # Each asset's prices are laid onto the full grid, absent periods carrying
-    # NaN, and an offset that lands on one is skipped like a missing bar.
-    grid_idx = {d: i for i, d in enumerate(sorted_df["date"].unique().sort().to_list())}
-    n_grid = len(grid_idx)
-    event_assets = set(events["asset_id"].unique().to_list())
-    asset_prices: dict[str, np.ndarray] = {}
-    for aid in event_assets:
-        adf = sorted_df.filter(pl.col("asset_id") == aid)
-        prices = np.full(n_grid, np.nan, dtype=np.float64)
-        positions = np.fromiter(
-            (grid_idx[d] for d in adf["date"].to_list()),
-            dtype=np.int64,
-            count=adf.height,
-        )
-        prices[positions] = adf[price_col].to_numpy().astype(np.float64)
-        asset_prices[aid] = prices
-
-    rows: list[dict] = []
-    for row in events.iter_rows(named=True):
-        aid = row["asset_id"]
-        edate = row["date"]
-        direction = np.sign(row[factor_col])
-
-        prices = asset_prices[aid]
-        idx = grid_idx.get(edate)
-        if idx is None:
-            continue
-
-        for k in offsets:
-            if k > 0:
-                entry_idx = idx + 1
-                exit_idx = idx + 1 + k
-                if entry_idx >= n_grid or exit_idx >= n_grid:
-                    continue
-                entry_p = prices[entry_idx]
-                exit_p = prices[exit_idx]
-                if not np.isfinite(entry_p) or not np.isfinite(exit_p):
-                    continue
-                if entry_p < EPSILON:
-                    continue
-                raw_ret = exit_p / entry_p - 1
-                signed_ret = float(direction * raw_ret)
-            else:
-                bar_idx = idx + k
-                prev_idx = bar_idx - 1
-                if bar_idx < 0 or prev_idx < 0 or bar_idx >= n_grid:
-                    continue
-                bar_p = prices[bar_idx]
-                prev_p = prices[prev_idx]
-                if not np.isfinite(bar_p) or not np.isfinite(prev_p):
-                    continue
-                if prev_p < EPSILON:
-                    continue
-                raw_ret = bar_p / prev_p - 1
-                signed_ret = float(direction * raw_ret)
-
-            rows.append(
-                {
-                    "offset": k,
-                    "date": edate,
-                    "asset_id": aid,
-                    "signed_return": signed_ret,
-                    "sign": float(direction),
-                }
-            )
-
-    if not rows:
-        return pl.DataFrame(schema=empty_schema)  # type: ignore[arg-type]
-
-    return pl.DataFrame(rows).with_columns(
-        pl.col("offset").cast(pl.Int32),
-        pl.col("date").cast(date_dtype),
+    resolved_offsets = [-6, -3, -1, 1, 6, 12, 24] if offsets is None else offsets
+    resolved_prices = _coerce_price_data(
+        price_data,
+        data=data,
+        func_name="compute_event_returns",
+        price_col=price_col,
     )
+    returns, _ = _compute_event_returns_with_audit(
+        data,
+        price_data=resolved_prices,
+        offsets=resolved_offsets,
+        factor_col=factor_col,
+        price_col=price_col,
+    )
+    return returns

--- a/factrix/metrics/_primitives/_event_returns.py
+++ b/factrix/metrics/_primitives/_event_returns.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
 import numpy as np
 import numpy.typing as npt
 import polars as pl
-from typing_extensions import TypedDict
 
 from factrix._axis import (
     Aggregation,

--- a/factrix/metrics/_primitives/_mfe_mae.py
+++ b/factrix/metrics/_primitives/_mfe_mae.py
@@ -11,6 +11,7 @@ from factrix._axis import (
     OutputShape,
     SpecRole,
 )
+from factrix._data_input import DataInput, _coerce_price_data
 from factrix._metric_index import cell
 from factrix._stats.constants import DEFAULT_MIN_ESTIMATION_PERIODS
 from factrix._types import EPSILON
@@ -39,7 +40,28 @@ def _empty_mfe_mae_schema(date_dtype: pl.DataType) -> dict[str, pl.DataType]:
         "est_sigma": pl.Float64(),
         "bars_to_mfe": pl.Int32(),
         "bars_to_mae": pl.Int32(),
+        "path_status": pl.String(),
+        "censor_reason": pl.String(),
         "ragged_period_grid_note": pl.String(),
+    }
+
+
+def _censored_mfe_mae_row(
+    event_date: object, asset_id: object, reason: str
+) -> dict[str, object]:
+    """One auditable event whose requested excursion path was unavailable."""
+    return {
+        "date": event_date,
+        "asset_id": asset_id,
+        "mfe": None,
+        "mae": None,
+        "mfe_z": None,
+        "mae_z": None,
+        "est_sigma": None,
+        "bars_to_mfe": None,
+        "bars_to_mae": None,
+        "path_status": "censored",
+        "censor_reason": reason,
     }
 
 
@@ -75,6 +97,7 @@ def _validate_compute_mfe_mae(m: MetricBase) -> None:
 def compute_mfe_mae(
     data: pl.DataFrame,
     *,
+    price_data: DataInput | None = None,
     window: int = 20,
     estimation_window: int = 60,
     min_estimation_periods: int = DEFAULT_MIN_ESTIMATION_PERIODS,
@@ -145,18 +168,51 @@ def compute_mfe_mae(
         ``bars_to_mfe`` / ``bars_to_mae`` are ``0`` when the floor binds —
         the excursion is attained at entry, before any path bar — and
         otherwise stay 1-based offsets into the post-event window.
+
+    Args:
+        data: Evaluation panel owning event dates and factor values.
+        price_data: Optional complete ``date, asset_id, price`` panel. When
+            supplied, excursion and estimation windows walk this price grid
+            while events still come only from ``data``.
+
+    Returns:
+        One row per eligible event. A complete path has
+        ``path_status="computed"``; an event with no computable path is
+        retained with null excursion fields, ``path_status="censored"``, and
+        a machine-readable ``censor_reason``.
     """
     date_dtype = data.schema["date"]
     empty_schema = _empty_mfe_mae_schema(date_dtype)
-
-    if price_col not in data.columns:
-        return pl.DataFrame(schema=empty_schema)
 
     sorted_df = data.sort(["asset_id", "date"])
     events = sorted_df.filter(pl.col(factor_col) != 0)
 
     if len(events) == 0:
         return pl.DataFrame(schema=empty_schema)
+
+    resolved_prices = _coerce_price_data(
+        price_data,
+        data=data,
+        func_name="compute_mfe_mae",
+        price_col=price_col,
+    )
+    paths = data if resolved_prices is None else resolved_prices
+    ragged_note = _ragged_event_grid_message(paths) or ""
+    if price_col not in paths.columns:
+        return pl.DataFrame(
+            [
+                _censored_mfe_mae_row(
+                    row["date"], row["asset_id"], "missing_price_column"
+                )
+                for row in events.iter_rows(named=True)
+            ]
+        ).with_columns(
+            pl.col("date").cast(date_dtype),
+            pl.col("mfe", "mae", "mfe_z", "mae_z", "est_sigma").cast(pl.Float64),
+            pl.col("bars_to_mfe").cast(pl.Int32),
+            pl.col("bars_to_mae").cast(pl.Int32),
+            pl.lit(ragged_note, dtype=pl.String).alias("ragged_period_grid_note"),
+        )
 
     # One partition pass over the event-bearing assets instead of an
     # ``asset_id == a`` filter per asset (which re-scanned the whole panel N
@@ -169,7 +225,7 @@ def compute_mfe_mae(
     # excursion rather than a period that is stepped over (which stretched a
     # ``window``-period excursion across more grid periods on a ragged name).
     # The grid is the whole panel's, so non-event assets still define it.
-    dense, _ = _densify_on_period_grid(sorted_df)
+    dense, _ = _densify_on_period_grid(paths.sort(["asset_id", "date"]))
     asset_groups: dict[str, tuple[dict, np.ndarray]] = {}
     for key, asset_data in (
         dense.filter(pl.col("asset_id").is_in(list(event_assets)))
@@ -187,19 +243,41 @@ def compute_mfe_mae(
         event_date = row["date"]
         direction = 1.0 if row[factor_col] > 0 else -1.0
 
-        date_to_idx, prices = asset_groups[asset_id]
+        group = asset_groups.get(asset_id)
+        if group is None:
+            rows.append(
+                _censored_mfe_mae_row(event_date, asset_id, "asset_not_in_price_data")
+            )
+            continue
+        date_to_idx, prices = group
         idx = date_to_idx.get(event_date)
         if idx is None:
+            rows.append(
+                _censored_mfe_mae_row(
+                    event_date, asset_id, "event_date_not_on_price_grid"
+                )
+            )
             continue
 
         entry_price = prices[idx]
-        if not np.isfinite(entry_price) or entry_price < EPSILON:
+        if not np.isfinite(entry_price):
+            rows.append(
+                _censored_mfe_mae_row(event_date, asset_id, "missing_entry_price")
+            )
+            continue
+        if entry_price < EPSILON:
+            rows.append(
+                _censored_mfe_mae_row(event_date, asset_id, "invalid_entry_price")
+            )
             continue
 
         # ``window`` grid periods after the event bar, whether or not this
         # asset trades on all of them.
         end_idx = min(idx + window + 1, len(prices))
         if idx + 1 >= end_idx:
+            rows.append(
+                _censored_mfe_mae_row(event_date, asset_id, "window_out_of_bounds")
+            )
             continue
 
         future_prices = prices[idx + 1 : end_idx]
@@ -209,6 +287,9 @@ def compute_mfe_mae(
         # poisons the extremes with NaN nor pulls a later period into the
         # window to replace itself.
         if not np.isfinite(signed_returns).any():
+            rows.append(
+                _censored_mfe_mae_row(event_date, asset_id, "missing_path_prices")
+            )
             continue
         signed_returns = np.where(np.isfinite(signed_returns), signed_returns, np.nan)
 
@@ -261,6 +342,8 @@ def compute_mfe_mae(
                 "est_sigma": est_sigma,
                 "bars_to_mfe": bars_to_mfe,
                 "bars_to_mae": bars_to_mae,
+                "path_status": "computed",
+                "censor_reason": "",
             }
         )
 
@@ -269,13 +352,12 @@ def compute_mfe_mae(
 
     return pl.DataFrame(rows).with_columns(
         pl.col("date").cast(date_dtype),
+        pl.col("mfe", "mae", "mfe_z", "mae_z", "est_sigma").cast(pl.Float64),
         pl.col("bars_to_mfe").cast(pl.Int32),
         pl.col("bars_to_mae").cast(pl.Int32),
         # Raggedness is a property of the panel, which only this node sees;
         # ``mfe_mae`` reads the note off the frame and records the code there.
         # Empty rather than null on a dense panel, so a caller's ``drop_nulls``
         # over the per-event table does not empty it.
-        pl.lit(_ragged_event_grid_message(data) or "", dtype=pl.String).alias(
-            "ragged_period_grid_note"
-        ),
+        pl.lit(ragged_note, dtype=pl.String).alias("ragged_period_grid_note"),
     )

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -25,6 +25,7 @@ from factrix._axis import (
     Aggregation,
     FactorDensity,
 )
+from factrix._data_input import DataInput, _coerce_price_data
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
 from factrix._types import DDOF, EPSILON
@@ -35,7 +36,10 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _warn_ragged_event_grid,
 )
-from factrix.metrics._primitives import compute_event_returns
+from factrix.metrics._primitives import compute_event_returns as compute_event_returns
+from factrix.metrics._primitives._event_returns import (
+    _compute_event_returns_with_audit,
+)
 
 __all__ = [
     "event_around_return",
@@ -94,6 +98,7 @@ def _unconditional_bar_return(
 def event_around_return(
     data: pl.DataFrame,
     *,
+    price_data: DataInput | None = None,
     offsets: list[int] | None = None,
     factor_col: str = "factor",
     price_col: str = "price",
@@ -120,10 +125,17 @@ def event_around_return(
 
     Args:
         data: Panel with ``date, asset_id, factor, price``.
+        price_data: Optional complete ``date, asset_id, price`` panel. Events
+            come from ``data``; offsets and the unconditional bar-return
+            baseline use this full price grid. Pass the raw panel when
+            ``data`` came from ``compute_forward_return``.
         offsets: Defaults to ``[-6, -3, -1, 1, 6, 12, 24]``.
 
     Returns:
-        MetricResult with per-offset stats in metadata. When price data is
+        MetricResult with per-offset stats and audit counts in metadata.
+        Every ``per_offset[k]`` includes ``eligible``, ``computed``,
+        ``censored``, and ``censor_reasons``; ``n`` remains an alias for the
+        computed count. When price data is
         unavailable or the unconditional baseline cannot be computed from
         valid positive prices, returns a short-circuit MetricResult
         (``value=NaN``) so all metrics share a single return contract.
@@ -193,24 +205,42 @@ def event_around_return(
         >>> result.name == ""
         True
     """
-    if offsets is None:
-        offsets = [-6, -3, -1, 1, 6, 12, 24]
-
-    event_rets = compute_event_returns(
+    resolved_offsets = [-6, -3, -1, 1, 6, 12, 24] if offsets is None else offsets
+    resolved_prices = _coerce_price_data(
+        price_data,
+        data=data,
+        func_name="event_around_return",
+        price_col=price_col,
+    )
+    event_rets, offset_audit = _compute_event_returns_with_audit(
         data,
-        offsets=offsets,
+        price_data=resolved_prices,
+        offsets=resolved_offsets,
         factor_col=factor_col,
         price_col=price_col,
     )
+    per_offset: dict[int, dict[str, object]] = {
+        offset: {**audit, "mean": None, "n": int(audit["computed"])}
+        for offset, audit in offset_audit.items()
+    }
+    n_events_eligible = (
+        int(next(iter(offset_audit.values()))["eligible"]) if offset_audit else 0
+    )
 
     if event_rets.is_empty():
+        only_missing_price = bool(offset_audit) and all(
+            audit["censor_reasons"] == {"missing_price_column": n_events_eligible}
+            for audit in offset_audit.values()
+        )
         return _short_circuit_output(
             "event_around_return",
-            "no_price_data",
+            "no_price_data" if only_missing_price else "no_computed_event_offsets",
             descriptive=True,
             n_obs=0,
             n_obs_axis="events",
-            per_offset={},
+            n_events=0,
+            n_events_eligible=n_events_eligible,
+            per_offset=per_offset,
         )
 
     n_events = event_rets.select("date", "asset_id").n_unique()
@@ -218,7 +248,8 @@ def event_around_return(
     # every offset is measured against. A bad observed price invalidates the
     # whole baseline; dropping only its affected return would silently change
     # the estimand and still publish a finite-looking hit rate.
-    baseline, n_invalid_prices = _unconditional_bar_return(data, price_col)
+    path_data = data if resolved_prices is None else resolved_prices
+    baseline, n_invalid_prices = _unconditional_bar_return(path_data, price_col)
     if baseline is None:
         reason = (
             "invalid_price_data" if n_invalid_prices else "no_finite_baseline_returns"
@@ -230,20 +261,19 @@ def event_around_return(
             n_obs=n_events,
             n_obs_axis="events",
             n_events=n_events,
+            n_events_eligible=n_events_eligible,
             n_invalid_prices=n_invalid_prices,
             baseline_bar_return=None,
-            per_offset={},
+            per_offset=per_offset,
         )
 
-    per_offset: dict[int, dict] = {}
     pre_leakage_vals: list[float] = []
     pre_leakage_se: list[float] = []
 
-    for k in offsets:
+    for k in resolved_offsets:
         subset = event_rets.filter(pl.col("offset") == k)
         n = len(subset)
         if n < 5:
-            per_offset[k] = {"mean": None, "n": n}
             continue
 
         arr = subset["signed_return"].to_numpy()
@@ -256,6 +286,7 @@ def event_around_return(
         mean_v = float(np.mean(excess))
         se = float(np.std(excess, ddof=DDOF) / np.sqrt(n)) if n > 1 else float("nan")
         per_offset[k] = {
+            **offset_audit[k],
             "mean": mean_v,
             "se": se,
             # The scale the score has to be read against: |mean| of a true null
@@ -292,7 +323,10 @@ def event_around_return(
     # row count is not it; the distinct event count is.
     warning_codes: list[str] = []
     _warn_ragged_event_grid(
-        "event_around_return", data, warning_codes, expected_warnings=expected_warnings
+        "event_around_return",
+        path_data,
+        warning_codes,
+        expected_warnings=expected_warnings,
     )
 
     return MetricResult(
@@ -303,6 +337,7 @@ def event_around_return(
         warning_codes=tuple(warning_codes),
         metadata={
             "n_events": n_events,
+            "n_events_eligible": n_events_eligible,
             "per_offset": per_offset,
             "baseline_bar_return": baseline,
             # The null scale of the headline: E|x̄| ≈ 0.8 σ/√n > 0 under no

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -36,6 +36,13 @@ from factrix.metrics._helpers import (
     _short_circuit_output,
     _warn_ragged_event_grid,
 )
+
+# Re-exported so the primitive and its metric verb share one import path, the
+# way ``mfe_mae`` re-exports ``compute_mfe_mae``. The redundant alias is the
+# explicit re-export form: nothing in this module body calls it, so a plain
+# import would read as dead. It stays out of ``__all__`` on purpose — the
+# module's declared surface is the metric verb, and the docs page documents the
+# primitive in prose rather than rendering its API a second time.
 from factrix.metrics._primitives import compute_event_returns as compute_event_returns
 from factrix.metrics._primitives._event_returns import (
     _compute_event_returns_with_audit,

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -101,6 +101,9 @@ def mfe_mae(
         data (empty input or fewer than ``MIN_EVENTS_HARD`` rows), returns a
         short-circuit MetricResult (``value=NaN``, ``metadata["reason"]``
         set) so all metrics share a single return contract.
+        ``metadata`` always reports ``n_events_eligible``,
+        ``n_events_computed``, ``n_events_censored``, and
+        ``censor_reasons`` when the producer output is non-empty.
 
     Notes:
         Headline ``ratio = MFE_p50 / |MAE_p25|`` =
@@ -167,6 +170,10 @@ def mfe_mae(
             descriptive=True,
             mfe_mae_ratio=float("nan"),
             n_events=0,
+            n_events_eligible=0,
+            n_events_computed=0,
+            n_events_censored=0,
+            censor_reasons={},
         )
 
     # The panel itself is one DAG node upstream, so compute_mfe_mae measures
@@ -181,10 +188,53 @@ def mfe_mae(
             expected_warnings=expected_warnings,
         )
 
-    mfe = mfe_mae_df["mfe"].drop_nulls().drop_nans()
-    mae = mfe_mae_df["mae"].drop_nulls().drop_nans()
+    valid = mfe_mae_df.filter(pl.col("mfe").is_finite() & pl.col("mae").is_finite())
+    n_events_eligible = mfe_mae_df.height
+    n_events = valid.height
+    n_events_censored = n_events_eligible - n_events
+    if "censor_reason" in mfe_mae_df.columns:
+        reason_rows = (
+            mfe_mae_df.filter(pl.col("censor_reason") != "")
+            .group_by("censor_reason")
+            .len()
+        )
+        censor_reasons = {
+            str(reason): int(count) for reason, count in reason_rows.iter_rows()
+        }
+    elif n_events_censored:
+        censor_reasons = {"non_finite_excursion": n_events_censored}
+    else:
+        censor_reasons = {}
 
-    n_events = min(len(mfe), len(mae))
+    audit = {
+        "n_events": n_events,
+        "n_events_eligible": n_events_eligible,
+        "n_events_computed": n_events,
+        "n_events_censored": n_events_censored,
+        "censor_reasons": censor_reasons,
+    }
+    if n_events == 0:
+        reason = (
+            "no_price_data"
+            if censor_reasons == {"missing_price_column": n_events_eligible}
+            else "no_complete_event_paths"
+        )
+        return _short_circuit_output(
+            "mfe_mae",
+            reason,
+            descriptive=True,
+            n_obs=0,
+            n_obs_axis="events",
+            mfe_mae_ratio=float("nan"),
+            n_events=n_events,
+            n_events_eligible=n_events_eligible,
+            n_events_computed=n_events,
+            n_events_censored=n_events_censored,
+            censor_reasons=censor_reasons,
+        )
+
+    mfe = valid["mfe"]
+    mae = valid["mae"]
     sc = _enforce_min_floor(
         mfe_mae,
         "mfe_mae",
@@ -195,6 +245,10 @@ def mfe_mae(
         warning_codes=tuple(warning_codes),
         mfe_mae_ratio=float("nan"),
         n_events=n_events,
+        n_events_eligible=n_events_eligible,
+        n_events_computed=n_events,
+        n_events_censored=n_events_censored,
+        censor_reasons=censor_reasons,
     )
     if sc is not None:
         return sc
@@ -211,13 +265,16 @@ def mfe_mae(
         "mae_p25": mae_p25,
         "mfe_mae_ratio": ratio,
         "mfe_mae_ratio_status": status,
-        "n_events": n_events,
+        **audit,
     }
 
     # Normalized quantiles (apples-to-apples across horizons / vol regimes).
     if "mfe_z" in mfe_mae_df.columns:
-        mfe_z = mfe_mae_df["mfe_z"].drop_nulls().drop_nans()
-        mae_z = mfe_mae_df["mae_z"].drop_nulls().drop_nans()
+        z_valid = valid.filter(
+            pl.col("mfe_z").is_finite() & pl.col("mae_z").is_finite()
+        )
+        mfe_z = z_valid["mfe_z"]
+        mae_z = z_valid["mae_z"]
         if len(mfe_z) >= MIN_EVENTS_HARD and len(mae_z) >= MIN_EVENTS_HARD:
             mfe_z_p50 = float(mfe_z.quantile(0.50))  # type: ignore[arg-type]
             mae_z_p25 = float(mae_z.quantile(0.25))  # type: ignore[arg-type]

--- a/factrix/metrics/mfe_mae.py
+++ b/factrix/metrics/mfe_mae.py
@@ -163,10 +163,15 @@ def mfe_mae(
         >>> result.name == ""
         True
     """
+    # An absent price column no longer empties the frame: the producer keeps
+    # one ``missing_price_column`` row per event, and the count-zero branch
+    # below names that case. What is left here is a panel that carried no
+    # event at all, which is its own reason - ``no_price_data`` would send a
+    # reader hunting for a price column this branch never inspected.
     if mfe_mae_df.is_empty():
         return _short_circuit_output(
             "mfe_mae",
-            "no_price_data",
+            "no_events",
             descriptive=True,
             mfe_mae_ratio=float("nan"),
             n_events=0,
@@ -202,6 +207,8 @@ def mfe_mae(
             str(reason): int(count) for reason, count in reason_rows.iter_rows()
         }
     elif n_events_censored:
+        # Every in-tree producer path stamps ``censor_reason``; this attributes
+        # the censored count for a frame a caller assembled by hand.
         censor_reasons = {"non_finite_excursion": n_events_censored}
     else:
         censor_reasons = {}

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -167,7 +167,12 @@ class TestEventAroundReturn:
         result = event_around_return(no_price_data)
         assert math.isnan(result.value)
         assert result.metadata["reason"] == "no_price_data"
-        assert result.metadata["per_offset"] == {}
+        assert result.metadata["per_offset"]
+        eligible = result.metadata["n_events_eligible"]
+        assert all(
+            audit["censor_reasons"] == {"missing_price_column": eligible}
+            for audit in result.metadata["per_offset"].values()
+        )
 
     def test_reports_its_sample_size_on_the_event_axis(self, event_data):
         # n_obs is the library's single source of truth for sample size, and
@@ -206,7 +211,7 @@ class TestEventAroundReturn:
         assert result.metadata["reason"] == "invalid_price_data"
         assert result.metadata["n_invalid_prices"] == 1
         assert result.metadata["baseline_bar_return"] is None
-        assert result.metadata["per_offset"] == {}
+        assert result.metadata["per_offset"]
         assert fx.WarningCode.METRIC_UNAVAILABLE.value in result.warning_codes
 
 

--- a/tests/test_event_period_grid.py
+++ b/tests/test_event_period_grid.py
@@ -354,12 +354,15 @@ class TestRaggedExcursionWindow:
         # A dense name on the same panel is untouched.
         assert out.filter(pl.col("asset_id") == "A").height == 1
 
-    def test_excursion_entirely_inside_the_hole_yields_no_event(self) -> None:
+    def test_excursion_entirely_inside_the_hole_is_censored(self) -> None:
         # Event at period 59, hole 60-79, window 10: every period of the
         # excursion is missing for B, so there is no excursion to report.
         panel = _panel(gap=(60, 80), event_at=59)
         out = compute_mfe_mae(panel, window=10)
-        assert out.filter(pl.col("asset_id") == "B").height == 0
+        censored = out.filter(pl.col("asset_id") == "B")
+        assert censored.height == 1
+        assert censored["path_status"][0] == "censored"
+        assert censored["censor_reason"][0] == "missing_path_prices"
         assert out.filter(pl.col("asset_id") == "A").height == 1
 
 

--- a/tests/test_event_price_data.py
+++ b/tests/test_event_price_data.py
@@ -1,0 +1,264 @@
+"""Full price paths stay separate from the forward-return sample (#1051)."""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+import factrix as fx
+import polars as pl
+import pytest
+from factrix._errors import UserInputError
+from factrix.metrics import ic
+from factrix.metrics.event_horizon import compute_event_returns, event_around_return
+from factrix.metrics.mfe_mae import compute_mfe_mae, mfe_mae
+
+
+def _event_panel(
+    *,
+    n_assets: int = 6,
+    n_dates: int = 100,
+    event_at: int = 70,
+) -> pl.DataFrame:
+    dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(n_dates)]
+    rows: list[dict[str, object]] = []
+    for asset_index in range(n_assets):
+        growth = 1.004 + asset_index * 0.0001
+        for index, current_date in enumerate(dates):
+            rows.append(
+                {
+                    "date": current_date,
+                    "asset_id": f"A{asset_index}",
+                    "factor": 1.0 if index == event_at else 0.0,
+                    "price": 100.0 * growth**index,
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+def test_full_price_data_restores_offset_lost_from_forward_return_tail() -> None:
+    raw = _event_panel(n_assets=1)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    truncated = compute_event_returns(panel, offsets=[24])
+    restored = compute_event_returns(panel, price_data=raw, offsets=[24])
+
+    assert truncated.is_empty()
+    assert restored.height == 1
+    prices = raw["price"].to_list()
+    assert restored["signed_return"][0] == pytest.approx(prices[95] / prices[71] - 1)
+
+
+def test_direct_path_primitives_honor_custom_price_column() -> None:
+    raw = _event_panel(n_assets=1).rename({"price": "close"})
+    panel = raw.with_columns(pl.lit(0.0).alias("forward_return"))
+
+    event_returns = compute_event_returns(
+        panel.drop("close"),
+        price_data=raw,
+        offsets=[1],
+        price_col="close",
+    )
+    excursions = compute_mfe_mae(
+        panel.drop("close"),
+        price_data=raw,
+        price_col="close",
+        window=5,
+        estimation_window=20,
+    )
+
+    assert event_returns.height == 1
+    assert excursions.height == 1
+    assert excursions["path_status"][0] == "computed"
+
+
+def test_evaluate_routes_full_price_data_and_reports_offset_audit() -> None:
+    raw = _event_panel()
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    result = fx.evaluate(
+        panel,
+        price_data=raw,
+        metrics={"path": event_around_return(offsets=[-1, 24])},
+        factor_cols=["factor"],
+        strict=False,
+    )["factor"].metrics["path"]
+
+    audit = result.metadata["per_offset"][24]
+    assert audit["eligible"] == 6
+    assert audit["computed"] == 6
+    assert audit["censored"] == 0
+    assert audit["censor_reasons"] == {}
+    assert audit["n"] == 6
+    assert audit["mean"] is not None
+    assert result.n_obs == 6
+
+
+def test_mfe_mae_uses_full_price_data_without_entering_return_sample() -> None:
+    raw = _event_panel()
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    result = fx.evaluate(
+        panel,
+        price_data=raw,
+        metrics={"mfe": mfe_mae()},
+        factor_cols=["factor"],
+        strict=False,
+    )["factor"].metrics["mfe"]
+
+    assert result.n_obs == 6
+    assert result.metadata["n_events_eligible"] == 6
+    assert result.metadata["n_events_computed"] == 6
+    assert result.metadata["n_events_censored"] == 0
+    assert result.metadata["censor_reasons"] == {}
+
+
+def test_price_data_does_not_change_forward_return_metric_sample() -> None:
+    raw = fx.datasets.make_cs_panel(n_assets=40, n_dates=80, rng=1051)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+
+    without_prices = fx.evaluate(
+        panel,
+        metrics={"ic": ic()},
+        factor_cols=["factor"],
+    )["factor"].metrics["ic"]
+    with_prices = fx.evaluate(
+        panel,
+        price_data=raw,
+        metrics={"ic": ic()},
+        factor_cols=["factor"],
+    )["factor"].metrics["ic"]
+
+    assert with_prices.value == without_prices.value
+    assert with_prices.p_value == without_prices.p_value
+    assert with_prices.n_obs == without_prices.n_obs
+    assert with_prices.metadata == without_prices.metadata
+
+
+def test_full_price_grid_is_independent_of_coarser_evaluation_grid() -> None:
+    raw = _event_panel(n_assets=1, event_at=60)
+    grid = raw["date"].unique().sort()
+    panel = fx.preprocess.compute_forward_return(
+        raw,
+        forward_periods=5,
+        dates=grid.gather_every(10),
+    )
+
+    restored = compute_event_returns(panel, price_data=raw, offsets=[24])
+
+    assert panel["date"].n_unique() < raw["date"].n_unique()
+    assert restored.height == 1
+    prices = raw["price"].to_list()
+    assert restored["signed_return"][0] == pytest.approx(prices[85] / prices[61] - 1)
+
+
+def test_ragged_price_path_reports_computed_and_censored_offsets() -> None:
+    raw = _event_panel(n_assets=2, n_dates=50, event_at=20)
+    missing_exit = date(2020, 1, 1) + timedelta(days=27)
+    ragged_prices = raw.filter(
+        ~((pl.col("asset_id") == "A1") & (pl.col("date") == missing_exit))
+    )
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=2)
+
+    result = event_around_return(
+        panel,
+        price_data=ragged_prices,
+        offsets=[6],
+    )
+
+    audit = result.metadata["per_offset"][6]
+    assert audit["eligible"] == 2
+    assert audit["computed"] == 1
+    assert audit["censored"] == 1
+    assert audit["censor_reasons"] == {"missing_exit_price": 1}
+
+
+def test_mfe_mae_retains_censored_events_with_reason() -> None:
+    raw = _event_panel(n_assets=4, n_dates=20, event_at=19)
+    event_data = raw.with_columns(pl.lit(0.0).alias("forward_return"))
+
+    paths = compute_mfe_mae(event_data, price_data=raw, window=5)
+    result = mfe_mae(paths)
+
+    assert paths.height == 4
+    assert paths["path_status"].unique().to_list() == ["censored"]
+    assert paths["censor_reason"].unique().to_list() == ["window_out_of_bounds"]
+    assert math.isnan(result.value)
+    assert result.metadata["reason"] == "no_complete_event_paths"
+    assert result.metadata["n_events_eligible"] == 4
+    assert result.metadata["n_events_computed"] == 0
+    assert result.metadata["n_events_censored"] == 4
+    assert result.metadata["censor_reasons"] == {"window_out_of_bounds": 4}
+
+
+def test_mfe_mae_counts_mixed_computed_and_censored_paths() -> None:
+    raw = _event_panel(n_assets=6)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    incomplete_prices = raw.filter(pl.col("asset_id") != "A5")
+
+    paths = compute_mfe_mae(panel, price_data=incomplete_prices, window=5)
+    result = mfe_mae(paths)
+
+    assert paths.height == 6
+    assert result.metadata["n_events_eligible"] == 6
+    assert result.metadata["n_events_computed"] == 5
+    assert result.metadata["n_events_censored"] == 1
+    assert result.metadata["censor_reasons"] == {"asset_not_in_price_data": 1}
+    assert result.n_obs == 5
+
+
+def test_mfe_mae_sample_floor_counts_only_computed_paths() -> None:
+    raw = _event_panel(n_assets=4)
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    incomplete_prices = raw.filter(pl.col("asset_id") != "A3")
+
+    result = fx.evaluate(
+        panel,
+        price_data=incomplete_prices,
+        metrics={"mfe": mfe_mae()},
+        factor_cols=["factor"],
+        strict=False,
+    )["factor"].metrics["mfe"]
+
+    assert math.isnan(result.value)
+    assert result.metadata["reason"] == "insufficient_events"
+    assert result.metadata["n_events_eligible"] == 4
+    assert result.metadata["n_events_computed"] == 3
+    assert result.metadata["n_events_censored"] == 1
+    assert result.n_obs == 3
+
+
+def test_evaluate_rejects_misaligned_price_key_dtype() -> None:
+    raw = _event_panel()
+    panel = fx.preprocess.compute_forward_return(raw, forward_periods=5)
+    misaligned = raw.with_columns(pl.col("date").cast(pl.Datetime("us")))
+
+    with pytest.raises(UserInputError) as excinfo:
+        fx.evaluate(
+            panel,
+            price_data=misaligned,
+            metrics={"path": event_around_return()},
+            factor_cols=["factor"],
+        )
+
+    assert excinfo.value.func_name == "evaluate"
+    assert excinfo.value.field == "price_data.date"
+
+
+def test_evaluate_horizons_automatically_preserves_full_price_grid() -> None:
+    raw = _event_panel()
+
+    results = fx.evaluate_horizons(
+        raw,
+        metrics={"path": event_around_return(offsets=[-1, 24])},
+        factor_cols=["factor"],
+        forward_periods=[5, 10],
+        strict=False,
+    )
+
+    assert len(results) == 2
+    for result in results:
+        audit = result.metrics["path"].metadata["per_offset"][24]
+        assert audit["eligible"] == 6
+        assert audit["computed"] == 6
+        assert audit["censored"] == 0

--- a/tests/test_event_price_data.py
+++ b/tests/test_event_price_data.py
@@ -262,3 +262,23 @@ def test_evaluate_horizons_automatically_preserves_full_price_grid() -> None:
         assert audit["eligible"] == 6
         assert audit["computed"] == 6
         assert audit["censored"] == 0
+
+
+def test_duplicate_price_rows_are_explained_as_a_price_grid_defect() -> None:
+    """A duplicated price row is not a fabricated forward return.
+
+    ``price_data`` never feeds the forward-return shift, so the panel
+    validator's explanation of a duplicate key names the wrong quantity
+    on this path. The price grid's own failure is that one period holds
+    two prices, and the excursion walk cannot say which one it entered
+    at.
+    """
+    raw = _event_panel(n_assets=1)
+    duplicated = pl.concat([raw, raw.head(1)])
+
+    with pytest.raises(UserInputError) as excinfo:
+        compute_event_returns(raw, price_data=duplicated, offsets=[1])
+
+    message = str(excinfo.value)
+    assert "price_data" in message
+    assert "The forward return shifts by row position" not in message

--- a/tests/test_mfe_mae.py
+++ b/tests/test_mfe_mae.py
@@ -111,9 +111,11 @@ class TestComputeMfeMae:
             (finite["mae"] / scale).to_numpy(),
         )
 
-    def test_no_price_returns_empty(self, no_price_data):
+    def test_no_price_returns_censored_events(self, no_price_data):
         result = compute_mfe_mae(no_price_data, window=10)
-        assert result.is_empty()
+        assert result.height == no_price_data.filter(pl.col("factor") != 0).height
+        assert result["path_status"].unique().to_list() == ["censored"]
+        assert result["censor_reason"].unique().to_list() == ["missing_price_column"]
 
     def test_no_events_returns_empty(self):
         df = pl.DataFrame(

--- a/tests/test_mfe_mae.py
+++ b/tests/test_mfe_mae.py
@@ -216,8 +216,65 @@ class TestMfeMae:
         )
         result = mfe_mae(empty)
         assert math.isnan(result.value)
-        assert result.metadata["reason"] == "no_price_data"
+        assert result.metadata["reason"] == "no_events"
         assert result.metadata["n_events"] == 0
+
+    def test_zero_events_and_missing_prices_are_distinct_reasons(self):
+        """An empty producer frame means no events, never absent prices.
+
+        ``compute_mfe_mae`` keeps one censored row per event when the
+        price column is absent, so the empty frame is reachable only
+        when the panel carried no event at all. The two conditions need
+        two reasons: a reader who sees ``no_price_data`` goes looking
+        for a price column that is, in this branch, already there.
+        """
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(6)]
+        priced_without_events = pl.DataFrame(
+            {
+                "date": pl.Series(dates, dtype=pl.Datetime("ms")),
+                "asset_id": ["A"] * 6,
+                "factor": [0.0] * 6,
+                "price": [100.0 + i for i in range(6)],
+            }
+        )
+        events_without_price = pl.DataFrame(
+            {
+                "date": pl.Series(dates, dtype=pl.Datetime("ms")),
+                "asset_id": ["A"] * 6,
+                "factor": [0.0, 1.0, 0.0, 1.0, 0.0, 0.0],
+            }
+        )
+
+        no_events = mfe_mae(compute_mfe_mae(priced_without_events, window=3))
+        no_prices = mfe_mae(compute_mfe_mae(events_without_price, window=3))
+
+        assert (no_events.metadata["reason"], no_prices.metadata["reason"]) == (
+            "no_events",
+            "no_price_data",
+        )
+        assert no_events.metadata["n_events_eligible"] == 0
+        assert no_prices.metadata["n_events_eligible"] == 2
+
+    def test_frame_without_censor_reason_falls_back_to_non_finite(self):
+        """A hand-built producer frame carries no ``censor_reason``.
+
+        Pinning test: this passes on the unchanged codebase. It fixes
+        the fallback's reachability against silent drift, because every
+        in-tree producer path stamps the column and only a frame a
+        caller assembled by hand can reach the branch.
+        """
+        dates = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(3)]
+        hand_built = pl.DataFrame(
+            {
+                "date": pl.Series(dates, dtype=pl.Datetime("ms")),
+                "asset_id": ["A", "B", "C"],
+                "mfe": [float("nan"), float("nan"), float("nan")],
+                "mae": [float("nan"), float("nan"), float("nan")],
+            }
+        )
+        result = mfe_mae(hand_built)
+        assert result.metadata["censor_reasons"] == {"non_finite_excursion": 3}
+        assert result.metadata["reason"] == "no_complete_event_paths"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_short_circuit_contract_consistency.py
+++ b/tests/test_short_circuit_contract_consistency.py
@@ -81,7 +81,7 @@ CaseFactory = Callable[[], MetricResult]
                     mae=pl.Float64,
                 )
             ),
-            "no_price_data",
+            "no_events",
             UserInputError,
             id="mfe_mae",
         ),


### PR DESCRIPTION
## Summary

- add a run-level price_data panel so event offsets and MFE/MAE windows retain raw tail and between-evaluation-date prices
- keep event eligibility and forward-return samples owned by data, preventing price-only rows from entering return metrics or sample floors
- report eligible, computed, censored, and reason counts for event offsets and excursion paths
- document the three-grid ownership contract and the pre-1.0 MFE/MAE row-retention migration

## Verification

- pre-commit Ruff hooks passed
- mypy factrix passed (83 source files)
- local full pytest excluding the unavailable mkdocs-material inventory-only file: 3811 passed, 50 skipped
- local doctests: 96 passed, 1 skipped
- focused price-path regressions: 12 passed
- offline sdist and wheel build passed
- GitHub Actions: lint/mypy, Python 3.12-3.14 on Linux/macOS/Windows, dependency floors, doctests, wheel smoke, strict docs build, and link check all passed

Closes #1051