### PR TITLE
docs: name the keys and axes the code actually has

### DIFF
--- a/docs/api/metrics/event_horizon.md
+++ b/docs/api/metrics/event_horizon.md
@@ -76,6 +76,11 @@ title: factrix.metrics.event_horizon
     Any observed non-finite or non-positive `price` invalidates that baseline,
     so the metric returns `value=NaN`, an empty `per_offset` mapping, and
     `WarningCode.METRIC_UNAVAILABLE` with `reason="invalid_price_data"`.
+    A baseline that no valid price could form at all takes the same branch —
+    empty `per_offset`, same warning — under `reason="no_finite_baseline_returns"`
+    (no asset yielded a finite single-period return, e.g. a panel whose prices
+    never fall on two adjacent periods); `n_invalid_prices` is `0` there, which
+    is what separates the two.
     Raw paths may already have been formed before the baseline check, so
     `n_events` / `n_obs` still report the distinct events that computation
     actually used. Their per-offset computed/censored counts are deliberately

--- a/docs/api/metrics/oos_decay.md
+++ b/docs/api/metrics/oos_decay.md
@@ -117,10 +117,16 @@ number.
 $(t,\, t + \texttt{forward\_periods}]$, so the last in-sample observations
 are partly realised inside the out-of-sample window. `oos_decay_splits`
 drops `forward_periods` periods off the end of each in-sample window —
-counted on the panel's distinct-date grid, never calendar time — which is
-the purge of Lopez de Prado (2018). The gap comes off the **in-sample** side
-only: the out-of-sample window is the thing being validated and is never
-shortened to protect the window it is validated against.
+counted on the series' own distinct-date grid *after* the non-finite drop,
+never calendar time — which is the purge of Lopez de Prado (2018). Because
+that drop only removes periods, the resulting gap spans **at least**
+`forward_periods` periods of the producing panel's grid (a 104-period series
+with 4 non-finite observations inside the band gives a 10-panel-period gap at
+`forward_periods=5`). Purging wider than the horizon is safe; purging
+narrower would leave the leakage the gap exists for. The gap comes off the
+**in-sample** side only: the out-of-sample window is the thing being
+validated and is never shortened to protect the window it is validated
+against.
 
 ```python title="Illustrative"
 from factrix.metrics import oos_decay_splits

--- a/docs/api/partial-conjunction-across-metrics.md
+++ b/docs/api/partial-conjunction-across-metrics.md
@@ -22,8 +22,8 @@ screen = fx.multi_factor.partial_conjunction_across_metrics(
 )
 
 screen.to_frame()
-# factor | pc_p | adj_p | survived | active
-#        | n_tests | n_passed_uncorr
+# factor | pc_p | adj_p | survived | eligible
+#        | family_size | n_passed_uncorr
 ```
 
 This differs from [`bhy_across_metrics`](bhy-across-metrics.md): pooled BHY

--- a/docs/examples/multi_factor_screening.md
+++ b/docs/examples/multi_factor_screening.md
@@ -100,7 +100,7 @@ for res in results:
 
 ## 3. Apply BHY
 
-The input list is the family. `bhy` runs one Benjamini-Yekutieli step-up over all results and returns a dict of `BhyResult` containers keyed by metric label. Each `BhyResult` exposes `.survivors`, `.adj_p`, `.q`, `.expand_over`, and `.n_tests` for audit.
+The input list is the family. `bhy` runs one Benjamini-Yekutieli step-up over all results and returns a dict of `BhyResult` containers keyed by metric label. Each `BhyResult` exposes `.survivors`, `.adj_p`, `.q`, `.expand_over`, `.family_size`, and `.family` for audit.
 
 ```python
 bhy_ic = fx.multi_factor.bhy(results, metrics=["ic"], q=0.05)["ic"]

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -512,7 +512,10 @@ Pre/post-event return profile; descriptive.
   non-positive price instead withdraws the entire curve with
   `reason=invalid_price_data`, an empty `per_offset` mapping, and
   `WarningCode.METRIC_UNAVAILABLE`; `n_invalid_prices` reports the offending
-  row count. `n_events` / `n_obs` still report the events used by the raw-path
+  row count. A baseline that no valid price could form takes the same branch —
+  same empty `per_offset` and same warning — under
+  `reason=no_finite_baseline_returns` with `n_invalid_prices=0`. `n_events` /
+  `n_obs` still report the events used by the raw-path
   computation, but its per-offset counts are withheld because that curve was
   discarded. Null prices remain valid missing data on a ragged panel.
 

--- a/examples/multi_factor_screening.ipynb
+++ b/examples/multi_factor_screening.ipynb
@@ -143,7 +143,7 @@
    "source": [
     "## 3. Apply BHY\n",
     "\n",
-    "The input list is the family. `bhy` runs one Benjamini-Yekutieli step-up over all results and returns a dict of `BhyResult` containers keyed by metric label. Each `BhyResult` exposes `.survivors`, `.adj_p`, `.q`, `.expand_over`, and `.n_tests` for audit.\n"
+    "The input list is the family. `bhy` runs one Benjamini-Yekutieli step-up over all results and returns a dict of `BhyResult` containers keyed by metric label. Each `BhyResult` exposes `.survivors`, `.adj_p`, `.q`, `.expand_over`, `.family_size`, and `.family` for audit.\n"
    ]
   },
   {

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -176,10 +176,22 @@ def _detect_scope(raw: Any) -> tuple[FactorScope, str, int]:
         ``(scope, reason, n_identified_periods)`` where ``n_identified_periods``
         is the number of periods that carried a finite cell — the sample the
         decision was actually read from, not the panel's period count.
+
+        **Exception:** the ``n_assets <= 1`` short circuit below reads no cell
+        at all — the scope axis is trivially COMMON at one asset, whatever the
+        cells hold — so it has no identified-period count to report and
+        returns the panel's period count instead. Nothing consumes the number
+        there: :func:`_scope_unidentifiable_warning` fires only on the
+        unidentifiable ``INDIVIDUAL`` fallback, which this branch never takes.
     """
     n_assets = int(raw["asset_id"].n_unique())
     n_periods = int(raw["date"].n_unique())
     if n_assets <= 1:
+        # Documented exception to the third element's contract: this branch
+        # reads no cell, so it has no identified-period count and returns
+        # ``n_periods`` — not "periods that carried a finite cell". Safe
+        # because the only consumer, ``_scope_unidentifiable_warning``,
+        # excludes ``n_assets <= 1`` outright.
         return (
             FactorScope.COMMON,
             f"n_assets = {n_assets}: scope axis trivially COMMON at n_assets == 1",

--- a/factrix/_results.py
+++ b/factrix/_results.py
@@ -43,7 +43,8 @@ class MetricResult:
             single integer count is not meaningful (e.g. multi-window
             CAAR series).
         n_obs_axis: Sample dimension ``n_obs`` counts along — one of
-            ``"periods"`` / ``"events"`` / ``"pairs"`` / ``"assets"``.
+            ``"periods"`` / ``"events"`` / ``"pairs"`` / ``"asset_pairs"`` /
+            ``"assets"``.
             A bare count is uninterpretable without its axis (a
             Fama-MacBeth ``n_obs`` is periods; a pooled-OLS one is
             ``(date, asset)`` pairs), so producers stamp the axis
@@ -309,7 +310,7 @@ class EvaluationResult:
         | ``alternative`` | str \| null | ``MetricResult.alternative`` |
         | ``stat`` | f64 \| null | ``MetricResult.stat`` |
         | ``n_obs`` | i64 \| null | ``MetricResult.n_obs`` — estimator effective sample size |
-        | ``n_obs_axis`` | str \| null | ``MetricResult.n_obs_axis`` — axis ``n_obs`` counts along (``periods`` / ``events`` / ``pairs`` / ``assets``) |
+        | ``n_obs_axis`` | str \| null | ``MetricResult.n_obs_axis`` — axis ``n_obs`` counts along (``periods`` / ``events`` / ``pairs`` / ``asset_pairs`` / ``assets``) |
         | ``is_applicable`` | bool | false for ``strict=False`` short-circuits |
         | ``reason`` | str \| null | short-circuit reason when not applicable |
         | ``warning_codes`` | list[str] | per-metric warning codes — bundle records sourced on this metric, unioned (de-duplicated, first-seen order) with ``MetricResult.warning_codes`` |

--- a/factrix/metrics/oos_decay.py
+++ b/factrix/metrics/oos_decay.py
@@ -229,11 +229,15 @@ def oos_decay(
               ``"insufficient_oos_periods"``
 
     Notes:
-        For multi-fraction sweeps, call ``oos_decay`` per fraction and
-        aggregate on the caller side::
-
-            results = {f: oos_decay(series, is_ratio=f) for f in (0.6, 0.7, 0.8)}
-            median = statistics.median(r.value for r in results.values())
+        **One call is one split.** A regime change landing near the cut point
+        can reverse this gate, so for a fraction-robust read use
+        :func:`oos_decay_splits`, which runs this same primitive over a set of
+        fractions the caller declares up front, purges the overlapping
+        in-sample tail, and reports one aggregate verdict plus every
+        individual split. A caller-side loop over ``is_ratio`` does neither:
+        the overlapping-horizon leakage at each boundary stays unpurged, and
+        the rule that turns the per-split ratios into one verdict is never
+        declared.
 
         Descriptive only — no ``p_value`` is emitted.
 
@@ -486,7 +490,9 @@ def _run_one_split(
     """Run the primitive at one cut point with the purge gap applied.
 
     *clean* carries one finite observation per period, sorted by date, so
-    ``int(n * fraction)`` is a period index on the distinct-date grid. The
+    ``int(n * fraction)`` is a period index on the retained distinct-date
+    grid — the series' own grid after the non-finite drop, which is also the
+    grid the purge below is counted on. The
     purge drops the ``purge_periods`` periods immediately **before** that
     index — the in-sample tail whose forward-return windows reach into the
     out-of-sample side — and the primitive is then called on the surviving
@@ -636,8 +642,17 @@ def oos_decay_splits(
         ``n_sign_flips`` rather than by corrupting the number.
 
         **Purge.** ``forward_periods`` periods are dropped off the end of
-        each in-sample window, counted on the panel's distinct-date grid
-        (never calendar time). A value stamped at period ``t`` built from a
+        each in-sample window, counted on the series' own distinct-date grid
+        **after** the non-finite drop (never calendar time) — the same grid
+        the split index is taken on. Dropping observations only removes
+        periods from that grid, so the resulting gap spans **at least**
+        ``forward_periods`` periods of the producing panel's grid, and more
+        wherever the band it covers had missing values: on a 104-period
+        series with 4 non-finite observations inside the band,
+        ``forward_periods=5`` leaves a gap of 10 panel periods. Purging wider
+        than the horizon is safe — it only removes in-sample observations —
+        where purging narrower would leave the leakage the gap exists for.
+        A value stamped at period ``t`` built from a
         ``forward_periods``-period forward return is realised over
         ``(t, t + forward_periods]``, so without the gap the last in-sample
         observations are partly realised inside the out-of-sample window —


### PR DESCRIPTION
## Summary

Seven documentation statements that contradicted the code they describe, found
while auditing the merged #1062 series. Every item was re-measured against the
current tree before editing. **Documentation and docstrings only — no behaviour
changes**; `factrix/` edits are docstrings and comments.

| # | Where | Was | Is |
|---|---|---|---|
| 1 | `docs/api/partial-conjunction-across-metrics.md` | `to_frame()` comment listed `active` / `n_tests` | `eligible` / `family_size` |
| 2 | `examples/multi_factor_screening.ipynb` | `BhyResult` exposes `.n_tests` | `.family_size`, `.family` |
| 3 | `oos_decay` docstring `Notes` | recommended an unpurged caller-side fraction sweep (#1059) | points at `oos_decay_splits` (#1082) and says what the loop leaves undone |
| 4 | `oos_decay_splits` docstring + docs page | purge counted "on the panel's distinct-date grid" | on the series' own grid **after** the non-finite drop |
| 5 | `factrix/_results.py` ×2 | `SampleAxis` listed without `asset_pairs` | full five-token list |
| 6 | `docs/api/metrics/event_horizon.md`, `docs/reference/stat-keys-by-metric.md` | withdrawn curve named only `reason="invalid_price_data"` | also `no_finite_baseline_returns` |
| 7 | `_detect_scope` `Returns:` | third element "is the number of periods that carried a finite cell" | exception documented for the `n_assets <= 1` short circuit |

## Measurements

- **1.** `CrossMetricPartialConjunctionResult.to_frame()` builds
  `['factor','pc_p','adj_p','survived','eligible','family_size','n_passed_uncorr']`
  (`factrix/_multi_factor.py:657`). `CrossMetricBhyResult.to_frame()` genuinely
  keeps `active` (`:521`), so `docs/api/bhy-across-metrics.md:25` was confirmed
  correct and left untouched.
- **2.** `hasattr(BhyResult, "n_tests")` is `False`; `family_size` and `family`
  are dataclass fields. The docs page is generated from the notebook by
  `scripts/mkdocs_hooks/render_example_notebooks.py`, so the edit is in the
  notebook and the page regenerated — editing the page alone is reverted by the
  next build.
- **4.** The purge is applied to `clean` (post-`_finite_expr` filter), so it is
  counted on the retained grid. Measured on a 104-period series with 4
  non-finite observations inside the purge band and `forward_periods=5`: last
  in-sample date `64`, first out-of-sample date `74` — a **10-period** gap on
  the producing panel's grid for a 5-period horizon. That direction is safe
  (it only removes in-sample observations); the reverse would not be, and the
  wording now says so.
- **5.** `factrix/_types.py:189` is
  `Literal["periods", "events", "pairs", "asset_pairs", "assets"]`;
  `directional_pair_accuracy` stamps `n_obs_axis="asset_pairs"` at `:160` and
  `:215`. Swept the tree for the stale four-value list: the only two copies
  were `factrix/_results.py:46` and `:312`, both fixed. `factrix/_errors.py:177`
  already listed all five, and `_metric_index._AXES` is the `SampleThreshold`
  *floor* axis tuple (no `asset_pairs` field exists) — correct as is, and
  changing it would be a behaviour change.
- **6.** Both reasons come off the same `if baseline is None:` branch with
  `per_offset={}` (`factrix/metrics/event_horizon.py:302-322`). Reached
  `no_finite_baseline_returns` on a 6-asset panel whose prices never fall on two
  adjacent periods (so no finite single-period return exists) with `offsets=[2]`
  (a multi-period offset still computes): `reason='no_finite_baseline_returns'`,
  `per_offset={}`, `n_invalid_prices=0`, `metric_unavailable`. `n_invalid_prices`
  is what separates the two, and the docs now say so.
- **7.** `_detect_scope` on a single-asset all-NaN panel returns
  `(COMMON, 'n_assets = 1: ...', 4)` on a 4-period panel — `n_periods`, from a
  branch that reads no cell. The number is unused there: `scope_periods` has one
  consumer (`_scope_unidentifiable_warning`), which returns early on
  `n_assets <= 1`.

## Verification

Run from the worktree with `.venv/Scripts/python.exe`:

- `ruff check .` — All checks passed
- `ruff format --check .` — 253 files already formatted
- `mypy factrix` — Success: no issues found in 83 source files
- `pytest -q -p no:faulthandler` — **4142 passed, 44 skipped** (re-run after the
  notebook regeneration; no test pinned any of the old wording, so none had to
  change)
- `pytest --doctest-modules factrix -q` — 97 passed, 1 skipped
- `mkdocs build --strict` — built in 26.29s; `docs/llms.txt` / `llms-full.txt`
  regenerated identically
