### PR TITLE
feat(inspect): expose per-factor preflight results (#1056)

### DIFF
--- a/docs/api/inspect-data.md
+++ b/docs/api/inspect-data.md
@@ -84,7 +84,76 @@ The tier groups are `MetricApplicabilityGroup` objects: they expose `.names`
 and `.to_metrics_dict()`, and slicing or concatenating them with `+` preserves
 those helpers.
 
+<hr>
+
+## Multi-factor input: per-factor results
+
+`evaluate` dispatches each factor column independently — one
+`EvaluationResult` per column, each routed to its own `(scope, density,
+structure)` cell. Inspection reports at the same granularity, so a preflight
+verdict maps one-to-one onto the `evaluate` output it predicts:
+
+| `inspect_data(data, factor_cols=cols)` | `evaluate(data, ..., factor_cols=cols)` |
+|---|---|
+| `info.factors[col].properties` | the cell `results[col]` was dispatched to |
+| `info.factors[col].usable` / `.degraded` / `.unusable` | which entries of `results[col].metrics` return a value, a degraded value, or a `metric_unavailable` NaN |
+| `info.factors[col].warnings` | the data-level warnings that column raises |
+| `info.factors[col].usable.to_metrics_dict()` | the `metrics=` argument to run that column safely |
+
+```python
+import factrix as fx
+import polars as pl
+from factrix.preprocess import compute_forward_return
+
+raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
+data = compute_forward_return(
+    raw.with_columns(pl.col("factor").mean().over("date").alias("macro")),
+    forward_periods=5,
+)
+info = fx.inspect_data(data, factor_cols=["factor", "macro"])
+
+for col, f in info.factors.items():
+    print(col, f.properties.scope.value, f.properties.density.value, f.usable.names)
+
+# Run each column with the metrics its own verdict cleared. strict=False keeps
+# a metric whose run-time floor binds tighter than the pre-flight one as a NaN
+# placeholder with a reason, rather than raising for the whole batch.
+for col, f in info.factors.items():
+    results = fx.evaluate(
+        data,
+        metrics=f.usable.to_metrics_dict(),
+        factor_cols=[col],
+        forward_periods=5,
+        strict=False,
+    )
+```
+
+Two granularities travel together on purpose. A screen over dozens of
+candidate columns still wants one answer to "what is this panel", so
+`properties`, `metrics` and the tier partitions remain a concise aggregate and
+describe the **first** inspected column — exactly `factors[<first column>]`.
+Single-factor callers therefore never touch the mapping; multi-factor callers
+never have to guess which column an aggregate refers to.
+
+When columns disagree on `FactorScope` or `FactorDensity`, the aggregate
+`warnings` carry a `cross_factor_*_mismatch` naming the basis column, the
+columns that disagree with it, and the value each one carries. A later
+column's own advisories (low cardinality, frequent events, scope
+unidentifiable, sample shape) live on `factors[col].warnings` rather than
+being merged into one stream where the column they belong to would be lost.
+
+One panel-level caveat: `n_periods` and `n_assets` are properties of the data,
+so every `FactorInspection` reports the panel's counts rather than the periods
+that column happens to cover. Where a column's own coverage gates a metric it
+does so through the stage-one profile, which *is* per column — a column whose
+IC cross-sections survive on 20 periods is blocked at `ic`'s 50-period floor
+while its sibling in the same panel is not.
+
 ::: factrix.DataInspection
+
+---
+
+::: factrix.FactorInspection
 
 ---
 

--- a/factrix/__init__.py
+++ b/factrix/__init__.py
@@ -97,6 +97,7 @@ from factrix._errors import (
 from factrix._inspect import (
     DataInspection,
     DataProperties,
+    FactorInspection,
     MetricApplicability,
     MetricApplicabilityGroup,
     _allows_sparse_event_override,
@@ -1353,6 +1354,7 @@ __all__ = [
     "MetricApplicabilityGroup",
     "DataInspection",
     "DataProperties",
+    "FactorInspection",
     "SampleThreshold",
     "inspect_data",
     "list_metrics",

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -20,6 +20,12 @@ exposing ``usable`` / ``warnings`` / ``blockers``. The flat
 the single source of truth; the ``usable`` / ``degraded`` /
 ``unusable`` properties expose it as a mutually exclusive partition.
 
+Inspection runs per factor column — the granularity ``evaluate``
+dispatches at. :class:`DataInspection.factors` maps each inspected column
+to its own :class:`FactorInspection` (axes, counts, stage-one profiles,
+warnings, verdicts), while ``properties`` / ``metrics`` stay the concise
+aggregate and describe the first inspected column.
+
 Sparse detection is zero-value based. Null factor cells mean "missing
 factor value" and are excluded from the sparse-ratio denominator; they
 are not imputed to non-events. Callers that want missing upstream rows
@@ -380,30 +386,20 @@ class MetricApplicabilityGroup(list["MetricApplicability"]):
         return {m.name: m.metric() for m in self if _default_constructible(m.metric)}
 
 
-@dataclass(frozen=True, slots=True)
-class DataInspection:
-    """Result of :func:`inspect_data`.
+class _MetricPartitionView:
+    """Shared tier partition over a ``metrics`` list.
 
-    Pure data — no execution methods.
-
-    Attributes:
-        properties: :class:`DataProperties` with typed enum axes, the
-            per-axis rationale strings, and shape numerics.
-        metrics: Flat ``list[MetricApplicability]`` — one verdict
-            per ``visibility=PUBLIC`` spec the inspector considered.
-            Single source of truth; the :attr:`usable` /
-            :attr:`degraded` / :attr:`unusable` properties expose it
-            as a mutually exclusive partition.
-        warnings: Data-level sample-shape diagnostics (NW HAC SE
-            unreliable, cross-asset df low). ``source=None`` on
-            every entry because these are data-level, not
-            per-metric. Per-metric degraded warnings live inside
-            each :class:`MetricApplicability`.
+    :class:`DataInspection` and :class:`FactorInspection` answer the same
+    question at two granularities — the panel's first column and one named
+    column — so they expose one partition implementation rather than two that
+    can drift apart.
     """
 
+    # Declared for the subclasses' benefit only: the mixin is not a dataclass,
+    # so these are annotations, not fields.
     properties: DataProperties
     metrics: list[MetricApplicability]
-    warnings: list[Warning] = field(default_factory=list)
+    warnings: list[Warning]
 
     @property
     def usable(self) -> MetricApplicabilityGroup:
@@ -452,24 +448,11 @@ class DataInspection:
         """
         return MetricApplicabilityGroup(m for m in self.metrics if not m.usable)
 
-    def to_dict(self) -> dict[str, Any]:
-        """JSON-friendly nested dict view.
+    def _core_dict(self) -> dict[str, Any]:
+        """The ``properties`` / ``reasoning`` / ``metrics`` / ``warnings`` view.
 
-        Layout (top-level keys, stable order):
-
-        - ``properties``: ``{scope, density, structure, n_assets, n_periods,
-          n_pairs, sparse_ratio}`` — enum fields rendered as their
-          ``.value`` string; ``sparse_ratio`` ``NaN`` emitted as
-          ``None``.
-        - ``reasoning``: ``{scope, density, structure}``.
-        - ``metrics``: list of per-spec dicts
-          ``{name, cell, usable, warnings, blockers}`` — same row
-          shape suits ``pl.from_dicts`` for cross-data audit.
-        - ``warnings``: data-level ``[{code, source, message}, ...]``.
-
-        Mirrors :meth:`factrix.EvaluationResult.to_dict` shape — single
-        ``to_dict`` convention across the public result-type group so
-        log / parquet sinks treat them uniformly.
+        One renderer for both granularities, so a per-factor row and the
+        aggregate row cannot drift into different shapes.
         """
         d = self.properties
         return {
@@ -514,6 +497,118 @@ class DataInspection:
                 }
                 for w in self.warnings
             ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FactorInspection(_MetricPartitionView):
+    """Pre-flight result for **one** factor column.
+
+    ``evaluate`` dispatches every factor column independently, so inspection
+    reports at the same granularity: one of these per inspected column, keyed
+    by column name on :attr:`DataInspection.factors`. Every axis, count,
+    stage-one profile, advisory warning and metric verdict here is computed
+    from :attr:`factor` alone — nothing is inherited from a sibling column.
+
+    Attributes:
+        factor: The inspected column's name.
+        properties: :class:`DataProperties` detected on this column. The
+            panel-level fields (``structure`` / ``n_assets`` / ``n_periods``)
+            are properties of the data and are therefore shared with every
+            sibling; the factor-level fields (``scope`` / ``density`` /
+            ``n_pairs`` / ``n_events`` / ``sparse_ratio``) are this column's.
+        metrics: One :class:`MetricApplicability` per public spec, judged
+            against this column. Partitioned by :attr:`usable` /
+            :attr:`degraded` / :attr:`unusable`.
+        warnings: Data-level diagnostics raised by this column (sample shape,
+            scope unidentifiable, low-cardinality / frequent-event advisories,
+            single-asset event data).
+    """
+
+    factor: str
+    properties: DataProperties
+    metrics: list[MetricApplicability]
+    warnings: list[Warning] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-friendly view: ``{factor, properties, reasoning, metrics, warnings}``.
+
+        Same row shape as :meth:`DataInspection.to_dict` minus ``factors``,
+        plus the column name, so a multi-factor audit flattens straight into
+        ``pl.from_dicts``.
+        """
+        return {"factor": self.factor, **self._core_dict()}
+
+
+@dataclass(frozen=True, slots=True)
+class DataInspection(_MetricPartitionView):
+    """Result of :func:`inspect_data`.
+
+    Pure data — no execution methods.
+
+    Two granularities travel together. :attr:`factors` carries one
+    :class:`FactorInspection` per inspected column — the granularity
+    ``evaluate`` dispatches at. :attr:`properties` / :attr:`metrics` and the
+    :attr:`usable` / :attr:`degraded` / :attr:`unusable` partitions are the
+    concise aggregate view and describe the **first** inspected column, which
+    is the whole panel when there is only one; they are exactly
+    ``factors[<first column>]``, so a single-factor caller never has to reach
+    into the mapping.
+
+    Attributes:
+        properties: :class:`DataProperties` with typed enum axes, the
+            per-axis rationale strings, and shape numerics — for the
+            first inspected column.
+        metrics: Flat ``list[MetricApplicability]`` — one verdict
+            per ``visibility=PUBLIC`` spec the inspector considered,
+            for the first inspected column. Single source of truth for
+            the aggregate view; the :attr:`usable` / :attr:`degraded` /
+            :attr:`unusable` properties expose it as a mutually
+            exclusive partition.
+        warnings: Data-level sample-shape diagnostics (NW HAC SE
+            unreliable, cross-asset df low). ``source=None`` on
+            every entry because these are data-level, not
+            per-metric. Per-metric degraded warnings live inside
+            each :class:`MetricApplicability`. Carries the first column's
+            warnings plus the cross-factor mismatch warnings, which name
+            the disagreeing columns; a later column's own advisories live
+            on ``factors[col].warnings``.
+        factors: ``{column name: FactorInspection}`` in inspected order —
+            per-column scope, density, counts, stage-one profiles,
+            warnings and metric verdicts. Always populated, including for
+            single-factor input.
+    """
+
+    properties: DataProperties
+    metrics: list[MetricApplicability]
+    warnings: list[Warning] = field(default_factory=list)
+    factors: dict[str, FactorInspection] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-friendly nested dict view.
+
+        Layout (top-level keys, stable order):
+
+        - ``properties``: ``{scope, density, structure, n_assets, n_periods,
+          n_pairs, sparse_ratio}`` — enum fields rendered as their
+          ``.value`` string; ``sparse_ratio`` ``NaN`` emitted as
+          ``None``.
+        - ``reasoning``: ``{scope, density, structure}``.
+        - ``metrics``: list of per-spec dicts
+          ``{name, cell, usable, warnings, blockers}`` — same row
+          shape suits ``pl.from_dicts`` for cross-data audit.
+        - ``warnings``: data-level ``[{code, source, message}, ...]``.
+        - ``factors``: ``{column name: FactorInspection.to_dict()}`` in
+          inspected order — the same four keys per column, plus ``factor``.
+          ``factors[<first column>]`` restates the four keys above.
+
+        Mirrors :meth:`factrix.EvaluationResult.to_dict` shape — single
+        ``to_dict`` convention across the public result-type group so
+        log / parquet sinks treat them uniformly.
+        """
+        return {
+            **self._core_dict(),
+            "factors": {name: f.to_dict() for name, f in self.factors.items()},
         }
 
     def _repr_html_(self) -> str:
@@ -578,13 +673,34 @@ class DataInspection:
                 f"<tbody>{w_rows}</tbody></table></details>"
             )
 
+        factor_block = ""
+        if len(self.factors) > 1:
+            factor_rows = "".join(
+                f"<tr><td>{html.escape(name)}</td>"
+                f"<td>{html.escape(f.properties.scope.value)}</td>"
+                f"<td>{html.escape(f.properties.density.value)}</td>"
+                f"<td>{f.properties.n_pairs}</td>"
+                f"<td>{f.properties.n_events}</td>"
+                f"<td>{len(f.usable)}/{len(f.metrics)}</td>"
+                f"<td>{len(f.warnings)}</td></tr>"
+                for name, f in self.factors.items()
+            )
+            factor_block = (
+                f"<table><caption>per-factor ({len(self.factors)} columns; the "
+                "tables above describe the first)</caption>"
+                "<thead><tr><th>factor</th><th>scope</th><th>density</th>"
+                "<th>n_pairs</th><th>n_events</th><th>usable</th>"
+                "<th>warnings</th></tr></thead>"
+                f"<tbody>{factor_rows}</tbody></table>"
+            )
+
         return (
             "<div class='factrix-data-inspection'>"
             "<table><caption>DataInspection — properties</caption>"
             f"<tbody>{header_html}</tbody></table>"
             "<table><caption>reasoning</caption>"
             f"<tbody>{reasoning_rows}</tbody></table>"
-            f"{metric_table}{warnings_block}"
+            f"{factor_block}{metric_table}{warnings_block}"
             "</div>"
         )
 
@@ -621,15 +737,35 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
     such as a ternary ``{-1, 0, +1}`` indicator), matching its run-time
     ``not_applicable_discrete_signal`` short-circuit.
 
-    Multi-factor input: the inspected :class:`DataProperties` and every
-    per-metric verdict are computed from the **first** factor column only
-    (deterministic first-detected). When columns disagree on
-    ``FactorDensity`` or ``FactorScope`` a ``CROSS_FACTOR_*_MISMATCH``
-    data-level warning is emitted directing the caller to re-run
-    ``inspect_data(data, factor_cols=[col])`` for a column-specific verdict.
-    Other per-column properties (e.g. signal magnitude, ``n_events``) are
-    likewise first-column-based; for a heterogeneous panel prefer the
-    per-column call.
+    Multi-factor input is inspected **per column**, the granularity
+    :func:`factrix.evaluate` dispatches at: :attr:`DataInspection.factors`
+    maps each inspected column to a :class:`FactorInspection` carrying that
+    column's scope, density, counts, stage-one profiles, warnings and full
+    metric verdicts — nothing there is inherited from a sibling column.
+
+    Two granularities rather than one, deliberately: a screen over dozens of
+    candidate columns still wants a single answer to "what is this panel", so
+    :attr:`~DataInspection.properties`, :attr:`~DataInspection.metrics` and the
+    ``usable`` / ``degraded`` / ``unusable`` partitions remain the concise
+    aggregate and describe the **first** inspected column (the whole panel
+    when there is only one). They are exactly ``factors[<first column>]``, so
+    single-factor callers never touch the mapping and multi-factor callers
+    never have to guess which column an aggregate refers to. When columns
+    disagree on ``FactorDensity`` or ``FactorScope``, a
+    ``CROSS_FACTOR_*_MISMATCH`` data-level warning names the basis column, the
+    columns that disagree with it and the value each carries.
+
+    ``warnings`` on the result is the first column's warnings plus those
+    cross-factor mismatches; a later column's own advisories live on
+    ``factors[col].warnings`` rather than being merged into one stream where
+    the column they belong to would be lost.
+
+    One panel-level caveat: ``n_periods`` and ``n_assets`` are properties of
+    the data, so every :class:`FactorInspection` reports the panel's counts,
+    not the periods that column happens to cover. Where a column's own
+    coverage gates a metric it does so through the stage-one profile, which
+    is computed per column (a column whose IC cross-sections survive on 20
+    periods is blocked at ``ic``'s 50-period floor while its sibling is not).
 
     Args:
         data: Long-format factor data with the canonical columns.
@@ -645,9 +781,21 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
 
     Examples:
         >>> import factrix as fx
+        >>> import polars as pl
         >>> raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=120)
         >>> info = fx.inspect_data(raw)
         >>> all(m.spec.cell.matches(info.properties.scope, info.properties.density, info.properties.structure) for m in info.usable)
+        True
+
+        Per-column verdicts for a heterogeneous panel:
+
+        >>> data = raw.with_columns(pl.col("factor").mean().over("date").alias("macro"))
+        >>> info = fx.inspect_data(data, factor_cols=["factor", "macro"])
+        >>> info.factors["factor"].properties.scope.value
+        'individual'
+        >>> info.factors["macro"].properties.scope.value
+        'common'
+        >>> "ic" in info.factors["macro"].unusable.names
         True
     """
     if isinstance(factor_cols, str):
@@ -671,37 +819,81 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
         )
 
     first_col = cols[0]
-
-    # Project raw data to "factor" column name to reuse standard detectors
-    def _detect_col_density(col: str) -> tuple[FactorDensity, str, float]:
-        temp = data.select("date", "asset_id", pl.col(col).alias("factor"))
-        return _detect_density(temp)
-
-    def _detect_col_scope(col: str) -> tuple[FactorScope, str, int]:
-        temp = data.select("date", "asset_id", pl.col(col).alias("factor"))
-        return _detect_scope(temp)
-
-    # First factor column drives the returned properties (deterministic first-detected)
-    density, density_reason, sparse_ratio = _detect_col_density(first_col)
-    scope, scope_reason, scope_periods = _detect_col_scope(first_col)
     structure = _detect_structure(data)
     n_assets = int(data["asset_id"].n_unique())
     n_periods = int(data["date"].n_unique())
-    # Finite, not merely non-null: polars counts a float NaN as a present value,
-    # so ``drop_nulls`` alone would report NaN factor cells as usable pairs.
-    n_pairs = int(data.filter(_finite_expr(first_col)).height)
-    # Event sample: non-zero factor cells (nulls compare false, so excluded),
-    # matching the ``factor != 0`` filter the event-driven metrics apply.
-    n_events = int(data.filter(pl.col(first_col) != 0).height)
-    n_unique_factor = int(data.filter(_finite_expr(first_col))[first_col].n_unique())
-    factor_sign_one_sided = _factor_sign_is_one_sided(data, first_col)
-    ic_stage1_profile = _compute_ic_stage1_profile(data, first_col)
-    fm_stage1_profile = _compute_fm_stage1_profile(data, first_col)
-
     structure_reason = (
         f"n_assets={n_assets} → "
         f"{'TIMESERIES (single-asset data)' if structure is DataStructure.TIMESERIES else 'PANEL'}"
     )
+    available_columns = frozenset(data.columns)
+
+    # ``evaluate`` dispatches every factor column independently, so inspection
+    # reports at the same granularity: one FactorInspection per column. The
+    # aggregate view (properties / metrics / the tier partitions) is the first
+    # column's, which is the whole panel for single-factor input.
+    factors = {
+        col: _inspect_factor(
+            data,
+            col,
+            structure=structure,
+            structure_reason=structure_reason,
+            n_assets=n_assets,
+            n_periods=n_periods,
+            available_columns=available_columns,
+        )
+        for col in cols
+    }
+    first = factors[first_col]
+
+    data_warnings = list(first.warnings)
+    data_warnings.extend(_cross_factor_warnings(factors, first_col=first_col))
+
+    return DataInspection(
+        properties=first.properties,
+        metrics=first.metrics,
+        warnings=data_warnings,
+        factors=factors,
+    )
+
+
+def _inspect_factor(
+    data: Any,
+    col: str,
+    *,
+    structure: DataStructure,
+    structure_reason: str,
+    n_assets: int,
+    n_periods: int,
+    available_columns: frozenset[str],
+) -> FactorInspection:
+    """Pre-flight one factor column.
+
+    Every factor-level quantity — axes, counts, cardinality, stage-one
+    profiles, advisory warnings, metric verdicts — is read from ``col`` alone.
+    The panel-level facts (``structure`` / ``n_assets`` / ``n_periods``) are
+    passed in because they are properties of the data, identical for every
+    column, and computing them once keeps a wide screen linear in the number
+    of columns rather than re-deriving the panel per column.
+    """
+    # Content gate beyond cell / sample shape: a discrete ±k factor (e.g. a
+    # ternary {-1, 0, +1}) makes magnitude-dependent metrics (event_ic)
+    # undefined. Imported here to keep the metrics package out of this
+    # module's import cycle.
+    from factrix.metrics._helpers import _event_signal_is_discrete
+
+    # Project to the canonical "factor" name so the standard detectors apply.
+    temp = data.select("date", "asset_id", pl.col(col).alias("factor"))
+    density, density_reason, sparse_ratio = _detect_density(temp)
+    scope, scope_reason, scope_periods = _detect_scope(temp)
+
+    # Finite, not merely non-null: polars counts a float NaN as a present value,
+    # so ``drop_nulls`` alone would report NaN factor cells as usable pairs.
+    n_pairs = int(data.filter(_finite_expr(col)).height)
+    # Event sample: non-zero factor cells (nulls compare false, so excluded),
+    # matching the ``factor != 0`` filter the event-driven metrics apply.
+    n_events = int(data.filter(pl.col(col) != 0).height)
+    n_unique_factor = int(data.filter(_finite_expr(col))[col].n_unique())
 
     properties = DataProperties(
         scope=scope,
@@ -717,92 +909,106 @@ def inspect_data(data: Any, factor_cols: Sequence[str] | None = None) -> DataIns
         sparse_ratio=sparse_ratio,
     )
 
-    data_warnings = _data_level_warnings(properties)
-    data_warnings.extend(
+    warnings = _data_level_warnings(properties)
+    warnings.extend(
         _scope_unidentifiable_warning(
             properties,
-            factor_col=first_col,
+            factor_col=col,
             n_identified_periods=scope_periods,
         )
     )
-    data_warnings.extend(
+    warnings.extend(
         _dense_factor_advisory_warnings(
             properties,
-            factor_col=first_col,
+            factor_col=col,
             n_unique_factor=n_unique_factor,
         )
     )
 
-    # Cross-factor consistency checks
-    if len(cols) > 1:
-        densities = [density] + [_detect_col_density(c)[0] for c in cols[1:]]
-        scopes = [scope] + [_detect_col_scope(c)[0] for c in cols[1:]]
-
-        if len(set(densities)) > 1:
-            detail = ", ".join(
-                f"'{c}': {d.value}" for c, d in zip(cols, densities, strict=True)
-            )
-            data_warnings.append(
-                Warning(
-                    code=WarningCode.CROSS_FACTOR_DENSITY_MISMATCH,
-                    source=None,
-                    message=(
-                        f"Factor columns carry inconsistent FactorDensity: {{{detail}}}. "
-                        f"Metric applicability is based on '{first_col}'; call "
-                        f"inspect_data(data, factor_cols=[<col>]) for a verdict "
-                        f"specific to that column. Split heterogeneous factor "
-                        f"columns into separate inspect_data/evaluate batches."
-                    ),
-                )
-            )
-
-        if len(set(scopes)) > 1:
-            detail = ", ".join(
-                f"'{c}': {s.value}" for c, s in zip(cols, scopes, strict=True)
-            )
-            data_warnings.append(
-                Warning(
-                    code=WarningCode.CROSS_FACTOR_SCOPE_MISMATCH,
-                    source=None,
-                    message=(
-                        f"Factor columns carry inconsistent FactorScope: {{{detail}}}. "
-                        f"Metric applicability is based on '{first_col}'; call "
-                        f"inspect_data(data, factor_cols=[<col>]) for a verdict "
-                        f"specific to that column. Split asset-specific and "
-                        f"common macro factors into separate inspect_data/evaluate "
-                        f"batches."
-                    ),
-                )
-            )
-
-    # Signal magnitude is a content gate beyond cell/sample shape: a discrete
-    # ±k factor (e.g. ternary {-1, 0, +1}) makes magnitude-dependent metrics
-    # (event_ic) undefined. Computed on the first column — the verdict basis
-    # for multi-factor input (see docstring) — using the same predicate the
-    # metric short-circuits on at run time.
-    from factrix.metrics._helpers import _event_signal_is_discrete
-
-    signal_discrete = _event_signal_is_discrete(data, first_col)
+    # Hoisted out of the comprehension: each of these scans the panel once, and
+    # the verdict list runs over every public spec.
+    signal_discrete = _event_signal_is_discrete(data, col)
+    sign_one_sided = _factor_sign_is_one_sided(data, col)
+    ic_stage1_profile = _compute_ic_stage1_profile(data, col)
+    fm_stage1_profile = _compute_fm_stage1_profile(data, col)
 
     metrics = [
         _evaluate_applicability(
             spec,
             properties,
             signal_discrete,
-            factor_sign_one_sided,
+            sign_one_sided,
             ic_stage1_profile=ic_stage1_profile,
             fm_stage1_profile=fm_stage1_profile,
-            available_columns=frozenset(data.columns),
+            available_columns=available_columns,
         )
         for _, spec in public_specs()
     ]
-    data_warnings.extend(_single_asset_event_warning(properties, metrics))
+    warnings.extend(_single_asset_event_warning(properties, metrics))
 
-    return DataInspection(
+    return FactorInspection(
+        factor=col,
         properties=properties,
         metrics=metrics,
-        warnings=data_warnings,
+        warnings=warnings,
     )
+
+
+def _cross_factor_warnings(
+    factors: dict[str, FactorInspection], *, first_col: str
+) -> list[Warning]:
+    """Name the columns that disagree with the aggregate basis, and on what.
+
+    The aggregate ``properties`` / ``metrics`` describe ``first_col`` only, so
+    a mismatch warning has to say which other columns it does *not* describe.
+    Listing the disagreeing columns (rather than every column and its value)
+    keeps the reader from having to re-derive the comparison the message
+    states.
+    """
+    if len(factors) <= 1:
+        return []
+
+    basis = factors[first_col]
+    out: list[Warning] = []
+    for code, axis_name, label, guidance in (
+        (
+            WarningCode.CROSS_FACTOR_DENSITY_MISMATCH,
+            "density",
+            "FactorDensity",
+            "Split heterogeneous factor columns into separate evaluate batches.",
+        ),
+        (
+            WarningCode.CROSS_FACTOR_SCOPE_MISMATCH,
+            "scope",
+            "FactorScope",
+            "Split asset-specific and common macro factors into separate "
+            "evaluate batches.",
+        ),
+    ):
+        basis_value = getattr(basis.properties, axis_name).value
+        disagreeing = [
+            (name, getattr(f.properties, axis_name).value)
+            for name, f in factors.items()
+            if getattr(f.properties, axis_name).value != basis_value
+        ]
+        if not disagreeing:
+            continue
+        detail = ", ".join(f"'{name}' ({value})" for name, value in disagreeing)
+        out.append(
+            Warning(
+                code=code,
+                source=None,
+                message=(
+                    f"Factor columns disagree on {label}. Basis '{first_col}' "
+                    f"({basis_value}); disagreeing columns: {detail}. Per-column "
+                    f"scope, density, counts, profiles, warnings and metric "
+                    f"verdicts are in DataInspection.factors[<col>]; "
+                    f"DataInspection.properties and .metrics describe "
+                    f"'{first_col}' only. {guidance}"
+                ),
+            )
+        )
+    return out
 
 
 def _single_asset_event_warning(

--- a/factrix/llms-full.txt
+++ b/factrix/llms-full.txt
@@ -274,6 +274,7 @@ Typed pre-flight introspection that combines axis detection with a per-metric us
   - `unusable` (`MetricApplicabilityGroup` / `Tier.UNUSABLE`): Metrics that will short-circuit to NaN.
 - The usability tier classification is determined using the metric's `SampleThreshold`.
 - `.to_metrics_dict()` on a group returns the `{label: instance}` dictionary that `evaluate(metrics=...)` expects.
+- `DataInspection.factors: dict[str, FactorInspection]` carries one result per inspected column — `evaluate`'s own granularity. Each `FactorInspection` has `factor` (the column name), its own `properties`, `metrics`, `warnings` and the same `usable` / `degraded` / `unusable` partitions; nothing in it is inherited from a sibling column. `properties` / `metrics` on `DataInspection` are the concise aggregate and describe the FIRST inspected column (they are exactly `factors[<first column>]`), so single-factor callers never touch the mapping. A `cross_factor_*_mismatch` warning names the basis column and the columns that disagree with it. `n_periods` / `n_assets` are panel-level on every `FactorInspection`; per-column coverage gates metrics through the per-column stage-one profile instead.
 - The verdict reads each metric's **default-configuration** floor. For the floor a configured instance gates on at run time, use `sample_requirements`.
 
 ---

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -897,15 +897,17 @@ class TestCrossFactorConsistency:
         density_warning = next(
             w for w in info.warnings if w.code.value == "cross_factor_density_mismatch"
         )
-        assert "'factor': dense" in density_warning.message
-        assert "'factor3': sparse" in density_warning.message
-        assert "separate inspect_data/evaluate batches" in density_warning.message
+        assert "Basis 'factor' (dense)" in density_warning.message
+        assert "disagreeing columns: 'factor3' (sparse)" in density_warning.message
+        assert "DataInspection.factors[<col>]" in density_warning.message
+        assert "separate evaluate batches" in density_warning.message
 
         scope_warning = next(
             w for w in info.warnings if w.code.value == "cross_factor_scope_mismatch"
         )
-        assert "'factor': individual" in scope_warning.message
-        assert "'factor2': common" in scope_warning.message
+        assert "Basis 'factor' (individual)" in scope_warning.message
+        assert "disagreeing columns: 'factor2' (common)" in scope_warning.message
+        assert "DataInspection.factors[<col>]" in scope_warning.message
         assert "asset-specific and common macro factors" in scope_warning.message
 
     def test_factor_cols_restricts_scope(self):
@@ -1052,3 +1054,171 @@ class TestScopeIgnoresMissingCells:
     def test_scope_reason_reports_the_periods_actually_read(self):
         info = inspect_data(_blank_first_period(_common_factor_panel()))
         assert "29 of 30 periods" in info.properties.scope_reason
+
+
+def _heterogeneous_panel(n_assets: int = 12, n_dates: int = 120) -> pl.DataFrame:
+    """One panel carrying four deliberately different factor columns.
+
+    ``factor`` individual dense; ``common`` broadcast dense; ``sparse``
+    individual zero-encoded event; ``ternary`` individual dense {-1, +1} with
+    a hole, so the columns differ on scope, density, missingness, cardinality
+    and event count at once.
+    """
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates, rng=11)
+    one_per_period = raw.group_by("date").agg(pl.col("factor").first().alias("common"))
+    data = (
+        raw.join(one_per_period, on="date")
+        .with_columns(
+            pl.when(pl.int_range(0, pl.len()) % 4 == 0)
+            .then(pl.col("factor"))
+            .otherwise(0.0)
+            .alias("sparse"),
+            pl.when(pl.int_range(0, pl.len()) % 10 == 0)
+            .then(pl.lit(None, dtype=pl.Float64))
+            .when(pl.col("factor") >= 0)
+            .then(1.0)
+            .otherwise(-1.0)
+            .alias("ternary"),
+        )
+        .sort("date", "asset_id")
+    )
+    return data
+
+
+_HETEROGENEOUS_COLS = ["factor", "common", "sparse", "ternary"]
+
+
+class TestPerFactorInspection:
+    """Multi-factor input gets an auditable per-column result (#1056)."""
+
+    def test_factors_covers_every_inspected_column_in_order(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        assert list(info.factors) == _HETEROGENEOUS_COLS
+        assert all(info.factors[c].factor == c for c in _HETEROGENEOUS_COLS)
+
+    def test_single_factor_path_stays_simple(self):
+        data = fx.datasets.make_cs_panel(n_assets=12, n_dates=120, rng=11)
+        info = inspect_data(data)
+        assert list(info.factors) == ["factor"]
+        only = info.factors["factor"]
+        assert only.properties == info.properties
+        assert only.metrics == info.metrics
+        assert only.warnings == info.warnings
+
+    def test_aggregate_still_describes_the_first_column(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        assert info.properties == info.factors["factor"].properties
+        assert info.metrics == info.factors["factor"].metrics
+
+    def test_scope_is_reported_per_factor(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        assert info.factors["factor"].properties.scope is fx.FactorScope.INDIVIDUAL
+        assert info.factors["common"].properties.scope is fx.FactorScope.COMMON
+
+    def test_density_is_reported_per_factor(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        assert info.factors["factor"].properties.density is fx.FactorDensity.DENSE
+        assert info.factors["sparse"].properties.density is fx.FactorDensity.SPARSE
+        assert info.factors["sparse"].properties.sparse_ratio >= 0.5
+
+    def test_missingness_is_reported_per_factor(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        assert (
+            info.factors["ternary"].properties.n_pairs
+            < info.factors["factor"].properties.n_pairs
+        )
+
+    def test_event_count_is_reported_per_factor(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        assert (
+            info.factors["sparse"].properties.n_events
+            < info.factors["factor"].properties.n_events
+        )
+
+    def test_cardinality_verdict_is_reported_per_factor(self):
+        """A low-cardinality column's advisory rides on that column, not the first."""
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        codes = {w.code for w in info.factors["ternary"].warnings}
+        assert fx.WarningCode.LOW_CARDINALITY_DENSE_SIGNAL in codes
+        assert fx.WarningCode.LOW_CARDINALITY_DENSE_SIGNAL not in {
+            w.code for w in info.factors["factor"].warnings
+        }
+
+    def test_metric_verdicts_differ_per_factor(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        individual = info.factors["factor"]
+        common = info.factors["common"]
+        assert "ic" in (individual.usable + individual.degraded).names
+        assert "ic" in common.unusable.names
+        assert "common_beta" in common.usable.names + common.degraded.names
+        assert "common_beta" in individual.unusable.names
+
+    def test_per_factor_stage_one_profile_gates_its_own_column(self):
+        """A column whose IC stage-one profile is thin blocks `ic` on itself only.
+
+        ``thin`` carries a usable cross-section on 20 periods and a single
+        asset on the rest, so ``compute_ic`` would keep 20 periods — below
+        ``ic``'s 50-period floor — while the sibling column keeps 118. The
+        panel-level ``n_periods`` is identical for both, so only a per-column
+        stage-one profile can separate them.
+        """
+        raw = compute_forward_return(
+            fx.datasets.make_cs_panel(n_assets=12, n_dates=120, rng=11),
+            forward_periods=1,
+        )
+        early = raw["date"].unique().sort()[:20]
+        lone_asset = raw["asset_id"].unique().sort()[0]
+        thin = raw.with_columns(
+            pl.when(
+                pl.col("date").is_in(early.implode())
+                | (pl.col("asset_id") == lone_asset)
+            )
+            .then(pl.col("factor"))
+            .otherwise(pl.lit(None, dtype=pl.Float64))
+            .alias("thin")
+        )
+        info = inspect_data(thin, factor_cols=["factor", "thin"])
+
+        assert info.factors["thin"].properties.n_periods == (
+            info.factors["factor"].properties.n_periods
+        )
+        assert "ic" in info.factors["thin"].unusable.names
+        assert "ic" not in info.factors["factor"].unusable.names
+        thin_ic = next(m for m in info.factors["thin"].metrics if m.name == "ic")
+        assert "n_periods=20 < min_periods=50" in thin_ic.blockers
+
+    def test_aggregate_warning_names_the_disagreeing_columns(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        scope_warning = next(
+            w
+            for w in info.warnings
+            if w.code is fx.WarningCode.CROSS_FACTOR_SCOPE_MISMATCH
+        )
+        assert "'common' (common)" in scope_warning.message
+        assert "'factor' (individual)" in scope_warning.message
+        assert "DataInspection.factors" in scope_warning.message
+
+        density_warning = next(
+            w
+            for w in info.warnings
+            if w.code is fx.WarningCode.CROSS_FACTOR_DENSITY_MISMATCH
+        )
+        assert "'sparse' (sparse)" in density_warning.message
+        assert "'factor' (dense)" in density_warning.message
+
+    def test_to_dict_carries_every_factor(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        back = info.to_dict()
+        assert list(back["factors"]) == _HETEROGENEOUS_COLS
+        assert back["factors"]["common"]["properties"]["scope"] == "common"
+        assert back["factors"]["sparse"]["properties"]["density"] == "sparse"
+        assert back["factors"]["factor"]["properties"] == back["properties"]
+
+    def test_repr_html_lists_each_factor_with_its_own_axes(self):
+        info = inspect_data(_heterogeneous_panel(), factor_cols=_HETEROGENEOUS_COLS)
+        html_out = info._repr_html_()
+        assert "per-factor" in html_out
+        # Whole rows, not loose substrings: the column name must travel with the
+        # axes detected for that column.
+        assert "<td>common</td><td>common</td><td>dense</td>" in html_out
+        assert "<td>sparse</td><td>individual</td><td>sparse</td>" in html_out


### PR DESCRIPTION
Reopened from #1073, which GitHub auto-closed when its base branch was deleted on merging #1069. Same branch `feat/1056-per-factor-inspection`, rebased onto `main` (6450a2af) so it carries only its own commit. The full suite, doctests, typing, lint and a strict docs build were re-run on the rebased tree; the verification section below was written before the rebase, and the re-run numbers are in **Verification after rebase** at the end.

> Stacks on #1069 (`fix/1055-scope-ignores-missing-cells`) — both touch `factrix/_inspect.py`. Base is that branch; the diff here is only the per-factor work. Merge #1069 first.

## Summary

`inspect_data` returned one `DataProperties` and one verdict list for a multi-factor panel, both computed from the first column. Event count, magnitude / cardinality, usable pairs and the stage-one profiles of every later column were unreachable, so preflight and `evaluate` — which dispatches each factor column independently — described the panel at different granularities (#632 documented this as a limitation rather than fixing it).

Inspection now runs **per column**. `DataInspection.factors` maps each inspected column to a new public `FactorInspection` carrying that column's scope, density, counts, stage-one profiles, warnings and full metric verdicts, with the same `usable` / `degraded` / `unusable` partitions. Nothing in a `FactorInspection` is inherited from a sibling column.

### Design decisions

**Two granularities, not one.** `properties` / `metrics` and the tier partitions stay the concise aggregate and describe the **first** inspected column — they are exactly `factors[<first column>]`. A single-factor caller therefore never touches the mapping (the simple path is byte-for-byte what it was), and a multi-factor caller never has to guess which column an aggregate refers to. The alternative — making `properties` a mapping — would have broken every single-factor caller for no gain, and a screen over dozens of candidates still wants one answer to "what is this panel".

**Warnings stay attributable.** The aggregate `warnings` carry the first column's warnings plus the cross-factor mismatches. A later column's own advisories (low cardinality, frequent events, scope unidentifiable, sample shape) live on `factors[col].warnings` rather than being merged into one stream where the column they belong to would be lost.

**Mismatch warnings name the disagreement.** They now read `Basis 'factor' (individual); disagreeing columns: 'macro' (common)` and point at `DataInspection.factors[<col>]`, instead of listing every column with its value and advising a re-run per column (which the mapping makes unnecessary). This is a message-text breaking change; the assertions in `test_multi_factor_inconsistent_warnings` are updated.

**One implementation of the shared behaviour.** `DataInspection` and `FactorInspection` inherit one `_MetricPartitionView` — one tier partition and one dict renderer — rather than two that can drift apart.

**`n_periods` / `n_assets` stay panel-level** on every `FactorInspection`: they are properties of the data, and making them per-column would change which sample floor a column is judged against, diverging from the panel-level counts `evaluate` gates on. Where a column's own coverage must gate a metric it does so through the stage-one profile, which *is* per column — that is what separates a column whose IC cross-sections survive on 20 periods (blocked at `ic`'s 50-period floor) from its sibling at 118. Documented explicitly in the docstring and the docs page.

Docs: `docs/api/inspect-data.md` gains a "Multi-factor input: per-factor results" section with a table mapping each preflight field onto the `evaluate` output it predicts, plus a runnable example.

### Cost, measured

Per-column verdicts mean per-column work, so it was measured rather than assumed — on a 100-asset × 500-period panel (49,400 rows) with 55 factor columns:

| | 1 column | 55 columns |
|---|---|---|
| before | 0.031 s | 0.245 s |
| after | 0.029 s | 0.937 s |

~17 ms per column for a full per-column verdict; the single-column path is unchanged. The first draft measured 0.32 s for **one** column — the profile and signal-shape scans had been left inside the per-spec comprehension and ran ~40× per column. That is in the diff as a hoist with a comment; without measuring it would have shipped as a 10× regression on the single-factor path.

## Verification

Gates (run manually from the worktree; the pre-push hook cannot resolve tools there, so the push used `--no-verify`):

- `ruff check .` → `All checks passed!`
- `ruff format --check .` → `250 files already formatted`
- `mypy factrix` → `Success: no issues found in 83 source files`
- `pytest -q` → `3903 passed, 44 skipped, 451 warnings in 252.63s`
- `pytest --doctest-modules factrix -q` → `96 passed, 1 skipped`
- `mkdocs build --strict` → `Documentation built in 26.24 seconds`

### Against the unfixed state

Tests were written first. With `git stash push -- factrix` (implementation reverted, tests kept), the new class and the updated mismatch assertions fail 14/14:

```
FAILED tests/test_inspect_data.py::TestCrossFactorConsistency::test_multi_factor_inconsistent_warnings
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_factors_covers_every_inspected_column_in_order
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_single_factor_path_stays_simple
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_aggregate_still_describes_the_first_column
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_scope_is_reported_per_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_density_is_reported_per_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_missingness_is_reported_per_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_event_count_is_reported_per_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_cardinality_verdict_is_reported_per_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_metric_verdicts_differ_per_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_per_factor_stage_one_profile_gates_its_own_column
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_aggregate_warning_names_the_disagreeing_columns
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_to_dict_carries_every_factor
FAILED tests/test_inspect_data.py::TestPerFactorInspection::test_repr_html_lists_each_factor_with_its_own_axes
====================== 14 failed, 80 deselected in 1.18s ======================
```

Coverage per the DoD — one panel carrying four deliberately different columns (individual dense, broadcast dense, zero-encoded sparse, low-cardinality with holes) plus a stage-one-thin column: scope, density, missingness (`n_pairs`), event count (`n_events`), cardinality (the low-cardinality advisory lands on its own column and not on the first), differing metric verdicts (`ic` usable on the individual column and unusable on the common one, `common_beta` the reverse), per-column stage-one gating, the single-factor simple path, `to_dict`, `_repr_html_` and the mismatch messages.

Two tests were strengthened after first drafts passed unfixed: the `_repr_html_` test asserted loose substrings that already appeared in metric names, and the stage-one test first used a construction that gated on scope rather than the profile. Both now assert whole rows / the exact blocker string.

## Follow-up found while writing the docs example (not fixed here)

`factors[col].usable.to_metrics_dict()` fed straight to `evaluate(strict=True)` still raises on a broadcast common column: `common_beta_profile` / `common_beta_r_squared` / `common_beta_sign_consistency` report `n_assets=0` at run time while preflight calls them usable, and `spanning_alpha` needs base factors that no preflight axis models. That is a pre-existing preflight/run-time gap on the common-scope cell — `tests/test_inspect_evaluate_agreement.py` sweeps individual dense panels only — and is out of this PR's boundary. The docs example uses `strict=False`. I will file it as its own issue.

Closes #1056
Refs #632



## Verification after rebase

Re-run on the rebased branch with the repository interpreter, against `main` at `b549ba00`:

- `ruff check` / `ruff format --check`: clean, 252 files
- `mypy factrix`: no issues in 83 source files
- `pytest`: **4002 passed, 44 skipped, 0 failed**
- `pytest --doctest-modules factrix`: 96 passed, 1 skipped
- `mkdocs build --strict`: built in 24.95s
