### PR TITLE
fix(inference): preserve p-value tail provenance

### DIFF
--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -1,0 +1,37 @@
+---
+title: factrix.inference
+---
+
+::: factrix.inference
+
+## Direct `compute` result
+
+Every series-mean member has the same direct-call shape:
+
+```python
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+from factrix.inference import NEWEY_WEST
+
+data = pl.DataFrame(
+    {
+        "date": [date(2024, 1, 1) + timedelta(days=i) for i in range(60)],
+        "value": np.linspace(-0.1, 0.2, 60),
+    }
+)
+result = NEWEY_WEST.compute(
+    data,
+    value_col="value",
+    overlap_periods=5,
+    alternative="greater",
+)
+assert result.alternative == "greater"
+```
+
+`InferenceResult.p_value` is always paired with
+`InferenceResult.alternative`, which is the validated `"two-sided"`,
+`"greater"`, or `"less"` tail passed to the statistical kernel. Read these
+two fields together; metadata contains method-specific diagnostics such as
+bandwidth, effective degrees of freedom, or bootstrap seed.

--- a/docs/api/metrics/monotonicity.md
+++ b/docs/api/metrics/monotonicity.md
@@ -36,6 +36,9 @@ title: factrix.metrics.monotonicity
     metadata, not the headline — $\mathbb{E}|\rho| > 0$ under $H_0$ by
     Jensen, so mean $|\rho|$ has an `n_groups`-dependent noise floor
     (0.67 / 0.42 / 0.27 at $K = 3 / 5 / 10$) that reads like evidence.
+    The accompanying `signed_spearman_p_value` is explicitly two-sided and
+    reports `signed_spearman_alternative="two-sided"`; it is separate from
+    the headline MR test's one-sided `alternative="greater"`.
 
 </div>
 

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -573,8 +573,11 @@ frequency on the same panels is 5.0% / 5.0% / 4.0% at a nominal 5%.
   [Resampling knobs](statistical-methods.md#resampling-knobs)).
 - *descriptive Spearman shape*: `mean_abs_spearman` (magnitude, ≥ 0),
   `mean_signed` (direction consistency), `signed_spearman_t`,
-  `signed_spearman_p_value`. A high magnitude with a near-zero signed mean
-  still says the factor sorts returns but flips sign across dates.
+  `signed_spearman_p_value`, and `signed_spearman_alternative` (always
+  `"two-sided"`). This secondary test asks whether mean signed Spearman differs
+  from zero in either direction; it does not use the distinct headline MR
+  test's one-sided `alternative="greater"`. A high magnitude with a near-zero
+  signed mean still says the factor sorts returns but flips sign across dates.
 - *descriptive*: `n_valid_periods`, `n_groups`, `tie_ratio`, `tie_policy`.
 - `warning_codes` (conditional): `HIGH_TIE_RATIO` under
   `tie_policy="ordinal"`, `FEW_ASSETS` when the median per-period

--- a/factrix/inference/__init__.py
+++ b/factrix/inference/__init__.py
@@ -9,6 +9,10 @@ metric accept?" is answered per-metric (e.g. ``ic`` accepts
 
 The namespace is scoped to the **series-mean** family
 (``compute(data, *, value_col, overlap_periods, alternative="two-sided")``).
+Every call returns an ``InferenceResult`` whose ``alternative`` field records
+the validated tail passed to the statistical kernel alongside its ``p_value``;
+direct callers therefore do not need external call-site state to interpret the
+reported probability.
 Slice / panel methods
 keep their multivariate compute in ``factrix.slicing`` until they move
 onto the same ``metric(inference=...)`` path; they are deliberately not

--- a/factrix/inference/_base.py
+++ b/factrix/inference/_base.py
@@ -20,6 +20,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from factrix._types import PValueAlternative
+
 if TYPE_CHECKING:
     from factrix._codes import WarningCode
 
@@ -47,7 +49,8 @@ class InferenceResult:
     """Harmonized return shape for an ``Inference.compute`` call.
 
     ``stat`` / ``p_value`` are the test statistic and its requested-tail p-value;
-    they feed a ``MetricResult`` directly. ``metadata`` is a flat
+    ``alternative`` names that tail on the same result, and all three feed a
+    ``MetricResult`` directly. ``metadata`` is a flat
     ``str -> Any`` map (non-overlapping emits ``stride`` / sample counts;
     Newey-West emits ``newey_west_lags``). ``warnings`` carries soft-floor /
     kernel-clamp signals.
@@ -55,6 +58,7 @@ class InferenceResult:
 
     stat: float
     p_value: float
+    alternative: PValueAlternative
     metadata: Mapping[str, Any]
     warnings: frozenset[WarningCode]
     # Point estimate and sample size of the series the test actually ran on.

--- a/factrix/inference/series_mean.py
+++ b/factrix/inference/series_mean.py
@@ -205,6 +205,7 @@ class NonOverlapping:
         return InferenceResult(
             stat=t_stat,
             p_value=p_value,
+            alternative=alternative,
             estimate=float(sampled.mean()) if n_sampled else None,
             n_obs=n_sampled,
             metadata={
@@ -314,6 +315,7 @@ class NeweyWest:
         return InferenceResult(
             stat=t_stat,
             p_value=p_value,
+            alternative=alternative,
             metadata={
                 "newey_west_lags": newey_west_lags,
                 "hac_dof": _har_dof(n, newey_west_lags, overlap_periods)
@@ -400,6 +402,7 @@ class HansenHodrick:
         return InferenceResult(
             stat=t_stat,
             p_value=p_value,
+            alternative=alternative,
             metadata={"kernel": "rectangular", "variance_clamped": clamped},
             warnings=warnings,
             estimate=float(vals.mean()) if n else None,
@@ -548,6 +551,7 @@ class StationaryBootstrap:
         return InferenceResult(
             stat=float(vals.mean()) if n else float("nan"),
             p_value=p_value,
+            alternative=alternative,
             metadata=dict(boot_metadata),
             warnings=warnings,
             estimate=float(vals.mean()) if n else None,

--- a/factrix/metrics/monotonicity.py
+++ b/factrix/metrics/monotonicity.py
@@ -290,6 +290,12 @@ def monotonicity(
         signed mean still tells the useful story that the factor sorts returns
         but flips sign across dates.
 
+        The secondary signed-Spearman t-test remains two-sided: it asks whether
+        the mean signed correlation differs from zero in either direction. Its
+        ``signed_spearman_alternative`` metadata labels that tail explicitly,
+        because the headline is a different, one-sided MR hypothesis whose
+        ``alternative="greater"`` must not be borrowed for this p-value.
+
         **Deviation from the paper.** Patton-Timmermann bootstrap the raw
         (unstudentised) differences, which is what runs here. Their studentised
         variant is not implemented.
@@ -464,6 +470,7 @@ def monotonicity(
         mean_mono = float(np.mean(mono_arr))
         std_mono = float(np.std(mono_arr, ddof=DDOF))
         t_signed = _calc_t_stat(mean_mono, std_mono, len(mono_arr))
+        signed_spearman_alternative: Literal["two-sided"] = "two-sided"
         metadata: dict[str, object] = {
             "method": (
                 "Patton-Timmermann (2010) MR test; stationary-bootstrap "
@@ -474,7 +481,12 @@ def monotonicity(
             "mean_abs_spearman": avg_mono,
             "mean_signed": mean_mono,
             "signed_spearman_t": t_signed,
-            "signed_spearman_p_value": _p_value_from_t(t_signed, len(mono_arr)),
+            "signed_spearman_p_value": _p_value_from_t(
+                t_signed,
+                len(mono_arr),
+                signed_spearman_alternative,
+            ),
+            "signed_spearman_alternative": signed_spearman_alternative,
             "n_valid_periods": len(mono_arr),
             "n_groups": n_groups,
             "tie_ratio": tie_ratios[f],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -236,6 +236,7 @@ nav:
               - trend: api/metrics/trend.md
               - oos_decay: api/metrics/oos_decay.md
       - Supporting modules:
+          - inference: api/inference.md
           - stats: api/stats.md
           - datasets: api/datasets.md
           - preprocess: api/preprocess.md

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -125,7 +125,12 @@ class TestNonOverlapping:
 
 @pytest.mark.parametrize(
     "member",
-    [NON_OVERLAPPING, NEWEY_WEST, StationaryBootstrap(n_resamples=199, rng=0)],
+    [
+        NON_OVERLAPPING,
+        NEWEY_WEST,
+        HansenHodrick(),
+        StationaryBootstrap(n_resamples=199, rng=0),
+    ],
 )
 @pytest.mark.parametrize("sign", [1.0, -1.0])
 def test_series_mean_members_honor_predeclared_tail(member, sign: float) -> None:
@@ -144,6 +149,47 @@ def test_series_mean_members_honor_predeclared_tail(member, sign: float) -> None
     favored = "greater" if sign > 0 else "less"
     opposed = "less" if sign > 0 else "greater"
     assert p[favored] < p["two-sided"] < p[opposed]
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        NON_OVERLAPPING,
+        NEWEY_WEST,
+        HansenHodrick(),
+        StationaryBootstrap(n_resamples=199, rng=0),
+    ],
+)
+@pytest.mark.parametrize("alternative", ["two-sided", "greater", "less"])
+def test_series_mean_result_labels_the_tail_used_in_arithmetic(
+    member, alternative
+) -> None:
+    values = np.linspace(-0.1, 0.5, 80) + 0.2
+    result = member.compute(
+        _series_df(values),
+        value_col="ic",
+        overlap_periods=1,
+        alternative=alternative,
+    )
+
+    if isinstance(member, StationaryBootstrap):
+        expected_p, _ = _block_bootstrap_diff_p(
+            values,
+            n_resamples=member.n_resamples,
+            overlap_periods=1,
+            alternative=alternative,
+            rng=0,
+        )
+    else:
+        expected_p = _p_value_from_t(
+            result.stat,
+            result.n_obs,
+            alternative,
+            dof=result.metadata.get("hac_dof"),
+        )
+
+    assert result.p_value == pytest.approx(expected_p)
+    assert result.alternative == alternative
 
 
 @pytest.mark.parametrize(

--- a/tests/test_monotonicity.py
+++ b/tests/test_monotonicity.py
@@ -5,6 +5,7 @@ import math
 import factrix as fx
 import pytest
 from factrix._codes import WarningCode
+from factrix._stats import _p_value_from_t
 from factrix.metrics.monotonicity import monotonicity
 
 
@@ -91,6 +92,37 @@ class TestComputeMonotonicity:
         assert result.value > 0
         assert result.p_value == pytest.approx(1 / 200)
         assert result.metadata["mr_direction"] == "decreasing"
+
+    def test_signed_spearman_secondary_p_labels_its_two_sided_tail(self, noisy_panel):
+        result = monotonicity(
+            noisy_panel,
+            overlap_periods=1,
+            n_groups=5,
+            n_resamples=199,
+            rng=0,
+        )["factor"]
+        metadata = result.metadata
+        signed_alternative = metadata["signed_spearman_alternative"]
+
+        assert result.alternative == "greater"
+        assert signed_alternative == "two-sided"
+        assert metadata["signed_spearman_p_value"] == pytest.approx(
+            _p_value_from_t(
+                metadata["signed_spearman_t"],
+                metadata["n_valid_periods"],
+                signed_alternative,
+            )
+        )
+        assert metadata["signed_spearman_p_value"] == pytest.approx(
+            2
+            * _p_value_from_t(
+                metadata["signed_spearman_t"],
+                metadata["n_valid_periods"],
+                result.alternative,
+            ),
+            rel=1e-12,
+            abs=0.0,
+        )
 
     def test_insufficient_periods(self):
         from datetime import datetime


### PR DESCRIPTION
## Summary

- add `InferenceResult.alternative` and populate it from all four series-mean inference members
- verify every member's three tail labels against the p-value arithmetic
- add an executable direct-call inference API example and document the result contract
- label monotonicity's secondary signed-Spearman p-value as two-sided, distinct from the one-sided MR headline
- document the secondary tail and sweep the remaining secondary p-values for mismatched provenance

## Secondary p-value sweep

- quantile long/short leg tests already carry `leg_alternative=two-sided`
- Fama-MacBeth's uncorrected p-value is two-sided like its headline test
- common-quantile's Spearman p-value is two-sided like its headline Wald test
- monotonicity was the only secondary p-value whose tail differed from the headline without its own label

## Verification

Executed locally:

- #1102 regression against the unfixed tree: **12 failed as expected** (4 members x 3 tails)
- #1100 regression against the unfixed tree: **1 failed as expected**
- `ruff check .`: passed
- `ruff format --check factrix tests`: passed
- both issue commits inspected: no GPG signature and no `Signed-off-by` trailer

Not executed locally:

- complete pytest suite with the required development and documentation extras; the previously reported full-suite and affected-suite counts came from an incomplete environment and have been removed
- `python -m mypy factrix`; the earlier statement that CI was authoritative was not a local result
- `mkdocs build --strict` with the complete documentation environment

Closes #1100
Closes #1102