### PR TITLE
fix(tradability): align cost and turnover contracts

### DIFF
--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -51,6 +51,10 @@ title: factrix.metrics.quantile
     diagnostics as its equal-weighted sibling, so the comparison is
     like-for-like rather than one leg being quietly less guarded.
 
+    The lag is one period on the sampled panel's distinct-date grid, within
+    each asset. If an asset is absent at the exact preceding grid period, its
+    current row has no lag and drops; an older stale weight is not substituted.
+
 -   __Per-bucket mean returns for monotonicity charts__
 
     ---

--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -55,6 +55,15 @@ title: factrix.metrics.quantile
     each asset. If an asset is absent at the exact preceding grid period, its
     current row has no lag and drops; an older stale weight is not substituted.
 
+    A stale weight carried across the hole would be look-ahead-free too, but
+    it is a longer, asset-dependent lag; one grid period keeps the weight lag
+    equal to the rebalance stride and matches `rank_turnover`. The cost is
+    rows: an asset absent at period *t* also loses *t+1*, so a ragged panel
+    whose thin periods alternate with full ones can drop most of its sample
+    and short-circuit as `metric_unavailable`. Read `drop_rate` and
+    `max_assets_per_date` to see what survived, or pass `lag_weights=False`
+    when the weights are already lagged.
+
 -   __Per-bucket mean returns for monotonicity charts__
 
     ---

--- a/docs/api/metrics/quantile.md
+++ b/docs/api/metrics/quantile.md
@@ -60,9 +60,12 @@ title: factrix.metrics.quantile
     equal to the rebalance stride and matches `rank_turnover`. The cost is
     rows: an asset absent at period *t* also loses *t+1*, so a ragged panel
     whose thin periods alternate with full ones can drop most of its sample
-    and short-circuit as `metric_unavailable`. Read `drop_rate` and
-    `max_assets_per_date` to see what survived, or pass `lag_weights=False`
-    when the weights are already lagged.
+    and short-circuit as `metric_unavailable`. A successful result reports the
+    post-lag breadth as `median_cross_section`; an insufficient-assets
+    short-circuit reports `max_assets_per_date`. `drop_rate` is narrower: it
+    counts period-level spread values lost after bucketing, not asset rows
+    removed by the lag. Pass `lag_weights=False` when the weights are already
+    lagged.
 
 -   __Per-bucket mean returns for monotonicity charts__
 

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -129,9 +129,9 @@ float through the formula.
 
 | Input | Domain | Why |
 |---|---|---|
-| `gross_spread` | finite | A non-finite spread has no reading as a per-period return. |
-| `turnover` | finite, $0 \le \tau \le 1$ | The one-way per-leg replaced fraction above. `rank_turnover` lives in $[0, 2]$ and does not belong here. |
-| `estimated_cost_bps` | finite, $\ge 0$; `None` is invalid | A one-way per-trade cost. Omit the argument to use `net_spread`'s 30 bps default; `None` is not a default sentinel. A negative cost would make trading a source of return. |
+| `gross_spread` | finite real numeric scalar; `bool` / strings rejected | A non-finite spread has no reading as a per-period return. |
+| `turnover` | finite real numeric scalar, $0 \le \tau \le 1$; `bool` / strings rejected | The one-way per-leg replaced fraction above. `rank_turnover` lives in $[0, 2]$ and does not belong here. |
+| `estimated_cost_bps` | finite real numeric scalar, $\ge 0$; `None`, `bool` and strings rejected | A one-way per-trade cost. Omit the argument to use `net_spread`'s 30 bps default; `None` is not a default sentinel. A negative cost would make trading a source of return. |
 | `holding_periods` | integer $\ge 1$ | A rebalance interval in underlying return periods. |
 
 A violation raises `UserInputError`, with the same bounds applied to a bare

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -114,9 +114,13 @@ not two approximations of each other.
     departed name and double the survivor: $\tau = 0.5$, where the $1 - m/k$
     reading was $0$.
 
-    A rebalance is skipped when *either* date leaves *either* leg empty: a
-    weight change needs both portfolios to exist. `metadata["n_rebalances"]`
-    counts the rebalances actually priced, and `mean_tail_size` /
+    A leg's churn is skipped only when that leg is empty on either date. Its
+    valid sample is reported as `metadata["n_top_rebalances"]` or
+    `metadata["n_bottom_rebalances"]`; an empty opposite leg does not erase a
+    well-defined long-only diagnostic. The headline long-short `value` still
+    needs both legs and `metadata["n_rebalances"]` counts that joint sample.
+    Consequently, `value` equals the arithmetic mean of the two published
+    per-leg means only when their samples coincide. `mean_tail_size` /
     `mean_top_tail_size` / `mean_bottom_tail_size` report the **current** leg
     sizes at $t$ — they equal the turnover denominator only while the legs do
     not shrink.

--- a/docs/api/metrics/tradability.md
+++ b/docs/api/metrics/tradability.md
@@ -131,7 +131,7 @@ float through the formula.
 |---|---|---|
 | `gross_spread` | finite | A non-finite spread has no reading as a per-period return. |
 | `turnover` | finite, $0 \le \tau \le 1$ | The one-way per-leg replaced fraction above. `rank_turnover` lives in $[0, 2]$ and does not belong here. |
-| `estimated_cost_bps` | finite, $\ge 0$ | A one-way per-trade cost. A negative cost would make trading a source of return. |
+| `estimated_cost_bps` | finite, $\ge 0$; `None` is invalid | A one-way per-trade cost. Omit the argument to use `net_spread`'s 30 bps default; `None` is not a default sentinel. A negative cost would make trading a source of return. |
 | `holding_periods` | integer $\ge 1$ | A rebalance interval in underlying return periods. |
 
 A violation raises `UserInputError`, with the same bounds applied to a bare

--- a/docs/reference/stat-keys-by-metric.md
+++ b/docs/reference/stat-keys-by-metric.md
@@ -1195,10 +1195,14 @@ inference.
 
 #### `notional_turnover`
 
-- *descriptive*: `n_rebalances`, `n_groups`, `overlap_periods`,
-  `rebalance_lag`, `mean_top_turnover`, `mean_bottom_turnover`
+- *descriptive*: `n_rebalances` (joint long-short sample),
+  `n_top_rebalances`, `n_bottom_rebalances` (per-leg samples), `n_groups`,
+  `overlap_periods`, `rebalance_lag`, `mean_top_turnover`,
+  `mean_bottom_turnover`
   (each leg's mean one-way replaced fraction, `0.5 * sum |w_t - w_{t-1}|` =
-  `1 - overlap / max(prior, current) leg size`; `value` is their mean —
+  `1 - overlap / max(prior, current) leg size`; `value` is their per-date mean
+  on the joint sample and need not equal the arithmetic mean of published leg
+  means when one leg has additional valid rebalances —
   `mean_top_turnover` is the matched proxy for an equal-weight top-quantile
   long-only book), `mean_tail_size`, `mean_top_tail_size`,
   `mean_bottom_tail_size` (the **current** leg sizes at `t`, which equal the

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -1926,7 +1926,8 @@ def _lag_within_asset(
     reaching across the hole to a stale observation.
     """
     dense_lag = (
-        data.select(by).unique()
+        data.select(by)
+        .unique()
         .join(data.select("date").unique(), how="cross")
         .join(data.select(by, "date", col), on=[by, "date"], how="left")
         .sort([by, "date"])

--- a/factrix/metrics/_helpers.py
+++ b/factrix/metrics/_helpers.py
@@ -1919,17 +1919,24 @@ def _lag_within_asset(
 ) -> pl.DataFrame:
     """Replace ``col`` with its per-asset lag; drop rows where the lag is null.
 
-    Common post-sampling pattern: after ``_sample_non_overlapping`` sorts
-    the panel to the rebalance schedule, we want each row's ``col`` to
-    carry the value observed one sampled period earlier on the same
-    asset (weight[t-1], rank[t-1], ...). Single helper so the whole
-    codebase lags the same way — sort by (asset, date), shift within
-    asset, drop the first row per asset.
+    A period is a position on ``data``'s distinct-date grid, not an asset's
+    row position. The helper therefore densifies only the ``(asset, date,
+    value)`` projection before shifting. If an asset is absent at the exact
+    prior grid period, its current row has no lag and is dropped instead of
+    reaching across the hole to a stale observation.
     """
-    return (
-        data.sort([by, "date"])
+    dense_lag = (
+        data.select(by).unique()
+        .join(data.select("date").unique(), how="cross")
+        .join(data.select(by, "date", col), on=[by, "date"], how="left")
+        .sort([by, "date"])
         .with_columns(pl.col(col).shift(periods).over(by).alias(col))
+    )
+    return (
+        data.drop(col)
+        .join(dense_lag, on=[by, "date"], how="left")
         .drop_nulls([col])
+        .sort([by, "date"])
     )
 
 

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -688,7 +688,12 @@ def quantile_spread_vw(
         factrix lags weights by one **sampled grid** period within asset by
         default (not one raw row) so the lag aligns with the rebalance stride.
         A ragged asset does not borrow a stale weight from two or more grid
-        periods earlier. Under
+        periods earlier: that weight is look-ahead-free but carries a longer,
+        asset-dependent lag, and the grid rule keeps the lag equal to the
+        rebalance stride for every asset. On a ragged panel this costs rows —
+        an asset absent at period t also loses t+1 — so check ``drop_rate``
+        and ``max_assets_per_date``, or pass ``lag_weights=False`` when the
+        supplied weights are already lagged. Under
         ``inference=NEWEY_WEST`` there is no stride — every date is its own
         rebalance — so the lag is one bar there, and the first date drops out
         for want of a lagged weight;

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -637,9 +637,11 @@ def quantile_spread_vw(
     \end{aligned}
     $$
 
-    Weights are **lagged by one sampled period per asset** by default
+    Weights are **lagged by one period on the sampled panel grid** by default
     (``lag_weights=True``): a portfolio rebalanced at date t uses the
-    market-cap observed at the previous rebalance, not at t. Pairing
+    market-cap observed at the previous rebalance, not at t. An asset absent
+    at that exact prior grid period has no usable lag at t; factrix does not
+    reach across the gap to an older row. Pairing
     contemporaneous ``market_cap[t]`` with ``forward_return[t→t+h]`` is
     a classic look-ahead trap — market cap measured on date t embeds
     news that the t→t+h return has not yet realized.
@@ -665,9 +667,10 @@ def quantile_spread_vw(
             MA(h-1) overlap in a HAC SE.
         alternative: Requested tail for the headline mean-spread test; fix a
             one-sided direction before inspecting the evaluated sample.
-        lag_weights: When True (default), shift ``weight_col`` by 1
-            period per asset (on the non-overlap-sampled frame) before
-            weighting. When False, use weights as supplied.
+        lag_weights: When True (default), shift ``weight_col`` by 1 period on
+            the non-overlap-sampled frame's distinct-date grid, within asset,
+            before weighting. A row missing its exact prior-grid observation
+            drops. When False, use weights as supplied.
 
     Returns:
         MetricResult with per-period mean VW spread, t-stat, and p-value.
@@ -682,8 +685,10 @@ def quantile_spread_vw(
             spread[t] = vw_top[t] - vw_bot[t]
             value = mean_t spread[t];  t = sqrt(n) * value / std(spread)
 
-        factrix lags weights by one **sampled** period per asset by default
-        (not one raw bar) so the lag aligns with the rebalance stride. Under
+        factrix lags weights by one **sampled grid** period within asset by
+        default (not one raw row) so the lag aligns with the rebalance stride.
+        A ragged asset does not borrow a stale weight from two or more grid
+        periods earlier. Under
         ``inference=NEWEY_WEST`` there is no stride — every date is its own
         rebalance — so the lag is one bar there, and the first date drops out
         for want of a lagged weight;

--- a/factrix/metrics/quantile.py
+++ b/factrix/metrics/quantile.py
@@ -691,9 +691,12 @@ def quantile_spread_vw(
         periods earlier: that weight is look-ahead-free but carries a longer,
         asset-dependent lag, and the grid rule keeps the lag equal to the
         rebalance stride for every asset. On a ragged panel this costs rows —
-        an asset absent at period t also loses t+1 — so check ``drop_rate``
-        and ``max_assets_per_date``, or pass ``lag_weights=False`` when the
-        supplied weights are already lagged. Under
+        an asset absent at period t also loses t+1. Successful results expose
+        the surviving breadth as ``median_cross_section``; an insufficient-
+        assets short-circuit exposes ``max_assets_per_date``. ``drop_rate``
+        instead counts period-level spreads lost after bucketing, not rows
+        removed by the lag. Pass ``lag_weights=False`` when the supplied
+        weights are already lagged. Under
         ``inference=NEWEY_WEST`` there is no stride — every date is its own
         rebalance — so the lag is one bar there, and the first date drops out
         for want of a lagged weight;

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -29,7 +29,7 @@ Notes:
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import polars as pl
@@ -57,6 +57,7 @@ from factrix.metrics._helpers import (
     _assign_quantile_groups,
     _enforce_min_floor,
     _finite_expr,
+    _is_finite_number,
     _median_universe_size,
     _sample_non_overlapping,
     _short_circuit_output,
@@ -824,19 +825,22 @@ def _propagate_unavailable(
     )
 
 
-def _validate_finite(value: float, *, func_name: str, field: str, detail: str) -> None:
-    """Reject a non-finite scalar before it reaches the cost algebra."""
-    if not math.isfinite(value):
+def _validate_finite(
+    value: object, *, func_name: str, field: str, detail: str
+) -> float:
+    """Return a finite real scalar; reject coercible non-numeric inputs."""
+    if not _is_finite_number(value):
         raise UserInputError(
             func_name=func_name,
             field=field,
             value=value,
-            expected=f"a finite float. {detail}",
+            expected=f"a finite real number (bool and strings rejected). {detail}",
             docs_path=_DOCS_TRADABILITY,
         )
+    return float(cast(int | float, value))
 
 
-def _validate_turnover(value: float, *, func_name: str) -> None:
+def _validate_turnover(value: object, *, func_name: str) -> float:
     """``turnover`` is the one-way per-leg replaced fraction, so it is in [0, 1].
 
     ``notional_turnover`` reports ``0.5 * sum |w_t - w_{t-1}|`` averaged over
@@ -846,35 +850,40 @@ def _validate_turnover(value: float, *, func_name: str) -> None:
     ``+inf`` and ``net_spread`` used to *raise* the alpha it was meant to
     charge — and a value above 1 prices trades the book cannot make.
     """
-    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+    if not _is_finite_number(value) or not 0.0 <= float(
+        cast(int | float, value)
+    ) <= 1.0:
         raise UserInputError(
             func_name=func_name,
             field="turnover",
             value=value,
             expected=(
-                "a finite fraction inside [0, 1]. It is the one-way per-leg "
+                "a finite real number inside [0, 1] (bool and strings "
+                "rejected). It is the one-way per-leg "
                 "notional replaced per rebalance (0.5 * sum |dw|, top/bottom "
                 "averaged) that notional_turnover reports; rank_turnover's "
                 "value lives in [0, 2] and does not belong here."
             ),
             docs_path=_DOCS_TRADABILITY,
         )
+    return float(cast(int | float, value))
 
 
-def _validate_estimated_cost_bps(value: float, *, func_name: str) -> None:
+def _validate_estimated_cost_bps(value: object, *, func_name: str) -> float:
     """``estimated_cost_bps`` is a one-way cost, so it is finite and >= 0."""
-    if not math.isfinite(value) or value < 0.0:
+    if not _is_finite_number(value) or float(cast(int | float, value)) < 0.0:
         raise UserInputError(
             func_name=func_name,
             field="estimated_cost_bps",
             value=value,
             expected=(
-                "a finite bps cost >= 0. It is the one-way (per-trade) cost "
-                "of a single buy or sell; a negative cost would make trading "
-                "a source of return."
+                "a finite real bps cost >= 0 (bool and strings rejected). It "
+                "is the one-way (per-trade) cost of a single buy or sell; a "
+                "negative cost would make trading a source of return."
             ),
             docs_path=_DOCS_TRADABILITY,
         )
+    return float(cast(int | float, value))
 
 
 def _unpack_cost_inputs(
@@ -883,7 +892,6 @@ def _unpack_cost_inputs(
     holding_periods: int,
     *,
     func_name: str,
-    estimated_cost_bps: float | None = None,
 ) -> tuple[float, float, dict[str, Any]] | MetricResult:
     """Resolve the two cost inputs, police their domain, and pair-check them.
 
@@ -905,8 +913,8 @@ def _unpack_cost_inputs(
        the one reported.
     2. **Domain validation.** Whatever survives — a bare scalar or an
        *available* result's ``value``, held to the same bounds either way —
-       must be a finite spread, a turnover inside ``[0, 1]``, and a finite
-       non-negative ``estimated_cost_bps``.
+       must be a finite spread and a turnover inside ``[0, 1]``. The
+       ``net_spread`` boundary validates its own cost before calling here.
     3. **Pairing check.** The ``n_groups`` cross-check.
 
     Returns:
@@ -932,14 +940,14 @@ def _unpack_cost_inputs(
             holding_periods=holding_periods,
         )
 
-    spread_value = float(
+    spread_raw = (
         gross_spread.value if isinstance(gross_spread, MetricResult) else gross_spread
     )
-    turnover_value = float(
+    turnover_raw = (
         turnover.value if isinstance(turnover, MetricResult) else turnover
     )
-    _validate_finite(
-        spread_value,
+    spread_value = _validate_finite(
+        spread_raw,
         func_name=func_name,
         field="gross_spread",
         detail=(
@@ -948,9 +956,7 @@ def _unpack_cost_inputs(
             "priced, but a non-finite bare scalar has no reading."
         ),
     )
-    _validate_turnover(turnover_value, func_name=func_name)
-    if estimated_cost_bps is not None:
-        _validate_estimated_cost_bps(estimated_cost_bps, func_name=func_name)
+    turnover_value = _validate_turnover(turnover_raw, func_name=func_name)
 
     checked: dict[str, Any] = {}
     spread_meta = (
@@ -1399,12 +1405,15 @@ def net_spread(
             ),
             docs_path=_DOCS_TRADABILITY,
         )
+    estimated_cost_bps = _validate_estimated_cost_bps(
+        estimated_cost_bps,
+        func_name="net_spread",
+    )
     resolved = _unpack_cost_inputs(
         gross_spread,
         turnover,
         holding_periods,
         func_name="net_spread",
-        estimated_cost_bps=estimated_cost_bps,
     )
     if isinstance(resolved, MetricResult):
         return resolved

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -863,9 +863,10 @@ def _validate_turnover(value: object, *, func_name: str) -> float:
     ``+inf`` and ``net_spread`` used to *raise* the alpha it was meant to
     charge — and a value above 1 prices trades the book cannot make.
     """
-    if not _is_finite_number(value) or not 0.0 <= float(
-        cast(int | float, value)
-    ) <= 1.0:
+    if (
+        not _is_finite_number(value)
+        or not 0.0 <= float(cast(int | float, value)) <= 1.0
+    ):
         raise UserInputError(
             func_name=func_name,
             field="turnover",
@@ -956,9 +957,7 @@ def _unpack_cost_inputs(
     spread_raw = (
         gross_spread.value if isinstance(gross_spread, MetricResult) else gross_spread
     )
-    turnover_raw = (
-        turnover.value if isinstance(turnover, MetricResult) else turnover
-    )
+    turnover_raw = turnover.value if isinstance(turnover, MetricResult) else turnover
     spread_value = _validate_finite(
         spread_raw,
         func_name=func_name,

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -1388,6 +1388,17 @@ def net_spread(
         >>> result.name == ""
         True
     """
+    if estimated_cost_bps is None:
+        raise UserInputError(
+            func_name="net_spread",
+            field="estimated_cost_bps",
+            value=None,
+            expected=(
+                "a finite bps cost >= 0. None is not a default sentinel; "
+                "omit the argument to use the 30 bps default."
+            ),
+            docs_path=_DOCS_TRADABILITY,
+        )
     resolved = _unpack_cost_inputs(
         gross_spread,
         turnover,

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -863,10 +863,8 @@ def _validate_turnover(value: object, *, func_name: str) -> float:
     ``+inf`` and ``net_spread`` used to *raise* the alpha it was meant to
     charge — and a value above 1 prices trades the book cannot make.
     """
-    if (
-        not _is_finite_number(value)
-        or not 0.0 <= float(cast(int | float, value)) <= 1.0
-    ):
+    numeric = float(cast(int | float, value)) if _is_finite_number(value) else None
+    if numeric is None or not 0.0 <= numeric <= 1.0:
         raise UserInputError(
             func_name=func_name,
             field="turnover",
@@ -880,7 +878,7 @@ def _validate_turnover(value: object, *, func_name: str) -> float:
             ),
             docs_path=_DOCS_TRADABILITY,
         )
-    return float(cast(int | float, value))
+    return numeric
 
 
 def _validate_estimated_cost_bps(value: object, *, func_name: str) -> float:

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -703,12 +703,8 @@ def notional_turnover(
         .join(prev_leg_sizes, on="prev_date")
         .join(overlaps, on="date")
         .with_columns(
-            ((pl.col("n_top") > 0) & (pl.col("n_top_prev") > 0)).alias(
-                "top_defined"
-            ),
-            ((pl.col("n_bot") > 0) & (pl.col("n_bot_prev") > 0)).alias(
-                "bot_defined"
-            ),
+            ((pl.col("n_top") > 0) & (pl.col("n_top_prev") > 0)).alias("top_defined"),
+            ((pl.col("n_bot") > 0) & (pl.col("n_bot_prev") > 0)).alias("bot_defined"),
         )
         # WHY max: for an equal-weight leg of ``k`` names now and ``j`` before
         # with ``m`` survivors, ``0.5 * Σ|w_t − w_{t−1}|`` evaluates in closed

--- a/factrix/metrics/tradability.py
+++ b/factrix/metrics/tradability.py
@@ -557,7 +557,12 @@ def notional_turnover(
         Metadata: ``n_rebalances``, ``n_groups``, ``overlap_periods`` (the
         panel's stamp, unchanged), ``rebalance_lag`` (the stride actually
         sampled at), ``mean_top_turnover`` / ``mean_bottom_turnover`` (each
-        leg's mean replaced fraction — ``value`` is their mean),
+        leg's mean replaced fraction, each over the rebalances where that leg
+        exists on both dates), ``n_top_rebalances`` /
+        ``n_bottom_rebalances`` (those per-leg sample sizes). ``value`` is the
+        per-date mean of the two legs over the joint ``n_rebalances`` sample;
+        it equals the arithmetic mean of the two published leg means only when
+        their samples coincide.
         ``mean_tail_size`` (per-date average of ``(|Q_top| + |Q_bot|)/2`` at
         ``t``, the *current* leg sizes — the turnover denominator is
         ``max(|Q(t)|, |Q(t-1)|)``, so the two coincide only while the legs do
@@ -598,9 +603,11 @@ def notional_turnover(
         joiner) with a one-way cost per trade. Summing the legs here
         instead would double-count against those coefficients.
 
-        A rebalance is skipped when *either* date leaves *either* leg empty:
-        the difference between two weight vectors needs both portfolios to
-        exist, and there is no book to resize into or out of nothing.
+        A leg's churn is undefined when that leg is empty on either date, but
+        this does not discard the other leg's well-defined churn. The headline
+        long-short ``value`` requires both legs and reports its joint sample as
+        ``n_rebalances``; the per-leg means report their own sample sizes as
+        ``n_top_rebalances`` and ``n_bottom_rebalances``.
 
     References:
         [Novy-Marx-Velikov (2016)][novy-marx-velikov-2016], "A Taxonomy of
@@ -695,14 +702,13 @@ def notional_turnover(
         leg_sizes.join(date_map, on="date")
         .join(prev_leg_sizes, on="prev_date")
         .join(overlaps, on="date")
-        # Both books must exist for a weight change to be defined: a rebalance
-        # into or out of an empty leg is not a turnover, it is the absence of
-        # one of the two portfolios the difference is taken between.
-        .filter(
-            (pl.col("n_top") > 0)
-            & (pl.col("n_bot") > 0)
-            & (pl.col("n_top_prev") > 0)
-            & (pl.col("n_bot_prev") > 0)
+        .with_columns(
+            ((pl.col("n_top") > 0) & (pl.col("n_top_prev") > 0)).alias(
+                "top_defined"
+            ),
+            ((pl.col("n_bot") > 0) & (pl.col("n_bot_prev") > 0)).alias(
+                "bot_defined"
+            ),
         )
         # WHY max: for an equal-weight leg of ``k`` names now and ``j`` before
         # with ``m`` survivors, ``0.5 * Σ|w_t − w_{t−1}|`` evaluates in closed
@@ -715,20 +721,27 @@ def notional_turnover(
             pl.max_horizontal("n_top", "n_top_prev").alias("n_top_book"),
             pl.max_horizontal("n_bot", "n_bot_prev").alias("n_bot_book"),
         )
-        # Each leg's replaced fraction is kept on its own: the long-short
-        # ``value`` is their mean, but a long-only top-quantile book pays only
-        # the top leg's churn, and the two can differ materially.
         .with_columns(
-            (1 - pl.col("n_top_kept") / pl.col("n_top_book")).alias("top_turnover"),
-            (1 - pl.col("n_bot_kept") / pl.col("n_bot_book")).alias("bot_turnover"),
+            pl.when(pl.col("top_defined"))
+            .then(1 - pl.col("n_top_kept") / pl.col("n_top_book"))
+            .alias("top_turnover"),
+            pl.when(pl.col("bot_defined"))
+            .then(1 - pl.col("n_bot_kept") / pl.col("n_bot_book"))
+            .alias("bot_turnover"),
         )
+        # The headline is a long-short quantity, so it requires both legs.
+        # Per-leg diagnostics remain defined on their own samples instead of
+        # losing a valid rebalance when only the opposite book is empty.
         .with_columns(
-            ((pl.col("top_turnover") + pl.col("bot_turnover")) / 2).alias("turnover")
+            pl.when(pl.col("top_defined") & pl.col("bot_defined"))
+            .then((pl.col("top_turnover") + pl.col("bot_turnover")) / 2)
+            .alias("turnover")
         )
         .sort("date")
     )
 
-    if per_date.is_empty():
+    joint_rebalances = per_date.filter(pl.col("turnover").is_not_null())
+    if joint_rebalances.is_empty():
         # Name the binding axis. The overwhelmingly common cause is a
         # cross-section too thin to fill ``n_groups`` buckets (the default
         # ``n_groups=10`` empties every date on an allocation-sized universe),
@@ -749,24 +762,28 @@ def notional_turnover(
             descriptive=True,
         )
 
-    turnover_arr = per_date["turnover"].to_numpy()
+    turnover_arr = joint_rebalances["turnover"].to_numpy()
     mean_turnover = float(np.mean(turnover_arr))
     mean_top_turnover = float(per_date["top_turnover"].mean())  # type: ignore[arg-type]
     mean_bottom_turnover = float(per_date["bot_turnover"].mean())  # type: ignore[arg-type]
+    n_top_rebalances = per_date["top_turnover"].drop_nulls().len()
+    n_bottom_rebalances = per_date["bot_turnover"].drop_nulls().len()
     tail_pct = 1.0 / n_groups
 
-    mean_top_tail_size = float(per_date["n_top"].mean())  # type: ignore[arg-type]
-    mean_bottom_tail_size = float(per_date["n_bot"].mean())  # type: ignore[arg-type]
+    mean_top_tail_size = float(joint_rebalances["n_top"].mean())  # type: ignore[arg-type]
+    mean_bottom_tail_size = float(joint_rebalances["n_bot"].mean())  # type: ignore[arg-type]
     mean_tail_size = (mean_top_tail_size + mean_bottom_tail_size) / 2
     return MetricResult(
         value=mean_turnover,
         # Rebalances — one per adjacent-period transition, not (date, asset)
         # pairs; the axis is periods.
-        n_obs=int(per_date.height),
+        n_obs=int(joint_rebalances.height),
         n_obs_axis="periods",
         warning_codes=tuple(warning_codes),
         metadata={
-            "n_rebalances": int(per_date.height),
+            "n_rebalances": int(joint_rebalances.height),
+            "n_top_rebalances": n_top_rebalances,
+            "n_bottom_rebalances": n_bottom_rebalances,
             "n_groups": n_groups,
             "overlap_periods": overlap_periods,
             "rebalance_lag": lag,

--- a/tests/test_drop_rate_warning_phase2.py
+++ b/tests/test_drop_rate_warning_phase2.py
@@ -140,8 +140,14 @@ class TestSpreadTools:
         # (not null) — the ratio used to come back as a NaN spread that
         # ``drop_nulls`` kept, so drop_rate read 0.0 while a NaN sat in the
         # tested sample. An empty leg is now null: dropped, and counted.
+        # Keep this schema test focused on empty quantile legs. With lagged
+        # weights, a name entering after a thin date correctly has no prior
+        # period weight, so this deliberately ragged fixture becomes thin on
+        # every date and short-circuits before the drop-stat surface.
         with pytest.warns(UserWarning, match="of periods dropped"):
-            result = quantile_spread_vw(_spread_panel(), overlap_periods=1)
+            result = quantile_spread_vw(
+                _spread_panel(), overlap_periods=1, lag_weights=False
+            )
         assert set(DROP_STAT_KEYS) <= set(result.metadata)
         assert result.metadata["drop_rate"] == pytest.approx(0.5, abs=0.02)
         assert "NaN" in result.metadata["drop_reason"]

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -11,6 +11,7 @@ from factrix._errors import IncompatibleInferenceError
 from factrix._stats import _p_value_from_t
 from factrix.inference import NEWEY_WEST
 from factrix.inference.series_mean import HANSEN_HODRICK
+from factrix.metrics._helpers import _lag_within_asset
 from factrix.metrics.quantile import (
     compute_spread_series,
     quantile_spread,
@@ -255,6 +256,36 @@ class TestQuantileSpreadVW:
         # Default lag drops exactly the first sampled row per asset on
         # the balanced panel — strict shrinkage of the effective window.
         assert default.metadata["n_periods"] < explicit_off.metadata["n_periods"]
+
+    @pytest.mark.parametrize("strides", [[1], [1, 17]])
+    def test_weight_lag_uses_the_sampled_period_grid(self, strides):
+        """A ragged asset cannot borrow a weight from two periods earlier."""
+        dates = [datetime(2024, 1, 1)]
+        for i in range(1, 8):
+            step = strides[(i - 1) % len(strides)]
+            dates.append(dates[-1] + timedelta(days=step))
+        panel = pl.DataFrame(
+            [
+                {
+                    "date": date,
+                    "asset_id": asset,
+                    "grid_period": period,
+                    "market_cap": float(1000 * (period + 1)),
+                }
+                for period, date in enumerate(dates)
+                for asset in ("A", "B")
+                if (asset, period) != ("B", 3)
+            ]
+        ).with_columns(pl.col("date").cast(pl.Datetime("ms")))
+
+        lagged = _lag_within_asset(panel, "market_cap")
+
+        assert lagged.filter(
+            (pl.col("asset_id") == "B") & (pl.col("grid_period") == 4)
+        ).is_empty()
+        assert lagged.filter(
+            (pl.col("asset_id") == "B") & (pl.col("grid_period") == 5)
+        )["market_cap"].item() == 5000.0
 
     def test_missing_weight_col(self):
         df = pl.DataFrame(

--- a/tests/test_quantile.py
+++ b/tests/test_quantile.py
@@ -283,9 +283,12 @@ class TestQuantileSpreadVW:
         assert lagged.filter(
             (pl.col("asset_id") == "B") & (pl.col("grid_period") == 4)
         ).is_empty()
-        assert lagged.filter(
-            (pl.col("asset_id") == "B") & (pl.col("grid_period") == 5)
-        )["market_cap"].item() == 5000.0
+        assert (
+            lagged.filter((pl.col("asset_id") == "B") & (pl.col("grid_period") == 5))[
+                "market_cap"
+            ].item()
+            == 5000.0
+        )
 
     def test_missing_weight_col(self):
         df = pl.DataFrame(

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -894,6 +894,24 @@ class TestCostAlgebraDomain:
         with pytest.raises(UserInputError, match="estimated_cost_bps"):
             net_spread(0.001, turnover=0.2, estimated_cost_bps=bad)
 
+    def test_none_cost_is_rejected_at_the_public_boundary(self):
+        """A user's ``None`` is an invalid cost, not an internal sentinel."""
+        with pytest.raises(UserInputError, match="estimated_cost_bps"):
+            net_spread(  # type: ignore[arg-type]
+                0.001,
+                turnover=0.2,
+                estimated_cost_bps=None,
+            )
+
+    def test_breakeven_cost_has_no_estimated_cost_input(self):
+        """The sibling without a cost argument keeps that API boundary."""
+        with pytest.raises(TypeError, match="estimated_cost_bps"):
+            breakeven_cost(  # type: ignore[call-arg]
+                0.001,
+                turnover=0.2,
+                estimated_cost_bps=30.0,
+            )
+
     def test_a_metric_result_carrying_an_out_of_domain_value_is_rejected(self):
         """An *available* result is held to the same domain as a bare float."""
         turnover = MetricResult(value=1.4, metadata={"n_groups": 5})

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -912,6 +912,30 @@ class TestCostAlgebraDomain:
                 estimated_cost_bps=30.0,
             )
 
+    @pytest.mark.parametrize("bad", [True, False, "0.5"])
+    def test_gross_spread_rejects_coercible_non_numeric_scalars(self, bad):
+        with pytest.raises(UserInputError, match="gross_spread"):
+            breakeven_cost(bad, turnover=0.2)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad", [True, False, "0.5"])
+    def test_turnover_rejects_coercible_non_numeric_scalars(self, bad):
+        with pytest.raises(UserInputError, match="turnover"):
+            breakeven_cost(0.001, turnover=bad)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad", [True, False, "30"])
+    def test_cost_rejects_coercible_non_numeric_scalars(self, bad):
+        with pytest.raises(UserInputError, match="estimated_cost_bps"):
+            net_spread(  # type: ignore[arg-type]
+                0.001,
+                turnover=0.2,
+                estimated_cost_bps=bad,
+            )
+
+    def test_plain_float_metric_results_remain_valid_cost_inputs(self):
+        spread = MetricResult(value=0.001, metadata={"n_groups": 5})
+        turnover = MetricResult(value=0.2, metadata={"n_groups": 5})
+        assert breakeven_cost(spread, turnover=turnover).value == pytest.approx(62.5)
+
     def test_a_metric_result_carrying_an_out_of_domain_value_is_rejected(self):
         """An *available* result is held to the same domain as a bare float."""
         turnover = MetricResult(value=1.4, metadata={"n_groups": 5})

--- a/tests/test_tradability.py
+++ b/tests/test_tradability.py
@@ -810,6 +810,21 @@ class TestChangingUniverseNotionalTurnover:
         )
         assert out.value == pytest.approx(0.0)
 
+    def test_each_leg_keeps_rebalances_when_only_the_other_leg_is_empty(self):
+        """A thin top book does not erase well-defined bottom-book churn."""
+        full = {asset: float(i) for i, asset in enumerate("ABCDEFGHIJ")}
+        members = [full.copy() for _ in range(21)]
+        members[10] = {"C": 2.0}
+
+        out = self._run(members, n_groups=5)
+
+        assert out.value == pytest.approx(0.0)
+        assert out.metadata["mean_top_turnover"] == pytest.approx(0.0)
+        assert out.metadata["mean_bottom_turnover"] == pytest.approx(0.1)
+        assert out.metadata["n_rebalances"] == 18
+        assert out.metadata["n_top_rebalances"] == 18
+        assert out.metadata["n_bottom_rebalances"] == 20
+
     def test_delisted_holding_is_no_longer_missed(self):
         """A top-leg name delists and is not replaced.
 


### PR DESCRIPTION
## Summary

- distinguish an invalid `estimated_cost_bps=None` from the sibling helper's absent argument
- reject boolean and string cost-algebra scalars before numeric coercion
- compute each turnover leg on its own valid rebalance sample while retaining a joint sample for the long-short headline
- lag value weights on the sampled panel's distinct-period grid so ragged assets cannot borrow stale weights across holes
- document the scalar domains, per-leg sample counts, and period-grid lag contract

## Quantitative contract

`notional_turnover` now reports three explicit sample sizes:

- `n_rebalances`: transitions where both legs exist, used by the long-short headline
- `n_top_rebalances`: transitions used by `mean_top_turnover`
- `n_bottom_rebalances`: transitions used by `mean_bottom_turnover`

The per-leg means are no longer forced onto the joint sample. Consequently, the headline equals the arithmetic mean of the two published leg means only when their samples coincide.

## Period-grid lag: what it costs

`_lag_within_asset` now shifts on the sampled panel's distinct-date grid, so
an asset absent at period *t* also loses *t+1* — its exact prior-grid weight
does not exist and no older observation is substituted. A stale carried weight
would be look-ahead-free as well, but it is a longer, asset-dependent lag; the
grid rule keeps every asset on the rebalance stride and matches the choice
`rank_turnover` made in #1098. The trade-off and the row loss are now recorded
where a caller reads them (`quantile_spread_vw` docstring, `docs/api/metrics/quantile.md`).

Measured on the deliberately ragged `_spread_panel` fixture in
`tests/test_drop_rate_warning_phase2.py` (3 assets on even periods, 50 on odd):

| | main | this branch |
|---|---|---|
| rows surviving the lag | 5300 → 5250 | 5300 → 597 |
| assets surviving the lag | 50 | 3 |
| result | 99 periods, `drop_rate` 0.50 | `metric_unavailable`, `insufficient_assets_for_quantile_groups` |

That fixture exists to pin the drop-stat schema on empty quantile legs, not to
exercise weight lagging, so it now passes `lag_weights=False` and keeps testing
what it was written for. Callers on ragged panels should read `median_cross_section` on successful
results or `max_assets_per_date` on an insufficient-assets short-circuit.
`drop_rate` separately counts period-level spreads lost after bucketing; it
does not count asset rows removed by the lag. Callers can also pre-lag their
weights and pass `lag_weights=False`.

## Verification

Executed locally (detached worktree on this branch, project venv):

- `ruff check .` and `ruff format --check .`: clean, 254 files
- `python -m mypy factrix`: no issues in 83 source files
- `python -m pytest -q`: **4192 passed, 44 skipped, 0 failed**
- `python -m pytest --doctest-modules factrix/metrics/quantile.py`: 4 passed
- `python -m mkdocs build --strict`: built clean

Closes #1089
Closes #1090
Closes #1091
Closes #1099

