### PR TITLE
fix(inspect): align pre-flight and runtime contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,57 @@ jobs:
       - name: Run pytest
         run: uv run --python 3.12 pytest -rs
 
+  docs-no-theme:
+    name: pytest (docs machinery, no theme)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.x"
+          enable-cache: true
+
+      # This intentionally constructs the one dependency boundary no declared
+      # extra represents: mkdocstrings is importable but mkdocs-material is
+      # absent. It proves the false direction of ``requires_theme``; the
+      # all-extras matrix above proves the two marked tests run with the theme.
+      - name: Install docs machinery without the theme
+        shell: bash
+        run: |
+          uv sync --frozen --python 3.12 --extra dev
+          uv pip install --python .venv \
+            "mkdocstrings==1.0.4" "mkdocstrings-python==2.0.3"
+          .venv/bin/python - <<'PY'
+          import importlib.metadata
+          import importlib.util
+
+          assert importlib.util.find_spec("mkdocstrings") is not None
+          try:
+              importlib.metadata.version("mkdocs-material")
+          except importlib.metadata.PackageNotFoundError:
+              pass
+          else:
+              raise AssertionError("mkdocs-material must be absent in this CI cell")
+          PY
+
+      - name: Assert the requires_theme skips
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +e
+          output=$(uv run --python 3.12 pytest -q -rs --color=no \
+            tests/test_docs_inventory_cache_warmup.py 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          test "$status" -eq 0
+          grep -Fq "19 passed, 2 skipped" <<<"$output"
+          reason="resolving mkdocs.yml requires mkdocs-material from the docs extra"
+          grep -Fq "$reason" <<<"$output"
+
   floor:
     name: pytest (declared dependency floor, no pandas, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -41,6 +41,13 @@ The named `all` extra is the optional runtime bundle; it does not include the
 development and docs toolchains. Use `--all-extras` when every declared extra
 is required.
 
+CI exercises both sides of the docs-theme boundary. The all-extras test matrix
+runs the two tests that resolve `mkdocs.yml`. A separate `docs-no-theme` cell
+installs `mkdocstrings` without `mkdocs-material` and asserts that exactly those
+two tests skip for the `requires_theme` reason while the other 19 module tests
+run. This is distinct from `dev-extra`, where the module skips during
+collection because the complete docs machinery is absent.
+
 On Windows, enable UTF-8 for Markdown and diagnostic tests if the console does
 not already do so:
 

--- a/tests/test_inspect_evaluate_agreement.py
+++ b/tests/test_inspect_evaluate_agreement.py
@@ -38,9 +38,7 @@ _N_ASSETS = (5, 8, 12, 20, 40)
 _N_PERIODS = (60, 120, 240)
 _HORIZONS = (1, 5)
 
-_FactorShape = Literal[
-    "individual", "common_time_varying", "common_zero_variance"
-]
+_FactorShape = Literal["individual", "common_time_varying", "common_zero_variance"]
 _FACTOR_SHAPES: tuple[_FactorShape, ...] = (
     "individual",
     "common_time_varying",
@@ -59,6 +57,21 @@ _NO_DEFAULT_INSTANCE = frozenset({"breakeven_cost", "net_spread"})
 # already excluded by the ``no_*`` rule below; named here so the exclusion is
 # not mistaken for an untested metric.
 _PROJECTION_GAP = frozenset({"quantile_spread_vw"})
+
+# The zero-variance COMMON shape exists specifically to exercise the
+# producer-survivor bridge fixed in #1074. Other metrics have data-content
+# contracts outside SampleThreshold: common_quantile_spread requires enough
+# distinct historical values, while directional_hit_rate keeps a point
+# estimate but withholds its test on a one-sided signal. Sweeping those here
+# would turn this sample-shape invariant into a different contract.
+_COMMON_BETA_CONSUMERS = frozenset(
+    {
+        "common_beta",
+        "common_beta_profile",
+        "common_beta_r_squared",
+        "common_beta_sign_consistency",
+    }
+)
 
 
 def _panel(
@@ -90,11 +103,19 @@ def _shapes() -> list[tuple[int, int, int]]:
     return [(n, t, h) for n in _N_ASSETS for t in _N_PERIODS for h in _HORIZONS]
 
 
-def _metric_names() -> list[str]:
-    """Public ``role=METRIC`` specs — the ones ``inspect_data`` verdicts and
+def _metric_names(factor_shape: _FactorShape) -> list[str]:
+    """Return the metrics belonging to this sample-shape invariant.
+
+    Public ``role=METRIC`` specs are what ``inspect_data`` verdicts and
     ``evaluate`` accepts directly (PIPELINE producers are pulled via
-    ``requires=`` and cannot be evaluated on their own)."""
-    return sorted({spec.name for _, spec in public_specs()} - _NO_DEFAULT_INSTANCE)
+    ``requires=`` and cannot be evaluated on their own). The zero-variance
+    COMMON regression narrows that set to the consumers whose upstream asset
+    survival is the sample shape under test.
+    """
+    names = {spec.name for _, spec in public_specs()} - _NO_DEFAULT_INSTANCE
+    if factor_shape == "common_zero_variance":
+        names &= _COMMON_BETA_CONSUMERS
+    return sorted(names)
 
 
 def _run(panel: pl.DataFrame, name: str, *, strict: bool):
@@ -138,7 +159,7 @@ def test_inspect_verdict_matches_evaluate_outcome(
     usable = _verdicts(panel)
 
     disagreements: list[str] = []
-    for name in _metric_names():
+    for name in _metric_names(factor_shape):
         if name not in usable:
             continue  # not a public METRIC spec (pipeline producer)
         try:
@@ -175,7 +196,7 @@ def test_strict_raises_exactly_when_inspect_says_unusable(
     legal_axes = {"periods", "assets", "events", "pairs", "asset_pairs"}
 
     disagreements: list[str] = []
-    for name in _metric_names():
+    for name in _metric_names(factor_shape):
         if name not in usable:
             continue
         raised: str | None = None
@@ -297,7 +318,7 @@ def test_no_silent_nan_and_p_value_is_never_a_sentinel(
        that never ran as a clean result.
     """
     panel = _panel(n_assets, n_periods, forward_periods)
-    for name in _metric_names():
+    for name in _metric_names("individual"):
         try:
             out = _run(panel, name, strict=False)
         except fx.IncompatibleAxisError:

--- a/tests/test_inspect_evaluate_agreement.py
+++ b/tests/test_inspect_evaluate_agreement.py
@@ -59,11 +59,14 @@ _NO_DEFAULT_INSTANCE = frozenset({"breakeven_cost", "net_spread"})
 _PROJECTION_GAP = frozenset({"quantile_spread_vw"})
 
 # The zero-variance COMMON shape exists specifically to exercise the
-# producer-survivor bridge fixed in #1074. Other metrics have data-content
-# contracts outside SampleThreshold: common_quantile_spread requires enough
-# distinct historical values, while directional_hit_rate keeps a point
-# estimate but withholds its test on a one-sided signal. Sweeping those here
-# would turn this sample-shape invariant into a different contract.
+# producer-survivor bridge fixed in #1074, so the sweep runs on the metrics
+# whose upstream asset survival is that bridge. Two other metrics disagree on
+# this shape for reasons outside SampleThreshold, and both are filed rather
+# than accepted: common_quantile_spread is pre-flighted usable but refused at
+# run time as insufficient_factor_variation (#1115), and directional_hit_rate
+# is pre-flighted unusable but runs (#1116). Measured on this branch with the
+# narrowing below removed: 60/60 zero-variance cells fail, and those two are
+# the only disagreeing metrics. Re-widen this set when #1115 and #1116 close.
 _COMMON_BETA_CONSUMERS = frozenset(
     {
         "common_beta",

--- a/tests/test_inspect_evaluate_agreement.py
+++ b/tests/test_inspect_evaluate_agreement.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from typing import Literal
 
 import factrix as fx
 import polars as pl
@@ -36,6 +37,15 @@ from factrix.preprocess import compute_forward_return
 _N_ASSETS = (5, 8, 12, 20, 40)
 _N_PERIODS = (60, 120, 240)
 _HORIZONS = (1, 5)
+
+_FactorShape = Literal[
+    "individual", "common_time_varying", "common_zero_variance"
+]
+_FACTOR_SHAPES: tuple[_FactorShape, ...] = (
+    "individual",
+    "common_time_varying",
+    "common_zero_variance",
+)
 
 # Metrics whose default constructor needs a positional argument (scalar
 # helpers such as breakeven_cost / net_spread take an upstream value, not a
@@ -56,19 +66,23 @@ def _panel(
     n_periods: int,
     forward_periods: int,
     *,
-    common_factor: bool = False,
+    factor_shape: _FactorShape = "individual",
 ) -> pl.DataFrame:
-    """Dense individual- or common-factor panel with optional schema columns.
+    """Dense panel spanning individual and both common-factor regressions.
 
     ``market_cap`` is present so a weight-consuming metric fails (or not) on
     sample shape rather than on a missing column — the sweep tests the shape
-    gate.
+    gate. The time-varying common control keeps stage-1 factor variation; the
+    zero-variance shape forces every per-asset regression to drop, which is
+    the producer/pre-flight disagreement the COMMON sweep must detect.
     """
     raw = fx.datasets.make_cs_panel(
         n_assets=n_assets, n_dates=n_periods, rng=17
     ).with_columns(pl.lit(1.0e9).alias("market_cap"))
-    if common_factor:
+    if factor_shape == "common_time_varying":
         raw = raw.with_columns(pl.col("factor").first().over("date"))
+    elif factor_shape == "common_zero_variance":
+        raw = raw.with_columns(pl.lit(1.0).alias("factor"))
     return compute_forward_return(raw, forward_periods=forward_periods)
 
 
@@ -113,14 +127,14 @@ def _is_out_of_scope(reason: object) -> bool:
 
 
 @pytest.mark.parametrize("n_assets,n_periods,forward_periods", _shapes())
-@pytest.mark.parametrize("common_factor", [False, True], ids=["individual", "common"])
+@pytest.mark.parametrize("factor_shape", _FACTOR_SHAPES)
 def test_inspect_verdict_matches_evaluate_outcome(
     n_assets: int,
     n_periods: int,
     forward_periods: int,
-    common_factor: bool,
+    factor_shape: _FactorShape,
 ) -> None:
-    panel = _panel(n_assets, n_periods, forward_periods, common_factor=common_factor)
+    panel = _panel(n_assets, n_periods, forward_periods, factor_shape=factor_shape)
     usable = _verdicts(panel)
 
     disagreements: list[str] = []
@@ -140,23 +154,23 @@ def test_inspect_verdict_matches_evaluate_outcome(
                 f"reason={out.metadata.get('reason')!r}"
             )
     assert not disagreements, (
-        f"scope={'common' if common_factor else 'individual'} "
+        f"shape={factor_shape} "
         f"N={n_assets} T={n_periods} h={forward_periods}: " + "; ".join(disagreements)
     )
 
 
 @pytest.mark.parametrize("n_assets,n_periods,forward_periods", _shapes())
-@pytest.mark.parametrize("common_factor", [False, True], ids=["individual", "common"])
+@pytest.mark.parametrize("factor_shape", _FACTOR_SHAPES)
 def test_strict_raises_exactly_when_inspect_says_unusable(
     n_assets: int,
     n_periods: int,
     forward_periods: int,
-    common_factor: bool,
+    factor_shape: _FactorShape,
 ) -> None:
     """``strict=True`` must refuse precisely the shapes pre-flight calls
     unusable, and the refusal must be the documented exception type carrying a
     legal axis token."""
-    panel = _panel(n_assets, n_periods, forward_periods, common_factor=common_factor)
+    panel = _panel(n_assets, n_periods, forward_periods, factor_shape=factor_shape)
     usable = _verdicts(panel)
     legal_axes = {"periods", "assets", "events", "pairs", "asset_pairs"}
 
@@ -183,7 +197,7 @@ def test_strict_raises_exactly_when_inspect_says_unusable(
         if raised is None and not usable[name]:
             disagreements.append(f"{name}: pre-flight unusable but strict ran")
     assert not disagreements, (
-        f"scope={'common' if common_factor else 'individual'} "
+        f"shape={factor_shape} "
         f"N={n_assets} T={n_periods} h={forward_periods}: " + "; ".join(disagreements)
     )
 
@@ -221,8 +235,12 @@ def test_common_beta_preflight_uses_assets_surviving_the_producer() -> None:
 
 
 def test_common_beta_preflight_keeps_time_varying_broadcast_factor() -> None:
-    """COMMON broadcasting alone must not make per-asset regressions unusable."""
-    panel = _panel(20, 120, 5, common_factor=True)
+    """Control: COMMON broadcasting alone keeps regressions usable.
+
+    This passes before the #1074 fix by design; it pins the valid neighbouring
+    regime while the zero-variance sweep cells provide regression force.
+    """
+    panel = _panel(20, 120, 5, factor_shape="common_time_varying")
     info = fx.inspect_data(panel, factor_cols=["factor"])
     beta_consumers = {
         "common_beta_profile",


### PR DESCRIPTION
## Summary

- add a CI cell where mkdocstrings is installed but mkdocs-material is deliberately absent
- assert the docs inventory produces 19 passes, exactly two `requires_theme` skips, and the expected skip reason
- sweep individual, time-varying COMMON, and zero-variance COMMON shapes through the full public metric inventory
- pre-flight `common_quantile_spread` on the same usable per-date distinct-factor gate as runtime
- classify a one-sided `directional_hit_rate` factor as degraded: the hit-rate estimate survives while the PT statistic and p-value are withheld
- align the directional-hit-rate docstring and user docs with the existing finite-value `DEGENERATE_VARIANCE` result contract

## Quantitative contract

The all-extras matrix proves the theme-present direction. The partial-docs cell proves the theme-absent direction and rejects an accidental module-level skip.

The inspect/evaluate grid contains 90 cells per invariant: 30 individual, 30 time-varying COMMON controls, and 30 zero-variance COMMON regressions. Every shape now exercises the same full public metric inventory.

For default `common_quantile_spread(n_groups=5)`, pre-flight counts distinct values on the same finite per-date factor/return series runtime constructs and blocks `n_distinct < 2 * n_groups`. For `directional_hit_rate`, one-sided predictions keep the descriptive hit rate but cannot identify the Pesaran-Timmermann test; pre-flight therefore attaches `DEGENERATE_VARIANCE` without making the metric unusable.

## Verification

Actually run on this machine for current head `9d9ecf1b`:

- `git diff --check` — passed
- commit/trailer inspection — passed; no GPG signature, `Signed-off-by`, bot co-author, or generator trailer

Not run on this machine:

- Python quality gates — this machine uses the restricted environment described in the repository workflow; no unavailable gate is reported as passed

Remote CI on current head `9d9ecf1b` is running. Its actual outcomes will be recorded here after completion.

Measured earlier on the separate verification machine (project venv, `pytest -p no:randomly`) before the #1115/#1116 fixes:

| state | result |
|---|---|
| `factrix/_inspect.py` reverted to `2c8f8b01^` (pre-#1085), regression sweep | **60 failed / 60** |
| prior branch head with the common-beta-only narrowing | 214 passed (whole file), 0 failed |
| prior branch head with the narrowing removed | **60 failed / 60**; `common_quantile_spread` and `directional_hit_rate` were the only disagreeing metrics |

Those measured failures motivated #1115 and #1116. No current-head Python result is inferred from them.

Closes #1094
Closes #1096
Closes #1115
Closes #1116