### PR TITLE
fix(event): withhold audits for withdrawn curves

### DIFF
--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -74,8 +74,13 @@ title: factrix.metrics.event_horizon
 !!! warning "Invalid prices withdraw the curve"
     `event_around_return` needs a finite unconditional bar-return baseline.
     Any observed non-finite or non-positive `price` invalidates that baseline,
-    so the metric returns `value=NaN`, audited `per_offset` entries, and
+    so the metric returns `value=NaN`, an empty `per_offset` mapping, and
     `WarningCode.METRIC_UNAVAILABLE` with `reason="invalid_price_data"`.
+    Raw paths may already have been formed before the baseline check, so
+    `n_events` / `n_obs` still report the distinct events that computation
+    actually used. Their per-offset computed/censored counts are deliberately
+    withheld because the curve they would describe was discarded. This is the
+    explicit short-circuit exception to the censor-audit contract below.
     Missing (`null`) observations remain allowed on ragged panels; fix invalid
     observed prices rather than interpreting a contaminated finite hit rate.
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -510,9 +510,11 @@ Pre/post-event return profile; descriptive.
   negative offset cleared the 5-event floor — `0.0` there was the *best*
   possible score for a quantity never computed. An observed non-finite or
   non-positive price instead withdraws the entire curve with
-  `reason=invalid_price_data`, audited `per_offset` entries, and
+  `reason=invalid_price_data`, an empty `per_offset` mapping, and
   `WarningCode.METRIC_UNAVAILABLE`; `n_invalid_prices` reports the offending
-  row count. Null prices remain valid missing data on a ragged panel.
+  row count. `n_events` / `n_obs` still report the events used by the raw-path
+  computation, but its per-offset counts are withheld because that curve was
+  discarded. Null prices remain valid missing data on a ragged panel.
 
 - *benchmark horizon*: offset `k > 0` is a simple return from `t+1` to
   `t+1+k`, so its `benchmark` is `(1 + baseline_bar_return)**k - 1` — the

--- a/factrix/metrics/event_horizon.py
+++ b/factrix/metrics/event_horizon.py
@@ -177,12 +177,15 @@ def event_around_return(
 
     Returns:
         MetricResult with per-offset stats and audit counts in metadata.
-        Every ``per_offset[k]`` includes ``eligible``, ``computed``,
+        Every published ``per_offset[k]`` includes ``eligible``, ``computed``,
         ``censored``, and ``censor_reasons``; ``n`` remains an alias for the
-        computed count. When price data is
-        unavailable or the unconditional baseline cannot be computed from
-        valid positive prices, returns a short-circuit MetricResult
-        (``value=NaN``) so all metrics share a single return contract.
+        computed count. When price data is unavailable, the censor audit
+        explains why no path was computed. When the unconditional baseline
+        cannot be computed from valid positive prices, the whole curve is
+        withdrawn and ``per_offset`` is empty rather than publishing counts
+        from the discarded raw-path computation. Both cases return a
+        short-circuit MetricResult (``value=NaN``) so all metrics share a
+        single return contract.
 
     Notes:
         For each offset ``k``: ``mean, median, p25, p75, hit_rate``
@@ -311,7 +314,11 @@ def event_around_return(
             n_invalid_prices=n_invalid_prices,
             baseline_bar_return=None,
             n_assets_in_baseline=n_assets_in_baseline,
-            per_offset=per_offset,
+            # The raw paths ran, so n_events remains reportable, but no
+            # per-offset curve survived the invalid baseline. Publishing its
+            # intermediate counts under the final curve key makes discarded
+            # work look like a partially available result.
+            per_offset={},
         )
 
     pre_leakage_vals: list[float] = []

--- a/tests/test_event_horizon.py
+++ b/tests/test_event_horizon.py
@@ -196,7 +196,7 @@ class TestEventAroundReturn:
         assert result.n_obs == 0
         assert result.n_obs_axis == "events"
 
-    def test_zero_price_withholds_contaminated_baseline(self, event_data):
+    def test_zero_price_withholds_curve_and_its_per_offset_audit(self, event_data):
         poisoned = event_data.with_row_index("_row").with_columns(
             pl.when(pl.col("_row") == 0)
             .then(0.0)
@@ -211,7 +211,9 @@ class TestEventAroundReturn:
         assert result.metadata["reason"] == "invalid_price_data"
         assert result.metadata["n_invalid_prices"] == 1
         assert result.metadata["baseline_bar_return"] is None
-        assert result.metadata["per_offset"]
+        assert result.metadata["per_offset"] == {}
+        assert result.n_obs > 0
+        assert result.metadata["n_events"] == result.n_obs
         assert fx.WarningCode.METRIC_UNAVAILABLE.value in result.warning_codes
 
 


### PR DESCRIPTION
## Summary

- keep `per_offset` empty when an invalid baseline withdraws the entire event curve
- retain `n_events` / `n_obs` as the event count actually used by the raw-path computation
- document the baseline-withdrawal exception to the censor-audit contract
- add an against-unfixed regression for the exact short-circuit metadata shape

## Verification

- `uv run pre-commit run --all-files --hook-stage pre-commit`
- `uv run mypy factrix`
- `uv run pytest -p no:faulthandler tests/test_event_horizon.py tests/test_event_price_data.py tests/test_docs_stat_keys_by_metric.py tests/test_docs_examples.py -q` (156 passed, 44 skipped)

Closes #1077