### PR TITLE
fix(metrics): reject unidentified pooled beta slopes (#1104)

### DIFF
--- a/docs/api/metrics/fm_beta.md
+++ b/docs/api/metrics/fm_beta.md
@@ -69,6 +69,12 @@ title: factrix.metrics.fm_beta
     If a finite-sample two-way covariance is non-PSD, the OLS slope remains
     descriptive but its test is withheld rather than replaced by one-way
     inference.
+    A rank-deficient pooled design does not identify a slope: factrix returns
+    `value=NaN`, withholds `stat` / `p_value` / `alternative`, and records
+    `variance_status="singular_pooled_design_matrix"` plus
+    `degenerate_variance`. This differs from a covariance failure after a
+    full-rank fit, where the identified slope remains available and only the
+    test fields are withheld.
 
 -   __Cross-section-robust pooled inference__
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -184,9 +184,10 @@ is emitted.
   the cluster count G < 3 the test is short-circuited with `stat =
   None`, `value = NaN`, and `p_value = 1.0`: with two clusters the sample
   cannot support a clustered estimate, so the algebraic slope is not
-  exposed as a usable pooled beta. A non-PSD two-way covariance is the
-  other withheld-inference regime and keeps `value` — see
-  `variance_status` below.
+  exposed as a usable pooled beta. Rank-deficient designs withhold the
+  unidentified slope and all test fields without fabricating a conservative
+  p-value. Covariance failures after a full-rank fit keep the identified
+  `value` but withhold the test — see `variance_status` below.
 - Sample size: `MetricResult.n_obs` (row count entering the test).
 - *descriptive*: `overlap_periods` (the injected evaluation-grid horizon) and
   `overlap_adjustment_applied`. The latter is `False` for clustered covariance,
@@ -202,6 +203,13 @@ is emitted.
   support a slope test. The pooled OLS slope remains available, but `stat` /
   `p_value` are withheld with `WarningCode.DEGENERATE_VARIANCE`; factrix does
   not substitute a one-way covariance.
+- *descriptive* (conditional): `variance_status` =
+  `"singular_pooled_design_matrix"` for a rank-deficient design or a covariance
+  inversion failure. A rank-deficient design also carries `design_rank` and
+  `n_parameters` and has no identified `value`; if OLS was full rank and only
+  covariance inversion failed, its identified slope remains available. Both
+  shapes withhold `stat` / `p_value` / `alternative` and carry
+  `WarningCode.DEGENERATE_VARIANCE`.
 - *descriptive* (Driscoll-Kraay path, `driscoll_kraay=True`):
   `se_method` (`"driscoll_kraay"`), `n_periods` (length of the
   cross-sectional score-sum series), and `driscoll_kraay_lags` (the

--- a/factrix/metrics/fm_beta.py
+++ b/factrix/metrics/fm_beta.py
@@ -62,6 +62,7 @@ from factrix.inference.series_mean import _persistent_array_beyond_horizon
 from factrix.metrics._base import MetricBase
 from factrix.metrics._decorators import metric
 from factrix.metrics._helpers import (
+    _degenerate_metric_output,
     _degenerate_test_fields,
     _enforce_min_floor,
     _finite_expr,
@@ -511,6 +512,28 @@ def _cluster_codes(clusters: np.ndarray) -> tuple[np.ndarray, int]:
 _MIN_DK_PERIODS_HARD: int = 3
 
 
+def _pooled_beta_withheld_inference(
+    slope: float,
+    n_obs: int,
+    metadata: dict[str, object],
+) -> MetricResult:
+    """Keep an identified pooled slope when only its inference is unavailable."""
+    warning_codes: list[str] = []
+    stat, p_value, alternative = _degenerate_test_fields(
+        float("nan"), float("nan"), "two-sided", metadata, warning_codes
+    )
+    return MetricResult(
+        value=slope,
+        p_value=p_value,
+        alternative=alternative,
+        n_obs=n_obs,
+        n_obs_axis="pairs",
+        stat=stat,
+        metadata=metadata,
+        warning_codes=tuple(warning_codes),
+    )
+
+
 def _pooled_beta_driscoll_kraay(
     data: pl.DataFrame,
     X: np.ndarray,
@@ -557,11 +580,22 @@ def _pooled_beta_driscoll_kraay(
         cov, n_periods, lags_used = _dk_cov(X, resid, period_ids, lags=resolved_lags)
         dk_meta = {"n_periods": n_periods, "driscoll_kraay_lags": lags_used}
     except np.linalg.LinAlgError:
-        return _short_circuit_output(
-            "pooled_beta",
-            "singular_pooled_design_matrix",
-            n_obs=n_obs,
-            n_obs_axis="pairs",
+        return _pooled_beta_withheld_inference(
+            slope,
+            n_obs,
+            {
+                "stat_type": "t",
+                "h0": "β=0",
+                "method": f"Pooled OLS + Driscoll-Kraay (1998) SE ({cluster_col})",
+                "se_method": "driscoll_kraay",
+                "n_periods": n_periods,
+                "driscoll_kraay_lags": resolved_lags,
+                "hac_scale": hac_scale,
+                "hac_dof": hac_dof,
+                "overlap_periods": overlap_periods,
+                "overlap_adjustment_applied": True,
+                "variance_status": "singular_pooled_design_matrix",
+            },
         )
 
     n_periods = int(dk_meta["n_periods"])
@@ -707,10 +741,13 @@ def pooled_beta(
     Short-circuits to ``value=NaN`` / ``stat=None`` / $p=1.0$ when
     ``n_obs < 10`` (no regression), when the effective $G < 3$ (clustered SE
     undefined), or, on the DK path, when fewer than 3 distinct periods leave
-    the cross-sectional HAC undefined. The slope computed before an SE floor
-    fails is not exposed as the headline value: without a valid covariance
-    estimate, downstream aggregation cannot distinguish it from a fully
-    inferential pooled beta.
+    the cross-sectional HAC undefined. A rank-deficient pooled design instead
+    reports the degenerate non-test shape: neither the slope nor its test is
+    identified, so ``value=NaN`` and ``stat`` / ``p_value`` / ``alternative``
+    are ``None`` with ``DEGENERATE_VARIANCE``. If a full-rank fit identified
+    the slope but the requested covariance subsequently fails, the slope stays
+    available while only those three test fields are withheld under the same
+    warning code.
 
     Args:
         data: Panel containing the regression columns and cluster keys.
@@ -876,18 +913,35 @@ def pooled_beta(
 
     X = np.column_stack([np.ones(n_obs), x])
     try:
-        beta, _, _, _ = np.linalg.lstsq(X, y, rcond=None)
+        beta, _, design_rank, _ = np.linalg.lstsq(X, y, rcond=None)
     except np.linalg.LinAlgError:
-        return _short_circuit_output(
-            "pooled_beta",
-            "singular_pooled_design_matrix",
+        return _degenerate_metric_output(
             n_obs=n_obs,
             n_obs_axis="pairs",
+            alternative_requested="two-sided",
+            variance_status="pooled_design_solver_failure",
+        )
+
+    k = X.shape[1]
+    if design_rank < k:
+        # With an intercept and a constant factor the minimum-norm coefficient
+        # returned by ``lstsq`` is only one arbitrary decomposition of the
+        # fitted constant. It changes when the factor's constant scale changes,
+        # so neither that coefficient nor a test of it is identified.
+        rank_metadata: dict[str, object] = {
+            "variance_status": "singular_pooled_design_matrix",
+            "design_rank": int(design_rank),
+            "n_parameters": k,
+        }
+        return _degenerate_metric_output(
+            n_obs=n_obs,
+            n_obs_axis="pairs",
+            alternative_requested="two-sided",
+            **rank_metadata,
         )
 
     slope = float(beta[1])
     resid = y - X @ beta
-    k = X.shape[1]
 
     if driscoll_kraay:
         return _pooled_beta_driscoll_kraay(
@@ -968,15 +1022,21 @@ def pooled_beta(
         with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
             xtx_inv = np.linalg.inv(X.T @ X)
     except np.linalg.LinAlgError:
-        # Same convention: a singular design admits no t, and ``stat=0.0``
-        # read as a computed zero rather than a refusal.
-        return MetricResult(
-            value=slope,
-            n_obs=n_obs,
-            n_obs_axis="pairs",
-            stat=None,
-            metadata={"signal_status": "degenerate_variance"},
-            warning_codes=(WarningCode.DEGENERATE_VARIANCE.value,),
+        singular_metadata: dict[str, object] = {
+            "stat_type": "t",
+            "h0": "β=0",
+            "method": method_desc,
+            "overlap_periods": overlap_periods,
+            "overlap_adjustment_applied": False,
+            "variance_status": "singular_pooled_design_matrix",
+            **cluster_metadata,
+        }
+        if n_non_finite_dropped:
+            singular_metadata["dropped_pairs"] = n_non_finite_dropped
+        return _pooled_beta_withheld_inference(
+            slope,
+            n_obs,
+            singular_metadata,
         )
 
     with np.errstate(divide="ignore", over="ignore", invalid="ignore"):

--- a/tests/test_pooled_beta_driscoll_kraay.py
+++ b/tests/test_pooled_beta_driscoll_kraay.py
@@ -10,11 +10,16 @@ divergence case), short period series short-circuit / warn, and
 from __future__ import annotations
 
 import warnings
+from datetime import datetime, timedelta
 
+import factrix as fx
 import numpy as np
 import polars as pl
 import pytest
+from factrix._axis import DataStructure, FactorDensity, FactorScope
 from factrix._codes import WarningCode
+from factrix._multi_factor import _is_inactive_hypothesis
+from factrix._results import EvaluationResult
 from factrix._stats import _resolve_scalar_wald_hac
 from factrix.metrics.fm_beta import pooled_beta
 
@@ -106,18 +111,96 @@ class TestDriscollKraayPath:
         assert res.p_value == 1.0
         assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
 
-    def test_singular_design_has_its_own_reason(self):
-        df = _common_factor_panel(n_dates=12, n_assets=10, rho=0.2).with_columns(
-            pl.lit(1.0).alias("factor")
+    def test_singular_design_withholds_unidentified_slope_and_test(self):
+        rng = np.random.default_rng(7)
+        dates = [datetime(2024, 1, 1) + timedelta(days=i) for i in range(40)]
+        df = pl.DataFrame(
+            [
+                {
+                    "date": date,
+                    "asset_id": f"A{asset}",
+                    "factor": 1.0,
+                    "forward_return": float(rng.normal(0, 0.01)),
+                }
+                for asset in range(5)
+                for date in dates
+            ]
         )
 
-        res = pooled_beta(df, driscoll_kraay=True)
+        clustered = pooled_beta(df, overlap_periods=1)
+        dk = pooled_beta(df, driscoll_kraay=True, overlap_periods=1)
 
-        assert np.isnan(res.value)
-        assert res.stat is None
-        assert res.p_value == 1.0
-        assert res.metadata["reason"] == "singular_pooled_design_matrix"
-        assert WarningCode.METRIC_UNAVAILABLE.value in res.warning_codes
+        for result in (clustered, dk):
+            assert np.isnan(result.value)
+            assert result.stat is None
+            assert result.p_value is None
+            assert result.alternative is None
+            assert result.metadata["signal_status"] == "degenerate_zero_variance"
+            assert result.metadata["alternative_requested"] == "two-sided"
+            assert result.metadata["variance_status"] == "singular_pooled_design_matrix"
+            assert result.metadata["design_rank"] == 1
+            assert result.metadata["n_parameters"] == 2
+            assert result.is_applicable
+            assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
+            fx._enforce_strict({"pb": result})
+
+        evaluation = EvaluationResult(
+            factor="factor",
+            cell=(
+                FactorScope.INDIVIDUAL,
+                FactorDensity.DENSE,
+                DataStructure.PANEL,
+            ),
+            forward_periods=1,
+            overlap_periods=1,
+            n_periods=40,
+            n_pairs=200,
+            n_assets=5,
+            metrics={"pb": dk},
+            plan="",
+        )
+        assert _is_inactive_hypothesis(evaluation, "pb")
+
+    def test_dk_covariance_failure_keeps_identified_slope(self, monkeypatch):
+        df = _common_factor_panel(n_dates=40, n_assets=5, rho=0.2)
+        clustered = pooled_beta(df, overlap_periods=1)
+
+        def _raise_singular(*args, **kwargs):
+            raise np.linalg.LinAlgError("test covariance failure")
+
+        monkeypatch.setattr("factrix._stats.hac._driscoll_kraay_cov", _raise_singular)
+        dk = pooled_beta(df, driscoll_kraay=True, overlap_periods=1)
+
+        assert dk.value == pytest.approx(clustered.value)
+        assert dk.stat is None
+        assert dk.p_value is None
+        assert dk.alternative is None
+        assert dk.metadata["signal_status"] == "degenerate_zero_variance"
+        assert dk.metadata["alternative_requested"] == "two-sided"
+        assert dk.metadata["variance_status"] == "singular_pooled_design_matrix"
+        assert dk.is_applicable
+        assert WarningCode.DEGENERATE_VARIANCE.value in dk.warning_codes
+        fx._enforce_strict({"pb": dk})
+
+    def test_lstsq_failure_uses_degenerate_non_test_contract(self, monkeypatch):
+        df = _common_factor_panel(n_dates=40, n_assets=5, rho=0.2)
+
+        def _raise_solver_failure(*args, **kwargs):
+            raise np.linalg.LinAlgError("test solver failure")
+
+        monkeypatch.setattr(np.linalg, "lstsq", _raise_solver_failure)
+        result = pooled_beta(df, overlap_periods=1)
+
+        assert np.isnan(result.value)
+        assert result.stat is None
+        assert result.p_value is None
+        assert result.alternative is None
+        assert result.metadata["signal_status"] == "degenerate_zero_variance"
+        assert result.metadata["alternative_requested"] == "two-sided"
+        assert result.metadata["variance_status"] == "pooled_design_solver_failure"
+        assert result.is_applicable
+        assert WarningCode.DEGENERATE_VARIANCE.value in result.warning_codes
+        fx._enforce_strict({"pb": result})
 
     def test_mutually_exclusive_with_two_way_cluster(self):
         df = _common_factor_panel(n_dates=40, n_assets=10, rho=0.2)


### PR DESCRIPTION
## Summary

- reject rank-deficient pooled designs before either covariance path can expose NumPy's arbitrary minimum-norm coefficient
- preserve an identified pooled slope when only Driscoll-Kraay or clustered covariance inversion fails, while withholding `stat`, `p_value`, and `alternative`
- route all degeneracies through the existing `degenerate_variance` contract so BHY marks them inactive and strict mode remains consistent
- document the distinct unidentified-design and withheld-inference result shapes

## Quantitative correction to the issue premise

The issue reproduction uses a constant factor together with an intercept. Its design rank is 1 for 2 parameters, so the reported `-0.0006598097969293243` is not an identified slope; it is NumPy's minimum-norm split of the fitted constant. Rescaling the same constant factor from 1 to 2 changes that coefficient to `-0.0005278478375434594` without changing any information in the sample.

This PR therefore withholds the slope for the reproduced rank-deficient design. It still implements the issue's intended estimate-preservation rule for the valid case: when OLS is full rank and only covariance estimation fails, the identified slope survives and only inference is withheld.

## Verification

Executed locally:

- unfixed targeted regression: **3 failed as expected**
- fixed targeted regression: **3 passed**
- related tests: **149 passed**
- `ruff check .`: passed
- `ruff format --check factrix tests`: passed
- commit object inspection: no GPG signature and no `Signed-off-by` trailer

Not executed locally:

- complete pytest suite with the required development and documentation extras; the previously reported full-suite count came from an incomplete environment and has been removed
- `python -m mypy factrix`; the earlier statement that CI was authoritative was not a local result
- `mkdocs build --strict` with the complete documentation environment

Closes #1104