### PR TITLE
fix(compare): preserve data and deterministic ranks

### DIFF
--- a/docs/api/compare.md
+++ b/docs/api/compare.md
@@ -57,7 +57,7 @@ The returned `pl.DataFrame` contains the following columns:
 | `metrics` | (required) | `list[str]` of metric labels to include in the leaderboard. |
 | `sort_by` | `None` | Any output column produced before ranking: `factor`, `forward_periods`, `params` keys, metric value columns such as `ic`, or p-value columns such as `ic_p_value` / `<metric_label>_p_value`. `None` keeps the original list order. |
 | `descending` | `None` | Sort direction for `sort_by`. `None` resolves it from the column under the [direction rule](#sort-direction); `True` / `False` states it outright and always wins. There is no global direction default. |
-| `rank_method` | `"min"` | How equal `sort_by` values are numbered: `"min"` (tied rows share the best rank, next rank skips: `1, 1, 3`), `"dense"` (share the rank, no gap: `1, 1, 2`), `"ordinal"` (every row numbered `1..N`). Polars' `Expr.rank` methods. |
+| `rank_method` | `"min"` | How equal `sort_by` values are numbered: `"min"` (tied rows share the best rank, next rank skips: `1, 1, 3`), `"dense"` (share the rank, no gap: `1, 1, 2`), `"ordinal"` (every row numbered `1..N`, using the deterministic [tie order](#ties-order-and-missing-values)). Polars' `Expr.rank` methods. |
 
 ### Sort direction
 
@@ -80,10 +80,12 @@ signed metrics such as `predictive_beta`, `fm_beta` and `spanning_alpha`, where
 ### Ties, order, and missing values
 
 Rows sort on `sort_by`, then on `factor` and `forward_periods` ascending, then on
-any `params` column of a sortable dtype, so the output does not depend on the
-order of the input `results`. Rows equal on every one of those columns are
-indistinguishable and keep input order among themselves; under `"min"` and
-`"dense"` they carry the same rank anyway.
+the remaining params and output columns, so the output does not depend on the
+order of the input `results`. List, struct and other columns Polars cannot sort
+natively use a canonical, type-tagged string as an internal ordering key; the
+returned column and its values stay unchanged. Rows equal on every one of those
+columns are indistinguishable and keep input order among themselves; under
+`"min"` and `"dense"` they carry the same rank anyway.
 
 A `null` or `NaN` `sort_by` value sorts **last** in both directions and carries a
 `null` rank under every `rank_method` — a row with no value has no place in the

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -267,29 +267,39 @@ def _rank(
     data: pl.DataFrame, *, sort_by: str, descending: bool, rank_method: RankMethod
 ) -> pl.DataFrame:
     """Sort ``data`` on ``sort_by`` and attach the ``rank`` column."""
+    sort_key_name = _unused_column_name(data.columns, _SORT_KEY)
     key = pl.col(sort_by)
     if data.schema[sort_by] in (pl.Float32, pl.Float64):
         # Fold NaN into null so "missing last" holds in both directions.
         key = pl.when(key.is_nan()).then(None).otherwise(key)
-    data = data.with_columns(key.alias(_SORT_KEY))
-    tiebreaks = _sortable_tiebreaks(data.drop(_SORT_KEY), sort_by)
+    data = data.with_columns(key.alias(sort_key_name))
+    tiebreaks = _sortable_tiebreaks(data.drop(sort_key_name), sort_by)
     data = data.sort(
-        [_SORT_KEY, *tiebreaks],
+        [sort_key_name, *tiebreaks],
         descending=[descending, *[False] * len(tiebreaks)],
         nulls_last=True,
     )
     if rank_method == "ordinal":
         ranks = pl.int_range(1, data.height + 1, dtype=pl.Int64)
     else:
-        ranks = pl.col(_SORT_KEY).rank(method=rank_method, descending=descending)
+        ranks = pl.col(sort_key_name).rank(method=rank_method, descending=descending)
     data = data.with_columns(
-        pl.when(pl.col(_SORT_KEY).is_null())
+        pl.when(pl.col(sort_key_name).is_null())
         .then(None)
         .otherwise(ranks)
         .cast(pl.Int64)
         .alias("rank")
     )
-    return data.drop(_SORT_KEY)
+    return data.drop(sort_key_name)
+
+
+def _unused_column_name(columns: Iterable[str], preferred: str) -> str:
+    """Return an internal column name that cannot shadow caller data."""
+    occupied = set(columns)
+    candidate = preferred
+    while candidate in occupied:
+        candidate = f"_{candidate}"
+    return candidate
 
 
 def _ordered_keys(maps: Iterable[Mapping[str, Any]]) -> list[str]:

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -112,6 +112,9 @@ def compare(
     and ``forward_periods`` ascending, then on params and output columns.
     Columns Polars cannot sort natively use a canonical, type-tagged string
     only as an internal ordering key; their returned values are untouched.
+    That key orders lexicographically on the string, not on the value's own
+    semantics — ``[10, 2]`` sorts before ``[2, 1]`` — so read such an order
+    as stable, not as meaningful.
     The output therefore does not depend on the order of ``results``. Rows
     equal on every one of those columns are indistinguishable and keep input
     order among themselves.

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -263,24 +263,24 @@ def _canonical_sort_value(value: object) -> str | None:
         value = value.to_list()
     type_name = f"{type(value).__module__}.{type(value).__qualname__}"
     if isinstance(value, Mapping):
-        items = sorted(
+        mapping_items = sorted(
             (
                 _canonical_sort_value(key) or "builtins.NoneType:None",
                 _canonical_sort_value(item) or "builtins.NoneType:None",
             )
             for key, item in value.items()
         )
-        return f"{type_name}:{items!r}"
+        return f"{type_name}:{mapping_items!r}"
     if isinstance(value, list | tuple):
-        items = [
+        sequence_items = [
             _canonical_sort_value(item) or "builtins.NoneType:None" for item in value
         ]
-        return f"{type_name}:{items!r}"
+        return f"{type_name}:{sequence_items!r}"
     if isinstance(value, set | frozenset):
-        items = sorted(
+        set_items = sorted(
             _canonical_sort_value(item) or "builtins.NoneType:None" for item in value
         )
-        return f"{type_name}:{items!r}"
+        return f"{type_name}:{set_items!r}"
     return f"{type_name}:{value!r}"
 
 

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -109,10 +109,12 @@ def compare(
       :class:`UserInputError`. Pass ``descending`` explicitly there.
 
     Row order and ties: rows are sorted on ``sort_by``, then on ``factor``
-    and ``forward_periods`` ascending, then on any params column of a
-    sortable dtype. The output therefore does not depend on the order of
-    ``results``. Rows equal on every one of those columns are
-    indistinguishable and keep input order among themselves.
+    and ``forward_periods`` ascending, then on params and output columns.
+    Columns Polars cannot sort natively use a canonical, type-tagged string
+    only as an internal ordering key; their returned values are untouched.
+    The output therefore does not depend on the order of ``results``. Rows
+    equal on every one of those columns are indistinguishable and keep input
+    order among themselves.
 
     Missing values: a ``null`` or ``NaN`` ``sort_by`` value sorts **last**
     in both directions and carries a ``null`` rank under every
@@ -248,32 +250,93 @@ def _resolve_descending(
     return False
 
 
-def _sortable_tiebreaks(data: pl.DataFrame, sort_by: str) -> list[str]:
-    """Return the deterministic secondary sort keys, in application order."""
+def _is_natively_sortable(dtype: pl.DataType) -> bool:
+    """Whether Polars can use ``dtype`` directly as a leaderboard key."""
+    return (
+        dtype.is_numeric()
+        or dtype.is_temporal()
+        or dtype in (pl.Boolean, pl.String)
+    )
+
+
+def _canonical_sort_value(value: object) -> str | None:
+    """Return a stable, type-preserving ordering token for a nested value."""
+    if value is None:
+        return None
+    if isinstance(value, pl.Series):
+        value = value.to_list()
+    type_name = f"{type(value).__module__}.{type(value).__qualname__}"
+    if isinstance(value, Mapping):
+        items = sorted(
+            (
+                _canonical_sort_value(key) or "builtins.NoneType:None",
+                _canonical_sort_value(item) or "builtins.NoneType:None",
+            )
+            for key, item in value.items()
+        )
+        return f"{type_name}:{items!r}"
+    if isinstance(value, list | tuple):
+        items = [
+            _canonical_sort_value(item) or "builtins.NoneType:None" for item in value
+        ]
+        return f"{type_name}:{items!r}"
+    if isinstance(value, set | frozenset):
+        items = sorted(
+            _canonical_sort_value(item) or "builtins.NoneType:None" for item in value
+        )
+        return f"{type_name}:{items!r}"
+    return f"{type_name}:{value!r}"
+
+
+def _deterministic_tiebreaks(
+    data: pl.DataFrame, sort_by: str
+) -> tuple[pl.DataFrame, list[str], list[str]]:
+    """Attach canonical keys where needed and return all secondary keys."""
     keys = [c for c in _IDENTITY_COLS if c != sort_by]
+    hidden: list[str] = []
     for name, dtype in data.schema.items():
         if name in _IDENTITY_COLS or name == sort_by:
             continue
-        if (
-            dtype.is_numeric()
-            or dtype.is_temporal()
-            or dtype in (pl.Boolean, pl.String)
-        ):
+        if _is_natively_sortable(dtype):
             keys.append(name)
-    return keys
+            continue
+        hidden_name = _unused_column_name(
+            [*data.columns, *hidden], f"__factrix_tiebreak_{len(hidden)}"
+        )
+        data = data.with_columns(
+            pl.Series(
+                hidden_name,
+                [_canonical_sort_value(value) for value in data[name].to_list()],
+                dtype=pl.String,
+            )
+        )
+        keys.append(hidden_name)
+        hidden.append(hidden_name)
+    return data, keys, hidden
 
 
 def _rank(
     data: pl.DataFrame, *, sort_by: str, descending: bool, rank_method: RankMethod
 ) -> pl.DataFrame:
     """Sort ``data`` on ``sort_by`` and attach the ``rank`` column."""
+    data, tiebreaks, hidden_tiebreaks = _deterministic_tiebreaks(data, sort_by)
     sort_key_name = _unused_column_name(data.columns, _SORT_KEY)
+    dtype = data.schema[sort_by]
     key = pl.col(sort_by)
-    if data.schema[sort_by] in (pl.Float32, pl.Float64):
+    if dtype in (pl.Float32, pl.Float64):
         # Fold NaN into null so "missing last" holds in both directions.
         key = pl.when(key.is_nan()).then(None).otherwise(key)
-    data = data.with_columns(key.alias(sort_key_name))
-    tiebreaks = _sortable_tiebreaks(data.drop(sort_key_name), sort_by)
+        data = data.with_columns(key.alias(sort_key_name))
+    elif _is_natively_sortable(dtype):
+        data = data.with_columns(key.alias(sort_key_name))
+    else:
+        data = data.with_columns(
+            pl.Series(
+                sort_key_name,
+                [_canonical_sort_value(value) for value in data[sort_by].to_list()],
+                dtype=pl.String,
+            )
+        )
     data = data.sort(
         [sort_key_name, *tiebreaks],
         descending=[descending, *[False] * len(tiebreaks)],
@@ -290,7 +353,7 @@ def _rank(
         .cast(pl.Int64)
         .alias("rank")
     )
-    return data.drop(sort_key_name)
+    return data.drop(sort_key_name, *hidden_tiebreaks)
 
 
 def _unused_column_name(columns: Iterable[str], preferred: str) -> str:

--- a/factrix/_compare.py
+++ b/factrix/_compare.py
@@ -252,11 +252,7 @@ def _resolve_descending(
 
 def _is_natively_sortable(dtype: pl.DataType) -> bool:
     """Whether Polars can use ``dtype`` directly as a leaderboard key."""
-    return (
-        dtype.is_numeric()
-        or dtype.is_temporal()
-        or dtype in (pl.Boolean, pl.String)
-    )
+    return dtype.is_numeric() or dtype.is_temporal() or dtype in (pl.Boolean, pl.String)
 
 
 def _canonical_sort_value(value: object) -> str | None:

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import itertools
+
 import pytest
 from factrix._compare import compare
 from factrix._errors import UserInputError
@@ -257,6 +259,37 @@ def test_rank_is_invariant_to_input_order(method, order):
     assert df["factor"].to_list() == ["a", "b", "c"]
     expected = {"min": [1, 1, 3], "dense": [1, 1, 2], "ordinal": [1, 2, 3]}[method]
     assert df["rank"].to_list() == expected
+
+
+def test_ordinal_rank_is_invariant_for_list_valued_params():
+    make_spec("ic")
+    windows = ((1, 2), (3, 4), (5, 6), (7, 8))
+    orderings = set()
+    for order in itertools.permutations(windows):
+        results = [
+            make_result(
+                factor="same",
+                p=0.1,
+                metric="ic",
+                value=0.05,
+                params={"window": list(window)},
+            )
+            for window in order
+        ]
+        board = compare(
+            results,
+            metrics=["ic"],
+            sort_by="ic_p_value",
+            rank_method="ordinal",
+        )
+        orderings.add(tuple(tuple(value) for value in board["window"].to_list()))
+        assert board["rank"].to_list() == [1, 2, 3, 4]
+
+    assert orderings == {windows}
+
+    by_window = compare(results, metrics=["ic"], sort_by="window")
+    sorted_windows = tuple(tuple(value) for value in by_window["window"].to_list())
+    assert sorted_windows == windows
 
 
 def test_unknown_rank_method_raises():

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -144,6 +144,22 @@ def test_param_keys_propagate_with_null_fill():
     assert b_row["sector"] == "tech" and b_row["region"] is None
 
 
+def test_internal_sort_key_name_cannot_drop_a_params_column():
+    make_spec("ic")
+    key = "__factrix_sort_key"
+    results = [
+        make_result(factor="same", p=0.1, metric="ic", params={key: 2}),
+        make_result(factor="same", p=0.1, metric="ic", params={key: 1}),
+    ]
+
+    ranked = compare(results, metrics=["ic"], sort_by="ic_p_value")
+    sorted_by_param = compare(results, metrics=["ic"], sort_by=key)
+
+    assert ranked[key].to_list() == [1, 2]
+    assert sorted_by_param[key].to_list() == [1, 2]
+    assert key in ranked.columns
+
+
 def test_p_column_populated_when_metadata_present():
     make_spec("ic")
     results = [make_result(factor="f1", p=0.042, metric="ic", value=0.05)]


### PR DESCRIPTION
## Summary

- derive a non-colliding internal sort-key name so a params column named `__factrix_sort_key` remains visible and sortable
- canonicalize list, struct, and other non-native sortable values into internal type-tagged ordering keys
- keep caller-visible params values unchanged while making ordinal ranks invariant to input permutations
- link the `rank_method=ordinal` parameter contract to the deterministic tie rules

## Determinism contract

Native numeric, temporal, boolean, and string columns keep their Polars ordering. Other dtypes use a canonical type-tagged representation only for sorting; the original output column is preserved. Rows equal on every visible output column remain indistinguishable.

## Ordering caveat

The canonical key orders lexicographically on the tagged string, not on the
value's own semantics: measured, `_canonical_sort_value([10, 2])` sorts before
`_canonical_sort_value([2, 1])`. The docstring now says so, so callers read
such an order as stable rather than meaningful.

## Verification

Executed locally (detached worktree on this branch, project venv):

- `ruff check .` and `ruff format --check .`: clean, 254 files
- `python -m mypy factrix`: no issues in 83 source files
- `python -m pytest -q`: **4179 passed, 44 skipped, 0 failed**
- `python -m pytest -k compare`: 54 passed, 1 skipped
- `python -m mkdocs build --strict`: built clean

Closes #1092
Closes #1093
