### PR TITLE
feat(oos_decay): provide a first-class robust split workflow (#1059)

### DIFF
--- a/docs/api/metrics/oos_decay.md
+++ b/docs/api/metrics/oos_decay.md
@@ -7,6 +7,7 @@ title: factrix.metrics.oos_decay
       show_root_members_full_path: true
       members:
         - oos_decay
+        - oos_decay_splits
 
 <hr>
 
@@ -68,22 +69,77 @@ title: factrix.metrics.oos_decay
     decay around 32 %; factrix's default `survival_threshold = 0.5`
     sits inside that window.
 
--   __Sweep the split fraction caller-side__
+-   __Sweep the split fraction with `oos_decay_splits`__
 
     ---
 
-    One call is one `is_ratio`. To read survival across several
-    fractions, call `oos_decay` per fraction and aggregate yourself —
-    the median absorbs a regime change that lands inside one split,
-    where the mean would not.
+    One `oos_decay` call is one `is_ratio`, and a regime change landing
+    near that cut point can reverse the gate.
+    `oos_decay_splits` runs the same primitive over a set of fractions
+    the caller declares up front (default `(0.6, 0.7, 0.8)`), purges the
+    overlapping in-sample tail, and reports one aggregate verdict plus
+    every individual split.
 
 </div>
+
+## Robustness sweep — `oos_decay_splits`
+
+!!! warning "Robustness validation, not another model search"
+    The split set is declared **before** the sweep runs, every split is
+    reported, the aggregate rule is fixed, and no $p$-value is emitted
+    anywhere — so there is nothing to correct for and no best split to
+    select. Re-running with different fraction sets until one passes turns
+    it back into an uncorrected search. The pre-declaration is the only
+    thing preventing that, and the library cannot enforce it for you.
+
+**Aggregate rule.** `status = "PASS"` requires all three of:
+
+1. every declared split assessable (a split that could not be computed
+   withholds the aggregate: `value` is NaN, `reason = "unassessable_splits"`
+   — "cannot assess" must not read as "passed");
+2. **no** split sign-flipped;
+3. the **median** survival ratio at or above `survival_threshold`.
+
+Direction and magnitude are aggregated differently on purpose. A sign flip
+says the factor predicts the wrong way over some contiguous tail, which the
+single-split primitive already treats as a hard veto — a majority vote over
+splits would launder it. A magnitude below the bar at one cut point is
+exactly the arbitrariness the median is there to absorb (50 % breakdown
+point, and order-invariant, so the declaration order cannot move the
+verdict). The median is fixed rather than exposed as a knob: choosing an
+aggregate after seeing the per-split ratios is the search this closes off.
+When the gate vetoes on a sign flip, `value` still carries the median that
+ran — the veto lives in `status` and `n_sign_flips`, not in a corrupted
+number.
+
+**Purge gap.** A value stamped at period $t$ built from a
+`forward_periods`-period forward return is realised over
+$(t,\, t + \texttt{forward\_periods}]$, so the last in-sample observations
+are partly realised inside the out-of-sample window. `oos_decay_splits`
+drops `forward_periods` periods off the end of each in-sample window —
+counted on the panel's distinct-date grid, never calendar time — which is
+the purge of Lopez de Prado (2018). The gap comes off the **in-sample** side
+only: the out-of-sample window is the thing being validated and is never
+shortened to protect the window it is validated against.
+
+```python title="Illustrative"
+from factrix.metrics import oos_decay_splits
+
+out = oos_decay_splits(
+    ic_df, value_col="ic", split_fractions=(0.6, 0.7, 0.8), forward_periods=5,
+)
+print(out.value, out.metadata["status"])           # median ratio, aggregate gate
+for split in out.metadata["splits"]:               # provenance, ascending
+    print(split["split_fraction"], split["n_is"], split["n_oos"],
+          split["survival"], split["sign_flipped"], split["status"])
+```
 
 ## Choosing a function
 
 | Goal                                                                          | Function                |
 |-------------------------------------------------------------------------------|-------------------------|
 | Single-split OOS survival + sign-flip gate on a `(date, value)` series        | `oos_decay` |
+| Purged survival across a pre-declared set of splits, with provenance          | `oos_decay_splits` |
 
 ## Worked example — IC series fed into oos_decay
 
@@ -110,12 +166,12 @@ title: factrix.metrics.oos_decay
           out.metadata["mean_is"], out.metadata["mean_oos"])
     # 0.7   0.0771   0.0719   (approximate)
 
-    # One call is one split; sweep the fraction caller-side when you want
-    # a fraction-robust read.
-    import statistics
-    sweep = {f: oos_decay(ic_df, value_col="ic", is_ratio=f)
-             for f in (0.6, 0.7, 0.8)}
-    print(statistics.median(r.value for r in sweep.values()))
+    # One call is one split. For a fraction-robust read, declare the split
+    # set up front and let oos_decay_splits purge and aggregate it.
+    from factrix.metrics import oos_decay_splits
+
+    swept = oos_decay_splits(ic_df, value_col="ic", forward_periods=5)
+    print(swept.value, swept.metadata["status"], swept.metadata["n_sign_flips"])
     ```
 
 ## See also

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -77,6 +77,7 @@ contrasts, not a sidecar to a primary value.
 | [`clustering_hhi`][factrix.metrics.clustering_hhi.clustering_hhi] | none — descriptive | — | event-period Herfindahl-Hirschman index (HHI) |
 | [`mfe_mae`][factrix.metrics.mfe_mae.mfe_mae] | none — descriptive | — | MFE_p50 / \|MAE_p75\| |
 | [`oos_decay`][factrix.metrics.oos_decay.oos_decay] | none — descriptive | — | survival = \|mean_oos\| / \|mean_is\| |
+| [`oos_decay_splits`][factrix.metrics.oos_decay.oos_decay_splits] | none — descriptive | — | median survival across the declared splits |
 | [`spanning_alpha`][factrix.metrics.spanning.spanning_alpha] | HAR HAC `t` on α | `p_value` | spanning α |
 | [`greedy_forward_selection`][factrix.metrics.spanning.greedy_forward_selection] | none — selection meta | — | (NaN; results in metadata) |
 | [`ic_trend`][factrix.metrics.trend.ic_trend] | Mann-Kendall `tau` on the index | `p_value` | Theil-Sen slope |
@@ -748,6 +749,35 @@ hypothesis test.
 
 - *descriptive*: `status` (`"PASS"` / `"VETOED"`), `sign_flipped`,
   `is_ratio`, `mean_is`, `mean_oos`, `survival_threshold`.
+
+##### `oos_decay_splits` — robustness sweep over the primitive
+
+Not a registered metric: a plain workflow function over `oos_decay`, so it
+carries no `MetricSpec` and does not route through `evaluate`. Documented
+here because its `MetricResult` shares this page's schema.
+
+`MetricResult.stat = None`; the same PASS/VETO gate as the primitive, read
+off a pre-declared set of split fractions rather than one. `value` is the
+median survival ratio across those splits, and is `NaN` when any declared
+split could not be assessed.
+
+- *descriptive*: `status` (`"PASS"` / `"VETOED"`), `splits` (one record per
+  declared fraction, ascending — each carrying `split_fraction`, `n_is`,
+  `n_oos`, `purge_periods`, `survival`, `sign_flipped`, `status`, and where
+  the primitive emitted them `mean_is`, `mean_oos`, `reason`,
+  `signal_status`), `split_fractions`, `n_splits`, `n_assessable`,
+  `n_sign_flips`, `aggregate` (`"median"`), `sign_flip_policy`
+  (`"any_flip_vetoes"`), `forward_periods`, `purge_periods`,
+  `survival_threshold`.
+- *descriptive* (conditional, withheld aggregate): `reason` —
+  `"unassessable_splits"` when at least one declared split produced no
+  finite ratio. The aggregate is defined over the declared set, so it is
+  withheld rather than recomputed over whichever subset survived.
+- `forward_periods` and `purge_periods` carry the same number by
+  construction: the purge gap applied is the forward-return window declared.
+  Both are emitted because the first names what the caller declared and the
+  second names what the split actually removed; they would part company if a
+  future variant ever clipped the gap.
 
 ### `spanning` (`factrix.metrics.spanning`)
 

--- a/factrix/metrics/__init__.py
+++ b/factrix/metrics/__init__.py
@@ -35,7 +35,7 @@ Single-asset x Continuous:
     predictive_beta -- TIMESERIES dense predictive regression with NW HAC
 
 Series diagnostics -- axis-agnostic on ``(date, value)``:
-    positive_rate, ic_trend, oos_decay
+    positive_rate, ic_trend, oos_decay, oos_decay_splits
 
 Scope-agnostic (run in either scope; ``cell`` scope is ``None``):
     directional_hit_rate -- small-N robust, Pesaran-Timmermann directional
@@ -91,7 +91,7 @@ from factrix.metrics.mfe_mae import (
     mfe_mae,
 )
 from factrix.metrics.monotonicity import monotonicity
-from factrix.metrics.oos_decay import oos_decay
+from factrix.metrics.oos_decay import oos_decay, oos_decay_splits
 from factrix.metrics.positive_rate import positive_rate
 from factrix.metrics.predictive_beta import predictive_beta
 from factrix.metrics.quantile import (
@@ -132,6 +132,7 @@ __all__ = [
     "mfe_mae",
     "monotonicity",
     "oos_decay",
+    "oos_decay_splits",
     "net_spread",
     "notional_turnover",
     "pooled_beta",

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -1,14 +1,16 @@
 """Out-of-sample (OOS) persistence analysis for any time-indexed series.
 
 This tool is agnostic to what the series represents — it only knows
-about a single IS/OOS split on a time-indexed numeric sequence.
+about IS/OOS splits on a time-indexed numeric sequence.
 
 Notes:
-    **Pipeline.** Time-series only, single IS/OOS window split on a 1-D
-    series; descriptive decay diagnostic (no formal H_0).
+    **Pipeline.** Time-series only, IS/OOS window split on a 1-D series;
+    descriptive decay diagnostic (no formal H_0). ``oos_decay`` is the
+    single-split primitive; ``oos_decay_splits`` is the robustness
+    workflow that runs it over a pre-declared set of split fractions.
 
     **Input.** DataFrame with ``date, value`` (IC series, CAAR series,
-    spread series).
+    spread series), one row per period.
 
     **Output.** MetricResult with ``value`` = survival ratio +
     sign-flip / status detail in ``metadata``.
@@ -16,6 +18,9 @@ Notes:
 
 from __future__ import annotations
 
+import math
+import statistics
+from collections.abc import Sequence
 from typing import Literal
 
 import polars as pl
@@ -30,23 +35,26 @@ from factrix._axis import (
 from factrix._codes import WarningCode
 from factrix._metric_index import SampleThreshold, cell
 from factrix._results import MetricResult
-from factrix._types import EPSILON, MIN_OOS_PERIODS_HARD
+from factrix._types import DEFAULT_FORWARD_PERIODS, EPSILON, MIN_OOS_PERIODS_HARD
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
     DEGENERATE_SIGNAL_STATUS,
     _enforce_min_floor,
+    _finite_expr,
     _finite_values,
     _resolve_series_value_col,
     _short_circuit_output,
     _surface_null_drop,
     _validate_half_open_unit_interval,
     _validate_open_unit_interval,
+    _validate_positive_count,
 )
 from factrix.metrics.ic import compute_ic
 
 __all__ = [
     "oos_decay",
+    "oos_decay_splits",
 ]
 
 GateStatus = Literal["PASS", "VETOED"]
@@ -54,6 +62,26 @@ GateStatus = Literal["PASS", "VETOED"]
 # Minimum observations each side of the split must carry for its mean to be
 # a window statistic rather than a single point.
 _MIN_SPLIT_OBS = 2
+
+#: Split set ``oos_decay_splits`` declares when the caller declares none.
+#: The three fractions the docs have always recommended sweeping — wide
+#: enough that a break has to sit near all three cut points to move the
+#: median, small enough that each side stays a readable window.
+DEFAULT_SPLIT_FRACTIONS: tuple[float, ...] = (0.6, 0.7, 0.8)
+
+#: The aggregate rule. Fixed, not a knob: a choice of aggregate made after
+#: seeing the per-split ratios is a model search, which is exactly what this
+#: workflow exists to close off. The median is order-invariant and has a 50 %
+#: breakdown point, so a break landing inside one cut point cannot carry the
+#: verdict; the mean would.
+_AGGREGATE_RULE = "median"
+
+#: The sign-flip rule. A flip at any declared split vetoes: an out-of-sample
+#: sign reversal says the factor predicts the wrong direction over some
+#: contiguous tail, and the single-split primitive already treats that as a
+#: hard veto rather than a weak survival ratio. Aggregating direction the way
+#: magnitude is aggregated would launder that hard veto into a majority vote.
+_SIGN_FLIP_POLICY = "any_flip_vetoes"
 
 
 def _validate_oos_decay(m: MetricBase) -> None:
@@ -358,6 +386,360 @@ def oos_decay(
     )
     return MetricResult(
         value=survival,
+        n_obs=n,
+        n_obs_axis="periods",
+        stat=None,
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
+    )
+
+
+def _validate_oos_decay_splits(
+    split_fractions: Sequence[float],
+    survival_threshold: float,
+    forward_periods: int,
+) -> tuple[float, ...]:
+    """Validate every knob of :func:`oos_decay_splits` at one site.
+
+    The workflow is a plain function, so it has no ``@metric`` constructor
+    hook to carry its knob contract; this is the equivalent single chokepoint,
+    called before any data work, and the knob validators live here rather than
+    scattered through the body for the same reason they live in the hook for
+    every registered metric.
+
+    Returns the declared split set in canonical (ascending) order, which is
+    what makes the workflow's output independent of the order the caller
+    declared them in. A repeated fraction is rejected rather than
+    de-duplicated: it would double-weight one cut point inside the median
+    without saying so.
+    """
+    from factrix._errors import UserInputError
+
+    declared = tuple(split_fractions)
+    if not declared:
+        raise UserInputError(
+            func_name="oos_decay_splits",
+            field="split_fractions",
+            value=declared,
+            expected=(
+                "a non-empty set of split fractions, declared before the "
+                "sweep is run. An empty set has no aggregate to report."
+            ),
+            docs_path="api/metrics/oos_decay",
+        )
+    for fraction in declared:
+        _validate_open_unit_interval(
+            fraction,
+            func_name="oos_decay_splits",
+            field="split_fractions",
+            detail=(
+                "0 leaves no in-sample window and 1 leaves no out-of-sample "
+                "window, so no survival ratio is defined at that cut point."
+            ),
+            docs_path="api/metrics/oos_decay",
+        )
+    if len(set(declared)) != len(declared):
+        raise UserInputError(
+            func_name="oos_decay_splits",
+            field="split_fractions",
+            value=declared,
+            expected=(
+                "distinct split fractions; a repeated fraction double-weights "
+                "one cut point in the aggregate without changing the reported "
+                "number of splits."
+            ),
+            docs_path="api/metrics/oos_decay",
+        )
+    _validate_half_open_unit_interval(
+        survival_threshold,
+        func_name="oos_decay_splits",
+        field="survival_threshold",
+        detail=(
+            "It is the share of the in-sample mean magnitude the factor must "
+            "retain out of sample, applied to the aggregate across splits."
+        ),
+        docs_path="api/metrics/oos_decay",
+    )
+    _validate_positive_count(
+        forward_periods,
+        func_name="oos_decay_splits",
+        field="forward_periods",
+        detail=(
+            "It is the purge gap in periods on the distinct-date grid, taken "
+            "from the forward-return window the series values were built "
+            "from; a window shorter than one period does not exist."
+        ),
+        docs_path="api/metrics/oos_decay",
+    )
+    return tuple(sorted(declared))
+
+
+def _run_one_split(
+    clean: pl.DataFrame,
+    value_col: str,
+    *,
+    fraction: float,
+    purge_periods: int,
+    survival_threshold: float,
+    expected_warnings: tuple[str, ...],
+) -> tuple[dict[str, object], tuple[str, ...]]:
+    """Run the primitive at one cut point with the purge gap applied.
+
+    *clean* carries one finite observation per period, sorted by date, so
+    ``int(n * fraction)`` is a period index on the distinct-date grid. The
+    purge drops the ``purge_periods`` periods immediately **before** that
+    index — the in-sample tail whose forward-return windows reach into the
+    out-of-sample side — and the primitive is then called on the surviving
+    frame. Nothing is taken off the out-of-sample side: the window being
+    validated is never shortened to protect the window it is validated
+    against.
+
+    The synthetic ``is_ratio`` handed to the primitive is
+    ``(n_is + 0.5) / height``, which is the cut the primitive's own
+    ``int(n * is_ratio)`` reproduces exactly — half a period of slack either
+    way, against a floating-point error of a few ulps.
+    """
+    n = clean.height
+    split_idx = int(n * fraction)
+    is_end = split_idx - purge_periods
+    if is_end < _MIN_SPLIT_OBS or n - split_idx < _MIN_SPLIT_OBS:
+        # WHY a distinct reason: the primitive's ``insufficient_oos_periods``
+        # means "the series is too short". Here the series may be ample and
+        # the *purge* is what emptied the in-sample side, so reusing that
+        # sentinel would send a reader looking for more data when what they
+        # need is a nearer cut point or a shorter horizon.
+        return {
+            "split_fraction": fraction,
+            "n_is": max(is_end, 0),
+            "n_oos": n - split_idx,
+            "purge_periods": purge_periods,
+            "survival": float("nan"),
+            "sign_flipped": False,
+            "status": "VETOED",
+            "reason": "purged_split_too_short",
+        }, ()
+
+    sub = pl.concat([clean.head(is_end), clean.slice(split_idx)])
+    is_ratio = (is_end + 0.5) / sub.height
+    result = oos_decay(
+        sub,
+        value_col=value_col,
+        is_ratio=is_ratio,
+        survival_threshold=survival_threshold,
+        expected_warnings=expected_warnings,
+    )
+    # Report the split the primitive actually cut at, not the one requested.
+    n_is = int(sub.height * is_ratio)
+    record: dict[str, object] = {
+        "split_fraction": fraction,
+        "n_is": n_is,
+        "n_oos": sub.height - n_is,
+        "purge_periods": purge_periods,
+        "survival": result.value,
+        "sign_flipped": result.metadata["sign_flipped"],
+        "status": result.metadata["status"],
+        "mean_is": result.metadata.get("mean_is"),
+        "mean_oos": result.metadata.get("mean_oos"),
+    }
+    if "reason" in result.metadata:
+        record["reason"] = result.metadata["reason"]
+    if "signal_status" in result.metadata:
+        record["signal_status"] = result.metadata["signal_status"]
+    return record, result.warning_codes
+
+
+def oos_decay_splits(
+    series: pl.DataFrame,
+    value_col: str = "value",
+    split_fractions: Sequence[float] = DEFAULT_SPLIT_FRACTIONS,
+    survival_threshold: float = 0.5,
+    forward_periods: int = DEFAULT_FORWARD_PERIODS,
+    *,
+    expected_warnings: tuple[str, ...] = (),
+) -> MetricResult:
+    """Purged out-of-sample (OOS) survival over a pre-declared set of splits.
+
+    Robustness validation of :func:`oos_decay`, not a second search over it.
+    A single cut point can reverse the single-split gate when a regime change
+    lands near it; this runs the same primitive at every fraction in a set
+    the caller declares **before** seeing any result, and reports one
+    aggregate verdict plus every individual split.
+
+    Args:
+        series: DataFrame with ``date`` and ``value_col``, one row per period
+            on its own distinct-date grid — the same contract
+            :func:`oos_decay` enforces.
+        value_col: Numeric column to evaluate.
+        split_fractions: The declared cut points, each strictly inside
+            ``(0, 1)`` and distinct (default ``(0.6, 0.7, 0.8)``). Order does
+            not matter: the set is canonicalised ascending, and the aggregate
+            is order-invariant.
+        survival_threshold: Minimum **aggregate** survival ratio for
+            ``status="PASS"`` (default ``0.5``), in ``(0, 1]``. Passed through
+            unchanged to each split, so the per-split statuses read against
+            the same bar.
+        forward_periods: Length in periods of the forward-return window the
+            series values were built from (default
+            :data:`~factrix._types.DEFAULT_FORWARD_PERIODS`). This is the
+            purge gap: the last ``forward_periods`` periods of each in-sample
+            window are dropped, so no in-sample observation's return window
+            reaches into the out-of-sample side.
+        expected_warnings: Declared warning codes, passed to each split.
+
+    Raises:
+        UserInputError: ``split_fractions`` is empty, carries a duplicate, or
+            carries a value outside ``(0, 1)``; ``survival_threshold`` is
+            outside ``(0, 1]``; ``forward_periods`` is not an integer ``>= 1``;
+            or ``series`` carries more than one row for some date.
+
+    Returns:
+        MetricResult with:
+
+        - ``value``: the **median** survival ratio across the declared
+        splits. NaN when any declared split could not be assessed — the
+        aggregate is defined over the set that was declared, not over
+        whichever subset happened to compute, and a silently narrowed
+        sample would read as a verdict.
+        - ``n_obs``: periods that entered the sweep (after the non-finite
+        drop), on the ``"periods"`` axis.
+        - ``stat``: ``None`` — descriptive, like the primitive. No
+        ``p_value`` is emitted, so there is no multiplicity to correct.
+        - ``metadata``:
+
+            - ``status`` (``"PASS"`` | ``"VETOED"``)
+            - ``splits``: one record per declared fraction, ascending, each
+            with ``split_fraction``, ``n_is``, ``n_oos``, ``purge_periods``,
+            ``survival``, ``sign_flipped``, ``status``, and (where the
+            primitive emitted them) ``mean_is``, ``mean_oos``, ``reason``,
+            ``signal_status``
+            - ``split_fractions`` (tuple), ``n_splits``, ``n_assessable``,
+            ``n_sign_flips``
+            - ``aggregate`` (``"median"``), ``sign_flip_policy``
+            (``"any_flip_vetoes"``)
+            - ``forward_periods``, ``purge_periods``, ``survival_threshold``
+            - ``reason`` (str, withheld aggregate only):
+            ``"unassessable_splits"``
+
+    Notes:
+        **Aggregate rule.** ``status="PASS"`` requires all three of: every
+        declared split assessable, **no** split sign-flipped, and the median
+        survival ratio at or above ``survival_threshold``. Direction and
+        magnitude are aggregated differently on purpose — a sign flip says
+        the factor predicts the wrong way over some tail, which a majority
+        vote would launder, while a magnitude below the bar at one cut point
+        is exactly the arbitrariness the median is here to absorb. The median
+        is fixed rather than exposed as a knob: choosing an aggregate after
+        seeing the per-split ratios is the search this workflow closes off.
+
+        ``value`` is still reported when the gate vetoes on a sign flip — it
+        is the ratio that ran, and the veto is recorded in ``status`` and
+        ``n_sign_flips`` rather than by corrupting the number.
+
+        **Purge.** ``forward_periods`` periods are dropped off the end of
+        each in-sample window, counted on the panel's distinct-date grid
+        (never calendar time). A value stamped at period ``t`` built from a
+        ``forward_periods``-period forward return is realised over
+        ``(t, t + forward_periods]``, so without the gap the last in-sample
+        observations are partly realised inside the out-of-sample window —
+        the boundary leakage [Lopez-de-Prado (2018)][lopez-de-prado-2018]
+        purges. The gap comes off the in-sample side only; the out-of-sample
+        window is what is being validated and is never shortened for it. A
+        series with no forward window (a contemporaneous spread) still
+        passes ``forward_periods=1``, which drops one period — conservative,
+        and cheaper than a knob that turns the guard off.
+
+        **Multiplicity.** This is robustness validation, not an additional
+        model search, and the distinction is what keeps it honest. The split
+        set is declared up front, every split is reported, the aggregate is
+        fixed, and no ``p_value`` is emitted anywhere — so there is nothing
+        to correct and no best split to select. Re-running with different
+        fraction sets until one passes converts it into an uncorrected
+        search; the pre-declaration is the only thing preventing that, and
+        the library cannot enforce it for you.
+
+    References:
+        - [Lopez-de-Prado (2018)][lopez-de-prado-2018]: purging and
+          embargoing overlapping train/test windows; CPCV.
+        - [McLean-Pontiff (2016)][mclean-pontiff-2016]: post-publication
+          decay the ``survival_threshold`` default is calibrated against.
+
+    Examples:
+        >>> import factrix as fx
+        >>> from factrix.metrics.ic import compute_ic
+        >>> from factrix.metrics.oos_decay import oos_decay_splits
+        >>> from factrix.preprocess import compute_forward_return
+        >>> panel = compute_forward_return(
+        ...     fx.datasets.make_cs_panel(n_assets=80, n_dates=240, rng=0),
+        ...     forward_periods=5,
+        ... )
+        >>> series = compute_ic(panel)["factor"].select("date", "ic")
+        >>> result = oos_decay_splits(series, value_col="ic", forward_periods=5)
+        >>> result.metadata["split_fractions"]
+        (0.6, 0.7, 0.8)
+        >>> len(result.metadata["splits"])
+        3
+    """
+    declared = _validate_oos_decay_splits(
+        split_fractions, survival_threshold, forward_periods
+    )
+    value_col = _resolve_series_value_col(series, value_col)
+    _require_one_row_per_period(series)
+    # Cleaned once, up front: every split then runs on the same period grid,
+    # and the drop is surfaced once here rather than re-warned per split.
+    clean = series.sort("date").filter(_finite_expr(value_col))
+    n = clean.height
+
+    splits: list[dict[str, object]] = []
+    warning_codes: list[str] = []
+    for fraction in declared:
+        record, codes = _run_one_split(
+            clean,
+            value_col,
+            fraction=fraction,
+            purge_periods=forward_periods,
+            survival_threshold=survival_threshold,
+            expected_warnings=expected_warnings,
+        )
+        splits.append(record)
+        warning_codes.extend(c for c in codes if c not in warning_codes)
+
+    survivals = [float(s["survival"]) for s in splits]  # type: ignore[arg-type]
+    assessable = [v for v in survivals if math.isfinite(v)]
+    n_sign_flips = sum(1 for s in splits if s["sign_flipped"])
+    all_assessable = len(assessable) == len(splits)
+    aggregate = statistics.median(assessable) if all_assessable else float("nan")
+
+    status: GateStatus = (
+        "PASS"
+        if all_assessable and n_sign_flips == 0 and aggregate >= survival_threshold
+        else "VETOED"
+    )
+    metadata: dict[str, object] = {
+        "status": status,
+        "splits": tuple(splits),
+        "split_fractions": declared,
+        "n_splits": len(splits),
+        "n_assessable": len(assessable),
+        "n_sign_flips": n_sign_flips,
+        "aggregate": _AGGREGATE_RULE,
+        "sign_flip_policy": _SIGN_FLIP_POLICY,
+        "forward_periods": forward_periods,
+        "purge_periods": forward_periods,
+        "survival_threshold": survival_threshold,
+    }
+    if not all_assessable:
+        metadata["reason"] = "unassessable_splits"
+    _surface_null_drop(
+        n_periods_in=series.height,
+        n_periods_out=n,
+        drop_reason="null / NaN / +-inf value observations in the series",
+        metric_name="oos_decay_splits",
+        metadata=metadata,
+        warning_codes=warning_codes,
+        expected_warnings=expected_warnings,
+    )
+    return MetricResult(
+        value=aggregate,
         n_obs=n,
         n_obs_axis="periods",
         stat=None,

--- a/tests/test_oos.py
+++ b/tests/test_oos.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 from factrix._results import MetricResult
-from factrix.metrics.oos_decay import oos_decay
+from factrix.metrics.oos_decay import oos_decay, oos_decay_splits
 
 
 class TestOOSDecay:
@@ -318,3 +318,212 @@ class TestOneRowPerPeriod:
         )["factor"].metrics["oos_decay"]
         assert direct.value == pytest.approx(routed.value)
         assert direct.metadata["status"] == routed.metadata["status"]
+
+
+#: A structural break parked just before the default 0.7 cut point. The last
+#: 30 periods sum to exactly zero, so the 0.7 split reads an out-of-sample
+#: mean of 0 and VETOES; the 0.6 and 0.8 splits both survive comfortably.
+_BREAK_AT_070 = [1.0] * 60 + [4.0] * 10 + [-4.0] * 10 + [2.0] * 20
+
+#: Same shape, but the last 30 periods sum to ``-1`` instead of ``0``: the
+#: 0.7 split now reads a *negative* out-of-sample mean against a positive
+#: in-sample mean, so exactly one of the three splits sign-flips while the
+#: median survival ratio stays well above the threshold.
+_FLIP_AT_070 = [1.0] * 60 + [4.0] * 10 + [-4.0] * 10 + [1.95] * 20
+
+
+class TestSplitSweepContract:
+    """The declared split set, its aggregate rule, and its provenance."""
+
+    def test_every_declared_split_is_returned(self):
+        result = oos_decay_splits(_series(_BREAK_AT_070), forward_periods=1)
+        splits = result.metadata["splits"]
+        assert [s["split_fraction"] for s in splits] == [0.6, 0.7, 0.8]
+        for split in splits:
+            assert set(split) >= {
+                "split_fraction",
+                "n_is",
+                "n_oos",
+                "purge_periods",
+                "survival",
+                "sign_flipped",
+                "status",
+            }
+
+    def test_provenance_records_what_ran(self):
+        result = oos_decay_splits(
+            _series(_BREAK_AT_070), split_fractions=(0.5, 0.75), forward_periods=3
+        )
+        assert result.metadata["split_fractions"] == (0.5, 0.75)
+        assert result.metadata["n_splits"] == 2
+        assert result.metadata["aggregate"] == "median"
+        assert result.metadata["sign_flip_policy"] == "any_flip_vetoes"
+        assert result.metadata["forward_periods"] == 3
+        assert result.metadata["purge_periods"] == 3
+        assert result.metadata["survival_threshold"] == 0.5
+        assert result.n_obs == 100
+        assert result.n_obs_axis == "periods"
+        assert result.stat is None
+
+    def test_aggregation_is_order_invariant(self):
+        series = _series(_BREAK_AT_070)
+        forward = dict(split_fractions=(0.6, 0.7, 0.8), forward_periods=1)
+        reverse = dict(split_fractions=(0.8, 0.7, 0.6), forward_periods=1)
+        shuffled = dict(split_fractions=(0.7, 0.6, 0.8), forward_periods=1)
+        a = oos_decay_splits(series, **forward)
+        b = oos_decay_splits(series, **reverse)
+        c = oos_decay_splits(series, **shuffled)
+        assert a.value == b.value == c.value
+        assert a.metadata == b.metadata == c.metadata
+
+    def test_structural_break_near_one_cut_point_does_not_decide_the_gate(self):
+        """The whole point of the sweep: one arbitrary cut reverses the
+        single-split gate, the pre-declared set does not follow it."""
+        series = _series(_BREAK_AT_070)
+        single = oos_decay(series, is_ratio=0.7)
+        assert single.metadata["status"] == "VETOED"
+        assert single.value < 0.5
+
+        swept = oos_decay_splits(series, forward_periods=1)
+        per_split = {s["split_fraction"]: s["status"] for s in swept.metadata["splits"]}
+        assert per_split == {0.6: "PASS", 0.7: "VETOED", 0.8: "PASS"}
+        assert swept.metadata["status"] == "PASS"
+        assert swept.value == pytest.approx(1.0, rel=1e-6)
+
+    def test_any_sign_flip_vetoes_even_when_the_median_survives(self):
+        """Direction is a unanimity requirement, magnitude is a median."""
+        result = oos_decay_splits(_series(_FLIP_AT_070), forward_periods=1)
+        assert result.metadata["n_sign_flips"] == 1
+        assert result.metadata["status"] == "VETOED"
+        # The aggregate ratio is still reported — it is what ran; the veto
+        # comes from the flip policy, not from the magnitude.
+        assert result.value == pytest.approx(0.975, rel=1e-6)
+        assert result.value > result.metadata["survival_threshold"]
+
+
+#: Flat probe for the purge tests: every period carries the same value, so
+#: anything that leaks out of the purge gap moves the answer loudly instead
+#: of cancelling against the rest of the window.
+_PURGE_PROBE = [1.0] * 100
+
+
+class TestSplitSweepPurge:
+    """Overlapping forward-return windows are purged off the IS tail."""
+
+    def test_purge_shortens_is_only(self):
+        result = oos_decay_splits(
+            _series(_PURGE_PROBE), split_fractions=(0.7,), forward_periods=5
+        )
+        (split,) = result.metadata["splits"]
+        assert split["purge_periods"] == 5
+        assert split["n_is"] == 65  # int(100 * 0.7) - 5
+        assert split["n_oos"] == 30  # the validated window is never shortened
+
+    def test_purged_periods_cannot_reach_the_statistic(self):
+        """The leakage guard: values inside the purge gap are not read.
+
+        Both halves are asserted. Poisoning periods 65-69 has to *move* the
+        un-purged single-split answer — otherwise the second half of this
+        test would pass on any implementation, purge or no purge.
+        """
+        base = list(_PURGE_PROBE)
+        poisoned = list(base)
+        poisoned[65:70] = [1000.0] * 5  # the 5 periods the purge removes at 0.7
+
+        unpurged_clean = oos_decay(_series(base), is_ratio=0.7)
+        unpurged_dirty = oos_decay(_series(poisoned), is_ratio=0.7)
+        assert unpurged_clean.value == pytest.approx(1.0)
+        assert unpurged_clean.metadata["status"] == "PASS"
+        assert unpurged_dirty.value < 0.02
+        assert unpurged_dirty.metadata["status"] == "VETOED"
+
+        kwargs = dict(split_fractions=(0.7,), forward_periods=5)
+        clean = oos_decay_splits(_series(base), **kwargs)
+        dirty = oos_decay_splits(_series(poisoned), **kwargs)
+        assert clean.value == pytest.approx(1.0)
+        assert dirty.value == pytest.approx(clean.value)
+        assert dirty.metadata["splits"] == clean.metadata["splits"]
+        assert dirty.metadata["status"] == "PASS"
+
+    def test_a_one_period_purge_still_drops_a_period(self):
+        """``forward_periods=1`` on a contemporaneous series still drops the
+        single overlapping period; the split index itself is unchanged."""
+        result = oos_decay_splits(
+            _series(_PURGE_PROBE), split_fractions=(0.7,), forward_periods=1
+        )
+        (split,) = result.metadata["splits"]
+        assert (split["n_is"], split["n_oos"]) == (69, 30)
+
+
+class TestSplitSweepValidation:
+    def test_empty_split_set_rejected(self):
+        from factrix import UserInputError
+
+        with pytest.raises(UserInputError, match="split_fractions"):
+            oos_decay_splits(_series(_BREAK_AT_070), split_fractions=())
+
+    def test_duplicate_fractions_rejected(self):
+        """A repeated fraction would double-weight the median."""
+        from factrix import UserInputError
+
+        with pytest.raises(UserInputError, match="split_fractions"):
+            oos_decay_splits(_series(_BREAK_AT_070), split_fractions=(0.6, 0.6, 0.8))
+
+    @pytest.mark.parametrize("bad", [1.0, 0.0, -0.2, float("nan"), True, "0.7"])
+    def test_out_of_range_fraction_rejected(self, bad):
+        from factrix import UserInputError
+
+        with pytest.raises(UserInputError, match="split_fractions"):
+            oos_decay_splits(_series(_BREAK_AT_070), split_fractions=(0.6, bad))
+
+    @pytest.mark.parametrize("bad", [0, -1, True, 2.5])
+    def test_non_count_forward_periods_rejected(self, bad):
+        from factrix import UserInputError
+
+        with pytest.raises(UserInputError, match="forward_periods"):
+            oos_decay_splits(_series(_BREAK_AT_070), forward_periods=bad)
+
+    @pytest.mark.parametrize("bad", [0.0, 1.5, float("nan"), True])
+    def test_threshold_domain_matches_the_primitive(self, bad):
+        from factrix import UserInputError
+
+        with pytest.raises(UserInputError, match="survival_threshold"):
+            oos_decay_splits(_series(_BREAK_AT_070), survival_threshold=bad)
+
+    def test_duplicate_dates_rejected_like_the_primitive(self):
+        from datetime import datetime, timedelta
+
+        import polars as pl
+        from factrix import UserInputError
+
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(40)]
+        series = pl.DataFrame(
+            {"date": [*dates, dates[9]], "value": [1.0] * 41}
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+        with pytest.raises(UserInputError, match="one row per period"):
+            oos_decay_splits(series)
+
+
+class TestSplitSweepUnassessable:
+    """A withheld split is not a passing one, and the aggregate is over the
+    *declared* set, not over whichever subset happened to work."""
+
+    def test_a_short_circuited_split_withholds_the_aggregate(self):
+        # 18 periods, purge 8: the 0.5 cut leaves a 1-period in-sample
+        # window, the 0.9 cut is still assessable.
+        result = oos_decay_splits(
+            _series([1.0] * 12 + [0.9] * 6),
+            split_fractions=(0.5, 0.9),
+            forward_periods=8,
+        )
+        assert math.isnan(result.value)
+        assert result.metadata["status"] == "VETOED"
+        assert result.metadata["reason"] == "unassessable_splits"
+        assert result.metadata["n_assessable"] == 1
+        assert result.metadata["n_splits"] == 2
+        # Every declared split is still reported, for diagnosis — and the
+        # purge-emptied one says so, rather than borrowing the primitive's
+        # "the series is too short" sentinel.
+        first, second = result.metadata["splits"]
+        assert first["reason"] == "purged_split_too_short"
+        assert math.isfinite(second["survival"])


### PR DESCRIPTION
Reopened from #1075, which GitHub auto-closed when its base branch was deleted on merging #1065. Same branch `feat/1059-oos-decay-robust-splits`, rebased onto `main` (39b7fff9) so it carries only its own commit. The full suite, doctests, typing, lint and a strict docs build were re-run on the rebased tree; the verification section below was written before the rebase, and the re-run numbers are in **Verification after rebase** at the end.

> `factrix/metrics/oos_decay.py`; this PR targets that branch, so review the
> diff against it rather than against `main`. Merge #1065 first.

## Summary

`oos_decay` exposes one fixed cut point. Measured on a 100-period series with
a structural break parked at 0.7 (the fixture this PR adds):

```
is_ratio=0.6: survival=1.0000 status=PASS
is_ratio=0.7: survival=0.0000 status=VETOED
is_ratio=0.8: survival=2.6667 status=PASS
```

One arbitrary fraction decides the gate. The docs told callers to sweep the
fraction themselves, which left the aggregate rule, the sign-flip policy, the
overlapping-horizon purge and the provenance to be reinvented per caller.

`oos_decay_splits` is that sweep as one entry point built on the **unchanged**
primitive — no `oos_decay` semantics move in this PR.

### Design decisions

**Declared split set.** `split_fractions` (default `(0.6, 0.7, 0.8)`) must be
non-empty, distinct, and each strictly inside `(0, 1)`. It is canonicalised
ascending, so the order the caller declared them in cannot move the verdict. A
repeated fraction is rejected rather than de-duplicated — it would
double-weight one cut point inside the aggregate without changing the reported
`n_splits`.

**Aggregate rule — median, and it is not a knob.** `status="PASS"` requires all
three of: every declared split assessable; **no** split sign-flipped; the
**median** survival ratio at or above `survival_threshold`.

Direction and magnitude are aggregated differently on purpose. A sign flip says
the factor predicts the wrong way over some contiguous tail, which the
single-split primitive already treats as a hard veto — a majority vote across
splits would launder it. A magnitude below the bar at one cut point is exactly
the arbitrariness the median is there to absorb (50 % breakdown point, and
order-invariant). The median is fixed rather than exposed as an `aggregate=`
knob because choosing an aggregate *after* seeing the per-split ratios is the
search this workflow exists to close off.

When the gate vetoes on a sign flip, `value` still carries the median that ran
— the veto lives in `status` / `n_sign_flips`, not in a corrupted number.

**Unassessable splits withhold the aggregate.** If any declared split produces
no finite ratio, `value` is NaN with `reason="unassessable_splits"` and
`status="VETOED"`. The aggregate is defined over the set that was *declared*;
recomputing it over whichever subset happened to work would report a silently
narrowed sample as a verdict, and "cannot assess" must not read as "passed".
Every split is still returned for diagnosis.

**Purge.** `forward_periods` periods are dropped off the end of each in-sample
window, counted on the distinct-date grid (never calendar time). A value
stamped at period `t` built from a `forward_periods`-period forward return is
realised over `(t, t + forward_periods]`, so without the gap the last in-sample
observations are partly realised inside the out-of-sample window. The gap comes
off the **in-sample** side only: the out-of-sample window is the thing being
validated and is never shortened to protect the window it is validated against.
A cut whose in-sample side the purge empties reports its own
`reason="purged_split_too_short"` rather than borrowing the primitive's
`insufficient_oos_periods`, which means "the series is too short" — a reader
who sees it needs a nearer cut point or a shorter horizon, not more data.

**Provenance.** `metadata["splits"]` carries one record per declared fraction
(ascending) with `split_fraction`, `n_is`, `n_oos`, `purge_periods`,
`survival`, `sign_flipped`, `status`, plus `mean_is` / `mean_oos` / `reason` /
`signal_status` where the primitive emitted them. Beside it: `status`,
`split_fractions`, `n_splits`, `n_assessable`, `n_sign_flips`, `aggregate`,
`sign_flip_policy`, `forward_periods`, `purge_periods`, `survival_threshold`.
The per-split `n_is` is read back off the split the primitive actually cut at,
not the one requested. No `p_value` is emitted anywhere.

**Multiplicity.** Documented on the page as a warning admonition: the split set
is declared up front, every split is reported, the aggregate is fixed, and no
`p_value` exists — so there is nothing to correct and no best split to select.
Re-running with different fraction sets until one passes converts it into an
uncorrected search; the pre-declaration is the only thing preventing that, and
the library cannot enforce it.

**Placement.** A plain function in `factrix/metrics/oos_decay.py`, exported
through `factrix.metrics.__all__` — not `factrix/__init__.py`, which exports
cross-metric workflows (`by_slice`, `compare`) but no metrics-package symbol,
so top-level export would be the inconsistent choice here. It is deliberately
**not** a registered `@metric`: it has no `MetricSpec` and does not route
through `evaluate`, because it is a caller-side robustness read over a metric,
not a new statistic in the cell taxonomy. Since it has no `@metric` constructor
hook, its knob contract lives in one `_validate_oos_decay_splits` chokepoint
called before any data work — the same single-site rule
`test_no_metric_body_calls_a_knob_validator` enforces for registered metrics.

## Verification

All gates run from the worktree with `.venv/Scripts/python.exe` (`PYTHONUTF8=1`).

- `ruff check .` — All checks passed
- `ruff format --check .` — 250 files already formatted
- `mypy factrix` — Success: no issues found in 83 source files
- `pytest -q -p no:faulthandler` — **3920 passed, 49 skipped** in 232s
- `pytest --doctest-modules factrix -q` — 97 passed, 1 skipped
- `mkdocs build --strict` — Documentation built in 24.18 seconds

### The new tests fail against the unfixed state

**1. The symbol does not exist on the base branch**, so the whole file fails to
collect — necessary, but weak evidence on its own:

```
E   ImportError: cannot import name 'oos_decay_splits' from 'factrix.metrics.oos_decay'
=========================== short test summary info ===========================
ERROR tests/test_oos.py
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

**2. So each behavioural guard was checked against its own defect**, by
disabling the mechanism it claims to guard (`is_end = split_idx` — purge off —
and `return declared` — canonicalisation off) and re-running:

```
E   comparison failed
      Obtained: 0.013820335636722605
      Expected: 1.0 ± 1.0e-06
    tests/test_oos.py:444   (test_purged_periods_cannot_reach_the_statistic)
E   assert (70, 30) == (69, 30)      tests/test_oos.py:455
E   assert False  where False = isnan(0.9282051282051282)   tests/test_oos.py:519

FAILED tests/test_oos.py::TestSplitSweepContract::test_aggregation_is_order_invariant
FAILED tests/test_oos.py::TestSplitSweepPurge::test_purge_shortens_is_only
FAILED tests/test_oos.py::TestSplitSweepPurge::test_purged_periods_cannot_reach_the_statistic
FAILED tests/test_oos.py::TestSplitSweepPurge::test_a_one_period_purge_still_drops_a_period
FAILED tests/test_oos.py::TestSplitSweepUnassessable::test_a_short_circuited_split_withholds_the_aggregate
================= 5 failed, 21 passed, 34 deselected in 0.20s =================
```

### One guard was vacuous and was rewritten

`test_purged_periods_cannot_reach_the_statistic` originally poisoned the purge
gap of the `_BREAK_AT_070` fixture. Measured directly, it proved nothing:

```
purge=0 clean survival = 0.000000
purge=0 dirty survival = 0.000000
differ: False
```

On that fixture the out-of-sample mean is exactly 0, so `survival = 0 / |mean_is|`
is 0 whatever the in-sample tail contains — the test would have passed with the
purge deleted. It now runs on a flat `_PURGE_PROBE` series and asserts **both**
halves: that the poisoned periods *do* move the un-purged single-split answer
(`1.0000 → 0.0138`, PASS → VETOED), and that they leave the purged sweep at
`1.0`. The first assertion is what stops the second from passing vacuously.

### Structural break, measured

```
--- single-split primitive, per fraction (no purge) ---
  is_ratio=0.6: survival=1.0000 status=PASS
  is_ratio=0.7: survival=0.0000 status=VETOED
  is_ratio=0.8: survival=2.6667 status=PASS
  sweep: median=1.0000 status=PASS
```

`test_structural_break_near_one_cut_point_does_not_decide_the_gate` pins exactly
this contrast. `test_any_sign_flip_vetoes_even_when_the_median_survives` pins
the other direction on a near-identical fixture whose 0.7 cut flips sign: the
median is 0.975 — comfortably above the 0.5 threshold — and the gate still
VETOES, so the flip policy is doing the work rather than the magnitude.

### Incidental

`n_sign_flipped` was renamed to `n_sign_flips` before landing: it matched the
FX008 short-circuit-flag grammar (`*_flipped`) and would have been counted as a
stage flag by `test_fx008_docstring_count_matches_the_grammar`. It is a count,
not a stage flag, so renaming the key beat widening that lint's ledger for a
false positive.

Closes #1059



## Verification after rebase

Re-run on the rebased branch with the repository interpreter, against `main` at `b549ba00`:

- `ruff check` / `ruff format --check`: clean, 252 files
- `mypy factrix`: no issues in 83 source files
- `pytest`: **4015 passed, 45 skipped, 0 failed**
- `pytest --doctest-modules factrix`: 97 passed, 1 skipped
- `mkdocs build --strict`: built in 26.14s
