### PR TITLE
test(dev): make the documented pytest environment sufficient

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,33 @@ jobs:
       - name: Run pytest
         run: uv run --python ${{ matrix.python }} pytest
 
+  dev-extra:
+    name: pytest (documented contributor setup, --extra dev)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      # The contributing guides tell a new contributor to install exactly this
+      # and then run the complete suite. #1061: the docs-site tests need the
+      # separate ``docs`` extra, so this job proves they skip with a reason
+      # instead of failing the advertised command. ``-rs`` puts each reason in
+      # the log, so an extra that quietly stopped being installed is visible.
+      # This job passes on the tree as it stands: it pins the documented
+      # setup against drift — a newly collected test importing a docs-only
+      # dependency — rather than proving a fix.
+      - name: Install the documented contributor environment
+        run: uv sync --frozen --python 3.12 --extra dev
+
+      - name: Run pytest
+        run: uv run --python 3.12 pytest -rs
+
   floor:
     name: pytest (declared dependency floor, no pandas, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,11 @@ python scripts/setup_dev.py   # installs the pre-commit framework hooks
 uv run pytest
 ```
 
+`--extra dev` is enough for `uv run pytest` to pass; the docs-site tests skip
+themselves, with a reason, until the `docs` extra is installed. Use
+`uv sync --frozen --all-extras` (what CI runs) to make the docs and pandas
+checks run rather than skip, and `uv run pytest -rs` to see every skip reason.
+
 ## Development cycle
 
 ```bash
@@ -28,7 +33,8 @@ gh pr create
 ## Before opening a PR
 
 - Keep the change scoped and include tests for new metrics, result fields, or API parameters.
-- Run `uv run pytest` locally.
+- Run `uv run pytest` locally, on an `--all-extras` environment so no check
+  silently skips.
 - Use `cz commit` for Conventional Commits.
 - Do not append commit signature trailers unless a future DCO policy explicitly
   requires them.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -17,6 +17,11 @@ python scripts/setup_dev.py
 uv run pytest
 ```
 
+`uv sync --extra dev` is sufficient for `uv run pytest` to finish green: the
+tests that build or resolve the MkDocs site skip themselves, with a reason, when
+the `docs` extra is absent. Add `--extra docs` (or `--all-extras`) to make those
+checks run instead of skip; `uv run pytest -rs` lists the skip reasons.
+
 `pyproject.toml` and `uv.lock` define the environment. Do not install packages
 directly into `.venv`; use `uv add`, update the project metadata, and commit the
 lockfile change together.
@@ -179,7 +184,11 @@ uv run mkdocs build --strict
 ```
 
 Use `uv sync --frozen --all-extras` before the complete run so optional adapter
-tests do not execute against a partially installed pandas/pyarrow environment.
+tests do not execute against a partially installed pandas/pyarrow environment,
+and so the docs-site tests run rather than skip — `uv sync --extra dev` alone
+leaves both the pandas adapter and the docs checks unexercised. `uv run pytest
+-rs` prints the reason for every skip, so a missing extra is visible rather than
+silent.
 
 ## Python and API changes
 

--- a/tests/test_docs_inventory_cache_warmup.py
+++ b/tests/test_docs_inventory_cache_warmup.py
@@ -11,6 +11,7 @@ non-fatal so ``mkdocstrings`` reports whatever it finds in its own terms.
 
 from __future__ import annotations
 
+import importlib.metadata
 import pathlib
 import re
 import urllib.error
@@ -28,6 +29,30 @@ from scripts.mkdocs_hooks.warm_inventory_cache import (
 # the module there rather than dragging mkdocs into the declared floor.
 yaml = pytest.importorskip("yaml", reason="docs extra not installed")
 pytest.importorskip("mkdocstrings", reason="docs extra not installed")
+
+
+def _theme_installed() -> bool:
+    """Is the theme ``mkdocs.yml`` names resolvable by ``load_config``?
+
+    ``mkdocstrings`` requires ``mkdocs`` but not ``mkdocs-material``, so an
+    environment can import both and still abort ``load_config`` with
+    ``Unrecognised theme name: 'material'``. Only the two tests below resolve
+    the real config; the rest of the module exercises the hook and must keep
+    running. Report the missing distribution rather than the aborted build.
+    """
+    try:
+        importlib.metadata.version("mkdocs-material")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    return True
+
+
+#: Resolving ``mkdocs.yml`` needs the theme it declares; ``--extra docs``
+#: installs it.
+requires_theme = pytest.mark.skipif(
+    not _theme_installed(),
+    reason="resolving mkdocs.yml requires mkdocs-material from the docs extra",
+)
 
 MKDOCS_YML = pathlib.Path("mkdocs.yml")
 
@@ -185,6 +210,7 @@ def test_warm_up_is_not_itself_fatal(downloader, capsys) -> None:
     assert "unavailable" in capsys.readouterr().out
 
 
+@requires_theme
 def test_config_walk_finds_the_urls_mkdocs_actually_resolves() -> None:
     """The walk must fail loudly, not return ``[]``.
 
@@ -209,6 +235,7 @@ def test_config_walk_finds_the_urls_mkdocs_actually_resolves() -> None:
     assert set(found) == set(declared)
 
 
+@requires_theme
 def test_config_walk_is_not_silently_empty_on_a_renamed_key() -> None:
     """Renaming the key must change the result, so the pin above has teeth."""
     from mkdocs.config import load_config


### PR DESCRIPTION
## Summary

The contributing guides tell a new contributor to install `uv sync --extra dev`
and then run the complete `uv run pytest`, but nothing pinned that the
advertised command finishes green on the environment the guides describe. This
takes option (c) from the issue: the docs-site checks skip with an explicit
reason when the `docs` extra is absent, both guides say so, and a CI job runs
the minimal setup.

- `tests/test_docs_inventory_cache_warmup.py` — the module guard skipped on
  `mkdocstrings`, which requires `mkdocs` but **not** `mkdocs-material`. The two
  tests that resolve `mkdocs.yml` through `load_config` therefore aborted with
  `Unrecognised theme name: 'material'` — the exact error from the issue —
  rather than skipping. They now carry a `requires_theme` skip marker keyed on
  the `mkdocs-material` distribution, the way `tests/test_docs_paths.py` already
  guards its site build. The other 19 tests in the module exercise the hook
  itself and keep running.
- `.github/workflows/test.yml` — new `dev-extra` job: `uv sync --frozen
  --python 3.12 --extra dev` then `uv run pytest -rs`, so the documented
  contributor setup is exercised on every run and every skip reason is in the
  log.
- `CONTRIBUTING.md` and `docs/development/contributing.md` now agree: `--extra
  dev` is enough for `uv run pytest` to pass, the docs-site checks skip until
  `--extra docs` / `--all-extras` is installed, and `-rs` shows the reasons.

## Verification

**Reproduction of the issue's error (unfixed tree).** A dev environment plus
`mkdocstrings[python]` — mkdocs present, theme absent:

```
tests\test_docs_inventory_cache_warmup.py .............FF......          [100%]
E   mkdocs.exceptions.Abort: Aborted with a configuration error!
ERROR    mkdocs.config:base.py:380 Config value 'theme': Unrecognised theme name: 'material'. The available installed themes are: mkdocs, readthedocs
=================== 2 failed, 19 passed, 1 skipped in 8.25s ===================
```

Both failures are `load_config(str(MKDOCS_YML))` — the guard this PR adds. With
the fix, the same environment and command:

```
SKIPPED [1] tests\test_docs_inventory_cache_warmup.py:213: resolving mkdocs.yml requires mkdocs-material from the docs extra
SKIPPED [1] tests\test_docs_inventory_cache_warmup.py:238: resolving mkdocs.yml requires mkdocs-material from the docs extra
======================== 19 passed, 3 skipped in 1.55s ========================
```

**The documented environment runs its advertised command.** Fresh
`uv sync --frozen --extra dev` in this worktree, then the complete suite with
skip reasons shown (Windows, Python 3.13):

```
SKIPPED [1] tests\test_docs_inventory_cache_warmup.py:31: docs extra not installed
SKIPPED [1] tests\test_docs_paths.py:20: docs-path validation requires the docs extra
SKIPPED [1] tests\test_adapt.py:196: could not import 'pandas': No module named 'pandas'
SKIPPED [2] tests\test_data_input.py:50: could not import 'pandas': No module named 'pandas'
========= 3800 passed, 50 skipped, 451 warnings in 245.99s (0:04:05) ==========
```

**Full-extras environment unaffected** — the new marker must not skip when the
theme is installed: `21 passed in 1.49s` for
`tests/test_docs_inventory_cache_warmup.py`.

**Gates.** `ruff check .` → `All checks passed!`; `ruff format --check .` →
`250 files already formatted`; `mkdocs build --strict` → `Documentation built
in 29.71 seconds`.

**Scope note on the new CI job.** `dev-extra` passes on the tree as it stands —
with no docs deps at all, `mkdocs` never imports and the module guards already
skipped. It is a pin against drift (a newly collected test importing a
docs-only dependency), not regression proof, and the job comment says so. The
guard that was shown to fail on the unfixed state is the `requires_theme`
marker, reproduced above.

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
