### PR TITLE
fix(oos_decay): validate threshold and time-index contract

### DIFF
--- a/docs/api/metrics/oos_decay.md
+++ b/docs/api/metrics/oos_decay.md
@@ -33,6 +33,30 @@ title: factrix.metrics.oos_decay
     $|\mathrm{mean}_{\text{OOS}}| / |\mathrm{mean}_{\text{IS}}|$ on a
     single `is_ratio` split.
 
+-   __One row per period, finite values only__
+
+    ---
+
+    The split is a count of periods on the series' own distinct-date
+    grid, taken positionally after a sort by date. A duplicated date has
+    no defined position in that sort, so it could put the same
+    chronological period on both sides of the boundary; it raises
+    `UserInputError` rather than being aggregated under a rule the
+    caller never chose. Null / NaN / $\pm\infty$ observations are
+    dropped first and recorded in `metadata`, so `n_obs` and the split
+    index count the same periods.
+
+-   __`survival_threshold` is a retention fraction__
+
+    ---
+
+    Its domain is the finite half-open interval $(0, 1]$, validated at
+    construction. Outside it the knob stops gating and starts forcing:
+    $\le 0$ passes every series a ratio exists for, `float("nan")`
+    vetoes every one of them, and `True` reads as `1.0`. A threshold
+    above 1 would demand out-of-sample *amplification* rather than
+    survival — read `value` directly for that question.
+
 -   __Sign-flip veto__
 
     ---

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -1964,6 +1964,23 @@ def _validate_choice(
         )
 
 
+def _is_finite_number(value: object) -> bool:
+    """``value`` is a real, finite number — bool, NaN and ±inf excluded.
+
+    The shared type guard every numeric-knob validator applies before it
+    compares. A bool is an int to Python and a string is not a number at all;
+    both would otherwise reach the comparison and either pass (``True`` is 1)
+    or raise a bare ``TypeError`` instead of the library's own diagnostic.
+    NaN fails every comparison and ±inf passes any one-sided bound, so a
+    range check alone is not enough to catch either.
+    """
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int | float)
+        and math.isfinite(value)
+    )
+
+
 def _validate_open_unit_interval(
     value: float,
     *,
@@ -1979,17 +1996,39 @@ def _validate_open_unit_interval(
     """
     from factrix._errors import UserInputError
 
-    # A bool is an int to Python and a string is not a number at all; both
-    # would otherwise reach the comparison and either pass (``True`` is 1) or
-    # raise a bare TypeError instead of the library's own diagnostic. NaN
-    # fails every comparison, so it lands here too.
-    numeric = not isinstance(value, bool) and isinstance(value, int | float)
-    if not numeric or not 0.0 < float(value) < 1.0:
+    if not _is_finite_number(value) or not 0.0 < float(value) < 1.0:
         raise UserInputError(
             func_name=func_name,
             field=field,
             value=value,
             expected=f"a fraction strictly inside (0, 1). {detail}",
+            docs_path=docs_path,
+        )
+
+
+def _validate_half_open_unit_interval(
+    value: object,
+    *,
+    func_name: str,
+    field: str,
+    detail: str,
+    docs_path: str,
+) -> None:
+    """Reject a fraction knob outside the half-open interval ``(0, 1]``.
+
+    The twin of :func:`_validate_open_unit_interval` for a knob whose upper
+    endpoint is a legal request rather than a degeneracy — a *retention*
+    fraction, where ``1`` means "keep all of it" and only ``0`` (keep nothing,
+    so the comparison it gates can never fail) is meaningless.
+    """
+    from factrix._errors import UserInputError
+
+    if not _is_finite_number(value) or not 0.0 < float(value) <= 1.0:  # type: ignore[arg-type]
+        raise UserInputError(
+            func_name=func_name,
+            field=field,
+            value=value,
+            expected=f"a fraction inside (0, 1]. {detail}",
             docs_path=docs_path,
         )
 

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -36,9 +36,11 @@ from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     DEGENERATE_SIGNAL_STATUS,
     _enforce_min_floor,
+    _finite_values,
     _resolve_series_value_col,
     _short_circuit_output,
     _surface_null_drop,
+    _validate_half_open_unit_interval,
     _validate_open_unit_interval,
 )
 from factrix.metrics.ic import compute_ic
@@ -55,7 +57,12 @@ _MIN_SPLIT_OBS = 2
 
 
 def _validate_oos_decay(m: MetricBase) -> None:
-    """``is_ratio`` splits the series, so it is a fraction strictly inside (0, 1)."""
+    """Both gate knobs are fractions, checked before any data work.
+
+    ``is_ratio`` splits the series, so it is strictly inside ``(0, 1)``;
+    ``survival_threshold`` is the share of in-sample magnitude the factor must
+    retain, so it is inside ``(0, 1]``.
+    """
     _validate_open_unit_interval(
         m.is_ratio,  # type: ignore[attr-defined]
         func_name="oos_decay",
@@ -63,6 +70,57 @@ def _validate_oos_decay(m: MetricBase) -> None:
         detail=(
             "0 leaves no in-sample window and 1 leaves no out-of-sample "
             "window, so no survival ratio is defined."
+        ),
+        docs_path="api/metrics/oos_decay",
+    )
+    # WHY: an unvalidated threshold silently forces the gate rather than
+    # failing. The survival ratio is a non-negative magnitude ratio, so any
+    # value <= 0 PASSes every series a ratio can be computed for (a gate that
+    # cannot veto is not a gate), NaN fails every comparison and so VETOES
+    # every series, and ``True`` is 1.0 to Python. ``> 1`` asks for
+    # out-of-sample *amplification*, which is not the decay this diagnostic
+    # gates on; ask for it with an explicit read of ``value`` instead.
+    _validate_half_open_unit_interval(
+        m.survival_threshold,  # type: ignore[attr-defined]
+        func_name="oos_decay",
+        field="survival_threshold",
+        detail=(
+            "It is the share of the in-sample mean magnitude the factor must "
+            "retain out of sample; 0 passes every series and a value above 1 "
+            "demands out-of-sample amplification rather than survival."
+        ),
+        docs_path="api/metrics/oos_decay",
+    )
+
+
+def _require_one_row_per_period(series: pl.DataFrame) -> None:
+    """Reject a series carrying more than one observation per distinct date.
+
+    The split is a *period* count on the series' own distinct-date grid, taken
+    positionally after sorting. A duplicated date has no defined position in
+    that sort, so the cut can fall between two observations of the same period
+    and put one chronological period on both sides of the IS/OOS boundary —
+    the leakage the split exists to prevent. Rejected rather than aggregated:
+    the DAG producers (``compute_ic``, ``compute_spread_series``) emit exactly
+    one row per period, so no aggregation rule is needed to match them, and
+    picking one silently (mean? last?) would apply a statistic the caller
+    never asked for. Follows ``spanning``'s treatment of the same input shape.
+    """
+    n_periods = series["date"].n_unique()
+    if n_periods == series.height:
+        return
+    from factrix._errors import UserInputError
+
+    raise UserInputError(
+        func_name="oos_decay",
+        field="series",
+        value=f"{series.height} rows for {n_periods} distinct periods",
+        expected=(
+            "one row per period on the series' distinct-date grid. A "
+            "duplicated date makes the IS/OOS cut ambiguous, so the same "
+            "period can land on both sides of the split. Aggregate to one "
+            "observation per period first, e.g. "
+            'series.group_by("date").mean().sort("date")'
         ),
         docs_path="api/metrics/oos_decay",
     )
@@ -94,16 +152,27 @@ def oos_decay(
     survival ratio), and checks for an IS/OOS sign flip.
 
     Args:
-        series: DataFrame with ``date`` and ``value_col``, sorted by date.
-        value_col: Numeric column to evaluate.
-        is_ratio: Fraction of the series allocated to IS (default ``0.7``).
-            Must lie strictly inside ``(0, 1)``.
+        series: DataFrame with ``date`` and ``value_col``, carrying exactly
+            **one row per period** on its own distinct-date grid (what every
+            producer in the DAG emits). Row order is irrelevant — the series
+            is sorted by date here.
+        value_col: Numeric column to evaluate. Null, NaN and ±inf
+            observations are dropped and the drop is recorded in
+            ``metadata``; the periods that remain are the split's grid.
+        is_ratio: Fraction of the retained periods allocated to IS (default
+            ``0.7``). Must lie strictly inside ``(0, 1)``.
         survival_threshold: Minimum survival ratio for ``status="PASS"``
-            (default ``0.5``).
+            (default ``0.5``). It is the share of the in-sample mean
+            magnitude the factor must retain out of sample, so its domain is
+            the finite half-open interval ``(0, 1]``.
 
     Raises:
-        UserInputError: ``is_ratio`` is not strictly inside ``(0, 1)``.
-            Raised at construction, before any data work.
+        UserInputError: ``is_ratio`` is not strictly inside ``(0, 1)``, or
+            ``survival_threshold`` is not inside ``(0, 1]`` (bool, NaN, ±inf
+            and non-numeric included). Raised at construction, before any
+            data work.
+        UserInputError: ``series`` carries more than one row for some date.
+            Raised at call time, before the split.
 
     Returns:
         MetricResult with:
@@ -150,6 +219,23 @@ def oos_decay(
         ``reason="insufficient_oos_periods"`` rather than reporting a
         survival ratio computed from a single point.
 
+        **Input contract.** The split is a count of periods on the series'
+        own distinct-date grid, taken positionally after sorting by date, so
+        the series must carry one row per period. A duplicated date has no
+        defined position in that sort and can put the same chronological
+        period on both sides of the boundary; it is rejected rather than
+        aggregated under a guessed rule (see :class:`UserInputError` above).
+        Non-finite observations are dropped first, so ``n_obs`` and the split
+        index both count the periods that actually reached the means.
+
+        **Threshold domain.** ``survival_threshold`` is validated as a finite
+        fraction inside ``(0, 1]``. Outside that range the knob stops gating
+        and starts forcing: ``<= 0`` PASSes every series a ratio exists for,
+        ``float("nan")`` VETOES every one of them, and ``True`` silently
+        reads as ``1.0``. A threshold above 1 would demand out-of-sample
+        amplification rather than survival — read ``value`` directly for
+        that question.
+
     References:
         - [McLean-Pontiff (2016)][mclean-pontiff-2016]: post-publication
           returns ~58% lower than in-sample, with ~32% of that drop
@@ -176,8 +262,12 @@ def oos_decay(
         True
     """
     value_col = _resolve_series_value_col(series, value_col)
+    _require_one_row_per_period(series)
     sorted_series = series.sort("date")
-    vals = sorted_series[value_col].drop_nulls().drop_nans()
+    # One row per period, so dropping the non-finite observations leaves one
+    # value per surviving period: `n` counts periods on the series' own
+    # distinct-date grid and the split index below is a period count.
+    vals = _finite_values(sorted_series[value_col])
     n = len(vals)
 
     sc = _enforce_min_floor(
@@ -260,7 +350,7 @@ def oos_decay(
     _surface_null_drop(
         n_periods_in=sorted_series.height,
         n_periods_out=n,
-        drop_reason="null / NaN value observations in the series",
+        drop_reason="null / NaN / +-inf value observations in the series",
         metric_name="oos_decay",
         metadata=metadata,
         warning_codes=warning_codes,

--- a/tests/test_knob_validation.py
+++ b/tests/test_knob_validation.py
@@ -72,6 +72,7 @@ BOUNDED_KNOBS: list[tuple[str, dict[str, Any], str]] = [
     ("breakeven_cost", {"turnover": 0.2, "holding_periods": 0}, "holding_periods"),
     ("net_spread", {"turnover": 0.2, "holding_periods": 0}, "holding_periods"),
     ("oos_decay", {"is_ratio": 1.0}, "is_ratio"),
+    ("oos_decay", {"survival_threshold": 1.5}, "survival_threshold"),
     ("ic_trend", {"adf_threshold": 1.5}, "adf_threshold"),
     ("predictive_beta", {"adf_threshold": 0.0}, "adf_threshold"),
     ("common_beta_profile", {"neutral_epsilon": -1.0}, "neutral_epsilon"),

--- a/tests/test_oos.py
+++ b/tests/test_oos.py
@@ -178,3 +178,143 @@ class TestDegenerateInSampleMean:
         result = oos_decay(_series([1.0] * 20 + [0.5] * 20), is_ratio=0.5)
         assert result.value == pytest.approx(0.5)
         assert "signal_status" not in result.metadata
+
+
+class TestSurvivalThresholdValidation:
+    """``survival_threshold`` is a retention fraction, not a free float.
+
+    An unvalidated threshold silently forces the gate: ``-1.0`` passes every
+    series (a ratio is never negative), ``float("nan")`` fails every
+    comparison and so VETOES every series, and ``True`` is ``1.0`` to Python.
+    """
+
+    @pytest.mark.parametrize(
+        "survival_threshold",
+        [
+            0.0,
+            -0.1,
+            1.5,
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            True,
+            "0.5",
+            None,
+        ],
+    )
+    def test_out_of_domain_threshold_raises(
+        self, survival_threshold, ic_series_positive
+    ):
+        from factrix import UserInputError
+
+        with pytest.raises(UserInputError, match="survival_threshold"):
+            oos_decay(ic_series_positive, survival_threshold=survival_threshold)
+
+    @pytest.mark.parametrize("survival_threshold", [1e-9, 0.5, 1.0])
+    def test_in_domain_threshold_accepted(self, survival_threshold, ic_series_positive):
+        result = oos_decay(ic_series_positive, survival_threshold=survival_threshold)
+        assert result.metadata["survival_threshold"] == survival_threshold
+
+    def test_threshold_boundary_is_inclusive(self):
+        """``survival == survival_threshold`` PASSes: the gate is ``>=``."""
+        series = _series([1.0] * 20 + [0.5] * 20)
+        assert (
+            oos_decay(series, is_ratio=0.5, survival_threshold=0.5).metadata["status"]
+            == "PASS"
+        )
+        assert (
+            oos_decay(series, is_ratio=0.5, survival_threshold=0.5 + 1e-9).metadata[
+                "status"
+            ]
+            == "VETOED"
+        )
+
+
+class TestOneRowPerPeriod:
+    """The series is indexed by period: one observation per distinct date."""
+
+    def test_duplicate_dates_rejected(self):
+        from datetime import datetime, timedelta
+
+        import polars as pl
+        from factrix import UserInputError
+
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(20)]
+        # The 15th period carries two observations, so the row-count split
+        # can cut *between* them and put one period on both sides.
+        dup_dates = [*dates, dates[14]]
+        values = [0.02] * 20 + [-5.0]
+        series = pl.DataFrame({"date": dup_dates, "value": values}).with_columns(
+            pl.col("date").cast(pl.Datetime("ms"))
+        )
+        with pytest.raises(UserInputError, match="one row per period"):
+            oos_decay(series)
+
+    def test_infinite_values_are_dropped_like_nan(self):
+        """±inf is not a finite observation; it must not reach a mean."""
+        from datetime import datetime, timedelta
+
+        import numpy as np
+        import polars as pl
+
+        rng = np.random.default_rng(7)
+        vals = list(rng.normal(0.05, 0.02, 40))
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(40)]
+        clean = pl.DataFrame({"date": dates, "value": vals}).with_columns(
+            pl.col("date").cast(pl.Datetime("ms"))
+        )
+        dirty = pl.DataFrame(
+            {
+                "date": dates + [dates[-1] + timedelta(days=i + 1) for i in range(2)],
+                "value": [*vals, float("inf"), float("-inf")],
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        r_dirty, r_clean = oos_decay(dirty), oos_decay(clean)
+        assert math.isfinite(r_dirty.value)
+        assert r_dirty.value == pytest.approx(r_clean.value)
+        assert r_dirty.n_obs == r_clean.n_obs == 40
+
+    def test_missing_observations_do_not_shift_the_period_split(self):
+        """The split counts *retained* periods, so a null period drops out
+        of the grid entirely rather than straddling the boundary."""
+        from datetime import datetime, timedelta
+
+        import polars as pl
+
+        values: list[float | None] = [1.0] * 20 + [0.5] * 20
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(40)]
+        with_gaps = pl.DataFrame(
+            {
+                "date": dates + [dates[-1] + timedelta(days=i + 1) for i in range(2)],
+                "value": values + [None] * 2,
+            }
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        compact = pl.DataFrame({"date": dates, "value": values}).with_columns(
+            pl.col("date").cast(pl.Datetime("ms"))
+        )
+        gapped = oos_decay(with_gaps, is_ratio=0.5)
+        assert gapped.value == pytest.approx(oos_decay(compact, is_ratio=0.5).value)
+        assert gapped.value == pytest.approx(0.5)
+        assert gapped.n_obs == 40
+
+    def test_direct_call_matches_dag_produced_series(self):
+        """A ``compute_ic`` frame is one row per period; the direct call on
+        the same frame must agree with the DAG-routed one."""
+        import factrix as fx
+        from factrix.metrics.ic import compute_ic
+        from factrix.metrics.oos_decay import oos_decay as _oos
+        from factrix.preprocess import compute_forward_return
+
+        panel = compute_forward_return(
+            fx.datasets.make_cs_panel(n_assets=40, n_dates=120, rng=3),
+            forward_periods=5,
+        )
+        ic_df = compute_ic(panel)["factor"]
+        assert ic_df["date"].n_unique() == ic_df.height
+        direct = _oos(ic_df, value_col="ic")
+        routed = fx.evaluate(
+            panel, metrics={"oos_decay": _oos()}, factor_cols=["factor"]
+        )["factor"].metrics["oos_decay"]
+        assert direct.value == pytest.approx(routed.value)
+        assert direct.metadata["status"] == routed.metadata["status"]


### PR DESCRIPTION
## Summary

`oos_decay` validated `is_ratio` but nothing else. Two contracts were missing.

**1. `survival_threshold` had no domain.** The survival ratio is a non-negative
magnitude ratio, so the knob silently forced the gate instead of gating it:

| passed value | old behaviour |
|---|---|
| `-0.1`, `0.0` | PASS on every series a ratio exists for — a gate that cannot veto |
| `float("nan")` | VETOED on every series (NaN fails every comparison) |
| `True` | read as `1.0` |
| `"0.5"`, `None` | bare `TypeError` from `oos_decay.py:243`, not a factrix diagnostic |

It now has a documented finite domain — the half-open interval `(0, 1]`, read as
"the share of the in-sample mean magnitude the factor must retain out of sample"
— enforced at construction through the same `UserInputError` path `is_ratio`
already used. A value above 1 asks for out-of-sample *amplification* rather than
survival; that question is answered by reading `value` directly, so it is out of
the knob's domain rather than a silently accepted stricter gate.

New shared helper `_validate_half_open_unit_interval`, the twin of the existing
`_validate_open_unit_interval`, plus the bool/NaN/inf type guard factored out of
both as `_is_finite_number` (this also closes `is_ratio=inf` on the same path —
it was already rejected by the range comparison, so no behaviour changed there).

**2. The chronological sample unit was not the period.** The split is a
positional cut on the date-sorted series, so a duplicated date has no defined
position in that sort and the cut could put the same chronological period on
both sides of the IS/OOS boundary — exactly the leakage the split exists to
prevent. Duplicates are now **rejected**, not aggregated:

- every DAG producer (`compute_ic`, `compute_spread_series`) already emits one
  row per period, so no aggregation rule is needed for direct-call/DAG parity;
- picking one silently (mean? last?) would apply a statistic the caller never
  asked for;
- `spanning` already rejects the same input shape for the same reason, so this
  follows an existing precedent rather than inventing a policy.

The error names the row/period counts and suggests
`series.group_by("date").mean().sort("date")` for callers who do want a mean.

**3. `±inf` now drops with null and NaN.** The value column went through
`drop_nulls().drop_nans()`, which keeps `±inf`; one infinite observation made
the window mean infinite and the survival ratio NaN. It now uses the repo-wide
`_finite_values` predicate. With one row per period guaranteed, `n_obs` and the
split index count the same periods on the distinct-date grid — so a missing
observation drops the period out of the grid entirely instead of shifting the
boundary through a half-present period. The recorded `drop_reason` was updated
to name what it actually drops.

Docs: two new cards on `docs/api/metrics/oos_decay.md` (input contract, threshold
domain) and the `Args` / `Raises` / `Notes` sections of the docstring.
`survival_threshold` joins the `BOUNDED_KNOBS` table in `test_knob_validation.py`,
which is the one place that enumerates construction-time bounds.

## Verification

All gates run from the worktree with `.venv/Scripts/python.exe` (`PYTHONUTF8=1`).

- `ruff check .` — All checks passed
- `ruff format --check .` — 250 files already formatted
- `mypy factrix` — Success: no issues found in 83 source files
- `pytest -q -p no:faulthandler` — **3893 passed, 49 skipped** in 334s
- `pytest --doctest-modules factrix -q` — 96 passed, 1 skipped
- `mkdocs build --strict` — Documentation built in 28.50 seconds

### The new tests fail against the unfixed state

Run on `origin/main`'s `oos_decay.py` with the new tests in place —
**11 failed, 6 passed**:

```
E   Failed: DID NOT RAISE UserInputError      (x5: 0.0, -0.1, 1.5, nan, inf, -inf, True)
E   TypeError: '>=' not supported between instances of 'float' and 'str'
    factrix\metrics\oos_decay.py:243: TypeError
E   TypeError: '>=' not supported between instances of 'float' and 'NoneType'
    factrix\metrics\oos_decay.py:243: TypeError
E   Failed: DID NOT RAISE UserInputError      (tests/test_oos.py:250, duplicate dates)
E   assert False
     +  where False = <built-in function isfinite>(nan)
     +    where nan = MetricResult(?=nan, n_obs=42 periods).value   (±inf reached the mean)

FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[0.0]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[-0.1]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[1.5]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[nan]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[inf]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[-inf]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[True]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[0.5]
FAILED tests/test_oos.py::TestSurvivalThresholdValidation::test_out_of_domain_threshold_raises[None]
FAILED tests/test_oos.py::TestOneRowPerPeriod::test_duplicate_dates_rejected
FAILED tests/test_oos.py::TestOneRowPerPeriod::test_infinite_values_are_dropped_like_nan
=========== 11 failed, 6 passed, 17 deselected, 1 warning in 0.49s ============
```

Three of the six that passed unfixed are **pinning tests**, labelled as such
here rather than presented as regression proof — they fix a decision against
silent drift, they do not guard a defect:

- `test_in_domain_threshold_accepted` — `1e-9 / 0.5 / 1.0` stay legal, i.e. the
  new bound is not over-tight at either end;
- `test_threshold_boundary_is_inclusive` — the gate is `>=`, so
  `survival == survival_threshold` PASSes and `+1e-9` above it VETOES;
- `test_missing_observations_do_not_shift_the_period_split` and
  `test_direct_call_matches_dag_produced_series` — the parity these fix was
  already held for null-only input on a unique-date grid; they pin it now that
  the grid is a contract rather than an accident.

Closes #1058
