### PR TITLE
fix(stats): bound automatic block fallbacks (#1101)

### DIFF
--- a/factrix/_stats/bootstrap.py
+++ b/factrix/_stats/bootstrap.py
@@ -202,12 +202,18 @@ def _politis_white_block_length(values: np.ndarray) -> float:
     Falls back to ``max(1, 1.75 · T^(1/3))`` (the widely-cited practical
     PW approximation, also used by ``factrix.stats.bootstrap``) when
     the series is too short, autocovariance is degenerate, or the
-    spectral estimate yields a non-finite ratio. Returns a ``float``;
-    callers that need an integer block size round at the call site.
+    spectral estimate yields a non-finite ratio. The fallback is capped at
+    :func:`_max_block_length`, exactly like the plug-in path, so an automatic
+    resolver never returns a value its own kernel rejects. Returns a
+    ``float``; callers that need an integer block size round at the call site.
     """
     x = np.asarray(values, dtype=float)
     n = len(x)
-    fallback = max(1.0, 1.75 * n ** (1.0 / 3.0)) if n >= 1 else 1.0
+    fallback = (
+        min(max(1.0, 1.75 * n ** (1.0 / 3.0)), float(_max_block_length(n)))
+        if n >= 1
+        else 1.0
+    )
     if n < 4 or not np.all(np.isfinite(x)):
         return fallback
 

--- a/tests/inference/test_series_mean.py
+++ b/tests/inference/test_series_mean.py
@@ -331,6 +331,14 @@ class TestStationaryBootstrap:
         )
         assert WarningCode.UNRELIABLE_SE_SHORT_PERIODS in result.warnings
 
+    @pytest.mark.parametrize("n", [2, 4, 8, 9, 12])
+    def test_constant_small_samples_reach_the_degenerate_fallback(self, n) -> None:
+        result = STATIONARY_BOOTSTRAP.compute(
+            _series_df(np.full(n, 2.0)), value_col="ic", overlap_periods=1
+        )
+        assert result.metadata["studentized"] is False
+        assert WarningCode.DEGENERATE_VARIANCE in result.warnings
+
     def test_min_input_periods_matches_newey_west(self) -> None:
         assert STATIONARY_BOOTSTRAP.min_input_periods(
             5

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -10,6 +10,7 @@ from factrix._errors import UserInputError
 from factrix._stats.bootstrap import (
     _block_bootstrap_diff_p,
     _count_extreme,
+    _max_block_length,
     _politis_white_block_length,
     _stationary_block_indices,
 )
@@ -38,13 +39,19 @@ class TestPolitisWhiteBlockLength:
         assert L_persist > L_iid
 
     def test_fallback_on_short_series(self):
-        # n=3 < 4 → fallback to 1.75 * n^(1/3).
+        # n=3 < 4 → practical fallback, capped at the admissible maximum.
         L = _politis_white_block_length(np.array([1.0, 2.0, 3.0]))
-        assert pytest.approx(max(1.0, 1.75 * 3 ** (1.0 / 3.0))) == L
+        expected = min(max(1.0, 1.75 * 3 ** (1.0 / 3.0)), _max_block_length(3))
+        assert L == pytest.approx(expected)
 
     def test_fallback_on_zero_variance(self):
         L = _politis_white_block_length(np.zeros(100))
         assert pytest.approx(max(1.0, 1.75 * 100 ** (1.0 / 3.0))) == L
+
+    @pytest.mark.parametrize("n", [2, 4, 8, 9, 12, 13, 30])
+    def test_every_fallback_respects_the_kernel_bound(self, n):
+        length = _politis_white_block_length(np.ones(n))
+        assert 1.0 <= length <= _max_block_length(n)
 
 
 class TestPolitisWhiteUpperBound:
@@ -274,7 +281,8 @@ class TestRejectsNonFinite:
 
     def test_politis_white_falls_back_on_nan(self):
         x = np.array([0.1, float("nan"), 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
-        assert _politis_white_block_length(x) == pytest.approx(1.75 * 8 ** (1 / 3))
+        expected = min(1.75 * 8 ** (1 / 3), _max_block_length(8))
+        assert _politis_white_block_length(x) == pytest.approx(expected)
 
 
 class TestStudentizedRoot:

--- a/tests/stats/test_block_bootstrap.py
+++ b/tests/stats/test_block_bootstrap.py
@@ -42,7 +42,7 @@ class TestPolitisWhiteBlockLength:
         # n=3 < 4 → practical fallback, capped at the admissible maximum.
         L = _politis_white_block_length(np.array([1.0, 2.0, 3.0]))
         expected = min(max(1.0, 1.75 * 3 ** (1.0 / 3.0)), _max_block_length(3))
-        assert L == pytest.approx(expected)
+        assert pytest.approx(expected) == L
 
     def test_fallback_on_zero_variance(self):
         L = _politis_white_block_length(np.zeros(100))


### PR DESCRIPTION
## Summary

- cap every Politis-White fallback at the same admissible block-length maximum as the plug-in path
- keep automatic resolution inside the downstream kernel's accepted domain for short, constant, and non-finite series
- pin the small-sample degenerate-variance path so it reaches the documented raw-mean root instead of rejecting an internal default

## Contract

An automatically resolved block length is always inside `[1, ceil(min(3*sqrt(n), n/3))]`. Explicit user-supplied out-of-range values remain validation errors and are not silently clamped.

## Verification

Actually run on this machine:

- `git diff --check` — passed
- commit/trailer inspection — passed; no GPG signature, `Signed-off-by`, bot co-author, or generator trailer

Actually run by remote CI on current head `b5e7b107`:

- lint and mypy — passed
- pytest on Python 3.12–3.14 across Ubuntu, macOS, and Windows — passed
- documented dev setup and dependency-floor/no-pandas cells — passed
- doctests and wheel import smoke — passed
- 17 successful checks, no failures or pending checks

Closes #1101