### PR TITLE
feat(compare): tie-aware ranks and explicit sort semantics

### DIFF
--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -29,7 +29,8 @@ compare(
     *,
     metrics: list[str],
     sort_by: str | None = None,
-    descending: bool = True,
+    descending: bool | None = None,
+    rank_method: Literal["min", "dense", "ordinal"] = "min",
 ) -> pl.DataFrame
 ```
 
@@ -55,18 +56,61 @@ The returned `pl.DataFrame` contains the following columns:
 |-------|---------|---------|
 | `metrics` | (required) | `list[str]` of metric labels to include in the leaderboard. |
 | `sort_by` | `None` | Any output column produced before ranking: `factor`, `forward_periods`, `params` keys, metric value columns such as `ic`, or p-value columns such as `ic_p_value` / `<metric_label>_p_value`. `None` keeps the original list order. |
-| `descending` | `True` | Whether to sort in descending order (higher is better). Set to `False` for lower-is-better metrics. |
+| `descending` | `None` | Sort direction for `sort_by`. `None` resolves it from the column under the [direction rule](#sort-direction); `True` / `False` states it outright and always wins. There is no global direction default. |
+| `rank_method` | `"min"` | How equal `sort_by` values are numbered: `"min"` (tied rows share the best rank, next rank skips: `1, 1, 3`), `"dense"` (share the rank, no gap: `1, 1, 2`), `"ordinal"` (every row numbered `1..N`). Polars' `Expr.rank` methods. |
 
-`rank` is created after sorting, so it is not a valid `sort_by` key. To sort
-by significance, use the p-value column and set `descending=False`:
+### Sort direction
+
+`compare()` has no global `descending` default: a lower-is-better key must never
+inherit a higher-is-better sort. With `descending=None` the direction comes from
+the column itself.
+
+| `sort_by` column | Resolved direction |
+|---|---|
+| `<metric_label>_p_value` | ascending — a smaller p-value is stronger evidence |
+| `factor`, `forward_periods`, `params` keys | ascending — these label a row, they do not score it |
+| `ic`, `ic_ir`, `quantile_spread`, `quantile_spread_vw`, `common_quantile_spread`, `net_spread`, `breakeven_cost` | descending — higher is better by the metric's own definition |
+| `rank_turnover`, `notional_turnover` | ascending — turnover is a cost driver |
+| any other metric label | `UserInputError` — pass `descending` explicitly |
+
+The last row covers custom evaluation labels (`metrics={"ic_nw": ic(...)}`) and
+signed metrics such as `predictive_beta`, `fm_beta` and `spanning_alpha`, where
+"largest positive value" is a different question from "strongest effect".
+
+### Ties, order, and missing values
+
+Rows sort on `sort_by`, then on `factor` and `forward_periods` ascending, then on
+any `params` column of a sortable dtype, so the output does not depend on the
+order of the input `results`. Rows equal on every one of those columns are
+indistinguishable and keep input order among themselves; under `"min"` and
+`"dense"` they carry the same rank anyway.
+
+A `null` or `NaN` `sort_by` value sorts **last** in both directions and carries a
+`null` rank under every `rank_method` — a row with no value has no place in the
+ranking.
+
+### Examples
+
+`rank` is created after sorting, so it is not a valid `sort_by` key.
 
 ```python title="Illustrative"
-df = fx.compare(results, metrics=["ic"], sort_by="ic_p_value", descending=False)
+# Alpha / information-ratio style metric: higher is better, resolved for you.
+df = fx.compare(results, metrics=["ic", "ic_ir"], sort_by="ic_ir")
+
+# Turnover: lower is better, resolved the same way.
+df = fx.compare(results, metrics=["rank_turnover"], sort_by="rank_turnover")
+
+# Significance screen; equally significant factors share one rank.
+df = fx.compare(results, metrics=["ic"], sort_by="ic_p_value", rank_method="min")
+
+# A custom label carries no direction, so state one.
+df = fx.compare(results, metrics=["ic_nw"], sort_by="ic_nw", descending=True)
 ```
 
 For signed metrics such as `predictive_beta`, sorting by the raw value answers
 "largest positive effect", not "strongest evidence". A strongly negative but
-highly significant factor will rank low under `sort_by="predictive_beta"` with
-the default descending order. Use the p-value column for significance screens,
+highly significant factor ranks low under `sort_by="predictive_beta",
+descending=True` — which is why those labels have no resolved direction and must
+be given one. Use the p-value column for significance screens,
 or sort on `abs(value)` in caller code when magnitude regardless of sign is the
 intended ranking.

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -11,7 +11,7 @@ union + null-fill — so a result missing ``region`` surfaces as a
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 
@@ -19,13 +19,46 @@ from factrix._errors import UserInputError
 from factrix._multi_factor import _require_non_empty_results, _validate_metric_list
 from factrix._results import EvaluationResult, _float_or_none
 
+RankMethod = Literal["min", "dense", "ordinal"]
+
+_RANK_METHODS: tuple[RankMethod, ...] = ("min", "dense", "ordinal")
+
+# Sort direction for metric columns whose direction follows from the
+# metric's own definition: a return-like or evidence-like quantity that
+# is better when larger, or a cost driver that is better when smaller.
+# Signed metrics (``predictive_beta``, ``fm_beta``, ``spanning_alpha``,
+# ``caar``, ``ic_trend`` …) are deliberately absent — "largest positive
+# value" is not the same question as "strongest effect", so those keys
+# require an explicit ``descending``.
+_HIGHER_IS_BETTER: frozenset[str] = frozenset(
+    {
+        "ic",
+        "ic_ir",
+        "quantile_spread",
+        "quantile_spread_vw",
+        "common_quantile_spread",
+        "net_spread",
+        "breakeven_cost",
+    }
+)
+_LOWER_IS_BETTER: frozenset[str] = frozenset({"rank_turnover", "notional_turnover"})
+
+# Identity columns that also serve as deterministic tiebreakers.
+_IDENTITY_COLS: tuple[str, ...] = ("factor", "forward_periods")
+
+# Hidden ordering key: the sort column with NaN folded into null so that
+# "missing last" holds in both directions (polars orders NaN as the
+# largest float, which would otherwise put it first under descending).
+_SORT_KEY = "__factrix_sort_key"
+
 
 def compare(
     results: list[EvaluationResult],
     *,
     metrics: list[str],
     sort_by: str | None = None,
-    descending: bool = True,
+    descending: bool | None = None,
+    rank_method: RankMethod = "min",
 ) -> pl.DataFrame:
     """Render a wide leaderboard ``pl.DataFrame`` for multiple metrics.
 
@@ -47,15 +80,43 @@ def compare(
             before ranking: identity columns, params keys, metric value
             columns, or ``<metric_label>_p_value`` columns. ``None`` keeps
             input order and omits the ``rank`` column.
-        descending: Sort direction applied to ``sort_by``. Default
-            ``True`` (higher-is-better, the common case for ``ic`` /
-            ``alpha`` / information ratio). Pass ``descending=False``
-            for lower-is-better metrics such as ``rank_turnover`` or any
-            cost / drag metric. :class:`str` deliberately does
-            not carry a ``higher_is_better`` flag — encoding sort
-            direction in the type system bakes in a default that
-            silently mis-ranks when wrong. No-op when ``sort_by`` is
-            ``None``.
+        descending: Sort direction applied to ``sort_by``. ``None`` (the
+            default) resolves the direction from the column itself, under
+            the rule below; pass ``True`` / ``False`` to state it
+            outright, which always wins over the rule. There is no global
+            direction default — a lower-is-better key must never inherit
+            a higher-is-better sort. No-op when ``sort_by`` is ``None``.
+        rank_method: How equal ``sort_by`` values are numbered in the
+            ``rank`` column. ``"min"`` (default) gives tied rows the same,
+            best rank and leaves a gap (``1, 1, 3``); ``"dense"`` gives the
+            same rank without a gap (``1, 1, 2``); ``"ordinal"`` numbers
+            every row ``1..N``, ties broken by the row order described
+            below. Names and semantics are Polars'
+            ``Expr.rank`` methods.
+
+    Direction rule (``descending=None``):
+
+    - a ``<metric_label>_p_value`` column sorts **ascending** — a smaller
+      p-value is stronger evidence;
+    - ``factor``, ``forward_periods`` and params keys sort **ascending**;
+      they label a row rather than score it, so natural order applies;
+    - a metric value column sorts by the direction its metric is defined
+      with: ``ic``, ``ic_ir``, ``quantile_spread``, ``quantile_spread_vw``,
+      ``common_quantile_spread``, ``net_spread`` and ``breakeven_cost``
+      descending; ``rank_turnover`` and ``notional_turnover`` ascending;
+    - any other metric label — a custom evaluation label such as
+      ``ic_nw``, or a signed metric such as ``predictive_beta`` — raises
+      :class:`UserInputError`. Pass ``descending`` explicitly there.
+
+    Row order and ties: rows are sorted on ``sort_by``, then on ``factor``
+    and ``forward_periods`` ascending, then on any params column of a
+    sortable dtype. The output therefore does not depend on the order of
+    ``results``. Rows equal on every one of those columns are
+    indistinguishable and keep input order among themselves.
+
+    Missing values: a ``null`` or ``NaN`` ``sort_by`` value sorts **last**
+    in both directions and carries a ``null`` rank under every
+    ``rank_method`` — a row with no value has no place in the ranking.
 
     Returns:
         ``pl.DataFrame`` with column order ``factor``,
@@ -67,23 +128,47 @@ def compare(
     Raises:
         UserInputError: Empty ``results``; ``metrics`` not a non-empty
             ``list[str]``; any metric absent from any result's
-            outputs; ``sort_by`` not present in the output columns.
+            outputs; ``rank_method`` not one of ``min`` / ``dense`` /
+            ``ordinal``; ``sort_by`` not present in the output columns;
+            ``sort_by`` naming a metric column of unknown direction while
+            ``descending`` is ``None``.
 
     Examples:
-        Multi-metric wide leaderboard sorted on IC:
+        Alpha / information-ratio style metric — higher is better, and
+        the direction rule knows it:
 
         >>> board = fx.compare(  # doctest: +SKIP
-        ...     results, metrics=["ic", "sharpe"], sort_by="ic"
+        ...     results, metrics=["ic", "ic_ir"], sort_by="ic_ir"
         ... )
 
-        Lower-is-better metric (``descending=False``):
+        Turnover — lower is better, resolved the same way:
 
         >>> board = fx.compare(  # doctest: +SKIP
-        ...     results, metrics=["rank_turnover"], sort_by="rank_turnover", descending=False
+        ...     results, metrics=["rank_turnover"], sort_by="rank_turnover"
+        ... )
+
+        Significance screen on a p-value column, ties sharing one rank:
+
+        >>> board = fx.compare(  # doctest: +SKIP
+        ...     results, metrics=["ic"], sort_by="ic_p_value", rank_method="min"
+        ... )
+
+        A custom label carries no direction, so state one:
+
+        >>> board = fx.compare(  # doctest: +SKIP
+        ...     results, metrics=["ic_nw"], sort_by="ic_nw", descending=True
         ... )
     """
     metric_list = _validate_metric_list(metrics, func_name="compare", field="metrics")
     _require_non_empty_results(results, func_name="compare")
+    if rank_method not in _RANK_METHODS:
+        raise UserInputError(
+            func_name="compare",
+            field="rank_method",
+            value=rank_method,
+            candidates=_RANK_METHODS,
+            docs_path="api/compare#parameter-details",
+        )
     param_keys = _ordered_keys(r.params for r in results)
     rows: list[dict[str, Any]] = []
     for r in results:
@@ -112,22 +197,99 @@ def compare(
         rows.append(row)
 
     data = pl.DataFrame(rows)
-    if sort_by is not None:
-        sort_candidates = list(data.columns)
-        if sort_by not in sort_candidates:
-            raise UserInputError(
-                func_name="compare",
-                field="sort_by",
-                value=sort_by,
-                expected="one of the columns produced by compare()",
-                candidates=sort_candidates,
-                docs_path="api/compare#parameter-details",
-            )
-        data = data.sort(sort_by, descending=descending, nulls_last=True)
-        data = data.with_columns(
-            pl.int_range(1, data.height + 1, dtype=pl.Int64).alias("rank")
+    if sort_by is None:
+        return data
+
+    sort_candidates = list(data.columns)
+    if sort_by not in sort_candidates:
+        raise UserInputError(
+            func_name="compare",
+            field="sort_by",
+            value=sort_by,
+            expected="one of the columns produced by compare()",
+            candidates=sort_candidates,
+            docs_path="api/compare#parameter-details",
         )
-    return data
+    resolved = _resolve_descending(sort_by, descending, metric_list=metric_list)
+    return _rank(data, sort_by=sort_by, descending=resolved, rank_method=rank_method)
+
+
+def _resolve_descending(
+    sort_by: str, descending: bool | None, *, metric_list: list[str]
+) -> bool:
+    """Return the sort direction actually applied to ``sort_by``.
+
+    An explicit ``descending`` is used as given. Otherwise the direction
+    comes from the column's kind — p-value column, identity/params
+    column, or a metric label of known direction — and an unknown metric
+    label is an error rather than a silent default.
+    """
+    if descending is not None:
+        return descending
+    if sort_by in metric_list:
+        if sort_by in _HIGHER_IS_BETTER:
+            return True
+        if sort_by in _LOWER_IS_BETTER:
+            return False
+        raise UserInputError(
+            func_name="compare",
+            field="descending",
+            value=descending,
+            expected=(
+                f"an explicit True / False for sort_by={sort_by!r}: compare() "
+                "resolves a direction only for p-value columns, identity and "
+                "params columns, and metric labels of known direction "
+                f"(higher is better: {sorted(_HIGHER_IS_BETTER)}; lower is "
+                f"better: {sorted(_LOWER_IS_BETTER)})"
+            ),
+            docs_path="api/compare#parameter-details",
+        )
+    # p-value columns, identity columns and params keys all sort ascending.
+    return False
+
+
+def _sortable_tiebreaks(data: pl.DataFrame, sort_by: str) -> list[str]:
+    """Return the deterministic secondary sort keys, in application order."""
+    keys = [c for c in _IDENTITY_COLS if c != sort_by]
+    for name, dtype in data.schema.items():
+        if name in _IDENTITY_COLS or name == sort_by:
+            continue
+        if (
+            dtype.is_numeric()
+            or dtype.is_temporal()
+            or dtype in (pl.Boolean, pl.String)
+        ):
+            keys.append(name)
+    return keys
+
+
+def _rank(
+    data: pl.DataFrame, *, sort_by: str, descending: bool, rank_method: RankMethod
+) -> pl.DataFrame:
+    """Sort ``data`` on ``sort_by`` and attach the ``rank`` column."""
+    key = pl.col(sort_by)
+    if data.schema[sort_by] in (pl.Float32, pl.Float64):
+        # Fold NaN into null so "missing last" holds in both directions.
+        key = pl.when(key.is_nan()).then(None).otherwise(key)
+    data = data.with_columns(key.alias(_SORT_KEY))
+    tiebreaks = _sortable_tiebreaks(data.drop(_SORT_KEY), sort_by)
+    data = data.sort(
+        [_SORT_KEY, *tiebreaks],
+        descending=[descending, *[False] * len(tiebreaks)],
+        nulls_last=True,
+    )
+    if rank_method == "ordinal":
+        ranks = pl.int_range(1, data.height + 1, dtype=pl.Int64)
+    else:
+        ranks = pl.col(_SORT_KEY).rank(method=rank_method, descending=descending)
+    data = data.with_columns(
+        pl.when(pl.col(_SORT_KEY).is_null())
+        .then(None)
+        .otherwise(ranks)
+        .cast(pl.Int64)
+        .alias("rank")
+    )
+    return data.drop(_SORT_KEY)
 
 
 def _ordered_keys(maps: Iterable[Mapping[str, Any]]) -> list[str]:

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -439,11 +439,20 @@ def compare(
     *,
     metrics: list[str],
     sort_by: str | None = None,
-    descending: bool = True,
+    descending: bool | None = None,
+    rank_method: Literal["min", "dense", "ordinal"] = "min",
 ) -> pl.DataFrame:
 ```
 
 Renders a wide leaderboard `pl.DataFrame` stacking metric values and p-values side-by-side.
+`rank_method` is tie-aware by default: equal `sort_by` values share one rank
+(`min`), and row order is fixed by `factor` / `forward_periods` / params
+tiebreakers rather than by input order. `descending=None` resolves the direction
+from the column — p-value, identity and params columns ascending, `ic` / `ic_ir`
+/ spread / `net_spread` / `breakeven_cost` descending, `rank_turnover` /
+`notional_turnover` ascending — and raises for any other metric label, so a
+lower-is-better key cannot inherit a higher-is-better sort. Null / NaN sort
+values place last in both directions and carry a null rank.
 
 ---
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -192,3 +192,146 @@ def test_sort_by_unknown_output_column_raises():
     with pytest.raises(UserInputError, match="unknown sort_by") as excinfo:
         compare(results, metrics=["ic"], sort_by="sharpe")
     assert "ic_p_value" in str(excinfo.value)
+
+
+# --- #1060: tie-aware ranks and explicit sort semantics ---------------------
+
+
+def _ic_results(values: dict[str, float]) -> list:
+    make_spec("ic")
+    return [
+        make_result(factor=f, p=0.1, metric="ic", value=v) for f, v in values.items()
+    ]
+
+
+def test_rank_method_defaults_to_min_and_ties_share_one_rank():
+    results = _ic_results({"a": 0.05, "b": 0.05, "c": 0.01})
+    df = compare(results, metrics=["ic"], sort_by="ic", descending=True)
+    assert df["factor"].to_list() == ["a", "b", "c"]
+    assert df["rank"].to_list() == [1, 1, 3]
+
+
+def test_rank_method_dense_closes_the_gap_after_a_tie():
+    results = _ic_results({"a": 0.05, "b": 0.05, "c": 0.01})
+    df = compare(
+        results, metrics=["ic"], sort_by="ic", descending=True, rank_method="dense"
+    )
+    assert df["rank"].to_list() == [1, 1, 2]
+
+
+def test_rank_method_ordinal_numbers_every_row():
+    results = _ic_results({"a": 0.05, "b": 0.05, "c": 0.01})
+    df = compare(
+        results, metrics=["ic"], sort_by="ic", descending=True, rank_method="ordinal"
+    )
+    assert df["rank"].to_list() == [1, 2, 3]
+
+
+@pytest.mark.parametrize("method", ["min", "dense", "ordinal"])
+@pytest.mark.parametrize(
+    "order",
+    [("a", "b", "c"), ("c", "b", "a"), ("b", "a", "c"), ("c", "a", "b")],
+)
+def test_rank_is_invariant_to_input_order(method, order):
+    values = {"a": 0.05, "b": 0.05, "c": 0.01}
+    results = _ic_results({f: values[f] for f in order})
+    df = compare(
+        results, metrics=["ic"], sort_by="ic", descending=True, rank_method=method
+    )
+    assert df["factor"].to_list() == ["a", "b", "c"]
+    expected = {"min": [1, 1, 3], "dense": [1, 1, 2], "ordinal": [1, 2, 3]}[method]
+    assert df["rank"].to_list() == expected
+
+
+def test_unknown_rank_method_raises():
+    results = _ic_results({"a": 0.05})
+    with pytest.raises(UserInputError, match="unknown rank_method") as excinfo:
+        compare(
+            results,
+            metrics=["ic"],
+            sort_by="ic",
+            descending=True,
+            rank_method="average",  # type: ignore[arg-type]
+        )
+    assert "ordinal" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("descending", [True, False])
+def test_null_metric_value_sorts_last_and_carries_null_rank(descending):
+    make_spec("ic")
+    results = [
+        make_result(factor="hi", p=0.1, metric="ic", value=0.10),
+        make_result(factor="missing", p=0.1, metric="ic", value=float("nan")),
+        make_result(factor="lo", p=0.1, metric="ic", value=0.01),
+    ]
+    df = compare(results, metrics=["ic"], sort_by="ic", descending=descending)
+    assert df["factor"].to_list()[-1] == "missing"
+    assert df["rank"].to_list()[-1] is None
+
+
+@pytest.mark.parametrize("descending", [True, False])
+def test_nan_in_a_params_sort_column_sorts_last(descending):
+    make_spec("ic")
+    results = [
+        make_result(factor="a", p=0.1, metric="ic", params={"cutoff": 1.0}),
+        make_result(factor="nan", p=0.1, metric="ic", params={"cutoff": float("nan")}),
+        make_result(factor="b", p=0.1, metric="ic", params={"cutoff": 2.0}),
+    ]
+    df = compare(results, metrics=["ic"], sort_by="cutoff", descending=descending)
+    assert df["factor"].to_list()[-1] == "nan"
+    assert df["rank"].to_list()[-1] is None
+
+
+def test_direction_inferred_ascending_for_p_value_column():
+    make_spec("ic")
+    results = [
+        make_result(factor="weak", p=0.5, metric="ic", value=0.10),
+        make_result(factor="strong", p=0.01, metric="ic", value=0.01),
+    ]
+    df = compare(results, metrics=["ic"], sort_by="ic_p_value")
+    assert df["factor"].to_list() == ["strong", "weak"]
+
+
+def test_direction_inferred_ascending_for_turnover():
+    make_spec("rank_turnover")
+    results = [
+        make_result(factor="high_to", p=0.5, metric="rank_turnover", value=0.80),
+        make_result(factor="low_to", p=0.5, metric="rank_turnover", value=0.10),
+    ]
+    df = compare(results, metrics=["rank_turnover"], sort_by="rank_turnover")
+    assert df["factor"].to_list() == ["low_to", "high_to"]
+
+
+def test_direction_inferred_descending_for_ic():
+    results = _ic_results({"lo": 0.01, "hi": 0.10})
+    df = compare(results, metrics=["ic"], sort_by="ic")
+    assert df["factor"].to_list() == ["hi", "lo"]
+
+
+def test_direction_inferred_ascending_for_identity_column():
+    results = _ic_results({"b": 0.01, "a": 0.10})
+    df = compare(results, metrics=["ic"], sort_by="factor")
+    assert df["factor"].to_list() == ["a", "b"]
+
+
+def test_unknown_direction_metric_requires_explicit_descending():
+    make_spec("predictive_beta")
+    results = [
+        make_result(factor="a", p=0.1, metric="predictive_beta", value=0.5),
+        make_result(factor="b", p=0.1, metric="predictive_beta", value=-0.9),
+    ]
+    with pytest.raises(UserInputError, match="descending") as excinfo:
+        compare(results, metrics=["predictive_beta"], sort_by="predictive_beta")
+    assert "predictive_beta" in str(excinfo.value)
+
+
+def test_explicit_descending_overrides_inference():
+    make_spec("rank_turnover")
+    results = [
+        make_result(factor="high_to", p=0.5, metric="rank_turnover", value=0.80),
+        make_result(factor="low_to", p=0.5, metric="rank_turnover", value=0.10),
+    ]
+    df = compare(
+        results, metrics=["rank_turnover"], sort_by="rank_turnover", descending=True
+    )
+    assert df["factor"].to_list() == ["high_to", "low_to"]


### PR DESCRIPTION
## Summary

`compare(..., sort_by=...)` sorted on one key and stamped `1..N`, so equal metric
values were separated by input order under a column called `rank`, and the global
`descending=True` default let a lower-is-better key (turnover, a p-value) inherit
a higher-is-better sort.

- **`rank_method`** — `"min"` (default), `"dense"`, `"ordinal"`, the Polars
  `Expr.rank` methods. Tied rows share one rank unless `"ordinal"` is asked for.
- **Order-invariance** — rows break ties on `factor`, `forward_periods`, then any
  `params` column of a sortable dtype, so the frame (and the ordinal rank) no
  longer depends on the order of `results`. Rows equal on all of those are
  indistinguishable and keep input order among themselves; under `min`/`dense`
  they carry the same rank anyway.
- **Direction** — `descending` now defaults to `None` and is resolved from the
  column: `<label>_p_value`, `factor`, `forward_periods` and params keys
  ascending; `ic`, `ic_ir`, `quantile_spread`, `quantile_spread_vw`,
  `common_quantile_spread`, `net_spread`, `breakeven_cost` descending;
  `rank_turnover`, `notional_turnover` ascending. Any other metric label raises
  `UserInputError` naming the column and both tables. Signed metrics
  (`predictive_beta`, `fm_beta`, `spanning_alpha`, `caar`, `ic_trend`) are
  deliberately absent — "largest positive value" is not "strongest effect", so
  they must be given a direction. An explicit `descending` always wins.
- **Missing values** — a `null` or `NaN` sort value places **last in both
  directions** and carries a `null` rank under every method. Polars orders `NaN`
  as the largest float, so `NaN` was previously ranked *first* under
  `descending=True`; the sort now runs on a hidden key with `NaN` folded into
  `null`.

Docs: `docs/api/compare.md` gains the signature, a direction table, a ties /
missing-values section, and alpha-IR, turnover, p-value and custom-label
examples; the `compare` entry in `factrix/llms-full.txt` is updated.

**Breaking (pre-1.0, no shim):** `descending` defaults to `None` instead of
`True`; `rank` is tie-aware by default; sorting a metric label with no documented
direction now requires `descending` explicitly.

## Verification

All gates run from the worktree with the repo interpreter.

Guards run against the unfixed implementation first — 24 of the 24 new cases
failed (`24 failed, 17 passed`), including:

```
__________ test_rank_method_defaults_to_min_and_ties_share_one_rank ___________
    assert df["rank"].to_list() == [1, 1, 3]
E   assert [1, 2, 3] == [1, 1, 3]
______________ test_rank_is_invariant_to_input_order[order1-min] ______________
E   TypeError: compare() got an unexpected keyword argument 'rank_method'
______________ test_nan_in_a_params_sort_column_sorts_last[True] ______________
    assert df["factor"].to_list()[-1] == "nan"
E   AssertionError: assert 'a' == 'nan'
________ test_null_metric_value_sorts_last_and_carries_null_rank[True] ________
    assert df["rank"].to_list()[-1] is None
E   assert 3 is None
____________ test_direction_inferred_ascending_for_turnover ___________________
    assert df["factor"].to_list() == ["low_to", "high_to"]
E   AssertionError: assert ['high_to', 'low_to'] == ['low_to', 'high_to']
_________ test_unknown_direction_metric_requires_explicit_descending __________
E   Failed: DID NOT RAISE UserInputError
```

The order-invariance guard runs all three rank methods across four input
permutations of the same three factors (two of them tied), asserting both the row
order and the rank vector.

After the change:

- `pytest -q -p no:faulthandler` — `3904 passed, 45 skipped, 451 warnings in 315.13s`
- `pytest tests/test_compare.py` — `41 passed`
- `pytest --doctest-modules factrix -q` — `96 passed, 1 skipped`
- `ruff check .` — `All checks passed!`
- `ruff format --check .` — `250 files already formatted`
- `mypy factrix` — `Success: no issues found in 83 source files`
- `mkdocs build --strict` — `Documentation built in 27.21 seconds`

Direction-table entries are taken from each metric's own definition rather than
assumed: `breakeven_cost` ("if the actual one-way trading cost is below this, the
factor's alpha survives" — higher is better), `net_spread` (spread after costs),
the spread family, `ic` / `ic_ir`, and turnover as a cost driver. Every metric
whose direction is not settled by its definition is excluded and therefore
requires an explicit `descending`.

Closes #1060
