### PR TITLE
fix(tradability): pair rank turnover on the period grid, not asset rows

### DIFF
--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -339,13 +339,38 @@ def rank_turnover(
         pl.len().over("date").alias("n_curr"),
     ).sort("asset_id", "date")
 
-    # Lag-within-asset avoids a self-join on (prev_date, asset_id):
-    # rank_prev at date_k is this asset's rank at the previous *sampled*
-    # date, which is the prior row in each asset's sorted group.
-    paired = ranked.with_columns(
-        pl.col("rank_curr").shift(1).over("asset_id").alias("rank_prev"),
-        pl.col("n_curr").shift(1).over("asset_id").alias("n_prev"),
-    ).drop_nulls(["rank_prev"])
+    # Pair on the sampled *period grid*, not on each asset's own rows.
+    # ``shift(1).over("asset_id")`` reaches back to the asset's previous
+    # surviving row, which on a ragged panel is more than ``lag`` periods
+    # away: the asset is then compared against a rank it held two or more
+    # periods earlier while every other name is compared one period back,
+    # so ``rebalance_lag`` is not the stride actually applied to it. A
+    # factor that reverses each period reads as a name that never moved,
+    # and ``n_obs`` is unchanged, so nothing announces the substitution.
+    # ``notional_turnover`` already pairs this way; one date_map keeps the
+    # two members of this family counting the same quantity.
+    # ``_sample_non_overlapping`` already strided the grid by ``lag``, so
+    # adjacent *sampled* periods are one rebalance apart: the map shifts by
+    # one on this grid, not by ``lag`` again.
+    sampled_dates = ranked["date"].unique().sort()
+    date_map = pl.DataFrame(
+        {"date": sampled_dates[1:], "prev_date": sampled_dates[:-1]}
+    )
+    previous = ranked.select(
+        pl.col("date").alias("prev_date"),
+        "asset_id",
+        pl.col("rank_curr").alias("rank_prev"),
+        pl.col("n_curr").alias("n_prev"),
+    )
+    # An inner join drops the rebalances an asset cannot form — absent at
+    # the previous sampled period, it has no prior rank to move from. That
+    # is the same row set ``drop_nulls(["rank_prev"])`` kept before, minus
+    # the pairs that were reaching across a hole.
+    paired = (
+        ranked.join(date_map, on="date", how="inner")
+        .join(previous, on=["prev_date", "asset_id"], how="inner")
+        .sort("asset_id", "date")
+    )
 
     if quantile is not None:
         in_tail = (

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -984,3 +984,63 @@ class TestCostAlgebraDomain:
         out = net_spread(0.001, turnover=turnover, estimated_cost_bps=cost)
         assert out.value <= 0.001
         assert out.metadata["cost_drag"] >= 0.0
+
+
+class TestRankTurnoverPairsOnThePeriodGrid:
+    """``rebalance_lag`` is a count of periods, for every asset alike."""
+
+    @staticmethod
+    def _panel(*, strides: list[int], drop: set[tuple[str, int]] | None = None):
+        dates: list[datetime] = []
+        cursor = datetime(2020, 1, 1)
+        for index in range(12):
+            dates.append(cursor)
+            cursor += timedelta(days=strides[index % len(strides)])
+        rows: list[dict[str, object]] = []
+        for asset in range(6):
+            for index, current in enumerate(dates):
+                if drop and (f"A{asset}", index) in drop:
+                    continue
+                rows.append(
+                    {
+                        "date": current,
+                        "asset_id": f"A{asset}",
+                        # sign flips every period, so a pair one period apart
+                        # is a full rank reversal and a pair two periods apart
+                        # is no change at all
+                        "factor": (1 if index % 2 == 0 else -1) * (asset + 1),
+                        "forward_return": 0.01,
+                    }
+                )
+        return pl.DataFrame(rows)
+
+    def test_a_missing_period_does_not_pair_across_the_gap(self) -> None:
+        """One absent cell must not silently widen that asset's lag.
+
+        Pairing on each asset's own surviving rows reaches back to the
+        previous *row*, which on a ragged panel is two periods away. The
+        factor flips sign every period, so the fabricated pair reads as
+        no turnover at all and drags the headline down — with ``n_obs``
+        unchanged, so nothing announces it.
+        """
+        dense = rank_turnover(rebalance_lag=1)(
+            self._panel(strides=[1]), overlap_periods=1
+        )
+        ragged = rank_turnover(rebalance_lag=1)(
+            self._panel(strides=[1], drop={("A5", 4)}), overlap_periods=1
+        )
+
+        assert dense.value == pytest.approx(2.0)
+        # The one unpairable rebalance drops out; it is not paired across
+        # the hole and read as a name that did not move.
+        assert ragged.value == pytest.approx(2.0, abs=0.005)
+
+    def test_pairing_is_invariant_to_the_calendar(self) -> None:
+        """The grid is a period count; the dates' spacing is not read."""
+        even = rank_turnover(rebalance_lag=1)(
+            self._panel(strides=[1], drop={("A5", 4)}), overlap_periods=1
+        )
+        uneven = rank_turnover(rebalance_lag=1)(
+            self._panel(strides=[1, 17], drop={("A5", 4)}), overlap_periods=1
+        )
+        assert even.value == pytest.approx(uneven.value, rel=1e-12)


### PR DESCRIPTION
Found by a period-grid sweep of every `shift()` site while auditing the closed issues of the #1062 series. Not a regression of #872 — that issue separated `rebalance_lag` from the return overlap and left the pairing itself on asset rows.

## The defect

`_sample_non_overlapping` strides the grid correctly, but the pairing that follows is `shift(1).over("asset_id")` — the asset's previous **surviving row**. On a ragged panel that row is more than `rebalance_lag` periods away, so one name is compared against a rank it held two or more periods earlier while every other name is compared one period back. `rebalance_lag` is then not the stride actually applied to it, which is the period-grid principle and "report what ran" at the same time.

Measured on a 12-period grid, 6 assets, a factor that reverses sign every period, one asset missing one period:

| | value | `n_obs` |
|---|---|---|
| dense | 2.0000000000 | 11 |
| ragged | 1.9388478941 | 11 |

Because the factor flips each period, the fabricated pair spans two periods and therefore compares two ranks of the same parity: the name reads as never having moved. That drags the headline 3% with `n_obs` unchanged, so nothing announces the substitution. The measured pairing gaps for that asset are `[1, 1, 1, 2, 1, 1, 1, 1, 1, 1]` — one reach across the hole.

Identical under date strides `[1]` and `[1, 17]`, so it is the row pairing and not the calendar.

## The fix

Pairing now goes through a `date_map` built from the sampled distinct dates — the way `notional_turnover` in the same file already does it, so the two members of this family count the same quantity. An asset absent at the previous sampled period forms no pair, which is the row set `drop_nulls(["rank_prev"])` already kept, minus the pairs that were reaching across a hole.

One subtlety worth flagging for review: the map shifts by **one on the sampled grid**, not by `lag`. `_sample_non_overlapping` has already strided by `rebalance_lag`, so shifting by `lag` again double-counts it — I made that mistake first and `test_non_overlapping_skips_intermediate_noise` caught it (`assert 2 == 3`), which is a fair sign that existing coverage is load-bearing here.

## Against-unfixed evidence

The guard was written first and run on `2c8f8b01`:

```
FAILED tests/test_tradability.py::TestRankTurnoverPairsOnThePeriodGrid::test_a_missing_period_does_not_pair_across_the_gap
E   assert 1.93884789412309 == 2.0 ± 0.005
1 failed, 1 passed
```

The one that passes is the calendar-invariance control: it holds before and after, and pins that the fix reads periods rather than dates.

## Verification

Run on the branch with the repository interpreter:

- `ruff check` / `ruff format --check`: clean, 253 files
- `mypy factrix`: no issues in 83 source files
- `pytest`: **4144 passed, 44 skipped, 0 failed**
- `pytest --doctest-modules factrix`: 97 passed, 1 skipped
- `mkdocs build --strict`: built in 26.10s

Refs #872