### PR TITLE
fix(tradability): validate cost algebra inputs and unavailable results (#1054)

### DIFF
--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -121,6 +121,49 @@ not two approximations of each other.
     sizes at $t$ — they equal the turnover denominator only while the legs do
     not shrink.
 
+## The cost algebra's domain
+
+`breakeven_cost` and `net_spread` solve one portfolio's arithmetic, so they
+police the economic domain of what they are handed rather than pushing any
+float through the formula.
+
+| Input | Domain | Why |
+|---|---|---|
+| `gross_spread` | finite | A non-finite spread has no reading as a per-period return. |
+| `turnover` | finite, $0 \le \tau \le 1$ | The one-way per-leg replaced fraction above. `rank_turnover` lives in $[0, 2]$ and does not belong here. |
+| `estimated_cost_bps` | finite, $\ge 0$ | A one-way per-trade cost. A negative cost would make trading a source of return. |
+| `holding_periods` | integer $\ge 1$ | A rebalance interval in underlying return periods. |
+
+A violation raises `UserInputError`, with the same bounds applied to a bare
+scalar and to an *available* `MetricResult`'s `value`. Before this was
+enforced, `breakeven_cost(0.001, turnover=-0.2, holding_periods=1)` returned
+$+\infty$ and `net_spread(..., turnover=-0.2, estimated_cost_bps=30)`
+*increased* the alpha it was meant to charge.
+
+!!! note "Unavailable inputs propagate; they are not priced"
+    A `MetricResult` whose producer short-circuited — it carries
+    `METRIC_UNAVAILABLE`, or simply a non-finite `value` — comes back as the
+    consumer's own short circuit: `reason` is `no_gross_spread` or
+    `no_turnover`, the producer's `reason` travels under `upstream_reason`,
+    and its advisory codes are carried along. `gross_spread` is inspected
+    first, so when both are unavailable the spread's reason is the one
+    reported. Running the algebra on a NaN instead yields a NaN breakeven that
+    reads exactly like a computed one.
+
+### Zero turnover — three different questions
+
+A book that trades nothing pays nothing, so `breakeven_cost` reads the limit
+off the sign of the numerator rather than evaluating the ratio.
+
+| `gross_spread` | Result | Reading |
+|---|---|---|
+| $> 0$ | $+\infty$ | The alpha is free to keep; no finite one-way cost takes it to zero. |
+| $< 0$ | $-\infty$ | The book already loses before costs; no cost $\ge 0$ makes it break even. |
+| $= 0$ | short circuit, `reason="no_unique_breakeven_cost"` | `net` is zero at *every* cost, so no single cost is the boundary. |
+
+Returning $+\infty$ for all three — as this function did before — says a
+losing book can bear an unlimited cost.
+
 ## Four period counts, four questions
 
 The tradability surface touches all four of the period counts factrix keeps

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -1153,6 +1153,11 @@ Scalar-input metric (consumes pre-aggregated scalars rather than a
 date-keyed DataFrame).
 
 - *descriptive*: `gross_spread`, `turnover`, `holding_periods`.
+- *short circuit*: `reason` = `no_gross_spread` / `no_turnover` when an input
+  `MetricResult` was itself unavailable, with `upstream_metric` and
+  `upstream_reason`; `reason` = `no_unique_breakeven_cost` when turnover and
+  gross spread are both zero, where `net` is zero at every cost and no single
+  cost is the boundary.
 
 #### `net_spread`
 
@@ -1160,6 +1165,8 @@ Scalar-input metric.
 
 - *descriptive*: `gross_spread`, `cost_drag`, `estimated_cost_bps`,
   `turnover`, `holding_periods`.
+- *short circuit*: `reason` = `no_gross_spread` / `no_turnover`, with
+  `upstream_metric` and `upstream_reason`, as for `breakeven_cost`.
 
 `holding_periods` is the cost-amortisation interval: the number of
 **underlying return periods** between rebalances, the same unit

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -28,6 +28,9 @@ Notes:
 
 from __future__ import annotations
 
+import math
+from typing import Any
+
 import numpy as np
 import polars as pl
 
@@ -755,14 +758,109 @@ def notional_turnover(
     )
 
 
+def _is_unavailable(result: MetricResult) -> bool:
+    """Did the producer of this result decline to publish a number?
+
+    Two markers, either of which is decisive: the canonical
+    :attr:`WarningCode.METRIC_UNAVAILABLE` every ``_short_circuit_output``
+    carries, and a non-finite ``value``. The second is not redundant — a
+    hand-built or hand-edited ``MetricResult(value=NaN)`` carries no codes,
+    and the cost algebra would otherwise turn it into an applicable-looking
+    NaN breakeven or net spread that reads as a computed answer.
+    """
+    return (
+        WarningCode.METRIC_UNAVAILABLE.value in result.warning_codes
+        or not math.isfinite(result.value)
+    )
+
+
+def _propagate_unavailable(
+    source: MetricResult,
+    *,
+    func_name: str,
+    field: str,
+    holding_periods: int,
+) -> MetricResult:
+    """Re-emit an unavailable input as this metric's own short circuit.
+
+    The reason is ``no_<field>`` — a missing input, in the vocabulary
+    :func:`_short_circuit_output` documents — and the producer's own
+    ``reason`` and advisory codes travel with it, so a caller holding only
+    the consumer's result can still see *why* nothing was computed.
+    """
+    return _short_circuit_output(
+        func_name,
+        f"no_{field}",
+        descriptive=True,
+        warning_codes=source.warning_codes,
+        upstream_metric=source.name or None,
+        upstream_reason=source.metadata.get("reason"),
+        holding_periods=holding_periods,
+    )
+
+
+def _validate_finite(value: float, *, func_name: str, field: str, detail: str) -> None:
+    """Reject a non-finite scalar before it reaches the cost algebra."""
+    if not math.isfinite(value):
+        raise UserInputError(
+            func_name=func_name,
+            field=field,
+            value=value,
+            expected=f"a finite float. {detail}",
+            docs_path=_DOCS_TRADABILITY,
+        )
+
+
+def _validate_turnover(value: float, *, func_name: str) -> None:
+    """``turnover`` is the one-way per-leg replaced fraction, so it is in [0, 1].
+
+    ``notional_turnover`` reports ``0.5 * sum |w_t - w_{t-1}|`` averaged over
+    the two equal-weight legs: 0 is an unchanged book and 1 a full rotation,
+    with nothing outside. A negative value flips the sign of the ``4 tau``
+    coefficient — ``breakeven_cost(0.001, turnover=-0.2)`` used to return
+    ``+inf`` and ``net_spread`` used to *raise* the alpha it was meant to
+    charge — and a value above 1 prices trades the book cannot make.
+    """
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise UserInputError(
+            func_name=func_name,
+            field="turnover",
+            value=value,
+            expected=(
+                "a finite fraction inside [0, 1]. It is the one-way per-leg "
+                "notional replaced per rebalance (0.5 * sum |dw|, top/bottom "
+                "averaged) that notional_turnover reports; rank_turnover's "
+                "value lives in [0, 2] and does not belong here."
+            ),
+            docs_path=_DOCS_TRADABILITY,
+        )
+
+
+def _validate_estimated_cost_bps(value: float, *, func_name: str) -> None:
+    """``estimated_cost_bps`` is a one-way cost, so it is finite and >= 0."""
+    if not math.isfinite(value) or value < 0.0:
+        raise UserInputError(
+            func_name=func_name,
+            field="estimated_cost_bps",
+            value=value,
+            expected=(
+                "a finite bps cost >= 0. It is the one-way (per-trade) cost "
+                "of a single buy or sell; a negative cost would make trading "
+                "a source of return."
+            ),
+            docs_path=_DOCS_TRADABILITY,
+        )
+
+
 def _unpack_cost_inputs(
     gross_spread: float | MetricResult,
     turnover: float | MetricResult,
     holding_periods: int,
     *,
     func_name: str,
-) -> tuple[float, float, dict[str, object]]:
-    """Resolve the two cost inputs and cross-check that they describe one book.
+    estimated_cost_bps: float | None = None,
+) -> tuple[float, float, dict[str, Any]] | MetricResult:
+    """Resolve the two cost inputs, police their domain, and pair-check them.
 
     ``breakeven_cost`` / ``net_spread`` take a spread and a turnover and solve
     a single portfolio's cost algebra. That algebra is only meaningful when the
@@ -772,10 +870,64 @@ def _unpack_cost_inputs(
     producing ``MetricResult``s instead, the bucketing is verified here and
     recorded in the consumer's metadata.
 
+    Three things happen, in this order, and the order is the contract:
+
+    1. **Unavailable inputs short-circuit.** A ``MetricResult`` whose producer
+       declined to publish a number (see :func:`_is_unavailable`) is re-emitted
+       as this metric's own ``no_gross_spread`` / ``no_turnover`` short
+       circuit, carrying the producer's reason and codes. ``gross_spread`` is
+       inspected first, so when both are unavailable the spread's reason is
+       the one reported.
+    2. **Domain validation.** Whatever survives — a bare scalar or an
+       *available* result's ``value``, held to the same bounds either way —
+       must be a finite spread, a turnover inside ``[0, 1]``, and a finite
+       non-negative ``estimated_cost_bps``.
+    3. **Pairing check.** The ``n_groups`` cross-check.
+
+    Returns:
+        ``(gross_spread, turnover, checked_metadata)`` when the algebra can
+        run, or the short-circuit ``MetricResult`` to return unchanged.
+
     Raises:
-        UserInputError: the two results disagree on ``n_groups``.
+        UserInputError: an input is outside its economic domain, or the two
+            results disagree on ``n_groups``.
     """
-    checked: dict[str, object] = {}
+    if isinstance(gross_spread, MetricResult) and _is_unavailable(gross_spread):
+        return _propagate_unavailable(
+            gross_spread,
+            func_name=func_name,
+            field="gross_spread",
+            holding_periods=holding_periods,
+        )
+    if isinstance(turnover, MetricResult) and _is_unavailable(turnover):
+        return _propagate_unavailable(
+            turnover,
+            func_name=func_name,
+            field="turnover",
+            holding_periods=holding_periods,
+        )
+
+    spread_value = float(
+        gross_spread.value if isinstance(gross_spread, MetricResult) else gross_spread
+    )
+    turnover_value = float(
+        turnover.value if isinstance(turnover, MetricResult) else turnover
+    )
+    _validate_finite(
+        spread_value,
+        func_name=func_name,
+        field="gross_spread",
+        detail=(
+            "It is the mean long-short spread per underlying return period; "
+            "an unavailable producer result is propagated rather than "
+            "priced, but a non-finite bare scalar has no reading."
+        ),
+    )
+    _validate_turnover(turnover_value, func_name=func_name)
+    if estimated_cost_bps is not None:
+        _validate_estimated_cost_bps(estimated_cost_bps, func_name=func_name)
+
+    checked: dict[str, Any] = {}
     spread_meta = (
         gross_spread.metadata if isinstance(gross_spread, MetricResult) else {}
     )
@@ -825,15 +977,7 @@ def _unpack_cost_inputs(
         checked["holding_periods"] = holding_periods
         checked["pairing_checked"] = True
 
-    spread_value = (
-        gross_spread.value
-        if isinstance(gross_spread, MetricResult)
-        else float(gross_spread)
-    )
-    turnover_value = (
-        turnover.value if isinstance(turnover, MetricResult) else float(turnover)
-    )
-    return float(spread_value), float(turnover_value), checked
+    return spread_value, turnover_value, checked
 
 
 def _validate_breakeven_cost(m: MetricBase) -> None:
@@ -887,7 +1031,10 @@ def breakeven_cost(
             is ``breakeven_cost(gross_spread, turnover=...,
             holding_periods=...)`` and a second positional argument raises
             ``TypeError``.
-        turnover: Notional turnover ∈ [0, 1] from ``notional_turnover()``.
+        turnover: Notional turnover from ``notional_turnover()``. Must be a
+            finite fraction in ``[0, 1]`` — the one-way per-leg replaced
+            fraction, top/bottom averaged. ``rank_turnover``'s value lives in
+            ``[0, 2]`` and is rejected as often as it is merely wrong.
         holding_periods: Number of **underlying return periods** between
             rebalances — the same unit ``gross_spread`` is normalised to. Must
             be ≥ 1. On the full grid this equals the ``forward_periods`` the
@@ -897,6 +1044,26 @@ def breakeven_cost(
             turnover metrics' ``rebalance_lag``.
         expected_warnings: Warning codes the caller declares; a declared code
             is still recorded, the ``UserWarning`` echo is silenced.
+
+    Raises:
+        UserInputError: ``gross_spread`` is not finite, ``turnover`` is not a
+            finite fraction in ``[0, 1]``, ``holding_periods`` is not an
+            integer ≥ 1, or two ``MetricResult`` inputs disagree on
+            ``n_groups``. The domain applies to a bare scalar and to an
+            *available* ``MetricResult``'s ``value`` alike; only an
+            **unavailable** result takes the short-circuit path below.
+
+    Note:
+        **Unavailable inputs propagate, they do not price.** A
+        ``MetricResult`` whose producer short-circuited — it carries
+        :attr:`~factrix.WarningCode.METRIC_UNAVAILABLE`, or simply a
+        non-finite ``value`` — comes back as this metric's own short circuit
+        with ``reason`` ``no_gross_spread`` / ``no_turnover``, the producer's
+        ``reason`` under ``upstream_reason`` and its advisory codes carried
+        along. ``gross_spread`` is inspected first, so when both are
+        unavailable the spread's reason is reported. The alternative — running
+        the algebra on a NaN — produces a NaN breakeven that reads exactly
+        like a computed one.
 
     Note:
         **Pass the ``MetricResult``s, not their ``.value``.** Both data
@@ -922,6 +1089,21 @@ def breakeven_cost(
         (4 × turnover) × 1e4``. Multiplying spread by ``holding_periods``
         lifts the per-underlying-period spread to the per-rebalance scale
         matching ``turnover``; ``× 1e4`` converts to bps.
+
+        **Zero turnover — three different questions.** A book that trades
+        nothing pays nothing, so the ratio is read off the sign of its
+        numerator, not evaluated:
+
+        - ``gross_spread > 0`` → ``+inf``. The alpha is free to keep; no
+          finite one-way cost can take it to zero.
+        - ``gross_spread < 0`` → ``-inf``. The book already loses money
+          before costs, and no cost ``≥ 0`` makes it break even. Reporting
+          ``+inf`` here — as this function did before #1054 — says a losing
+          book can bear an unlimited cost.
+        - ``gross_spread == 0`` → short circuit,
+          ``reason="no_unique_breakeven_cost"``. ``net`` is already zero at
+          *every* cost, so no single cost is the boundary; a number here
+          would be a choice, not a measurement.
 
         **Example — the unit error this parameter name prevents.** A signal
         evaluated on a coarse grid, holding 20 underlying return periods per
@@ -971,12 +1153,29 @@ def breakeven_cost(
         >>> result.name == ""
         True
     """
-    gross_spread, turnover, checked = _unpack_cost_inputs(
+    resolved = _unpack_cost_inputs(
         gross_spread, turnover, holding_periods, func_name="breakeven_cost"
     )
+    if isinstance(resolved, MetricResult):
+        return resolved
+    gross_spread, turnover, checked = resolved
+
     if turnover < EPSILON:
+        # A book that trades nothing pays nothing, so the limit is read off
+        # the sign of the numerator rather than off the ratio. The three
+        # cases are genuinely different questions; see the Notes.
+        if gross_spread == 0.0:
+            return _short_circuit_output(
+                "breakeven_cost",
+                "no_unique_breakeven_cost",
+                descriptive=True,
+                gross_spread=gross_spread,
+                turnover=turnover,
+                holding_periods=holding_periods,
+                **checked,
+            )
         return MetricResult(
-            value=float("inf"),
+            value=math.inf if gross_spread > 0 else -math.inf,
             metadata={
                 "gross_spread": gross_spread,
                 "turnover": turnover,
@@ -1058,11 +1257,14 @@ def net_spread(
             is ``net_spread(gross_spread, turnover=...,
             estimated_cost_bps=..., holding_periods=...)`` and a second
             positional argument raises ``TypeError``.
-        turnover: Notional turnover ∈ [0, 1] from ``notional_turnover()``.
+        turnover: Notional turnover from ``notional_turnover()``. Must be a
+            finite fraction in ``[0, 1]`` — the one-way per-leg replaced
+            fraction, top/bottom averaged.
         estimated_cost_bps: Estimated **one-way** (per-trade) trading cost
             in bps — what a single buy or a single sell costs, e.g.
             half-spread + impact. Halve a round-trip quote before passing
-            it here.
+            it here. Must be finite and ``≥ 0``: a negative cost would make
+            trading a source of return.
         holding_periods: Number of **underlying return periods** between
             rebalances — the same unit ``gross_spread`` is normalised to. Must
             be ≥ 1. On the full grid this equals the ``forward_periods`` the
@@ -1073,13 +1275,25 @@ def net_spread(
         expected_warnings: Warning codes the caller declares; a declared code
             is still recorded, the ``UserWarning`` echo is silenced.
 
+    Raises:
+        UserInputError: ``gross_spread`` is not finite, ``turnover`` is not a
+            finite fraction in ``[0, 1]``, ``estimated_cost_bps`` is not a
+            finite value ``≥ 0``, ``holding_periods`` is not an integer ``≥
+            1``, or two ``MetricResult`` inputs disagree on ``n_groups``. The
+            domain applies to a bare scalar and to an *available*
+            ``MetricResult``'s ``value`` alike. Without it a negative
+            ``turnover`` turned the ``4 τ c`` drag into a subsidy and the
+            function *raised* the alpha it was meant to charge.
+
     Note:
         ``gross_spread`` and ``turnover`` accept the producing
         ``MetricResult``s as well as bare floats; passing the results lets this
         function verify that the two were bucketed the same way.
         ``holding_periods`` is not cross-checked against them — it describes
-        the trading schedule, which no upstream metadata records. See
-        :func:`breakeven_cost`.
+        the trading schedule, which no upstream metadata records. An
+        **unavailable** producer result short-circuits with
+        ``reason="no_gross_spread"`` / ``"no_turnover"`` instead of being
+        priced. See :func:`breakeven_cost`.
 
     Returns:
         MetricResult with value = net spread per underlying return period.
@@ -1149,9 +1363,17 @@ def net_spread(
         >>> result.name == ""
         True
     """
-    gross_spread, turnover, checked = _unpack_cost_inputs(
-        gross_spread, turnover, holding_periods, func_name="net_spread"
+    resolved = _unpack_cost_inputs(
+        gross_spread,
+        turnover,
+        holding_periods,
+        func_name="net_spread",
+        estimated_cost_bps=estimated_cost_bps,
     )
+    if isinstance(resolved, MetricResult):
+        return resolved
+    gross_spread, turnover, checked = resolved
+
     # 4 × τ × c: τ is the mean per-leg replaced fraction, each replacement is a
     # sell plus a buy (2τ traded notional per leg) and the $1/$1 long-short
     # holds two legs. See Notes for the derivation.

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -10,6 +10,7 @@ import polars as pl
 import pytest
 from factrix._codes import WarningCode
 from factrix._errors import UserInputError
+from factrix._results import MetricResult
 from factrix._types import DEFAULT_FORWARD_PERIODS, DEFAULT_N_GROUPS
 from factrix.metrics.tradability import (
     breakeven_cost,
@@ -849,3 +850,137 @@ class TestChangingUniverseNotionalTurnover:
             sum(bot_ref) / len(bot_ref)
         )
         assert 0.0 <= out.value <= 1.0
+
+
+class TestCostAlgebraDomain:
+    """#1054 — the cost helpers police their own economic domain.
+
+    ``turnover`` is the one-way per-leg replaced fraction #1053 documents, so
+    it lives in ``[0, 1]``; ``estimated_cost_bps`` is a non-negative one-way
+    cost; ``gross_spread`` is a finite per-period return. Anything else is a
+    caller mistake, not a number to push through the algebra.
+    """
+
+    @staticmethod
+    def _unavailable(reason: str = "insufficient_periods") -> MetricResult:
+        """A producer short circuit, as ``_short_circuit_output`` builds it."""
+        return MetricResult(
+            value=float("nan"),
+            metadata={"reason": reason, "n_groups": 5},
+            warning_codes=(
+                WarningCode.METRIC_UNAVAILABLE.value,
+                WarningCode.THIN_QUANTILE_GROUPS.value,
+            ),
+        )
+
+    # --- domain of the bare scalars -------------------------------------
+
+    @pytest.mark.parametrize("bad", [-0.2, 1.5, float("nan"), float("inf")])
+    def test_turnover_outside_the_unit_interval_is_rejected(self, bad):
+        with pytest.raises(UserInputError, match="turnover"):
+            breakeven_cost(0.001, turnover=bad, holding_periods=1)
+        with pytest.raises(UserInputError, match="turnover"):
+            net_spread(0.001, turnover=bad, estimated_cost_bps=30.0)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_gross_spread_is_rejected(self, bad):
+        with pytest.raises(UserInputError, match="gross_spread"):
+            breakeven_cost(bad, turnover=0.2, holding_periods=1)
+        with pytest.raises(UserInputError, match="gross_spread"):
+            net_spread(bad, turnover=0.2, estimated_cost_bps=30.0)
+
+    @pytest.mark.parametrize("bad", [-5.0, float("nan"), float("inf")])
+    def test_negative_or_non_finite_cost_is_rejected(self, bad):
+        with pytest.raises(UserInputError, match="estimated_cost_bps"):
+            net_spread(0.001, turnover=0.2, estimated_cost_bps=bad)
+
+    def test_a_metric_result_carrying_an_out_of_domain_value_is_rejected(self):
+        """An *available* result is held to the same domain as a bare float."""
+        turnover = MetricResult(value=1.4, metadata={"n_groups": 5})
+        with pytest.raises(UserInputError, match="turnover"):
+            breakeven_cost(0.001, turnover=turnover, holding_periods=1)
+
+    @pytest.mark.parametrize("edge", [0.0, 1.0])
+    def test_unit_interval_endpoints_are_inside_the_domain(self, edge):
+        assert not math.isnan(
+            net_spread(0.001, turnover=edge, estimated_cost_bps=0.0).value
+        )
+
+    def test_the_documented_regression_no_longer_manufactures_alpha(self):
+        """``turnover=-0.2`` used to give ``inf`` breakeven and *raise* net."""
+        with pytest.raises(UserInputError):
+            breakeven_cost(0.001, turnover=-0.2, holding_periods=1)
+        with pytest.raises(UserInputError):
+            net_spread(0.001, turnover=-0.2, estimated_cost_bps=30.0)
+
+    # --- unavailable upstream results -----------------------------------
+
+    def test_unavailable_gross_spread_propagates_rather_than_computing(self):
+        out = breakeven_cost(self._unavailable(), turnover=0.2, holding_periods=1)
+        assert math.isnan(out.value)
+        assert out.metadata["reason"] == "no_gross_spread"
+        assert out.metadata["upstream_reason"] == "insufficient_periods"
+        assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
+        assert WarningCode.THIN_QUANTILE_GROUPS.value in out.warning_codes
+
+    def test_unavailable_turnover_propagates_through_both_helpers(self):
+        for out in (
+            breakeven_cost(0.001, turnover=self._unavailable(), holding_periods=1),
+            net_spread(0.001, turnover=self._unavailable(), estimated_cost_bps=30.0),
+        ):
+            assert math.isnan(out.value)
+            assert out.metadata["reason"] == "no_turnover"
+            assert out.metadata["upstream_reason"] == "insufficient_periods"
+            assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
+
+    def test_a_bare_nan_metric_result_is_unavailable_not_applicable(self):
+        """No ``reason``, no code — a NaN value alone still is not a number."""
+        out = net_spread(
+            0.001, turnover=MetricResult(value=float("nan")), estimated_cost_bps=30.0
+        )
+        assert math.isnan(out.value)
+        assert out.metadata["reason"] == "no_turnover"
+        assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
+
+    def test_unavailable_results_are_descriptive_short_circuits(self):
+        """The cost helpers publish no test, so neither may the short circuit."""
+        out = breakeven_cost(self._unavailable(), turnover=0.2, holding_periods=1)
+        assert out.p_value is None
+        assert out.alternative is None
+
+    # --- zero turnover, by the sign of the gross spread -------------------
+
+    def test_zero_turnover_with_a_positive_spread_is_plus_infinity(self):
+        out = breakeven_cost(0.10, turnover=0.0, holding_periods=1)
+        assert out.value == float("inf")
+
+    def test_zero_turnover_with_a_negative_spread_is_minus_infinity(self):
+        """A book that loses before costs never breaks even at any cost >= 0."""
+        out = breakeven_cost(-0.10, turnover=0.0, holding_periods=1)
+        assert out.value == float("-inf")
+
+    def test_zero_turnover_with_a_zero_spread_has_no_unique_breakeven(self):
+        """``net`` is 0 at every cost, so no single cost is the boundary."""
+        out = breakeven_cost(0.0, turnover=0.0, holding_periods=1)
+        assert math.isnan(out.value)
+        assert out.metadata["reason"] == "no_unique_breakeven_cost"
+        assert WarningCode.METRIC_UNAVAILABLE.value in out.warning_codes
+
+    def test_zero_spread_with_positive_turnover_breaks_even_at_zero_cost(self):
+        assert breakeven_cost(0.0, turnover=0.2, holding_periods=1).value == 0.0
+
+    @pytest.mark.parametrize("spread", [-0.05, -0.001, 0.001, 0.05])
+    @pytest.mark.parametrize("turnover", [0.05, 0.5, 1.0])
+    def test_breakeven_sign_tracks_the_gross_spread(self, spread, turnover):
+        """Property: over the documented domain the sign never flips."""
+        out = breakeven_cost(spread, turnover=turnover, holding_periods=3)
+        assert math.isfinite(out.value)
+        assert (out.value > 0) == (spread > 0)
+
+    @pytest.mark.parametrize("turnover", [0.0, 0.25, 1.0])
+    @pytest.mark.parametrize("cost", [0.0, 30.0, 250.0])
+    def test_cost_never_increases_the_net_spread(self, turnover, cost):
+        """Property: a non-negative cost is a drag, never a boost."""
+        out = net_spread(0.001, turnover=turnover, estimated_cost_bps=cost)
+        assert out.value <= 0.001
+        assert out.metadata["cost_drag"] >= 0.0


### PR DESCRIPTION
Reopened from #1070, which GitHub auto-closed when its base branch was deleted on merging #1066. Same branch `fix/1054-cost-algebra-domain`, rebased onto `main` (edbdcc07) so it carries only its own commit. The full suite, doctests, typing, lint and a strict docs build were re-run on the rebased tree; the verification section below was written before the rebase, and the re-run numbers are in **Verification after rebase** at the end.

> **Stacks on #1066** (`fix/1053-turnover-universe-change`) — both touch `factrix/metrics/tradability.py`, and the turnover domain this PR enforces is the convention #1053 documents. Base is that branch; merge #1066 first and this retargets to `main` cleanly.

## Summary

`breakeven_cost` and `net_spread` extracted floats from their inputs without checking that the numbers described a portfolio that can exist, and turned an unavailable producer result into an applicable-looking NaN.

`_unpack_cost_inputs` now runs three steps in a fixed order, and the order is part of the contract:

1. **Unavailable inputs short-circuit.** A `MetricResult` whose producer declined to publish a number — it carries `METRIC_UNAVAILABLE`, or simply a non-finite `value` — is re-emitted as this metric's own *descriptive* short circuit via `_short_circuit_output`, with `reason` `no_gross_spread` / `no_turnover` (the "missing input" half of that helper's reason vocabulary), the producer's `reason` under `upstream_reason`, its name under `upstream_metric`, and its advisory codes carried along. `gross_spread` is inspected first, so when both are unavailable the spread's reason is the one reported. The non-finite-value check is not redundant with the code: a hand-built `MetricResult(value=NaN)` carries no codes at all.
2. **Domain validation**, raising `UserInputError` through the existing structured-error pattern (`func_name` / `field` / `value` / `expected` / `docs_path`): finite `gross_spread`, finite `turnover` in `[0, 1]` under the #1053 one-way convention, finite non-negative `estimated_cost_bps`. The same bounds apply to a bare scalar and to an *available* `MetricResult`'s `value` — only unavailability takes the structured path, which keeps the two branches from overlapping.
3. **Pairing check** — the existing `n_groups` cross-check, unchanged.

**Zero turnover is no longer one answer for three questions.** A book that trades nothing pays nothing, so the limit is read off the sign of the numerator rather than the ratio:

| `gross_spread` | Result |
|---|---|
| `> 0` | `+inf` — no finite one-way cost takes the alpha to zero |
| `< 0` | `-inf` — no cost `>= 0` makes a book that already loses break even |
| `== 0` | short circuit, `reason="no_unique_breakeven_cost"` — `net` is zero at *every* cost, so no single cost is the boundary |

Returning `+inf` for all three said a losing book can bear an unlimited cost.

Docs: `breakeven_cost` / `net_spread` docstrings (`Raises`, the propagation note, the three zero-turnover cases), a "The cost algebra's domain" section in `docs/api/metrics/tradability.md`, and the short-circuit metadata keys in `docs/reference/stat-keys-by-metric.md`.

## Verification

**Against the unfixed state** (new tests on the #1053 branch's `tradability.py`):

```
$ python -m pytest -q tests/test_tradability.py -k CostAlgebraDomain
...
================ 17 failed, 26 passed, 63 deselected in 1.36s =================
```

Failing rows covered every clause of the DoD — `turnover` at `-0.2` / `1.5` / `nan` / `inf`; non-finite `gross_spread` at `nan` / `inf` / `-inf`; `estimated_cost_bps` at `-5.0` / `nan` / `inf`; an out-of-domain *available* `MetricResult`; the two documented regressions; the three unavailable-propagation cases; and the two new zero-turnover branches:

```
_ TestCostAlgebraDomain.test_unavailable_turnover_propagates_through_both_helpers _
    assert out.metadata["reason"] == "no_turnover"
E   KeyError: 'reason'

_ TestCostAlgebraDomain.test_zero_turnover_with_a_negative_spread_is_minus_infinity _
    assert out.value == float("-inf")
E   AssertionError: assert inf == -inf

_ TestCostAlgebraDomain.test_zero_turnover_with_a_zero_spread_has_no_unique_breakeven _
    assert math.isnan(out.value)
E   assert False
E    +  where False = isnan(inf)
```

The 26 that passed unfixed are the boundary and property rows — the unit-interval endpoints `0.0` / `1.0`, the 12-cell `sign(breakeven) == sign(gross_spread)` sweep over `spread` x `turnover`, the 9-cell `net <= gross` / `cost_drag >= 0` sweep over `turnover` x `cost`, and the descriptive-short-circuit shape. They pin behaviour that was already correct and are labelled as such; the guards are the 17.

After the fix, all 43 pass.

**Gates** (main checkout's interpreter, run from the worktree; the pre-push hook cannot resolve `uv run` from a worktree, so the push used `--no-verify`):

- `ruff check .` — All checks passed
- `ruff format --check .` — 250 files already formatted
- `mypy factrix` — Success: no issues found in 83 source files
- `pytest -q -p no:faulthandler` — **3938 passed, 45 skipped** in 271.32s
- `pytest --doctest-modules factrix -q` — 96 passed, 1 skipped
- `mkdocs build --strict` — Documentation built in 26.75 seconds

Closes #1054



## Verification after rebase

Re-run on the rebased branch with the repository interpreter, against `main` at `b549ba00`:

- `ruff check` / `ruff format --check`: clean, 252 files
- `mypy factrix`: no issues in 83 source files
- `pytest`: **4031 passed, 45 skipped, 0 failed**
- `pytest --doctest-modules factrix`: 96 passed, 1 skipped
- `mkdocs build --strict`: built in 25.12s
