### PR TITLE
fix(inspect): advise, not refuse, a one-sided directional signal (#1116)

### DIFF
--- a/docs/reference/metric-applicability.md
+++ b/docs/reference/metric-applicability.md
@@ -142,7 +142,7 @@ Min sample*. `MIN_*` constants resolve to values in the
 
 | Metric | Sample axis | Min sample |
 |---|---|---|
-| [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | pooled `(date, asset)` signs | non-overlapping obs `≥ MIN_DIRECTIONAL_PAIRS_HARD`; warn if below `MIN_DIRECTIONAL_PAIRS_WARN` |
+| [`directional_hit_rate`][factrix.metrics.directional_hit_rate.directional_hit_rate] | pooled `(date, asset)` signs | non-overlapping obs `≥ MIN_DIRECTIONAL_PAIRS_HARD`; warn if below `MIN_DIRECTIONAL_PAIRS_WARN` ; a one-sided `sign(factor)` is usable with a `degenerate_variance` advisory — the hit rate is kept, the PT test withheld |
 
 ## Sample-size constants
 [](){ #sample-size-constants }

--- a/factrix/_inspect.py
+++ b/factrix/_inspect.py
@@ -1148,12 +1148,26 @@ def _evaluate_applicability(
         )
 
     if spec.name == "directional_hit_rate" and factor_sign_one_sided:
-        blockers.append(
-            "one-sided directional signal: sign(factor) has only one non-zero "
-            "side, so directional_hit_rate would return degenerate_variance "
-            "at run time; center, threshold, "
-            "or encode a true two-sided directional signal before using this "
-            "metric"
+        # Advisory, not a blocker: the run does not short-circuit here. It
+        # returns the hit rate — which on a one-sided signal is the
+        # unconditional realised-direction rate — and withholds the PT test
+        # under DEGENERATE_VARIANCE, so pre-flight reports that same outcome
+        # rather than promising a refusal the run never performs (#1116).
+        warnings.append(
+            Warning(
+                code=WarningCode.DEGENERATE_VARIANCE,
+                source=spec.name,
+                message=(
+                    "one-sided directional signal: sign(factor) has only one "
+                    "non-zero side, so P* collapses to the realised up-rate "
+                    "and the Pesaran-Timmermann variance is zero. The metric "
+                    "returns the hit rate — the unconditional positive-return "
+                    "rate, not a directional one — with a null statistic and "
+                    "p-value under degenerate_variance. Center, threshold, or "
+                    "encode a true two-sided directional signal to obtain a "
+                    "test."
+                ),
+            )
         )
 
     # Optional-schema precondition: a metric gated on an optional column

--- a/factrix/metrics/directional_hit_rate.py
+++ b/factrix/metrics/directional_hit_rate.py
@@ -144,7 +144,14 @@ def directional_hit_rate(
         *negatively* related to forward returns scores poorly here — flip
         its sign before testing. Degenerate samples (all predictions or
         all realisations one-signed, or a non-positive variance estimate)
-        short-circuit: $P_*$ is then 1 and the statistic is undefined. This
+        keep the hit rate and withhold the test: ``value`` is still
+        $\hat P$ — on a one-sided signal that is the unconditional
+        realised-direction rate, a defined number but not a *directional*
+        one — while ``stat`` and ``p_value`` are null under
+        ``WarningCode.DEGENERATE_VARIANCE``. The metric does **not**
+        short-circuit to ``metric_unavailable`` there, and
+        :func:`~factrix.inspect_data` reports the shape as usable carrying
+        that same advisory rather than as a blocker (#1116). This
         is why ``return_col`` must be sign-symmetric around zero — a
         risk-adjusted return (e.g. ``forward_return / forward_realized_vol``)
         qualifies, but an always-positive magnitude target (realised

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -6,6 +6,7 @@ import math
 
 import factrix as fx
 import polars as pl
+import pytest
 from factrix._inspect import (
     DataInspection,
     DataProperties,
@@ -355,17 +356,23 @@ class TestDeclaredPeriodsFloorsVisible:
         assert da.usable is True
         assert da.warnings == []
 
-    def test_directional_hit_rate_blocks_one_sided_factor_sign(self):
+    def test_directional_hit_rate_advises_on_a_one_sided_factor_sign(self):
+        # The run keeps the hit rate and withholds the test, so pre-flight
+        # advises rather than refuses (#1116); it used to blocker this shape
+        # while strict=True ran it.
         raw = fx.datasets.make_cs_panel(n_assets=20, n_dates=80)
         data = raw.with_columns((pl.col("factor").abs() + 0.1).alias("factor"))
 
         info = inspect_data(data)
         da = _by_name(info, "directional_hit_rate")
 
-        assert da.usable is False
-        assert da in info.unusable
-        assert any("one-sided directional signal" in b for b in da.blockers)
-        assert any("degenerate_variance" in b for b in da.blockers)
+        assert da.usable is True
+        assert da not in info.unusable
+        assert da.blockers == []
+        advisory = next(
+            w for w in da.warnings if w.code is fx.WarningCode.DEGENERATE_VARIANCE
+        )
+        assert "one-sided directional signal" in advisory.message
 
     def test_top_concentration_declares_periods_floors(self):
         from factrix._types import (
@@ -1222,3 +1229,46 @@ class TestPerFactorInspection:
         # axes detected for that column.
         assert "<td>common</td><td>common</td><td>dense</td>" in html_out
         assert "<td>sparse</td><td>individual</td><td>sparse</td>" in html_out
+
+
+def _one_sided_sign_panel(n_assets: int = 20, n_dates: int = 120) -> pl.DataFrame:
+    """Panel whose factor has one non-zero sign, so sign(factor) never varies."""
+    raw = fx.datasets.make_cs_panel(n_assets=n_assets, n_dates=n_dates, rng=17)
+    return compute_forward_return(
+        raw.with_columns(pl.col("factor").abs() + 1.0), forward_periods=5
+    )
+
+
+class TestDirectionalHitRateOneSidedSignal:
+    """Pre-flight reports the outcome the run produces, not a short-circuit (#1116)."""
+
+    def test_one_sided_signal_is_usable_with_an_advisory(self):
+        verdict = _by_name(
+            inspect_data(_one_sided_sign_panel()), "directional_hit_rate"
+        )
+        assert verdict.usable, verdict.blockers
+        advisory = next(
+            w for w in verdict.warnings if w.code is fx.WarningCode.DEGENERATE_VARIANCE
+        )
+        assert "one-sided directional signal" in advisory.message
+
+    def test_the_run_returns_a_hit_rate_with_that_warning(self):
+        panel = _one_sided_sign_panel()
+        assert _by_name(inspect_data(panel), "directional_hit_rate").usable
+        from factrix.metrics.directional_hit_rate import directional_hit_rate
+
+        out = directional_hit_rate(panel, overlap_periods=5)
+        assert out.metadata.get("reason") is None
+        assert "degenerate_variance" in out.warning_codes
+        assert out.value == pytest.approx(out.metadata["p_correct"])
+
+    def test_a_two_sided_signal_carries_no_advisory(self):
+        panel = compute_forward_return(
+            fx.datasets.make_cs_panel(n_assets=20, n_dates=120, rng=17),
+            forward_periods=5,
+        )
+        verdict = _by_name(inspect_data(panel), "directional_hit_rate")
+        assert verdict.usable, verdict.blockers
+        assert not [
+            w for w in verdict.warnings if w.code is fx.WarningCode.DEGENERATE_VARIANCE
+        ]


### PR DESCRIPTION
## Summary

`inspect_data` marked `directional_hit_rate` **unusable** on a one-sided sign signal with a blocker promising that the metric "would return degenerate_variance at run time". The run does no such refusal: with one non-zero sign, `P*` collapses to the realised up-rate, `var_s` is zero, and the metric returns the hit rate with `stat` / `p_value` null under `WarningCode.DEGENERATE_VARIANCE`. `strict=True` therefore ran the shape pre-flight had refused.

## The design call

The issue offered two ways to make pre-flight and run time agree: make the metric short-circuit, or retire the blocker. This takes the second.

A hit rate on a one-sided signal is a defined number — the unconditional positive-return rate — but not a *directional* one, and factrix's canonical rule for that case is [architecture.md](docs/development/architecture.md): a degenerate dispersion withholds the test "while retaining a valid point estimate". Short-circuiting would delete a value the metric can compute and would be the breaking change of the two. The advisory now says what the number means, so a reader is not left to assume it measures skill.

Recorded in the `directional_hit_rate` docstring (which also claimed a short-circuit that never happened) and in `docs/reference/metric-applicability.md`.

## Contract

One-sided `sign(factor)` → `usable=True` carrying:

```
degenerate_variance: one-sided directional signal: sign(factor) has only one
non-zero side, so P* collapses to the realised up-rate and the
Pesaran-Timmermann variance is zero. The metric returns the hit rate — the
unconditional positive-return rate, not a directional one — with a null
statistic and p-value under degenerate_variance. Center, threshold, or encode a
true two-sided directional signal to obtain a test.
```

## Verification

Measured on a verification machine (project venv, `pytest -p no:randomly`):

- the three new tests in `tests/test_inspect_data.py::TestDirectionalHitRateOneSidedSignal` against the **unfixed** `_inspect.py`: 2 failed (pre-flight refused; the run did not), 1 passed (the two-sided control, which must not gain an advisory)
- after the change: 3 passed; whole file 97 passed
- `test_directional_hit_rate_blocks_one_sided_factor_sign` pinned the old blocker and is rewritten as `test_directional_hit_rate_advises_on_a_one_sided_factor_sign` — the same panel, the new contract
- `python -m pytest -q`: **4180 passed, 44 skipped, 0 failed**
- `ruff check` / `ruff format --check`: clean
- `python -m mypy factrix`: no issues in 83 source files
- `python -m pytest --doctest-modules factrix/metrics/directional_hit_rate.py`: 2 passed
- `python -m mkdocs build --strict`: built clean

Closes #1116
