### PR TITLE
fix(event): benchmark each offset over its own horizon (#1052)

### DIFF
--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -26,6 +26,31 @@ title: factrix.metrics.event_horizon
     the default factrix presentation; downstream consumers should not
     re-cumulate the pre-event leg.
 
+!!! info "Three quantities, one curve"
+    `per_offset[k]` reports an **abnormal** return, never a raw one, and the
+    metric's headline `value` is a third quantity again. Keeping them apart
+    is the difference between reading event alpha and reading the drift the
+    asset had anyway.
+
+    | Quantity | What it is | Where it appears |
+    |---|---|---|
+    | Raw cumulative return | The formula in the table above, sign-adjusted, with nothing subtracted | Not published; recover it as `mean + benchmark` |
+    | Abnormal (excess) return | Raw return minus that offset's `benchmark` | `per_offset[k]["mean"]`, and every dispersion key beside it |
+    | Leakage score | Mean of the absolute abnormal returns over the *negative* offsets | the metric's `value` |
+
+    The `benchmark` is the panel's unconditional return **over the same
+    horizon as the offset it is subtracted from**: `baseline_bar_return` for
+    offsets at or below zero, and `(1 + baseline_bar_return)**k - 1` for
+    offset $k > 0$, which is a $k$-period return. Subtracting one period of
+    drift from a $k$-period return leaves roughly $k - 1$ periods of it in
+    the answer, and on a panel that merely trends that residue reads as event
+    alpha. On a pure-drift panel every offset now prices to zero.
+
+    `baseline_bar_return` is formed as one mean per asset, pooled with equal
+    weight, and `n_assets_in_baseline` reports how many assets entered it.
+    Pooling every period observation instead would let a long-history name
+    outvote a short one on a ragged panel.
+
 !!! warning "Descriptive only — no p-value is produced"
     `event_around_return` runs no hypothesis test: `p_value` is `None`, and
     `per_offset[k]` carries `{mean, median, p25, p75, hit_rate, n}` — the

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -497,10 +497,12 @@ Pre/post-event return profile; descriptive.
 - *descriptive*: `n_events` (distinct `(date, asset)` events behind the
   curve — also `n_obs`, axis `events`; one event contributes one row per
   offset, so this is not the row count), `per_offset` (dict
-  `offset → {mean, se, t, median, p25, p75, hit_rate, n}`, all measured as
-  **excess over** `baseline_bar_return`), `baseline_bar_return` (the panel's
-  unconditional mean single-bar return, subtracted so a trending asset does
-  not read as leaky), `leakage_null_scale` (`≈ 0.8 × mean se` — what the
+  `offset → {benchmark, mean, se, t, median, p25, p75, hit_rate, n}`, all
+  measured as **excess over that offset's own** `benchmark`),
+  `baseline_bar_return` (the panel's unconditional mean single-*period*
+  return, subtracted so a trending asset does not read as leaky),
+  `n_assets_in_baseline` (assets behind that mean — one mean per asset,
+  pooled with equal weight), `leakage_null_scale` (`≈ 0.8 × mean se` — what the
   headline is worth under *no* leakage, since `E|x̄| > 0` always and shrinks
   as events accumulate). `reason` is set to
   `no_pre_event_offset_with_enough_events` and `value` is `NaN` when no
@@ -510,6 +512,13 @@ Pre/post-event return profile; descriptive.
   `reason=invalid_price_data`, audited `per_offset` entries, and
   `WarningCode.METRIC_UNAVAILABLE`; `n_invalid_prices` reports the offending
   row count. Null prices remain valid missing data on a ragged panel.
+
+- *benchmark horizon*: offset `k > 0` is a simple return from `t+1` to
+  `t+1+k`, so its `benchmark` is `(1 + baseline_bar_return)**k - 1` — the
+  baseline compounded over the periods that offset actually spans. Offsets at
+  or below zero are single-period returns and keep `baseline_bar_return`
+  itself. Each `per_offset` member publishes the `benchmark` subtracted from
+  it, so the arithmetic can be reproduced from the metadata alone.
 - `p_value` is `None` — no hypothesis test runs, and no offset carries a
   `p`: the headline `value` is the pre-event leakage score and per-horizon
   `hit_rate` is a raw fraction of positive signed returns. Offsets overlap

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -60,24 +60,36 @@ _EH_CELL = cell(None, FactorDensity.SPARSE, structure=None)
 
 def _unconditional_bar_return(
     data: pl.DataFrame, price_col: str
-) -> tuple[float | None, int]:
-    """Mean single-bar return across the whole panel, per asset then pooled.
+) -> tuple[float | None, int, int]:
+    """Mean single-period return, per asset and then equally weighted.
 
-    The pre-event offsets are single-bar returns, so an asset that drifts up
-    0.1% a bar has pre-event means of 0.1% with no information leakage at all.
-    Subtracting this baseline makes the leakage score measure what its name
-    says. Returns ``None`` when it cannot be computed. A non-finite or
-    non-positive observed price invalidates the baseline rather than being
-    silently dropped: otherwise a contaminated denominator can manufacture
-    an infinite baseline and a finite-looking hit rate.
+    An asset that drifts up 0.1% a period has offset means of 0.1% with no
+    information leakage at all. Subtracting this baseline makes the leakage
+    score measure what its name says. Returns ``None`` when it cannot be
+    computed. A non-finite or non-positive observed price invalidates the
+    baseline rather than being silently dropped: otherwise a contaminated
+    denominator can manufacture an infinite baseline and a finite-looking hit
+    rate.
 
-    The bar is one step on the panel's period grid, matching the offsets it is
-    subtracted from: on a ragged panel a step across an asset's missing periods
-    is not a one-period return and drops out rather than inflating the
-    baseline.
+    The period is one step on the panel's period grid, matching the offsets
+    the baseline is subtracted from: on a ragged panel a step across an
+    asset's missing periods is not a one-period return and drops out rather
+    than inflating the baseline.
+
+    **Weighting.** Each asset contributes one mean, and the means are pooled
+    with equal weight. Pooling every period observation directly instead lets
+    an asset with a long history outvote a short one, so on a ragged panel the
+    baseline drifts toward the longest name rather than describing the panel;
+    the events being scored are not weighted that way either. The returned
+    count is the number of assets that actually entered the mean, so a reader
+    can tell how the weighting was formed.
+
+    Returns:
+        The baseline, the count of invalid observed prices, and the number of
+        assets behind the baseline.
     """
     if price_col not in data.columns or "asset_id" not in data.columns:
-        return None, 0
+        return None, 0, 0
 
     price = pl.col(price_col).cast(pl.Float64, strict=False)
     invalid_price = pl.col(price_col).is_not_null() & (
@@ -85,15 +97,40 @@ def _unconditional_bar_return(
     )
     n_invalid_prices = data.filter(invalid_price).height
     if n_invalid_prices:
-        return None, n_invalid_prices
+        return None, n_invalid_prices, 0
 
     dense, _ = _densify_on_period_grid(data)
-    rets = dense.with_columns(
-        (pl.col(price_col) / pl.col(price_col).shift(1).over("asset_id") - 1).alias(
-            "_bar_ret"
+    per_asset = (
+        dense.with_columns(
+            (pl.col(price_col) / pl.col(price_col).shift(1).over("asset_id") - 1).alias(
+                "_bar_ret"
+            )
         )
-    ).filter(_finite_expr("_bar_ret"))["_bar_ret"]
-    return (float(rets.mean()), 0) if len(rets) else (None, 0)  # type: ignore[arg-type]
+        .filter(_finite_expr("_bar_ret"))
+        .group_by("asset_id")
+        .agg(pl.col("_bar_ret").mean().alias("_asset_mean"))
+    )
+    if per_asset.is_empty():
+        return None, 0, 0
+    return float(per_asset["_asset_mean"].mean()), 0, per_asset.height  # type: ignore[arg-type]
+
+
+def _horizon_benchmark(baseline: float, offset: int) -> float:
+    """The baseline compounded over the periods ``offset`` actually spans.
+
+    Offset ``k > 0`` is a simple return from ``t+1`` to ``t+1+k``, i.e. a
+    ratio of two prices ``k`` periods apart, so its benchmark is the same
+    ratio built from the mean single-period return: ``(1 + mu)**k - 1``.
+    Subtracting one period of ``mu`` from it left roughly ``k - 1`` periods
+    of drift in the answer, which reads as event alpha on a panel that
+    merely trends.
+
+    Offsets at or below zero are single-period returns and keep the
+    single-period benchmark.
+    """
+    if offset <= 0:
+        return baseline
+    return float((1.0 + baseline) ** offset - 1.0)
 
 
 @metric(
@@ -256,7 +293,9 @@ def event_around_return(
     # whole baseline; dropping only its affected return would silently change
     # the estimand and still publish a finite-looking hit rate.
     path_data = data if resolved_prices is None else resolved_prices
-    baseline, n_invalid_prices = _unconditional_bar_return(path_data, price_col)
+    baseline, n_invalid_prices, n_assets_in_baseline = _unconditional_bar_return(
+        path_data, price_col
+    )
     if baseline is None:
         reason = (
             "invalid_price_data" if n_invalid_prices else "no_finite_baseline_returns"
@@ -271,6 +310,7 @@ def event_around_return(
             n_events_eligible=n_events_eligible,
             n_invalid_prices=n_invalid_prices,
             baseline_bar_return=None,
+            n_assets_in_baseline=n_assets_in_baseline,
             per_offset=per_offset,
         )
 
@@ -284,16 +324,23 @@ def event_around_return(
             continue
 
         arr = subset["signed_return"].to_numpy()
-        # Excess over the unconditional bar return: a trending asset's bars are
-        # non-zero on average whether or not an event is coming, and that drift
-        # entered the leakage score directly. The return is signed, so the
-        # baseline is signed the same way: a short event's bar carries -mu,
-        # and subtracting +mu from it scored the drift twice over.
-        excess = arr - baseline * subset["sign"].to_numpy()
+        # Excess over the unconditional return *of this offset's own horizon*:
+        # a trending asset's periods are non-zero on average whether or not an
+        # event is coming, and that drift entered the leakage score directly.
+        # The return is signed, so the benchmark is signed the same way: a
+        # short event's period carries -mu, and subtracting +mu from it scored
+        # the drift twice over.
+        benchmark = _horizon_benchmark(baseline, k)
+        excess = arr - benchmark * subset["sign"].to_numpy()
         mean_v = float(np.mean(excess))
         se = float(np.std(excess, ddof=DDOF) / np.sqrt(n)) if n > 1 else float("nan")
         per_offset[k] = {
             **offset_audit[k],
+            # The benchmark this offset was actually measured against, not the
+            # single-period baseline it was built from: the two differ at every
+            # positive offset, and a reader checking the arithmetic needs the
+            # quantity that was subtracted.
+            "benchmark": benchmark,
             "mean": mean_v,
             "se": se,
             # The scale the score has to be read against: |mean| of a true null
@@ -347,6 +394,10 @@ def event_around_return(
             "n_events_eligible": n_events_eligible,
             "per_offset": per_offset,
             "baseline_bar_return": baseline,
+            # How the baseline was weighted: one mean per asset, pooled
+            # equally. Reading the number without the count cannot tell a
+            # panel-wide drift from one long name's.
+            "n_assets_in_baseline": n_assets_in_baseline,
             # The null scale of the headline: E|x̄| ≈ 0.8 σ/√n > 0 under no
             # leakage at all, so the score shrinks as events accumulate and
             # cannot be read against a fixed "should be ~0" target.

--- a/tests/test_event_benchmark_horizon.py
+++ b/tests/test_event_benchmark_horizon.py
@@ -1,0 +1,115 @@
+"""The excess benchmark matches the horizon it is subtracted from (#1052)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+from factrix.metrics.event_horizon import event_around_return
+
+OFFSETS = [-3, -1, 1, 6, 12, 24]
+
+
+def _drift_only_panel(
+    *,
+    n_assets: int = 8,
+    n_dates: int = 200,
+    growth: float = 1.004,
+    event_every: int = 17,
+    first_event: int = 40,
+) -> pl.DataFrame:
+    """Every asset compounds at exactly ``growth`` per period, forever.
+
+    No event carries information here: the price path is the same whether
+    or not the factor fired. Every excess return is therefore zero by
+    construction, at every offset, and any residue is the benchmark
+    failing to match the horizon it was subtracted from.
+    """
+    dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(n_dates)]
+    rows: list[dict[str, object]] = []
+    for asset_index in range(n_assets):
+        for index, current_date in enumerate(dates):
+            is_event = index >= first_event and (index - asset_index) % event_every == 0
+            rows.append(
+                {
+                    "date": current_date,
+                    "asset_id": f"A{asset_index}",
+                    "factor": 1.0 if is_event else 0.0,
+                    "price": 100.0 * growth**index,
+                }
+            )
+    return pl.DataFrame(rows)
+
+
+def test_drift_only_panel_has_no_excess_at_any_offset() -> None:
+    """A pure-drift panel is the null: every offset must price to zero.
+
+    Offset ``k > 0`` is a ``k``-period return from ``t+1`` to ``t+1+k``,
+    so subtracting one single-period baseline leaves roughly ``k - 1``
+    periods of drift in the answer and reads as event alpha.
+    """
+    result = event_around_return(_drift_only_panel(), offsets=OFFSETS)
+
+    per_offset = result.metadata["per_offset"]
+    residues = {
+        offset: per_offset[offset]["mean"]
+        for offset in OFFSETS
+        if per_offset[offset].get("mean") is not None
+    }
+    assert set(residues) == set(OFFSETS), residues
+    for offset, mean in residues.items():
+        assert mean == pytest.approx(0.0, abs=1e-12), (
+            f"offset {offset} keeps {mean:.6g} of pure drift"
+        )
+
+
+def test_baseline_weights_assets_equally_on_a_ragged_panel() -> None:
+    """The docstring's per-asset baseline is what the code computes.
+
+    Pooling every bar observation lets an asset with a longer history
+    outvote a short one. Two assets with different drifts and very
+    different history lengths pin the difference: the equal-weighted
+    baseline is the mean of the two per-asset drifts, while the pooled
+    one sits near the long asset's.
+    """
+    long_growth, short_growth = 1.006, 1.001
+    dates = [date(2020, 1, 1) + timedelta(days=index) for index in range(120)]
+    rows: list[dict[str, object]] = []
+    for index, current_date in enumerate(dates):
+        rows.append(
+            {
+                "date": current_date,
+                "asset_id": "LONG",
+                "factor": 1.0 if index in (60, 80, 100) else 0.0,
+                "price": 100.0 * long_growth**index,
+            }
+        )
+        if index >= 100:
+            rows.append(
+                {
+                    "date": current_date,
+                    "asset_id": "SHORT",
+                    "factor": 1.0 if index == 110 else 0.0,
+                    "price": 50.0 * short_growth ** (index - 100),
+                }
+            )
+    result = event_around_return(pl.DataFrame(rows), offsets=[-1, 1])
+
+    equal_weighted = (long_growth - 1.0 + short_growth - 1.0) / 2.0
+    assert result.metadata["baseline_bar_return"] == pytest.approx(
+        equal_weighted, rel=1e-9
+    )
+    assert result.metadata["n_assets_in_baseline"] == 2
+
+
+def test_per_offset_reports_the_benchmark_it_subtracted() -> None:
+    """Each offset publishes the benchmark actually applied to it."""
+    result = event_around_return(_drift_only_panel(), offsets=[-1, 6])
+
+    baseline = result.metadata["baseline_bar_return"]
+    per_offset = result.metadata["per_offset"]
+    assert per_offset[-1]["benchmark"] == pytest.approx(baseline, rel=1e-12)
+    assert per_offset[6]["benchmark"] == pytest.approx(
+        (1.0 + baseline) ** 6 - 1.0, rel=1e-12
+    )


### PR DESCRIPTION
Stacked on #1064 (`fix/1051-event-price-data`), which owns the price-grid work this measures on. Retarget to `main` once #1064 merges.

## Summary

- offset `k > 0` is measured against `(1 + baseline)**k - 1`, the baseline compounded over the periods that offset actually spans; offsets at or below zero keep the single-period baseline
- each `per_offset` entry publishes the `benchmark` subtracted from it, so the arithmetic is reproducible from the metadata
- `baseline_bar_return` is now one mean per asset pooled with equal weight, matching what its docstring already claimed, with `n_assets_in_baseline` reporting how the weighting was formed
- docs distinguish raw cumulative return, abnormal return, and the leakage score, and say which one the curve publishes

## The defect

`event_around_return` subtracted one unconditional single-period return from every offset. That is the right unit for the pre-event offsets, which are single-period returns, but offset `k > 0` is a simple return from `t+1` to `t+1+k`. Subtracting one period of drift from a `k`-period return leaves roughly `k - 1` periods of it in the answer, and on a panel that merely trends the residue reads as event alpha.

Separately, the baseline helper's docstring described a per-asset mean pooled across assets while the implementation pooled every period observation directly, so a long-history name outvoted a short one on a ragged panel.

## Against-unfixed evidence

The three guards were written first and run on the unfixed tree:

```
FAILED tests/test_event_benchmark_horizon.py::test_drift_only_panel_has_no_excess_at_any_offset
E   AssertionError: offset 6 keeps 0.0202413 of pure drift
E   assert 0.02024128384614812 == 0.0 ± 1.0e-12
FAILED tests/test_event_benchmark_horizon.py::test_baseline_weights_assets_equally_on_a_ragged_panel
E   Obtained: 0.005311594202898546
E   Expected: 0.0034999999999999476 ± 3.5e-12
FAILED tests/test_event_benchmark_horizon.py::test_per_offset_reports_the_benchmark_it_subtracted
E   KeyError: 'benchmark'
3 failed, 1 warning
```

The drift-only panel compounds every asset at exactly 0.4% a period, so no event carries information and every offset prices to zero by construction. The residue at offset 6 is `(1.004**6 - 1) - 0.004 = 0.0202`, i.e. the five extra periods of drift the single-period benchmark left behind. All three pass after the fix.

The weighting guard pins two assets with different drifts and very different history lengths: equal-weighted gives 0.0035, the pooled mean gave 0.00531 — sitting near the long asset's 0.006 rather than describing the panel.

## Verification

Run from this branch with the repository interpreter:

- `ruff check` / `ruff format --check`: clean, 252 files
- `mypy factrix`: no issues in 83 source files
- `pytest`: **3898 passed, 45 skipped, 0 failed**
- `pytest --doctest-modules factrix`: 96 passed, 1 skipped
- `mkdocs build --strict`: built in 24.45s

`.github/workflows/test.yml` triggers only on `pull_request: branches: [main]`, so the pytest and lint matrix does not run while this PR targets a stacked base. Its small green rollup is a stacking artifact; the matrix fires on retarget.

Closes #1052